### PR TITLE
[INT-140] Investigate image missing in exported HTML

### DIFF
--- a/.claude/ci-failures/intexuraos-fix_INT-140-image-missing-html.jsonl
+++ b/.claude/ci-failures/intexuraos-fix_INT-140-image-missing-html.jsonl
@@ -1,0 +1,1 @@
+{"ts":"2026-01-17T19:15:26.526Z","project":"intexuraos","branch":"fix/INT-140-image-missing-html","runNumber":1,"passed":true,"durationMs":140756,"failureCount":0,"failures":[]}


### PR DESCRIPTION
## Context

Addresses: [INT-140](https://linear.app/pbuchman/issue/INT-140/image-missing-in-exported-html-after-research-enhancement)

This is an **investigation PR** - no code changes required. The reported issue does not represent a bug.

## Investigation Summary

The user reported that an enhanced research from January 16th had no image in the exported HTML. Investigation of GCP logs and Firestore data reveals:

### Researches Examined

| Research ID | Title | Started At | Has Cover Image | Source Research ID |
|------------|-------|------------|-----------------|-------------------|
| `479d0ce3...` | Evaluating LLMs for Expense Analysis | 2026-01-16T22:07:39Z | ✅ YES | `9949630d...` |
| `9949630d...` | Best LLMs for Expense Analysis Research | 2026-01-16T21:27:38Z | ❌ NO | None |

### Key Findings

**1. The enhanced research DOES have an image:**
- Cover image ID: `4d79032c-fb8e-4e72-8c0d-1093d4e7e48b`
- Image URL: `https://intexuraos.cloud/images/4d79032c-fb8e-4e72-8c0d-1093d4e7e48b-ai-expense-analysis-pipeline.png`
- HTML contains: `<img class="cover-image" src="..." alt="Evaluating LLMs for Expense Analysis">`

**2. The SOURCE research lacks an image (expected):**
- Logs show: `[4.4.1a] No API keys available for image generation (neither Google nor OpenAI key set)`
- This is the original research before enhancement

**3. Log evidence for enhanced research:**
```
2026-01-16T22:10:27Z [4.4.1] Starting cover image generation
2026-01-16T22:10:27Z [4.4.1b] Selected image model: gemini-2.5-flash-image (Google key: present, OpenAI key: present)
2026-01-16T22:10:27Z [4.4.2] Calling image-service /internal/images/prompts/generate (model: gemini-2.5-pro)
2026-01-16T22:10:59Z [4.4.3] Prompt generated (title: AI Expense Analysis Pipeline)
2026-01-16T22:11:06Z [4.4.4] Cover image generation completed (id: 4d79032c-fb8e-4e72-8c0d-1093d4e7e48b)
```

### Possible User Confusion

The user may have been looking at:
1. **The source research HTML** (which legitimately has no image due to missing API keys at creation time)
2. **A cached version** of the page
3. **A different research** than the one they enhanced at ~9-10 PM

### Additional Research Without Image (Jan 16th)

Found one enhanced research from earlier in the day without an image:
- `336a5d6a...` "Gran Canaria January Shore Spinning Spots" started at 05:36:13
- Logs confirm: `[4.4.1a] No API keys available for image generation`

This research was created ~17 hours before the evening session and is unrelated to the user's 9 PM enhancement.

## Conclusion

**No bug exists.** The image generation system works correctly:
- When API keys are present → Image is generated and attached
- When API keys are missing → Image generation is skipped with appropriate logging

The enhanced research from the evening of January 16th has a cover image properly generated and displayed.

## Testing

- [x] Verified image URL is accessible (HTTP 200)
- [x] Verified HTML contains cover-image tag
- [x] Verified Firestore document contains coverImageId in shareInfo
- [x] `pnpm run ci:tracked` passes

## Cross-References

- **Linear Issue**: [INT-140](https://linear.app/pbuchman/issue/INT-140/image-missing-in-exported-html-after-research-enhancement)
- **Related Issue**: INT-138 (LMS selection issue - already resolved)

---

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>