### PR TITLE
Remove unused vibe-kanban-web-companion dependency

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -32,8 +32,7 @@
     "remark-gfm": "^4.0.1",
     "vega": "^5.28.0",
     "vega-embed": "^6.25.0",
-    "vega-lite": "^5.18.0",
-    "vibe-kanban-web-companion": "^0.0.5"
+    "vega-lite": "^5.18.0"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.1.8",

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,6 +1,5 @@
 import { HashRouter, Navigate, Route, Routes, useParams } from 'react-router-dom';
 import { Auth0Provider } from '@auth0/auth0-react';
-import { VibeKanbanWebCompanion } from 'vibe-kanban-web-companion';
 import { AuthProvider, SyncQueueProvider, useAuth } from '@/context';
 import { PWAProvider } from '@/context/pwa-context';
 import { AndroidInstallBanner, IOSInstallBanner, UpdateBanner } from '@/components/pwa-banners';
@@ -406,7 +405,6 @@ export function App(): React.JSX.Element {
           </AuthProvider>
         </HashRouter>
       </Auth0Provider>
-      <VibeKanbanWebCompanion />
     </PWAProvider>
   );
 }


### PR DESCRIPTION
## Summary
- Removed `vibe-kanban-web-companion` import from `App.tsx`
- Removed `<VibeKanbanWebCompanion />` component usage
- Removed `vibe-kanban-web-companion` from `package.json` dependencies

## Test plan
- [x] Vite dev server starts without import errors
- [ ] Verify web app builds successfully
- [ ] Verify no runtime errors in browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)