### PR TITLE
refactor(actions-agent): improve test coverage INT-168

### DIFF
--- a/.claude/ci-failures/intexuraos-2-refactor_INT-168-actions-agent-coverage.jsonl
+++ b/.claude/ci-failures/intexuraos-2-refactor_INT-168-actions-agent-coverage.jsonl
@@ -1,0 +1,1 @@
+{"ts":"2026-01-21T17:20:01.619Z","project":"intexuraos-2","branch":"refactor/INT-168-actions-agent-coverage","workspace":"actions-agent","runNumber":1,"passed":true,"durationMs":106669,"failureCount":0,"failures":[]}

--- a/apps/actions-agent/src/__tests__/infra/http/notesServiceHttpClient.test.ts
+++ b/apps/actions-agent/src/__tests__/infra/http/notesServiceHttpClient.test.ts
@@ -179,6 +179,57 @@ describe('createNotesServiceHttpClient', () => {
       }
     });
 
+    it('returns error on OK response with invalid JSON', async () => {
+      nock(baseUrl).post('/internal/notes').reply(200, 'not valid json', {
+        'Content-Type': 'text/plain',
+      });
+
+      const client = createNotesServiceHttpClient({ baseUrl, internalAuthToken, logger: silentLogger });
+      const result = await client.createNote({
+        userId: 'user-456',
+        title: 'Test',
+        content: '',
+        tags: [],
+        source: 'actions-agent',
+        sourceId: 'action-123',
+      });
+
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) {
+        expect(result.error.message).toContain('Invalid response from notes-agent');
+      }
+    });
+
+    it('returns ServiceFeedback with errorCode from successful data response', async () => {
+      nock(baseUrl)
+        .post('/internal/notes')
+        .reply(200, {
+          success: true,
+          data: {
+            status: 'failed',
+            message: 'Processing failed',
+            errorCode: 'PROCESSING_ERROR',
+          },
+        });
+
+      const client = createNotesServiceHttpClient({ baseUrl, internalAuthToken, logger: silentLogger });
+      const result = await client.createNote({
+        userId: 'user-456',
+        title: 'Test',
+        content: '',
+        tags: [],
+        source: 'actions-agent',
+        sourceId: 'action-123',
+      });
+
+      expect(isOk(result)).toBe(true);
+      if (isOk(result)) {
+        expect(result.value.status).toBe('failed');
+        expect(result.value.message).toBe('Processing failed');
+        expect(result.value.errorCode).toBe('PROCESSING_ERROR');
+      }
+    });
+
     it('sends correct request body', async () => {
       const scope = nock(baseUrl)
         .post('/internal/notes', {


### PR DESCRIPTION
## Summary
- Add tests for invalid JSON responses in notes and todos HTTP clients
- Add tests for errorCode conditional spreads in researchAgentClient
- Add tests for message conditional in completed action responses (execute usecases)
- Add tests for WhatsApp notification when resourceUrl is missing
- Add tests for summary parameter in linearAgentHttpClient
- Add tests for expectedStatuses as array in actionRepository
- Branch coverage improved from 95.46% to 98.42%

## Test plan
- [x] All actions-agent tests pass (469 tests)
- [x] TypeScript compilation passes
- [x] Lint passes
- [x] Coverage meets 95% threshold (now at 98.42%)
- [x] Full workspace verification passes

## Remaining uncovered branches
The following branches remain uncovered as they are defensive/environmental code:
- `LOG_LEVEL` env var fallback in commandsAgentClient, localActionServiceClient, researchAgentClient
- `clearTimeout()` calls in HTTP clients (always execute when request succeeds)

Fixes INT-168

🤖 Generated with [Claude Code](https://claude.com/claude-code)