### PR TITLE
Add parent issue execution workflow to Linear skill

### DIFF
--- a/.claude/skills/linear/SKILL.md
+++ b/.claude/skills/linear/SKILL.md
@@ -33,17 +33,20 @@ Manage Linear issues, branches, and PRs with enforced workflow and cross-linking
 8. **Checkpoint Pattern**: After completing an issue, STOP and wait for user instruction before proceeding
 9. **Done Forbidden**: Never move issues to Done — maximum agent-controlled state is QA
 10. **95% Coverage MINIMUM**: All tests listed in issues MUST be implemented. Do NOT simplify work.
+11. **Parent Execution Mode**: When working on parent issues with children, execute ALL children continuously without stopping between them. Single branch and single PR for the parent.
 
 ## Invocation Detection
 
 The skill automatically detects intent from input:
 
-| Input Pattern                   | Type               | Workflow                                                 |
-| ------------------------------- | ------------------ | -------------------------------------------------------- |
-| `/linear` (no args)             | Random Todo        | [random-todo.md](workflows/random-todo.md)               |
-| `/linear <task description>`    | Create New         | [create-issue.md](workflows/create-issue.md)             |
-| `/linear INT-<number>`          | Work Existing      | [work-existing.md](workflows/work-existing.md)           |
-| `/linear https://sentry.io/...` | Sentry Integration | [sentry-integration.md](workflows/sentry-integration.md) |
+| Input Pattern                   | Type               | Workflow                                                   |
+| ------------------------------- | ------------------ | ---------------------------------------------------------- |
+| `/linear` (no args)             | Random Todo        | [random-todo.md](workflows/random-todo.md)                 |
+| `/linear <task description>`    | Create New         | [create-issue.md](workflows/create-issue.md)               |
+| `/linear INT-<number>`          | Work Existing      | [work-existing.md](workflows/work-existing.md)*            |
+| `/linear https://sentry.io/...` | Sentry Integration | [sentry-integration.md](workflows/sentry-integration.md)   |
+
+*Routes to [parent-execution.md](workflows/parent-execution.md) if issue has child subissues
 
 ## Auto-Splitting Detection
 

--- a/.claude/skills/linear/templates/subtask-description.md
+++ b/.claude/skills/linear/templates/subtask-description.md
@@ -2,6 +2,31 @@
 
 Template for child issues created during plan splitting.
 
+---
+
+## Parent Execution Mode Variant
+
+When child issues are executed via the **parent execution workflow** (invoked with `/linear INT-<parent>`), include this header at the top of the description:
+
+````markdown
+## 🚨 PARENT EXECUTION MODE
+
+This issue is part of **parent issue execution**. The workflow:
+
+1. Executes ALL children in tier order continuously
+2. Does **NOT** stop between children
+3. Creates **ONE PR** for the parent issue
+4. Uses **ONE branch** named after the parent
+
+**DO NOT STOP** after completing this task — the parent execution loop continues automatically to the next child.
+
+---
+````
+
+**When to use:** Add this variant when the subtask will be executed as part of a parent issue batch, not as a standalone issue.
+
+---
+
 ## Template
 
 ````markdown

--- a/.claude/skills/linear/workflows/parent-execution.md
+++ b/.claude/skills/linear/workflows/parent-execution.md
@@ -1,0 +1,311 @@
+# Parent Issue Execution Workflow
+
+**Trigger:** Redirected from [work-existing.md](work-existing.md) when issue has child subissues
+
+---
+
+## Overview
+
+When `/linear INT-XXX` is called with a parent issue that has child subissues, this workflow executes **ALL children continuously** without stopping between them. This enables completing multi-step features in a single session.
+
+**Key Differences from Single-Issue Workflow:**
+
+| Aspect    | Single Issue (`work-existing.md`) | Parent Execution (this workflow)      |
+| --------- | --------------------------------- | ------------------------------------- |
+| Branch    | Per-issue (`fix/INT-302`)         | Parent only (`refactor/INT-301`)      |
+| Execution | One issue → STOP → wait           | All children continuously             |
+| PR        | One per issue                     | Single PR for parent                  |
+| Resume    | N/A                               | Detect interruption, continue         |
+
+---
+
+## 🚨 CRITICAL: Branch Creation
+
+**A task FAILS if you start working on `development` or `main`.**
+
+Before ANY work:
+1. Check current branch: `git branch --show-current`
+2. If on `development` or `main` → CREATE BRANCH FIRST (see Step 3)
+3. Only then proceed with execution loop
+
+---
+
+## Steps
+
+### 1. Validate Entry Point
+
+This workflow should only be reached via redirect from `work-existing.md`. Confirm:
+- Issue was fetched with `mcp__linear__get_issue`
+- Subissues were detected with `mcp__linear__issue_read(method: "get_sub_issues")`
+- Children array is non-empty
+
+### 2. Analyze Children Structure
+
+```
+1. Call mcp__linear__issue_read(method: "get_sub_issues", issueId: "<parent-id>")
+2. For each child, extract:
+   - Issue ID
+   - Title (contains [tier-X] prefix)
+   - Current state
+   - Blockers (if any)
+3. Sort children by tier number (ascending)
+```
+
+**Tier Extraction:**
+- Parse `[tier-X]` from title prefix
+- `[tier-0]` = Setup/prerequisites (execute first)
+- `[tier-1]` = Independent deliverables
+- `[tier-2]` = Integration work
+- `[tier-3+]` = Verification/finalization
+
+### 3. Create Branch (MANDATORY)
+
+**Single branch for ALL children, named after parent:**
+
+```bash
+git fetch origin
+git checkout -b <type>/INT-<parent-id> origin/development
+```
+
+**Branch Type Extraction:**
+Extract type from parent title prefix:
+
+| Parent Title Prefix | Branch Type  | Example                |
+| ------------------- | ------------ | ---------------------- |
+| `[feature]`         | `feature/`   | `feature/INT-301`      |
+| `[bug]`             | `fix/`       | `fix/INT-301`          |
+| `[refactor]`        | `refactor/`  | `refactor/INT-301`     |
+| `[docs]`            | `docs/`      | `docs/INT-301`         |
+| Other/None          | `feature/`   | `feature/INT-301`      |
+
+### 4. Update Parent State (MANDATORY)
+
+```
+Call mcp__linear__update_issue
+- Issue: Parent issue
+- State: "In Progress"
+```
+
+### 5. Determine Resume Point
+
+Check child states to find where to start/resume:
+
+```
+FOR each child in tier order:
+  IF state == "In Progress":
+    → Resume here (was interrupted mid-execution)
+    BREAK
+
+  IF state == "Backlog" AND no unresolved blockers:
+    → Start here (next unstarted task)
+    BREAK
+
+  IF state in ["In Review", "QA", "Done"]:
+    → Skip (already completed)
+    CONTINUE
+
+  IF state == "Backlog" AND has unresolved blockers:
+    → Skip for now (circle back after blockers resolve)
+    CONTINUE
+```
+
+**Resume States:**
+
+| Child State | Action                          |
+| ----------- | ------------------------------- |
+| In Progress | Resume here (was interrupted)   |
+| Backlog     | Start fresh (if no blockers)    |
+| In Review   | Skip (completed)                |
+| QA          | Skip (completed)                |
+| Done        | Skip (completed)                |
+
+### 6. Execute Children Loop (NO CHECKPOINTS)
+
+**⚠️ CRITICAL: DO NOT STOP between children. Execute continuously.**
+
+```
+FOR each child starting from resume point:
+  IF child completed (In Review/QA/Done):
+    SKIP
+    CONTINUE to next child
+
+  IF child blocked:
+    LOG "Skipping INT-XXX (blocked by INT-YYY)"
+    CONTINUE to next child
+
+  // === Execute Child ===
+
+  1. Update child state to "In Progress"
+     Call mcp__linear__update_issue(state: "In Progress")
+
+  2. Implement the task described in child issue
+     - Read requirements from child description
+     - Make code changes
+     - Follow all CLAUDE.md rules
+
+  3. Run CI verification (MUST PASS)
+     pnpm run ci:tracked
+
+     IF CI fails:
+       Fix ALL errors (ownership mindset)
+       Re-run until passes
+
+  4. Commit changes with child ID
+     git add -A
+     git commit -m "INT-<child-id>: <child-title-summary>"
+
+  5. Update child state to "In Review"
+     Call mcp__linear__update_issue(state: "In Review")
+
+  6. Update parent ledger (State Tracking section)
+     Move child from "Now" to "Done" checklist
+
+  // === NO STOP — Continue immediately to next child ===
+```
+
+### 7. Handle Blocked Children (Circle Back)
+
+After initial pass, if any children were skipped due to blockers:
+
+```
+blocked_children = children where state == "Backlog" AND was_skipped
+
+FOR each blocked_child:
+  IF blockers now resolved (blocking issues in In Review/QA/Done):
+    Execute child (same as Step 6)
+  ELSE:
+    Report: "Cannot complete INT-XXX — blocked by INT-YYY (still in progress)"
+```
+
+### 8. Create Single PR (After ALL Children Complete)
+
+**Only create PR when ALL children are in In Review or later:**
+
+```bash
+git fetch origin
+git merge origin/development  # Resolve conflicts if any
+
+git push -u origin <type>/INT-<parent-id>
+
+gh pr create --base development \
+  --title "[INT-<parent-id>] <parent-title>" \
+  --body "$(cat <<'EOF'
+## Summary
+<summary of all changes across children>
+
+## Child Issues Completed
+- [x] INT-<child-1>: <title>
+- [x] INT-<child-2>: <title>
+- [x] INT-<child-3>: <title>
+
+## Test Plan
+- [ ] All CI checks pass
+- [ ] <verification items>
+
+Fixes INT-<parent-id>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+### 9. Update Parent State to In Review
+
+```
+Call mcp__linear__update_issue
+- Issue: Parent issue
+- State: "In Review"
+```
+
+### 10. Cross-Link Summary
+
+Display completion summary:
+
+```
+Parent Issue Execution Complete
+===============================
+Parent: INT-<parent-id> - <title>
+Branch: <type>/INT-<parent-id>
+PR: #<pr-number>
+
+Children Completed:
+- INT-<child-1>: <title> → In Review
+- INT-<child-2>: <title> → In Review
+- INT-<child-3>: <title> → In Review
+
+All artifacts cross-linked via GitHub integration.
+```
+
+---
+
+## State Transitions
+
+| Event                     | Issue  | From        | To          |
+| ------------------------- | ------ | ----------- | ----------- |
+| Start parent execution    | Parent | Backlog     | In Progress |
+| Begin child work          | Child  | Backlog     | In Progress |
+| Complete child work       | Child  | In Progress | In Review   |
+| All children done, PR up  | Parent | In Progress | In Review   |
+
+---
+
+## Ledger Updates
+
+After each child completion, update the parent issue's State Tracking section:
+
+**Before child completion:**
+```markdown
+### Now
+- [ ] INT-302: [tier-0] Setup infrastructure
+
+### Next
+- [ ] INT-303: [tier-1] Implement core feature
+```
+
+**After child completion:**
+```markdown
+### Done
+- [x] INT-302: [tier-0] Setup infrastructure
+
+### Now
+- [ ] INT-303: [tier-1] Implement core feature
+```
+
+---
+
+## Interruption Recovery
+
+If execution is interrupted mid-workflow:
+
+1. **Re-invoke:** `/linear INT-<parent-id>`
+2. **Workflow detects:** Child in "In Progress" state
+3. **Resumes from:** That child (Step 5 resume logic)
+4. **Continues:** Through remaining children
+
+**The workflow is designed to be idempotent** — re-running with the same parent issue safely resumes from the correct point.
+
+---
+
+## Forbidden Patterns
+
+| Pattern                            | Why It's Wrong                              |
+| ---------------------------------- | ------------------------------------------- |
+| Creating branch per child          | Creates merge hell, loses context           |
+| Stopping after each child          | Defeats purpose of continuous execution     |
+| Creating PR per child              | Fragments review, loses cohesion            |
+| Skipping CI between children       | Accumulates failures, harder to debug       |
+| Moving parent to Done              | Only user can mark Done (terminal state)    |
+
+---
+
+## Checklist
+
+Before creating PR (all must be true):
+
+- [ ] Single branch created from parent ID
+- [ ] ALL children in In Review or later
+- [ ] ALL commits have child ID in message
+- [ ] `pnpm run ci:tracked` passes
+- [ ] Parent ledger updated (all children in Done section)
+- [ ] PR title contains parent ID `[INT-<parent-id>]`
+- [ ] Parent state updated to "In Review"

--- a/.claude/skills/linear/workflows/work-existing.md
+++ b/.claude/skills/linear/workflows/work-existing.md
@@ -66,6 +66,23 @@ Verify Linear, GitHub, GCloud available.
 - Extract: title, description, state, assignee
 ```
 
+### 2.5 Parent Issue Detection (MANDATORY)
+
+Check if this issue has child subissues:
+
+```
+Call mcp__linear__issue_read(method: "get_sub_issues", issueId: "INT-XXX")
+```
+
+**Routing Decision:**
+
+| Result                    | Action                                                    |
+| ------------------------- | --------------------------------------------------------- |
+| Children array non-empty  | **REDIRECT** to [parent-execution.md](parent-execution.md) |
+| Children array empty/null | Continue with single-issue workflow (Step 3 below)        |
+
+**Why:** Parent issues with children require continuous execution of ALL children without stopping. The parent-execution workflow handles branch naming, commit grouping, and PR creation differently.
+
 ### 3. Pre-Flight Branch Check (MANDATORY - BLOCKS ALL WORK)
 
 ⛔ **STOP: You MUST NOT be on `development` or `main` before making ANY changes.**


### PR DESCRIPTION
## Summary

- Adds new `parent-execution.md` workflow for executing parent issues with child subissues
- When `/linear INT-XXX` is called on a parent with children, executes ALL children continuously without stopping
- Single branch and single PR created for the parent (not per-child)
- Automatic resume from interruption by checking child states

## Key Behavioral Changes

| Aspect | Current (`work-existing.md`) | New (`parent-execution.md`) |
|--------|------------------------------|----------------------------|
| Branch | Per-issue (`fix/INT-302`) | Parent only (`refactor/INT-301`) |
| Execution | One issue → STOP → wait | All children continuously |
| PR | One per issue | Single PR for parent |
| Resume | N/A | Detect interruption, continue |

## Files Changed

| File | Change |
|------|--------|
| `workflows/parent-execution.md` | **NEW** - Main workflow with execution loop, resume logic, PR creation |
| `workflows/work-existing.md` | Added section 2.5 for parent detection and routing |
| `SKILL.md` | Updated invocation table, added core mandate #11 |
| `reference/state-machine.md` | Added parent execution flow diagram |
| `templates/subtask-description.md` | Added parent execution mode variant |

## Test Plan

- [ ] `/linear INT-XXX` with parent issue (has children) routes to new workflow
- [ ] `/linear INT-YYY` with single issue (no children) stays in work-existing
- [ ] Branch naming uses parent ID
- [ ] No STOP prompts between children
- [ ] Resume works after interruption

🤖 Generated with [Claude Code](https://claude.com/claude-code)