### PR TITLE
[INT-299] Fix CI output file collisions and enforce reuse

### DIFF
--- a/scripts/ci-capture.sh
+++ b/scripts/ci-capture.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# CI output capture with branch-safe naming
+# Prevents collisions between parallel CI runs and enables output reuse
+
+set -e
+
+BRANCH=$(git branch --show-current | sed 's/\//-/g')
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+OUTPUT="/tmp/ci-output-${BRANCH}-${TIMESTAMP}.txt"
+
+echo "Capturing CI output to: $OUTPUT"
+echo ""
+
+pnpm run ci:tracked 2>&1 | tee "$OUTPUT"
+EXIT_CODE=${PIPESTATUS[0]}
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "CI output captured to: $OUTPUT"
+echo ""
+echo "Reuse with grep (do NOT re-run CI):"
+echo "  grep -E \"(error|Error|ERROR)\" /tmp/ci-output-${BRANCH}-*.txt"
+echo "  grep -E \"FAIL\" /tmp/ci-output-${BRANCH}-*.txt"
+echo "  grep -E \"Coverage for\" /tmp/ci-output-${BRANCH}-*.txt"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+exit $EXIT_CODE


### PR DESCRIPTION
## Summary

- Updated CLAUDE.md CI output file patterns from fixed `/tmp/ci-output.txt` to branch-safe naming: `/tmp/ci-output-${BRANCH}-${TIMESTAMP}.txt`
- Added new "CI Efficiency (MANDATORY)" section with enforcement rules and DO/DON'T examples
- Created `scripts/ci-capture.sh` helper script for automatic branch-safe naming

## Why this matters

1. **Prevents collisions**: Multiple parallel CI runs no longer overwrite each other's output
2. **Enforces reuse**: Clear documentation that LLM should grep captured output, not re-run CI
3. **Saves time**: Each CI run takes 3-5 minutes; grepping existing output takes 0.1 seconds

## Test Plan

- [x] CI passes
- [x] Verified all `/tmp/ci-output.txt` references updated (except intentional WRONG example)
- [x] Helper script is executable
- [x] Wildcard pattern `${BRANCH}-*.txt` works for finding latest capture

Fixes INT-299

🤖 Generated with [Claude Code](https://claude.com/claude-code)