### PR TITLE
[INT-138] Validate inherited synthesis model API key

### DIFF
--- a/.claude/ci-failures/intexuraos-3-fix_INT-138-enhanced-research-lms-selection.jsonl
+++ b/.claude/ci-failures/intexuraos-3-fix_INT-138-enhanced-research-lms-selection.jsonl
@@ -1,0 +1,3 @@
+{"ts":"2026-01-17T18:15:46.337Z","project":"intexuraos-3","branch":"fix/INT-138-enhanced-research-lms-selection","workspace":"--","runNumber":1,"passed":false,"durationMs":1012,"failureCount":0,"failures":[]}
+{"ts":"2026-01-17T18:18:37.723Z","project":"intexuraos-3","branch":"fix/INT-138-enhanced-research-lms-selection","workspace":"research-agent","runNumber":2,"passed":true,"durationMs":164879,"failureCount":0,"failures":[]}
+{"ts":"2026-01-17T18:23:26.307Z","project":"intexuraos-3","branch":"fix/INT-138-enhanced-research-lms-selection","runNumber":3,"passed":true,"durationMs":218287,"failureCount":0,"failures":[]}


### PR DESCRIPTION
## Context

Addresses: [INT-138](https://linear.app/pbuchman/issue/INT-138/fix-multiple-issues-with-enhanced-research-and-lms-selection)

## What Changed

Fixed a bug where enhanced research could attempt to use models the user no longer has API keys for. When enhancing research without explicitly selecting a new synthesis model, the inherited synthesis model was not being validated against the user's available API keys.

## Reasoning

### Investigation Findings

The user reported that when enhancing research:
1. Even though Anthropic was shown as "disabled" in the UI (no API key)
2. The system still attempted to use Claude Opus for synthesis
3. This occurred when the source research used Claude Opus, and the user didn't explicitly change the synthesis model during enhancement

### Root Cause

In `researchRoutes.ts` the synthesis model validation (lines 1123-1131) only ran when `body.synthesisModel` was explicitly provided. When inheriting from source research:
- `createEnhancedResearch()` falls back to `source.synthesisModel` (line 261 in Research.ts)
- This inherited model was never validated against the user's current API keys

### Key Decisions

- **Validation at route level**: Added source research fetch BEFORE API key validation to know the effective synthesis model
- **Clear error messages**: User now receives proper MISCONFIGURED error with the specific model name when validation fails

## Testing

- [x] Added test: `returns 503 when API key is missing for inherited synthesis model`
- [x] Added test: `returns 500 when source research fetch fails`
- [x] All existing tests pass
- [x] `pnpm run ci:tracked` passes

## Cross-References

- **Linear Issue**: [INT-138](https://linear.app/pbuchman/issue/INT-138/fix-multiple-issues-with-enhanced-research-and-lms-selection)

---

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>