### PR TITLE
[INT-91] Add 'linear' to actions-agent schema validation

### DIFF
--- a/.claude/ci-failures/intexuraos-fix_INT-91-failing-commands.jsonl
+++ b/.claude/ci-failures/intexuraos-fix_INT-91-failing-commands.jsonl
@@ -1,0 +1,3 @@
+{"ts":"2026-01-16T16:39:10.993Z","project":"intexuraos","branch":"fix/INT-91-failing-commands","workspace":"--","runNumber":1,"passed":false,"durationMs":521,"failureCount":0,"failures":[]}
+{"ts":"2026-01-16T16:40:23.644Z","project":"intexuraos","branch":"fix/INT-91-failing-commands","workspace":"actions-agent","runNumber":2,"passed":true,"durationMs":66461,"failureCount":0,"failures":[]}
+{"ts":"2026-01-16T16:42:27.118Z","project":"intexuraos","branch":"fix/INT-91-failing-commands","runNumber":3,"passed":true,"durationMs":112048,"failureCount":0,"failures":[]}

--- a/apps/actions-agent/src/routes/internalRoutes.ts
+++ b/apps/actions-agent/src/routes/internalRoutes.ts
@@ -33,7 +33,7 @@ export const internalRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
             commandId: { type: 'string', description: 'Command ID that triggered this action' },
             type: {
               type: 'string',
-              enum: ['todo', 'research', 'note', 'link', 'calendar', 'reminder'],
+              enum: ['todo', 'research', 'note', 'link', 'calendar', 'reminder', 'linear'],
               description: 'Type of action',
             },
             title: { type: 'string', description: 'Action title' },

--- a/apps/actions-agent/src/routes/publicRoutes.ts
+++ b/apps/actions-agent/src/routes/publicRoutes.ts
@@ -9,7 +9,7 @@ const actionSchema = {
     id: { type: 'string' },
     userId: { type: 'string' },
     commandId: { type: 'string' },
-    type: { type: 'string', enum: ['todo', 'research', 'note', 'link', 'calendar', 'reminder'] },
+    type: { type: 'string', enum: ['todo', 'research', 'note', 'link', 'calendar', 'reminder', 'linear'] },
     confidence: { type: 'number' },
     title: { type: 'string' },
     status: {
@@ -151,7 +151,7 @@ export const publicRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
             status: { type: 'string', enum: ['processing', 'rejected', 'archived'] },
             type: {
               type: 'string',
-              enum: ['todo', 'research', 'note', 'link', 'calendar', 'reminder'],
+              enum: ['todo', 'research', 'note', 'link', 'calendar', 'reminder', 'linear'],
               description: 'New action type (only for pending/awaiting_approval actions)',
             },
           },

--- a/cloudbuild/cloudbuild.yaml
+++ b/cloudbuild/cloudbuild.yaml
@@ -103,7 +103,12 @@ steps:
     waitFor: ['pnpm-install']
     timeout: 900s
     entrypoint: 'bash'
-    args: ['cloudbuild/scripts/build-push-monitored.sh', 'promptvault-service', 'apps/promptvault-service/Dockerfile']
+    args:
+      [
+        'cloudbuild/scripts/build-push-monitored.sh',
+        'promptvault-service',
+        'apps/promptvault-service/Dockerfile',
+      ]
     env:
       - 'DOCKER_BUILDKIT=1'
       - 'ARTIFACT_REGISTRY_URL=${_ARTIFACT_REGISTRY_URL}'
@@ -114,7 +119,12 @@ steps:
     waitFor: ['pnpm-install']
     timeout: 900s
     entrypoint: 'bash'
-    args: ['cloudbuild/scripts/build-push-monitored.sh', 'image-service', 'apps/image-service/Dockerfile']
+    args:
+      [
+        'cloudbuild/scripts/build-push-monitored.sh',
+        'image-service',
+        'apps/image-service/Dockerfile',
+      ]
     env:
       - 'DOCKER_BUILDKIT=1'
       - 'ARTIFACT_REGISTRY_URL=${_ARTIFACT_REGISTRY_URL}'
@@ -125,7 +135,8 @@ steps:
     waitFor: ['pnpm-install']
     timeout: 900s
     entrypoint: 'bash'
-    args: ['cloudbuild/scripts/build-push-monitored.sh', 'api-docs-hub', 'apps/api-docs-hub/Dockerfile']
+    args:
+      ['cloudbuild/scripts/build-push-monitored.sh', 'api-docs-hub', 'apps/api-docs-hub/Dockerfile']
     env:
       - 'DOCKER_BUILDKIT=1'
       - 'ARTIFACT_REGISTRY_URL=${_ARTIFACT_REGISTRY_URL}'
@@ -136,7 +147,12 @@ steps:
     waitFor: ['pnpm-install']
     timeout: 900s
     entrypoint: 'bash'
-    args: ['cloudbuild/scripts/build-push-monitored.sh', 'notion-service', 'apps/notion-service/Dockerfile']
+    args:
+      [
+        'cloudbuild/scripts/build-push-monitored.sh',
+        'notion-service',
+        'apps/notion-service/Dockerfile',
+      ]
     env:
       - 'DOCKER_BUILDKIT=1'
       - 'ARTIFACT_REGISTRY_URL=${_ARTIFACT_REGISTRY_URL}'
@@ -194,10 +210,17 @@ steps:
   # --- Batch 2 Builds (wait for Batch 1 deploys) ---
   - name: 'gcr.io/cloud-builders/docker'
     id: 'build-push-user-service'
-    waitFor: ['deploy-promptvault-service', 'deploy-image-service', 'deploy-api-docs-hub', 'deploy-notion-service']
+    waitFor:
+      [
+        'deploy-promptvault-service',
+        'deploy-image-service',
+        'deploy-api-docs-hub',
+        'deploy-notion-service',
+      ]
     timeout: 900s
     entrypoint: 'bash'
-    args: ['cloudbuild/scripts/build-push-monitored.sh', 'user-service', 'apps/user-service/Dockerfile']
+    args:
+      ['cloudbuild/scripts/build-push-monitored.sh', 'user-service', 'apps/user-service/Dockerfile']
     env:
       - 'DOCKER_BUILDKIT=1'
       - 'ARTIFACT_REGISTRY_URL=${_ARTIFACT_REGISTRY_URL}'
@@ -205,10 +228,21 @@ steps:
 
   - name: 'gcr.io/cloud-builders/docker'
     id: 'build-push-whatsapp-service'
-    waitFor: ['deploy-promptvault-service', 'deploy-image-service', 'deploy-api-docs-hub', 'deploy-notion-service']
+    waitFor:
+      [
+        'deploy-promptvault-service',
+        'deploy-image-service',
+        'deploy-api-docs-hub',
+        'deploy-notion-service',
+      ]
     timeout: 900s
     entrypoint: 'bash'
-    args: ['cloudbuild/scripts/build-push-monitored.sh', 'whatsapp-service', 'apps/whatsapp-service/Dockerfile']
+    args:
+      [
+        'cloudbuild/scripts/build-push-monitored.sh',
+        'whatsapp-service',
+        'apps/whatsapp-service/Dockerfile',
+      ]
     env:
       - 'DOCKER_BUILDKIT=1'
       - 'ARTIFACT_REGISTRY_URL=${_ARTIFACT_REGISTRY_URL}'
@@ -216,10 +250,21 @@ steps:
 
   - name: 'gcr.io/cloud-builders/docker'
     id: 'build-push-app-settings-service'
-    waitFor: ['deploy-promptvault-service', 'deploy-image-service', 'deploy-api-docs-hub', 'deploy-notion-service']
+    waitFor:
+      [
+        'deploy-promptvault-service',
+        'deploy-image-service',
+        'deploy-api-docs-hub',
+        'deploy-notion-service',
+      ]
     timeout: 900s
     entrypoint: 'bash'
-    args: ['cloudbuild/scripts/build-push-monitored.sh', 'app-settings-service', 'apps/app-settings-service/Dockerfile']
+    args:
+      [
+        'cloudbuild/scripts/build-push-monitored.sh',
+        'app-settings-service',
+        'apps/app-settings-service/Dockerfile',
+      ]
     env:
       - 'DOCKER_BUILDKIT=1'
       - 'ARTIFACT_REGISTRY_URL=${_ARTIFACT_REGISTRY_URL}'
@@ -227,10 +272,21 @@ steps:
 
   - name: 'gcr.io/cloud-builders/docker'
     id: 'build-push-mobile-notifications-service'
-    waitFor: ['deploy-promptvault-service', 'deploy-image-service', 'deploy-api-docs-hub', 'deploy-notion-service']
+    waitFor:
+      [
+        'deploy-promptvault-service',
+        'deploy-image-service',
+        'deploy-api-docs-hub',
+        'deploy-notion-service',
+      ]
     timeout: 900s
     entrypoint: 'bash'
-    args: ['cloudbuild/scripts/build-push-monitored.sh', 'mobile-notifications-service', 'apps/mobile-notifications-service/Dockerfile']
+    args:
+      [
+        'cloudbuild/scripts/build-push-monitored.sh',
+        'mobile-notifications-service',
+        'apps/mobile-notifications-service/Dockerfile',
+      ]
     env:
       - 'DOCKER_BUILDKIT=1'
       - 'ARTIFACT_REGISTRY_URL=${_ARTIFACT_REGISTRY_URL}'
@@ -238,10 +294,21 @@ steps:
 
   - name: 'gcr.io/cloud-builders/docker'
     id: 'build-push-research-agent'
-    waitFor: ['deploy-promptvault-service', 'deploy-image-service', 'deploy-api-docs-hub', 'deploy-notion-service']
+    waitFor:
+      [
+        'deploy-promptvault-service',
+        'deploy-image-service',
+        'deploy-api-docs-hub',
+        'deploy-notion-service',
+      ]
     timeout: 900s
     entrypoint: 'bash'
-    args: ['cloudbuild/scripts/build-push-monitored.sh', 'research-agent', 'apps/research-agent/Dockerfile']
+    args:
+      [
+        'cloudbuild/scripts/build-push-monitored.sh',
+        'research-agent',
+        'apps/research-agent/Dockerfile',
+      ]
     env:
       - 'DOCKER_BUILDKIT=1'
       - 'ARTIFACT_REGISTRY_URL=${_ARTIFACT_REGISTRY_URL}'
@@ -310,10 +377,22 @@ steps:
   # --- Batch 3 Builds (wait for Batch 2 deploys) ---
   - name: 'gcr.io/cloud-builders/docker'
     id: 'build-push-commands-agent'
-    waitFor: ['deploy-user-service', 'deploy-whatsapp-service', 'deploy-app-settings-service', 'deploy-mobile-notifications-service', 'deploy-research-agent']
+    waitFor:
+      [
+        'deploy-user-service',
+        'deploy-whatsapp-service',
+        'deploy-app-settings-service',
+        'deploy-mobile-notifications-service',
+        'deploy-research-agent',
+      ]
     timeout: 900s
     entrypoint: 'bash'
-    args: ['cloudbuild/scripts/build-push-monitored.sh', 'commands-agent', 'apps/commands-agent/Dockerfile']
+    args:
+      [
+        'cloudbuild/scripts/build-push-monitored.sh',
+        'commands-agent',
+        'apps/commands-agent/Dockerfile',
+      ]
     env:
       - 'DOCKER_BUILDKIT=1'
       - 'ARTIFACT_REGISTRY_URL=${_ARTIFACT_REGISTRY_URL}'
@@ -321,10 +400,22 @@ steps:
 
   - name: 'gcr.io/cloud-builders/docker'
     id: 'build-push-actions-agent'
-    waitFor: ['deploy-user-service', 'deploy-whatsapp-service', 'deploy-app-settings-service', 'deploy-mobile-notifications-service', 'deploy-research-agent']
+    waitFor:
+      [
+        'deploy-user-service',
+        'deploy-whatsapp-service',
+        'deploy-app-settings-service',
+        'deploy-mobile-notifications-service',
+        'deploy-research-agent',
+      ]
     timeout: 900s
     entrypoint: 'bash'
-    args: ['cloudbuild/scripts/build-push-monitored.sh', 'actions-agent', 'apps/actions-agent/Dockerfile']
+    args:
+      [
+        'cloudbuild/scripts/build-push-monitored.sh',
+        'actions-agent',
+        'apps/actions-agent/Dockerfile',
+      ]
     env:
       - 'DOCKER_BUILDKIT=1'
       - 'ARTIFACT_REGISTRY_URL=${_ARTIFACT_REGISTRY_URL}'
@@ -332,10 +423,22 @@ steps:
 
   - name: 'gcr.io/cloud-builders/docker'
     id: 'build-push-data-insights-agent'
-    waitFor: ['deploy-user-service', 'deploy-whatsapp-service', 'deploy-app-settings-service', 'deploy-mobile-notifications-service', 'deploy-research-agent']
+    waitFor:
+      [
+        'deploy-user-service',
+        'deploy-whatsapp-service',
+        'deploy-app-settings-service',
+        'deploy-mobile-notifications-service',
+        'deploy-research-agent',
+      ]
     timeout: 900s
     entrypoint: 'bash'
-    args: ['cloudbuild/scripts/build-push-monitored.sh', 'data-insights-agent', 'apps/data-insights-agent/Dockerfile']
+    args:
+      [
+        'cloudbuild/scripts/build-push-monitored.sh',
+        'data-insights-agent',
+        'apps/data-insights-agent/Dockerfile',
+      ]
     env:
       - 'DOCKER_BUILDKIT=1'
       - 'ARTIFACT_REGISTRY_URL=${_ARTIFACT_REGISTRY_URL}'
@@ -343,10 +446,18 @@ steps:
 
   - name: 'gcr.io/cloud-builders/docker'
     id: 'build-push-notes-agent'
-    waitFor: ['deploy-user-service', 'deploy-whatsapp-service', 'deploy-app-settings-service', 'deploy-mobile-notifications-service', 'deploy-research-agent']
+    waitFor:
+      [
+        'deploy-user-service',
+        'deploy-whatsapp-service',
+        'deploy-app-settings-service',
+        'deploy-mobile-notifications-service',
+        'deploy-research-agent',
+      ]
     timeout: 900s
     entrypoint: 'bash'
-    args: ['cloudbuild/scripts/build-push-monitored.sh', 'notes-agent', 'apps/notes-agent/Dockerfile']
+    args:
+      ['cloudbuild/scripts/build-push-monitored.sh', 'notes-agent', 'apps/notes-agent/Dockerfile']
     env:
       - 'DOCKER_BUILDKIT=1'
       - 'ARTIFACT_REGISTRY_URL=${_ARTIFACT_REGISTRY_URL}'
@@ -354,10 +465,18 @@ steps:
 
   - name: 'gcr.io/cloud-builders/docker'
     id: 'build-push-todos-agent'
-    waitFor: ['deploy-user-service', 'deploy-whatsapp-service', 'deploy-app-settings-service', 'deploy-mobile-notifications-service', 'deploy-research-agent']
+    waitFor:
+      [
+        'deploy-user-service',
+        'deploy-whatsapp-service',
+        'deploy-app-settings-service',
+        'deploy-mobile-notifications-service',
+        'deploy-research-agent',
+      ]
     timeout: 900s
     entrypoint: 'bash'
-    args: ['cloudbuild/scripts/build-push-monitored.sh', 'todos-agent', 'apps/todos-agent/Dockerfile']
+    args:
+      ['cloudbuild/scripts/build-push-monitored.sh', 'todos-agent', 'apps/todos-agent/Dockerfile']
     env:
       - 'DOCKER_BUILDKIT=1'
       - 'ARTIFACT_REGISTRY_URL=${_ARTIFACT_REGISTRY_URL}'
@@ -426,10 +545,22 @@ steps:
   # --- Batch 4 Builds (wait for Batch 3 deploys) ---
   - name: 'gcr.io/cloud-builders/docker'
     id: 'build-push-bookmarks-agent'
-    waitFor: ['deploy-commands-agent', 'deploy-actions-agent', 'deploy-data-insights-agent', 'deploy-notes-agent', 'deploy-todos-agent']
+    waitFor:
+      [
+        'deploy-commands-agent',
+        'deploy-actions-agent',
+        'deploy-data-insights-agent',
+        'deploy-notes-agent',
+        'deploy-todos-agent',
+      ]
     timeout: 900s
     entrypoint: 'bash'
-    args: ['cloudbuild/scripts/build-push-monitored.sh', 'bookmarks-agent', 'apps/bookmarks-agent/Dockerfile']
+    args:
+      [
+        'cloudbuild/scripts/build-push-monitored.sh',
+        'bookmarks-agent',
+        'apps/bookmarks-agent/Dockerfile',
+      ]
     env:
       - 'DOCKER_BUILDKIT=1'
       - 'ARTIFACT_REGISTRY_URL=${_ARTIFACT_REGISTRY_URL}'
@@ -437,10 +568,22 @@ steps:
 
   - name: 'gcr.io/cloud-builders/docker'
     id: 'build-push-calendar-agent'
-    waitFor: ['deploy-commands-agent', 'deploy-actions-agent', 'deploy-data-insights-agent', 'deploy-notes-agent', 'deploy-todos-agent']
+    waitFor:
+      [
+        'deploy-commands-agent',
+        'deploy-actions-agent',
+        'deploy-data-insights-agent',
+        'deploy-notes-agent',
+        'deploy-todos-agent',
+      ]
     timeout: 900s
     entrypoint: 'bash'
-    args: ['cloudbuild/scripts/build-push-monitored.sh', 'calendar-agent', 'apps/calendar-agent/Dockerfile']
+    args:
+      [
+        'cloudbuild/scripts/build-push-monitored.sh',
+        'calendar-agent',
+        'apps/calendar-agent/Dockerfile',
+      ]
     env:
       - 'DOCKER_BUILDKIT=1'
       - 'ARTIFACT_REGISTRY_URL=${_ARTIFACT_REGISTRY_URL}'
@@ -448,10 +591,18 @@ steps:
 
   - name: 'gcr.io/cloud-builders/docker'
     id: 'build-push-linear-agent'
-    waitFor: ['deploy-commands-agent', 'deploy-actions-agent', 'deploy-data-insights-agent', 'deploy-notes-agent', 'deploy-todos-agent']
+    waitFor:
+      [
+        'deploy-commands-agent',
+        'deploy-actions-agent',
+        'deploy-data-insights-agent',
+        'deploy-notes-agent',
+        'deploy-todos-agent',
+      ]
     timeout: 900s
     entrypoint: 'bash'
-    args: ['cloudbuild/scripts/build-push-monitored.sh', 'linear-agent', 'apps/linear-agent/Dockerfile']
+    args:
+      ['cloudbuild/scripts/build-push-monitored.sh', 'linear-agent', 'apps/linear-agent/Dockerfile']
     env:
       - 'DOCKER_BUILDKIT=1'
       - 'ARTIFACT_REGISTRY_URL=${_ARTIFACT_REGISTRY_URL}'
@@ -459,7 +610,14 @@ steps:
 
   - name: 'gcr.io/cloud-builders/docker'
     id: 'build-push-web-agent'
-    waitFor: ['deploy-commands-agent', 'deploy-actions-agent', 'deploy-data-insights-agent', 'deploy-notes-agent', 'deploy-todos-agent']
+    waitFor:
+      [
+        'deploy-commands-agent',
+        'deploy-actions-agent',
+        'deploy-data-insights-agent',
+        'deploy-notes-agent',
+        'deploy-todos-agent',
+      ]
     timeout: 900s
     entrypoint: 'bash'
     args: ['cloudbuild/scripts/build-push-monitored.sh', 'web-agent', 'apps/web-agent/Dockerfile']
@@ -516,7 +674,14 @@ steps:
   # --- Web Frontend (builds in parallel with Batch 4 services) ---
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     id: 'fetch-web-config'
-    waitFor: ['deploy-commands-agent', 'deploy-actions-agent', 'deploy-data-insights-agent', 'deploy-notes-agent', 'deploy-todos-agent']
+    waitFor:
+      [
+        'deploy-commands-agent',
+        'deploy-actions-agent',
+        'deploy-data-insights-agent',
+        'deploy-notes-agent',
+        'deploy-todos-agent',
+      ]
     entrypoint: 'bash'
     args:
       - '-c'


### PR DESCRIPTION
## Context

Addresses: [INT-91](https://linear.app/pbuchman/issue/INT-91/failing-commands-execution)

## What Changed

Added `'linear'` to the Fastify schema enum in 3 locations in actions-agent:
- `internalRoutes.ts` - POST `/internal/actions` body schema
- `publicRoutes.ts` - `actionSchema` constant (used in response schemas)
- `publicRoutes.ts` - PATCH `/actions/:actionId` body schema

## Reasoning

### Root Cause Analysis

Commands to create Linear issues failed 3 times on Jan 16 around 11:50-11:53 UTC with error:
```
400 Bad Request - {"error":"[object Object]"}
```

**Investigation path:**
1. Checked commands-agent logs → found `Failed to create action via actions-agent` errors
2. Checked actions-agent logs → found Fastify validation error:
   ```
   body/type must be equal to one of the allowed values
   allowedValues: ["todo", "research", "note", "link", "calendar", "reminder"]
   ```

**Root cause:** When the `'linear'` action type was added to the domain model (`ActionType` in `action.ts`), the Fastify route schema definitions were not updated. Fastify validates requests BEFORE the route handler runs, so valid Linear actions were rejected at the schema validation layer.

### Key Decisions

- Added `'linear'` to all 3 enum definitions to ensure consistency across internal and public APIs
- The domain model already had `'linear'` - this was purely a schema sync issue

## Testing

- [x] `pnpm run verify:workspace:tracked actions-agent` passes (309 test files)
- [x] `pnpm run ci:tracked` passes (5015 tests)

## Cross-References

- **Linear Issue**: [INT-91](https://linear.app/pbuchman/issue/INT-91/failing-commands-execution)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)