### PR TITLE
INT-99 Fix duplicate notifications for linear actions

### DIFF
--- a/.claude/ci-failures/intexuraos-1-fix_INT-99-duplicate-notifications.jsonl
+++ b/.claude/ci-failures/intexuraos-1-fix_INT-99-duplicate-notifications.jsonl
@@ -1,0 +1,3 @@
+{"ts":"2026-01-16T20:57:39.329Z","project":"intexuraos-1","branch":"fix/INT-99-duplicate-notifications","workspace":"--","runNumber":1,"passed":false,"durationMs":609,"failureCount":0,"failures":[]}
+{"ts":"2026-01-16T20:57:45.627Z","project":"intexuraos-1","branch":"fix/INT-99-duplicate-notifications","workspace":"--","runNumber":2,"passed":false,"durationMs":377,"failureCount":0,"failures":[]}
+{"ts":"2026-01-16T21:02:43.058Z","project":"intexuraos-1","branch":"fix/INT-99-duplicate-notifications","runNumber":3,"passed":true,"durationMs":123295,"failureCount":0,"failures":[]}

--- a/apps/actions-agent/src/__tests__/fakes.ts
+++ b/apps/actions-agent/src/__tests__/fakes.ts
@@ -901,13 +901,15 @@ export function createFakeServices(deps: {
     }
   );
 
-  const handleLinearActionUseCase: HandleLinearActionUseCase =
-    createHandleLinearActionUseCase({
-      actionServiceClient: deps.actionServiceClient,
+  const handleLinearActionUseCase: HandleLinearActionUseCase = registerActionHandler(
+    createHandleLinearActionUseCase,
+    {
+      actionRepository,
       whatsappPublisher,
       webAppUrl: 'http://test.app',
       logger: silentLogger,
-    });
+    }
+  );
 
   const changeActionTypeUseCase: ChangeActionTypeUseCase =
     deps.changeActionTypeUseCase ??

--- a/apps/actions-agent/src/domain/usecases/handleLinearAction.ts
+++ b/apps/actions-agent/src/domain/usecases/handleLinearAction.ts
@@ -1,20 +1,18 @@
 /**
  * Handle Linear Action Use Case
  *
- * Handles incoming Linear action events by:
- * 1. Checking if action exists and is in valid state
- * 2. Setting to awaiting_approval
- * 3. Sending WhatsApp notification for approval
+ * Handles incoming Linear action events by sending WhatsApp notification for approval.
+ * Idempotency check and status update handled by registerActionHandler decorator.
  */
 
-import { ok, err, type Result, getErrorMessage } from '@intexuraos/common-core';
-import type { ActionServiceClient } from '../ports/actionServiceClient.js';
+import { ok, type Result } from '@intexuraos/common-core';
+import type { ActionRepository } from '../ports/actionRepository.js';
 import type { WhatsAppSendPublisher } from '@intexuraos/infra-pubsub';
 import type { ActionCreatedEvent } from '../models/actionEvent.js';
 import type { Logger } from 'pino';
 
 export interface HandleLinearActionDeps {
-  actionServiceClient: ActionServiceClient;
+  actionRepository: ActionRepository;
   whatsappPublisher: WhatsAppSendPublisher;
   webAppUrl: string;
   logger: Logger;
@@ -27,7 +25,7 @@ export interface HandleLinearActionUseCase {
 export function createHandleLinearActionUseCase(
   deps: HandleLinearActionDeps
 ): HandleLinearActionUseCase {
-  const { actionServiceClient, whatsappPublisher, webAppUrl, logger } = deps;
+  const { actionRepository: _actionRepository, whatsappPublisher, webAppUrl, logger } = deps;
 
   return {
     async execute(event: ActionCreatedEvent): Promise<Result<{ actionId: string }>> {
@@ -42,46 +40,7 @@ export function createHandleLinearActionUseCase(
         'Processing linear action'
       );
 
-      const actionResult = await actionServiceClient.getAction(event.actionId);
-      if (!actionResult.ok) {
-        logger.warn({ actionId: event.actionId }, 'Action not found, may have been deleted');
-        return ok({ actionId: event.actionId });
-      }
-
-      const action = actionResult.value;
-      if (action === null) {
-        logger.warn({ actionId: event.actionId }, 'Action not found, may have been deleted');
-        return ok({ actionId: event.actionId });
-      }
-
-      if (action.status !== 'pending') {
-        logger.info(
-          { actionId: event.actionId, currentStatus: action.status },
-          'Action already processed, skipping (idempotent)'
-        );
-        return ok({ actionId: event.actionId });
-      }
-
-      logger.info({ actionId: event.actionId }, 'Setting linear action to awaiting_approval');
-
-      const result = await actionServiceClient.updateActionStatus(
-        event.actionId,
-        'awaiting_approval'
-      );
-
-      if (!result.ok) {
-        logger.error(
-          {
-            actionId: event.actionId,
-            error: getErrorMessage(result.error),
-          },
-          'Failed to set linear action to awaiting_approval'
-        );
-        return err(new Error(`Failed to update action status: ${getErrorMessage(result.error)}`));
-      }
-
-      logger.info({ actionId: event.actionId }, 'Linear action set to awaiting_approval');
-
+      // Idempotency check and status update handled by registerActionHandler decorator
       const actionLink = `${webAppUrl}/#/inbox?action=${event.actionId}`;
       const message = `New Linear issue ready for approval: "${event.title}". Review it here: ${actionLink}`;
 
@@ -97,13 +56,13 @@ export function createHandleLinearActionUseCase(
       });
 
       if (!publishResult.ok) {
-        logger.error(
+        logger.warn(
           {
             actionId: event.actionId,
             userId: event.userId,
             error: publishResult.error.message,
           },
-          'Failed to publish WhatsApp message (non-fatal)'
+          'Failed to publish WhatsApp message (non-fatal, best-effort notification)'
         );
       } else {
         logger.info({ actionId: event.actionId }, 'WhatsApp approval notification sent for linear');

--- a/apps/actions-agent/src/services.ts
+++ b/apps/actions-agent/src/services.ts
@@ -301,8 +301,8 @@ export function initServices(config: ServiceConfig): void {
     }
   );
 
-  const handleLinearActionUseCase = createHandleLinearActionUseCase({
-    actionServiceClient,
+  const handleLinearActionUseCase = registerActionHandler(createHandleLinearActionUseCase, {
+    actionRepository,
     whatsappPublisher,
     webAppUrl: config.webAppUrl,
     logger: pino({ name: 'handleLinearAction' }),


### PR DESCRIPTION
## Summary
- Refactored `handleLinearAction` to use `registerActionHandler` wrapper for atomic idempotency
- Replaced HTTP-based `ActionServiceClient` with direct `ActionRepository` for atomic `updateStatusIf` operations  
- Removed manual idempotency check (read-check-write pattern) that caused race conditions

## Root Cause
The linear action handler was using a non-atomic pattern:
1. Read action status via HTTP (`getAction`)
2. Check if status === 'pending'
3. Update status via HTTP (`updateActionStatus`)

This created a race window where multiple Pub/Sub deliveries could both read 'pending' and proceed to send duplicate notifications.

## Fix
Now uses `registerActionHandler` wrapper which:
1. Atomically checks AND updates status via Firestore's `updateStatusIf`
2. Only invokes the handler if the atomic update succeeds
3. Matches the pattern already used by all other action handlers (research, todo, note, link, calendar)

Fixes INT-99

## Test plan
- [x] All 5056 tests pass
- [x] Full CI passes
- [ ] Deploy to dev and verify linear action notifications are no longer duplicated

🤖 Generated with [Claude Code](https://claude.ai/code)