### PR TITLE
[INT-404] Add gcloud builds region hook + clean CLAUDE.md

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -200,8 +200,6 @@ Then analyze with proper tools (in priority order):
 2. `rg "error|FAIL" /tmp/ci-*.txt -C3` — fast search with context
 3. For coverage: `jq '.total.branches.pct' coverage/coverage-summary.json`
 
-**⚠️ Hook enforced:** CI commands without tee capture are blocked. See `.claude/reference/ci-output-analysis.md`.
-
 ### Step 2: Fix or Ask (No Skipping, No Committing)
 
 | Failure Location    | Action                                                                     |
@@ -276,8 +274,6 @@ GOOGLE_APPLICATION_CREDENTIALS=$HOME/personal/gcloud-claude-code-dev.json \
 terraform validate
 ```
 
-**⚠️ Hook enforced:** Running `terraform` without env var clearing is blocked. See `.claude/hooks/validate-terraform.sh`.
-
 ### Step 5: Document Verification Result
 
 - ✅ "Verified: No terraform files changed"
@@ -319,8 +315,6 @@ GOOGLE_APPLICATION_CREDENTIALS=$HOME/personal/gcloud-claude-code-dev.json \
 terraform plan
 ```
 
-**⚠️ Hook enforced:** `.claude/hooks/validate-terraform.sh` blocks bare `terraform` commands.
-
 ### Terraform-Only Resource Creation
 
 **RULE: ALL persistent infrastructure MUST be created via Terraform. Direct CLI resource creation is FORBIDDEN.**
@@ -343,8 +337,6 @@ terraform plan
 ❌ WRONG: Need a bucket → gsutil mb gs://my-bucket → Done
 ✅ RIGHT: Need a bucket → Add to terraform/ → terraform plan → terraform apply → PR
 ```
-
-**⚠️ Hook enforced:** `.claude/hooks/validate-gcloud-resources.sh` blocks direct CLI resource creation.
 
 **Exception:** Truly ephemeral resources for debugging. Never new named resources.
 

--- a/.claude/hooks/validate-gcloud-builds.sh
+++ b/.claude/hooks/validate-gcloud-builds.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# BLOCK: gcloud builds commands without --region flag
+# Exit 0 = allow, Exit 2 = block with stderr message
+
+HOOK_NAME="validate-gcloud-builds"
+LOG_FILE="$(dirname "$0")/${HOOK_NAME}.log"
+
+log_blocked() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] BLOCKED: $1" >> "$LOG_FILE"
+}
+
+INPUT=$(cat)
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // ""')
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // ""')
+
+[[ "$TOOL_NAME" != "Bash" ]] && exit 0
+[[ -z "$COMMAND" ]] && exit 0
+
+# Pattern: gcloud builds (list|log|describe) without --region
+# Use POSIX-compatible regex (macOS grep doesn't support \s)
+if echo "$COMMAND" | grep -qE 'gcloud[[:space:]]+builds[[:space:]]+(list|log|describe)' && \
+   ! echo "$COMMAND" | grep -q -- '--region'; then
+    cat >&2 << 'EOF'
+BLOCKED: gcloud builds commands require --region flag.
+
+This project uses regional Cloud Build in europe-central2.
+Without --region, you'll query the wrong regional pool.
+
+CORRECT:
+  gcloud builds list --region=europe-central2 --project=intexuraos-dev-pbuchman
+  gcloud builds log BUILD_ID --region=europe-central2 --project=intexuraos-dev-pbuchman
+  gcloud builds describe BUILD_ID --region=europe-central2 --project=intexuraos-dev-pbuchman
+EOF
+    log_blocked "$COMMAND"
+    exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -51,6 +51,10 @@
           {
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/validate-verify-workspace.sh"
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/validate-gcloud-builds.sh"
           }
         ]
       },


### PR DESCRIPTION
## Summary

- Add validation hook `validate-gcloud-builds.sh` to block `gcloud builds` commands without `--region` flag
- Remove 4 redundant "Hook enforced" lines from CLAUDE.md (hooks provide self-documenting error messages)

## Problem

`gcloud builds list` and related commands require `--region=europe-central2` in this project because Cloud Build uses regional builds. Without the flag, commands query the wrong regional pool and return no results.

## Changes

| File | Change |
|------|--------|
| `.claude/hooks/validate-gcloud-builds.sh` | New hook - blocks commands without `--region` |
| `.claude/settings.json` | Register the new hook |
| `.claude/CLAUDE.md` | Remove 4 "Hook enforced" lines (~tokens saved) |

## Test plan

- [x] Hook blocks `gcloud builds list --project=...` (no region)
- [x] Hook allows `gcloud builds list --region=europe-central2 --project=...`
- [x] Error message is self-documenting with correct command examples

Fixes INT-404

🤖 Generated with [Claude Code](https://claude.com/claude-code)