### PR TITLE
Add composite_feeds updatedAt index

### DIFF
--- a/migrations/022_composite-feeds-updatedat-index.mjs
+++ b/migrations/022_composite-feeds-updatedat-index.mjs
@@ -1,0 +1,30 @@
+/**
+ * Migration 022: Composite Feeds UpdatedAt Index
+ *
+ * - Adds composite index for 'composite_feeds' collection (userId ASC, updatedAt DESC, __name__ DESC)
+ * - Required for queries that filter by userId and order by updatedAt
+ */
+
+export const metadata = {
+  id: '022',
+  name: 'composite-feeds-updatedat-index',
+  description: 'Add composite_feeds index with updatedAt sorting',
+  createdAt: '2026-01-13',
+};
+
+export const indexes = [
+  {
+    collectionGroup: 'composite_feeds',
+    queryScope: 'COLLECTION',
+    fields: [
+      { fieldPath: 'userId', order: 'ASCENDING' },
+      { fieldPath: 'updatedAt', order: 'DESCENDING' },
+      { fieldPath: '__name__', order: 'DESCENDING' },
+    ],
+  },
+];
+
+export async function up(context) {
+  console.log('  Deploying Firestore index for composite_feeds (userId, updatedAt)...');
+  await context.deployIndexes();
+}


### PR DESCRIPTION
## Summary
- Added composite index for `composite_feeds` collection with `userId ASC, updatedAt DESC, __name__ DESC`
- Required for queries that filter by userId and order by updatedAt (migration 022)

## Test plan
- [x] Migration script runs successfully
- [x] Index deployed to Firestore (intexuraos-dev-pbuchman)
- [ ] Verify queries work after index is fully active (~1-2 min build time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)