### PR TITLE
[INT-157] Fix PWA share creating duplicate inbox items

### DIFF
--- a/.claude/ci-failures/intexuraos-fix_INT-157-pwa-share-duplicate-inbox.jsonl
+++ b/.claude/ci-failures/intexuraos-fix_INT-157-pwa-share-duplicate-inbox.jsonl
@@ -1,0 +1,1 @@
+{"ts":"2026-01-19T13:40:25.442Z","project":"intexuraos","branch":"fix/INT-157-pwa-share-duplicate-inbox","runNumber":1,"passed":true,"durationMs":130557,"failureCount":0,"failures":[]}

--- a/apps/commands-agent/src/routes/commandsRoutes.ts
+++ b/apps/commands-agent/src/routes/commandsRoutes.ts
@@ -116,6 +116,7 @@ export const commandsRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
           properties: {
             text: { type: 'string', minLength: 1 },
             source: { type: 'string', enum: ['pwa-shared'] },
+            externalId: { type: 'string', minLength: 1 },
           },
           required: ['text', 'source'],
         },
@@ -168,10 +169,14 @@ export const commandsRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
         return;
       }
 
-      const { text, source } = request.body as { text: string; source: 'pwa-shared' };
-      const timestamp = Date.now();
-      const randomSuffix = Math.random().toString(36).substring(2, 9);
-      const externalId = `${String(timestamp)}-${randomSuffix}`;
+      const { text, source, externalId: clientExternalId } = request.body as {
+        text: string;
+        source: 'pwa-shared';
+        externalId?: string;
+      };
+
+      const externalId =
+        clientExternalId ?? `${String(Date.now())}-${Math.random().toString(36).substring(2, 9)}`;
 
       const { processCommandUseCase } = getServices();
       const result = await processCommandUseCase.execute({

--- a/apps/web/src/context/SyncQueueContext.tsx
+++ b/apps/web/src/context/SyncQueueContext.tsx
@@ -79,6 +79,7 @@ export function SyncQueueProvider({ children }: SyncQueueProviderProps): React.J
           const command = await createCommand(token, {
             text: item.content,
             source: item.source,
+            externalId: item.externalId,
           });
 
           markAsSynced(item.id, command.id);

--- a/apps/web/src/services/commandsApi.ts
+++ b/apps/web/src/services/commandsApi.ts
@@ -131,7 +131,7 @@ export async function batchGetActions(accessToken: string, actionIds: string[]):
 
 export async function createCommand(
   accessToken: string,
-  params: { text: string; source: CommandSourceType }
+  params: { text: string; source: CommandSourceType; externalId?: string }
 ): Promise<Command> {
   const response = await apiRequest<{ command: Command }>(
     config.commandsAgentServiceUrl,

--- a/apps/web/src/services/shareQueue.ts
+++ b/apps/web/src/services/shareQueue.ts
@@ -16,6 +16,7 @@ export interface ShareQueueItem {
   id: string;
   content: string;
   source: 'pwa-shared';
+  externalId: string;
   createdAt: string;
   retryCount: number;
   nextRetryAt: string;
@@ -34,6 +35,10 @@ export interface ShareHistoryItem {
 
 function generateId(): string {
   return `share_${String(Date.now())}_${Math.random().toString(36).slice(2, 9)}`;
+}
+
+function generateExternalId(): string {
+  return `${String(Date.now())}-${Math.random().toString(36).substring(2, 9)}`;
 }
 
 function truncateContent(content: string, maxLength = 100): string {
@@ -73,6 +78,7 @@ export function addToQueue(content: string): ShareQueueItem {
     id: generateId(),
     content,
     source: 'pwa-shared',
+    externalId: generateExternalId(),
     createdAt: new Date().toISOString(),
     retryCount: 0,
     nextRetryAt: new Date().toISOString(),


### PR DESCRIPTION
## Context

Addresses: [INT-157](https://linear.app/pbuchman/issue/INT-157/pwa-share-creates-approval-inbox-items)

## What Changed

Added client-side `externalId` generation for PWA share queue to enable idempotent command creation. Previously, each API retry would generate a new `externalId` server-side, bypassing the deduplication logic and creating duplicate inbox items.

### Changes by file:

| File | Change |
|------|--------|
| `apps/web/src/services/shareQueue.ts` | Added `externalId` field to `ShareQueueItem`, generated once when item is queued |
| `apps/web/src/services/commandsApi.ts` | Accept optional `externalId` parameter |
| `apps/web/src/context/SyncQueueContext.tsx` | Pass `externalId` to API on each request |
| `apps/commands-agent/src/routes/commandsRoutes.ts` | Use client-provided `externalId` if present, fallback to server-generated |

## Reasoning

### Root Cause Analysis

The commands-agent has proper deduplication at `processCommand.ts:62-73`:
```typescript
const existingCommand = await commandRepository.getById(commandId);
if (existingCommand !== null) {
  logger.info('Command already exists, skipping processing');
  return { command: existingCommand, isNew: false };
}
```

However, deduplication relies on `externalId` being the same for retries. The problem:

1. **Web app queues share** with ID `share_12345_abc`
2. **First API call** → server generates `externalId = "1705123456-xyz789"` → creates command
3. **Network timeout** → browser doesn't know if successful
4. **Retry** → server generates **new** `externalId = "1705123465-abc456"` → bypasses dedup → creates duplicate

WhatsApp sources don't have this issue because they use the external message ID (provided by WhatsApp).

### Fix

Generate `externalId` client-side when the share is first queued, persist it in localStorage, and send the same ID on every retry attempt. The server now accepts an optional `externalId` and only generates one if not provided.

## Testing

- [x] CI passes (5286 tests)
- [ ] Manual test: Share content via PWA → verify single inbox item
- [ ] Manual test: Share content, then go offline, come back online → verify no duplicates
- [ ] Manual test: Share content with slow network → verify deduplication works on retries

Fixes INT-157

---

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
🤖 Generated with [Claude Code](https://claude.com/claude-code)