### PR TITLE
[INT-391] Place unprioritized items between medium and low

### DIFF
--- a/apps/web/src/utils/__tests__/todoItemSort.test.ts
+++ b/apps/web/src/utils/__tests__/todoItemSort.test.ts
@@ -44,10 +44,11 @@ describe('sortTodoItems', () => {
 
     const result = sortTodoItems(items);
 
+    // Unprioritized items sort between medium and low
     expect(result[0].id).toBe('2'); // high
     expect(result[1].id).toBe('1'); // medium
-    expect(result[2].id).toBe('3'); // low
-    expect(result[3].id).toBe('4'); // none
+    expect(result[2].id).toBe('4'); // none (between medium and low)
+    expect(result[3].id).toBe('3'); // low
   });
 
   it('places urgent priority above high', () => {
@@ -62,6 +63,22 @@ describe('sortTodoItems', () => {
     expect(result[0].id).toBe('1'); // urgent, position 1
     expect(result[1].id).toBe('3'); // urgent, position 3
     expect(result[2].id).toBe('2'); // high
+  });
+
+  it('places unprioritized items between medium and low priority', () => {
+    const items = [
+      createMockItem({ id: '1', status: 'pending', priority: 'low', position: 1 }),
+      createMockItem({ id: '2', status: 'pending', priority: null, position: 2 }),
+      createMockItem({ id: '3', status: 'pending', priority: 'medium', position: 3 }),
+      createMockItem({ id: '4', status: 'pending', priority: null, position: 4 }),
+    ];
+
+    const result = sortTodoItems(items);
+
+    expect(result[0].id).toBe('3'); // medium
+    expect(result[1].id).toBe('2'); // none (between medium and low, position 2)
+    expect(result[2].id).toBe('4'); // none (between medium and low, position 4)
+    expect(result[3].id).toBe('1'); // low
   });
 
   it('maintains original position order within same priority and status', () => {
@@ -103,10 +120,10 @@ describe('sortTodoItems', () => {
 
     const result = sortTodoItems(items);
 
-    // Pending group first, ordered by priority: high > low > none
+    // Pending group first, ordered by priority: high > none > low
     expect(result[0].id).toBe('3'); // pending high
-    expect(result[1].id).toBe('2'); // pending low
-    expect(result[2].id).toBe('5'); // pending none
+    expect(result[1].id).toBe('5'); // pending none (between medium and low)
+    expect(result[2].id).toBe('2'); // pending low
 
     // Completed group after, ordered by priority: high > medium
     expect(result[3].id).toBe('1'); // completed high

--- a/apps/web/src/utils/todoItemSort.ts
+++ b/apps/web/src/utils/todoItemSort.ts
@@ -4,14 +4,14 @@ type PriorityKey = TodoPriority | 'null';
 
 /**
  * Priority order for sorting (highest to lowest).
- * Items with no priority (null) sort last within their completion group.
+ * Items with no priority (null) sort between medium and low.
  */
 const PRIORITY_ORDER: Readonly<Record<PriorityKey, number>> = {
   urgent: 4,
   high: 3,
   medium: 2,
+  null: 1.5,
   low: 1,
-  null: 0,
 } as const;
 
 /**
@@ -26,7 +26,7 @@ function getPriorityScore(item: TodoItem): number {
  *
  * Sort key (in order of precedence):
  * 1. Pending first - uncompleted items above completed
- * 2. Priority descending - urgent > high > medium > low > none
+ * 2. Priority descending - urgent > high > medium > none > low
  * 3. Original position - maintain insertion order within same priority
  */
 function compareTodoItems(a: TodoItem, b: TodoItem): number {
@@ -53,7 +53,7 @@ function compareTodoItems(a: TodoItem, b: TodoItem): number {
 /**
  * Sort todo items with the proper sort key:
  * 1. Pending first (uncompleted above completed)
- * 2. Priority descending (urgent > high > medium > low > none)
+ * 2. Priority descending (urgent > high > medium > none > low)
  * 3. Original position within same priority
  *
  * @param items - Todo items to sort


### PR DESCRIPTION
## Summary

- Changed priority score for unprioritized (null) items from 0 to 1.5
- Items without priority now sort between medium (2) and low (1) priority items
- Updated tests to verify new sorting order

## Changes

| File | Change |
|------|--------|
| `apps/web/src/utils/todoItemSort.ts` | Changed `null` priority score from 0 to 1.5 |
| `apps/web/src/utils/__tests__/todoItemSort.test.ts` | Updated tests + added explicit test for unprioritized placement |

## Test Plan

- [x] All existing tests updated to reflect new sort order
- [x] Added dedicated test for unprioritized items placement
- [x] Full CI passes

Fixes INT-391

🤖 Generated with [Claude Code](https://claude.com/claude-code)