### PR TITLE
[INT-392] Fix release skill to bump all package versions

### DIFF
--- a/.claude/commands/semver-release.md
+++ b/.claude/commands/semver-release.md
@@ -184,14 +184,25 @@ NEW_VERSION="X.Y.Z"
 # Update root package.json
 pnpm version $NEW_VERSION --no-git-tag-version
 
-# Update all apps
+# Update all apps (excluding dist directories)
 for app in apps/*/package.json; do
-  jq ".version = \"$NEW_VERSION\"" "$app" > tmp.json && mv tmp.json "$app"
+  if [[ ! "$app" == *"/dist/"* ]]; then
+    jq ".version = \"$NEW_VERSION\"" "$app" > tmp.json && mv tmp.json "$app"
+  fi
 done
 
-# Update all packages
+# Update all packages (excluding dist directories)
 for pkg in packages/*/package.json; do
-  jq ".version = \"$NEW_VERSION\"" "$pkg" > tmp.json && mv tmp.json "$pkg"
+  if [[ ! "$pkg" == *"/dist/"* ]]; then
+    jq ".version = \"$NEW_VERSION\"" "$pkg" > tmp.json && mv tmp.json "$pkg"
+  fi
+done
+
+# Update all workers (excluding dist directories)
+for worker in workers/*/package.json; do
+  if [[ ! "$worker" == *"/dist/"* ]]; then
+    jq ".version = \"$NEW_VERSION\"" "$worker" > tmp.json && mv tmp.json "$worker"
+  fi
 done
 
 # Regenerate lock file
@@ -209,7 +220,7 @@ Update the "Current Version" line at the top of CHANGELOG.md:
 ### 10. Commit Release
 
 ```bash
-git add CHANGELOG.md package.json package-lock.json apps/*/package.json packages/*/package.json
+git add CHANGELOG.md package.json package-lock.json apps/*/package.json packages/*/package.json workers/*/package.json
 git commit -m "Release vNEW_VERSION"
 ```
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -16,32 +16,66 @@
   "hooks": {
     "SessionStart": [
       {
-        "hooks": [{ "type": "command", "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/session-start-build.sh" }]
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/session-start-build.sh"
+          }
+        ]
       }
     ],
     "PreToolUse": [
       {
         "matcher": "Bash",
         "hooks": [
-          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/log-command-start.sh" },
-          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/validate-coverage-commands.sh" },
-          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/validate-terraform.sh" },
-          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/validate-gcloud-resources.sh" },
-          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/validate-ci-output-capture.sh" },
-          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/validate-verify-workspace.sh" }
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/log-command-start.sh"
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/validate-coverage-commands.sh"
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/validate-terraform.sh"
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/validate-gcloud-resources.sh"
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/validate-ci-output-capture.sh"
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/validate-verify-workspace.sh"
+          }
         ]
       },
       {
         "matcher": "Edit|Write",
-        "hooks": [{ "type": "command", "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/validate-coverage-config.sh" }]
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/validate-coverage-config.sh"
+          }
+        ]
       }
     ],
     "PostToolUse": [
       {
         "matcher": "Bash",
         "hooks": [
-          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/log-command-end.sh" },
-          { "type": "command", "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/rebuild-after-git.sh" }
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/log-command-end.sh"
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/rebuild-after-git.sh"
+          }
         ]
       }
     ]

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -23,17 +23,18 @@ Orchestrate a comprehensive 6-phase release workflow with checkpoints for user c
 3. **CI Gate**: `pnpm run ci:tracked` MUST pass before Phase 6 commits anything
 4. **Tag Push**: Phase 6 creates AND pushes the version tag to remote
 5. **Three Suggestions Only**: Phase 5 website audit produces EXACTLY 3 improvement suggestions
+6. **Monorepo Version Sync**: Phase 6 MUST update ALL package.json files (root, apps/\*, packages/\*, workers/\*) to the new version — not just the root
 
 ## Phase Overview
 
-| Phase | Name            | Interaction    | Key Actions                                   |
-| ----- | --------------- | -------------- | --------------------------------------------- |
-| 1     | Kickoff         | User Input     | Run semver analysis, detect modified services |
-| 2     | Service Docs    | Silent Batch   | Spawn service-scribe agents in parallel       |
-| 3     | High-Level Docs | **Checkpoint** | Propose docs/overview.md updates, wait        |
-| 4     | README          | **Checkpoint** | Propose "What's New" section, wait            |
-| 5     | Website         | **Checkpoint** | RecentUpdatesSection + 3 suggestions          |
-| 6     | Finalize        | Automatic      | CI check, commit, tag push, summary           |
+| Phase | Name            | Interaction    | Key Actions                                       |
+| ----- | --------------- | -------------- | ------------------------------------------------- |
+| 1     | Kickoff         | User Input     | Run semver analysis, detect modified services     |
+| 2     | Service Docs    | Silent Batch   | Spawn service-scribe agents in parallel           |
+| 3     | High-Level Docs | **Checkpoint** | Propose docs/overview.md updates, wait            |
+| 4     | README          | **Checkpoint** | Propose "What's New" section, wait                |
+| 5     | Website         | **Checkpoint** | RecentUpdatesSection + 3 suggestions              |
+| 6     | Finalize        | Automatic      | **Bump ALL versions**, CI check, commit, tag push |
 
 ## Tool Verification (Fail Fast)
 
@@ -199,12 +200,13 @@ When releasing a NEW major version (e.g., v3.0.0):
 
 ### Phase 6: Finalize
 
-1. Run `pnpm run ci:tracked` — MUST pass
-2. Stage all changes
-3. Commit with release message
-4. Create version tag
-5. Push tag to remote
-6. Display release summary
+1. **Update ALL package.json versions** — root, apps/\*, packages/\*, workers/\* (CRITICAL)
+2. Run `pnpm run ci:tracked` — MUST pass
+3. Stage all changes
+4. Commit with release message
+5. Create version tag
+6. Push tag to remote
+7. Display release summary
 
 ## Checkpoint Pattern
 

--- a/.claude/skills/release/workflows/full-release.md
+++ b/.claude/skills/release/workflows/full-release.md
@@ -409,7 +409,63 @@ Wait for each to complete before starting the next.
 
 ## Phase 6: Finalize
 
-### 6.1 CI Gate (MANDATORY)
+### 6.1 Update All Package Versions (MANDATORY)
+
+**CRITICAL:** All package.json files must have the same version. This ensures the monorepo stays in sync.
+
+```bash
+NEW_VERSION="X.Y.Z"  # From Phase 1 calculation
+
+# Update root package.json
+jq ".version = \"$NEW_VERSION\"" package.json > tmp.json && mv tmp.json package.json
+
+# Update all apps (excluding dist directories)
+for app in apps/*/package.json; do
+  if [[ ! "$app" == *"/dist/"* ]]; then
+    jq ".version = \"$NEW_VERSION\"" "$app" > tmp.json && mv tmp.json "$app"
+  fi
+done
+
+# Update all packages (excluding dist directories)
+for pkg in packages/*/package.json; do
+  if [[ ! "$pkg" == *"/dist/"* ]]; then
+    jq ".version = \"$NEW_VERSION\"" "$pkg" > tmp.json && mv tmp.json "$pkg"
+  fi
+done
+
+# Update all workers (excluding dist directories)
+for worker in workers/*/package.json; do
+  if [[ ! "$worker" == *"/dist/"* ]]; then
+    jq ".version = \"$NEW_VERSION\"" "$worker" > tmp.json && mv tmp.json "$worker"
+  fi
+done
+
+# Verify all versions are updated
+echo "Verifying all package.json versions..."
+MISMATCH=0
+for f in package.json apps/*/package.json packages/*/package.json workers/*/package.json; do
+  if [[ ! "$f" == *"/dist/"* ]]; then
+    version=$(jq -r '.version' "$f")
+    if [[ "$version" != "$NEW_VERSION" ]]; then
+      echo "MISMATCH: $f has version $version"
+      MISMATCH=1
+    fi
+  fi
+done
+if [[ $MISMATCH -eq 1 ]]; then
+  echo "ERROR: Version mismatch detected. Fix before proceeding."
+  exit 1
+fi
+echo "All package.json files updated to $NEW_VERSION"
+```
+
+**Why all packages?** In a monorepo, version consistency ensures:
+
+- Clear release tracking across all services
+- Deployment scripts can rely on consistent versioning
+- No confusion about which service is at which version
+
+### 6.2 CI Gate (MANDATORY)
 
 ```bash
 pnpm run ci:tracked
@@ -422,14 +478,14 @@ pnpm run ci:tracked
 3. Re-run CI
 4. Do NOT proceed until CI passes
 
-### 6.2 Stage All Changes
+### 6.3 Stage All Changes
 
 ```bash
 git status
 git add -A
 ```
 
-### 6.3 Commit Release
+### 6.4 Commit Release
 
 ```bash
 NEW_VERSION="X.Y.Z"  # From Phase 1
@@ -437,6 +493,7 @@ NEW_VERSION="X.Y.Z"  # From Phase 1
 git commit -m "$(cat <<'EOF'
 Release vX.Y.Z
 
+- Bumped all package.json versions to X.Y.Z
 - Updated service documentation
 - Updated docs/overview.md
 - Updated README "What's New" section
@@ -447,14 +504,14 @@ EOF
 )"
 ```
 
-### 6.4 Create and Push Tag
+### 6.5 Create and Push Tag
 
 ```bash
 git tag -a "v$NEW_VERSION" -m "Release v$NEW_VERSION"
 git push origin "v$NEW_VERSION"
 ```
 
-### 6.5 Display Summary
+### 6.6 Display Summary
 
 Use template from [`templates/release-summary.md`](../templates/release-summary.md).
 

--- a/apps/actions-agent/package.json
+++ b/apps/actions-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intexuraos/actions-agent",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/apps/api-docs-hub/package.json
+++ b/apps/api-docs-hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intexuraos/api-docs-hub",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/apps/app-settings-service/package.json
+++ b/apps/app-settings-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intexuraos/app-settings-service",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/apps/bookmarks-agent/package.json
+++ b/apps/bookmarks-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intexuraos/bookmarks-agent",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/apps/calendar-agent/package.json
+++ b/apps/calendar-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intexuraos/calendar-agent",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/apps/code-agent/package.json
+++ b/apps/code-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intexuraos/code-agent",
-  "version": "0.0.1",
+  "version": "2.1.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/apps/commands-agent/package.json
+++ b/apps/commands-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intexuraos/commands-agent",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/apps/data-insights-agent/package.json
+++ b/apps/data-insights-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intexuraos/data-insights-agent",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/apps/image-service/package.json
+++ b/apps/image-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intexuraos/image-service",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/apps/linear-agent/package.json
+++ b/apps/linear-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intexuraos/linear-agent",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/apps/mobile-notifications-service/package.json
+++ b/apps/mobile-notifications-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intexuraos/mobile-notifications-service",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/apps/notes-agent/package.json
+++ b/apps/notes-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intexuraos/notes-agent",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/apps/notion-service/package.json
+++ b/apps/notion-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intexuraos/notion-service",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/apps/research-agent/package.json
+++ b/apps/research-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intexuraos/research-agent",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/apps/todos-agent/package.json
+++ b/apps/todos-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intexuraos/todos-agent",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/apps/user-service/package.json
+++ b/apps/user-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intexuraos/user-service",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/apps/web-agent/package.json
+++ b/apps/web-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intexuraos/web-agent",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intexuraos/web",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/whatsapp-service/package.json
+++ b/apps/whatsapp-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intexuraos/whatsapp-service",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/packages/common-core/package.json
+++ b/packages/common-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intexuraos/common-core",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/packages/common-http/package.json
+++ b/packages/common-http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intexuraos/common-http",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/packages/http-contracts/package.json
+++ b/packages/http-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intexuraos/http-contracts",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/packages/http-server/package.json
+++ b/packages/http-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intexuraos/http-server",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/packages/infra-claude/package.json
+++ b/packages/infra-claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intexuraos/infra-claude",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/packages/infra-firestore/package.json
+++ b/packages/infra-firestore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intexuraos/infra-firestore",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/packages/infra-gemini/package.json
+++ b/packages/infra-gemini/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intexuraos/infra-gemini",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/packages/infra-glm/package.json
+++ b/packages/infra-glm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intexuraos/infra-glm",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/packages/infra-gpt/package.json
+++ b/packages/infra-gpt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intexuraos/infra-gpt",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/packages/infra-notion/package.json
+++ b/packages/infra-notion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intexuraos/infra-notion",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/packages/infra-perplexity/package.json
+++ b/packages/infra-perplexity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intexuraos/infra-perplexity",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/packages/infra-pubsub/package.json
+++ b/packages/infra-pubsub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intexuraos/infra-pubsub",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/packages/infra-sentry/package.json
+++ b/packages/infra-sentry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intexuraos/infra-sentry",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/packages/infra-whatsapp/package.json
+++ b/packages/infra-whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intexuraos/infra-whatsapp",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/packages/internal-clients/package.json
+++ b/packages/internal-clients/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intexuraos/internal-clients",
-  "version": "0.0.1",
+  "version": "2.1.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/llm-audit/package.json
+++ b/packages/llm-audit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intexuraos/llm-audit",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/packages/llm-contract/package.json
+++ b/packages/llm-contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intexuraos/llm-contract",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/packages/llm-factory/package.json
+++ b/packages/llm-factory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intexuraos/llm-factory",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/packages/llm-pricing/package.json
+++ b/packages/llm-pricing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intexuraos/llm-pricing",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/packages/llm-prompts/package.json
+++ b/packages/llm-prompts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intexuraos/llm-prompts",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/packages/llm-utils/package.json
+++ b/packages/llm-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intexuraos/llm-utils",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/workers/log-cleanup/package.json
+++ b/workers/log-cleanup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intexuraos/log-cleanup",
-  "version": "1.0.0",
+  "version": "2.1.0",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/workers/orchestrator/package.json
+++ b/workers/orchestrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intexuraos/orchestrator",
-  "version": "1.0.0",
+  "version": "2.1.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/workers/vm-lifecycle/package.json
+++ b/workers/vm-lifecycle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intexuraos/vm-lifecycle",
-  "version": "1.0.0",
+  "version": "2.1.0",
   "private": true,
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Sync all package.json versions to 2.1.0 (apps, packages, workers)
- Update `/release` skill to bump ALL package.json files in Phase 6
- Update `/semver-release` command to include workers directory
- Add 6th core mandate about monorepo version sync

## Root Cause
The `/release` skill's Phase 6 was missing the version bump step entirely. It referenced `NEW_VERSION` but never actually updated any package.json files. The `semver-release.md` command had the correct logic, but it wasn't integrated into the release workflow.

## Changes
1. **Sync existing versions**: All package.json files now at 2.1.0
2. **Release skill update**: Added step 6.1 "Update All Package Versions" that:
   - Updates root, apps/*, packages/*, workers/* package.json files
   - Excludes dist directories
   - Verifies all versions match before proceeding
3. **Added core mandate**: "Monorepo Version Sync" as 6th mandate

Fixes INT-392

🤖 Generated with [Claude Code](https://claude.ai/code)