### PR TITLE
INT-426 Fix duplicate v8 ignore comment

### DIFF
--- a/apps/research-agent/src/routes/internalRoutes.ts
+++ b/apps/research-agent/src/routes/internalRoutes.ts
@@ -363,7 +363,7 @@ export const internalRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
           const eventType =
             typeof parsed === 'object' && parsed !== null && 'type' in parsed
               ? (parsed as { type: unknown }).type
-              : 'unknown'; /* v8 ignore ts-type -- ternary fallback when parsed is not object or has no type property */ /* v8 ignore ts-type -- ternary fallback when parsed is not object or has no type property */
+              : 'unknown'; /* v8 ignore ts-type -- ternary fallback when parsed is not object or has no type property */
           request.log.warn({ type: eventType }, 'Unexpected event type');
           // PubSub ack pattern: always return 200 OK, errors logged separately
           return await reply.ok({});


### PR DESCRIPTION
## Summary
- Remove duplicate v8 ignore comment in `internalRoutes.ts:366`

## Test plan
- [x] v8 ignore validation passes (200 comments validated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)