### PR TITLE
Fix Docker builds for pnpm workspace

### DIFF
--- a/apps/actions-agent/Dockerfile
+++ b/apps/actions-agent/Dockerfile
@@ -42,7 +42,7 @@ COPY pnpm-lock.yaml ./
 
 # Copy generated production package.json and install deps
 COPY --from=builder /app/apps/actions-agent/dist/package.json ./
-RUN pnpm install --prod --frozen-lockfile
+RUN pnpm install --prod
 
 # Copy built file
 COPY --from=builder /app/apps/actions-agent/dist/index.js ./dist/

--- a/apps/api-docs-hub/Dockerfile
+++ b/apps/api-docs-hub/Dockerfile
@@ -42,7 +42,7 @@ COPY pnpm-lock.yaml ./
 
 # Copy generated production package.json and install deps
 COPY --from=builder /app/apps/api-docs-hub/dist/package.json ./
-RUN pnpm install --prod --frozen-lockfile
+RUN pnpm install --prod
 
 # Copy built file
 COPY --from=builder /app/apps/api-docs-hub/dist/index.js ./dist/

--- a/apps/app-settings-service/Dockerfile
+++ b/apps/app-settings-service/Dockerfile
@@ -42,7 +42,7 @@ COPY pnpm-lock.yaml ./
 
 # Copy generated production package.json and install deps
 COPY --from=builder /app/apps/app-settings-service/dist/package.json ./
-RUN pnpm install --prod --frozen-lockfile
+RUN pnpm install --prod
 
 # Copy built file
 COPY --from=builder /app/apps/app-settings-service/dist/index.js ./dist/

--- a/apps/bookmarks-agent/Dockerfile
+++ b/apps/bookmarks-agent/Dockerfile
@@ -42,7 +42,7 @@ COPY pnpm-lock.yaml ./
 
 # Copy generated production package.json and install deps
 COPY --from=builder /app/apps/bookmarks-agent/dist/package.json ./
-RUN pnpm install --prod --frozen-lockfile
+RUN pnpm install --prod
 
 # Copy built file
 COPY --from=builder /app/apps/bookmarks-agent/dist/index.js ./dist/

--- a/apps/calendar-agent/Dockerfile
+++ b/apps/calendar-agent/Dockerfile
@@ -42,7 +42,7 @@ COPY pnpm-lock.yaml ./
 
 # Copy generated production package.json and install deps
 COPY --from=builder /app/apps/calendar-agent/dist/package.json ./
-RUN pnpm install --prod --frozen-lockfile
+RUN pnpm install --prod
 
 # Copy built file
 COPY --from=builder /app/apps/calendar-agent/dist/index.js ./dist/

--- a/apps/commands-agent/Dockerfile
+++ b/apps/commands-agent/Dockerfile
@@ -42,7 +42,7 @@ COPY pnpm-lock.yaml ./
 
 # Copy generated production package.json and install deps
 COPY --from=builder /app/apps/commands-agent/dist/package.json ./
-RUN pnpm install --prod --frozen-lockfile
+RUN pnpm install --prod
 
 # Copy built file
 COPY --from=builder /app/apps/commands-agent/dist/index.js ./dist/

--- a/apps/data-insights-agent/Dockerfile
+++ b/apps/data-insights-agent/Dockerfile
@@ -42,7 +42,7 @@ COPY pnpm-lock.yaml ./
 
 # Copy generated production package.json and install deps
 COPY --from=builder /app/apps/data-insights-agent/dist/package.json ./
-RUN pnpm install --prod --frozen-lockfile
+RUN pnpm install --prod
 
 # Copy built file
 COPY --from=builder /app/apps/data-insights-agent/dist/index.js ./dist/

--- a/apps/image-service/Dockerfile
+++ b/apps/image-service/Dockerfile
@@ -42,7 +42,7 @@ COPY pnpm-lock.yaml ./
 
 # Copy generated production package.json and install deps
 COPY --from=builder /app/apps/image-service/dist/package.json ./
-RUN pnpm install --prod --frozen-lockfile
+RUN pnpm install --prod
 
 # Copy built file
 COPY --from=builder /app/apps/image-service/dist/index.js ./dist/

--- a/apps/mobile-notifications-service/Dockerfile
+++ b/apps/mobile-notifications-service/Dockerfile
@@ -42,7 +42,7 @@ COPY pnpm-lock.yaml ./
 
 # Copy generated production package.json and install deps
 COPY --from=builder /app/apps/mobile-notifications-service/dist/package.json ./
-RUN pnpm install --prod --frozen-lockfile
+RUN pnpm install --prod
 
 # Copy built file
 COPY --from=builder /app/apps/mobile-notifications-service/dist/index.js ./dist/

--- a/apps/notes-agent/Dockerfile
+++ b/apps/notes-agent/Dockerfile
@@ -42,7 +42,7 @@ COPY pnpm-lock.yaml ./
 
 # Copy generated production package.json and install deps
 COPY --from=builder /app/apps/notes-agent/dist/package.json ./
-RUN pnpm install --prod --frozen-lockfile
+RUN pnpm install --prod
 
 # Copy built file
 COPY --from=builder /app/apps/notes-agent/dist/index.js ./dist/

--- a/apps/notion-service/Dockerfile
+++ b/apps/notion-service/Dockerfile
@@ -42,7 +42,7 @@ COPY pnpm-lock.yaml ./
 
 # Copy generated production package.json and install deps
 COPY --from=builder /app/apps/notion-service/dist/package.json ./
-RUN pnpm install --prod --frozen-lockfile
+RUN pnpm install --prod
 
 # Copy built file
 COPY --from=builder /app/apps/notion-service/dist/index.js ./dist/

--- a/apps/promptvault-service/Dockerfile
+++ b/apps/promptvault-service/Dockerfile
@@ -42,7 +42,7 @@ COPY pnpm-lock.yaml ./
 
 # Copy generated production package.json and install deps
 COPY --from=builder /app/apps/promptvault-service/dist/package.json ./
-RUN pnpm install --prod --frozen-lockfile
+RUN pnpm install --prod
 
 # Copy built file
 COPY --from=builder /app/apps/promptvault-service/dist/index.js ./dist/

--- a/apps/research-agent/Dockerfile
+++ b/apps/research-agent/Dockerfile
@@ -42,7 +42,7 @@ COPY pnpm-lock.yaml ./
 
 # Copy generated production package.json and install deps
 COPY --from=builder /app/apps/research-agent/dist/package.json ./
-RUN pnpm install --prod --frozen-lockfile
+RUN pnpm install --prod
 
 # Copy built file
 COPY --from=builder /app/apps/research-agent/dist/index.js ./dist/

--- a/apps/todos-agent/Dockerfile
+++ b/apps/todos-agent/Dockerfile
@@ -42,7 +42,7 @@ COPY pnpm-lock.yaml ./
 
 # Copy generated production package.json and install deps
 COPY --from=builder /app/apps/todos-agent/dist/package.json ./
-RUN pnpm install --prod --frozen-lockfile
+RUN pnpm install --prod
 
 # Copy built file
 COPY --from=builder /app/apps/todos-agent/dist/index.js ./dist/

--- a/apps/user-service/Dockerfile
+++ b/apps/user-service/Dockerfile
@@ -42,7 +42,7 @@ COPY pnpm-lock.yaml ./
 
 # Copy generated production package.json and install deps
 COPY --from=builder /app/apps/user-service/dist/package.json ./
-RUN pnpm install --prod --frozen-lockfile
+RUN pnpm install --prod
 
 # Copy built file
 COPY --from=builder /app/apps/user-service/dist/index.js ./dist/

--- a/apps/web-agent/Dockerfile
+++ b/apps/web-agent/Dockerfile
@@ -42,7 +42,7 @@ COPY pnpm-lock.yaml ./
 
 # Copy generated production package.json and install deps
 COPY --from=builder /app/apps/web-agent/dist/package.json ./
-RUN pnpm install --prod --frozen-lockfile
+RUN pnpm install --prod
 
 # Copy built file
 COPY --from=builder /app/apps/web-agent/dist/index.js ./dist/

--- a/apps/whatsapp-service/Dockerfile
+++ b/apps/whatsapp-service/Dockerfile
@@ -42,7 +42,7 @@ COPY pnpm-lock.yaml ./
 
 # Copy generated production package.json and install deps
 COPY --from=builder /app/apps/whatsapp-service/dist/package.json ./
-RUN pnpm install --prod --frozen-lockfile
+RUN pnpm install --prod
 
 # Copy built file
 COPY --from=builder /app/apps/whatsapp-service/dist/index.js ./dist/


### PR DESCRIPTION
## Problem

Cloud Build deployments were failing because Dockerfiles used `--frozen-lockfile` in the production stage. The generated `dist/package.json` has different dependencies than the root `package.json` in the workspace lockfile, causing pnpm to fail.

## Solution

- Removed `--frozen-lockfile` from production stage `pnpm install --prod`
- Builder stage still uses `--frozen-lockfile` for reproducible builds
- Production stage uses minimal `--prod` flag since lockfile doesn't apply to the generated package.json

## Changes

- Updated 17 service Dockerfiles
- Verified builds locally with Docker

## Testing

\`\`\`bash
docker build -f apps/whatsapp-service/Dockerfile --no-cache .
docker build -f apps/user-service/Dockerfile --no-cache .
\`\`\`

Both builds completed successfully.