### PR TITLE
fix(ci): add trigger_phrase for zaiclaude workflow

### DIFF
--- a/.github/workflows/zai-claude.yml
+++ b/.github/workflows/zai-claude.yml
@@ -37,5 +37,6 @@ jobs:
           ANTHROPIC_BASE_URL: https://api.z.ai/api/anthropic
         with:
           anthropic_api_key: ${{ secrets.ZAI_API_KEY }}
+          trigger_phrase: '@zaiclaude'
           additional_permissions: |
             actions: read


### PR DESCRIPTION
## Summary
- Add `trigger_phrase: '@zaiclaude'` to action config

## Root Cause
The `claude-code-action` defaults `trigger_phrase` to `@claude`. Even though the job's `if` condition checked for `@zaiclaude`, the action itself was looking for `@claude` mentions.

## Test plan
- [ ] Comment `@zaiclaude help` on a PR/issue and verify the workflow triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)