### PR TITLE
[INT-98] Fix modal overflow with max-height and scroll

### DIFF
--- a/.claude/ci-failures/intexuraos-1-fix_INT-98-modal-overflowing.jsonl
+++ b/.claude/ci-failures/intexuraos-1-fix_INT-98-modal-overflowing.jsonl
@@ -1,0 +1,3 @@
+{"ts":"2026-01-16T18:11:33.885Z","project":"intexuraos-1","branch":"fix/INT-98-modal-overflowing","workspace":"--","runNumber":1,"passed":false,"durationMs":425,"failureCount":0,"failures":[]}
+{"ts":"2026-01-16T18:12:31.607Z","project":"intexuraos-1","branch":"fix/INT-98-modal-overflowing","workspace":"web","runNumber":2,"passed":true,"durationMs":50482,"failureCount":0,"failures":[]}
+{"ts":"2026-01-16T18:14:32.696Z","project":"intexuraos-1","branch":"fix/INT-98-modal-overflowing","runNumber":3,"passed":true,"durationMs":110744,"failureCount":0,"failures":[]}

--- a/apps/web/src/components/ActionDetailModal.tsx
+++ b/apps/web/src/components/ActionDetailModal.tsx
@@ -248,9 +248,9 @@ export function ActionDetailModal({
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
       onClick={handleBackdropClick}
     >
-      <div className="w-full max-w-lg rounded-xl bg-white shadow-2xl">
+      <div className="flex max-h-[90vh] w-full max-w-lg flex-col rounded-xl bg-white shadow-2xl">
         {/* Header */}
-        <div className="flex items-start justify-between border-b border-slate-200 p-4">
+        <div className="flex shrink-0 items-start justify-between border-b border-slate-200 p-4">
           <div className="flex items-start gap-3">
             <div className="mt-0.5 rounded-lg bg-slate-100 p-2">{getTypeIcon(selectedType)}</div>
             <div>
@@ -298,7 +298,7 @@ export function ActionDetailModal({
         </div>
 
         {/* Content */}
-        <div className="space-y-4 p-4">
+        <div className="min-h-0 flex-1 space-y-4 overflow-y-auto p-4">
           {/* Original command text */}
           {command !== undefined && (
             <div>
@@ -359,7 +359,7 @@ export function ActionDetailModal({
 
         {/* Actions or Success View */}
         {executionResult !== null ? (
-          <div className="border-t border-slate-200 p-4">
+          <div className="shrink-0 border-t border-slate-200 p-4">
             <div className="rounded-lg border border-green-200 bg-green-50 p-4">
               <div className="flex items-start gap-3">
                 <CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0 text-green-600" />
@@ -384,7 +384,7 @@ export function ActionDetailModal({
             </div>
           </div>
         ) : (
-          <div className="flex items-center justify-end gap-2 border-t border-slate-200 p-4 flex-nowrap">
+          <div className="flex shrink-0 flex-nowrap items-center justify-end gap-2 border-t border-slate-200 p-4">
             {isLoading ? (
               <div className="text-sm text-slate-500">Loading actions...</div>
             ) : (

--- a/apps/web/src/components/BookmarkConflictModal.tsx
+++ b/apps/web/src/components/BookmarkConflictModal.tsx
@@ -42,9 +42,9 @@ export function BookmarkConflictModal({
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
-      <div className="w-full max-w-lg rounded-xl bg-white shadow-2xl">
+      <div className="flex max-h-[90vh] w-full max-w-lg flex-col rounded-xl bg-white shadow-2xl">
         {/* Header */}
-        <div className="flex items-start justify-between border-b border-slate-200 p-4">
+        <div className="flex shrink-0 items-start justify-between border-b border-slate-200 p-4">
           <div className="flex items-start gap-3">
             <div className="mt-0.5 rounded-lg bg-amber-100 p-2">
               <AlertTriangle className="h-5 w-5 text-amber-600" />
@@ -67,7 +67,7 @@ export function BookmarkConflictModal({
         </div>
 
         {/* Content */}
-        <div className="p-4">
+        <div className="min-h-0 flex-1 overflow-y-auto p-4">
           <div className="rounded-lg border border-amber-200 bg-amber-50 p-4">
             <p className="text-sm text-amber-800">
               You already have this link saved in your bookmarks. Would you like to skip this
@@ -84,7 +84,7 @@ export function BookmarkConflictModal({
         </div>
 
         {/* Actions */}
-        <div className="flex items-center justify-end gap-2 border-t border-slate-200 p-4">
+        <div className="flex shrink-0 items-center justify-end gap-2 border-t border-slate-200 p-4">
           <Button variant="secondary" onClick={handleSkip} disabled={isUpdating}>
             Skip
           </Button>

--- a/apps/web/src/components/CommandDetailModal.tsx
+++ b/apps/web/src/components/CommandDetailModal.tsx
@@ -83,9 +83,9 @@ export function CommandDetailModal({
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
       onClick={handleBackdropClick}
     >
-      <div className="w-full max-w-lg rounded-xl bg-white shadow-2xl">
+      <div className="flex max-h-[90vh] w-full max-w-lg flex-col rounded-xl bg-white shadow-2xl">
         {/* Header */}
-        <div className="flex items-start justify-between border-b border-slate-200 p-4">
+        <div className="flex shrink-0 items-start justify-between border-b border-slate-200 p-4">
           <div className="flex items-start gap-3">
             <div className="mt-0.5 rounded-lg bg-slate-100 p-2">
               {isVoice ? (
@@ -119,7 +119,7 @@ export function CommandDetailModal({
         </div>
 
         {/* Content */}
-        <div className="space-y-4 p-4">
+        <div className="min-h-0 flex-1 space-y-4 overflow-y-auto p-4">
           {/* Command text */}
           <div>
             <h3 className="mb-2 text-xs font-medium uppercase tracking-wide text-slate-500">
@@ -189,7 +189,7 @@ export function CommandDetailModal({
         </div>
 
         {/* Footer - Close button */}
-        <div className="flex items-center justify-end border-t border-slate-200 p-4">
+        <div className="flex shrink-0 items-center justify-end border-t border-slate-200 p-4">
           <button
             onClick={onClose}
             className="rounded-lg bg-slate-100 px-4 py-2 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-200"


### PR DESCRIPTION
## Context

Addresses: [INT-98](https://linear.app/pbuchman/issue/INT-98/modal-overflowing)

## What Changed

Fixed modals overflowing screen height when content is long. Applied consistent flex layout pattern to three modal components:
- `ActionDetailModal`
- `CommandDetailModal`  
- `BookmarkConflictModal`

## Reasoning

### Problem
Modals could extend beyond viewport height when displaying long content (like verbose commands or classification reasoning), making them impossible to scroll and unusable.

### Solution
Applied the same pattern already used in `NoteDetailModal` and `TranscriptionDetailModal`:
- `max-h-[90vh]` - limits modal to 90% of viewport height
- `flex flex-col` - enables header/content/footer layout
- `shrink-0` on header/footer - prevents them from shrinking
- `flex-1 min-h-0 overflow-y-auto` on content - makes content scrollable

The `min-h-0` is crucial because flex children default to `min-height: auto` which prevents overflow scrolling.

## Testing

- [x] `pnpm run ci:tracked` passes
- [x] Verified all modal components have consistent overflow behavior

## Cross-References

- **Linear Issue**: [INT-98](https://linear.app/pbuchman/issue/INT-98/modal-overflowing)

---

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>