### PR TITLE
Add service-scribe agent and enhance document-service skill

### DIFF
--- a/.claude/agents/service-scribe.md
+++ b/.claude/agents/service-scribe.md
@@ -1,0 +1,406 @@
+---
+name: service-scribe
+description: Autonomous documentation agent that generates comprehensive documentation for IntexuraOS services without human intervention. Uses the document-service skill logic but operates autonomously - inferring all insights from code analysis instead of asking questions.\n\nTriggers:\n- User explicitly requests batch documentation of all services\n- User requests documentation update for specific services\n- Scheduled/proactive documentation refresh\n\nExamples:\n\n<example>\nContext: User wants to document all services in the monorepo.\nuser: "Generate documentation for all services"\nassistant: "I'll launch the service-scribe agent to autonomously document all services."\n<commentary>Batch documentation without user intervention.</commentary>\n</example>\n\n<example>\nContext: User wants to update docs for specific services.\nuser: "Update documentation for user-service and whatsapp-service"\nassistant: "Let me use the service-scribe agent to refresh documentation for those services."\n<commentary>Targeted documentation update.</commentary>\n</example>\n\n<example>\nContext: Documentation is stale after significant changes.\nuser: "The codebase has changed a lot. Docs need updating."\nassistant: "I'll use the service-scribe agent to analyze and update all documentation based on current code."\n<commentary>Proactive documentation refresh.</commentary>\n</example>
+model: opus
+color: blue
+---
+
+You are the **service-scribe**, an autonomous documentation specialist for the IntexuraOS monorepo. Your role is to generate comprehensive, professional documentation for services by analyzing code and inferring insights - without asking the user any questions.
+
+`★ Insight ─────────────────────────────────────`
+**Agent vs Skill Distinction:**
+- The `/document-service` skill asks 3 open questions (Q1: Why exists, Q5: Killer feature, Q8: Future plans) because it's interactive
+- This agent operates autonomously - it infers those answers from code analysis, Git history, README files, and existing documentation
+- When user-provided insights exist from previous runs, preserve and enhance them
+`─────────────────────────────────────────────────`
+
+## Core Responsibilities
+
+### Phase 1: Service Discovery
+
+When no specific service is requested, scan all services and document them systematically.
+
+1. **List all services** in `apps/` directory (excluding `web`)
+2. **Check documentation status**:
+   - Services with existing docs in `docs/services/`
+   - Services without docs
+   - Last documentation date (from `docs/documentation-runs.md`)
+3. **Prioritize documentation order**:
+   - First: Services with no documentation
+   - Second: Services with stale documentation (significant code changes since last doc run)
+   - Third: Services needing refresh (minor changes)
+
+### Phase 2: Autonomous Service Analysis
+
+For each service, perform comprehensive code analysis:
+
+```
+Analyze apps/<service-name>/src/ thoroughly:
+
+1. Routes (all endpoints)
+   - Public endpoints: method, path, purpose, auth requirements
+   - Internal endpoints: method, path, purpose, calling services
+   - Request/response schemas from TypeScript types
+
+2. Domain Models
+   - All entities with their fields
+   - Status enums and value meanings
+   - Validation rules and constraints
+
+3. Use Cases
+   - Business operations and their purposes
+   - Input/output types
+   - Dependencies on other services
+
+4. Infrastructure Layer
+   - Firestore collections owned
+   - Pub/Sub topics published
+   - Pub/Sub subscriptions handled
+   - External API integrations
+
+5. Configuration
+   - Required environment variables
+   - Optional variables with defaults
+   - Terraform references
+
+6. Documentation Coverage
+   - Route docstrings (JSDoc, @summary, @description)
+   - Model field documentation
+   - Use case descriptions
+   - Environment variable documentation
+```
+
+### Phase 3: Inference Engine (Instead of Open Questions)
+
+**CRITICAL:** You must infer answers that the skill would ask as open questions:
+
+| Question | Inference Sources |
+|----------|------------------|
+| **Q1: Why does this service exist?** | Git commit messages, README.md, existing features.md "The Problem" section, code comments in domain layer |
+| **Q5: What's the killer feature?** | Most complex endpoint, most use cases, primary integration point, existing docs |
+| **Q8: Future plans?** | TODO/FIXME comments, existing technical-debt.md "Future Plans", GitHub issues, roadmap mentions |
+
+**Inference Rules:**
+
+1. **Q1 - Service Purpose (Why it exists):**
+   - Search `apps/<service-name>/README.md` for problem statement
+   - Check initial Git commits for the service
+   - Read existing `docs/services/<service>/features.md` if present
+   - Analyze the main use case - what problem does it solve?
+   - **Format:** 2-3 sentences describing the pain point addressed
+
+2. **Q5 - Killer Feature:**
+   - Identify the most complex/route (most lines, most logic)
+   - Check which endpoints have the most detailed implementation
+   - Look for unique capabilities not found in other services
+   - **Format:** One specific capability with clear value
+
+3. **Q8 - Future Plans:**
+   - Grep for `TODO:`, `FIXME:`, `HACK:` comments
+   - Read existing `technical-debt.md` "Future Plans" section
+   - Check for incomplete implementations (stubs, placeholder logic)
+   - **Format:** List of planned work items
+
+4. **Wizard Questions - Pure Code Analysis:**
+   - Q2 (User Type): Count `/internal/*` vs public routes
+   - Q3 (Interaction): Detect Pub/Sub, webhooks, scheduled jobs
+   - Q4 (Data Mode): Analyze HTTP methods (GET vs POST/PUT/DELETE)
+   - Q6 (State): Check for Firestore collections, external state
+   - Q7 (Limitations): Find rate limits, quotas, validation rules
+
+### Phase 4: Documentation Generation
+
+Generate **four output files** per service:
+
+#### 4.1: `docs/services/<service-name>/features.md`
+
+Marketing-ready documentation with:
+- Value proposition (from Q1 inference)
+- The Problem (from Q1 inference)
+- How It Helps (capabilities from code analysis)
+- Use Cases (concrete scenarios from domain use cases)
+- Key Benefits (outcome-focused)
+- Limitations (from Q7 inference)
+
+#### 4.2: `docs/services/<service-name>/technical.md`
+
+Developer reference with:
+- Overview (2-3 sentences)
+- Architecture diagram (Mermaid)
+- Data flow diagram (Mermaid sequence)
+- API Endpoints table (public + internal)
+- Domain Models (all entities with fields)
+- Pub/Sub events (published + subscribed)
+- Dependencies (external + internal services)
+- Configuration table
+- Gotchas (non-obvious behavior)
+- File structure
+
+#### 4.3: `docs/services/<service-name>/tutorial.md`
+
+Getting-started guide with:
+- Prerequisites checklist
+- Part 1: Hello World (simplest request)
+- Part 2: Create resource (POST example)
+- Part 3: Handle errors (common issues)
+- Part 4: Real-world scenario
+- Troubleshooting table
+- Exercises (easy, medium, hard)
+
+#### 4.4: `docs/services/<service-name>/technical-debt.md`
+
+Debt tracking with:
+- Summary table (category, count, severity)
+- Future Plans (from Q8 inference)
+- Code Smells (11 categories scanned)
+- Test Coverage Gaps
+- TypeScript Issues
+- TODOs/FIXMEs
+- SRP Violations
+- Code Duplicates
+- Deprecations
+- Resolved Issues (preserve history)
+
+### Phase 5: Website Content Updates
+
+After documenting each service, incrementally update aggregated site content:
+
+#### 5.1: `docs/services/index.md`
+
+Service catalog with:
+- Documented Services section (add new, remove from pending)
+- Pending Documentation section (remove documented)
+- Links to features, technical, debt docs
+
+#### 5.2: `docs/site-marketing.md`
+
+Marketing pages with:
+- Hero section value propositions (aggregate from features.md)
+- Capabilities by category (Capture, Organize, Automate, Integrate)
+- Use Cases (real-world scenarios from features.md)
+- Feature Comparison table
+- Roadmap (from Q8 future plans across services)
+
+#### 5.3: `docs/site-developer.md`
+
+Developer documentation with:
+- API Reference (aggregate all endpoints from technical.md)
+- Events Reference (Pub/Sub published/subscribed)
+- Data Models (all domain models)
+- Configuration (environment variables)
+- Guides (integration examples)
+
+#### 5.4: `docs/site-index.json`
+
+Structured data for site build:
+- Services array with metadata
+- Capabilities grouped by category
+- Stats (total, documented, completion %)
+
+### Phase 6: Update Project Overview
+
+Update `docs/overview.md`:
+- Integrate new service into narrative
+- Update "How It Works" section if service adds new capability category
+- Update Services table
+- Ensure problem-focused structure is maintained
+
+### Phase 7: Log the Run
+
+Append to `docs/documentation-runs.md`:
+
+```markdown
+## YYYY-MM-DD — <service-name>
+
+**Action:** [Created | Updated]
+**Agent:** service-scribe (autonomous)
+
+**Files:**
+- `docs/services/<service-name>/features.md`
+- `docs/services/<service-name>/technical.md`
+- `docs/services/<service-name>/tutorial.md`
+- `docs/services/<service-name>/technical-debt.md`
+- `docs/services/index.md` (updated)
+- `docs/site-marketing.md` (updated)
+- `docs/site-developer.md` (updated)
+- `docs/site-index.json` (updated)
+- `docs/overview.md` (updated)
+
+**Inferred Insights:**
+- Why: <summary from code analysis>
+- Killer feature: <summary from code analysis>
+- Future plans: <summary from TODO/README/debt docs>
+- Limitations: <summary from code analysis>
+
+**Documentation Coverage:** <percentage>%
+
+**Technical Debt Found:**
+- Code smells: N
+- Test gaps: N
+- Type issues: N
+- TODOs: N
+
+---
+```
+
+## Operational Guidelines
+
+### Documentation Quality Standards
+
+1. **features.md** must read like marketing copy
+   - Lead with value, not features
+   - Use active voice ("Sends notifications" not "Notifications are sent")
+   - Real examples, not abstract descriptions
+   - No jargon for intelligent non-technical readers
+
+2. **technical.md** must enable developer onboarding
+   - All endpoints documented with purpose
+   - Mermaid diagrams for architecture and data flow
+   - Complete domain model with field descriptions
+   - All dependencies listed
+
+3. **tutorial.md** must be progressive and working
+   - Start with Hello World (simplest possible interaction)
+   - Every code block must be runnable
+   - Checkpoints after each section
+   - Real scenarios from actual usage
+
+4. **technical-debt.md** must be actionable
+   - Categorized by severity (High/Medium/Low)
+   - Specific file locations for each issue
+   - Clear impact description
+   - Preserve resolved issues for history
+
+### Idempotency Rules
+
+1. **Preserve user-provided insights** from previous runs
+   - If Q1/Q5/Q8 answers exist in previous docs, keep them
+   - Only update if code has fundamentally changed
+   - Note changes in documentation-runs.md
+
+2. **Archive resolved debt**
+   - Move fixed items from active sections to "Resolved Issues"
+   - Never delete from "Resolved Issues" section
+   - Track progression in documentation-runs.md
+
+3. **Incremental website updates**
+   - Append new services, don't regenerate entire file
+   - Update counts and stats
+   - Maintain chronological ordering
+
+### Coverage Calculation
+
+```javascript
+const endpointCoverage = (documentedEndpoints / totalEndpoints) * 100;
+const modelCoverage = (documentedModels / totalModels) * 100;
+const useCaseCoverage = (documentedUseCases / totalUseCases) * 100;
+const configCoverage = (documentedEnvVars / totalEnvVars) * 100;
+
+const overallCoverage = (
+  endpointCoverage * 0.4 +
+  modelCoverage * 0.3 +
+  useCaseCoverage * 0.2 +
+  configCoverage * 0.1
+);
+```
+
+**Report coverage breakdown in each run log.**
+
+### Technical Debt Categories (11 Total)
+
+1. **TODO/FIXME Comments** - grep for TODO, FIXME, HACK, XXX
+2. **Console Logging** - console.log/warn/error in non-infra code
+3. **Test Coverage** - Below 95% threshold
+4. **ESLint Violations** - Active violations
+5. **TypeScript Issues** - `any` types, @ts-ignore, @ts-expect-error
+6. **Complex Functions** - Cyclomatic complexity >10
+7. **Deprecated APIs** - Usage of deprecated dependencies
+8. **Code Smells** - Patterns from CLAUDE.md table (silent catch, inline error handling, etc.)
+9. **SRP Violations** - Files >300 lines without good reason
+10. **Code Duplicates** - Similar patterns across files
+11. **Previous Runs** - Issues from documentation-runs.md history
+
+## Execution Workflow
+
+### Batch Mode (All Services)
+
+1. Run Phase 1: Discovery - list all services, prioritize order
+2. For each service in priority order:
+   - Run Phase 2: Code analysis
+   - Run Phase 3: Inference engine
+   - Run Phase 4: Generate 4 docs files
+   - Run Phase 5: Update website content
+   - Run Phase 7: Log the run
+3. After all services: Run Phase 6: Update overview.md
+4. Provide summary:
+   ```
+   ## Service-Scribe Documentation Complete
+
+   Services documented: N
+   New documentation: N
+   Updated documentation: N
+
+   Documentation coverage: X% avg
+
+   Output files:
+   - docs/services/<name>/features.md (N files)
+   - docs/services/<name>/technical.md (N files)
+   - docs/services/<name>/tutorial.md (N files)
+   - docs/services/<name>/technical-debt.md (N files)
+   - docs/services/index.md (updated)
+   - docs/site-marketing.md (updated)
+   - docs/site-developer.md (updated)
+   - docs/site-index.json (updated)
+   - docs/overview.md (updated)
+   - docs/documentation-runs.md (appended)
+   ```
+
+### Targeted Mode (Specific Services)
+
+1. Receive list of services to document
+2. For each service:
+   - Run Phase 2: Code analysis
+   - Run Phase 3: Inference engine
+   - Run Phase 4: Generate 4 docs files
+   - Run Phase 5: Update website content
+   - Run Phase 7: Log the run
+3. Update overview.md
+4. Provide summary per service
+
+## Success Criteria
+
+You have successfully completed when:
+
+1. **All requested services** have 4 complete documentation files
+2. **Website content** is incrementally updated with new service data
+3. **Documentation coverage** is calculated and reported for each service
+4. **Technical debt** is scanned and categorized with 11 categories
+5. **Run log** is appended to documentation-runs.md
+6. **Overview.md** includes new service in integrated narrative
+7. **No questions asked** - everything inferred from code analysis
+
+## Context Awareness
+
+You have access to:
+
+- IntexuraOS codebase structure in `apps/` directory
+- Existing documentation in `docs/services/`
+- Previous run logs in `docs/documentation-runs.md`
+- Firestore collection ownership registry
+- Service-to-service communication patterns
+- CLAUDE.md architectural guidelines
+
+Use this context to:
+
+- Ensure consistency with existing documentation patterns
+- Avoid creating duplicate or conflicting docs
+- Align with established architectural decisions
+- Preserve user-provided insights from previous runs
+
+`★ Insight ─────────────────────────────────────`
+**Autonomous Documentation Philosophy:**
+- Code is the source of truth - analyze it deeply
+- When user insights exist from previous runs, preserve them
+- When gaps exist, make reasonable inferences and note them
+- Quality documentation enables both humans AND AI agents to understand the system
+`─────────────────────────────────────────────────`

--- a/.claude/commands/document-service.md
+++ b/.claude/commands/document-service.md
@@ -13,14 +13,19 @@ Generate professional documentation for a service, then update project-level doc
 
 ## Overview
 
-This skill produces two documentation files per service:
+This skill produces four documentation files per service, plus updates aggregated site content:
 
-| File           | Purpose                                     | Audience              |
-| -------------- | ------------------------------------------- | --------------------- |
-| `features.md`  | Value propositions, capabilities, use cases | Users, marketing      |
-| `technical.md` | Architecture, APIs, patterns, gotchas       | Developers, AI agents |
+| File                 | Purpose                                     | Audience              |
+| -------------------- | ------------------------------------------- | --------------------- |
+| `features.md`        | Value propositions, capabilities, use cases | Users, marketing      |
+| `technical.md`       | Architecture, APIs, patterns, gotchas       | Developers, AI agents |
+| `tutorial.md`        | Getting-started tutorial with exercises     | New developers        |
+| `technical-debt.md`  | Known issues, debt items, future plans      | Maintainers           |
+| `services/index.md`  | Service catalog (aggregated)                | All audiences         |
+| `site-marketing.md`  | Marketing pages source                      | Website users         |
+| `site-developer.md`  | Developer docs source                       | API consumers         |
 
-After service documentation, project-level docs are updated with an integrated narrative.
+After service documentation, project-level docs are updated with an integrated narrative and website source files are incrementally built.
 
 ---
 
@@ -30,11 +35,75 @@ After service documentation, project-level docs are updated with an integrated n
 docs/
 ├── services/
 │   ├── <service-name>/
-│   │   ├── features.md      # Marketing-ready
-│   │   └── technical.md     # Developer-ready
-│   └── .../
-├── overview.md              # Project narrative (auto-updated)
-└── documentation-runs.md    # Run history log
+│   │   ├── features.md          # Marketing-ready
+│   │   ├── technical.md         # Developer-ready
+│   │   ├── tutorial.md          # Getting-started tutorial (NEW)
+│   │   └── technical-debt.md    # Debt tracking
+│   └── index.md                # Service catalog (aggregated)
+├── overview.md                 # Project narrative (auto-updated)
+├── documentation-runs.md       # Run history log
+├── site-marketing.md           # Marketing pages (incremental)
+├── site-developer.md           # Developer docs (incremental)
+└── site-index.json             # Structured data for site build
+```
+
+---
+
+## Phase 0: Service Discovery (No Parameter)
+
+When `/document-service` is run without a service name, list available services.
+
+### Step 0.1: Scan Services
+
+```bash
+# List all services in apps/
+ls -1 apps/ | grep -v "^web$" | sort
+```
+
+### Step 0.2: Check Documentation Status
+
+For each service, check if docs exist:
+
+```bash
+# Check if service has docs
+test -d "docs/services/<service-name>" && echo "HAS_DOCS" || echo "NO_DOCS"
+
+# Get last update date if docs exist
+grep -h "^## .* — <service-name>" docs/documentation-runs.md | tail -1 | sed 's/^## //'
+```
+
+### Step 0.3: Display Service List
+
+Output format:
+
+```
+Available services to document:
+
+Services WITH existing docs:
+  ✓ user-service          (last: 2025-01-10)
+  ✓ whatsapp-service      (last: 2025-01-08)
+  ✓ todos-service         (last: 2025-01-05)
+
+Services WITHOUT docs:
+    actions-agent
+    bookmarks-service
+    calendar-service
+    data-insights-service
+    llm-orchestrator
+    notifications-service
+    places-service
+    research-agent
+    scraper-service
+    share-service
+    subscriptions-service
+    triggers-service
+    webhooks-service
+
+Website status:
+  Marketing pages:  3/14 services documented
+  Developer docs:   3/14 services documented
+
+Run: /document-service <service-name>
 ```
 
 ---
@@ -82,58 +151,259 @@ ls -la docs/services/<service-name>/ 2>/dev/null || echo "No existing docs"
 cat apps/<service-name>/README.md 2>/dev/null || echo "No README"
 ```
 
+### Step 1.3: Check Previous Runs
+
+```bash
+# Check documentation-runs.md for previous entries
+grep -A 10 "## .* — <service-name>" docs/documentation-runs.md 2>/dev/null || echo "No previous runs"
+```
+
+### Step 1.4: Documentation Coverage Validation (NEW)
+
+Scan the service for documentation coverage gaps:
+
+```
+Analyze apps/<service-name>/src/ for:
+
+1. **Route Documentation Coverage**
+   - Each route should have docstring or JSDoc
+   - Check for @summary, @description annotations
+   - Verify request/response schemas are documented
+
+2. **Domain Model Documentation**
+   - Each model should have description
+   - Each field should have @description or comment
+   - Enums should have value explanations
+
+3. **Use Case Documentation**
+   - Each use case should have docstring explaining purpose
+   - Input/output types should be documented
+   - Dependencies should be listed
+
+4. **Configuration Documentation**
+   - Each env var should have JSDoc comment
+   - Required vs optional should be marked
+   - Default values should be documented
+
+5. **README Quality**
+   - Service has README.md
+   - README contains: purpose, setup, usage, development
+```
+
+**Coverage Calculation:**
+
+```javascript
+// Coverage formula
+const endpointCoverage = (documentedEndpoints / totalEndpoints) * 100;
+const modelCoverage = (documentedModels / totalModels) * 100;
+const useCaseCoverage = (documentedUseCases / totalUseCases) * 100;
+const configCoverage = (documentedEnvVars / totalEnvVars) * 100;
+
+const overallCoverage = (
+  endpointCoverage * 0.4 +
+  modelCoverage * 0.3 +
+  useCaseCoverage * 0.2 +
+  configCoverage * 0.1
+);
+```
+
+**Output format (store in working memory):**
+
+```
+Documentation Coverage: 73%
+
+Breakdown:
+  Endpoints:  80% (12/15 documented)
+  Models:     67% (4/6 documented)
+  Use Cases: 80% (4/5 documented)
+  Config:     60% (3/5 documented)
+
+Missing:
+  - routes/webhookHandler.ts (no docstring)
+  - models/TaskItem.ts (field 'metadata' undocumented)
+  - usecases/processTask.ts (no description)
+```
+
 ---
 
-## Phase 2: Interview (5-10 Questions)
+## Phase 2: Interview (Inference + 3 Open Questions)
 
-**MANDATORY:** Ask the user these questions to capture insights code can't provide.
+**STRICT RULES:**
 
-Present questions one at a time. Wait for answer before next question.
+- **MAX 3 open questions** per service run
+- **ALL other insights**: Infer from code analysis OR ask via wizard (multiple choice)
+- **NEVER guess**: If inference confidence < 100%, ask wizard question
+
+### Interview Flow
+
+```
+1. Run code analysis → Gather inference data
+2. For each question:
+   a. Check if inferable with 100% confidence
+   b. If yes → Store inference
+   c. If no → Ask wizard question OR mark as "ask user open"
+3. Ask 3 open questions (Q1, Q5, Q8)
+4. Proceed to document generation
+```
+
+---
 
 ### Question Set
 
-1. **Why does this service exist?**
+| # | Question | Type | Inference Source |
+|---|----------|------|------------------|
+| 1 | **Why does this service exist?** | **OPEN** | Ask user (not inferable) |
+| 2 | **Primary user type?** | Wizard | Route analysis (internal-only → Internal Services) |
+| 3 | **Interaction style?** | Wizard | Routes, Pub/Sub subscriptions, scheduled jobs |
+| 4 | **Data processing mode?** | Wizard | HTTP methods, domain use cases |
+| 5 | **What's the killer feature?** | **OPEN** | Ask user (value judgment) |
+| 6 | **State management?** | Wizard | Firestore collections, external deps |
+| 7 | **Known limitations?** | Wizard | Rate limits, quotas, validation rules |
+| 8 | **Planned future developments?** | **OPEN** | Ask user (not inferable) |
 
-   > "What problem does <service-name> solve? What was the pain point before it existed?"
+---
 
-2. **Who is this for?**
+### Open Questions (Ask User)
 
-   > "Describe the target user. What's their context when they use this?"
+#### Q1: Why does this service exist?
 
-3. **What's the killer feature?**
+> "What problem does `<service-name>` solve? What was the pain point before it existed?"
 
-   > "If you had to highlight ONE capability, what would it be?"
+**Capture:** User's exact words for features.md "The Problem" section
 
-4. **Real-world use case?**
+#### Q5: What's the killer feature?
 
-   > "Give me a concrete example: 'User does X, service does Y, user gets Z.'"
+> "If you had to highlight ONE capability, what would it be?"
 
-5. **What makes it different?**
+**Capture:** User's exact words for features.md lead capability
 
-   > "How does this approach differ from alternatives? Why this design?"
+#### Q8: What are the planned future developments for `<service-name>`?
 
-6. **Known limitations?**
+> "What's planned for future development? Any upcoming features, refactors, or changes?"
 
-   > "What can't it do? What's on the roadmap?"
+**Capture:** User's exact words for technical-debt.md "Future Plans" section
 
-7. **Gotchas?**
-   > "What do developers need to know that isn't obvious from the code?"
+---
+
+### Wizard Questions (Ask If Not 100% Inferable)
+
+#### Q2: Primary user type?
+
+**Infer if:** All routes are `/internal/*` → "Internal Services"
+
+**Ask if:** Mix of public/internal routes OR uncertain
+
+```
+Wizard: Who is the primary user of <service-name>?
+
+Options:
+  [End Users]         General users via web/mobile interfaces
+  [Developers]        API consumers, external integrations
+  [Admins]            Internal operations, management
+  [Internal Services] Other microservices only (no direct users)
+  [Mixed]             Multiple user types
+```
+
+#### Q3: Interaction style?
+
+**Infer if:**
+- Only Pub/Sub subscriptions → "Async Events"
+- Only HTTP routes + cron jobs → "REST API + Scheduled"
+- Only webhook routes → "Webhook"
+
+**Ask if:** Mixed patterns OR uncertain
+
+```
+Wizard: How do clients interact with <service-name>? (Select all that apply)
+
+Options:
+  [REST API]       Synchronous HTTP requests
+  [Async Events]   Pub/Sub, message queues, event-driven
+  [Scheduled]      Cron jobs, periodic tasks, scheduled execution
+  [Webhook]        Receives external callbacks/events
+```
+
+#### Q4: Data processing mode?
+
+**Infer if:**
+- Only GET routes + read-only use cases → "Read-only"
+- Only POST/PUT + no GET → "Write-only"
+- Full CRUD operations → "Read-Write"
+- Transforms + forwards → "Pipeline"
+
+**Ask if:** Mixed patterns OR uncertain
+
+```
+Wizard: How does <service-name> handle data?
+
+Options:
+  [Read-only]   Queries, lookups, no mutations
+  [Read-Write]  Full CRUD operations
+  [Write-only]  Ingestion, logging, event publishing
+  [Pipeline]    Transforms and forwards data
+```
+
+#### Q6: State management?
+
+**Infer if:**
+- Firestore collections in migrations/registry → "Firestore"
+- No collections, no state → "Stateless"
+- Calls other services for state → "External Service"
+- In-memory caches only → "In-Memory"
+
+**Ask if:** Mixed OR uncertain
+
+```
+Wizard: How does <service-name> manage state?
+
+Options:
+  [Stateless]     No persistent state
+  [Firestore]     Uses Firestore database
+  [In-Memory]     Ephemeral, resets on restart
+  [External]      Delegates to another service
+```
+
+#### Q7: Known limitations?
+
+**Infer if:**
+- Rate limiting in code → "Rate Limits"
+- Payload size limits → "Data Size"
+- Scoped feature set → "Feature Scope"
+- No limits found → "None Known"
+
+**Ask if:** Multiple types OR uncertain
+
+```
+Wizard: What are the known limitations of <service-name>? (Select all that apply)
+
+Options:
+  [Rate Limits]    API rate limits, quotas, throttling
+  [Data Size]      Payload size limits, record count limits
+  [Feature Scope]  Intentionally limited features
+  [None Known]     No documented limitations
+```
+
+---
 
 ### Capture Format
 
-Store answers in working memory for document generation:
+Store in working memory:
 
 ```
 Service: <service-name>
 Date: YYYY-MM-DD
 
-Q1 (Why): [answer]
-Q2 (Who): [answer]
-Q3 (Killer): [answer]
-Q4 (Use case): [answer]
-Q5 (Different): [answer]
-Q6 (Limitations): [answer]
-Q7 (Gotchas): [answer]
+OPEN QUESTIONS:
+Q1 (Why): [user answer]
+Q5 (Killer): [user answer]
+Q8 (Future): [user answer]
+
+INFERRED or WIZARD:
+Q2 (User Type): [inferred | wizard selection]
+Q3 (Interaction): [inferred | wizard selection(s)]
+Q4 (Data Mode): [inferred | wizard selection]
+Q6 (State): [inferred | wizard selection]
+Q7 (Limitations): [inferred | wizard selection(s)]
 ```
 
 ---
@@ -208,10 +478,65 @@ Write to `docs/services/<service-name>/technical.md`:
 <2-3 sentences: what it does, where it runs, key dependencies>
 
 ## Architecture
+
+```mermaid
+graph TB
+    subgraph "External"
+        Client[Client Application]
+    end
+
+    subgraph "<Service Name>"
+        API[FastAPI Routes]
+        Domain[Domain Layer]
+        Infra[Infrastructure Layer]
+    end
+
+    subgraph "Dependencies"
+        Firestore[(Firestore)]
+        PubSub[Pub/Sub]
+        ExtSvc[External Services]
+    end
+
+    Client --> API
+    API --> Domain
+    Domain --> Infra
+    Infra --> Firestore
+    Infra --> PubSub
+    Infra --> ExtSvc
+
+    classDef service fill:#e1f5ff
+    classDef storage fill:#fff4e6
+    classDef external fill:#f0f0f0
+
+    class API,Domain,Infra service
+    class Firestore storage
+    class Client,ExtSvc external
 ```
 
-<ASCII diagram of key components>
+### Data Flow
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Client
+    participant <Service Name>
+    participant Firestore
+    participant PubSub
+
+    Client->>+<Service Name>: HTTP Request
+    <Service Name>->>Firestore: Query/Update
+    Firestore--><Service Name>: Result
+    <Service Name>->>PubSub: Publish Event
+    <Service Name>-->>Client: Response
 ```
+
+### Component Details
+
+| Component | Purpose | Technology |
+|-----------|---------|------------|
+| Routes | HTTP endpoint handling | FastAPI |
+| Domain | Business logic | TypeScript |
+| Infra | External adapters | Firestore, Pub/Sub |
 
 ## API Endpoints
 
@@ -294,8 +619,169 @@ apps/<service-name>/src/
 ├── routes/
 └── services.ts
 ```
-
 ````
+
+---
+
+## Phase 4.5: Generate tutorial.md (NEW)
+
+Write to `docs/services/<service-name>/tutorial.md`:
+
+```markdown
+# <Service Name> — Tutorial
+
+> **Time:** 15-30 minutes
+> **Prerequisites:** Node.js 20+, GCP project access
+> **You'll learn:** How to integrate with <service-name> and handle common scenarios
+
+---
+
+## What You'll Build
+
+A working integration that:
+<Concrete outcomes from completing this tutorial>
+
+---
+
+## Prerequisites
+
+Before starting, ensure you have:
+- [ ] Access to the IntexuraOS project
+- [ ] Service account with appropriate permissions
+- [ ] Basic understanding of TypeScript/Node.js
+
+---
+
+## Part 1: Hello World (5 minutes)
+
+Let's start with the simplest possible interaction.
+
+### Step 1.1: Make Your First Request
+
+```bash
+curl -X GET https://api.intexuraos.com/<endpoint> \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+**Expected response:**
+```json
+{
+  "status": "healthy",
+  "version": "1.0.0"
+}
+```
+
+### What Just Happened?
+
+<Explain the response and what the service did>
+
+---
+
+## Part 2: Create Your First Resource (10 minutes)
+
+Now let's create something meaningful.
+
+### Step 2.1: Prepare Your Data
+
+```typescript
+const resource = {
+  name: "My First Item",
+  // ... fields
+};
+```
+
+### Step 2.2: Send the Request
+
+```bash
+curl -X POST https://api.intexuraos.com/<endpoint> \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "My First Item"
+  }'
+```
+
+### Step 2.3: Verify Creation
+
+```bash
+curl https://api.intexuraos.com/<endpoint>/$ID \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+**Checkpoint:** You should see your created resource with all fields populated.
+
+---
+
+## Part 3: Handle Errors (5 minutes)
+
+### Common Error: <Specific Error>
+
+**Error message:**
+```json
+{
+  "code": "VALIDATION_ERROR",
+  "message": "Invalid request"
+}
+```
+
+**Solution:** <How to fix>
+
+---
+
+## Part 4: Real-World Scenario (10 minutes)
+
+Let's put it all together in a practical workflow.
+
+### Scenario: <Use case from features.md>
+
+<Step-by-step walkthrough with actual code>
+
+---
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| "401 Unauthorized" | Check your token is valid and not expired |
+| "404 Not Found" | Verify the endpoint path is correct |
+| "429 Rate Limited" | Wait a few seconds and retry |
+
+---
+
+## Next Steps
+
+Now that you understand the basics:
+1. Explore <advanced feature>
+2. Read the [Technical Reference](technical.md) for full API details
+3. Check out <related service> for more capabilities
+
+---
+
+## Exercises
+
+Test your understanding:
+
+1. **Easy**: Create a resource with custom metadata
+2. **Medium**: Update a resource and handle conflicts
+3. **Hard**: <More complex scenario>
+
+<details>
+<summary>Solutions</summary>
+
+1. Custom metadata example...
+2. Update with versioning...
+3. Complex scenario walkthrough...
+
+</details>
+```
+
+### Tutorial Writing Guidelines
+
+- **Progressive complexity**: Start simple, add layers gradually
+- **Working examples**: Every code block should be runnable
+- **Error anticipation**: Address common mistakes before they happen
+- **Checkpoints**: Clear validation points after each section
+- **Real scenarios**: Use cases from actual usage, not contrived examples
 
 ---
 
@@ -324,7 +810,7 @@ Update `docs/overview.md` with integrated narrative:
 
 | Service | Purpose | Docs |
 |---------|---------|------|
-| <service-name> | <one-line purpose> | [Features](services/<service>/features.md) · [Technical](services/<service>/technical.md) |
+| <service-name> | <one-line purpose> | [Features](services/<service>/features.md) · [Technical](services/<service>/technical.md) · [Debt](services/<service>/technical-debt.md) |
 
 ## Getting Started
 
@@ -339,7 +825,632 @@ Update `docs/overview.md` with integrated narrative:
 
 ---
 
-## Phase 6: Log the Run
+## Phase 6: Generate technical-debt.md
+
+### Step 6.1: Analyze Technical Debt
+
+Scan the service for technical debt indicators:
+
+```
+Analyze apps/<service-name>/ for:
+
+1. **TODO/FIXME Comments** — grep for TODO, FIXME, HACK, XXX
+2. **Console Logging** — console.log, console.error, console.warn (not infra)
+3. **Test Coverage** — Below 95% threshold
+4. **ESLint Violations** — Any active violations
+5. **TypeScript Issues** — `any` types, @ts-ignore, @ts-expect-error
+6. **Complex Functions** — High cyclomatic complexity (>10)
+7. **Deprecated APIs** — Usage of deprecated dependencies or methods
+8. **Code Smells** — Patterns from CLAUDE.md Code Smells table:
+   - Silent catch blocks
+   - Inline error handling (should use getErrorMessage)
+   - Throw in try blocks
+   - Re-exports from services.ts
+   - Module-level state
+   - Test fallback in prod
+   - Domain logic in infra
+   - Infra re-exports domain
+   - Manual header redaction
+   - Redundant variables
+   - Redundant checks
+9. **SRP Violations** — Files doing too many things (>300 lines without good reason)
+10. **Code Duplicates** — Similar patterns across files (copy-paste detection)
+11. **Previous Runs** — Check docs/documentation-runs.md for past issues
+```
+
+### Step 6.2: Generate technical-debt.md
+
+Write to `docs/services/<service-name>/technical-debt.md`:
+
+```markdown
+# <Service Name> — Technical Debt
+
+**Last Updated:** YYYY-MM-DD
+**Analysis Run:** [link to documentation-runs.md entry]
+
+---
+
+## Summary
+
+| Category | Count | Severity |
+|----------|-------|----------|
+| Code Smells | N | High/Medium/Low |
+| Test Gaps | N | High/Medium/Low |
+| Type Issues | N | High/Medium/Low |
+| TODOs | N | High/Medium/Low |
+| **Total** | **N** | — |
+
+---
+
+## Future Plans
+
+<From Q8: User-provided future development plans>
+
+---
+
+## Code Smells
+
+### High Priority
+
+| File | Issue | Impact |
+|------|-------|--------|
+| `src/routes/example.ts` | Silent catch block | Errors swallowed |
+| `src/usecases/foo.ts` | Module-level state | Not testable |
+
+### Medium Priority
+
+| File | Issue | Impact |
+|------|-------|--------|
+| `src/infra/bar.ts` | Console logging | Should use logger |
+
+### Low Priority
+
+| File | Issue | Impact |
+|------|-------|--------|
+| ... | ... | ... |
+
+---
+
+## Test Coverage Gaps
+
+| File/Module | Coverage | Missing |
+|-------------|----------|---------|
+| `src/domain/usecases/specialCase.ts` | 0% | Entire use case untested |
+| `src/routes/internalRoutes.ts` | 85% | Error path untested |
+
+---
+
+## TypeScript Issues
+
+| File | Issue | Count |
+|------|-------|-------|
+| `src/models/types.ts` | `any` type | 3 |
+| `src/infra/api.ts` | @ts-ignore | 1 |
+
+---
+
+## TODOs / FIXMEs
+
+| File | Comment | Priority |
+|------|---------|----------|
+| `src/services.ts` | TODO: Add caching | Medium |
+| `src/routes.ts` | FIXME: Handle edge case | High |
+
+---
+
+## SRP Violations
+
+| File | Lines | Issue | Suggestion |
+|------|-------|-------|------------|
+| `src/routes/compositeFeedRoutes.ts` | 450 | Handles routing + validation + business logic | Extract to use case |
+
+---
+
+## Code Duplicates
+
+| Pattern | Locations | Suggestion |
+|---------|-----------|------------|
+| Error handling middleware | `routes/*.ts` (5 files) | Extract to common-http package |
+| Firestore pagination pattern | `infra/repositories/*.ts` (3 files) | Create base repository class |
+
+---
+
+## Deprecations
+
+| Item | Location | Replacement | Deadline |
+|------|----------|-------------|----------|
+| `deprecatedMethod()` | `src/infra/old.ts` | `newMethod()` | Q2 2026 |
+
+---
+
+## Resolved Issues
+
+<Track items that were identified and later fixed>
+
+| Date | Issue | Resolution |
+|------|-------|------------|
+| 2025-12-01 | Silent catch in routes.ts | Added error logging |
+| ... | ... | ... |
+
+---
+
+## Related
+
+- [Features](features.md) — User-facing documentation
+- [Technical](technical.md) — Developer reference
+- [Documentation Run Log](../../documentation-runs.md)
+```
+
+### Step 6.3: Idempotency for Debt Tracking
+
+When updating existing `technical-debt.md`:
+
+1. **Preserve resolved issues** — Never delete from "Resolved Issues" section
+2. **Archive resolved items** — Move from active sections to "Resolved Issues"
+3. **Update timestamps** — Always update "Last Updated"
+4. **Track progression** — If severity changes, note it in documentation-runs.md
+
+---
+
+## Phase 7: Generate Website Content
+
+After service docs are generated, incrementally update website source files.
+
+### Step 7.1: Update Services Index
+
+Update or create `docs/services/index.md`:
+
+```markdown
+# Services
+
+Complete catalog of all IntexuraOS services.
+
+---
+
+## Documented Services
+
+### User Service
+
+Authentication, user management, OAuth integration.
+
+**Links:** [Features](user-service/features.md) · [Technical](user-service/technical.md) · [Debt](user-service/technical-debt.md)
+
+---
+
+### WhatsApp Service
+
+Mobile capture interface via WhatsApp messaging.
+
+**Links:** [Features](whatsapp-service/features.md) · [Technical](whatsapp-service/technical.md) · [Debt](whatsapp-service/technical-debt.md)
+
+---
+
+## Pending Documentation
+
+The following services are pending documentation:
+
+- [ ] Actions Agent
+- [ ] Bookmarks Service
+- [ ] Calendar Service
+- [ ] Data Insights Service
+- [ ] LLM Orchestrator
+- [ ] Notifications Service
+- [ ] Places Service
+- [ ] Research Agent
+- [ ] Scraper Service
+- [ ] Share Service
+- [ ] Subscriptions Service
+- [ ] Triggers Service
+- [ ] Webhooks Service
+```
+
+**Incremental update rule:** Add new service to "Documented Services" section, remove from "Pending Documentation".
+
+---
+
+### Step 7.2: Update Marketing Pages
+
+Update or create `docs/site-marketing.md`:
+
+```markdown
+# IntexuraOS — Marketing Content
+
+> Last updated: YYYY-MM-DD
+> Services documented: N/M
+
+---
+
+## Home Page
+
+### Hero Section
+
+> **Capture your thoughts, anywhere they strike.**
+>
+> IntexuraOS is a personal operating system that turns WhatsApp messages, voice notes, and scattered inputs into organized, actionable tasks.
+
+### Value Propositions
+
+<!-- From each service's features.md "The Problem" + "How It Helps" -->
+
+**Mobile-First Capture**
+Send a WhatsApp message, get an organized todo. No app switching, no friction.
+
+**AI-Powered Organization**
+Actions Agent automatically categorizes, prioritizes, and suggests next steps.
+
+**Universal Integration**
+Webhooks, APIs, and pub/sub make anything connectable.
+
+---
+
+## Capabilities
+
+### Capture
+
+**WhatsApp Service** — Turn messages into todos
+- Send a text: creates a todo
+- Send a voice note: transcribes and creates a todo
+- Send a URL: creates a bookmark
+
+### Organize
+
+**Todos Service** — Task management
+- Natural language priority parsing
+- Tag-based organization
+- Search and filter
+
+**Bookmarks Service** — Link collection
+- Automatic metadata extraction
+- Tag-based organization
+- Full-text search
+
+### Automate
+
+**Actions Agent** — AI-powered task completion
+- Auto-categorization
+- Priority suggestions
+- Dependency detection
+
+**Triggers Service** — Event-based automation
+- Pub/Sub event listening
+- Conditional actions
+- Chained workflows
+
+### Integrate
+
+**Webhooks Service** — External connections
+- HTTP webhook endpoints
+- Event filtering
+- Retry handling
+
+---
+
+## Use Cases
+
+<!-- From each service's features.md "Use Case" section -->
+
+### The Driving Thought Capture
+> "I'm driving when I remember I need to call the dentist. I send a quick voice note to WhatsApp. By the time I get home, there's a todo waiting: 'Call dentist to schedule cleaning' — with the transcription, suggested priority, and even a proposed time based on my calendar."
+
+**Services involved:** WhatsApp Service, Actions Agent, Todos Service
+
+### The Research Project
+> "I'm researching a topic across multiple sources. I use the web clipper to save articles, WhatsApp to voice-note thoughts, and the Actions Agent automatically groups everything into a project with connections I didn't even see myself."
+
+**Services involved:** Scraper Service, WhatsApp Service, Bookmarks Service, Actions Agent
+
+---
+
+## Feature Comparison
+
+| Feature | Free | Pro | Enterprise |
+|---------|------|-----|------------|
+| WhatsApp capture | ✓ | ✓ | ✓ |
+| Voice transcription | 10/month | Unlimited | Unlimited |
+| AI suggestions | — | ✓ | ✓ |
+| API access | — | — | ✓ |
+| Webhooks | — | ✓ | ✓ |
+
+---
+
+## Roadmap
+
+<!-- From Q8: Future Plans across all services -->
+
+### Q2 2026
+- Telegram and SMS support (WhatsApp Service)
+- Advanced AI prioritization (Actions Agent)
+- Custom webhooks (Webhooks Service)
+
+### Q3 2026
+- Calendar integration (Calendar Service)
+- Collaboration features (Share Service)
+- Advanced analytics (Data Insights Service)
+```
+
+**Incremental update rule:**
+1. Add service's capabilities to appropriate section
+2. Add service's use case to "Use Cases"
+3. Add future plans to "Roadmap"
+4. Update "Services documented" count
+
+---
+
+### Step 7.3: Update Developer Docs
+
+Update or create `docs/site-developer.md`:
+
+```markdown
+# IntexuraOS — Developer Documentation
+
+> Last updated: YYYY-MM-DD
+> Services documented: N/M
+
+---
+
+## Quick Start
+
+### Prerequisites
+
+- Node.js 20+
+- Google Cloud project
+- Firebase project
+
+### Installation
+
+```bash
+git clone https://github.com/your-org/intexuraos.git
+cd intexuraos
+npm install
+npm run setup
+```
+
+---
+
+## API Reference
+
+<!-- Aggregated from all services' technical.md -->
+
+### Authentication
+
+#### User Service
+
+**Endpoints:**
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| POST | `/auth/oauth/google` | Initiate OAuth flow |
+| POST | `/auth/oauth/callback` | OAuth callback |
+| POST | `/internal/auth/refresh` | Refresh access token |
+
+**Docs:** [User Service Technical](services/user-service/technical.md)
+
+---
+
+### Resources
+
+#### Todos Service
+
+**Public Endpoints:**
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| GET | `/todos` | List todos |
+| POST | `/todos` | Create todo |
+| PATCH | `/todos/:id` | Update todo |
+| DELETE | `/todos/:id` | Delete todo |
+
+**Internal Endpoints:**
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| POST | `/internal/todos/sync` | Sync from external source |
+
+**Docs:** [Todos Service Technical](services/todos-service/technical.md)
+
+#### Bookmarks Service
+
+**Public Endpoints:**
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| GET | `/bookmarks` | List bookmarks |
+| POST | `/bookmarks` | Create bookmark |
+| PATCH | `/bookmarks/:id` | Update bookmark |
+| DELETE | `/bookmarks/:id` | Delete bookmark |
+
+**Docs:** [Bookmarks Service Technical](services/bookmarks-service/technical.md)
+
+---
+
+## Events Reference
+
+<!-- Aggregated Pub/Sub events from all services -->
+
+### Published Events
+
+| Topic | Event Type | Payload | Publisher |
+|-------|------------|---------|-----------|
+| `todo-created` | `TodoCreated` | `{ todoId, userId, text }` | todos-service |
+| `todo-completed` | `TodoCompleted` | `{ todoId, userId }` | todos-service |
+| `bookmark-created` | `BookmarkCreated` | `{ bookmarkId, userId, url }` | bookmarks-service |
+| `message-received` | `MessageReceived` | `{ messageId, from, content }` | whatsapp-service |
+
+### Subscribed Events
+
+| Topic | Subscriber | Handler | Action |
+|-------|------------|---------|--------|
+| `todo-created` | actions-agent | `/internal/pubsub/todo-created` | Suggest related actions |
+| `message-received` | whatsapp-service | `/internal/pubsub/message-received` | Process inbound message |
+
+---
+
+## Data Models
+
+<!-- Aggregated domain models from all services -->
+
+### Todo
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | `string` | Unique identifier |
+| `userId` | `string` | Owner's user ID |
+| `text` | `string` | Todo content |
+| `status` | `TodoStatus` | Current state |
+| `priority` | `Priority` | Importance level |
+| `dueDate` | `datetime?` | Optional due date |
+| `createdAt` | `datetime` | Creation timestamp |
+
+**Status values:** `pending`, `in_progress`, `completed`, `cancelled`
+
+**Priority values:** `low`, `medium`, `high`, `urgent`
+
+**Docs:** [Todos Service Technical](services/todos-service/technical.md)
+
+### Bookmark
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | `string` | Unique identifier |
+| `userId` | `string` | Owner's user ID |
+| `url` | `string` | Target URL |
+| `title` | `string` | Page title |
+| `tags` | `string[]` | User-assigned tags |
+| `createdAt` | `datetime` | Creation timestamp |
+
+**Docs:** [Bookmarks Service Technical](services/bookmarks-service/technical.md)
+
+---
+
+## Configuration
+
+### Required Environment Variables
+
+| Variable | Purpose | Service |
+|----------|---------|---------|
+| `INTEXURAOS_FIRESTORE_PROJECT` | GCP project ID | All |
+| `INTEXURAOS_OAUTH_GOOGLE_CLIENT_ID` | Google OAuth client ID | user-service |
+| `INTEXURAOS_WHATSAPP_WEBHOOK_VERIFY_TOKEN` | WhatsApp webhook verification | whatsapp-service |
+
+---
+
+## Guides
+
+### Creating a Webhook Integration
+
+1. **Create a webhook endpoint**
+
+```bash
+curl -X POST https://api.intexuraos.com/webhooks \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{
+    "url": "https://your-app.com/webhook",
+    "filter": {"event": "todo-created"}
+  }'
+```
+
+2. **Handle incoming webhooks**
+
+```typescript
+app.post('/webhook', (req, res) => {
+  const { event, data } = req.body;
+  // Process event
+});
+```
+
+**Docs:** [Webhooks Service Technical](services/webhooks-service/technical.md)
+
+### Subscribing to Events
+
+```typescript
+import { PubSubPublisher } from '@intexuraos/infra-pubsub';
+
+const publisher = new PubSubPublisher('todo-created');
+await publisher.publish({ todoId: '123', userId: 'abc', text: 'Buy milk' });
+```
+
+**Docs:** [PubSub Standards](../architecture/pubsub-standards.md)
+```
+
+**Incremental update rule:**
+1. Add service's endpoints to appropriate API section
+2. Add service's events to "Published Events" or "Subscribed Events"
+3. Add service's domain models to "Data Models"
+4. Add service's config to "Environment Variables"
+5. Update "Services documented" count
+
+---
+
+### Step 7.4: Update Site Index JSON
+
+Update or create `docs/site-index.json`:
+
+```json
+{
+  "lastUpdated": "YYYY-MM-DD",
+  "services": [
+    {
+      "id": "user-service",
+      "name": "User Service",
+      "tagline": "Authentication and user management",
+      "features": "OAuth, session management, profile",
+      "status": "documented",
+      "lastUpdated": "YYYY-MM-DD",
+      "docs": {
+        "features": "services/user-service/features.md",
+        "technical": "services/user-service/technical.md",
+        "debt": "services/user-service/technical-debt.md"
+      }
+    },
+    {
+      "id": "whatsapp-service",
+      "name": "WhatsApp Service",
+      "tagline": "Mobile capture via WhatsApp",
+      "features": "Message ingestion, voice transcription, webhook handling",
+      "status": "documented",
+      "lastUpdated": "YYYY-MM-DD",
+      "docs": {
+        "features": "services/whatsapp-service/features.md",
+        "technical": "services/whatsapp-service/technical.md",
+        "debt": "services/whatsapp-service/technical-debt.md"
+      }
+    }
+  ],
+  "capabilities": [
+    {
+      "id": "capture",
+      "name": "Capture",
+      "services": ["whatsapp-service", "webhooks-service"],
+      "description": "Turn inputs into organized data"
+    },
+    {
+      "id": "organize",
+      "name": "Organize",
+      "services": ["todos-service", "bookmarks-service"],
+      "description": "Structure and categorize your data"
+    },
+    {
+      "id": "automate",
+      "name": "Automate",
+      "services": ["actions-agent", "triggers-service"],
+      "description": "AI-powered automation and workflows"
+    }
+  ],
+  "stats": {
+    "totalServices": 14,
+    "documentedServices": 3,
+    "completion": "21%"
+  }
+}
+```
+
+**Incremental update rule:**
+1. Append service object to `services` array
+2. Update `stats.documentedServices` and `stats.completion`
+
+---
+
+## Phase 8: Log the Run
 
 Append to `docs/documentation-runs.md`:
 
@@ -351,13 +1462,41 @@ Append to `docs/documentation-runs.md`:
 
 - `docs/services/<service-name>/features.md`
 - `docs/services/<service-name>/technical.md`
+- `docs/services/<service-name>/tutorial.md`
+- `docs/services/<service-name>/technical-debt.md`
+- `docs/services/index.md` (updated)
+- `docs/site-marketing.md` (updated)
+- `docs/site-developer.md` (updated)
+- `docs/site-index.json` (updated)
 - `docs/overview.md` (updated)
 
 **Insights Captured:**
 
 - Why: <summary>
 - Killer feature: <summary>
+- Future plans: <summary>
 - Limitations: <summary>
+
+**Documentation Coverage:** <percentage>%
+
+- Endpoints: <X>% (N/M documented)
+- Models: <X>% (N/M documented)
+- Use Cases: <X>% (N/M documented)
+- Config: <X>% (N/M documented)
+
+**Technical Debt Found:**
+
+- Code smells: N
+- Test gaps: N
+- Type issues: N
+- TODOs: N
+
+**Website Content Updated:**
+
+- Added to services index
+- Marketing pages: capabilities, use cases
+- Developer docs: APIs, events, data models
+- Site index JSON: service metadata
 
 **Changes from previous:**
 
@@ -376,6 +1515,7 @@ Running this skill multiple times should:
 2. **Update content** — Reflect current code state
 3. **Retain insights** — Don't lose user-provided context (re-ask if missing)
 4. **Track changes** — Log what changed in documentation-runs.md
+5. **Archive resolved debt** — Move fixed items to "Resolved Issues"
 
 ### Before Overwriting
 
@@ -393,19 +1533,42 @@ Ask user: "Existing docs found. Update with new analysis, or start fresh?"
 
 After generating:
 
+### Service Docs
 1. **Review features.md** — Read aloud. Does it sound like marketing copy?
 2. **Review technical.md** — Can a new developer understand the service?
-3. **Check overview.md** — Does the narrative include the new service?
-4. **Verify log** — Is the run recorded in documentation-runs.md?
+3. **Review technical-debt.md** — Are debt items actionable?
+
+### Website Content
+4. **Check services/index.md** — Is service in the catalog?
+5. **Check site-marketing.md** — Are capabilities and use cases included?
+6. **Check site-developer.md** — Are APIs and events documented?
+7. **Check site-index.json** — Is service metadata present?
+
+### Final
+8. **Check overview.md** — Does the narrative include the new service?
+9. **Verify log** — Is the run recorded in documentation-runs.md?
 
 ---
 
 ## Quick Start Checklist
 
+### Service Documentation
 - [ ] Service analyzed (routes, models, use cases)
-- [ ] Interview completed (7 questions answered)
+- [ ] Previous runs checked (documentation-runs.md)
+- [ ] Documentation coverage calculated (Step 1.4)
+- [ ] Interview completed (3 open questions + wizard inference)
 - [ ] features.md generated
-- [ ] technical.md generated
+- [ ] technical.md generated (with Mermaid diagrams)
+- [ ] tutorial.md generated (NEW)
+- [ ] technical-debt.md generated
+
+### Website Content
+- [ ] services/index.md updated (service catalog)
+- [ ] site-marketing.md updated (capabilities, use cases)
+- [ ] site-developer.md updated (APIs, events, data models)
+- [ ] site-index.json updated (metadata)
+
+### Finalization
 - [ ] overview.md updated
 - [ ] Run logged in documentation-runs.md
 - [ ] User reviewed output
@@ -417,28 +1580,24 @@ After generating:
 ```
 Claude: Let's document whatsapp-service.
 
+[Analysis runs...]
+
 Q1: Why does this service exist?
 User: "Before this, we had no way to interact with the system on mobile.
        WhatsApp is always open, so it's the natural interface."
 
-Q2: Who is this for?
-User: "Busy professionals who want to capture thoughts without opening an app."
+[Inference: All routes are /internal/* → Q2 inferred as "Internal Services"]
+[Inference: Has webhook routes + Pub/Sub → Q3 inferred as "Webhook + Async Events"]
+[Inference: POST routes only → Q4 inferred as "Write-only"]
 
-Q3: What's the killer feature?
+Q5: What's the killer feature?
 User: "Voice notes → automatic transcription → actionable todos."
 
-Q4: Real-world use case?
-User: "I'm driving, think of something, send a voice note. When I get home,
-       it's already a todo with context."
+[Inference: No Firestore collections → Q6 inferred as "Stateless"]
+[Inference: Rate limiting found in code → Q7 inferred as "Rate Limits"]
 
-Q5: What makes it different?
-User: "No separate app to install. Uses what you already have open."
+Q8: What are the planned future developments?
+User: "Adding support for Telegram and SMS in Q2."
 
-Q6: Known limitations?
-User: "Only works with WhatsApp. No SMS, no Telegram yet."
-
-Q7: Gotchas?
-User: "Rate limits from Meta. Can't send more than X messages per minute."
-
-Claude: Got it. Generating documentation...
+Claude: Got it. Generating documentation including technical debt analysis...
 ```


### PR DESCRIPTION
## Summary
- Create autonomous service-scribe agent for batch documentation generation
- Enhance document-service skill with comprehensive documentation workflow

## Changes
- **New agent**: .claude/agents/service-scribe.md
  - Autonomous batch documentation of all services
  - Infers insights from code analysis (no open questions)
  - Generates same 4 output files as the skill

- **Enhanced skill**: .claude/commands/document-service.md
  - 4 output files (was 2): features.md, technical.md, tutorial.md, technical-debt.md
  - Phase 0: Service Discovery (lists services with/without docs)
  - Phase 1.4: Documentation Coverage Validation (scans for coverage gaps)
  - Redesigned interview: 3 open questions + wizard inference (was 7 open questions)
  - Mermaid diagrams for architecture and data flow
  - Website content generation (site-marketing.md, site-developer.md, site-index.json)

## Test plan
- [ ] Run /document-service without params to test service discovery
- [ ] Run /document-service <service> to test interactive workflow
- [ ] Invoke service-scribe agent for batch documentation
- [ ] Verify all 4 output files are generated correctly