### PR TITLE
[INT-125] Fix silent success in linear-agent response envelope

### DIFF
--- a/.claude/ci-failures/intexuraos-fix_INT-125-linear-agent-response-envelope.jsonl
+++ b/.claude/ci-failures/intexuraos-fix_INT-125-linear-agent-response-envelope.jsonl
@@ -1,0 +1,3 @@
+{"ts":"2026-01-17T13:12:47.708Z","project":"intexuraos","branch":"fix/INT-125-linear-agent-response-envelope","workspace":"--","runNumber":1,"passed":false,"durationMs":350,"failureCount":0,"failures":[]}
+{"ts":"2026-01-17T13:13:34.139Z","project":"intexuraos","branch":"fix/INT-125-linear-agent-response-envelope","workspace":"linear-agent","runNumber":2,"passed":true,"durationMs":41069,"failureCount":0,"failures":[]}
+{"ts":"2026-01-17T13:15:53.417Z","project":"intexuraos","branch":"fix/INT-125-linear-agent-response-envelope","runNumber":3,"passed":true,"durationMs":127230,"failureCount":0,"failures":[]}

--- a/apps/linear-agent/src/__tests__/internalRoutes.test.ts
+++ b/apps/linear-agent/src/__tests__/internalRoutes.test.ts
@@ -85,9 +85,13 @@ describe('Internal Routes', () => {
       });
 
       expect(response.statusCode).toBe(200);
-      const body = JSON.parse(response.body) as { status: string; error: string };
-      expect(body.status).toBe('failed');
-      expect(body.error).toBe('Linear service unavailable');
+      const body = JSON.parse(response.body) as {
+        success: boolean;
+        data: { status: string; error: string };
+      };
+      expect(body.success).toBe(true);
+      expect(body.data.status).toBe('failed');
+      expect(body.data.error).toBe('Linear service unavailable');
     });
 
     it('returns 502 when connection repository fails', async () => {
@@ -142,13 +146,17 @@ describe('Internal Routes', () => {
 
       expect(response.statusCode).toBe(200);
       const body = JSON.parse(response.body) as {
-        status: string;
-        resource_url: string;
-        issue_identifier: string;
+        success: boolean;
+        data: {
+          status: string;
+          resource_url: string;
+          issue_identifier: string;
+        };
       };
-      expect(body.status).toBe('completed');
-      expect(body.resource_url).toBeDefined();
-      expect(body.issue_identifier).toBeDefined();
+      expect(body.success).toBe(true);
+      expect(body.data.status).toBe('completed');
+      expect(body.data.resource_url).toBeDefined();
+      expect(body.data.issue_identifier).toBeDefined();
     });
 
     it('returns 200 with failed status when extraction is invalid', async () => {
@@ -180,9 +188,13 @@ describe('Internal Routes', () => {
       });
 
       expect(response.statusCode).toBe(200);
-      const body = JSON.parse(response.body) as { status: string; error: string };
-      expect(body.status).toBe('failed');
-      expect(body.error).toBe('Not a valid issue request');
+      const body = JSON.parse(response.body) as {
+        success: boolean;
+        data: { status: string; error: string };
+      };
+      expect(body.success).toBe(true);
+      expect(body.data.status).toBe('failed');
+      expect(body.data.error).toBe('Not a valid issue request');
     });
 
     it('includes summary in payload when provided', async () => {
@@ -223,8 +235,12 @@ describe('Internal Routes', () => {
       });
 
       expect(response.statusCode).toBe(200);
-      const body = JSON.parse(response.body) as { status: string };
-      expect(body.status).toBe('completed');
+      const body = JSON.parse(response.body) as {
+        success: boolean;
+        data: { status: string };
+      };
+      expect(body.success).toBe(true);
+      expect(body.data.status).toBe('completed');
     });
 
     it('returns existing result for already processed action (idempotency)', async () => {
@@ -258,13 +274,17 @@ describe('Internal Routes', () => {
 
       expect(response.statusCode).toBe(200);
       const body = JSON.parse(response.body) as {
-        status: string;
-        resource_url: string;
-        issue_identifier: string;
+        success: boolean;
+        data: {
+          status: string;
+          resource_url: string;
+          issue_identifier: string;
+        };
       };
-      expect(body.status).toBe('completed');
-      expect(body.issue_identifier).toBe('ENG-99');
-      expect(body.resource_url).toBe('https://linear.app/team/issue/ENG-99');
+      expect(body.success).toBe(true);
+      expect(body.data.status).toBe('completed');
+      expect(body.data.issue_identifier).toBe('ENG-99');
+      expect(body.data.resource_url).toBe('https://linear.app/team/issue/ENG-99');
     });
 
     it('validates required action fields', async () => {
@@ -310,9 +330,13 @@ describe('Internal Routes', () => {
       });
 
       expect(response.statusCode).toBe(200);
-      const body = JSON.parse(response.body) as { status: string; error: string };
-      expect(body.status).toBe('failed');
-      expect(body.error).toBe('LLM service unavailable');
+      const body = JSON.parse(response.body) as {
+        success: boolean;
+        data: { status: string; error: string };
+      };
+      expect(body.success).toBe(true);
+      expect(body.data.status).toBe('failed');
+      expect(body.data.error).toBe('LLM service unavailable');
       expect(ctx.failedIssueRepository.count).toBe(1);
     });
   });

--- a/apps/linear-agent/src/routes/internalRoutes.ts
+++ b/apps/linear-agent/src/routes/internalRoutes.ts
@@ -58,10 +58,17 @@ export const internalRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
             description: 'Success',
             type: 'object',
             properties: {
-              status: { type: 'string', enum: ['completed', 'failed'] },
-              resource_url: { type: 'string', description: 'Frontend URL for created issue' },
-              issue_identifier: { type: 'string', description: 'Linear issue identifier (e.g., INT-123)' },
-              error: { type: 'string', description: 'Error message if failed' },
+              success: { type: 'boolean', enum: [true] },
+              data: {
+                type: 'object',
+                properties: {
+                  status: { type: 'string', enum: ['completed', 'failed'] },
+                  resource_url: { type: 'string', description: 'Frontend URL for created issue' },
+                  issue_identifier: { type: 'string', description: 'Linear issue identifier (e.g., INT-123)' },
+                  error: { type: 'string', description: 'Error message if failed' },
+                },
+              },
+              diagnostics: { $ref: 'Diagnostics#' },
             },
           },
           401: {
@@ -137,7 +144,7 @@ export const internalRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
         'internal/processLinearAction: complete'
       );
 
-      return await reply.send({
+      return await reply.ok({
         status: result.value.status,
         resource_url: result.value.resourceUrl,
         issue_identifier: result.value.issueIdentifier,


### PR DESCRIPTION
## Context

Addresses: [INT-125](https://linear.app/pbuchman/issue/INT-125/bug-fix-silent-success-in-linear-agent-response-envelope)

Fixes the bug where Linear issue creation shows "failed" on UI despite the issue being successfully created in Linear.

## What Changed

**File:** `apps/linear-agent/src/routes/internalRoutes.ts`

Changed `reply.send()` to `reply.ok()` on line 140:

```diff
-      return await reply.send({
+      return await reply.ok({
         status: result.value.status,
         resource_url: result.value.resourceUrl,
         issue_identifier: result.value.issueIdentifier,
         error: result.value.error,
       });
```

**Also updated:**
- OpenAPI schema for 200 response to reflect the wrapped envelope structure
- All related tests to expect `{ success: true, data: { ... } }` format

## Reasoning

### Root Cause

The `linearAgentHttpClient` in actions-agent (line 93) checks:
```typescript
if (!body.success || body.data === undefined) {
  return err(new Error(body.error?.message ?? 'Invalid response from linear-agent'));
}
```

When `body.success` is `undefined` (because `reply.send()` doesn't wrap with envelope), the check fails and returns "Invalid response from linear-agent" even though the Linear issue was successfully created.

### Investigation Findings

| Before | After |
|--------|-------|
| `{ "status": "completed", "resource_url": "..." }` | `{ "success": true, "data": { "status": "completed", "resource_url": "..." } }` |

The HTTP client already expected the envelope format, so this fix is backward-compatible.

## Testing

- [x] All tests updated to expect wrapped response format
- [x] `pnpm run verify:workspace:tracked linear-agent` passes
- [x] `pnpm run ci:tracked` passes (5090 tests, 100% coverage)

## Cross-References

- **Linear Issue**: [INT-125](https://linear.app/pbuchman/issue/INT-125)
- **Parent Issue**: [INT-124](https://linear.app/pbuchman/issue/INT-124)
- **Design Document**: [PR #490](https://github.com/pbuchman/intexuraos/pull/490)

---

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>