### PR TITLE
INT-88 Add zai to allowed LLM providers in internal route

### DIFF
--- a/.claude/ci-failures/intexuraos-fix_INT-88-provider-validation.jsonl
+++ b/.claude/ci-failures/intexuraos-fix_INT-88-provider-validation.jsonl
@@ -1,0 +1,2 @@
+{"ts":"2026-01-16T02:07:07.900Z","project":"intexuraos","branch":"fix/INT-88-provider-validation","workspace":"--","runNumber":1,"passed":false,"durationMs":3046,"failureCount":0,"failures":[]}
+{"ts":"2026-01-16T02:12:21.968Z","project":"intexuraos","branch":"fix/INT-88-provider-validation","workspace":"user-service","runNumber":2,"passed":true,"durationMs":304702,"failureCount":0,"failures":[]}

--- a/apps/user-service/src/routes/internalRoutes.ts
+++ b/apps/user-service/src/routes/internalRoutes.ts
@@ -125,7 +125,7 @@ export const internalRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
             uid: { type: 'string', description: 'User ID' },
             provider: {
               type: 'string',
-              enum: ['google', 'openai', 'anthropic', 'perplexity'],
+              enum: ['google', 'openai', 'anthropic', 'perplexity', 'zai'],
               description: 'LLM provider',
             },
           },


### PR DESCRIPTION
## Summary

- Added 'zai' to the allowed provider enum in the internal route `/internal/users/:uid/llm-keys/:provider/last-used`
- The route was rejecting valid 'zai' provider requests with validation error "params/provider must be equal to one of the allowed values"

Fixes INT-88

## Related

- [Sentry Issue](https://intexuraos-dev-pbuchman.sentry.io/issues/6291266790)
- The public `llmKeysRoutes.ts` already had 'zai' in its enum; this syncs the internal route

## Test plan

- [x] CI passes with `pnpm run verify:workspace:tracked user-service`
- [x] Existing tests cover the route behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)