### PR TITLE
[INT-389] Fix share history UX and sync recovery

### DIFF
--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -7,7 +7,7 @@ import { ChevronDown, LogOut, User, RefreshCw, RotateCcw, Server } from 'lucide-
 
 export function Header(): React.JSX.Element {
   const { user, logout, isAuthenticated } = useAuth();
-  const { pendingCount, isSyncing } = useSyncQueue();
+  const { pendingCount, isSyncing, isOnline, authFailed } = useSyncQueue();
   const { isInstalled } = usePWA();
   const { status: workersStatus } = useWorkersStatus();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -165,10 +165,22 @@ export function Header(): React.JSX.Element {
           <Link
             to="/settings/share-history"
             className="flex items-center justify-center rounded-lg p-2 text-sm transition-colors hover:bg-slate-100"
-            title={`${String(pendingCount)} pending - click to view history`}
+            title={
+              !isOnline
+                ? 'Offline - click to view history'
+                : authFailed
+                  ? 'Sign in to sync - click to view history'
+                  : `${String(pendingCount)} pending - click to view history`
+            }
           >
             <RefreshCw
-              className={`h-4 w-4 text-amber-500 ${isSyncing ? 'animate-spin' : 'animate-pulse'}`}
+              className={`h-4 w-4 ${
+                !isOnline || authFailed
+                  ? 'text-slate-400'
+                  : isSyncing
+                    ? 'text-amber-500 animate-spin'
+                    : 'text-amber-500 animate-pulse'
+              }`}
             />
           </Link>
         )}

--- a/apps/web/src/pages/ShareHistoryPage.tsx
+++ b/apps/web/src/pages/ShareHistoryPage.tsx
@@ -1,39 +1,12 @@
 import { useSyncQueue } from '@/context';
 import { Layout, Card } from '@/components';
 import { Share2, CheckCircle2, Clock, AlertCircle, RefreshCw, Trash2 } from 'lucide-react';
-import { clearHistory, type ShareStatus } from '@/services/shareQueue';
+import { clearHistory, type ShareHistoryItem } from '@/services/shareQueue';
 
-function StatusBadge({ status }: { status: ShareStatus }): React.JSX.Element {
-  switch (status) {
-    case 'synced':
-      return (
-        <span className="flex items-center gap-1 text-sm text-green-600">
-          <CheckCircle2 className="h-4 w-4" />
-          Synced
-        </span>
-      );
-    case 'syncing':
-      return (
-        <span className="flex items-center gap-1 text-sm text-blue-600">
-          <RefreshCw className="h-4 w-4 animate-spin" />
-          Syncing
-        </span>
-      );
-    case 'pending':
-      return (
-        <span className="flex items-center gap-1 text-sm text-amber-600">
-          <Clock className="h-4 w-4" />
-          Pending
-        </span>
-      );
-    case 'failed':
-      return (
-        <span className="flex items-center gap-1 text-sm text-red-600">
-          <AlertCircle className="h-4 w-4" />
-          Failed
-        </span>
-      );
-  }
+interface StatusTextProps {
+  item: ShareHistoryItem;
+  isOnline: boolean;
+  authFailed: boolean;
 }
 
 function formatDate(isoString: string): string {
@@ -52,8 +25,83 @@ function formatDate(isoString: string): string {
   return date.toLocaleDateString();
 }
 
+function getTimeUntilRetry(nextRetryAt: string): number {
+  return Math.max(0, new Date(nextRetryAt).getTime() - Date.now());
+}
+
+function formatDuration(ms: number): string {
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60) return `${String(seconds)}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${String(minutes)}m`;
+  const hours = Math.floor(minutes / 60);
+  return `${String(hours)}h`;
+}
+
+function StatusText({ item, isOnline, authFailed }: StatusTextProps): React.JSX.Element {
+  // Synced state
+  if (item.status === 'synced' && item.syncedAt !== undefined) {
+    return (
+      <span className="flex items-center gap-1 text-green-600">
+        <CheckCircle2 className="h-3 w-3" />
+        Synced {formatDate(item.syncedAt)}
+      </span>
+    );
+  }
+
+  // Syncing state
+  if (item.status === 'syncing') {
+    return (
+      <span className="flex items-center gap-1 text-blue-600">
+        <RefreshCw className="h-3 w-3 animate-spin" />
+        Syncing...
+      </span>
+    );
+  }
+
+  // Pending states
+  if (!isOnline) {
+    return (
+      <span className="flex items-center gap-1 text-slate-500">
+        <Clock className="h-3 w-3" />
+        Waiting for connection
+      </span>
+    );
+  }
+
+  if (authFailed) {
+    return (
+      <span className="flex items-center gap-1 text-red-600">
+        <AlertCircle className="h-3 w-3" />
+        Sign in to sync
+      </span>
+    );
+  }
+
+  // Pending with retry time
+  if (item.nextRetryAt !== undefined) {
+    const timeUntil = getTimeUntilRetry(item.nextRetryAt);
+    if (timeUntil > 0) {
+      return (
+        <span className="flex items-center gap-1 text-amber-600">
+          <Clock className="h-3 w-3" />
+          Retry in {formatDuration(timeUntil)}
+        </span>
+      );
+    }
+  }
+
+  // Default pending
+  return (
+    <span className="flex items-center gap-1 text-amber-600">
+      <Clock className="h-3 w-3" />
+      Pending
+    </span>
+  );
+}
+
 export function ShareHistoryPage(): React.JSX.Element {
-  const { history, pendingCount, isSyncing, refreshHistory } = useSyncQueue();
+  const { history, refreshHistory, isOnline, authFailed } = useSyncQueue();
 
   const handleClearHistory = (): void => {
     clearHistory();
@@ -73,13 +121,11 @@ export function ShareHistoryPage(): React.JSX.Element {
                 <div>
                   <h1 className="text-xl font-semibold text-slate-900">Share History</h1>
                   <p className="text-sm text-slate-500">
-                    {pendingCount > 0 ? (
-                      <span className="text-amber-600">
-                        {pendingCount} pending{isSyncing ? ', syncing...' : ''}
-                      </span>
-                    ) : (
-                      'All shares synced'
-                    )}
+                    {!isOnline ? (
+                      <span className="text-amber-600">Offline</span>
+                    ) : authFailed ? (
+                      <span className="text-red-600">Sign in to sync</span>
+                    ) : null}
                   </p>
                 </div>
               </div>
@@ -107,21 +153,14 @@ export function ShareHistoryPage(): React.JSX.Element {
               <div className="divide-y divide-slate-100">
                 {history.map((item) => (
                   <div key={item.id} className="py-4">
-                    <div className="mb-2 flex items-start justify-between gap-4">
-                      <p className="flex-1 text-sm text-slate-900">{item.contentPreview}</p>
-                      <StatusBadge status={item.status} />
-                    </div>
-                    <div className="flex items-center gap-4 text-xs text-slate-500">
-                      <span>{formatDate(item.createdAt)}</span>
-                      {item.syncedAt !== undefined && (
-                        <span>Synced {formatDate(item.syncedAt)}</span>
-                      )}
-                      {item.lastError !== undefined && (
-                        <span className="text-red-500" title={item.lastError}>
-                          Error: {item.lastError.slice(0, 50)}
-                          {item.lastError.length > 50 ? '...' : ''}
-                        </span>
-                      )}
+                    {/* Content preview with overflow fix */}
+                    <p className="text-sm text-slate-900 break-all line-clamp-2">{item.contentPreview}</p>
+
+                    {/* Unified footer with status */}
+                    <div className="mt-2 flex items-center gap-2 text-xs">
+                      <span className="text-slate-500">{formatDate(item.createdAt)}</span>
+                      <span className="text-slate-400">·</span>
+                      <StatusText item={item} isOnline={isOnline} authFailed={authFailed} />
                     </div>
                   </div>
                 ))}


### PR DESCRIPTION
## Summary

Fixed Share History UX issues including status display consolidation, automatic sync recovery, and long URL overflow handling.

## Changes

### shareQueue.ts
- Removed 'failed' status from ShareStatus (items now retry indefinitely)
- Added nextRetryAt to ShareHistoryItem interface
- Updated updateQueueItem to also update history with nextRetryAt/lastError
- Removed markAsFailed function (no longer needed)
- Removed isClientError function (no longer needed)

### SyncQueueContext.tsx
- Added isOnline state (tracks navigator.onLine)
- Added authFailed state (set on 401, cleared on re-auth)
- Added getStatusCode helper function
- Updated processQueue error handling:
  - 401 errors: stop syncing, set authFailed, wait for re-auth
  - Other errors: report to Sentry, retry with exponential backoff
- Added online/offline event listeners
- Exported isOnline and authFailed from context value

### ShareHistoryPage.tsx
- Removed StatusBadge component
- Added StatusText component with per-item status display:
  - Synced: green checkmark with timestamp
  - Syncing: blue spinner
  - Offline: slate "Waiting for connection"
  - Auth failed: red "Sign in to sync"
  - Pending with retry: amber "Retry in Xs/m/h"
  - Default pending: amber "Pending"
- Added helper functions: getTimeUntilRetry, formatDuration
- Fixed long URL overflow with CSS `break-all line-clamp-2`
- Updated header to show offline/auth status instead of pending count

### Header.tsx
- Updated sync indicator to show grey (text-slate-400) when offline or authFailed
- Updated title text to reflect offline/auth state

## Design Document

Full implementation spec: [docs/designs/INT-389-share-history-ux-design.md](https://github.com/pbuchman/intexuraos/blob/development/docs/designs/INT-389-share-history-ux-design.md)

Fixes INT-389