### PR TITLE
[coverage] Add tests for calendar-agent uncovered branches

### DIFF
--- a/apps/calendar-agent/src/__tests__/calendarRoutes.test.ts
+++ b/apps/calendar-agent/src/__tests__/calendarRoutes.test.ts
@@ -499,6 +499,30 @@ describe('Calendar Routes', () => {
       expect(response.statusCode).toBe(200);
     });
 
+    it('updates event with attendees', async () => {
+      const jwt = await createJwt('user-123');
+      fakeCalendarClient.addEvent({
+        id: 'event-123',
+        summary: 'Event',
+        start: { dateTime: '2025-01-01T10:00:00Z' },
+        end: { dateTime: '2025-01-01T11:00:00Z' },
+      });
+
+      const response = await app.inject({
+        method: 'PATCH',
+        url: '/calendar/events/event-123',
+        headers: { authorization: `Bearer ${jwt}` },
+        payload: {
+          attendees: [
+            { email: 'attendee1@example.com' },
+            { email: 'attendee2@example.com', optional: true },
+          ],
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+    });
+
     it('returns 403 when not connected', async () => {
       const jwt = await createJwt('user-123');
       fakeUserService.setTokenError('NOT_CONNECTED', 'Not connected');


### PR DESCRIPTION
## Summary

- Added test for `getEvent` with organizer having all fields defined
- Added tests for `mapErrorToCalendarError` when message is undefined
- Added test for `PATCH /calendar/events/:id` with attendees array

## Coverage Improvements

`googleCalendarClient.ts`:
- Lines 42, 45, 48: `buildEventPerson` with all fields (email, displayName, self)
- Lines 138, 143: `mapErrorToCalendarError` message fallback when undefined

`calendarRoutes.ts`:
- Line 120: `buildUpdateEventInput` with attendees defined

## Test plan

- [x] All new tests pass

Closes PBU-33