### PR TITLE
INT-70 Add llm-common restructuring plan

### DIFF
--- a/docs/plans/llm-common-restructuring.md
+++ b/docs/plans/llm-common-restructuring.md
@@ -39,39 +39,39 @@ packages/llm-common/src/
 
 ### 1.2 Current Exports by Category
 
-| Module              | Exports                                                                                          |
-|---------------------|--------------------------------------------------------------------------------------------------|
-| `types.ts`          | `PromptBuilder`, `PromptDeps`                                                                    |
-| `generation/`       | `titlePrompt`, `labelPrompt`, `feedNamePrompt` + types                                           |
-| `classification/`   | `commandClassifierPrompt`, `calendarActionExtractionPrompt`, `linearActionExtractionPrompt`      |
-| `todos/`            | `itemExtractionPrompt` + types                                                                   |
-| `image/`            | `thumbnailPrompt` + types                                                                        |
-| `validation/`       | `inputQualityPrompt`, `inputImprovementPrompt`, guards, repair prompts                           |
-| `context/`          | `buildInferResearchContextPrompt`, `buildInferSynthesisContextPrompt`, guards, repair, types     |
-| `researchPrompt.ts` | `buildResearchPrompt`                                                                            |
-| `synthesisPrompt.ts`| `buildSynthesisPrompt`, `SynthesisReport`, `AdditionalSource`                                    |
-| `attribution.ts`    | `parseAttributionLine`, `parseSections`, `buildSourceMap`, `validateSynthesisAttributions`, etc. |
-| `redaction.ts`      | `redactToken`, `redactObject`, `SENSITIVE_FIELDS`                                                |
-| `llm/`              | `createLlmParseError`, `logLlmParseError`, `withLlmParseErrorLogging`                            |
-| `dataInsights/`     | `dataAnalysisPrompt`, `chartDefinitionPrompt`, `dataTransformPrompt`, parsers, repair            |
+| Module               | Exports                                                                                          |
+| -------------------- | ------------------------------------------------------------------------------------------------ |
+| `types.ts`           | `PromptBuilder`, `PromptDeps`                                                                    |
+| `generation/`        | `titlePrompt`, `labelPrompt`, `feedNamePrompt` + types                                           |
+| `classification/`    | `commandClassifierPrompt`, `calendarActionExtractionPrompt`, `linearActionExtractionPrompt`      |
+| `todos/`             | `itemExtractionPrompt` + types                                                                   |
+| `image/`             | `thumbnailPrompt` + types                                                                        |
+| `validation/`        | `inputQualityPrompt`, `inputImprovementPrompt`, guards, repair prompts                           |
+| `context/`           | `buildInferResearchContextPrompt`, `buildInferSynthesisContextPrompt`, guards, repair, types     |
+| `researchPrompt.ts`  | `buildResearchPrompt`                                                                            |
+| `synthesisPrompt.ts` | `buildSynthesisPrompt`, `SynthesisReport`, `AdditionalSource`                                    |
+| `attribution.ts`     | `parseAttributionLine`, `parseSections`, `buildSourceMap`, `validateSynthesisAttributions`, etc. |
+| `redaction.ts`       | `redactToken`, `redactObject`, `SENSITIVE_FIELDS`                                                |
+| `llm/`               | `createLlmParseError`, `logLlmParseError`, `withLlmParseErrorLogging`                            |
+| `dataInsights/`      | `dataAnalysisPrompt`, `chartDefinitionPrompt`, `dataTransformPrompt`, parsers, repair            |
 
 ### 1.3 Consumer Mapping
 
-| Consumer App/Package      | Imports                                                                                         |
-|---------------------------|-------------------------------------------------------------------------------------------------|
-| **research-agent**        | `buildSynthesisPrompt`, `titlePrompt`, `SynthesisContext`, `ResearchContext`, context inference, attribution, validation |
-| **data-insights-agent**   | `dataAnalysisPrompt`, `chartDefinitionPrompt`, `dataTransformPrompt`, `titlePrompt`, `feedNamePrompt`, parsers |
-| **commands-agent**        | `commandClassifierPrompt`                                                                       |
-| **calendar-agent**        | `calendarActionExtractionPrompt`                                                                |
-| **linear-agent**          | `linearActionExtractionPrompt`                                                                  |
-| **todos-agent**           | `itemExtractionPrompt`                                                                          |
-| **infra-gemini**          | `buildResearchPrompt`                                                                           |
-| **infra-gpt**             | `buildResearchPrompt`                                                                           |
-| **infra-claude**          | `buildResearchPrompt`                                                                           |
-| **infra-glm**             | `buildResearchPrompt`                                                                           |
-| **infra-perplexity**      | `buildResearchPrompt`                                                                           |
-| **common-http**           | `redactToken`, `redactObject`, `SENSITIVE_FIELDS`                                               |
-| **llm-contract**          | `thumbnailPrompt`                                                                               |
+| Consumer App/Package    | Imports                                                                                                                  |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| **research-agent**      | `buildSynthesisPrompt`, `titlePrompt`, `SynthesisContext`, `ResearchContext`, context inference, attribution, validation |
+| **data-insights-agent** | `dataAnalysisPrompt`, `chartDefinitionPrompt`, `dataTransformPrompt`, `titlePrompt`, `feedNamePrompt`, parsers           |
+| **commands-agent**      | `commandClassifierPrompt`                                                                                                |
+| **calendar-agent**      | `calendarActionExtractionPrompt`                                                                                         |
+| **linear-agent**        | `linearActionExtractionPrompt`                                                                                           |
+| **todos-agent**         | `itemExtractionPrompt`                                                                                                   |
+| **infra-gemini**        | `buildResearchPrompt`                                                                                                    |
+| **infra-gpt**           | `buildResearchPrompt`                                                                                                    |
+| **infra-claude**        | `buildResearchPrompt`                                                                                                    |
+| **infra-glm**           | `buildResearchPrompt`                                                                                                    |
+| **infra-perplexity**    | `buildResearchPrompt`                                                                                                    |
+| **common-http**         | `redactToken`, `redactObject`, `SENSITIVE_FIELDS`                                                                        |
+| **llm-contract**        | `thumbnailPrompt`                                                                                                        |
 
 ---
 
@@ -138,19 +138,20 @@ packages/llm-common/src/
 
 ### 2.2 Key Decisions
 
-| Decision                                    | Rationale                                                    |
-|---------------------------------------------|--------------------------------------------------------------|
-| Create `research/` domain                   | Groups research-specific prompts and attribution together    |
+| Decision                                    | Rationale                                                       |
+| ------------------------------------------- | --------------------------------------------------------------- |
+| Create `research/` domain                   | Groups research-specific prompts and attribution together       |
 | Create `synthesis/` as separate domain      | Synthesis has its own context inference, distinct from research |
-| Create `shared/` for cross-cutting concerns | `redaction.ts` is used by `common-http`, not research-specific |
-| Keep `classification/` unchanged            | Already well-organized by consumer domain                    |
-| Keep `generation/` unchanged                | Already well-organized; used by multiple consumers           |
-| Move `llm/parseError.ts` to `shared/`       | Generic LLM error handling, not domain-specific              |
-| Maintain backward-compatible exports        | No breaking changes to consumers                             |
+| Create `shared/` for cross-cutting concerns | `redaction.ts` is used by `common-http`, not research-specific  |
+| Keep `classification/` unchanged            | Already well-organized by consumer domain                       |
+| Keep `generation/` unchanged                | Already well-organized; used by multiple consumers              |
+| Move `llm/parseError.ts` to `shared/`       | Generic LLM error handling, not domain-specific                 |
+| Maintain backward-compatible exports        | No breaking changes to consumers                                |
 
 ### 2.3 Migration Path
 
 **Phase 1: Create new structure (non-breaking)**
+
 1. Create `research/`, `synthesis/`, `shared/` directories
 2. Move files to new locations
 3. Update internal imports within llm-common
@@ -158,6 +159,7 @@ packages/llm-common/src/
 5. Verify all consumers still work (no import changes required)
 
 **Phase 2: Update consumers (optional, future)**
+
 1. Update consumer imports to use domain-specific paths (e.g., `@intexuraos/llm-common/research`)
 2. Add package.json exports for subpath imports
 3. Deprecate flat imports in favor of domain imports
@@ -168,37 +170,37 @@ packages/llm-common/src/
 
 ### 3.1 Files to Move
 
-| Current Location                    | New Location                          |
-|-------------------------------------|---------------------------------------|
-| `researchPrompt.ts`                 | `research/buildResearchPrompt.ts`     |
-| `synthesisPrompt.ts`                | `research/buildSynthesisPrompt.ts`    |
-| `attribution.ts`                    | `research/attribution.ts`             |
-| `context/inferResearchContext.ts`   | `research/contextInference.ts`        |
-| `context/inferSynthesisContext.ts`  | `synthesis/contextInference.ts`       |
-| `context/guards.ts`                 | Split: `research/guards.ts` + `synthesis/guards.ts` |
-| `context/types.ts`                  | Split: `research/types.ts` + `synthesis/types.ts` |
-| `context/buildRepairPrompt.ts`      | Split by domain                       |
-| `redaction.ts`                      | `shared/redaction.ts`                 |
-| `types.ts`                          | `shared/types.ts`                     |
-| `llm/parseError.ts`                 | `shared/parseError.ts`                |
+| Current Location                   | New Location                                        |
+| ---------------------------------- | --------------------------------------------------- |
+| `researchPrompt.ts`                | `research/buildResearchPrompt.ts`                   |
+| `synthesisPrompt.ts`               | `research/buildSynthesisPrompt.ts`                  |
+| `attribution.ts`                   | `research/attribution.ts`                           |
+| `context/inferResearchContext.ts`  | `research/contextInference.ts`                      |
+| `context/inferSynthesisContext.ts` | `synthesis/contextInference.ts`                     |
+| `context/guards.ts`                | Split: `research/guards.ts` + `synthesis/guards.ts` |
+| `context/types.ts`                 | Split: `research/types.ts` + `synthesis/types.ts`   |
+| `context/buildRepairPrompt.ts`     | Split by domain                                     |
+| `redaction.ts`                     | `shared/redaction.ts`                               |
+| `types.ts`                         | `shared/types.ts`                                   |
+| `llm/parseError.ts`                | `shared/parseError.ts`                              |
 
 ### 3.2 Files to Keep in Place
 
-| File/Directory        | Reason                                        |
-|-----------------------|-----------------------------------------------|
-| `classification/`     | Already domain-organized                      |
-| `generation/`         | Already domain-organized                      |
-| `dataInsights/`       | Already domain-organized                      |
-| `validation/`         | Already domain-organized                      |
-| `todos/`              | Already domain-organized                      |
-| `image/`              | Already domain-organized                      |
+| File/Directory    | Reason                   |
+| ----------------- | ------------------------ |
+| `classification/` | Already domain-organized |
+| `generation/`     | Already domain-organized |
+| `dataInsights/`   | Already domain-organized |
+| `validation/`     | Already domain-organized |
+| `todos/`          | Already domain-organized |
+| `image/`          | Already domain-organized |
 
 ### 3.3 Directories to Remove
 
-| Directory     | Reason                                               |
-|---------------|------------------------------------------------------|
-| `context/`    | Contents distributed to `research/` and `synthesis/` |
-| `llm/`        | Contents moved to `shared/`                          |
+| Directory  | Reason                                               |
+| ---------- | ---------------------------------------------------- |
+| `context/` | Contents distributed to `research/` and `synthesis/` |
+| `llm/`     | Contents moved to `shared/`                          |
 
 ---
 
@@ -231,12 +233,12 @@ Each domain will have its own `index.ts` that exports only domain-relevant items
 
 ## 5. Risk Assessment
 
-| Risk                          | Likelihood | Impact | Mitigation                                    |
-|-------------------------------|------------|--------|-----------------------------------------------|
-| Import path breakage          | Low        | High   | Maintain all existing exports in root index   |
-| Circular dependencies         | Medium     | Medium | Careful ordering of imports; lint enforcement |
-| Test path breakage            | Medium     | Low    | Update test imports alongside source files    |
-| Type resolution issues        | Low        | Medium | Verify TypeScript paths after restructure     |
+| Risk                   | Likelihood | Impact | Mitigation                                    |
+| ---------------------- | ---------- | ------ | --------------------------------------------- |
+| Import path breakage   | Low        | High   | Maintain all existing exports in root index   |
+| Circular dependencies  | Medium     | Medium | Careful ordering of imports; lint enforcement |
+| Test path breakage     | Medium     | Low    | Update test imports alongside source files    |
+| Type resolution issues | Low        | Medium | Verify TypeScript paths after restructure     |
 
 ---
 
@@ -268,13 +270,132 @@ After restructuring, verify:
 
 ---
 
-## 8. Open Questions
+## 8. Consumer Import Updates (Phase 2)
 
-1. **Subpath exports:** Should we add `exports` field to `package.json` for `@intexuraos/llm-common/research` style imports? (Deferred to Phase 2)
+Phase 1 maintains backward compatibility — consumers don't need to change. Phase 2 (optional) updates consumers to use domain-specific imports for better clarity and tree-shaking.
 
-2. **Context directory:** The current `context/` directory mixes research and synthesis concerns. Should we create a `contextInference/` shared module instead of splitting? (Decision: Split by domain for clarity)
+### 8.1 research-agent
 
-3. **Attribution ownership:** Attribution is currently only used by research-agent. Should it stay in `research/` or move to `shared/`? (Decision: Keep in `research/` since it's synthesis-specific)
+| Current Import                                                                 | New Import                                             |
+|--------------------------------------------------------------------------------|--------------------------------------------------------|
+| `import { buildSynthesisPrompt, SynthesisContext } from '@intexuraos/llm-common'` | `import { buildSynthesisPrompt, SynthesisContext } from '@intexuraos/llm-common/research'` |
+| `import { ResearchContext } from '@intexuraos/llm-common'`                     | `import { ResearchContext } from '@intexuraos/llm-common/research'`                        |
+| `import { titlePrompt } from '@intexuraos/llm-common'`                         | `import { titlePrompt } from '@intexuraos/llm-common/generation'`                          |
+| `import { stripAttributionLines } from '@intexuraos/llm-common'`               | `import { stripAttributionLines } from '@intexuraos/llm-common/research'`                  |
+| `import { buildInferResearchContextPrompt, ... } from '@intexuraos/llm-common'`| `import { buildInferResearchContextPrompt, ... } from '@intexuraos/llm-common/research'`   |
+| `import { inputQualityPrompt, ... } from '@intexuraos/llm-common'`             | `import { inputQualityPrompt, ... } from '@intexuraos/llm-common/validation'`              |
+
+**Files to update:** 9 files in `apps/research-agent/src/`
+
+### 8.2 data-insights-agent
+
+| Current Import                                                          | New Import                                                              |
+|-------------------------------------------------------------------------|-------------------------------------------------------------------------|
+| `import { dataAnalysisPrompt, ... } from '@intexuraos/llm-common'`      | `import { dataAnalysisPrompt, ... } from '@intexuraos/llm-common/dataInsights'` |
+| `import { titlePrompt } from '@intexuraos/llm-common'`                  | `import { titlePrompt } from '@intexuraos/llm-common/generation'`       |
+| `import { feedNamePrompt } from '@intexuraos/llm-common'`               | `import { feedNamePrompt } from '@intexuraos/llm-common/generation'`    |
+
+**Files to update:** 6 files in `apps/data-insights-agent/src/`
+
+### 8.3 commands-agent
+
+| Current Import                                                    | New Import                                                                     |
+|-------------------------------------------------------------------|--------------------------------------------------------------------------------|
+| `import { commandClassifierPrompt } from '@intexuraos/llm-common'`| `import { commandClassifierPrompt } from '@intexuraos/llm-common/classification'` |
+
+**Files to update:** 1 file (`apps/commands-agent/src/infra/gemini/classifier.ts`)
+
+### 8.4 calendar-agent
+
+| Current Import                                                           | New Import                                                                          |
+|--------------------------------------------------------------------------|-------------------------------------------------------------------------------------|
+| `import { calendarActionExtractionPrompt } from '@intexuraos/llm-common'`| `import { calendarActionExtractionPrompt } from '@intexuraos/llm-common/classification'` |
+
+**Files to update:** 1 file (`apps/calendar-agent/src/infra/gemini/calendarActionExtractionService.ts`)
+
+### 8.5 linear-agent
+
+| Current Import                                                         | New Import                                                                        |
+|------------------------------------------------------------------------|-----------------------------------------------------------------------------------|
+| `import { linearActionExtractionPrompt } from '@intexuraos/llm-common'`| `import { linearActionExtractionPrompt } from '@intexuraos/llm-common/classification'` |
+
+**Files to update:** 1 file (`apps/linear-agent/src/infra/llm/linearActionExtractionService.ts`)
+
+### 8.6 todos-agent
+
+| Current Import                                                  | New Import                                                         |
+|-----------------------------------------------------------------|--------------------------------------------------------------------|
+| `import { itemExtractionPrompt } from '@intexuraos/llm-common'` | `import { itemExtractionPrompt } from '@intexuraos/llm-common/todos'` |
+
+**Files to update:** 1 file (`apps/todos-agent/src/infra/gemini/todoItemExtractionService.ts`)
+
+### 8.7 infra-* packages (gemini, gpt, claude, glm, perplexity)
+
+| Current Import                                               | New Import                                                       |
+|--------------------------------------------------------------|------------------------------------------------------------------|
+| `import { buildResearchPrompt } from '@intexuraos/llm-common'`| `import { buildResearchPrompt } from '@intexuraos/llm-common/research'` |
+
+**Files to update:** 5 files (one per infra package)
+
+### 8.8 common-http
+
+| Current Import                                                              | New Import                                                                 |
+|-----------------------------------------------------------------------------|----------------------------------------------------------------------------|
+| `import { redactToken, redactObject, SENSITIVE_FIELDS } from '@intexuraos/llm-common'` | `import { redactToken, redactObject, SENSITIVE_FIELDS } from '@intexuraos/llm-common/shared'` |
+
+**Files to update:** 2 files (`packages/common-http/src/index.ts`, `packages/common-http/src/http/logger.ts`)
+
+### 8.9 llm-contract
+
+| Current Import                                            | New Import                                                    |
+|-----------------------------------------------------------|---------------------------------------------------------------|
+| `import { thumbnailPrompt } from '@intexuraos/llm-common'`| `import { thumbnailPrompt } from '@intexuraos/llm-common/image'` |
+
+**Files to update:** 1 file (`packages/llm-contract/src/helpers.ts`)
+
+### 8.10 Summary
+
+| Consumer              | Files to Update | Complexity |
+|-----------------------|-----------------|------------|
+| research-agent        | 9               | Medium     |
+| data-insights-agent   | 6               | Low        |
+| commands-agent        | 1               | Trivial    |
+| calendar-agent        | 1               | Trivial    |
+| linear-agent          | 1               | Trivial    |
+| todos-agent           | 1               | Trivial    |
+| infra-* (5 packages)  | 5               | Trivial    |
+| common-http           | 2               | Trivial    |
+| llm-contract          | 1               | Trivial    |
+| **Total**             | **27**          | Low-Medium |
+
+### 8.11 package.json Exports Configuration
+
+To enable subpath imports, add to `packages/llm-common/package.json`:
+
+```json
+{
+  "exports": {
+    ".": "./dist/index.js",
+    "./research": "./dist/research/index.js",
+    "./synthesis": "./dist/synthesis/index.js",
+    "./classification": "./dist/classification/index.js",
+    "./generation": "./dist/generation/index.js",
+    "./dataInsights": "./dist/dataInsights/index.js",
+    "./validation": "./dist/validation/index.js",
+    "./todos": "./dist/todos/index.js",
+    "./image": "./dist/image/index.js",
+    "./shared": "./dist/shared/index.js"
+  }
+}
+```
+
+---
+
+## 9. Open Questions
+
+1. **Context directory:** The current `context/` directory mixes research and synthesis concerns. Should we create a `contextInference/` shared module instead of splitting? (Decision: Split by domain for clarity)
+
+2. **Attribution ownership:** Attribution is currently only used by research-agent. Should it stay in `research/` or move to `shared/`? (Decision: Keep in `research/` since it's synthesis-specific)
 
 ---
 


### PR DESCRIPTION
## Context

Addresses: [INT-70](https://linear.app/pbuchman/issue/INT-70/pbu-69-plan-llm-common-restructuring-approach)
Parent issue: [INT-69](https://linear.app/pbuchman/issue/INT-69/refactor-restructure-llm-common-with-per-package-directories)

## What Changed

Added a comprehensive restructuring plan for the `llm-common` package at `docs/plans/llm-common-restructuring.md`.

## Reasoning

The `llm-common` package has grown organically with a mix of domain-organized directories (`classification/`, `generation/`, `dataInsights/`) and flat root-level files (`researchPrompt.ts`, `synthesisPrompt.ts`, `attribution.ts`). This inconsistency makes it harder to understand:
- Which exports are used by which consumers
- Where to add new functionality
- How different modules relate to each other

### Investigation Findings

**Current structure analysis:**
- 8 existing domain directories (already well-organized)
- 5 flat root-level files that should be organized by domain
- 12 consuming apps/packages with distinct import patterns

**Consumer mapping reveals clear domains:**
| Domain        | Primary Consumers                              |
|---------------|------------------------------------------------|
| Research      | research-agent, infra-gemini/gpt/claude/glm/perplexity |
| Classification| commands-agent, calendar-agent, linear-agent   |
| Data Insights | data-insights-agent                            |
| Shared        | common-http (redaction only)                   |

### Key Decisions

1. **Create `research/` domain** — Groups `buildResearchPrompt`, `buildSynthesisPrompt`, `attribution`, and context inference
2. **Create `synthesis/` domain** — Separates synthesis context inference from research
3. **Create `shared/` domain** — Cross-cutting utilities like `redaction.ts` and `parseError.ts`
4. **Maintain backward compatibility** — All existing imports continue to work via barrel exports

## Testing

- [x] Manual testing completed (documentation only)
- [x] `pnpm run ci:tracked` passes

## Cross-References

- **Linear Issue**: [INT-70](https://linear.app/pbuchman/issue/INT-70/pbu-69-plan-llm-common-restructuring-approach)
- **Parent Issue**: [INT-69](https://linear.app/pbuchman/issue/INT-69/refactor-restructure-llm-common-with-per-package-directories)
- **Implementation Issue**: [INT-71](https://linear.app/pbuchman/issue/INT-71/pbu-69-implement-llm-common-restructuring) (blocked by this)

---

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>