### PR TITLE
INT-141 Fix missing timezone in calendar events

### DIFF
--- a/.claude/ci-failures/intexuraos-fix_INT-141-calendar-timezone.jsonl
+++ b/.claude/ci-failures/intexuraos-fix_INT-141-calendar-timezone.jsonl
@@ -1,0 +1,2 @@
+{"ts":"2026-01-17T20:55:28.931Z","project":"intexuraos","branch":"fix/INT-141-calendar-timezone","workspace":"--","runNumber":1,"passed":false,"durationMs":346,"failureCount":0,"failures":[]}
+{"ts":"2026-01-17T20:56:27.759Z","project":"intexuraos","branch":"fix/INT-141-calendar-timezone","workspace":"calendar-agent","runNumber":2,"passed":true,"durationMs":52065,"failureCount":0,"failures":[]}

--- a/apps/calendar-agent/src/__tests__/fakes.ts
+++ b/apps/calendar-agent/src/__tests__/fakes.ts
@@ -59,6 +59,8 @@ export class FakeGoogleCalendarClient implements GoogleCalendarClient {
   private updateResult: Result<CalendarEvent, CalendarError> | null = null;
   private deleteResult: Result<void, CalendarError> | null = null;
   private freeBusyResult: Result<Map<string, FreeBusySlot[]>, CalendarError> | null = null;
+  private calendarTimezone = 'Europe/Warsaw';
+  private timezoneResult: Result<string, CalendarError> | null = null;
 
   addEvent(event: CalendarEvent): void {
     this.events.push(event);
@@ -86,6 +88,25 @@ export class FakeGoogleCalendarClient implements GoogleCalendarClient {
 
   setFreeBusyResult(result: Result<Map<string, FreeBusySlot[]>, CalendarError>): void {
     this.freeBusyResult = result;
+  }
+
+  setCalendarTimezone(timezone: string): void {
+    this.calendarTimezone = timezone;
+  }
+
+  setTimezoneResult(result: Result<string, CalendarError>): void {
+    this.timezoneResult = result;
+  }
+
+  async getCalendarTimezone(
+    _accessToken: string,
+    _calendarId: string,
+    _logger: unknown
+  ): Promise<Result<string, CalendarError>> {
+    if (this.timezoneResult !== null) {
+      return this.timezoneResult;
+    }
+    return ok(this.calendarTimezone);
   }
 
   async listEvents(

--- a/apps/calendar-agent/src/__tests__/infra/googleCalendarClient.test.ts
+++ b/apps/calendar-agent/src/__tests__/infra/googleCalendarClient.test.ts
@@ -123,6 +123,59 @@ describe('GoogleCalendarClientImpl', () => {
     });
   });
 
+  describe('getCalendarTimezone', () => {
+    it('gets timezone successfully', async () => {
+      nock(GOOGLE_CALENDAR_API)
+        .get('/calendar/v3/calendars/primary')
+        .reply(200, {
+          id: 'primary',
+          summary: 'Primary Calendar',
+          timeZone: 'America/New_York',
+        });
+
+      const result = await client.getCalendarTimezone(TEST_ACCESS_TOKEN, TEST_CALENDAR_ID, mockLogger);
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value).toBe('America/New_York');
+      }
+    });
+
+    it('defaults to UTC when timeZone is not present', async () => {
+      nock(GOOGLE_CALENDAR_API)
+        .get('/calendar/v3/calendars/primary')
+        .reply(200, {
+          id: 'primary',
+          summary: 'Primary Calendar',
+        });
+
+      const result = await client.getCalendarTimezone(TEST_ACCESS_TOKEN, TEST_CALENDAR_ID, mockLogger);
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value).toBe('UTC');
+      }
+    });
+
+    it('returns error on API failure', async () => {
+      nock(GOOGLE_CALENDAR_API)
+        .get('/calendar/v3/calendars/primary')
+        .reply(401, {
+          error: {
+            code: 401,
+            message: 'Invalid credentials',
+          },
+        });
+
+      const result = await client.getCalendarTimezone(TEST_ACCESS_TOKEN, TEST_CALENDAR_ID, mockLogger);
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe('TOKEN_ERROR');
+      }
+    });
+  });
+
   describe('getEvent', () => {
     it('gets event successfully', async () => {
       nock(GOOGLE_CALENDAR_API)

--- a/apps/calendar-agent/src/domain/ports.ts
+++ b/apps/calendar-agent/src/domain/ports.ts
@@ -19,6 +19,12 @@ import type {
 import type { CalendarError } from './errors.js';
 
 export interface GoogleCalendarClient {
+  getCalendarTimezone(
+    accessToken: string,
+    calendarId: string,
+    logger: Logger
+  ): Promise<Result<string, CalendarError>>;
+
   listEvents(
     accessToken: string,
     calendarId: string,

--- a/apps/calendar-agent/src/infra/google/googleCalendarClient.ts
+++ b/apps/calendar-agent/src/infra/google/googleCalendarClient.ts
@@ -177,6 +177,28 @@ function filterUndefined<T extends Record<string, unknown>>(obj: T): Partial<T> 
 }
 
 export class GoogleCalendarClientImpl implements GoogleCalendarClient {
+  async getCalendarTimezone(
+    accessToken: string,
+    calendarId: string,
+    logger: Logger
+  ): Promise<Result<string, CalendarError>> {
+    logger.debug({ calendarId }, 'GoogleCalendarClient.getCalendarTimezone: request');
+    try {
+      const oauth2Client = new google.auth.OAuth2();
+      oauth2Client.setCredentials({ access_token: accessToken });
+      const calendar = google.calendar({ version: 'v3', auth: oauth2Client });
+
+      const response = await calendar.calendars.get({ calendarId });
+      const timeZone = response.data.timeZone ?? 'UTC';
+      logger.debug({ calendarId, timeZone }, 'GoogleCalendarClient.getCalendarTimezone: response');
+      return ok(timeZone);
+    } catch (error) {
+      const calendarError = mapErrorToCalendarError(error);
+      logger.error({ calendarId, error: calendarError }, 'GoogleCalendarClient.getCalendarTimezone: error');
+      return err(calendarError);
+    }
+  }
+
   async listEvents(
     accessToken: string,
     calendarId: string,


### PR DESCRIPTION
## Summary

Fixes the Sentry error "Missing time zone definition for start time" by adding proper timezone handling to Google Calendar event creation.

**Root Cause:** The `toEventDateTime()` function was not including the `timeZone` field. Google Calendar API requires this when `dateTime` is set.

**Solution:**
1. Added `calendar.readonly` scope to OAuth requests (new users get this automatically)
2. Added `getCalendarTimezone()` to fetch timezone from Google Calendar API
3. Events now include `timeZone` field from user's calendar settings
4. Existing users with old scope get `TOKEN_ERROR` prompting them to reconnect

## Changes

**calendar-agent:**
- `domain/ports.ts` - Added `getCalendarTimezone` to interface
- `infra/google/googleCalendarClient.ts` - Implemented timezone fetching
- `domain/useCases/processCalendarAction.ts` - Integrated timezone, returns `TOKEN_ERROR` for missing scope

**user-service:**
- `infra/google/googleOAuthClient.ts` - Added `calendar.readonly` scope

## Test Plan

- [x] All 5162 tests pass
- [x] Tests cover: timezone fetching, event creation with timezone, TOKEN_ERROR on permission denied, all-day events without timezone

Fixes INT-141

🤖 Generated with [Claude Code](https://claude.com/claude-code)