### PR TITLE
[INT-183] Improve transcription accuracy for LLM/LLMs terms

### DIFF
--- a/apps/api-docs-hub/src/index.ts
+++ b/apps/api-docs-hub/src/index.ts
@@ -6,8 +6,9 @@ import { initSentry } from '@intexuraos/infra-sentry';
 import { buildServer } from './server.js';
 import { loadConfig } from './config.js';
 
+const sentryDsn = process.env['INTEXURAOS_SENTRY_DSN'];
 initSentry({
-  dsn: process.env['INTEXURAOS_SENTRY_DSN'],
+  ...(sentryDsn !== undefined && { dsn: sentryDsn }),
   environment: process.env['INTEXURAOS_ENVIRONMENT'] ?? 'development',
   serviceName: 'api-docs-hub',
 });

--- a/apps/whatsapp-service/src/infra/speechmatics/adapter.ts
+++ b/apps/whatsapp-service/src/infra/speechmatics/adapter.ts
@@ -109,8 +109,37 @@ const ADDITIONAL_VOCAB = [
   { content: 'Anthropic', sounds_like: ['an throw pick', 'an throp ik'] },
   { content: 'Perplexity', sounds_like: ['per plex ity'] },
   { content: 'Perplexity Sonar', sounds_like: ['perplexity sonar'] },
-  { content: 'LMS', sounds_like: ['el em ess', 'l m s'] },
-  { content: 'LLM', sounds_like: ['el el em', 'l l m'] },
+  { content: 'LMS', sounds_like: ['el em ess', 'learning management system'] },
+  {
+    content: 'LLM',
+    sounds_like: [
+      'el el em',
+      'elle em',
+      'large language model',
+      'ell ell em',
+      'double l m',
+      'ell l m',
+    ],
+  },
+  {
+    content: 'LLMs',
+    sounds_like: [
+      'el el ems',
+      'elle ems',
+      'large language models',
+      'ell ell ems',
+      'double l ms',
+      'ell l ms',
+    ],
+  },
+  {
+    content: 'large language model',
+    sounds_like: ['large lang model', 'large language model', 'large lang models'],
+  },
+  {
+    content: 'large language models',
+    sounds_like: ['large lang models', 'large language models', 'large lang model'],
+  },
 
   // Platform tools and services
   { content: 'Linear', sounds_like: ['line ear', 'linear app', 'lin ear', 'linear', 'leener'] },


### PR DESCRIPTION
## Context

Addresses: [INT-183](https://linear.app/pbuchman/issue/INT-183/improve-transcription-accuracy-for-specific-terms)

## What Changed

Enhanced the Speechmatics custom vocabulary (`ADDITIONAL_VOCAB`) to improve recognition of "LLM" and "LLMs" terms, distinguishing them from "LMS".

**Vocabulary Changes:**

1. **LLM entry** - Added multiple sounds_like patterns:
   - `el el em`, `elle em`, `large language model`, `ell ell em`, `double l m`, `ell l m`

2. **New LLMs entry** - Plural form with corresponding sounds_like:
   - `el el ems`, `elle ems`, `large language models`, `ell ell ems`, `double l ms`, `ell l ms`

3. **New phrase entries**:
   - `large language model` - maps to recognizing the full phrase
   - `large language models` - maps to recognizing the plural phrase

4. **LMS cleanup** - Removed confusing `l m s` pattern that could match "LLM" pronunciation. Now uses:
   - `el em ess`, `learning management system`

**Test Coverage:**

Added new test `includes LLM/LLMs vocabulary to distinguish from LMS` that verifies:
- LLM entry exists with proper sounds_like including "large language model"
- LLMs entry exists with sounds_like including "large language models"
- "large language models" phrase entry exists
- LMS doesn't contain confusing patterns

## Reasoning

### The Problem

When users say "large language models" or "LLMs", Speechmatics was transcribing it as "LMS" or "l m s" because:
1. The previous LLM entry only had basic phonetic patterns (`el el em`, `l l m`)
2. The LMS entry had `l m s` which phonetically overlaps with how some speakers pronounce "LLM"
3. There was no entry for the plural "LLMs"

### The Solution

1. **Added full phrase recognition**: By adding "large language model" and "large language models" as sounds_like patterns for LLM/LLMs, Speechmatics will recognize the full phrase and map it correctly
2. **Removed ambiguous LMS pattern**: The old `l m s` pattern for LMS could match misheard "LLM" pronunciations. Replaced with "learning management system" which is more specific
3. **Added plural forms**: Many users say "LLMs" in plural form which wasn't handled

### Key Decisions

- Used multiple phonetic variations to catch different pronunciation styles
- Added both acronym and expanded forms for comprehensive coverage
- Kept LMS entry but made it more specific to its actual meaning

## Additional Fix

Fixed a pre-existing TypeScript error in `apps/api-docs-hub/src/index.ts` where `process.env['INTEXURAOS_SENTRY_DSN']` (type `string | undefined`) was being passed to `initSentry()` which expected optional `string` with `exactOptionalPropertyTypes` enabled.

## Testing

- [x] Typecheck passes (`pnpm exec tsc --noEmit`)
- [x] Lint passes (`pnpm exec eslint`)
- [x] All 482 whatsapp-service tests pass
- [x] New test verifies LLM/LLMs vocabulary configuration

## Cross-References

- **Linear Issue**: [INT-183](https://linear.app/pbuchman/issue/INT-183/improve-transcription-accuracy-for-specific-terms)

---

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>