### PR TITLE
[INT-145] Add terraform module for claude-code-dev service account

### DIFF
--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -501,6 +501,18 @@ module "iam" {
 }
 
 # -----------------------------------------------------------------------------
+# Claude Code Dev Service Account (local development)
+# -----------------------------------------------------------------------------
+
+module "claude_code_dev" {
+  source = "../../modules/claude-code-dev"
+
+  project_id = var.project_id
+
+  depends_on = [google_project_service.apis]
+}
+
+# -----------------------------------------------------------------------------
 # Common Service Secrets (must be after secret_manager module)
 # -----------------------------------------------------------------------------
 
@@ -1813,4 +1825,9 @@ output "calendar_agent_url" {
 output "monitoring_dashboard_id" {
   description = "Monitoring dashboard ID"
   value       = module.monitoring.dashboard_id
+}
+
+output "claude_code_dev_service_account" {
+  description = "Claude Code dev service account email for local development"
+  value       = module.claude_code_dev.service_account_email
 }

--- a/terraform/modules/claude-code-dev/README.md
+++ b/terraform/modules/claude-code-dev/README.md
@@ -1,0 +1,134 @@
+# Claude Code Dev Service Account
+
+Terraform module for managing the `claude-code-dev` service account used for local development with Claude Code CLI.
+
+## Purpose
+
+This service account provides admin access for development workflows:
+
+- **Terraform operations** - plan, apply, destroy
+- **Firestore access** - queries, document manipulation
+- **GCS access** - bucket operations, signed URLs
+- **Secret Manager** - reading secrets for local development
+- **IAM operations** - service account management
+- **Cloud Build** - trigger management
+- **Cloud Run** - service deployment
+
+## Usage
+
+```hcl
+module "claude_code_dev" {
+  source = "../../modules/claude-code-dev"
+
+  project_id = var.project_id
+}
+```
+
+## Importing Existing Resources
+
+If the service account already exists (e.g., was created manually), import it into Terraform state before applying:
+
+```bash
+cd terraform/environments/dev
+
+# Import service account
+terraform import module.claude_code_dev.google_service_account.claude_code_dev \
+  projects/intexuraos-dev-pbuchman/serviceAccounts/claude-code-dev@intexuraos-dev-pbuchman.iam.gserviceaccount.com
+
+# Import each role binding (repeat for each role)
+terraform import 'module.claude_code_dev.google_project_iam_member.claude_code_dev_roles["roles/artifactregistry.admin"]' \
+  "intexuraos-dev-pbuchman roles/artifactregistry.admin serviceAccount:claude-code-dev@intexuraos-dev-pbuchman.iam.gserviceaccount.com"
+```
+
+## Recovery Procedure
+
+If the environment needs to be recreated (e.g., new GCP project), follow these steps:
+
+### 1. Apply Terraform
+
+```bash
+cd terraform/environments/dev
+GOOGLE_APPLICATION_CREDENTIALS=<existing-owner-key> terraform apply
+```
+
+### 2. Generate Service Account Key
+
+```bash
+gcloud iam service-accounts keys create ~/personal/gcloud-claude-code-dev.json \
+  --iam-account=claude-code-dev@<project-id>.iam.gserviceaccount.com
+```
+
+### 3. Activate Service Account
+
+```bash
+gcloud auth activate-service-account --key-file=~/personal/gcloud-claude-code-dev.json
+```
+
+### 4. Verify Access
+
+```bash
+gcloud auth list
+gcloud projects describe <project-id>
+```
+
+## Key Management
+
+**IMPORTANT:** Service account keys are NOT managed by Terraform.
+
+| Item            | Location                                 |
+| --------------- | ---------------------------------------- |
+| Key file        | `~/personal/gcloud-claude-code-dev.json` |
+| Version control | **NEVER** commit keys to the repository  |
+| Rotation        | Manually rotate keys via `gcloud` CLI    |
+
+### Key Rotation
+
+```bash
+# List existing keys
+gcloud iam service-accounts keys list \
+  --iam-account=claude-code-dev@<project-id>.iam.gserviceaccount.com
+
+# Create new key
+gcloud iam service-accounts keys create ~/personal/gcloud-claude-code-dev-new.json \
+  --iam-account=claude-code-dev@<project-id>.iam.gserviceaccount.com
+
+# After verifying new key works, delete old key
+gcloud iam service-accounts keys delete <key-id> \
+  --iam-account=claude-code-dev@<project-id>.iam.gserviceaccount.com
+```
+
+## Permissions Granted
+
+| Role                                   | Purpose                               |
+| -------------------------------------- | ------------------------------------- |
+| `roles/artifactregistry.admin`         | Docker image repository management    |
+| `roles/cloudbuild.connectionAdmin`     | Cloud Build GitHub connections        |
+| `roles/cloudscheduler.admin`           | Scheduled job management              |
+| `roles/compute.admin`                  | Load balancer, SSL certs, networking  |
+| `roles/firebase.admin`                 | Firebase/Identity Platform            |
+| `roles/iam.serviceAccountAdmin`        | Service account CRUD                  |
+| `roles/iam.workloadIdentityPoolAdmin`  | Workload Identity Federation          |
+| `roles/logging.admin`                  | Cloud Logging configuration           |
+| `roles/monitoring.admin`               | Monitoring dashboards and alerts      |
+| `roles/pubsub.admin`                   | Pub/Sub topics and subscriptions      |
+| `roles/resourcemanager.projectIamAdmin`| Project IAM policy management         |
+| `roles/run.admin`                      | Cloud Run service deployment          |
+| `roles/secretmanager.admin`            | Secret creation and access            |
+| `roles/serviceusage.serviceUsageAdmin` | API enablement                        |
+| `roles/storage.objectAdmin`            | GCS bucket and object management      |
+
+## Security Considerations
+
+1. **Key storage**: Store keys in a secure location outside the repository
+2. **Least privilege**: Uses specific admin roles instead of `roles/owner`
+3. **Audit logging**: All API calls are logged in Cloud Audit Logs
+4. **Key expiration**: GCP keys don't expire automatically; implement manual rotation
+
+## Outputs
+
+| Output                  | Description                            |
+| ----------------------- | -------------------------------------- |
+| `service_account_email` | Full email for the service account     |
+| `service_account_id`    | Unique ID of the service account       |
+| `service_account_name`  | Resource name for IAM bindings         |
+| `granted_roles`         | List of IAM roles granted              |

--- a/terraform/modules/claude-code-dev/main.tf
+++ b/terraform/modules/claude-code-dev/main.tf
@@ -1,0 +1,46 @@
+# Claude Code Dev Service Account Module
+# Creates a service account for local development with Claude Code CLI.
+# This service account provides admin access for development workflows
+# including terraform operations, Firestore queries, and resource management.
+#
+# IMPORTANT: Key management is external to Terraform.
+# After the service account is created, manually generate a key via:
+#   gcloud iam service-accounts keys create ~/personal/gcloud-claude-code-dev.json \
+#     --iam-account=claude-code-dev@${project_id}.iam.gserviceaccount.com
+#
+# Keys should be stored securely outside of version control.
+
+resource "google_service_account" "claude_code_dev" {
+  account_id   = "claude-code-dev"
+  display_name = "claude-code-dev"
+  description  = "Service account for Claude Code development"
+}
+
+# Project-level IAM roles for full terraform management capabilities
+locals {
+  project_roles = [
+    "roles/artifactregistry.admin",
+    "roles/cloudbuild.connectionAdmin",
+    "roles/cloudscheduler.admin",
+    "roles/compute.admin",
+    "roles/firebase.admin",
+    "roles/iam.serviceAccountAdmin",
+    "roles/iam.workloadIdentityPoolAdmin",
+    "roles/logging.admin",
+    "roles/monitoring.admin",
+    "roles/pubsub.admin",
+    "roles/resourcemanager.projectIamAdmin",
+    "roles/run.admin",
+    "roles/secretmanager.admin",
+    "roles/serviceusage.serviceUsageAdmin",
+    "roles/storage.objectAdmin",
+  ]
+}
+
+resource "google_project_iam_member" "claude_code_dev_roles" {
+  for_each = toset(local.project_roles)
+
+  project = var.project_id
+  role    = each.value
+  member  = "serviceAccount:${google_service_account.claude_code_dev.email}"
+}

--- a/terraform/modules/claude-code-dev/outputs.tf
+++ b/terraform/modules/claude-code-dev/outputs.tf
@@ -1,0 +1,19 @@
+output "service_account_email" {
+  description = "Claude Code dev service account email"
+  value       = google_service_account.claude_code_dev.email
+}
+
+output "service_account_id" {
+  description = "Claude Code dev service account unique ID"
+  value       = google_service_account.claude_code_dev.unique_id
+}
+
+output "service_account_name" {
+  description = "Claude Code dev service account resource name"
+  value       = google_service_account.claude_code_dev.name
+}
+
+output "granted_roles" {
+  description = "List of IAM roles granted to the service account"
+  value       = local.project_roles
+}

--- a/terraform/modules/claude-code-dev/variables.tf
+++ b/terraform/modules/claude-code-dev/variables.tf
@@ -1,0 +1,4 @@
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}


### PR DESCRIPTION
## Context

Addresses: [INT-145](https://linear.app/pbuchman/issue/INT-145/service-account-added-to-terraform)

## What Changed

- Created new terraform module `claude-code-dev` for managing the development service account
- Added module instantiation in `environments/dev/main.tf`
- Imported existing resources into terraform state (no infrastructure changes)
- Added comprehensive README with recovery and import procedures

### New Module: `terraform/modules/claude-code-dev/`

| File           | Purpose                                           |
| -------------- | ------------------------------------------------- |
| `main.tf`      | Service account + 15 IAM role bindings            |
| `variables.tf` | Project ID input                                  |
| `outputs.tf`   | Service account email, ID, name, granted roles    |
| `README.md`    | Documentation for recovery, import, key management |

### Permissions Granted (15 roles)

| Role                                   | Purpose                               |
| -------------------------------------- | ------------------------------------- |
| `roles/artifactregistry.admin`         | Docker image repository management    |
| `roles/cloudbuild.connectionAdmin`     | Cloud Build GitHub connections        |
| `roles/cloudscheduler.admin`           | Scheduled job management              |
| `roles/compute.admin`                  | Load balancer, SSL certs, networking  |
| `roles/firebase.admin`                 | Firebase/Identity Platform            |
| `roles/iam.serviceAccountAdmin`        | Service account CRUD                  |
| `roles/iam.workloadIdentityPoolAdmin`  | Workload Identity Federation          |
| `roles/logging.admin`                  | Cloud Logging configuration           |
| `roles/monitoring.admin`               | Monitoring dashboards and alerts      |
| `roles/pubsub.admin`                   | Pub/Sub topics and subscriptions      |
| `roles/resourcemanager.projectIamAdmin`| Project IAM policy management         |
| `roles/run.admin`                      | Cloud Run service deployment          |
| `roles/secretmanager.admin`            | Secret creation and access            |
| `roles/serviceusage.serviceUsageAdmin` | API enablement                        |
| `roles/storage.objectAdmin`            | GCS bucket and object management      |

## Reasoning

The goal is to codify the service account configuration in terraform for:

1. **Environment recovery** - If the GCP project needs to be recreated, the service account and permissions can be restored via `terraform apply`
2. **Documentation** - The module README documents key management, rotation, and import procedures
3. **Auditability** - Changes to the service account are now tracked in git

### Key Decisions

- **Separate module from IAM** - The existing IAM module is for Cloud Run service accounts with least-privilege patterns. The claude-code-dev account is a different category (admin/dev access), so it gets its own module.
- **Specific roles vs roles/owner** - Uses 15 specific admin roles instead of `roles/owner` for better security posture while maintaining full terraform management capabilities
- **No key management in terraform** - Service account keys are sensitive and should be managed manually outside of version control
- **Import instructions included** - Documentation includes terraform import commands for onboarding existing accounts

## Testing

- [x] `terraform validate` passes
- [x] `terraform fmt -check -recursive` passes  
- [x] `terraform plan` shows **no changes** (all resources imported)

## Cross-References

- **Linear Issue**: [INT-145](https://linear.app/pbuchman/issue/INT-145/service-account-added-to-terraform)

---

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>