### PR TITLE
[INT-268] URL-encode userId in user-service client

### DIFF
--- a/packages/internal-clients/src/user-service/client.ts
+++ b/packages/internal-clients/src/user-service/client.ts
@@ -62,11 +62,14 @@ export function createUserServiceClient(config: UserServiceConfig): UserServiceC
   return {
     async getApiKeys(userId: string): Promise<Result<DecryptedApiKeys, UserServiceError>> {
       try {
-        const response = await fetch(`${config.baseUrl}/internal/users/${userId}/llm-keys`, {
-          headers: {
-            'X-Internal-Auth': config.internalAuthToken,
-          },
-        });
+        const response = await fetch(
+          `${config.baseUrl}/internal/users/${encodeURIComponent(userId)}/llm-keys`,
+          {
+            headers: {
+              'X-Internal-Auth': config.internalAuthToken,
+            },
+          }
+        );
 
         if (!response.ok) {
           return err({
@@ -117,7 +120,7 @@ export function createUserServiceClient(config: UserServiceConfig): UserServiceC
       try {
         // Step 1: Fetch user settings to get default model
         const settingsResponse = await fetch(
-          `${config.baseUrl}/internal/users/${userId}/settings`,
+          `${config.baseUrl}/internal/users/${encodeURIComponent(userId)}/settings`,
           {
             headers: {
               'X-Internal-Auth': config.internalAuthToken,
@@ -160,11 +163,14 @@ export function createUserServiceClient(config: UserServiceConfig): UserServiceC
         const provider = getProviderForModel(defaultModel);
         const keyField = providerToKeyField(provider);
 
-        const keysResponse = await fetch(`${config.baseUrl}/internal/users/${userId}/llm-keys`, {
-          headers: {
-            'X-Internal-Auth': config.internalAuthToken,
-          },
-        });
+        const keysResponse = await fetch(
+          `${config.baseUrl}/internal/users/${encodeURIComponent(userId)}/llm-keys`,
+          {
+            headers: {
+              'X-Internal-Auth': config.internalAuthToken,
+            },
+          }
+        );
 
         if (!keysResponse.ok) {
           logger.error({ userId, status: keysResponse.status }, 'Failed to fetch API keys');
@@ -218,12 +224,15 @@ export function createUserServiceClient(config: UserServiceConfig): UserServiceC
 
     async reportLlmSuccess(userId: string, provider: LlmProvider): Promise<void> {
       try {
-        await fetch(`${config.baseUrl}/internal/users/${userId}/llm-keys/${provider}/last-used`, {
-          method: 'POST',
-          headers: {
-            'X-Internal-Auth': config.internalAuthToken,
-          },
-        });
+        await fetch(
+          `${config.baseUrl}/internal/users/${encodeURIComponent(userId)}/llm-keys/${provider}/last-used`,
+          {
+            method: 'POST',
+            headers: {
+              'X-Internal-Auth': config.internalAuthToken,
+            },
+          }
+        );
       } catch /* v8 ignore next -- best effort, silent failure intentional */ {
         // Best effort - don't block on failure
       }
@@ -235,7 +244,7 @@ export function createUserServiceClient(config: UserServiceConfig): UserServiceC
     ): Promise<Result<OAuthTokenResult, UserServiceError>> {
       try {
         const response = await fetch(
-          `${config.baseUrl}/internal/users/${userId}/oauth/${provider}/token`,
+          `${config.baseUrl}/internal/users/${encodeURIComponent(userId)}/oauth/${provider}/token`,
           {
             headers: { 'X-Internal-Auth': config.internalAuthToken },
           }


### PR DESCRIPTION
## Summary

Fixed security vulnerability where `userId` parameters were not URL-encoded in HTTP requests to user-service. This could lead to injection vulnerabilities when userIds contain special characters (e.g., Auth0 userIds with `|` character).

## Changes

- **`packages/internal-clients/src/user-service/client.ts`**: Added `encodeURIComponent()` to all 5 HTTP request paths that include userId:
  1. `getApiKeys()` → `/internal/users/${userId}/llm-keys`
  2. `getLlmClient()` settings → `/internal/users/${userId}/settings`
  3. `getLlmClient()` keys → `/internal/users/${userId}/llm-keys`
  4. `reportLlmSuccess()` → `/internal/users/${userId}/llm-keys/${provider}/last-used`
  5. `getOAuthToken()` → `/internal/users/${userId}/oauth/${provider}/token`

- **`packages/internal-clients/src/user-service/__tests__/client.test.ts`**: Added 7 new tests verifying URL encoding works correctly for:
  - Spaces (`user 123` → `user%20123`)
  - Plus (`user+123` → `user%2B123`)
  - Ampersand (`user&test` → `user%26test`)
  - Pipe/Auth0 format (`auth0|123` → `auth0%7C123`)
  - Slash (`user/with/slash` → `user%2Fwith%2Fslash`)

## Test Results

All 40 tests pass, including 7 new URL encoding tests.

Fixes INT-268