### PR TITLE
INT-160 Fix empty chart definition in Data Insights

### DIFF
--- a/.claude/ci-failures/intexuraos-fix_INT-160-chart-definition-empty.jsonl
+++ b/.claude/ci-failures/intexuraos-fix_INT-160-chart-definition-empty.jsonl
@@ -1,0 +1,3 @@
+{"ts":"2026-01-19T14:17:47.770Z","project":"intexuraos","branch":"fix/INT-160-chart-definition-empty","workspace":"--","runNumber":1,"passed":false,"durationMs":468,"failureCount":0,"failures":[]}
+{"ts":"2026-01-19T14:20:15.545Z","project":"intexuraos","branch":"fix/INT-160-chart-definition-empty","workspace":"data-insights-agent","runNumber":2,"passed":true,"durationMs":140482,"failureCount":0,"failures":[]}
+{"ts":"2026-01-19T14:23:04.432Z","project":"intexuraos","branch":"fix/INT-160-chart-definition-empty","runNumber":3,"passed":true,"durationMs":152595,"failureCount":0,"failures":[]}

--- a/apps/data-insights-agent/src/routes/dataInsightsSchemas.ts
+++ b/apps/data-insights-agent/src/routes/dataInsightsSchemas.ts
@@ -61,6 +61,7 @@ export const chartDefinitionResponseSchema = {
       properties: {
         vegaLiteConfig: {
           type: 'object',
+          additionalProperties: true,
           description: 'Vega-Lite chart configuration without data',
         },
         dataTransformInstructions: {
@@ -89,6 +90,7 @@ export const previewBodySchema = {
   properties: {
     chartConfig: {
       type: 'object',
+      additionalProperties: true,
       description: 'Vega-Lite chart configuration from chart definition endpoint',
     },
     transformInstructions: {


### PR DESCRIPTION
## Summary
- Fixed empty chart definition JSON in Data Insights visualizations
- Added `additionalProperties: true` to `vegaLiteConfig` in response schema
- Added `additionalProperties: true` to `chartConfig` in preview body schema

## Root Cause
Fastify's AJV validation strips properties not defined in JSON schemas by default. The `vegaLiteConfig` object was defined as `{ type: 'object' }` without `additionalProperties: true`, causing ALL properties in the Vega-Lite chart configuration to be stripped before reaching the frontend.

## Test plan
- [x] CI passes with all 5286 tests
- [ ] Manual verification: Configure a chart in Data Insights and confirm the JSON definition displays correctly
- [ ] Manual verification: Generate preview works with the populated chart config

Fixes INT-160

🤖 Generated with [Claude Code](https://claude.com/claude-code)