### PR TITLE
[PBU-51] Lower input validation failure to debug level

### DIFF
--- a/apps/research-agent/src/routes/researchRoutes.ts
+++ b/apps/research-agent/src/routes/researchRoutes.ts
@@ -440,7 +440,7 @@ export const researchRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
       // Validate
       const validationResult = await validator.validateInput(body.prompt);
       if (!validationResult.ok) {
-        request.log.warn(
+        request.log.debug(
           {
             requestId,
             errorCode: validationResult.error.code,


### PR DESCRIPTION
## Context

Addresses: [PBU-51](https://linear.app/pbuchman/issue/PBU-51)

Sentry Issue: [INTEXURAOS-DEVELOPMENT-8](https://piotr-buchman.sentry.io/issues/88530449/)

## What Changed

Changed log level from `warn` to `debug` for input validation failures in the `/research/validate-input` endpoint (line 443 in `researchRoutes.ts`).

## Reasoning

The `/research/validate-input` endpoint returns `quality: 2` (GOOD) as a fallback when LLM validation fails. This is **expected behavior** for handling LLM API errors, not a bug.

### Investigation Findings

From Sentry event data:
- `errorCode: "API_ERROR"`
- `errorMessage: "JSON parse error: Expected ',' or '}' after property value in JSON at position 33"`
- The LLM validation service failed due to malformed response
- API correctly handled this by returning fallback quality level

### Key Decisions

- Changed to `debug` level to prevent Sentry spam while preserving observability in Cloud Logging
- No test changes needed - existing tests verify the fallback behavior without checking log level

## Testing

- [x] Manual testing completed
- [x] `pnpm exec vitest run apps/research-agent/src/__tests__/routes.test.ts -t "validate-input"` passes (12 tests)

## Cross-References

- **Linear Issue**: [PBU-51](https://linear.app/pbuchman/issue/PBU-51)
- **Sentry Issue**: [INTEXURAOS-DEVELOPMENT-8](https://piotr-buchman.sentry.io/issues/88530449/)

---

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>