### PR TITLE
INT-316 Fix View resource link persistence

### DIFF
--- a/apps/actions-agent/src/__tests__/handleLinkAction.test.ts
+++ b/apps/actions-agent/src/__tests__/handleLinkAction.test.ts
@@ -178,7 +178,7 @@ describe('handleLinkAction usecase', () => {
       await fakeActionRepository.save(createAction());
 
       const fakeExecuteLinkAction = vi.fn().mockResolvedValue(
-        ok({ status: 'completed' as const, resource_url: '/#/bookmarks/bookmark-123' })
+        ok({ status: 'completed' as const, resourceUrl: '/#/bookmarks/bookmark-123' })
       );
 
       const usecase = registerActionHandler(createHandleLinkActionUseCase, {
@@ -253,7 +253,7 @@ describe('handleLinkAction usecase', () => {
       await fakeActionRepository.save(createAction());
 
       const fakeExecuteLinkAction = vi.fn().mockResolvedValue(
-        ok({ status: 'completed' as const, resource_url: '/#/bookmarks/bookmark-123' })
+        ok({ status: 'completed' as const, resourceUrl: '/#/bookmarks/bookmark-123' })
       );
 
       const usecase = registerActionHandler(createHandleLinkActionUseCase, {

--- a/apps/actions-agent/src/__tests__/handleNoteAction.test.ts
+++ b/apps/actions-agent/src/__tests__/handleNoteAction.test.ts
@@ -191,7 +191,7 @@ describe('handleNoteAction usecase', () => {
       await fakeActionRepository.save(createAction());
 
       const fakeExecuteNoteAction = vi.fn().mockResolvedValue(
-        ok({ status: 'completed' as const, resource_url: '/#/notes/note-123' })
+        ok({ status: 'completed' as const, resourceUrl: '/#/notes/note-123' })
       );
 
       const usecase = registerActionHandler(createHandleNoteActionUseCase, {

--- a/apps/actions-agent/src/__tests__/handleResearchAction.test.ts
+++ b/apps/actions-agent/src/__tests__/handleResearchAction.test.ts
@@ -191,7 +191,7 @@ describe('handleResearchAction usecase', () => {
       await fakeActionRepository.save(createAction());
 
       const fakeExecuteResearchAction = vi.fn().mockResolvedValue(
-        ok({ status: 'completed' as const, resource_url: '/#/research/research-123' })
+        ok({ status: 'completed' as const, resourceUrl: '/#/research/research-123' })
       );
 
       const usecase = registerActionHandler(createHandleResearchActionUseCase, {

--- a/apps/actions-agent/src/__tests__/handleTodoAction.test.ts
+++ b/apps/actions-agent/src/__tests__/handleTodoAction.test.ts
@@ -171,7 +171,7 @@ describe('handleTodoAction usecase', () => {
       await fakeActionRepository.save(createAction());
 
       const fakeExecuteTodoAction = vi.fn().mockResolvedValue(
-        ok({ status: 'completed' as const, resource_url: '/#/todos/todo-123' })
+        ok({ status: 'completed' as const, resourceUrl: '/#/todos/todo-123' })
       );
 
       const usecase = registerActionHandler(createHandleTodoActionUseCase, {

--- a/apps/web/src/components/ActionDetailModal.tsx
+++ b/apps/web/src/components/ActionDetailModal.tsx
@@ -242,6 +242,14 @@ export function ActionDetailModal({
         linkLabel,
       });
 
+      // Update parent state with resource_url in payload for persistence
+      onActionUpdated?.({
+        ...action,
+        status: 'completed',
+        payload: { ...action.payload, resource_url: normalizedUrl },
+        updatedAt: new Date().toISOString(),
+      });
+
       setExecutionResult({
         actionId: result.actionId,
         status: result.status,

--- a/apps/web/src/components/ActionItem.tsx
+++ b/apps/web/src/components/ActionItem.tsx
@@ -38,6 +38,7 @@ interface ActionItemProps {
   action: Action;
   onClick: () => void;
   onActionSuccess: (button: ResolvedActionButton) => void;
+  onActionUpdated?: (action: Action) => void;
   onDismiss: (actionId: string) => Promise<void>;
   isDismissing?: boolean;
 }
@@ -117,6 +118,7 @@ export function ActionItem({
   action,
   onClick,
   onActionSuccess,
+  onActionUpdated,
   onDismiss,
   isDismissing = false,
 }: ActionItemProps): React.JSX.Element {
@@ -150,16 +152,24 @@ export function ActionItem({
   ): void => {
     closeDropdown?.();
     if (result.status === 'completed') {
+      const normalizedUrl =
+        result.resourceUrl !== undefined ? normalizeResourceUrl(result.resourceUrl) : undefined;
       setExecutionState({
         type: 'success',
         message: button.onSuccess?.message ?? 'Action completed!',
-        ...(result.resourceUrl !== undefined && {
-          resourceUrl: normalizeResourceUrl(result.resourceUrl),
-        }),
+        ...(normalizedUrl !== undefined && { resourceUrl: normalizedUrl }),
         ...(button.onSuccess?.linkLabel !== undefined && {
           linkLabel: button.onSuccess.linkLabel,
         }),
       });
+      if (normalizedUrl !== undefined) {
+        onActionUpdated?.({
+          ...action,
+          status: 'completed',
+          payload: { ...action.payload, resource_url: normalizedUrl },
+          updatedAt: new Date().toISOString(),
+        });
+      }
     } else {
       setExecutionState({
         type: 'error',

--- a/apps/web/src/pages/InboxPage.tsx
+++ b/apps/web/src/pages/InboxPage.tsx
@@ -788,6 +788,11 @@ export function InboxPage(): React.JSX.Element {
                       void fetchData(true);
                     }
                   }}
+                  onActionUpdated={(updatedAction: Action): void => {
+                    setActions((prev) =>
+                      prev.map((a) => (a.id === updatedAction.id ? updatedAction : a))
+                    );
+                  }}
                   onDismiss={handleDismissAction}
                 />
               ))


### PR DESCRIPTION
## Summary
- Added `onActionUpdated` callback to `ActionItem` component to persist `resource_url` in action payload after execution
- Updated `ActionDetailModal` to also call `onActionUpdated` when action completes successfully
- Fixed test mock return values in `handle*Action.test.ts` files to use camelCase `resourceUrl` matching `ServiceFeedback` interface

## Problem
When actions were executed (e.g., creating a Todo, Note, etc.), the "View" link would appear immediately after execution (from local `executionState`) but would disappear after:
1. Dismissing the execution success panel
2. Closing and reopening the modal
3. Navigating away and returning

The link only appeared again after a full page refresh because the `resource_url` was never persisted in React state - only in the backend Firestore.

## Solution
After successful execution, components now call `onActionUpdated` with the updated action containing `resource_url` in its payload. This ensures the parent state is updated and the link persists across UI interactions.

## Test plan
- [x] All 6807 tests pass
- [x] CI passes
- [ ] Manual: Execute action → View link appears → Dismiss panel → View link still visible
- [ ] Manual: Execute action → Close modal → Reopen modal → View link still visible
- [ ] Manual: Execute action in list → View link appears → Click elsewhere → View link persists

Fixes INT-316

🤖 Generated with [Claude Code](https://claude.com/claude-code)