### PR TITLE
[PBU-46] Fix API key welcome message not shown on first test

### DIFF
--- a/.claude/ci-failures/intexuraos-1-fix_PBU-46.jsonl
+++ b/.claude/ci-failures/intexuraos-1-fix_PBU-46.jsonl
@@ -1,0 +1,2 @@
+{"ts":"2026-01-14T23:13:13.503Z","project":"intexuraos-1","branch":"fix/PBU-46","workspace":"--","runNumber":1,"passed":false,"durationMs":528,"failureCount":0,"failures":[]}
+{"ts":"2026-01-14T23:17:03.241Z","project":"intexuraos-1","branch":"fix/PBU-46","workspace":"web","runNumber":2,"passed":true,"durationMs":218155,"failureCount":0,"failures":[]}

--- a/apps/web/src/pages/ApiKeysSettingsPage.tsx
+++ b/apps/web/src/pages/ApiKeysSettingsPage.tsx
@@ -181,6 +181,7 @@ function ApiKeyRow({
 
   const handleTest = async (): Promise<void> => {
     setIsTesting(true);
+    setSaveSuccess(false);
     try {
       await onTest();
     } finally {


### PR DESCRIPTION
## Context

Addresses: [PBU-46](https://linear.app/pbuchman/issue/PBU-46)

## What Changed

Fixed the UI bug where the LLM welcome message was not displayed on the first successful API key test after saving a new key.

## Reasoning

### Root Cause

In `apps/web/src/pages/ApiKeysSettingsPage.tsx`, the component uses a `saveSuccess` flag to show a success message for 5 seconds after saving an API key. The conditional rendering logic was:

```tsx
{saveSuccess ? (
  <div>✓ API key validated and saved successfully</div>
) : savedTestResult !== null ? (
  <div>{savedTestResult.message}</div>
) : null}
```

When `saveSuccess` is `true`, the test result section is never evaluated. If the user clicked Test within 5 seconds of saving, the backend stored the test result and the hook optimistically updated local state, but the UI still showed the save success message.

### Fix

Added `setSaveSuccess(false)` at the start of `handleTest` to clear the save success state when testing begins, ensuring test results are immediately visible.

## Testing

- [x] Manual testing completed
- [x] `pnpm run verify:workspace:tracked -- web` passes

## Cross-References

- **Linear Issue**: [PBU-46](https://linear.app/pbuchman/issue/PBU-46)

---

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>