### PR TITLE
[INT-104] Initialize favourite field in research factory functions

### DIFF
--- a/.claude/ci-failures/intexuraos-2-fix_INT-101-retry-action-bug.jsonl
+++ b/.claude/ci-failures/intexuraos-2-fix_INT-101-retry-action-bug.jsonl
@@ -1,0 +1,2 @@
+{"ts":"2026-01-17T10:31:22.172Z","project":"intexuraos-2","branch":"fix/INT-101-retry-action-bug","workspace":"--","runNumber":1,"passed":false,"durationMs":337,"failureCount":0,"failures":[]}
+{"ts":"2026-01-17T10:32:20.282Z","project":"intexuraos-2","branch":"fix/INT-101-retry-action-bug","workspace":"actions-agent","runNumber":2,"passed":true,"durationMs":51941,"failureCount":0,"failures":[]}

--- a/.claude/ci-failures/intexuraos-2-fix_INT-104.jsonl
+++ b/.claude/ci-failures/intexuraos-2-fix_INT-104.jsonl
@@ -1,0 +1,2 @@
+{"ts":"2026-01-17T11:04:55.273Z","project":"intexuraos-2","branch":"fix/INT-104","workspace":"--","runNumber":1,"passed":false,"durationMs":467,"failureCount":0,"failures":[]}
+{"ts":"2026-01-17T11:06:47.678Z","project":"intexuraos-2","branch":"fix/INT-104","workspace":"research-agent","runNumber":2,"passed":true,"durationMs":105530,"failureCount":0,"failures":[]}

--- a/apps/research-agent/src/domain/research/models/Research.ts
+++ b/apps/research-agent/src/domain/research/models/Research.ts
@@ -141,6 +141,7 @@ export function createResearch(params: {
     status: 'pending',
     llmResults: createLlmResults(params.selectedModels),
     startedAt: now,
+    favourite: false,
   };
 
   if (params.inputContexts !== undefined && params.inputContexts.length > 0) {
@@ -185,6 +186,7 @@ export function createDraftResearch(params: {
     status: 'draft',
     llmResults: createLlmResults(params.selectedModels),
     startedAt: now,
+    favourite: false,
   };
 
   if (params.sourceActionId !== undefined) {
@@ -258,6 +260,7 @@ export function createEnhancedResearch(params: EnhanceResearchParams): Research 
     startedAt: now,
     sourceResearchId: source.id,
     sourceLlmCostUsd,
+    favourite: false,
   };
 
   if (allContexts.length > 0) {


### PR DESCRIPTION
## Context

Addresses: [INT-104](https://linear.app/pbuchman/issue/INT-104/bug-research-missing-favourite-field-causes-ui-query-to-exclude-it)

## What Changed

Added `favourite: false` initialization to all three research factory functions:
- `createResearch()` 
- `createDraftResearch()`
- `createEnhancedResearch()`

## Reasoning

New researches created via these factory functions didn't set the `favourite` field, leaving it as `null` in Firestore. The UI queries researches with:

```typescript
query.where('favourite', '==', false)
```

Firestore's `where('field', '==', value)` does NOT match documents where `field` is `null` - it treats missing/null fields as non-existent. This caused new researches to be invisible in the UI.

### Investigation Findings

- Found a research with title "Research miejsc do łowienia ryb na Gran Canarii" that was missing from UI
- Firestore query confirmed the document had `favourite: null`
- Applied data fix to existing document, now implementing code fix to prevent recurrence

### Key Decisions

- Initialize with `false` rather than checking for `undefined` in query - simpler and prevents field from ever being null
- Applied to all three factory functions for consistency

## Testing

- [x] Manual testing completed (verified research now appears in UI)
- [x] `pnpm run verify:workspace:tracked research-agent` passes

## Cross-References

- **Linear Issue**: [INT-104](https://linear.app/pbuchman/issue/INT-104/bug-research-missing-favourite-field-causes-ui-query-to-exclude-it)

---

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>