### PR TITLE
Fix duplicate notifications and visualization routing

### DIFF
--- a/apps/research-agent/src/domain/research/usecases/runSynthesis.ts
+++ b/apps/research-agent/src/domain/research/usecases/runSynthesis.ts
@@ -77,6 +77,13 @@ export async function runSynthesis(
 
   const research = researchResult.value;
 
+  // Guard against race conditions: if research is already being synthesized or completed,
+  // return early to prevent duplicate notifications
+  if (research.status === 'synthesizing' || research.status === 'completed') {
+    logger?.info('[4.1] Research already processing or completed, skipping synthesis');
+    return { ok: true };
+  }
+
   logger?.info('[4.1.1] Updating status to synthesizing');
   await researchRepo.update(researchId, { status: 'synthesizing' });
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -241,18 +241,18 @@ function AppRoutes(): React.JSX.Element {
         }
       />
       <Route
-        path="/data-insights/:id"
+        path="/data-insights/:feedId/visualizations"
         element={
           <ProtectedRoute>
-            <CompositeFeedFormPage />
+            <DataInsightsPage />
           </ProtectedRoute>
         }
       />
       <Route
-        path="/data-insights/composite-feeds/:feedId/visualizations"
+        path="/data-insights/:id"
         element={
           <ProtectedRoute>
-            <DataInsightsPage />
+            <CompositeFeedFormPage />
           </ProtectedRoute>
         }
       />


### PR DESCRIPTION
## Summary
- Fixed duplicate mobile notifications when creating research via WhatsApp voice
- Fixed visualization button routing to correctly navigate to DataInsightsPage

## Details

### Duplicate Mobile Notifications Fix
**Problem**: Users received duplicate mobile notifications when creating research via WhatsApp voice.

**Root Cause**: Race condition in `runSynthesis` when multiple Pub/Sub handlers process LLM completion events simultaneously. Both handlers would see the research as not-yet-synthesizing and proceed to send notifications.

**Solution**: Added status guard at the beginning of `runSynthesis` to return early if research is already in `synthesizing` or `completed` status.

**File**: `apps/research-agent/src/domain/research/usecases/runSynthesis.ts`

### Visualization Routing Fix  
**Problem**: Clicking "Visualizations" button on composite feed card redirected to inbox instead of visualizations page.

**Root Cause**: Route path mismatch - link was `/data-insights/:feedId/visualizations` but route was `/data-insights/composite-feeds/:feedId/visualizations`. Additionally, route order was incorrect (generic `:id` route before specific `:feedId/visualizations` route).

**Solution**: Simplified route path to `/data-insights/:feedId/visualizations` and moved it before the generic `:id` route for proper matching.

**File**: `apps/web/src/App.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)