### PR TITLE
[INT-406] Fix mobile layout in research detail page

### DIFF
--- a/apps/web/src/pages/ResearchDetailPage.tsx
+++ b/apps/web/src/pages/ResearchDetailPage.tsx
@@ -585,7 +585,7 @@ export function ResearchDetailPage(): React.JSX.Element {
               className={`h-5 w-5 ${research.favourite === true ? 'text-amber-400 fill-amber-400' : 'text-slate-300'}`}
             />
           </button>
-          <span className="text-sm text-slate-500">
+          <span className="text-sm text-slate-500 w-full sm:w-auto">
             {isProcessing || research.status === 'awaiting_confirmation'
               ? `Started ${formatElapsedTime(research.startedAt)}`
               : research.completedAt !== undefined


### PR DESCRIPTION
## Summary
- Add `w-full sm:w-auto` to timing span in `ResearchDetailPage.tsx`
- Fixes mobile layout where timing info should appear on separate line

## Test plan
- [x] Typecheck passes for web workspace
- [x] Lint passes for web workspace  
- [x] Tests pass for web workspace

## Fixes
Fixes INT-406

🤖 Generated with [Claude Code](https://claude.com/claude-code)