### PR TITLE
[INT-402] Add tests for cancelled/processing status branch coverage

### DIFF
--- a/.claude/ci-failures/intexuraos-1-fix_INT-402-coverage-updateTodoItem.jsonl
+++ b/.claude/ci-failures/intexuraos-1-fix_INT-402-coverage-updateTodoItem.jsonl
@@ -1,0 +1,3 @@
+{"ts":"2026-01-26T17:35:33.135Z","project":"intexuraos-1","branch":"fix/INT-402-coverage-updateTodoItem","runNumber":1,"passed":false,"durationMs":234223,"failureCount":1,"failures":[{"type":"verify","code":"VERIFY_FAIL","file":"unknown","line":0,"message":"FAILED","snippet":null,"context":null}]}
+{"ts":"2026-01-26T17:37:29.550Z","project":"intexuraos-1","branch":"fix/INT-402-coverage-updateTodoItem","workspace":"todos-agent","runNumber":2,"passed":true,"durationMs":87514,"failureCount":0,"failures":[]}
+{"ts":"2026-01-26T17:48:22.703Z","project":"intexuraos-1","branch":"fix/INT-402-coverage-updateTodoItem","workspace":"todos-agent","runNumber":3,"passed":true,"durationMs":85573,"failureCount":0,"failures":[]}


### PR DESCRIPTION
## Summary

- Added test case for updating item on cancelled todo - verifies cancelled status is preserved
- Added test case for updating item on processing todo - verifies processing status is preserved

## Test Coverage

These tests cover the ternary branch at lines 87-90 in `updateTodoItem.ts`:
```typescript
const newTodoStatus =
  todo.status === 'cancelled' || todo.status === 'processing'
    ? todo.status  // ← This branch is now covered
    : computeTodoStatus(updatedItems);
```

## Verification

- [x] All tests pass locally
- [x] `pnpm run verify:workspace:tracked todos-agent` passes

Fixes INT-402

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>