### PR TITLE
[INT-165] Remove LIVE indicator and simplify refresh button in inbox

### DIFF
--- a/.claude/ci-failures/intexuraos-2-fix_INT-165-inbox-indicators.jsonl
+++ b/.claude/ci-failures/intexuraos-2-fix_INT-165-inbox-indicators.jsonl
@@ -1,0 +1,3 @@
+{"ts":"2026-01-19T13:05:07.785Z","project":"intexuraos-2","branch":"fix/INT-165-inbox-indicators","workspace":"--","runNumber":1,"passed":false,"durationMs":422,"failureCount":0,"failures":[]}
+{"ts":"2026-01-19T13:06:19.065Z","project":"intexuraos-2","branch":"fix/INT-165-inbox-indicators","workspace":"web","runNumber":2,"passed":true,"durationMs":64770,"failureCount":0,"failures":[]}
+{"ts":"2026-01-19T13:09:16.091Z","project":"intexuraos-2","branch":"fix/INT-165-inbox-indicators","runNumber":3,"passed":true,"durationMs":165814,"failureCount":0,"failures":[]}

--- a/apps/web/src/pages/InboxPage.tsx
+++ b/apps/web/src/pages/InboxPage.tsx
@@ -3,7 +3,6 @@ import {
   ActionDetailModal,
   ActionItem,
   CommandDetailModal,
-  Button,
   Card,
   Layout,
 } from '@/components';
@@ -39,7 +38,6 @@ import {
   Loader2,
   MessageSquare,
   Mic,
-  Radio,
   RefreshCw,
   Search,
   Trash2,
@@ -277,7 +275,6 @@ export function InboxPage(): React.JSX.Element {
   const {
     changedActionIds,
     error: actionListenerError,
-    isListening: isActionsListening,
     clearChangedIds: clearActionChangedIds,
   } = useActionChanges(activeTab === 'actions');
 
@@ -285,12 +282,10 @@ export function InboxPage(): React.JSX.Element {
   const {
     changedCommandIds,
     error: commandListenerError,
-    isListening: isCommandsListening,
     clearChangedIds: clearCommandChangedIds,
   } = useCommandChanges(activeTab === 'commands');
 
   const listenerError = activeTab === 'actions' ? actionListenerError : commandListenerError;
-  const isListening = activeTab === 'actions' ? isActionsListening : isCommandsListening;
 
   // Ref for debounce timeout
   const actionsDebounceTimeoutRef = useRef<number | null>(null);
@@ -636,25 +631,16 @@ export function InboxPage(): React.JSX.Element {
       <div className="mb-6 flex items-center justify-between">
         <div>
           <h2 className="text-2xl font-bold text-slate-900">Inbox</h2>
-          <div className="flex items-center gap-2">
-            <p className="text-slate-600">Your commands and pending actions</p>
-            {isListening && (
-              <span className="inline-flex items-center gap-1 text-xs text-green-600">
-                <Radio className="h-3 w-3 animate-pulse" />
-                Live
-              </span>
-            )}
-          </div>
+          <p className="text-slate-600">Your commands and pending actions</p>
         </div>
-        <Button
-          variant="secondary"
+        <button
           onClick={handleRefresh}
-          isLoading={isRefreshing}
-          className="flex items-center gap-2"
+          disabled={isRefreshing}
+          className="rounded p-2 text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-600 disabled:opacity-50"
+          title="Refresh"
         >
-          <RefreshCw className={`h-4 w-4 ${isRefreshing ? 'animate-spin' : ''}`} />
-          Refresh
-        </Button>
+          <RefreshCw className={`h-5 w-5 ${isRefreshing ? 'animate-spin' : ''}`} />
+        </button>
       </div>
 
       {/* Real-time listener error warning */}


### PR DESCRIPTION
## Context

Addresses: [INT-165](https://linear.app/pbuchman/issue/INT-165/adjust-live-indicator-and-refresh-button-in-inbox)

## What Changed

- **Removed LIVE indicator**: The pulsing green "Live" text with radio icon has been completely removed from the inbox header
- **Simplified REFRESH button**: Changed from a prominent secondary button with text to a subtle icon-only button with muted slate colors that only become visible on hover

## Reasoning

The user requested reducing visual noise in the inbox UI:
1. The LIVE indicator was drawing too much attention with its pulsing animation and green color
2. The REFRESH button was too prominent for an action that rarely needs manual invocation (real-time updates are automatic via Firebase listeners)

### Design Approach

The new refresh button follows the existing pattern used elsewhere in the codebase (e.g., delete/archive buttons in `CommandItem`) - a subtle `text-slate-400` icon that becomes more visible on hover. This maintains consistency while reducing visual clutter.

## Testing

- [x] Manual testing completed
- [x] `pnpm run ci:tracked` passes

## Cross-References

- **Linear Issue**: [INT-165](https://linear.app/pbuchman/issue/INT-165/adjust-live-indicator-and-refresh-button-in-inbox)

---

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>