### PR TITLE
[INT-144] Add one-by-one question rule to CLAUDE.md

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -620,6 +620,16 @@ Use the same command: `pnpm run verify:workspace:tracked -- web` — adjusted be
 
 ---
 
+## User Communication
+
+**RULE: When asking clarifying questions, ask ONE question at a time.**
+
+Use the AskUserQuestion tool for each question separately. Do not batch multiple questions unless the user explicitly requests it (e.g., "ask me all questions at once").
+
+**Why:** One-by-one questioning allows focused responses and early course-correction.
+
+---
+
 ## Pull Request Workflow (DEFAULT)
 
 **When asked to create a PR, follow this default workflow:**

--- a/.claude/ci-failures/intexuraos-1-fix_INT-144.jsonl
+++ b/.claude/ci-failures/intexuraos-1-fix_INT-144.jsonl
@@ -1,0 +1,1 @@
+{"ts":"2026-01-18T11:08:27.878Z","project":"intexuraos-1","branch":"fix/INT-144","runNumber":1,"passed":true,"durationMs":184750,"failureCount":0,"failures":[]}

--- a/.claude/commands/linear.md
+++ b/.claude/commands/linear.md
@@ -2,6 +2,8 @@
 
 Manage Linear issues, branches, and PRs with enforced workflow and cross-linking.
 
+**Project Key:** `INT-` (e.g., `INT-123`, `INT-144`). All issue references in this document use generic `LIN-XXX` placeholders, but for this project always use `INT-XXX`.
+
 ## Usage
 
 ```
@@ -37,7 +39,7 @@ Manage Linear issues, branches, and PRs with enforced workflow and cross-linking
 
 ```bash
 /linear Fix authentication token not refreshing
-/linear LIN-42
+/linear INT-42                                    # Use INT- prefix for this project
 /linear https://intexuraos-dev-pbuchman.sentry.io/issues/123/
 /linear
 ```
@@ -52,7 +54,7 @@ The command automatically detects intent from input:
 | ------------------------------- | -------------------------------- | ------------------------------------------------------------ |
 | `/linear` (no args)             | Random Backlog (NON-INTERACTIVE) | Pick from Backlog/Todo and start working WITHOUT asking user |
 | `/linear <task description>`    | Create New                       | Detect bug/feature, create issue, start working              |
-| `/linear LIN-<number>`          | Work Existing                    | Start working on specific issue                              |
+| `/linear INT-<number>`          | Work Existing                    | Start working on specific issue (use INT- for this project)  |
 | `/linear https://sentry.io/...` | Sentry Integration               | Create Linear issue from Sentry error                        |
 
 ---


### PR DESCRIPTION
## Context

Addresses: [INT-144](https://linear.app/pbuchman/issue/INT-144/update-claudemd-add-rule-for-one-by-one-question-asking)

## What Changed

1. **CLAUDE.md**: Added "User Communication" section with rule for asking clarifying questions one at a time
2. **linear.md**: Added clear note that the project key is `INT-` and updated examples to use `INT-` prefix

## Reasoning

### One-by-One Question Rule

When gathering requirements or clarifying ambiguous tasks, asking multiple questions at once can overwhelm users and lead to:
- Partially addressed responses
- Lost context between multiple topics
- Difficulty in course-correcting early

The rule establishes that the AskUserQuestion tool should be used for each question separately unless the user explicitly requests batched questions.

### INT- Prefix Clarification

The linear.md documentation used generic placeholders (`LIN-XXX`, `PBU-XX`) which could cause confusion. Adding explicit mention of the `INT-` project key makes it clear what prefix to use for this repository.

## Testing

- [x] `pnpm run ci:tracked` passes
- [x] Documentation changes only - no code affected

## Cross-References

- **Linear Issue**: [INT-144](https://linear.app/pbuchman/issue/INT-144/update-claudemd-add-rule-for-one-by-one-question-asking)

---

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>