### PR TITLE
INT-133 Display improved prompt instead of original in results

### DIFF
--- a/.claude/ci-failures/intexuraos-3-fix_INT-133-display-improved-prompt.jsonl
+++ b/.claude/ci-failures/intexuraos-3-fix_INT-133-display-improved-prompt.jsonl
@@ -1,0 +1,3 @@
+{"ts":"2026-01-17T15:12:31.430Z","project":"intexuraos-3","branch":"fix/INT-133-display-improved-prompt","workspace":"--","runNumber":1,"passed":false,"durationMs":355,"failureCount":0,"failures":[]}
+{"ts":"2026-01-17T15:13:38.116Z","project":"intexuraos-3","branch":"fix/INT-133-display-improved-prompt","workspace":"research-agent","runNumber":2,"passed":true,"durationMs":61511,"failureCount":0,"failures":[]}
+{"ts":"2026-01-17T15:15:06.673Z","project":"intexuraos-3","branch":"fix/INT-133-display-improved-prompt","workspace":"web","runNumber":3,"passed":true,"durationMs":80542,"failureCount":0,"failures":[]}

--- a/apps/research-agent/src/__tests__/domain/research/models/Research.test.ts
+++ b/apps/research-agent/src/__tests__/domain/research/models/Research.test.ts
@@ -41,6 +41,32 @@ describe('Research factory functions', () => {
       expect(research.synthesisModel).toBe(LlmModels.ClaudeSonnet45);
       expect(research.llmResults).toHaveLength(2);
     });
+
+    it('stores originalPrompt when provided', () => {
+      const research = createResearch({
+        id: 'test-id',
+        userId: 'user-123',
+        prompt: 'Improved prompt with more context',
+        originalPrompt: 'Original poor prompt',
+        selectedModels: [LlmModels.Gemini25Flash],
+        synthesisModel: LlmModels.Gemini25Flash,
+      });
+
+      expect(research.prompt).toBe('Improved prompt with more context');
+      expect(research.originalPrompt).toBe('Original poor prompt');
+    });
+
+    it('does not set originalPrompt when not provided', () => {
+      const research = createResearch({
+        id: 'test-id',
+        userId: 'user-123',
+        prompt: 'Test prompt',
+        selectedModels: [LlmModels.Gemini25Flash],
+        synthesisModel: LlmModels.Gemini25Flash,
+      });
+
+      expect(research.originalPrompt).toBeUndefined();
+    });
   });
 
   describe('createDraftResearch', () => {

--- a/apps/research-agent/src/__tests__/routes.test.ts
+++ b/apps/research-agent/src/__tests__/routes.test.ts
@@ -380,6 +380,28 @@ describe('Research Routes - Authenticated', () => {
       expect(body.data.inputContexts).toHaveLength(1);
     });
 
+    it('stores originalPrompt when user accepted an improved suggestion', async () => {
+      const token = await createToken(TEST_USER_ID);
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/research',
+        headers: { authorization: `Bearer ${token}` },
+        payload: {
+          prompt: 'Improved prompt with more context and details',
+          originalPrompt: 'Original poor prompt',
+          selectedModels: [LlmModels.Gemini25Pro],
+          synthesisModel: LlmModels.Gemini25Pro,
+        },
+      });
+
+      expect(response.statusCode).toBe(201);
+      const body = JSON.parse(response.body) as { success: boolean; data: Research };
+      expect(body.success).toBe(true);
+      expect(body.data.prompt).toBe('Improved prompt with more context and details');
+      expect(body.data.originalPrompt).toBe('Original poor prompt');
+    });
+
     it('returns 500 on save failure', async () => {
       const token = await createToken(TEST_USER_ID);
       fakeRepo.setFailNextSave(true);

--- a/apps/research-agent/src/domain/research/models/Research.ts
+++ b/apps/research-agent/src/domain/research/models/Research.ts
@@ -88,6 +88,8 @@ export interface Research {
   userId: string;
   title: string;
   prompt: string;
+  /** Original user prompt before improvement. Only set when user accepted an improved suggestion. */
+  originalPrompt?: string;
   selectedModels: ResearchModel[];
   synthesisModel: ResearchModel;
   status: ResearchStatus;
@@ -125,6 +127,7 @@ export function createResearch(params: {
   id: string;
   userId: string;
   prompt: string;
+  originalPrompt?: string;
   selectedModels: ResearchModel[];
   synthesisModel: ResearchModel;
   inputContexts?: { content: string; label?: string | undefined }[];
@@ -143,6 +146,10 @@ export function createResearch(params: {
     startedAt: now,
     favourite: false,
   };
+
+  if (params.originalPrompt !== undefined) {
+    research.originalPrompt = params.originalPrompt;
+  }
 
   if (params.inputContexts !== undefined && params.inputContexts.length > 0) {
     research.inputContexts = params.inputContexts.map((ctx, idx) => {

--- a/apps/research-agent/src/domain/research/usecases/submitResearch.ts
+++ b/apps/research-agent/src/domain/research/usecases/submitResearch.ts
@@ -11,6 +11,8 @@ import type { RepositoryError, ResearchRepository } from '../ports/index.js';
 export interface SubmitResearchParams {
   userId: string;
   prompt: string;
+  /** Original user prompt before improvement. Set when user accepted an improved suggestion. */
+  originalPrompt?: string;
   selectedModels: ResearchModel[];
   synthesisModel: ResearchModel;
   inputContexts?: { content: string; label?: string | undefined }[];
@@ -36,6 +38,9 @@ export async function submitResearch(
     selectedModels: params.selectedModels,
     synthesisModel: params.synthesisModel,
   };
+  if (params.originalPrompt !== undefined) {
+    createParams.originalPrompt = params.originalPrompt;
+  }
   if (params.inputContexts !== undefined) {
     createParams.inputContexts = params.inputContexts;
   }

--- a/apps/research-agent/src/routes/researchRoutes.ts
+++ b/apps/research-agent/src/routes/researchRoutes.ts
@@ -66,6 +66,7 @@ import {
 
 interface CreateResearchBody {
   prompt: string;
+  originalPrompt?: string;
   selectedModels: ResearchModel[];
   synthesisModel?: ResearchModel;
   inputContexts?: { content: string; label?: string }[];
@@ -171,6 +172,9 @@ export const researchRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
         selectedModels: body.selectedModels,
         synthesisModel,
       };
+      if (body.originalPrompt !== undefined) {
+        submitParams.originalPrompt = body.originalPrompt;
+      }
       if (body.inputContexts !== undefined) {
         const contextsWithLabels = await generateContextLabels(
           body.inputContexts,

--- a/apps/research-agent/src/routes/schemas/common.ts
+++ b/apps/research-agent/src/routes/schemas/common.ts
@@ -91,6 +91,7 @@ export const researchSchema = {
     userId: { type: 'string' },
     title: { type: 'string' },
     prompt: { type: 'string' },
+    originalPrompt: { type: 'string', nullable: true },
     selectedModels: {
       type: 'array',
       items: supportedModelSchema,

--- a/apps/research-agent/src/routes/schemas/researchSchemas.ts
+++ b/apps/research-agent/src/routes/schemas/researchSchemas.ts
@@ -13,6 +13,11 @@ export const createResearchBodySchema = {
       minLength: 10,
       maxLength: 20000,
     },
+    originalPrompt: {
+      type: 'string',
+      maxLength: 20000,
+      description: 'Original user prompt before improvement. Set when user accepted an improved suggestion.',
+    },
     selectedModels: {
       type: 'array',
       items: supportedModelSchema,

--- a/apps/web/src/pages/ResearchDetailPage.tsx
+++ b/apps/web/src/pages/ResearchDetailPage.tsx
@@ -786,12 +786,25 @@ export function ResearchDetailPage(): React.JSX.Element {
         ) : null}
       </div>
 
-      <Card title="Original Prompt" className="mb-6">
+      <Card
+        title={research.originalPrompt !== undefined ? 'Improved Prompt' : 'Prompt'}
+        className="mb-6"
+      >
         <blockquote className="border-l-4 border-blue-400 bg-slate-50 py-3 pl-4 pr-3 italic">
           <p className="whitespace-pre-wrap text-slate-700">
             {renderPromptWithLinks(research.prompt)}
           </p>
         </blockquote>
+        {research.originalPrompt !== undefined ? (
+          <details className="mt-3">
+            <summary className="cursor-pointer text-sm text-slate-500 hover:text-slate-700">
+              Show original prompt
+            </summary>
+            <blockquote className="mt-2 border-l-4 border-slate-300 bg-slate-100 py-2 pl-4 pr-3 text-sm italic text-slate-500">
+              <p className="whitespace-pre-wrap">{research.originalPrompt}</p>
+            </blockquote>
+          </details>
+        ) : null}
       </Card>
 
       {/* Research Summary - show when we have usage data */}

--- a/apps/web/src/services/researchAgentApi.types.ts
+++ b/apps/web/src/services/researchAgentApi.types.ts
@@ -92,6 +92,8 @@ export interface Research {
   userId: string;
   title: string;
   prompt: string;
+  /** Original user prompt before improvement. Only set when user accepted an improved suggestion. */
+  originalPrompt?: string;
   selectedModels: SupportedModel[];
   synthesisModel: SupportedModel;
   status: ResearchStatus;
@@ -116,6 +118,8 @@ export interface Research {
  */
 export interface CreateResearchRequest {
   prompt: string;
+  /** Original user prompt before improvement. Set when user accepted an improved suggestion. */
+  originalPrompt?: string;
   selectedModels: SupportedModel[];
   synthesisModel: SupportedModel;
   inputContexts?: { content: string }[];


### PR DESCRIPTION
## Summary
- Added `originalPrompt` optional field to Research model to track user's initial input when they accept an improved prompt suggestion
- Backend routes now accept and store `originalPrompt` in Firestore
- UI displays "Improved Prompt" label when prompt was enhanced, with collapsible section to view original
- Added tests for the new functionality

Fixes INT-133

## Test Plan
- [ ] Create research with original prompt (no improvement) → Shows "Prompt" label
- [ ] Create research with improved prompt → Shows "Improved Prompt" label with collapsible original
- [ ] Verify CI passes with all tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)