### PR TITLE
Fix: disable providers with failed key tests in enhance modal

### DIFF
--- a/apps/web/src/pages/ResearchDetailPage.tsx
+++ b/apps/web/src/pages/ResearchDetailPage.tsx
@@ -256,6 +256,19 @@ export function ResearchDetailPage(): React.JSX.Element {
       ? []
       : PROVIDER_MODELS.filter((p) => keys[p.id] !== null).map((p) => p.id);
 
+  const failedProviders: Map<LlmProvider, string> = ((): Map<LlmProvider, string> => {
+    const map = new Map<LlmProvider, string>();
+    if (keys !== null) {
+      for (const provider of PROVIDER_MODELS) {
+        const testResult = keys.testResults[provider.id];
+        if (testResult?.status === 'failure') {
+          map.set(provider.id, testResult.message);
+        }
+      }
+    }
+    return map;
+  })();
+
   const copyToClipboard = async (text: string, section: string): Promise<void> => {
     await navigator.clipboard.writeText(text);
     setCopiedSection(section);
@@ -1034,6 +1047,7 @@ export function ResearchDetailPage(): React.JSX.Element {
                 onChange={handleEnhanceModelChange}
                 configuredProviders={configuredProviders}
                 disabledProviders={getExistingProviders()}
+                failedProviders={failedProviders}
                 disabled={enhancing}
               />
               <p className="text-xs text-slate-500 mt-2">


### PR DESCRIPTION
## Summary
- Fixed enhance modal allowing selection of providers with failed API key tests
- Added `failedProviders` Map computation to `ResearchDetailPage`
- Passed `failedProviders` prop to `ModelSelector` in enhance modal

## Changes
- `apps/web/src/pages/ResearchDetailPage.tsx`: Added failed providers check, same pattern as ResearchAgentPage

## Test plan
- [ ] Test API key in Settings and verify it fails
- [ ] Go to existing research, click Enhance
- [ ] Verify the failed provider is greyed out with "Test failed" warning