### PR TITLE
Track costs for failed auxiliary LLM calls

### DIFF
--- a/apps/llm-orchestrator/src/__tests__/fakes.ts
+++ b/apps/llm-orchestrator/src/__tests__/fakes.ts
@@ -582,3 +582,26 @@ export function createFailingContextInferrer(
     },
   };
 }
+
+/**
+ * Create a fake ContextInferenceProvider that fails but includes usage data
+ * (simulating LLM call success but parsing failure).
+ */
+export function createFailingContextInferrerWithUsage(
+  errorMessage = 'Test parsing failure',
+  usage = { inputTokens: 1000, outputTokens: 500, costUsd: 0.005 }
+): ContextInferenceProvider {
+  return {
+    async inferResearchContext(
+      _userQuery: string,
+      _opts?: InferResearchContextOptions
+    ): Promise<Result<ResearchContextResult, LlmError>> {
+      return err({ code: 'API_ERROR', message: errorMessage, usage });
+    },
+    async inferSynthesisContext(
+      _params: InferSynthesisContextParams
+    ): Promise<Result<SynthesisContextResult, LlmError>> {
+      return err({ code: 'API_ERROR', message: errorMessage, usage });
+    },
+  };
+}

--- a/apps/llm-orchestrator/src/domain/research/ports/llmProvider.ts
+++ b/apps/llm-orchestrator/src/domain/research/ports/llmProvider.ts
@@ -9,6 +9,7 @@ import type { SynthesisContext } from '@intexuraos/llm-common';
 export interface LlmError {
   code: 'API_ERROR' | 'TIMEOUT' | 'INVALID_KEY' | 'RATE_LIMITED';
   message: string;
+  usage?: LlmUsage;
 }
 
 export interface LlmUsage {

--- a/apps/llm-orchestrator/src/domain/research/usecases/processResearch.ts
+++ b/apps/llm-orchestrator/src/domain/research/usecases/processResearch.ts
@@ -101,10 +101,18 @@ export async function processResearch(
         deps.reportLlmSuccess(LlmModels.Gemini25Flash);
       }
     } else {
-      deps.logger.warn(
-        { researchId, error: contextResult.error },
-        '[2.4.2] Context inference failed, proceeding without context'
-      );
+      if (contextResult.error.usage !== undefined) {
+        auxiliaryCostUsd += contextResult.error.usage.costUsd ?? 0;
+        deps.logger.warn(
+          { researchId, error: contextResult.error, costUsd: contextResult.error.usage.costUsd },
+          '[2.4.2] Context inference failed but cost tracked'
+        );
+      } else {
+        deps.logger.warn(
+          { researchId, error: contextResult.error },
+          '[2.4.2] Context inference failed, proceeding without context'
+        );
+      }
     }
   }
 

--- a/apps/llm-orchestrator/src/domain/research/usecases/runSynthesis.ts
+++ b/apps/llm-orchestrator/src/domain/research/usecases/runSynthesis.ts
@@ -147,10 +147,18 @@ export async function runSynthesis(
         `[4.2.2] Synthesis context inferred successfully (costUsd: ${String(contextResult.value.usage.costUsd)})`
       );
     } else {
-      logger?.error(
-        { error: contextResult.error },
-        '[4.2.2] Synthesis context inference failed, proceeding without context'
-      );
+      if (contextResult.error.usage !== undefined) {
+        additionalCostUsd += contextResult.error.usage.costUsd ?? 0;
+        logger?.error(
+          { error: contextResult.error, costUsd: contextResult.error.usage.costUsd },
+          '[4.2.2] Synthesis context inference failed but cost tracked'
+        );
+      } else {
+        logger?.error(
+          { error: contextResult.error },
+          '[4.2.2] Synthesis context inference failed, proceeding without context'
+        );
+      }
     }
   }
 

--- a/apps/llm-orchestrator/src/infra/llm/ContextInferenceAdapter.ts
+++ b/apps/llm-orchestrator/src/infra/llm/ContextInferenceAdapter.ts
@@ -51,7 +51,18 @@ export class ContextInferenceAdapter implements ContextInferenceProvider {
     const parsed = parseJson(result.value.content, isResearchContext);
     if (!parsed.ok) {
       this.logger?.warn({ error: parsed.error }, 'Failed to parse research context');
-      return { ok: false, error: { code: 'API_ERROR', message: parsed.error } };
+      return {
+        ok: false,
+        error: {
+          code: 'API_ERROR',
+          message: parsed.error,
+          usage: {
+            inputTokens: result.value.usage.inputTokens,
+            outputTokens: result.value.usage.outputTokens,
+            costUsd: result.value.usage.costUsd,
+          },
+        },
+      };
     }
 
     const { usage } = result.value;
@@ -81,7 +92,18 @@ export class ContextInferenceAdapter implements ContextInferenceProvider {
     const parsed = parseJson(result.value.content, isSynthesisContext);
     if (!parsed.ok) {
       this.logger?.warn({ error: parsed.error }, 'Failed to parse synthesis context');
-      return { ok: false, error: { code: 'API_ERROR', message: parsed.error } };
+      return {
+        ok: false,
+        error: {
+          code: 'API_ERROR',
+          message: parsed.error,
+          usage: {
+            inputTokens: result.value.usage.inputTokens,
+            outputTokens: result.value.usage.outputTokens,
+            costUsd: result.value.usage.costUsd,
+          },
+        },
+      };
     }
 
     const { usage } = result.value;


### PR DESCRIPTION
## Summary

Fixes cost tracking gap for failed auxiliary LLM calls where the API succeeds but post-processing (JSON parsing) fails.

## Problem

When context inference calls failed due to schema validation errors, the LLM API call succeeded and consumed tokens, but the cost wasn't included in the research document's `totalCostUsd` field. 

**Example:** Research `3850ec9d-ef73-40af-b762-fec56d330569` was missing $0.002877 (2.75% of total cost) because the context inference call returned valid tokens but failed JSON parsing.

## Solution

- Extended `LlmError` interface to optionally include `usage?: LlmUsage`
- Updated `ContextInferenceAdapter` to preserve usage data when parsing fails
- Modified `processResearch` and `runSynthesis` to track costs from errors with usage data
- Added new test helper `createFailingContextInferrerWithUsage()` for testing
- Added test cases for both research and synthesis context inference failures

## Changes

| File | Change |
|------|--------|
| `ports/llmProvider.ts` | Added optional `usage` field to `LlmError` interface |
| `ContextInferenceAdapter.ts` | Return usage in error when LLM succeeds but parsing fails |
| `processResearch.ts` | Track `auxiliaryCostUsd` from failed context inference |
| `runSynthesis.ts` | Track `additionalCostUsd` from failed synthesis context inference |
| `fakes.ts` | Added `createFailingContextInferrerWithUsage()` helper |
| `*.test.ts` | Added test cases for cost tracking on parse failures |

## Test Plan

✅ All 453 tests passing
✅ Typecheck passed
✅ New tests verify cost tracking when:
  - Research context inference fails with usage data
  - Synthesis context inference fails with usage data

## Impact

- **Before:** Failed auxiliary calls were logged but not tracked in research costs
- **After:** All LLM costs are accurately tracked in `totalCostUsd`, even when post-processing fails
- **Backwards compatible:** Existing code continues to work (optional field)

🤖 Generated with [Claude Code](https://claude.com/claude-code)