### PR TITLE
[PBU-47] Fix GLM API key missing error after configuration

### DIFF
--- a/.claude/ci-failures/intexuraos-1-fix_PBU-47.jsonl
+++ b/.claude/ci-failures/intexuraos-1-fix_PBU-47.jsonl
@@ -1,0 +1,1 @@
+{"ts":"2026-01-14T23:25:59.601Z","project":"intexuraos-1","branch":"fix/PBU-47","workspace":"research-agent","runNumber":1,"passed":true,"durationMs":40460,"failureCount":0,"failures":[]}

--- a/apps/research-agent/src/__tests__/infra/userServiceClient.test.ts
+++ b/apps/research-agent/src/__tests__/infra/userServiceClient.test.ts
@@ -48,6 +48,27 @@ describe('UserServiceClient', () => {
       }
     });
 
+    it('returns zai API key when present', async () => {
+      nock(INTEXURAOS_USER_SERVICE_URL)
+        .get('/internal/users/user-123/llm-keys')
+        .matchHeader('X-Internal-Auth', INTERNAL_AUTH_TOKEN)
+        .reply(200, {
+          zai: 'zai-api-key',
+        });
+
+      const client = createUserServiceClient({
+        baseUrl: INTEXURAOS_USER_SERVICE_URL,
+        internalAuthToken: INTERNAL_AUTH_TOKEN,
+      });
+
+      const result = await client.getApiKeys('user-123');
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.zai).toBe('zai-api-key');
+      }
+    });
+
     it('returns empty object when no keys exist', async () => {
       nock(INTEXURAOS_USER_SERVICE_URL)
         .get('/internal/users/user-123/llm-keys')

--- a/apps/research-agent/src/infra/user/userServiceClient.ts
+++ b/apps/research-agent/src/infra/user/userServiceClient.ts
@@ -69,6 +69,7 @@ export function createUserServiceClient(config: UserServiceConfig): UserServiceC
           openai?: string | null;
           anthropic?: string | null;
           perplexity?: string | null;
+          zai?: string | null;
         };
 
         // Convert null values to undefined (null is used by JSON to distinguish from missing)
@@ -84,6 +85,9 @@ export function createUserServiceClient(config: UserServiceConfig): UserServiceC
         }
         if (data.perplexity !== null && data.perplexity !== undefined) {
           result.perplexity = data.perplexity;
+        }
+        if (data.zai !== null && data.zai !== undefined) {
+          result.zai = data.zai;
         }
 
         return ok(result);


### PR DESCRIPTION
## Context

Addresses: [PBU-47](https://linear.app/pbuchman/issue/PBU-47)

Fixes: [INTEXURAOS-DEVELOPMENT-4](https://piotr-buchman.sentry.io/issues/INTEXURAOS-DEVELOPMENT-4)

## What Changed

Fixed the GLM (Zai) API key retrieval in research-agent. The `userServiceClient.getApiKeys()` function was not extracting the `zai` provider from the user-service API response, causing GLM-4.7 research requests to fail with `[3.2] API key missing for model` error even after the user successfully validated and saved their API key.

## Reasoning

### Root Cause

In `apps/research-agent/src/infra/user/userServiceClient.ts`:

1. The response type definition only included `google`, `openai`, `anthropic`, and `perplexity`
2. The extraction logic only read these 4 providers from the response
3. The `zai` field returned by user-service was silently ignored

### Why It Appeared To Work

- User-service endpoint DOES return `zai` in the response
- The settings page could save and validate the key
- But research-agent couldn't read it, causing the error

### Fix

Added `zai` to:
- Response type definition (`data` object)
- Extraction logic (conditional check and result object)

## Testing

- [x] Manual testing completed
- [x] `pnpm run verify:workspace:tracked -- research-agent` passes
- [x] Added test case for zai provider in `userServiceClient.test.ts`

## Cross-References

- **Linear Issue**: [PBU-47](https://linear.app/pbuchman/issue/PBU-47)
- **Sentry Issue**: [INTEXURAOS-DEVELOPMENT-4](https://piotr-buchman.sentry.io/issues/INTEXURAOS-DEVELOPMENT-4)

---

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>