### PR TITLE
[INT-142] Accept number and boolean values in DefaultApplied

### DIFF
--- a/.claude/ci-failures/intexuraos-2-fix_INT-142.jsonl
+++ b/.claude/ci-failures/intexuraos-2-fix_INT-142.jsonl
@@ -1,0 +1,2 @@
+{"ts":"2026-01-17T20:51:34.928Z","project":"intexuraos-2","branch":"fix/INT-142","workspace":"llm-common","runNumber":1,"passed":false,"durationMs":882,"failureCount":0,"failures":[]}
+{"ts":"2026-01-17T20:53:43.680Z","project":"intexuraos-2","branch":"fix/INT-142","runNumber":2,"passed":true,"durationMs":121611,"failureCount":0,"failures":[]}

--- a/packages/llm-common/src/shared/__tests__/contextGuards.test.ts
+++ b/packages/llm-common/src/shared/__tests__/contextGuards.test.ts
@@ -7,6 +7,7 @@ import {
   isSafetyInfo,
   isStringArray,
   isObject,
+  isPrimitive,
 } from '../contextGuards.js';
 
 describe('DOMAINS constant', () => {
@@ -88,9 +89,50 @@ describe('isMode', () => {
   });
 });
 
+describe('isPrimitive', () => {
+  it('returns true for string values', () => {
+    expect(isPrimitive('hello')).toBe(true);
+    expect(isPrimitive('')).toBe(true);
+  });
+
+  it('returns true for number values', () => {
+    expect(isPrimitive(42)).toBe(true);
+    expect(isPrimitive(3.14)).toBe(true);
+    expect(isPrimitive(0)).toBe(true);
+    expect(isPrimitive(-1)).toBe(true);
+  });
+
+  it('returns true for boolean values', () => {
+    expect(isPrimitive(true)).toBe(true);
+    expect(isPrimitive(false)).toBe(true);
+  });
+
+  it('returns false for non-primitive values', () => {
+    expect(isPrimitive(null)).toBe(false);
+    expect(isPrimitive(undefined)).toBe(false);
+    expect(isPrimitive({})).toBe(false);
+    expect(isPrimitive([])).toBe(false);
+    expect(isPrimitive(() => undefined)).toBe(false);
+  });
+});
+
 describe('isDefaultApplied', () => {
-  it('returns true for valid default applied', () => {
+  it('returns true for valid default applied with string value', () => {
     expect(isDefaultApplied({ key: 'test', value: 'val', reason: 'why' })).toBe(true);
+  });
+
+  it('returns true for valid default applied with number value', () => {
+    expect(isDefaultApplied({ key: 'prefers_recent_years', value: 2, reason: 'recency' })).toBe(
+      true
+    );
+    expect(isDefaultApplied({ key: 'max_items', value: 10, reason: 'limit' })).toBe(true);
+  });
+
+  it('returns true for valid default applied with boolean value', () => {
+    expect(isDefaultApplied({ key: 'include_sources', value: true, reason: 'transparency' })).toBe(
+      true
+    );
+    expect(isDefaultApplied({ key: 'skip_cache', value: false, reason: 'performance' })).toBe(true);
   });
 
   it('returns false for invalid values', () => {
@@ -98,6 +140,12 @@ describe('isDefaultApplied', () => {
     expect(isDefaultApplied({})).toBe(false);
     expect(isDefaultApplied({ key: 'test' })).toBe(false);
     expect(isDefaultApplied('string')).toBe(false);
+  });
+
+  it('returns false when value is object or array', () => {
+    expect(isDefaultApplied({ key: 'test', value: {}, reason: 'why' })).toBe(false);
+    expect(isDefaultApplied({ key: 'test', value: [], reason: 'why' })).toBe(false);
+    expect(isDefaultApplied({ key: 'test', value: null, reason: 'why' })).toBe(false);
   });
 });
 

--- a/packages/llm-common/src/shared/contextGuards.ts
+++ b/packages/llm-common/src/shared/contextGuards.ts
@@ -47,11 +47,16 @@ export function isMode(value: unknown): value is Mode {
   return typeof value === 'string' && MODES.includes(value as Mode);
 }
 
+export function isPrimitive(value: unknown): value is string | number | boolean {
+  const type = typeof value;
+  return type === 'string' || type === 'number' || type === 'boolean';
+}
+
 export function isDefaultApplied(value: unknown): value is DefaultApplied {
   if (!isObject(value)) return false;
   return (
     typeof value['key'] === 'string' &&
-    typeof value['value'] === 'string' &&
+    isPrimitive(value['value']) &&
     typeof value['reason'] === 'string'
   );
 }

--- a/packages/llm-common/src/shared/contextTypes.ts
+++ b/packages/llm-common/src/shared/contextTypes.ts
@@ -54,7 +54,7 @@ export type Mode = 'compact' | 'standard' | 'audit';
 
 export interface DefaultApplied {
   key: string;
-  value: string;
+  value: string | number | boolean;
   reason: string;
 }
 


### PR DESCRIPTION
## Context

Addresses: [INT-142](https://linear.app/pbuchman/issue/INT-142/sentry-research-context-schema-validation-fails-for-numeric-values)

## What Changed

Updated `DefaultApplied` type and `isDefaultApplied` guard to accept `string | number | boolean` for the `value` field:

- `packages/llm-common/src/shared/contextTypes.ts` - Changed `value: string` to `value: string | number | boolean`
- `packages/llm-common/src/shared/contextGuards.ts` - Added `isPrimitive()` helper and updated guard to use it

## Reasoning

Research context inference was failing with "Schema validation failed" when LLMs returned numeric values in the `defaults_applied[].value` field.

### Investigation Findings

From Sentry issue INTEXURAOS-DEVELOPMENT-9:
- LLM returns `{ "key": "prefers_recent_years", "value": 2, "reason": "..." }`
- The guard expected `typeof value === 'string'` but received number
- This caused 15 occurrences of validation failures

### Key Decisions

- **Accept primitives, not just strings** - LLMs naturally return typed JSON values. Forcing string-only would require prompt engineering and coercion, adding complexity
- **Created `isPrimitive()` helper** - Clean separation of type check logic, reusable if needed elsewhere
- **Reject objects/arrays/null** - These complex types still fail validation as they're semantically incorrect for defaults

## Testing

- [x] Added tests for `isPrimitive()` (string, number, boolean, and negative cases)
- [x] Added tests for `isDefaultApplied()` with number and boolean values
- [x] `pnpm run ci:tracked` passes

## Cross-References

- **Linear Issue**: [INT-142](https://linear.app/pbuchman/issue/INT-142/sentry-research-context-schema-validation-fails-for-numeric-values)
- **Sentry Issue**: [INTEXURAOS-DEVELOPMENT-9](https://piotr-buchman.sentry.io/issues/INTEXURAOS-DEVELOPMENT-9)

---

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>