### PR TITLE
INT-159 Clean up URL after opening modal from deep link

### DIFF
--- a/.claude/ci-failures/intexuraos-fix_INT-159-clean-url-on-modal-close.jsonl
+++ b/.claude/ci-failures/intexuraos-fix_INT-159-clean-url-on-modal-close.jsonl
@@ -1,0 +1,1 @@
+{"ts":"2026-01-19T13:17:57.330Z","project":"intexuraos","branch":"fix/INT-159-clean-url-on-modal-close","runNumber":1,"passed":true,"durationMs":131127,"failureCount":0,"failures":[]}

--- a/apps/web/src/pages/InboxPage.tsx
+++ b/apps/web/src/pages/InboxPage.tsx
@@ -559,6 +559,10 @@ export function InboxPage(): React.JSX.Element {
       return;
     }
 
+    // Clean up URL immediately to prevent modal reappearing on refresh
+    const cleanHash = hash.split('?')[0] ?? '';
+    window.history.replaceState(null, '', cleanHash !== '' ? cleanHash : window.location.pathname);
+
     // First check if action is in current list (fast path)
     const actionInList = actions.find((a) => a.id === actionId);
     if (actionInList !== undefined) {


### PR DESCRIPTION
## Summary
- Fixes issue where inbox action modal would reappear on page refresh after being closed
- Uses `window.history.replaceState()` to clear URL query parameters immediately after opening modal from deep link
- Aligns InboxPage behavior with other pages (Notes, Bookmarks, Todos) that already clean up URL params

## Technical Details
InboxPage uses hash-based deep linking with `?action=<id>` in the URL hash (e.g., `/#/inbox?action=abc123`). Previously, the URL was not cleaned up after the modal opened, causing the modal to reopen if the user refreshed the page after closing it.

The fix clears the query parameters immediately after extracting the action ID, before the modal is shown.

## Comprehensive Modal Audit

### Modals WITH URL Deep Linking (5 total):

| Page              | URL Pattern              | Cleanup Status              |
|-------------------|--------------------------|------------------------------|
| NotesListPage     | `?id=<note-id>`          | ✅ Already handled           |
| BookmarksListPage | `?id=<bookmark-id>`      | ✅ Already handled           |
| TodosListPage     | `?id=<todo-id>`          | ✅ Already handled           |
| **InboxPage**     | `?action=<id>` (in hash) | 🔧 **Fixed in this PR**      |
| ResearchAgentPage | `?draftId=<draft-id>`    | ⚠️ No cleanup (intentional) |

### Modals WITHOUT URL Deep Linking (state-controlled):

| Component             | Notes                            |
|-----------------------|----------------------------------|
| ImageModal            | Opened via `messageId` prop      |
| ActionDetailModal     | Opened via `selectedAction` state|
| CommandDetailModal    | Opened via `selectedCommand` state|
| BookmarkConflictModal | Nested inside ActionDetailModal  |

**Note:** ResearchAgentPage intentionally keeps `?draftId` in URL for draft editing workflow - user needs to return to draft after refresh.

## Test plan
- [x] CI passes (5286 tests)
- [ ] Manual test: Navigate to `/#/inbox?action=<valid-id>` → modal opens
- [ ] Manual test: Close modal and refresh page → modal stays closed
- [ ] Manual test: Direct navigation to `/#/inbox` works normally

Fixes INT-159

🤖 Generated with [Claude Code](https://claude.com/claude-code)