### PR TITLE
[INT-192] Fix Cloud Run instance-based billing

### DIFF
--- a/terraform/modules/cloud-run-service/main.tf
+++ b/terraform/modules/cloud-run-service/main.tf
@@ -31,6 +31,10 @@ resource "google_cloud_run_v2_service" "service" {
           cpu    = var.cpu
           memory = var.memory
         }
+        # CPU is only allocated during request processing (request-based billing)
+        # Setting cpu_idle = true enables CPU throttling, which is more cost-effective
+        # than instance-based billing where CPU is always allocated.
+        cpu_idle = true
       }
 
       # Environment variables from Secret Manager
@@ -97,7 +101,9 @@ resource "google_cloud_run_v2_service" "service" {
       template[0].containers[0].image,
       # Ignore drift from gcloud/GCP API
       template[0].annotations,
-      template[0].containers[0].resources[0].cpu_idle,
+      # NOTE: cpu_idle is NOT ignored - Terraform enforces cpu_idle = true
+      # (request-based billing) to prevent accidental instance-based billing.
+      # See INT-192 for context on billing impact.
       client,
       client_version,
     ]


### PR DESCRIPTION
## Context

Addresses: [INT-192](https://linear.app/pbuchman/issue/INT-192/what-is-running-instance-based-billing-kill-it-asap)

## What Changed

Modified `terraform/modules/cloud-run-service/main.tf` to:
1. Remove `cpu_idle` from `ignore_changes` lifecycle block
2. Explicitly set `cpu_idle = true` in the resources block

This ensures Terraform enforces request-based billing (CPU throttling) and corrects any drift to instance-based billing.

## Investigation Findings

### Root Cause
"Running instance based billing" in GCP Cloud Run refers to **CPU always allocated** mode (`cpu-throttling: false`). This charges for the entire container lifetime, not just request processing time.

### Affected Services (11 with instance-based billing)

| Service | cpu-throttling | Impact |
|---------|---------------|--------|
| intexuraos-app-settings-service | **false** | ❌ Instance-based |
| intexuraos-bookmarks-agent | **false** | ❌ Instance-based |
| intexuraos-calendar-agent | **false** | ❌ Instance-based |
| intexuraos-commands-agent | **false** | ❌ Instance-based |
| intexuraos-data-insights-agent | **false** | ❌ Instance-based |
| intexuraos-image-service | **false** | ❌ Instance-based |
| intexuraos-linear-agent | **false** | ❌ Instance-based |
| intexuraos-notes-agent | **false** | ❌ Instance-based |
| intexuraos-research-agent | **false** | ❌ Instance-based |
| intexuraos-todos-agent | **false** | ❌ Instance-based |
| intexuraos-web-agent | **false** | ❌ Instance-based |

### Services Already Correct (7 with request-based billing)

| Service | cpu-throttling | Status |
|---------|---------------|--------|
| intexuraos-actions-agent | true | ✅ OK |
| intexuraos-api-docs-hub | true | ✅ OK |
| intexuraos-mobile-notifications-service | true | ✅ OK |
| intexuraos-notion-service | true | ✅ OK |
| intexuraos-promptvault-service | true | ✅ OK |
| intexuraos-user-service | true | ✅ OK |
| intexuraos-whatsapp-service | true | ✅ OK |

### Why This Happened
The Terraform module had `cpu_idle` in `ignore_changes`, so manual changes (via gcloud or Cloud Console) to enable instance-based billing were not corrected by Terraform.

## Post-Merge Action Required

After merging, run `terraform apply` to fix all 11 affected services:

```bash
cd terraform/environments/dev
GOOGLE_APPLICATION_CREDENTIALS=/home/pbuchman/service-account.json \
STORAGE_EMULATOR_HOST= FIRESTORE_EMULATOR_HOST= PUBSUB_EMULATOR_HOST= \
terraform plan

# Review the plan, then apply
GOOGLE_APPLICATION_CREDENTIALS=/home/pbuchman/service-account.json \
STORAGE_EMULATOR_HOST= FIRESTORE_EMULATOR_HOST= PUBSUB_EMULATOR_HOST= \
terraform apply
```

## Testing

- [ ] Terraform plan shows cpu_idle changes for affected services
- [ ] After terraform apply, verify services use request-based billing

## Cross-References

- **Linear Issue**: [INT-192](https://linear.app/pbuchman/issue/INT-192/what-is-running-instance-based-billing-kill-it-asap)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)