### PR TITLE
Add dev-** branch pattern to deploy workflow trigger

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - development
+      - 'dev-**'
   workflow_dispatch:
     inputs:
       force_strategy:


### PR DESCRIPTION
## Summary
- Adds `'dev-**'` branch pattern to deploy workflow triggers
- Deployments will now trigger automatically on push to any `dev-*` branch

## Test plan
- [ ] Merge this PR and verify deploy workflow triggers on `dev-*` branches