### PR TITLE
INT-163 Sort inbox actions by createdAt instead of updatedAt

### DIFF
--- a/.claude/ci-failures/intexuraos-feature_int-163-inbox-sorting-by-created.jsonl
+++ b/.claude/ci-failures/intexuraos-feature_int-163-inbox-sorting-by-created.jsonl
@@ -1,0 +1,3 @@
+{"ts":"2026-01-19T13:07:25.848Z","project":"intexuraos","branch":"feature/int-163-inbox-sorting-by-created","workspace":"--","runNumber":1,"passed":false,"durationMs":490,"failureCount":0,"failures":[]}
+{"ts":"2026-01-19T13:09:15.628Z","project":"intexuraos","branch":"feature/int-163-inbox-sorting-by-created","workspace":"actions-agent","runNumber":2,"passed":true,"durationMs":102564,"failureCount":0,"failures":[]}
+{"ts":"2026-01-19T13:11:41.472Z","project":"intexuraos","branch":"feature/int-163-inbox-sorting-by-created","runNumber":3,"passed":true,"durationMs":134218,"failureCount":0,"failures":[]}

--- a/apps/actions-agent/src/__tests__/infra/firestore/actionRepository.test.ts
+++ b/apps/actions-agent/src/__tests__/infra/firestore/actionRepository.test.ts
@@ -224,6 +224,35 @@ describe('FirestoreActionRepository', () => {
 
       expect(result).toHaveLength(2);
     });
+
+    it('sorts by createdAt descending, not updatedAt', async () => {
+      const olderCreatedAt = '2026-01-01T10:00:00.000Z';
+      const newerCreatedAt = '2026-01-02T10:00:00.000Z';
+      const recentUpdatedAt = '2026-01-03T10:00:00.000Z';
+
+      await repository.save(
+        createTestAction({
+          id: 'action-older',
+          userId: 'user-123',
+          createdAt: olderCreatedAt,
+          updatedAt: recentUpdatedAt,
+        })
+      );
+      await repository.save(
+        createTestAction({
+          id: 'action-newer',
+          userId: 'user-123',
+          createdAt: newerCreatedAt,
+          updatedAt: newerCreatedAt,
+        })
+      );
+
+      const result = await repository.listByUserId('user-123');
+
+      expect(result).toHaveLength(2);
+      expect(result[0]?.id).toBe('action-newer');
+      expect(result[1]?.id).toBe('action-older');
+    });
   });
 
   describe('listByStatus', () => {

--- a/apps/actions-agent/src/infra/firestore/actionRepository.ts
+++ b/apps/actions-agent/src/infra/firestore/actionRepository.ts
@@ -99,7 +99,7 @@ export function createFirestoreActionRepository(deps?: CreateFirestoreActionRepo
         query = query.where('status', 'in', options.status);
       }
 
-      const snapshot = await query.orderBy('updatedAt', 'desc').limit(100).get();
+      const snapshot = await query.orderBy('createdAt', 'desc').limit(100).get();
 
       return snapshot.docs.map((doc) => toAction(doc.id, doc.data() as ActionDoc));
     },

--- a/migrations/030_actions-createdAt-sorting-index.mjs
+++ b/migrations/030_actions-createdAt-sorting-index.mjs
@@ -1,0 +1,36 @@
+/**
+ * Migration 030: Actions createdAt Sorting Index
+ *
+ * Adds composite index for filtering actions by status while sorting by createdAt.
+ * Required for listByUserId() with status filter in actions-agent after INT-163.
+ *
+ * Query pattern: where(userId) + where(status in [...]) + orderBy(createdAt DESC)
+ *
+ * This replaces the updatedAt sorting with createdAt to prevent confusing
+ * ordering when actions are updated (e.g., approved) - the user expects to see
+ * actions in chronological order of creation, not last modification.
+ */
+
+export const metadata = {
+  id: '030',
+  name: 'actions-createdAt-sorting-index',
+  description: 'Add composite index for actions filtered by status and sorted by createdAt',
+  createdAt: '2026-01-19',
+};
+
+export const indexes = [
+  {
+    collectionGroup: 'actions',
+    queryScope: 'COLLECTION',
+    fields: [
+      { fieldPath: 'status', order: 'ASCENDING' },
+      { fieldPath: 'userId', order: 'ASCENDING' },
+      { fieldPath: 'createdAt', order: 'DESCENDING' },
+    ],
+  },
+];
+
+export async function up(context) {
+  console.log('  Deploying Firestore index for actions createdAt sorting...');
+  await context.deployIndexes();
+}


### PR DESCRIPTION
## Summary
- Changed inbox actions sorting from `updatedAt` to `createdAt` in the action repository
- Added migration 030 with composite index for status filtering with createdAt sorting
- Added test case to verify sorting behavior

## Problem
When actions were updated (e.g., approved, status changed), they would jump to the top of the inbox list due to `updatedAt` sorting. This caused confusion when approving actions because recently updated (not recently created) actions appeared first.

## Solution
Changed `listByUserId()` in the action repository to sort by `createdAt DESC` instead of `updatedAt DESC`. This ensures actions appear in chronological order based on when they were created, providing a stable and predictable ordering.

## Test plan
- [ ] Verified new test case passes: "sorts by createdAt descending, not updatedAt"
- [ ] CI passes with all 5287 tests
- [ ] Migration 030 adds required composite index

Fixes INT-163

🤖 Generated with [Claude Code](https://claude.ai/code)