### PR TITLE
Add rule against using forbidden phrases in CLAUDE.md

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -13,6 +13,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Ownership Mindset (MANDATORY)
 
 **RULE:** Any issue you find in the codebase is YOUR issue to fix. NEVER claim there were "pre-existing issues" or "pre-existing bugs."
+**RULE:** YOU MUST NOT USE WORDS "pre-existing", "unrelated", "not my fault", "not my responsibility". These are forbidden. Double-think before using them.
 
 - You see a problem → you own it → you fix it
 - No finger-pointing at "previous state" or "prior work"


### PR DESCRIPTION
This change introduces a new rule that prohibits the use of specific phrases such as "pre-existing," "unrelated," and "not my fault" in the codebase. This aims to promote accountability and ownership among developers.