### PR TITLE
[INT-194] Add --cpu-throttling to prevent billing drift

### DIFF
--- a/cloudbuild/scripts/deploy-actions-agent.sh
+++ b/cloudbuild/scripts/deploy-actions-agent.sh
@@ -29,6 +29,7 @@ gcloud run deploy "$CLOUD_RUN_SERVICE" \
   --image="$image" \
   --region="$REGION" \
   --platform=managed \
+  --cpu-throttling \
   --quiet
 
 log "Deployment complete for ${SERVICE}"

--- a/cloudbuild/scripts/deploy-api-docs-hub.sh
+++ b/cloudbuild/scripts/deploy-api-docs-hub.sh
@@ -29,6 +29,7 @@ gcloud run deploy "$CLOUD_RUN_SERVICE" \
   --image="$image" \
   --region="$REGION" \
   --platform=managed \
+  --cpu-throttling \
   --quiet
 
 log "Deployment complete for ${SERVICE}" 

--- a/cloudbuild/scripts/deploy-app-settings-service.sh
+++ b/cloudbuild/scripts/deploy-app-settings-service.sh
@@ -29,6 +29,7 @@ gcloud run deploy "$CLOUD_RUN_SERVICE" \
   --image="$image" \
   --region="$REGION" \
   --platform=managed \
+  --cpu-throttling \
   --quiet
 
 log "Deployment complete for ${SERVICE}"

--- a/cloudbuild/scripts/deploy-bookmarks-agent.sh
+++ b/cloudbuild/scripts/deploy-bookmarks-agent.sh
@@ -29,6 +29,7 @@ gcloud run deploy "$CLOUD_RUN_SERVICE" \
   --image="$image" \
   --region="$REGION" \
   --platform=managed \
+  --cpu-throttling \
   --quiet
 
 log "Deployment complete for ${SERVICE}"

--- a/cloudbuild/scripts/deploy-calendar-agent.sh
+++ b/cloudbuild/scripts/deploy-calendar-agent.sh
@@ -29,6 +29,7 @@ gcloud run deploy "$CLOUD_RUN_SERVICE" \
   --image="$image" \
   --region="$REGION" \
   --platform=managed \
+  --cpu-throttling \
   --quiet
 
 log "Deployment complete for ${SERVICE}"

--- a/cloudbuild/scripts/deploy-commands-agent.sh
+++ b/cloudbuild/scripts/deploy-commands-agent.sh
@@ -29,6 +29,7 @@ gcloud run deploy "$CLOUD_RUN_SERVICE" \
   --image="$image" \
   --region="$REGION" \
   --platform=managed \
+  --cpu-throttling \
   --quiet
 
 log "Deployment complete for ${SERVICE}"

--- a/cloudbuild/scripts/deploy-data-insights-agent.sh
+++ b/cloudbuild/scripts/deploy-data-insights-agent.sh
@@ -29,6 +29,7 @@ gcloud run deploy "$CLOUD_RUN_SERVICE" \
   --image="$image" \
   --region="$REGION" \
   --platform=managed \
+  --cpu-throttling \
   --quiet
 
 log "Deployment complete for ${SERVICE}"

--- a/cloudbuild/scripts/deploy-image-service.sh
+++ b/cloudbuild/scripts/deploy-image-service.sh
@@ -29,6 +29,7 @@ gcloud run deploy "$CLOUD_RUN_SERVICE" \
   --image="$image" \
   --region="$REGION" \
   --platform=managed \
+  --cpu-throttling \
   --quiet
 
 log "Deployment complete for ${SERVICE}"

--- a/cloudbuild/scripts/deploy-linear-agent.sh
+++ b/cloudbuild/scripts/deploy-linear-agent.sh
@@ -29,6 +29,7 @@ gcloud run deploy "$CLOUD_RUN_SERVICE" \
   --image="$image" \
   --region="$REGION" \
   --platform=managed \
+  --cpu-throttling \
   --quiet
 
 log "Deployment complete for ${SERVICE}"

--- a/cloudbuild/scripts/deploy-mobile-notifications-service.sh
+++ b/cloudbuild/scripts/deploy-mobile-notifications-service.sh
@@ -29,6 +29,7 @@ gcloud run deploy "$CLOUD_RUN_SERVICE" \
   --image="$image" \
   --region="$REGION" \
   --platform=managed \
+  --cpu-throttling \
   --quiet
 
 log "Deployment complete for ${SERVICE}"

--- a/cloudbuild/scripts/deploy-notes-agent.sh
+++ b/cloudbuild/scripts/deploy-notes-agent.sh
@@ -29,6 +29,7 @@ gcloud run deploy "$CLOUD_RUN_SERVICE" \
   --image="$image" \
   --region="$REGION" \
   --platform=managed \
+  --cpu-throttling \
   --quiet
 
 log "Deployment complete for ${SERVICE}"

--- a/cloudbuild/scripts/deploy-notion-service.sh
+++ b/cloudbuild/scripts/deploy-notion-service.sh
@@ -29,6 +29,7 @@ gcloud run deploy "$CLOUD_RUN_SERVICE" \
   --image="$image" \
   --region="$REGION" \
   --platform=managed \
+  --cpu-throttling \
   --quiet
 
 log "Deployment complete for ${SERVICE}"

--- a/cloudbuild/scripts/deploy-promptvault-service.sh
+++ b/cloudbuild/scripts/deploy-promptvault-service.sh
@@ -29,6 +29,7 @@ gcloud run deploy "$CLOUD_RUN_SERVICE" \
   --image="$image" \
   --region="$REGION" \
   --platform=managed \
+  --cpu-throttling \
   --quiet
 
 log "Deployment complete for ${SERVICE}" 

--- a/cloudbuild/scripts/deploy-research-agent.sh
+++ b/cloudbuild/scripts/deploy-research-agent.sh
@@ -29,6 +29,7 @@ gcloud run deploy "$CLOUD_RUN_SERVICE" \
   --image="$image" \
   --region="$REGION" \
   --platform=managed \
+  --cpu-throttling \
   --quiet
 
 log "Deployment complete for ${SERVICE}"

--- a/cloudbuild/scripts/deploy-todos-agent.sh
+++ b/cloudbuild/scripts/deploy-todos-agent.sh
@@ -29,6 +29,7 @@ gcloud run deploy "$CLOUD_RUN_SERVICE" \
   --image="$image" \
   --region="$REGION" \
   --platform=managed \
+  --cpu-throttling \
   --quiet
 
 log "Deployment complete for ${SERVICE}"

--- a/cloudbuild/scripts/deploy-user-service.sh
+++ b/cloudbuild/scripts/deploy-user-service.sh
@@ -29,6 +29,7 @@ gcloud run deploy "$CLOUD_RUN_SERVICE" \
   --image="$image" \
   --region="$REGION" \
   --platform=managed \
+  --cpu-throttling \
   --quiet
 
 log "Deployment complete for ${SERVICE}" 

--- a/cloudbuild/scripts/deploy-web-agent.sh
+++ b/cloudbuild/scripts/deploy-web-agent.sh
@@ -29,6 +29,7 @@ gcloud run deploy "$CLOUD_RUN_SERVICE" \
   --image="$image" \
   --region="$REGION" \
   --platform=managed \
+  --cpu-throttling \
   --quiet
 
 log "Deployment complete for ${SERVICE}"

--- a/cloudbuild/scripts/deploy-whatsapp-service.sh
+++ b/cloudbuild/scripts/deploy-whatsapp-service.sh
@@ -29,6 +29,7 @@ gcloud run deploy "$CLOUD_RUN_SERVICE" \
   --image="$image" \
   --region="$REGION" \
   --platform=managed \
+  --cpu-throttling \
   --quiet
 
 log "Deployment complete for ${SERVICE}" 


### PR DESCRIPTION
## Summary
- Add `--cpu-throttling` flag to all 18 Cloud Run deploy scripts
- Explicitly enforces request-based billing on every deploy
- Prevents drift if gcloud defaults ever change

## Root Cause Analysis
The billing drift in INT-192 occurred because `gcloud run deploy` was called without explicit `--cpu-throttling` flag. Combined with Terraform ignoring `template[0].annotations`, the setting could drift without detection.

## Changes
All deploy scripts now include:
```bash
gcloud run deploy "$CLOUD_RUN_SERVICE" \
  --image="$image" \
  --region="$REGION" \
  --platform=managed \
  --cpu-throttling \   # ← Added
  --quiet
```

## Test plan
- [ ] Verify scripts have correct syntax
- [ ] Deploy succeeds after merge
- [ ] Cloud Run services maintain `cpu-throttling: true`

Fixes [INT-194](https://linear.app/pbuchman/issue/INT-194)

🤖 Generated with [Claude Code](https://claude.com/claude-code)