### PR TITLE
Add processing status to default inbox filters

### DIFF
--- a/.claude/ci-failures/intexuraos-2-fix_INT-184-inbox-processing-filter.jsonl
+++ b/.claude/ci-failures/intexuraos-2-fix_INT-184-inbox-processing-filter.jsonl
@@ -1,0 +1,3 @@
+{"ts":"2026-01-21T00:55:19.059Z","project":"intexuraos-2","branch":"fix/INT-184-inbox-processing-filter","workspace":"--","runNumber":1,"passed":false,"durationMs":1628,"failureCount":0,"failures":[]}
+{"ts":"2026-01-21T01:01:25.604Z","project":"intexuraos-2","branch":"fix/INT-184-inbox-processing-filter","workspace":"web","runNumber":2,"passed":true,"durationMs":344484,"failureCount":0,"failures":[]}
+{"ts":"2026-01-21T01:10:40.377Z","project":"intexuraos-2","branch":"fix/INT-184-inbox-processing-filter","runNumber":3,"passed":true,"durationMs":531328,"failureCount":0,"failures":[]}

--- a/apps/web/src/pages/InboxPage.tsx
+++ b/apps/web/src/pages/InboxPage.tsx
@@ -259,15 +259,16 @@ export function InboxPage(): React.JSX.Element {
               s === 'approved' ||
               s === 'rejected' ||
               s === 'completed' ||
-              s === 'failed'
+              s === 'failed' ||
+              s === 'processing'
           );
         }
       } catch {
         // Invalid JSON, use defaults
       }
     }
-    // Default: show awaiting_approval and failed
-    return ['awaiting_approval', 'failed'];
+    // Default: show awaiting_approval, failed, and processing
+    return ['awaiting_approval', 'failed', 'processing'];
   });
   const [isFilterExpanded, setIsFilterExpanded] = useState(false);
 


### PR DESCRIPTION
## Summary
- Updates the default inbox filter to include 'processing' status alongside 'awaiting_approval' and 'failed'
- Users now see actions that are currently being processed in the inbox view by default
- Updates the localStorage filter validation to recognize 'processing' as a valid status value

## Test plan
- [ ] Load inbox page and verify 'processing' is checked by default in the filter dropdown
- [ ] Verify actions with 'processing' status appear in the inbox list
- [ ] Clear localStorage and reload to verify default filters include 'processing'

Fixes INT-184

🤖 Generated with [Claude Code](https://claude.com/claude-code)