### PR TITLE
[INT-103] Add gcloud service account verification instructions

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -105,6 +105,50 @@ grep -B2 "90\." /tmp/ci-output.txt | head -50
 
 ---
 
+## GCloud Authentication (MANDATORY)
+
+**RULE:** NEVER claim "gcloud is not authenticated" or "unauthenticated to gcloud" without first verifying service account credentials.
+
+### Service Account Credentials
+
+A service account key file is available at:
+
+```
+~/personal/gcloud-claude-code-dev.json
+```
+
+### Verification Before Claiming Auth Failure
+
+Before reporting any gcloud authentication issues, you MUST:
+
+1. **Check if credentials file exists:**
+
+   ```bash
+   ls -la ~/personal/gcloud-claude-code-dev.json
+   ```
+
+2. **Activate service account if needed:**
+
+   ```bash
+   gcloud auth activate-service-account --key-file=~/personal/gcloud-claude-code-dev.json
+   ```
+
+3. **Verify authentication:**
+
+   ```bash
+   gcloud auth list
+   ```
+
+### When to Use Service Account
+
+- Firestore queries for investigation
+- Any `gcloud` commands requiring project access
+- Accessing production/dev data for debugging
+
+**You are NEVER "unauthenticated" if the service account key file exists.** Activate it and proceed.
+
+---
+
 ## Architecture
 
 ```

--- a/.claude/ci-failures/intexuraos-docs_INT-103-gcloud-service-account.jsonl
+++ b/.claude/ci-failures/intexuraos-docs_INT-103-gcloud-service-account.jsonl
@@ -1,0 +1,1 @@
+{"ts":"2026-01-17T10:53:47.598Z","project":"intexuraos","branch":"docs/INT-103-gcloud-service-account","runNumber":1,"passed":true,"durationMs":116544,"failureCount":0,"failures":[]}

--- a/.claude/commands/linear.md
+++ b/.claude/commands/linear.md
@@ -101,7 +101,34 @@ Before ANY operation, verify all required tools are available.
 | ---------- | -------------------------------- | ---------------- |
 | Linear MCP | `mcp__linear-server__list_teams` | Issue management |
 | GitHub CLI | `gh auth status`                 | PR creation      |
-| GCloud     | `gcloud auth list`               | Firestore access |
+| GCloud     | See GCloud Verification below    | Firestore access |
+
+### GCloud Verification (MANDATORY)
+
+**RULE:** NEVER claim "gcloud is not authenticated" without first verifying service account credentials.
+
+**Service account key location:** `~/personal/gcloud-claude-code-dev.json`
+
+**Verification steps (in order):**
+
+1. Check if credentials file exists:
+
+   ```bash
+   ls -la ~/personal/gcloud-claude-code-dev.json
+   ```
+
+2. If `gcloud auth list` shows no active account, activate service account:
+
+   ```bash
+   gcloud auth activate-service-account --key-file=~/personal/gcloud-claude-code-dev.json
+   ```
+
+3. Verify authentication:
+   ```bash
+   gcloud auth list
+   ```
+
+**You are NEVER "unauthenticated" if the service account key file exists.** Activate it and proceed.
 
 ### Optional Tools
 
@@ -138,6 +165,15 @@ ERROR: /linear cannot proceed - Linear MCP unavailable
 
 Required for: Issue creation and state management
 Fix: Check MCP server configuration
+
+Aborting.
+```
+
+```
+ERROR: /linear cannot proceed - GCloud not authenticated
+
+Required for: Firestore access
+Fix: Run 'gcloud auth activate-service-account --key-file=~/personal/gcloud-claude-code-dev.json'
 
 Aborting.
 ```


### PR DESCRIPTION
## Context

Addresses: [INT-103](https://linear.app/pbuchman/issue/INT-103/docs-add-gcloud-service-account-credential-verification-instructions)

## What Changed

Added mandatory gcloud service account verification instructions to both `.claude/CLAUDE.md` and `.claude/commands/linear.md`:

### CLAUDE.md
- New "GCloud Authentication (MANDATORY)" section
- Documents service account key location: `~/personal/gcloud-claude-code-dev.json`
- Step-by-step verification process before claiming auth failure
- Rule: "You are NEVER 'unauthenticated' if the service account key file exists"

### linear.md
- Updated Tool Verification section with detailed GCloud verification steps
- Added GCloud-specific error example in Failure Handling section
- Changed GCloud verification from simple `gcloud auth list` to multi-step process

## Reasoning

Claude was previously claiming "gcloud is not authenticated" without first checking if service account credentials were available. This led to false failures in automated workflows when the fix was simply to activate the existing service account.

### Key Decisions

- Place instructions in BOTH files for redundancy (CLAUDE.md for general use, linear.md for /linear workflow)
- Require checking file existence FIRST, then activation if needed
- Make the rule explicit: never claim unauthenticated without verification

## Testing

- [x] `pnpm run ci:tracked` passes

## Cross-References

- **Linear Issue**: [INT-103](https://linear.app/pbuchman/issue/INT-103/docs-add-gcloud-service-account-credential-verification-instructions)

---

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>