### PR TITLE
[INT-314] Sort todo checklist items by status and priority

### DIFF
--- a/apps/web/src/pages/TodosListPage.tsx
+++ b/apps/web/src/pages/TodosListPage.tsx
@@ -22,6 +22,7 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { Button, Card, Input, Layout, RefreshIndicator } from '@/components';
 import { useTodos } from '@/hooks';
+import { sortTodoItems } from '@/utils/todoItemSort.js';
 import type {
   CreateTodoItemRequest,
   CreateTodoRequest,
@@ -645,10 +646,7 @@ function TodoModal({
 
             {currentTodo.items.length > 0 ? (
               <div className="divide-y divide-slate-100">
-                {currentTodo.items
-                  .slice()
-                  .sort((a, b) => a.position - b.position)
-                  .map((item) => (
+                {sortTodoItems(currentTodo.items).map((item) => (
                     <TodoItemRow
                       key={item.id}
                       item={item}

--- a/apps/web/src/utils/__tests__/todoItemSort.test.ts
+++ b/apps/web/src/utils/__tests__/todoItemSort.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'vitest';
+import { sortTodoItems } from '../todoItemSort.js';
+import type { TodoItem } from '@/types';
+
+function createMockItem(overrides: Partial<TodoItem> & { id: string }): TodoItem {
+  return {
+    id: overrides.id,
+    title: overrides.title ?? 'Test Item',
+    status: overrides.status ?? 'pending',
+    priority: overrides.priority ?? null,
+    dueDate: overrides.dueDate ?? null,
+    position: overrides.position ?? 0,
+    completedAt: overrides.completedAt ?? null,
+    todoId: 'test-todo-id',
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+describe('sortTodoItems', () => {
+  it('sorts pending items before completed items', () => {
+    const items = [
+      createMockItem({ id: '1', status: 'completed', position: 1 }),
+      createMockItem({ id: '2', status: 'pending', position: 2 }),
+      createMockItem({ id: '3', status: 'completed', position: 3 }),
+      createMockItem({ id: '4', status: 'pending', position: 4 }),
+    ];
+
+    const result = sortTodoItems(items);
+
+    expect(result[0].id).toBe('2');
+    expect(result[1].id).toBe('4');
+    expect(result[2].id).toBe('1');
+    expect(result[3].id).toBe('3');
+  });
+
+  it('sorts by priority descending within each completion group', () => {
+    const items = [
+      createMockItem({ id: '1', status: 'pending', priority: 'medium', position: 1 }),
+      createMockItem({ id: '2', status: 'pending', priority: 'high', position: 2 }),
+      createMockItem({ id: '3', status: 'pending', priority: 'low', position: 3 }),
+      createMockItem({ id: '4', status: 'pending', priority: null, position: 4 }),
+    ];
+
+    const result = sortTodoItems(items);
+
+    expect(result[0].id).toBe('2'); // high
+    expect(result[1].id).toBe('1'); // medium
+    expect(result[2].id).toBe('3'); // low
+    expect(result[3].id).toBe('4'); // none
+  });
+
+  it('places urgent priority above high', () => {
+    const items = [
+      createMockItem({ id: '1', status: 'pending', priority: 'urgent', position: 1 }),
+      createMockItem({ id: '2', status: 'pending', priority: 'high', position: 2 }),
+      createMockItem({ id: '3', status: 'pending', priority: 'urgent', position: 3 }),
+    ];
+
+    const result = sortTodoItems(items);
+
+    expect(result[0].id).toBe('1'); // urgent, position 1
+    expect(result[1].id).toBe('3'); // urgent, position 3
+    expect(result[2].id).toBe('2'); // high
+  });
+
+  it('maintains original position order within same priority and status', () => {
+    const items = [
+      createMockItem({ id: '1', status: 'pending', priority: 'high', position: 3 }),
+      createMockItem({ id: '2', status: 'pending', priority: 'high', position: 1 }),
+      createMockItem({ id: '3', status: 'pending', priority: 'high', position: 2 }),
+    ];
+
+    const result = sortTodoItems(items);
+
+    expect(result[0].id).toBe('2'); // position 1
+    expect(result[1].id).toBe('3'); // position 2
+    expect(result[2].id).toBe('1'); // position 3
+  });
+
+  it('sorts completed items by priority too', () => {
+    const items = [
+      createMockItem({ id: '1', status: 'completed', priority: 'low', position: 1 }),
+      createMockItem({ id: '2', status: 'completed', priority: 'high', position: 2 }),
+      createMockItem({ id: '3', status: 'pending', priority: 'low', position: 3 }),
+    ];
+
+    const result = sortTodoItems(items);
+
+    expect(result[0].id).toBe('3'); // pending low
+    expect(result[1].id).toBe('2'); // completed high
+    expect(result[2].id).toBe('1'); // completed low
+  });
+
+  it('handles mixed status and priority correctly', () => {
+    const items = [
+      createMockItem({ id: '1', status: 'completed', priority: 'high', position: 1 }),
+      createMockItem({ id: '2', status: 'pending', priority: 'low', position: 2 }),
+      createMockItem({ id: '3', status: 'pending', priority: 'high', position: 3 }),
+      createMockItem({ id: '4', status: 'completed', priority: 'medium', position: 4 }),
+      createMockItem({ id: '5', status: 'pending', priority: null, position: 5 }),
+    ];
+
+    const result = sortTodoItems(items);
+
+    // Pending group first, ordered by priority: high > low > none
+    expect(result[0].id).toBe('3'); // pending high
+    expect(result[1].id).toBe('2'); // pending low
+    expect(result[2].id).toBe('5'); // pending none
+
+    // Completed group after, ordered by priority: high > medium
+    expect(result[3].id).toBe('1'); // completed high
+    expect(result[4].id).toBe('4'); // completed medium
+  });
+
+  it('returns empty array for empty input', () => {
+    const result = sortTodoItems([]);
+    expect(result).toEqual([]);
+  });
+
+  it('returns single item for single item input', () => {
+    const items = [createMockItem({ id: '1', status: 'pending', priority: 'high', position: 1 })];
+    const result = sortTodoItems(items);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('1');
+  });
+
+  it('does not mutate the original array', () => {
+    const items = [
+      createMockItem({ id: '1', status: 'completed', position: 1 }),
+      createMockItem({ id: '2', status: 'pending', position: 2 }),
+    ];
+
+    const originalOrder = items.map((i) => i.id);
+    sortTodoItems(items);
+
+    expect(items.map((i) => i.id)).toEqual(originalOrder);
+  });
+});

--- a/apps/web/src/utils/todoItemSort.ts
+++ b/apps/web/src/utils/todoItemSort.ts
@@ -1,0 +1,64 @@
+import type { TodoItem, TodoPriority } from '@/types';
+
+type PriorityKey = TodoPriority | 'null';
+
+/**
+ * Priority order for sorting (highest to lowest).
+ * Items with no priority (null) sort last within their completion group.
+ */
+const PRIORITY_ORDER: Readonly<Record<PriorityKey, number>> = {
+  urgent: 4,
+  high: 3,
+  medium: 2,
+  low: 1,
+  null: 0,
+} as const;
+
+/**
+ * Get the numeric priority score for a todo item.
+ */
+function getPriorityScore(item: TodoItem): number {
+  return PRIORITY_ORDER[item.priority ?? 'null'];
+}
+
+/**
+ * Compare two todo items for sorting.
+ *
+ * Sort key (in order of precedence):
+ * 1. Pending first - uncompleted items above completed
+ * 2. Priority descending - urgent > high > medium > low > none
+ * 3. Original position - maintain insertion order within same priority
+ */
+function compareTodoItems(a: TodoItem, b: TodoItem): number {
+  // Primary: completed items go to the bottom
+  const aCompleted = a.status === 'completed';
+  const bCompleted = b.status === 'completed';
+
+  if (aCompleted !== bCompleted) {
+    return aCompleted ? 1 : -1;
+  }
+
+  // Secondary: priority descending (higher priority first)
+  const aPriorityScore = getPriorityScore(a);
+  const bPriorityScore = getPriorityScore(b);
+
+  if (aPriorityScore !== bPriorityScore) {
+    return bPriorityScore - aPriorityScore;
+  }
+
+  // Tertiary: original position (ascending)
+  return a.position - b.position;
+}
+
+/**
+ * Sort todo items with the proper sort key:
+ * 1. Pending first (uncompleted above completed)
+ * 2. Priority descending (urgent > high > medium > low > none)
+ * 3. Original position within same priority
+ *
+ * @param items - Todo items to sort
+ * @returns New array with sorted items
+ */
+export function sortTodoItems<T extends TodoItem>(items: readonly T[]): T[] {
+  return [...items].sort(compareTodoItems);
+}


### PR DESCRIPTION
## Summary
- Added `sortTodoItems` utility function that sorts todo checklist items with the proper sort key:
  1. **Pending first** - Uncompleted items always above completed
  2. **Priority descending** - Urgent > High > Medium > Low > None
  3. **Original position** - Within same priority, maintain insertion order
- Updated `TodoModal` to use the new sorting logic
- Added comprehensive tests (9 test cases)

## Files Changed
- `apps/web/src/utils/todoItemSort.ts` (new) - Sorting utility
- `apps/web/src/utils/__tests__/todoItemSort.test.ts` (new) - Tests
- `apps/web/src/pages/TodosListPage.tsx` - Use new sorting

## Test Plan
- [x] All 9 new tests pass for sortTodoItems utility
- [x] CI passes (6237 tests)
- [x] Typecheck passes
- [x] Lint passes

Fixes INT-314