### PR TITLE
[INT-179] Change @zai-claude trigger to @zaiclaude

### DIFF
--- a/.github/workflows/zai-claude.yml
+++ b/.github/workflows/zai-claude.yml
@@ -13,10 +13,10 @@ on:
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@zai-claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@zai-claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@zai-claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@zai-claude') || contains(github.event.issue.title, '@zai-claude')))
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@zaiclaude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@zaiclaude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@zaiclaude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@zaiclaude') || contains(github.event.issue.title, '@zaiclaude')))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -33,18 +33,9 @@ jobs:
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1
-        with:
-          anthropic_api_key: ${{ secrets.ZAI_API_KEY }}
         env:
           ANTHROPIC_BASE_URL: https://api.z.ai/api/anthropic
-          # This is an optional setting that allows Claude to read CI results on PRs
+        with:
+          anthropic_api_key: ${{ secrets.ZAI_API_KEY }}
           additional_permissions: |
             actions: read
-
-          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
-          # prompt: 'Update the pull request description to include a summary of changes.'
-
-          # Optional: Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'


### PR DESCRIPTION
## Summary
- Update Z.ai workflow to trigger on `@zaiclaude` mentions (instead of `@zai-claude`)
- Fix YAML structure (env block at step level, before with)
- Clean up unnecessary comments

## Test plan
- [ ] Verify workflow triggers when mentioning `@zaiclaude` in an issue comment
- [ ] Verify workflow does NOT trigger on `@zai-claude` mentions
- [ ] Confirm Z.ai API key is configured in repo secrets

Fixes [INT-179](https://linear.app/pbuchman/issue/INT-179)

🤖 Generated with [Claude Code](https://claude.com/claude-code)