### PR TITLE
Fix internal-clients exports for Docker builds

### DIFF
--- a/packages/internal-clients/package.json
+++ b/packages/internal-clients/package.json
@@ -3,15 +3,8 @@
   "version": "0.0.1",
   "private": true,
   "type": "module",
-  "main": "./dist/index.js",
-  "module": "./dist/index.js",
-  "types": "./dist/index.d.ts",
   "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "default": "./dist/index.js"
-    }
+    ".": "./src/index.ts"
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
## Summary
- Changed `internal-clients` package to export from `src/` instead of `dist/`
- This aligns with other workspace packages (`llm-factory`, `llm-pricing`, etc.)

## Root Cause
The `internal-clients` package exported from `dist/`:
```json
"exports": {
  ".": {
    "types": "./dist/index.d.ts",
    "import": "./dist/index.js"
  }
}
```

During Docker builds, esbuild tries to resolve `@intexuraos/internal-clients` but can't find `dist/index.js` because the package hasn't been compiled yet.

## Fix
Changed to export from `src/` like other packages:
```json
"exports": {
  ".": "./src/index.ts"
}
```

This allows esbuild to bundle the package directly without requiring a separate build step.

## Test plan
- [x] `pnpm build` succeeds
- [x] `pnpm run ci:tracked` passes (6087 tests)
- [ ] Cloud Build succeeds for calendar-agent
- [ ] Full intexuraos-dev-deploy trigger succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)