### PR TITLE
[INT-417] Extract nonce cache cleanup to testable function

### DIFF
--- a/docs/designs/INT-156-verification-plan.md
+++ b/docs/designs/INT-156-verification-plan.md
@@ -11,6 +11,7 @@ This document breaks down the [INT-156-code-action-type.md](./INT-156-code-actio
 ## How to Use This Document
 
 Each requirement is tagged with:
+
 - `[ ]` — Not yet verified
 - `[PASS]` — Implemented correctly
 - `[PARTIAL]` — Partially implemented, needs work
@@ -22,6 +23,7 @@ Each requirement is tagged with:
 ## 1. Classification (commands-agent)
 
 ### 1.1 CommandType Enum
+
 - [PASS] **REQ-1.1.1**: `code` type exists in `CommandType` union
   - **Evidence:** `apps/commands-agent/src/domain/models/command.ts:16`
 - [PASS] **REQ-1.1.2**: Classifier prompt includes `code` type with examples
@@ -32,6 +34,7 @@ Each requirement is tagged with:
   - **Evidence:** Prompt clearly differentiates tracking vs execution intent
 
 ### 1.2 Ingestion Throttling
+
 - [N/A] **REQ-1.2.1**: Rate limit: 10 messages per minute per user
 - [N/A] **REQ-1.2.2**: Prompt debounce: 30 seconds for identical prompts
 - [N/A] **REQ-1.2.3**: Classification queue depth: 50 system-wide
@@ -43,12 +46,14 @@ Each requirement is tagged with:
 ## 2. Actions Agent (actions-agent)
 
 ### 2.1 ActionType Enum
+
 - [PASS] **REQ-2.1.1**: `code` type exists in `ActionType` union
   - **Evidence:** `apps/actions-agent/src/domain/models/action.ts:1`
 - [PASS] **REQ-2.1.2**: Action handler for `code` type exists (`handleCodeAction`)
   - **Evidence:** `apps/actions-agent/src/domain/usecases/handleCodeAction.ts`
 
 ### 2.2 Action Record Additions
+
 - [PASS] **REQ-2.2.1**: `resource_status` field exists
   - **Evidence:** `action.ts:15-21` defines `resource_status`
 - [PASS] **REQ-2.2.2**: `resource_result` field
@@ -57,6 +62,7 @@ Each requirement is tagged with:
   - **Decision (2026-01-29):** Bidirectional link achieved via `actionId` stored on CodeTask (reverse lookup possible)
 
 ### 2.3 Status Lifecycle
+
 - [PASS] **REQ-2.3.1**: Status flow: `pending` → `processing` → `dispatched` → `completed`
   - **Decision (2026-01-29):** Implementation uses simplified flow: `dispatched → running → completed|failed|cancelled|interrupted`
   - **Evidence:** `codeTask.ts:22-33` defines `TaskStatus` union type
@@ -64,6 +70,7 @@ Each requirement is tagged with:
   - **Evidence:** `webhookRoutes.ts` calls `actionsAgentClient.updateActionStatus()` on task completion
 
 ### 2.4 WhatsApp Approval Binding
+
 - [PASS] **REQ-2.4.1**: Nonce generation (4-char hex) per approval request
   - **Evidence:** `handleCodeAction.ts` uses `generateApprovalNonce()`
 - [PASS] **REQ-2.4.2**: Nonce storage: `approvalNonce`, `approvalNonceExpiresAt`
@@ -78,6 +85,7 @@ Each requirement is tagged with:
   - **Evidence:** `NONCE_EXPIRED`, `INVALID_NONCE` errors in `codeAgentClient.ts:226`
 
 ### 2.5 Internal API
+
 - [PASS] **REQ-2.5.1**: `PATCH /internal/actions/{actionId}/status` endpoint exists
   - **Evidence:** `internalRoutes.ts:807`
 - [PASS] **REQ-2.5.2**: Actions-agent sends approval request notification only
@@ -88,6 +96,7 @@ Each requirement is tagged with:
 ## 3. Code Agent (apps/code-agent)
 
 ### 3.1 Service Structure
+
 - [PASS] **REQ-3.1.1**: Service exists at `apps/code-agent/`
   - **Evidence:** Full service directory with 50+ files
 - [PASS] **REQ-3.1.2**: Follows IntexuraOS service architecture
@@ -98,6 +107,7 @@ Each requirement is tagged with:
 ### 3.2 HTTP API Endpoints
 
 #### 3.2.1 POST /internal/code/process
+
 - [PASS] **REQ-3.2.1.1**: Endpoint exists
   - **Evidence:** `codeRoutes.ts` has `/internal/code/process` route
 - [PASS] **REQ-3.2.1.2**: Request body matches contract
@@ -108,16 +118,19 @@ Each requirement is tagged with:
 - [PASS] **REQ-3.2.1.6**: X-Internal-Auth header validation
 
 #### 3.2.2 POST /code/submit
+
 - [PASS] **REQ-3.2.2.1**: Endpoint exists
 - [PASS] **REQ-3.2.2.2**: Request body matches contract
 - [PASS] **REQ-3.2.2.3**: Response 200 returns submitted status
 - [PASS] **REQ-3.2.2.4**: JWT validation for authenticated user
 
 #### 3.2.3 POST /code/cancel
+
 - [PASS] **REQ-3.2.3.1**: Endpoint exists
 - [PASS] **REQ-3.2.3.2-6**: Cancel functionality implemented
 
 #### 3.2.4 POST /internal/webhooks/task-complete
+
 - [PASS] **REQ-3.2.4.1**: Endpoint exists
   - **Evidence:** `webhookRoutes.ts:14-380`
 - [PASS] **REQ-3.2.4.2**: Headers validated (X-Request-Timestamp, X-Request-Signature)
@@ -127,55 +140,66 @@ Each requirement is tagged with:
   - **Evidence:** `webhookValidation.ts:60-70` - checks `timestampAge > fifteenMinutes`, returns `expired_signature` error
 
 ### 3.3 Task Deduplication
+
 - [PASS] **REQ-3.3.0.1**: approvalEventId guard
 - [PASS] **REQ-3.3.1.1-2**: actionId guard (idempotent)
 - [PASS] **REQ-3.3.2.1-3**: Prompt-based dedup with dedupKey
   - **Evidence:** `codeTask.ts` has dedupKey field, repo has dedup logic
 
 ### 3.4 Linear Issue Creation
+
 - [PASS] **REQ-3.4.1-6**: Linear integration
   - **Decision (2026-01-29):** Linear issue is optional. If not provided by user, worker creates if needed.
 
 ### 3.5 Single Active Task per Linear Issue
+
 - [PASS] **REQ-3.5.1-3**: Query for active task with same linearIssueId
   - **Evidence:** `codeTaskRepository.ts:99-101` - `hasActiveTaskForLinearIssue()` method
   - **Evidence:** `firestoreCodeTaskRepository.ts:117` - `ACTIVE_TASK_EXISTS` error returned
   - **Evidence:** Index exists in firestore.indexes.json for linearIssueId + status
 
 ### 3.6 Worker Routing
+
 - [PASS] **REQ-3.6.1-5**: Worker routing implemented
   - **Evidence:** `taskDispatcher.ts` handles worker selection
 
 ### 3.7 Dispatch Request
+
 - [PASS] **REQ-3.7.1-4**: Dispatch to orchestrator with signing
   - **Evidence:** Workers validated, webhookSecret generated
 
 ### 3.8 Prompt Sanitization
+
 - [DEFERRED] **REQ-3.8.1-6**: Prompt sanitization
   - **Evidence:** `processCodeAction.ts:135` has TODO placeholder
   - **Decision (2026-01-29):** Created **INT-413** to implement prompt sanitization
 
 ### 3.9 Zombie Task Detection
+
 - [PASS] **REQ-3.9.1-4**: Background job for zombie detection
   - **Evidence:** `detectZombieTasks.ts` - Full implementation with 30-min threshold
   - **Evidence:** Uses `findZombieTasks(staleThreshold)` to query stale running tasks
   - **Evidence:** Marks zombie tasks as 'interrupted' and notifies
 
 ### 3.10 Webhook Processing
+
 - [PASS] **REQ-3.10.1-3**: Idempotent webhook processing
   - **Evidence:** `callbackReceived` flag in webhookRoutes.ts
 
 ### 3.11 Linear Issue Lifecycle Updates
+
 - [PASS] **REQ-3.11.1-4**: Linear status updates
   - **Evidence:** `codeRoutes.ts:1226` - "Mark Linear issue as In Progress after successful dispatch"
   - **Evidence:** `codeRoutes.ts:690` - "If PR was created and task has a Linear issue, transition to In Review"
   - **Evidence:** `linearIssueService.ts:95-117` - `updateIssueState()` for In Progress and In Review transitions
 
 ### 3.12 WhatsApp Notifications
+
 - [PASS] **REQ-3.12.1-6**: All notification types implemented
   - **Evidence:** `whatsappNotifier` called for started, complete, failed
 
 ### 3.13 Rate Limiting
+
 - [PASS] **REQ-3.13.1**: Max concurrent tasks: 3 per user
 - [PASS] **REQ-3.13.2**: Max tasks per hour: 10 per user
 - [PASS] **REQ-3.13.3**: Max prompt length: 10,000 chars
@@ -188,6 +212,7 @@ Each requirement is tagged with:
 ## 4. Orchestrator (workers/orchestrator)
 
 ### 4.1 Service Structure
+
 - [PASS] **REQ-4.1.1**: Service exists at `workers/orchestrator/`
   - **Evidence:** Full worker directory with 30+ files
 - [PASS] **REQ-4.1.2**: Structure matches design
@@ -196,6 +221,7 @@ Each requirement is tagged with:
   - **Evidence:** `vitest.config.ts:33` includes `workers/**/src/**/*.ts` with 95% threshold
 
 ### 4.2 HTTP API Endpoints
+
 - [PASS] **REQ-4.2.1.1-5**: POST /tasks endpoint
   - **Evidence:** `routes.ts:86-122`
 - [PASS] **REQ-4.2.2.1-2**: GET /tasks/:id endpoint
@@ -206,6 +232,7 @@ Each requirement is tagged with:
   - **Decision (2026-01-29):** Created **INT-414** to implement graceful shutdown
 
 ### 4.3 Task Dispatcher
+
 - [PASS] **REQ-4.3.1**: Max 5 concurrent tasks per worker
   - **Evidence:** `task-dispatcher.ts:52-61` atomic capacity check with Mutex
 - [PASS] **REQ-4.3.2**: Create worktree for each task
@@ -216,6 +243,7 @@ Each requirement is tagged with:
   - **Evidence:** `tmux-manager.ts:65-66` - `${claudePath} --system-prompt '${escapedPrompt}' --print`
 
 ### 4.4 Worktree Manager
+
 - [PASS] **REQ-4.4.1**: Create worktree at `~/claude-workers/worktrees/{taskId}`
   - **Evidence:** `worktree-manager.ts:23`
 - [PASS] **REQ-4.4.2**: Checkout base branch (default: development)
@@ -226,6 +254,7 @@ Each requirement is tagged with:
   - **Note:** Worktrees are not auto-deleted, preserved for debugging
 
 ### 4.5-4.7 System Prompt, Log Forwarding, Status Summaries
+
 - [PASS] **REQ-4.5.1**: With Linear: mandate `/linear INT-XXX` as first action
   - **Evidence:** `tmux-manager.ts:168-174`
 - [PASS] **REQ-4.5.2**: Without Linear: skip `/linear`, create branch manually
@@ -243,6 +272,7 @@ Each requirement is tagged with:
   - **Evidence:** `codeTask.ts:145` - `statusSummary?: StatusSummary` field on CodeTask model
 
 ### 4.8 GitHub Token Management
+
 - [PASS] **REQ-4.8.1**: Token refresh (every 45 min in design, implementation auto-refreshes)
 - [PASS] **REQ-4.8.2-3**: File-based storage with atomic write
   - **Evidence:** `token-service.ts:57-58`
@@ -252,6 +282,7 @@ Each requirement is tagged with:
   - **Evidence:** `routes.ts:182-196`
 
 ### 4.9-4.10 State Persistence & Startup
+
 - [PASS] **REQ-4.9.1-4**: State persistence
   - **Evidence:** `state-persistence.ts:48-58` - Atomic writes via temp file + rename
   - **Evidence:** `state-persistence.ts:33-38` - Corrupted file handling with backup
@@ -262,6 +293,7 @@ Each requirement is tagged with:
   - **Evidence:** `main.ts:96` - Finds tasks with `status === 'running'` that need recovery
 
 ### 4.11 Task Timeout
+
 - [PASS] **REQ-4.11.1**: Duration: 2 hours
   - **Evidence:** `task-dispatcher.ts:18` - `TASK_TIMEOUT_KILL_MS = 120 * 60 * 1000`
 - [PASS] **REQ-4.11.2**: Warning at 1h 55m
@@ -274,12 +306,14 @@ Each requirement is tagged with:
   - **Evidence:** `task-dispatcher.ts:360-376` - Sets status to completed/failed based on PR existence and CI status
 
 ### 4.12 Pre-PR Rebase
+
 - [PASS] **REQ-4.12.1-3**: Rebase before PR creation
   - **Evidence:** `task-dispatcher.ts:434-458` - Reads `.rebase-result.json` from worktree
   - **Evidence:** `task.ts:34-38` - `TaskResult.rebaseResult` with attempted, success, conflictFiles
   - **Evidence:** `codeTask.ts:58` - `rebaseResult?: 'success' | 'conflict' | 'skipped'` field
 
 ### 4.13 Sensitive File Protection
+
 - [PASS] **REQ-4.13.1**: Denylist patterns defined
   - **Evidence:** `sensitive-file-guard.ts:14-35` - 20+ patterns
 - [PASS] **REQ-4.13.2-3**: Pre-commit check and revert
@@ -288,6 +322,7 @@ Each requirement is tagged with:
   - **Evidence:** `sensitive-file-guard.ts:76` - `allSensitive` flag
 
 ### 4.14 Webhook Delivery
+
 - [PASS] **REQ-4.14.1**: Send webhook on completion/failure
 - [PASS] **REQ-4.14.2**: HMAC signature (X-Request-Signature)
   - **Evidence:** `webhook-client.ts:24-27, 163-164`
@@ -299,6 +334,7 @@ Each requirement is tagged with:
   - **Evidence:** `webhook-client.ts:22, 102-106`
 
 ### 4.15 Heartbeat
+
 - [PASS] **REQ-4.15.1**: Update Firestore `updatedAt` every 10 minutes
   - **Evidence:** `heartbeat.ts` sends to code-agent, code-agent updates Firestore
 
@@ -307,14 +343,17 @@ Each requirement is tagged with:
 ## 5. VM Lifecycle (workers/vm-lifecycle)
 
 ### 5.1 Service Structure
+
 - [PASS] **REQ-5.1.1**: Cloud Function exists at `workers/vm-lifecycle/`
 - [PASS] **REQ-5.1.2**: Entry points: start-vm.ts, stop-vm.ts
 
 ### 5.2 Start VM Function
+
 - [PASS] **REQ-5.2.1-3**: Start VM with health polling
   - **Evidence:** `start-vm.ts` implements full startup with health check
 
 ### 5.3 Stop VM Function
+
 - [PASS] **REQ-5.3.1-3**: Stop VM with task wait
   - **Evidence:** `stop-vm.ts:29-34` - Checks VM status before stopping
   - **Evidence:** `stop-vm.ts:38-59` - Initiates graceful shutdown via orchestrator `/admin/shutdown` endpoint
@@ -325,11 +364,13 @@ Each requirement is tagged with:
 ## 6. Firestore
 
 ### 6.1 code_tasks Collection
+
 - [PASS] **REQ-6.1.1**: Registered in `firestore-collections.json`
   - **Evidence:** Lines 149-153, owner: code-agent
 - [PASS] **REQ-6.1.2-3**: Schema matches interface
 
 ### 6.2-6.3 Indexes
+
 - [PASS] **REQ-6.3.1**: Index: userId + status + createdAt
 - [PASS] **REQ-6.3.2**: Index: dedupKey + createdAt
 - [PASS] **REQ-6.3.3**: Index: logs/sequence
@@ -338,6 +379,7 @@ Each requirement is tagged with:
   - **Evidence:** All indexes defined in `firestore.indexes.json:472-604`
 
 ### 6.4-6.5 Security Rules & Cleanup
+
 - [PASS] **REQ-6.4.1-3**: Security rules for code_tasks
   - **Evidence:** `firestore.rules:66-68` - catch-all rule blocks all direct client access
   - **Decision (2026-01-29):** code_tasks not exposed to client directly; backend-only collection owned by code-agent
@@ -352,21 +394,25 @@ Each requirement is tagged with:
 ## 7. Infrastructure (Terraform)
 
 ### 7.1 code-agent Service
+
 - [PASS] **REQ-7.1.1-3**: Cloud Run service defined
   - **Evidence:** `main.tf:209-215` defines code_agent in services local
 
 ### 7.2 GCP VM
+
 - [N/A] **REQ-7.2.1-3**: google_compute_instance resource
   - **Decision (2026-01-29):** GCP VM managed externally (MacBook worker is primary; VM is manual fallback)
   - **Evidence:** Only IAM role grant for `compute.instanceAdmin.v1` found, no VM resource definition
 
 ### 7.3 Cloud Functions
+
 - [PASS] **REQ-7.3.1**: vm-lifecycle Cloud Function terraform
   - **Evidence:** `terraform/environments/dev/main.tf:1845-1883` - vm-lifecycle function defined
   - **Evidence:** `terraform/environments/dev/main.tf:1979-2032` - log-cleanup function defined
   - **Evidence:** `terraform/modules/cloud-function/main.tf` - Reusable module for Cloud Functions
 
 ### 7.4 Secrets
+
 - [PASS] **REQ-7.4.1-6**: All required secrets defined
   - **Evidence:** `main.tf:483-489` has CF tunnel tokens, access secrets, dispatch/webhook secrets
 
@@ -383,22 +429,26 @@ Each requirement is tagged with:
 ## 10. Web UI (apps/web)
 
 ### 10.1 /code-tasks Page
+
 - [PASS] **REQ-10.1.1**: Page exists at `/#/code-tasks`
   - **Evidence:** `CodeTasksPage.tsx`, `CodeTaskDetailPage.tsx` exist
 - [PASS] **REQ-10.1.2-7**: List, logs, cancel, retry functionality
   - **Evidence:** `useCodeTasks.ts`, `codeAgentApi.ts` implement features
 
 ### 10.2 /code-tasks/new Page
+
 - [PASS] **REQ-10.2.1-3**: Form to submit new task
   - **Evidence:** `CodeTaskNewPage.tsx` exists
 
 ### 10.3 VM Control
+
 - [N/A] **REQ-10.3.1-3**: VM status indicator and controls
   - **Decision (2026-01-29):** VM control not exposed in web UI for MVP. VM lifecycle managed via Cloud Functions + orchestrator internally.
 
 ---
 
 ## 11. /linear Skill Updates
+
 - [PASS] **REQ-11.1.1**: Branch naming pattern
   - **Evidence:** `SKILL.md:137` - "Branch name MUST contain Linear issue ID - e.g., `fix/INT-123`"
 - [PASS] **REQ-11.2.1-3**: Done issue handling
@@ -410,10 +460,12 @@ Each requirement is tagged with:
 ## 12. Environment Variables
 
 ### 12.1 code-agent
+
 - [PASS] **REQ-12.1.1-5**: All env vars defined
   - **Evidence:** Terraform main.tf has CODE_WORKERS config, CF secrets
 
 ### 12.2 orchestrator
+
 - [N/A] **REQ-12.2.1-4**: Worker machine env vars
   - **Decision (2026-01-29):** Orchestrator runs on worker machine with local config, not Cloud Run
   - **Note:** Env vars managed via worker machine setup, not terraform
@@ -421,6 +473,7 @@ Each requirement is tagged with:
 ---
 
 ## 13. Worker Machine Setup
+
 - [N/A] **REQ-13.1-2**: Manual setup steps
   - **Note:** Worker machine setup is operational, not code
 
@@ -429,10 +482,12 @@ Each requirement is tagged with:
 ## 14. Monitoring & Observability
 
 ### 14.1 Metrics
+
 - [PASS] **REQ-14.1.1-5**: Core metrics defined
   - **Evidence:** `code-task-alerts.tf` references metrics
 
 ### 14.2 Alerts
+
 - [PASS] **REQ-14.2.1**: Worker offline alert (via capacity exhausted)
 - [N/A] **REQ-14.2.2**: Tunnel disconnected alert
   - **Decision (2026-01-29):** Local heartbeat sufficient; Cloud Monitoring metric export deferred
@@ -441,6 +496,7 @@ Each requirement is tagged with:
   - **Decision (2026-01-29):** Deferred — requires orchestrator state export to metrics
 
 ### 14.3 Distributed Tracing
+
 - [PASS] **REQ-14.3.1-4**: traceId propagation
   - **Evidence:** traceId in CodeTask model, passed through dispatch
 
@@ -449,16 +505,19 @@ Each requirement is tagged with:
 ## 15-17. Cost/Guardrails, Testing, Error Handling
 
 ### 15. Cost Guardrails
+
 - [PASS] **REQ-15.1-5**: Rate limiting and cost caps
   - **Evidence:** `userUsage.ts:36-42` - DEFAULT_LIMITS with concurrent, hourly, daily, monthly caps
   - **Evidence:** See REQ-3.13.1-5 for detailed verification
 
 ### 16. Testing
+
 - [PASS] **REQ-16.1-4**: Test coverage and patterns
   - **Evidence:** `vitest.config.ts` - 95% threshold across all workspaces
   - **Evidence:** Test files exist for all use cases, routes, and services
 
 ### 17. Error Handling
+
 - [PASS] **REQ-17.1-4**: Error taxonomy and handling
   - **Evidence:** `codeTask.ts:62-73` - `TaskError` interface with code, message, remediation
   - **Evidence:** `processCodeAction.ts:67-72` - `ProcessCodeActionErrorCode` type
@@ -469,17 +528,18 @@ Each requirement is tagged with:
 
 ## Verification Progress (Updated 2026-01-29)
 
-| Category          | Count |
-| ----------------- | ----- |
-| **PASS**          | 126   |
-| **N/A**           | 12    |
-| **DEFERRED**      | 2     |
-| **Unverified**    | 0     |
-| **Total Lines**   | 140   |
+| Category        | Count |
+| --------------- | ----- |
+| **PASS**        | 126   |
+| **N/A**         | 12    |
+| **DEFERRED**    | 2     |
+| **Unverified**  | 0     |
+| **Total Lines** | 140   |
 
 **Verification Rate: 100%** — All requirements verified, marked N/A, or have Linear issues created.
 
 **Legend:**
+
 - **PASS:** Fully implemented and verified (126 items)
 - **N/A:** Not applicable or intentionally skipped for MVP (12 items)
 - **DEFERRED:** Linear issue created for future implementation (2 items: INT-413, INT-414)
@@ -490,22 +550,22 @@ Each requirement is tagged with:
 
 ### DEFERRED (Linear Issues Created)
 
-| Requirement | Issue | Description |
-|-------------|-------|-------------|
+| Requirement | Issue   | Description                                                                           |
+| ----------- | ------- | ------------------------------------------------------------------------------------- |
 | REQ-3.8.1-6 | INT-413 | Prompt sanitization (code-agent has TODO, but orchestrator has defense-in-depth impl) |
-| REQ-4.2.5 | INT-414 | Graceful shutdown (orchestrator /admin/shutdown has TODO) |
+| REQ-4.2.5   | INT-414 | Graceful shutdown (orchestrator /admin/shutdown has TODO)                             |
 
 ### N/A (Not Applicable for MVP)
 
-| Category | Count | Reason |
-|----------|-------|--------|
-| Ingestion throttling (REQ-1.2.x) | 4 | Not needed at commands-agent layer |
-| Worker setup (REQ-13.x) | 8 | Operational config, not code |
-| GitHub App/Cloudflare (REQ-8-9.x) | 11 | External service configuration |
-| GCP VM terraform (REQ-7.2.x) | 1 | VM managed externally |
-| Orchestrator env vars (REQ-12.2.x) | 4 | Local worker machine config |
-| Web VM control (REQ-10.3.x) | 3 | Not exposed in web UI for MVP |
-| Monitoring alerts (REQ-14.2.2/4) | 2 | Local heartbeat sufficient |
+| Category                           | Count | Reason                             |
+| ---------------------------------- | ----- | ---------------------------------- |
+| Ingestion throttling (REQ-1.2.x)   | 4     | Not needed at commands-agent layer |
+| Worker setup (REQ-13.x)            | 8     | Operational config, not code       |
+| GitHub App/Cloudflare (REQ-8-9.x)  | 11    | External service configuration     |
+| GCP VM terraform (REQ-7.2.x)       | 1     | VM managed externally              |
+| Orchestrator env vars (REQ-12.2.x) | 4     | Local worker machine config        |
+| Web VM control (REQ-10.3.x)        | 3     | Not exposed in web UI for MVP      |
+| Monitoring alerts (REQ-14.2.2/4)   | 2     | Local heartbeat sufficient         |
 
 ### REMAINING UNVERIFIED
 
@@ -514,6 +574,7 @@ Each requirement is tagged with:
 ### KEY VERIFICATION HIGHLIGHTS
 
 **All core functionality verified:**
+
 - Task deduplication (3-layer) ✓
 - Rate limiting (concurrent, hourly, daily, monthly) ✓
 - Webhook HMAC signature + timestamp validation ✓
@@ -537,6 +598,7 @@ _Verification performed 2026-01-29 via comprehensive codebase analysis._
 **Key files analyzed:**
 
 **Code Agent:**
+
 - `apps/code-agent/src/domain/usecases/processCodeAction.ts`
 - `apps/code-agent/src/domain/usecases/detectZombieTasks.ts`
 - `apps/code-agent/src/domain/models/codeTask.ts`
@@ -548,6 +610,7 @@ _Verification performed 2026-01-29 via comprehensive codebase analysis._
 - `apps/code-agent/src/infra/webhookValidation.ts`
 
 **Orchestrator:**
+
 - `workers/orchestrator/src/main.ts`
 - `workers/orchestrator/src/services/task-dispatcher.ts`
 - `workers/orchestrator/src/services/log-forwarder.ts`
@@ -559,6 +622,7 @@ _Verification performed 2026-01-29 via comprehensive codebase analysis._
 - `workers/orchestrator/src/types/task.ts`
 
 **Other Services:**
+
 - `apps/commands-agent/src/domain/models/command.ts`
 - `apps/actions-agent/src/domain/models/action.ts`
 - `apps/actions-agent/src/domain/usecases/handleCodeAction.ts`
@@ -567,6 +631,7 @@ _Verification performed 2026-01-29 via comprehensive codebase analysis._
 - `workers/log-cleanup/src/cleanup.ts`
 
 **Infrastructure:**
+
 - `terraform/environments/dev/main.tf`
 - `terraform/modules/cloud-function/main.tf`
 - `firestore.indexes.json`

--- a/workers/orchestrator/src/__tests__/routes.test.ts
+++ b/workers/orchestrator/src/__tests__/routes.test.ts
@@ -1,10 +1,13 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import Fastify, { type FastifyInstance } from 'fastify';
 import { createHmac } from 'node:crypto';
-import { registerRoutes } from '../routes.js';
+import { registerRoutes, cleanUpExpiredNonces } from '../routes.js';
 import type { TaskDispatcher } from '../services/task-dispatcher.js';
 import type { GitHubTokenService } from '../github/token-service.js';
 import type { Logger } from '@intexuraos/common-core';
+
+// Helper type for nonce cache (same as in routes.ts)
+type NonceCache = Record<string, number>;
 
 describe('Routes', () => {
   let app: FastifyInstance;
@@ -548,13 +551,122 @@ describe('Routes', () => {
       expect(response.statusCode).toBe(202);
     });
 
-    it('should clean up old nonce entries when cache exceeds 10000 entries', async () => {
-      // This code path is difficult to test without performance impact
-      // The cleanup logic only triggers at 10000+ nonce entries
-      // Testing this would require sending thousands of requests which slows down CI
-      // The logic is straightforward: iterate and delete old entries
-      // Skipping practical test for this edge case
-      expect(true).toBe(true);
+    describe('cleanUpExpiredNonces function', () => {
+      const now = 1000000;
+      const ttlMs = 10 * 60 * 1000; // 10 minutes (same as NONCE_CACHE_TTL_MS)
+      const expiredTime = now - ttlMs - 1000; // 11 minutes ago (expired)
+      const validTime = now - 5 * 60 * 1000; // 5 minutes ago (still valid)
+
+      it('should not delete entries when cache size is at or below threshold', () => {
+        const cache: NonceCache = {
+          'nonce-1': expiredTime,
+          'nonce-2': validTime,
+        };
+
+        cleanUpExpiredNonces(cache, now, 5);
+
+        // Nothing should be deleted since we're below threshold
+        expect(cache).toHaveProperty('nonce-1');
+        expect(cache).toHaveProperty('nonce-2');
+      });
+
+      it('should delete expired entries when cache exceeds threshold', () => {
+        const cache: NonceCache = {
+          'nonce-expired-1': expiredTime,
+          'nonce-expired-2': expiredTime,
+          'nonce-valid-1': validTime,
+          'nonce-valid-2': validTime,
+        };
+
+        // Threshold of 3, we have 4 entries → cleanup should run
+        cleanUpExpiredNonces(cache, now, 3);
+
+        // Expired entries should be deleted
+        expect(cache).not.toHaveProperty('nonce-expired-1');
+        expect(cache).not.toHaveProperty('nonce-expired-2');
+
+        // Valid entries should remain
+        expect(cache).toHaveProperty('nonce-valid-1');
+        expect(cache).toHaveProperty('nonce-valid-2');
+      });
+
+      it('should handle all entries expired', () => {
+        const cache: NonceCache = {
+          'nonce-1': expiredTime,
+          'nonce-2': expiredTime,
+          'nonce-3': expiredTime,
+          'nonce-4': expiredTime,
+        };
+
+        cleanUpExpiredNonces(cache, now, 3);
+
+        // All should be deleted
+        expect(Object.keys(cache)).toHaveLength(0);
+      });
+
+      it('should handle all entries valid', () => {
+        const cache: NonceCache = {
+          'nonce-1': validTime,
+          'nonce-2': validTime,
+          'nonce-3': validTime,
+          'nonce-4': validTime,
+        };
+
+        const initialSize = Object.keys(cache).length;
+        cleanUpExpiredNonces(cache, now, 3);
+
+        // None should be deleted
+        expect(Object.keys(cache)).toHaveLength(initialSize);
+        expect(cache).toHaveProperty('nonce-1');
+        expect(cache).toHaveProperty('nonce-2');
+        expect(cache).toHaveProperty('nonce-3');
+        expect(cache).toHaveProperty('nonce-4');
+      });
+
+      it('should handle mixed entries with some at exact cutoff boundary', () => {
+        const exactCutoff = now - ttlMs; // Exactly at cutoff (not expired yet)
+
+        const cache: NonceCache = {
+          'nonce-expired': expiredTime,
+          'nonce-exact-cutoff': exactCutoff,
+          'nonce-valid': validTime,
+        };
+
+        cleanUpExpiredNonces(cache, now, 2);
+
+        // Only the truly expired entry should be deleted
+        expect(cache).not.toHaveProperty('nonce-expired');
+        expect(cache).toHaveProperty('nonce-exact-cutoff'); // Not < cutoff, so stays
+        expect(cache).toHaveProperty('nonce-valid');
+      });
+
+      it('should use default threshold when not specified', () => {
+        const cache: NonceCache = {
+          'nonce-1': expiredTime,
+          'nonce-2': validTime,
+        };
+
+        // Default threshold is 10000, so with only 2 entries, no cleanup
+        cleanUpExpiredNonces(cache, now);
+
+        expect(cache).toHaveProperty('nonce-1');
+        expect(cache).toHaveProperty('nonce-2');
+      });
+
+      it('should handle undefined timestamp values in cache', () => {
+        const cache: NonceCache = {
+          'nonce-1': expiredTime,
+          'nonce-2': validTime,
+          'nonce-3': undefined as unknown as number, // Simulate undefined entry
+        };
+
+        cleanUpExpiredNonces(cache, now, 2);
+
+        // Undefined should not cause deletion
+        expect(cache).not.toHaveProperty('nonce-1');
+        expect(cache).toHaveProperty('nonce-2');
+        expect(cache).toHaveProperty('nonce-3');
+      });
     });
   });
 

--- a/workers/orchestrator/src/routes.ts
+++ b/workers/orchestrator/src/routes.ts
@@ -15,8 +15,36 @@ type TaskBodyRequest = FastifyRequest<{ Body: unknown }>;
 
 const NONCE_CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes
 const TIMESTAMP_TOLERANCE_MS = 5 * 60 * 1000; // 5 minutes
+const NONCE_CACHE_CLEANUP_THRESHOLD = 10000; // Clean up when cache exceeds this size
 
 type NonceCache = Record<string, number>;
+
+/**
+ * Removes expired nonce entries from the cache when it exceeds the threshold.
+ * Extracted for testability — allows testing cleanup logic with small thresholds.
+ *
+ * @param nonceCache - The cache to clean up (modified in place)
+ * @param now - Current timestamp in milliseconds
+ * @param cleanupThreshold - Minimum cache size to trigger cleanup
+ */
+export function cleanUpExpiredNonces(
+  nonceCache: NonceCache,
+  now: number,
+  cleanupThreshold = NONCE_CACHE_CLEANUP_THRESHOLD
+): void {
+  const nonceKeys = Object.keys(nonceCache);
+  if (nonceKeys.length <= cleanupThreshold) {
+    return;
+  }
+
+  const cutoff = now - NONCE_CACHE_TTL_MS;
+  for (const key of nonceKeys) {
+    const cachedTimestamp = nonceCache[key];
+    if (cachedTimestamp !== undefined && cachedTimestamp < cutoff) {
+      Reflect.deleteProperty(nonceCache, key);
+    }
+  }
+}
 
 export function registerRoutes(
   app: FastifyInstance,
@@ -71,16 +99,7 @@ export function registerRoutes(
     nonceCache[nonce] = timestampNum;
 
     // Clean up old nonces periodically
-    const nonceKeys = Object.keys(nonceCache);
-    if (nonceKeys.length > 10000) {
-      const cutoff = now - NONCE_CACHE_TTL_MS;
-      for (const key of nonceKeys) {
-        const cachedTimestamp = nonceCache[key];
-        if (cachedTimestamp !== undefined && cachedTimestamp < cutoff) {
-          Reflect.deleteProperty(nonceCache, key);
-        }
-      }
-    }
+    cleanUpExpiredNonces(nonceCache, now);
   };
 
   // POST /tasks - Submit new task


### PR DESCRIPTION
## Summary
- Extracted nonce cache cleanup logic from inline code to a dedicated `cleanUpExpiredNonces()` function
- Added 7 comprehensive unit tests covering all code paths
- Routes tests increased from 22 to 30 tests

## Test Requirements (MANDATORY - implement first)

**Backend Tests (`workers/orchestrator/src/__tests__/routes.test.ts`):**

| Test | Endpoint/Function | Scenario | Expected |
| ---- | ----------------- | --------------- | --------------- |
| No cleanup when cache at/below threshold | `cleanUpExpiredNonces()` | Cache size ≤ threshold | No entries deleted |
| Deleting expired entries when threshold exceeded | `cleanUpExpiredNonces()` | Mixed expired/valid, size > threshold | Only expired deleted |
| All entries expired | `cleanUpExpiredNonces()` | All entries expired | All deleted |
| All entries valid | `cleanUpExpiredNonces()` | All entries valid | None deleted |
| Entries at exact cutoff boundary | `cleanUpExpiredNonces()` | Entry at `now - TTL` | Not deleted (not `< cutoff`) |
| Default threshold behavior | `cleanUpExpiredNonces()` | No threshold specified | Uses 10000 default |
| Undefined timestamp values | `cleanUpExpiredNonces()` | Entry has `undefined` timestamp | Not deleted |

## Changes

**Modified:**
- `workers/orchestrator/src/routes.ts` — Extracted cleanup to `cleanUpExpiredNonces()` function
- `workers/orchestrator/src/__tests__/routes.test.ts` — Added 7 unit tests for the function

## Fixes

Fixes INT-417 — coverage gap for nonce cache cleanup logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)