### PR TITLE
[INT-84] Add tests for calendar and linear action extraction prompts

### DIFF
--- a/.claude/ci-failures/intexuraos-fix_INT-84-coverage-llm-common-classification.jsonl
+++ b/.claude/ci-failures/intexuraos-fix_INT-84-coverage-llm-common-classification.jsonl
@@ -1,0 +1,2 @@
+{"ts":"2026-01-16T18:33:02.893Z","project":"intexuraos","branch":"fix/INT-84-coverage-llm-common-classification","workspace":"--","runNumber":1,"passed":false,"durationMs":446,"failureCount":0,"failures":[]}
+{"ts":"2026-01-16T18:37:34.438Z","project":"intexuraos","branch":"fix/INT-84-coverage-llm-common-classification","runNumber":2,"passed":true,"durationMs":231051,"failureCount":0,"failures":[]}

--- a/packages/llm-common/src/classification/__tests__/actionExtractionPrompts.test.ts
+++ b/packages/llm-common/src/classification/__tests__/actionExtractionPrompts.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { calendarActionExtractionPrompt } from '../calendarActionExtractionPrompt.js';
+import { linearActionExtractionPrompt } from '../linearActionExtractionPrompt.js';
+
+describe('calendarActionExtractionPrompt', () => {
+  it('builds prompt without truncation when text is within default max length', () => {
+    const prompt = calendarActionExtractionPrompt.build({
+      text: 'Meeting tomorrow at 3pm',
+      currentDate: '2024-01-15',
+    });
+    expect(prompt).toContain('Meeting tomorrow at 3pm');
+    expect(prompt).not.toContain('IMPORTANT: Text was truncated');
+  });
+
+  it('truncates text when exceeding custom maxDescriptionLength', () => {
+    const longText = 'a'.repeat(100);
+    const prompt = calendarActionExtractionPrompt.build(
+      { text: longText, currentDate: '2024-01-15' },
+      { maxDescriptionLength: 50 }
+    );
+    expect(prompt).toContain('IMPORTANT: Text was truncated to first 50 characters');
+    expect(prompt).toContain('a'.repeat(50));
+    expect(prompt).not.toContain('a'.repeat(51));
+  });
+
+  it('truncates text when exceeding default maxDescriptionLength (1000)', () => {
+    const longText = 'b'.repeat(1100);
+    const prompt = calendarActionExtractionPrompt.build({
+      text: longText,
+      currentDate: '2024-01-15',
+    });
+    expect(prompt).toContain('IMPORTANT: Text was truncated to first 1000 characters');
+    expect(prompt).toContain('b'.repeat(1000));
+    expect(prompt).not.toContain('b'.repeat(1001));
+  });
+
+  it('uses deps.maxDescriptionLength when provided even for short text', () => {
+    const prompt = calendarActionExtractionPrompt.build(
+      { text: 'short text', currentDate: '2024-01-15' },
+      { maxDescriptionLength: 5 }
+    );
+    expect(prompt).toContain('IMPORTANT: Text was truncated to first 5 characters');
+    expect(prompt).toContain('short');
+    expect(prompt).not.toContain('short text');
+  });
+
+  it('does not truncate when text length equals maxDescriptionLength', () => {
+    const exactText = 'x'.repeat(50);
+    const prompt = calendarActionExtractionPrompt.build(
+      { text: exactText, currentDate: '2024-01-15' },
+      { maxDescriptionLength: 50 }
+    );
+    expect(prompt).not.toContain('IMPORTANT: Text was truncated');
+    expect(prompt).toContain('x'.repeat(50));
+  });
+});
+
+describe('linearActionExtractionPrompt', () => {
+  it('builds prompt without truncation when text is within default max length', () => {
+    const prompt = linearActionExtractionPrompt.build({
+      text: 'Fix the login bug',
+    });
+    expect(prompt).toContain('Fix the login bug');
+    expect(prompt).not.toContain('IMPORTANT: Text was truncated');
+  });
+
+  it('truncates text when exceeding custom maxDescriptionLength', () => {
+    const longText = 'c'.repeat(100);
+    const prompt = linearActionExtractionPrompt.build(
+      { text: longText },
+      { maxDescriptionLength: 50 }
+    );
+    expect(prompt).toContain('IMPORTANT: Text was truncated to first 50 characters');
+    expect(prompt).toContain('c'.repeat(50));
+    expect(prompt).not.toContain('c'.repeat(51));
+  });
+
+  it('truncates text when exceeding default maxDescriptionLength (2000)', () => {
+    const longText = 'd'.repeat(2100);
+    const prompt = linearActionExtractionPrompt.build({ text: longText });
+    expect(prompt).toContain('IMPORTANT: Text was truncated to first 2000 characters');
+    expect(prompt).toContain('d'.repeat(2000));
+    expect(prompt).not.toContain('d'.repeat(2001));
+  });
+
+  it('does not truncate when text length equals maxDescriptionLength', () => {
+    const exactText = 'y'.repeat(100);
+    const prompt = linearActionExtractionPrompt.build(
+      { text: exactText },
+      { maxDescriptionLength: 100 }
+    );
+    expect(prompt).not.toContain('IMPORTANT: Text was truncated');
+    expect(prompt).toContain('y'.repeat(100));
+  });
+});


### PR DESCRIPTION
## Context

Addresses: [INT-84](https://linear.app/pbuchman/issue/INT-84/coveragellm-common-add-tests-for-calendar-and-linear-action-extraction)

## What Changed

Added comprehensive test coverage for truncation logic in:
- `packages/llm-common/src/classification/calendarActionExtractionPrompt.ts`
- `packages/llm-common/src/classification/linearActionExtractionPrompt.ts`

Both files had 50% branch coverage due to untested truncation paths. The new tests cover:
- Default max length behavior (no truncation)
- Custom maxDescriptionLength via deps
- Text truncation when exceeding max length
- Boundary condition: text length equals max length

## Reasoning

The truncation logic (lines 54-60 in calendar, 46-52 in linear) follows identical patterns:
1. `maxLength = deps?.maxDescriptionLength ?? defaultValue` - two branches
2. `text.length > maxLength ? slice : text` - conditional truncation
3. Truncation warning added to prompt only when needed

Tests ensure all branches are exercised and the truncation message format is correct.

## Testing

- [x] 9 new tests added (5 for calendar, 4 for linear)
- [x] `pnpm run ci:tracked` passes with 5036 tests
- [x] Both files now have 100% branch coverage

## Cross-References

- **Linear Issue**: [INT-84](https://linear.app/pbuchman/issue/INT-84/coveragellm-common-add-tests-for-calendar-and-linear-action-extraction)

---

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>