### PR TITLE
INT-78 Fix TypeError when spreading undefined arrays

### DIFF
--- a/apps/web/src/pages/LinearIssuesPage.tsx
+++ b/apps/web/src/pages/LinearIssuesPage.tsx
@@ -241,20 +241,14 @@ export function LinearIssuesPage(): React.JSX.Element {
   }
 
   // Group all issues by dashboard column
-  const allIssues = data?.issues ?? {
-    backlog: [],
-    unstarted: [],
-    started: [],
-    completed: [],
-    cancelled: [],
-  };
+  const allIssues = data?.issues;
 
   const flatIssues = [
-    ...allIssues.backlog,
-    ...allIssues.unstarted,
-    ...allIssues.started,
-    ...allIssues.completed,
-    ...allIssues.cancelled,
+    ...(allIssues?.backlog ?? []),
+    ...(allIssues?.unstarted ?? []),
+    ...(allIssues?.started ?? []),
+    ...(allIssues?.completed ?? []),
+    ...(allIssues?.cancelled ?? []),
   ];
 
   const columnIssues = groupIssuesByColumn(flatIssues);


### PR DESCRIPTION
## Context

Addresses: [INT-78](https://linear.app/pbuchman/issue/INT-78/typeerror-xunstarted-is-not-iterable)

Sentry Issue: [INTEXURSOS-WEB-DEVELOPMENT-3](https://piotr-buchman.sentry.io/issues/88764214/)

## What Changed

Fixed `TypeError: x.unstarted is not iterable` in `LinearIssuesPage.tsx:254`.

The issue occurred when spreading `allIssues.unstarted` (and other properties) which could be `undefined` if the API didn't return that field. The spread operator requires an iterable, so spreading `undefined` throws.

## Root Cause

The previous code used a fallback object for the entire `data?.issues`:
```typescript
const allIssues = data?.issues ?? { backlog: [], unstarted: [], ... };
```

This fallback only applied when `data?.issues` was completely `undefined`. But if the API returned `data.issues` with some missing properties (e.g., `unstarted: undefined`), those individual properties wouldn't get the fallback.

## Fix

Added nullish coalescing to each individual array:
```typescript
const flatIssues = [
  ...(allIssues?.backlog ?? []),
  ...(allIssues?.unstarted ?? []),
  ...(allIssues?.started ?? []),
  ...(allIssues?.completed ?? []),
  ...(allIssues?.cancelled ?? []),
];
```

## Testing

- [x] TypeScript typecheck passes
- [x] ESLint passes
- [x] All tests pass

## Cross-References

- **Linear Issue**: [INT-78](https://linear.app/pbuchman/issue/INT-78/typeerror-xunstarted-is-not-iterable)
- **Sentry Issue**: [INTEXURSOS-WEB-DEVELOPMENT-3](https://piotr-buchman.sentry.io/issues/88764214/)

---

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>