### PR TITLE
fix: PR review findings from INT-208 and INT-203

### DIFF
--- a/.claude/ci-failures/intexuraos-1-feature_INT-206.jsonl
+++ b/.claude/ci-failures/intexuraos-1-feature_INT-206.jsonl
@@ -1,2 +1,6 @@
 {"ts":"2026-01-22T20:41:26.117Z","project":"intexuraos-1","branch":"feature/INT-206","runNumber":1,"passed":true,"durationMs":336782,"failureCount":0,"failures":[]}
 {"ts":"2026-01-22T21:38:58.966Z","project":"intexuraos-1","branch":"feature/INT-206","runNumber":2,"passed":true,"durationMs":509713,"failureCount":0,"failures":[]}
+{"ts":"2026-01-23T08:35:42.266Z","project":"intexuraos-1","branch":"feature/INT-206","workspace":"--","runNumber":3,"passed":false,"durationMs":1137,"failureCount":0,"failures":[]}
+{"ts":"2026-01-23T08:35:46.022Z","project":"intexuraos-1","branch":"feature/INT-206","workspace":"--","runNumber":4,"passed":false,"durationMs":475,"failureCount":0,"failures":[]}
+{"ts":"2026-01-23T08:45:00.829Z","project":"intexuraos-1","branch":"feature/INT-206","workspace":"--","runNumber":5,"passed":false,"durationMs":504,"failureCount":0,"failures":[]}
+{"ts":"2026-01-23T08:50:16.286Z","project":"intexuraos-1","branch":"feature/INT-206","runNumber":6,"passed":true,"durationMs":254223,"failureCount":0,"failures":[]}

--- a/apps/web/src/pages/LinearIssuesPage.tsx
+++ b/apps/web/src/pages/LinearIssuesPage.tsx
@@ -306,7 +306,7 @@ export function LinearIssuesPage(): React.JSX.Element {
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [activeTab, setActiveTab] = useState<TabType>('backlog');
+  const [activeTab, setActiveTab] = useState<TabType>('todo');
   const [archiveExpanded, setArchiveExpanded] = useState(false);
   const [dismissedFailedIssueIds, setDismissedFailedIssueIds] = useState<Set<string>>(new Set());
 

--- a/apps/whatsapp-service/src/routes/webhookRoutes.ts
+++ b/apps/whatsapp-service/src/routes/webhookRoutes.ts
@@ -755,6 +755,10 @@ async function handleReactionMessage(
     return;
   }
 
+  // match[1] is guaranteed to exist and be non-empty because:
+  // 1. We returned early if match === null
+  // 2. The regex uses (.+) which requires at least one character
+  // TypeScript doesn't know this, so we need the fallback for type safety
   const actionId = match[1] ?? '';
   request.log.info(
     { eventId: savedEvent.id, correlationId, actionId, intent },
@@ -769,12 +773,8 @@ async function handleReactionMessage(
     replyText,
     userId,
     timestamp: new Date().toISOString(),
+    actionId,
   };
-
-  // Only include actionId if it was extracted from the correlationId
-  if (match[1] !== undefined) {
-    approvalReplyEvent.actionId = match[1];
-  }
 
   const approvalPublishResult = await eventPublisher.publishApprovalReply(approvalReplyEvent);
 


### PR DESCRIPTION
## Summary

Fixes issues found during comprehensive PR review of PRs merged to development on 2026-01-22.

## Changes

### INT-208 - Linear Board Redesign
- **LinearIssuesPage.tsx:309**: Changed default mobile tab from `'backlog'` to `'todo'` to match the new design hierarchy where Todo is now the primary entry point for unstarted work

### INT-203 - WhatsApp Reactions
- **webhookRoutes.ts:758-776**: Simplified reaction handling by always including `actionId` in the approval reply event (removing unnecessary conditional), and added clarifying comment about why the `?? ''` fallback is needed for TypeScript type safety

## Related Issues

- Fixes identified during PR #573, #575, #579 review
- See also: INT-211 (race condition - separate fix needed), INT-212 (design decision pending)

## Test Plan

- [x] CI passes (5684 tests)
- [ ] Verify Linear board mobile view defaults to Todo tab
- [ ] Verify WhatsApp reaction approval still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)