### PR TITLE
INT-135 Fix calendar event processing permission error

### DIFF
--- a/.claude/ci-failures/intexuraos-3-fix_INT-135-calendar-event-processing.jsonl
+++ b/.claude/ci-failures/intexuraos-3-fix_INT-135-calendar-event-processing.jsonl
@@ -1,0 +1,1 @@
+{"ts":"2026-01-17T15:35:34.305Z","project":"intexuraos-3","branch":"fix/INT-135-calendar-event-processing","runNumber":1,"passed":true,"durationMs":502378,"failureCount":0,"failures":[]}

--- a/docs/design/INT-124-action-feedback-mechanism.md
+++ b/docs/design/INT-124-action-feedback-mechanism.md
@@ -19,9 +19,9 @@ Users experience misleading feedback when executing actions via WhatsApp voice c
 
 ## Implementation Status
 
-| Phase | Issue | Status |
-|-------|-------|--------|
-| Phase 1: Hotfix | [INT-125](https://linear.app/pbuchman/issue/INT-125) | ✅ Completed |
+| Phase                         | Issue                                                | Status         |
+| ----------------------------- | ---------------------------------------------------- | -------------- |
+| Phase 1: Hotfix               | [INT-125](https://linear.app/pbuchman/issue/INT-125) | ✅ Completed   |
 | Phase 2: Standardize Contract | [INT-126](https://linear.app/pbuchman/issue/INT-126) | 🔄 In Progress |
 
 ---
@@ -48,13 +48,13 @@ export interface ActionFeedback {
 
 ### Key Decisions
 
-| Decision | Rationale | Date |
-|----------|-----------|------|
-| Single `message` field | Simpler than separate successMessage/failureReason; status determines context | 2026-01-17 |
-| `resourceUrl` only | Dropped `resourceIdentifier` - URL is sufficient, ID can be parsed if needed | 2026-01-17 |
-| `message` required | Every response MUST include user-facing feedback | 2026-01-17 |
-| `errorCode` required on failure | Enables debugging; standard codes defined in common-core | 2026-01-17 |
-| No metadata field | Keep it simple; add later if needed | 2026-01-17 |
+| Decision                        | Rationale                                                                     | Date       |
+| ------------------------------- | ----------------------------------------------------------------------------- | ---------- |
+| Single `message` field          | Simpler than separate successMessage/failureReason; status determines context | 2026-01-17 |
+| `resourceUrl` only              | Dropped `resourceIdentifier` - URL is sufficient, ID can be parsed if needed  | 2026-01-17 |
+| `message` required              | Every response MUST include user-facing feedback                              | 2026-01-17 |
+| `errorCode` required on failure | Enables debugging; standard codes defined in common-core                      | 2026-01-17 |
+| No metadata field               | Keep it simple; add later if needed                                           | 2026-01-17 |
 
 ---
 
@@ -113,14 +113,14 @@ export const ActionErrorCodes = {
 
 All 6 services must return `ActionFeedback`:
 
-| Service | Endpoint | Status |
-|---------|----------|--------|
-| linear-agent | `/internal/linear/process-action` | 🔄 Pending |
-| todos-agent | `/internal/todos` | 🔄 Pending |
-| notes-agent | `/internal/notes` | 🔄 Pending |
-| links-agent | `/internal/links` | 🔄 Pending |
-| calendar-agent | `/internal/calendar` | 🔄 Pending |
-| research-agent | `/internal/research` | 🔄 Pending |
+| Service        | Endpoint                          | Status     |
+| -------------- | --------------------------------- | ---------- |
+| linear-agent   | `/internal/linear/process-action` | 🔄 Pending |
+| todos-agent    | `/internal/todos`                 | 🔄 Pending |
+| notes-agent    | `/internal/notes`                 | 🔄 Pending |
+| links-agent    | `/internal/links`                 | 🔄 Pending |
+| calendar-agent | `/internal/calendar`              | 🔄 Pending |
+| research-agent | `/internal/research`              | 🔄 Pending |
 
 ---
 
@@ -153,12 +153,12 @@ For each downstream service, verify:
 
 ## Appendix: Affected Files
 
-| File | Change Type |
-|------|-------------|
-| `packages/common-core/src/types/actionFeedback.ts` | New file |
-| `packages/common-core/src/types/errorCodes.ts` | New file |
-| `apps/*/src/routes/internalRoutes.ts` | Update response |
-| `apps/actions-agent/src/infra/http/*Client.ts` | Parse `message` |
-| `apps/web/src/types/actionConfig.ts` | Add `message` to result |
-| `apps/web/src/pages/InboxPage.tsx` | Display backend message |
-| `apps/web/src/components/ConfigurableActionButton.tsx` | Pass `message` |
+| File                                                   | Change Type             |
+| ------------------------------------------------------ | ----------------------- |
+| `packages/common-core/src/types/actionFeedback.ts`     | New file                |
+| `packages/common-core/src/types/errorCodes.ts`         | New file                |
+| `apps/*/src/routes/internalRoutes.ts`                  | Update response         |
+| `apps/actions-agent/src/infra/http/*Client.ts`         | Parse `message`         |
+| `apps/web/src/types/actionConfig.ts`                   | Add `message` to result |
+| `apps/web/src/pages/InboxPage.tsx`                     | Display backend message |
+| `apps/web/src/components/ConfigurableActionButton.tsx` | Pass `message`          |

--- a/terraform/modules/iam/main.tf
+++ b/terraform/modules/iam/main.tf
@@ -410,6 +410,13 @@ resource "google_project_iam_member" "linear_agent_firestore" {
   member  = "serviceAccount:${google_service_account.linear_agent.email}"
 }
 
+# Calendar Agent: Firestore access
+resource "google_project_iam_member" "calendar_agent_firestore" {
+  project = var.project_id
+  role    = "roles/datastore.user"
+  member  = "serviceAccount:${google_service_account.calendar_agent.email}"
+}
+
 
 # All services: Cloud Logging (automatic for Cloud Run, but explicit)
 resource "google_project_iam_member" "user_service_logging" {


### PR DESCRIPTION
## Context

Addresses: [INT-135](https://linear.app/pbuchman/issue/INT-135/calendar-event-processing-fails-after-command-classification)

## What Changed

Added `roles/datastore.user` IAM permission to the calendar-agent service account in Terraform.

## Reasoning

### Investigation Findings

- Voice command via WhatsApp was correctly processed and classified as calendar
- Action approval/retry would fail with status "failed"
- Sentry error: `processCalendarAction: failed to check processed action` with `7 PERMISSION_DENIED: Missing or insufficient permissions.`
- Sentry issue: [INTEXURAOS-DEVELOPMENT-4](https://piotr-buchman.sentry.io/issues/INTEXURAOS-DEVELOPMENT-4) (49 occurrences)

### Root Cause

The calendar-agent service account was missing the `roles/datastore.user` IAM permission. This was an oversight when the idempotency feature was added in INT-97 - the code was added to use the `calendar_processed_actions` Firestore collection, but the corresponding IAM permission was never added.

All other agents that use Firestore (research-agent, commands-agent, actions-agent, linear-agent, etc.) have this permission, but calendar-agent was missed.

### Key Decisions

- Added the IAM permission in Terraform IAM module to match other agents' pattern
- No code changes needed - the issue is purely infrastructure configuration

## Testing

- [x] `pnpm run ci:tracked` passes
- [ ] After Terraform apply, verify calendar events can be created successfully

## Cross-References

- **Linear Issue**: [INT-135](https://linear.app/pbuchman/issue/INT-135/calendar-event-processing-fails-after-command-classification)
- **Sentry Issue**: [INTEXURAOS-DEVELOPMENT-4](https://piotr-buchman.sentry.io/issues/INTEXURAOS-DEVELOPMENT-4)

---

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>