### PR TITLE
[INT-136] Display chart configuration errors to user

### DIFF
--- a/.claude/ci-failures/intexuraos-fix_INT-136-chart-configuration-stuck.jsonl
+++ b/.claude/ci-failures/intexuraos-fix_INT-136-chart-configuration-stuck.jsonl
@@ -1,0 +1,1 @@
+{"ts":"2026-01-17T15:35:33.348Z","project":"intexuraos","branch":"fix/INT-136-chart-configuration-stuck","runNumber":1,"passed":true,"durationMs":521048,"failureCount":0,"failures":[]}

--- a/apps/web/src/pages/DataInsightsPage.tsx
+++ b/apps/web/src/pages/DataInsightsPage.tsx
@@ -20,6 +20,7 @@ export function DataInsightsPage(): React.JSX.Element {
   const {
     chartDefinition,
     generating: chartGenerating,
+    error: chartDefinitionError,
     generateDefinition,
     clearDefinition,
   } = useChartDefinition(feedId ?? '');
@@ -116,6 +117,20 @@ export function DataInsightsPage(): React.JSX.Element {
                   />
                 ))}
               </div>
+
+              {chartDefinitionError !== null && selectedInsight !== null && (
+                <div className="mt-6 rounded-lg border border-red-200 bg-red-50 p-4">
+                  <div className="flex items-start gap-2">
+                    <AlertCircle className="mt-0.5 h-5 w-5 flex-shrink-0 text-red-500" />
+                    <div>
+                      <p className="font-medium text-red-700">
+                        Failed to generate chart for: {selectedInsight.title}
+                      </p>
+                      <p className="mt-1 text-sm text-red-600">{chartDefinitionError}</p>
+                    </div>
+                  </div>
+                </div>
+              )}
 
               {chartDefinition !== null && selectedInsight !== null && (
                 <>


### PR DESCRIPTION
## Summary

- Fixes silent failure when chart configuration API call fails
- The `error` state from `useChartDefinition` hook was not being displayed to the user
- When the API call failed, the spinner would disappear with no feedback about the error

## Root Cause

The `useChartDefinition` hook properly captured errors:
```typescript
} catch (err) {
  setError(getErrorMessage(err, 'Failed to generate chart definition'));
  setChartDefinition(null);
}
```

But `DataInsightsPage` never destructured or displayed this error:
```typescript
const {
  chartDefinition,
  generating: chartGenerating,
  generateDefinition,
  clearDefinition,
  // error was missing!
} = useChartDefinition(feedId ?? '');
```

## Fix

1. Destructure `error` as `chartDefinitionError` from the hook
2. Add error display UI with red alert styling when error is present and insight is selected

## Test plan

- [x] CI passes with 5103 tests
- [ ] Manual testing: trigger API error and verify error message displays

Fixes INT-136

🤖 Generated with [Claude Code](https://claude.com/claude-code)