### PR TITLE
[INT-339] Use MarkdownContent for AI summary display

### DIFF
--- a/apps/web/src/components/MarkdownContent.tsx
+++ b/apps/web/src/components/MarkdownContent.tsx
@@ -1,0 +1,17 @@
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import rehypeHighlight from 'rehype-highlight';
+
+export interface MarkdownContentProps {
+  content: string;
+}
+
+export function MarkdownContent({ content }: MarkdownContentProps): React.JSX.Element {
+  return (
+    <div className="prose prose-slate max-w-none overflow-x-auto">
+      <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
+        {content}
+      </ReactMarkdown>
+    </div>
+  );
+}

--- a/apps/web/src/components/index.ts
+++ b/apps/web/src/components/index.ts
@@ -15,6 +15,7 @@ export { ImageThumbnail } from './ImageThumbnail.js';
 export { AudioPlayer } from './AudioPlayer.js';
 export { LinkPreview } from './LinkPreview.js';
 export { LinkPreviewList } from './LinkPreviewList.js';
+export { MarkdownContent, type MarkdownContentProps } from './MarkdownContent.js';
 export { ModelSelector, getSelectedModelsList, PROVIDER_MODELS } from './ModelSelector.js';
 export { VegaChart } from './VegaChart.js';
 export { RefreshIndicator } from './RefreshIndicator.js';

--- a/apps/web/src/pages/BookmarksListPage.tsx
+++ b/apps/web/src/pages/BookmarksListPage.tsx
@@ -17,7 +17,7 @@ import {
   Trash2,
   X,
 } from 'lucide-react';
-import { Button, Card, Input, Layout, RefreshIndicator } from '@/components';
+import { Button, Card, Input, Layout, MarkdownContent, RefreshIndicator } from '@/components';
 import { useAuth } from '@/context';
 import { useBookmarkChanges, useBookmarks } from '@/hooks';
 import { ApiError } from '@/services/apiClient';
@@ -378,7 +378,7 @@ function BookmarkModal({
                     <Sparkles className="h-4 w-4" />
                     AI Summary
                   </div>
-                  <p className="text-sm text-purple-900">{bookmark.aiSummary}</p>
+                  <MarkdownContent content={bookmark.aiSummary} />
                 </div>
               ) : null}
 


### PR DESCRIPTION
## Summary
- Replaced plain text `<p>` tag with `MarkdownContent` component for AI summary display
- MarkdownContent uses ReactMarkdown with remark-gfm and rehype-highlight plugins
- Properly renders formatting, line breaks, markdown, and code syntax highlighting

## Test plan
- [x] CI passed (6073 tests)
- [x] Typecheck passed
- [x] Lint passed
- [ ] Manual verification: View a bookmark with AI summary to confirm formatting is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)