### PR TITLE
[INT-158] Enhance link classification confidence

### DIFF
--- a/.claude/ci-failures/intexuraos-1-feature_INT-158-enhance-link-classification.jsonl
+++ b/.claude/ci-failures/intexuraos-1-feature_INT-158-enhance-link-classification.jsonl
@@ -1,0 +1,3 @@
+{"ts":"2026-01-19T14:15:55.689Z","project":"intexuraos-1","branch":"feature/INT-158-enhance-link-classification","workspace":"--","runNumber":1,"passed":false,"durationMs":951,"failureCount":0,"failures":[]}
+{"ts":"2026-01-19T14:17:02.404Z","project":"intexuraos-1","branch":"feature/INT-158-enhance-link-classification","workspace":"commands-agent","runNumber":2,"passed":true,"durationMs":61710,"failureCount":0,"failures":[]}
+{"ts":"2026-01-19T14:21:30.385Z","project":"intexuraos-1","branch":"feature/INT-158-enhance-link-classification","runNumber":3,"passed":true,"durationMs":249709,"failureCount":0,"failures":[]}

--- a/apps/commands-agent/src/domain/ports/classifier.ts
+++ b/apps/commands-agent/src/domain/ports/classifier.ts
@@ -1,4 +1,4 @@
-import type { CommandType } from '../models/command.js';
+import type { CommandType, CommandSourceType } from '../models/command.js';
 import type { ResearchModel } from '@intexuraos/llm-contract';
 import type { LlmGenerateClient } from '@intexuraos/llm-factory';
 
@@ -10,8 +10,12 @@ export interface ClassificationResult {
   selectedModels?: ResearchModel[];
 }
 
+export interface ClassifyOptions {
+  sourceType?: CommandSourceType;
+}
+
 export interface Classifier {
-  classify(text: string): Promise<ClassificationResult>;
+  classify(text: string, options?: ClassifyOptions): Promise<ClassificationResult>;
 }
 
 export type ClassifierFactory = (client: LlmGenerateClient) => Classifier;

--- a/apps/commands-agent/src/domain/usecases/processCommand.ts
+++ b/apps/commands-agent/src/domain/usecases/processCommand.ts
@@ -115,7 +115,7 @@ export function createProcessCommandUseCase(deps: {
 
       try {
         const classifier = classifierFactory(llmClientResult.value);
-        const classification = await classifier.classify(input.text);
+        const classification = await classifier.classify(input.text, { sourceType: input.sourceType });
 
         logger.info(
           {

--- a/packages/llm-common/src/classification/commandClassifierPrompt.ts
+++ b/packages/llm-common/src/classification/commandClassifierPrompt.ts
@@ -78,6 +78,10 @@ Signals: how does, what is, why, find out, learn about, ?
 **link** — URL to save
 Signals: contains http://, https://, or "save this link"
 - "https://example.com interesting article" → link
+**Higher confidence (0.90+) for links when:**
+- Sharing context phrases present: "check this out", "look at this", "you should see this", "found this", "sharing", "see this"
+- Explicit recommendation: "this is great", "interesting", "nice item", "cool link"
+- App-generated share format (clean URL with optional brief text)
 
 **note** — Information to store
 Signals: notes, idea, remember that, jot down


### PR DESCRIPTION
## Context

Addresses: [INT-158](https://linear.app/pbuchman/issue/INT-158/enhance-link-classification-confidence)

## What Changed

- Enhanced the command classifier prompt to detect contextual sharing phrases ("check this out", "look at this", "found this", etc.) and assign higher confidence (0.90+) for links with these signals
- Added a confidence boost (+0.1) for links shared via PWA (`pwa-shared` source type), since app-generated shares indicate strong user intent
- Updated the `Classifier` interface to accept an optional `ClassifyOptions` with `sourceType`
- Modified `processCommand` use case to pass `sourceType` to the classifier

## Reasoning

### Investigation Findings

The current classification system uses LLM-based classification with confidence scoring:
- Confidence determines auto-execution: ≥90% auto-saves links, <90% requires user approval
- Links shared via PWA (`pwa-shared`) already have a distinct `sourceType` that indicates intentional sharing from an app

### Key Decisions

- **Prompt-level enhancement**: Added detection for sharing context phrases to the LLM prompt, allowing the model to recognize signals like "check this out", "you should see this", "interesting", etc.
- **Code-level boost**: Added a 10% confidence boost for `pwa-shared` links since app-generated shares (e.g., from AliExpress app) indicate explicit user intent to save the link
- **Capped at 1.0**: Boosted confidence is clamped to prevent exceeding the valid range
- **Non-breaking change**: The `options` parameter is optional, maintaining backward compatibility

## Testing

- [x] Added tests for PWA-shared confidence boost (5 new test cases)
- [x] `pnpm run ci:tracked` passes

## Cross-References

- **Linear Issue**: [INT-158](https://linear.app/pbuchman/issue/INT-158/enhance-link-classification-confidence)

---

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>