### PR TITLE
INT-498 Handle 409 CONFLICT response in code-agent UI

### DIFF
--- a/apps/web/src/components/TaskConflictModal.tsx
+++ b/apps/web/src/components/TaskConflictModal.tsx
@@ -1,0 +1,97 @@
+import { AlertTriangle } from 'lucide-react';
+import { Button } from './ui/Button.js';
+
+export type ConflictReason = 'duplicate' | 'active' | 'duplicate_approval';
+
+interface TaskConflictModalProps {
+  isOpen: boolean;
+  taskId: string;
+  reason: ConflictReason;
+  onClose: () => void;
+  onNavigateToTask: (taskId: string) => void;
+}
+
+const CONFLICT_MESSAGES: Record<
+  ConflictReason,
+  { title: string; description: string }
+> = {
+  duplicate: {
+    title: 'Similar Task Detected',
+    description:
+      'A similar task was submitted in the last 5 minutes. You can view the existing task or close this to continue.',
+  },
+  active: {
+    title: 'Active Task Exists',
+    description:
+      'An active task already exists for this Linear issue. You can view the existing task or close this to continue.',
+  },
+  duplicate_approval: {
+    title: 'Already Processed',
+    description:
+      'This approval has already been processed. You can view the existing task or close this to continue.',
+  },
+};
+
+export function TaskConflictModal({
+  isOpen,
+  taskId,
+  reason,
+  onClose,
+  onNavigateToTask,
+}: TaskConflictModalProps): React.JSX.Element | null {
+  if (!isOpen) return null;
+
+  const messages = CONFLICT_MESSAGES[reason];
+
+  const handleNavigate = (): void => {
+    onNavigateToTask(taskId);
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <div className="flex max-h-[90vh] w-full max-w-lg flex-col rounded-xl bg-white shadow-2xl dark:bg-slate-800">
+        {/* Header */}
+        <div className="flex shrink-0 items-start justify-between border-b border-slate-200 p-4 dark:border-slate-700">
+          <div className="flex items-start gap-3">
+            <div className="mt-0.5 rounded-lg bg-amber-100 p-2 dark:bg-amber-900/50">
+              <AlertTriangle className="h-5 w-5 text-amber-600 dark:text-amber-400" />
+            </div>
+            <div>
+              <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+                {messages.title}
+              </h2>
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            className="rounded-lg p-2 text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-600 dark:hover:bg-slate-700 dark:hover:text-slate-300"
+            aria-label="Close"
+          >
+            ×
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="min-h-0 flex-1 overflow-y-auto p-4">
+          <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 dark:border-amber-800 dark:bg-amber-900/30">
+            <p className="text-sm text-amber-800 dark:text-amber-300">{messages.description}</p>
+            <p className="mt-2 truncate text-xs font-mono text-amber-700 dark:text-amber-400">
+              Task ID: {taskId}
+            </p>
+          </div>
+        </div>
+
+        {/* Actions */}
+        <div className="flex shrink-0 items-center justify-end gap-2 border-t border-slate-200 p-4 dark:border-slate-700">
+          <Button variant="secondary" onClick={onClose}>
+            Close
+          </Button>
+          <Button variant="primary" onClick={handleNavigate}>
+            View Existing Task
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/__tests__/TaskConflictModal.test.tsx
+++ b/apps/web/src/components/__tests__/TaskConflictModal.test.tsx
@@ -1,0 +1,150 @@
+/**
+ * Tests for TaskConflictModal component.
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { TaskConflictModal } from '../TaskConflictModal';
+import type { ConflictReason } from '../TaskConflictModal';
+
+// Mock lucide-react icons
+vi.mock('lucide-react', () => ({
+  AlertTriangle: (): React.JSX.Element => <div data-testid="alert-icon" />,
+}));
+
+// Mock Button component
+vi.mock('../ui/Button', () => ({
+  // @allow-missing-return-type -- Test mock, not production code
+  Button: ({
+    children,
+    onClick,
+    variant,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+    variant?: string;
+  }): React.JSX.Element => (
+    <button
+      onClick={onClick}
+      data-variant={variant ?? 'primary'}
+      type="button"
+    >
+      {children}
+    </button>
+  ),
+}));
+
+describe('TaskConflictModal', () => {
+  const defaultProps = {
+    isOpen: true,
+    taskId: 'task_fa7666d5-bdf1-4498-b52b-1c12af89a578',
+    reason: 'duplicate' as ConflictReason,
+    onClose: vi.fn(),
+    onNavigateToTask: vi.fn(),
+  };
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe('Rendering with different reasons', () => {
+    it('renders modal with duplicate reason', () => {
+      render(<TaskConflictModal {...defaultProps} reason="duplicate" />);
+
+      expect(screen.getByText('Similar Task Detected')).toBeInTheDocument();
+      expect(
+        screen.getByText(/A similar task was submitted in the last 5 minutes/)
+      ).toBeInTheDocument();
+      expect(screen.getByText(/task_fa7666d5-bdf1-4498-b52b-1c12af89a578/)).toBeInTheDocument();
+    });
+
+    it('renders modal with active reason', () => {
+      render(<TaskConflictModal {...defaultProps} reason="active" />);
+
+      expect(screen.getByText('Active Task Exists')).toBeInTheDocument();
+      expect(
+        screen.getByText(/An active task already exists for this Linear issue/)
+      ).toBeInTheDocument();
+    });
+
+    it('renders modal with duplicate_approval reason', () => {
+      render(<TaskConflictModal {...defaultProps} reason="duplicate_approval" />);
+
+      expect(screen.getByText('Already Processed')).toBeInTheDocument();
+      expect(
+        screen.getByText(/This approval has already been processed/)
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('User interactions', () => {
+    it('navigates to task on View Existing Task button click', () => {
+      const onNavigateToTask = vi.fn();
+      render(<TaskConflictModal {...defaultProps} onNavigateToTask={onNavigateToTask} />);
+
+      const viewButton = screen.getByRole('button', { name: 'View Existing Task' });
+      fireEvent.click(viewButton);
+
+      expect(onNavigateToTask).toHaveBeenCalledWith('task_fa7666d5-bdf1-4498-b52b-1c12af89a578');
+      // onClose should also be called after navigation
+      expect(defaultProps.onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('closes modal on Close button click', () => {
+      const onClose = vi.fn();
+      render(<TaskConflictModal {...defaultProps} onClose={onClose} />);
+
+      // Get the Close button by text (the action button in footer)
+      const closeButton = screen.getAllByRole('button', { name: 'Close' })[1];
+      fireEvent.click(closeButton);
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+      expect(defaultProps.onNavigateToTask).not.toHaveBeenCalled();
+    });
+
+    it('closes modal on X button click', () => {
+      const onClose = vi.fn();
+      render(<TaskConflictModal {...defaultProps} onClose={onClose} />);
+
+      // Get the X button by aria-label (the first Close button)
+      const closeButton = screen.getAllByRole('button', { name: 'Close' })[0];
+      fireEvent.click(closeButton);
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Modal visibility', () => {
+    it('does not render when isOpen is false', () => {
+      render(<TaskConflictModal {...defaultProps} isOpen={false} />);
+
+      expect(screen.queryByText('Similar Task Detected')).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'View Existing Task' })).not.toBeInTheDocument();
+    });
+
+    it('renders when isOpen is true', () => {
+      render(<TaskConflictModal {...defaultProps} isOpen={true} />);
+
+      expect(screen.getByText('Similar Task Detected')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'View Existing Task' })).toBeInTheDocument();
+    });
+  });
+
+  describe('Task ID display', () => {
+    it('displays the full task ID in monospace font', () => {
+      render(<TaskConflictModal {...defaultProps} />);
+
+      const taskIdElement = screen.getByText(/task_fa7666d5-bdf1-4498-b52b-1c12af89a578/);
+      expect(taskIdElement).toBeInTheDocument();
+      expect(taskIdElement.className).toContain('font-mono');
+    });
+
+    it('displays different task ID correctly', () => {
+      const differentTaskId = 'task_abc-123-def-456';
+      render(<TaskConflictModal {...defaultProps} taskId={differentTaskId} />);
+
+      expect(screen.getByText(new RegExp(differentTaskId))).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/components/index.ts
+++ b/apps/web/src/components/index.ts
@@ -1,5 +1,7 @@
 export { ActionDetailModal } from './ActionDetailModal.js';
 export { ConfirmSubmitModal } from './ConfirmSubmitModal.js';
+export { TaskConflictModal } from './TaskConflictModal.js';
+export type { ConflictReason } from './TaskConflictModal.js';
 export { ActionItem } from './ActionItem.js';
 export type { ExecutionState } from './ActionItem.js';
 export { ChartDefinitionDisplay } from './ChartDefinitionDisplay.js';

--- a/apps/web/src/pages/CodeTaskNewPage.tsx
+++ b/apps/web/src/pages/CodeTaskNewPage.tsx
@@ -3,11 +3,13 @@ import { Link, useNavigate } from 'react-router-dom';
 import { AlertCircle, Play, Link2, Sparkles } from 'lucide-react';
 import MDEditor from '@uiw/react-md-editor';
 import rehypeSanitize from 'rehype-sanitize';
-import { Button, Card, Layout, ConfirmSubmitModal } from '@/components';
+import { Button, Card, Layout, ConfirmSubmitModal, TaskConflictModal } from '@/components';
+import type { ConflictReason } from '@/components';
 import { LinearIssueCombobox } from '@/components';
 import { useCodeTasks, useLinearIssueOptions, useWorkersStatus } from '@/hooks';
 import type { CodeTaskWorkerType } from '@/types';
 import type { LinearIssueOption } from '@/hooks/useLinearIssueOptions';
+import { ApiError, parseConflictError } from '@/services/apiClient';
 
 const WORKER_TYPES: { id: CodeTaskWorkerType; name: string; description: string }[] = [
   { id: 'auto', name: 'Auto', description: 'Automatically select the best model' },
@@ -33,6 +35,8 @@ export function CodeTaskNewPage(): React.JSX.Element {
   const [selectedIssue, setSelectedIssue] = useState<LinearIssueOption | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [showConflictModal, setShowConflictModal] = useState(false);
+  const [conflictInfo, setConflictInfo] = useState<{ taskId: string; reason: ConflictReason } | null>(null);
 
   const { status: workersStatus, loading: workersLoading } = useWorkersStatus();
 
@@ -85,6 +89,7 @@ export function CodeTaskNewPage(): React.JSX.Element {
   const handleConfirmSubmit = async (): Promise<void> => {
     setSubmitting(true);
     setError(null);
+    setShowConflictModal(false);
 
     try {
       const requestData: {
@@ -111,13 +116,30 @@ export function CodeTaskNewPage(): React.JSX.Element {
       const taskId = await submitTask(requestData);
       void navigate(`/code-tasks/${taskId}`);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to submit task');
       setSubmitting(false);
+      if (err instanceof ApiError && err.code === 'CONFLICT') {
+        const parsedConflict = parseConflictError(err.message);
+        if (parsedConflict !== null) {
+          setConflictInfo(parsedConflict);
+          setShowConflictModal(true);
+          return;
+        }
+      }
+      setError(err instanceof Error ? err.message : 'Failed to submit task');
     }
   };
 
   const handleCancelModal = (): void => {
     setShowConfirmModal(false);
+  };
+
+  const handleNavigateToTask = (taskId: string): void => {
+    void navigate(`/code-tasks/${taskId}`);
+  };
+
+  const handleCloseConflictModal = (): void => {
+    setShowConflictModal(false);
+    setConflictInfo(null);
   };
 
   return (
@@ -394,6 +416,16 @@ export function CodeTaskNewPage(): React.JSX.Element {
         onConfirm={handleConfirmSubmit}
         onCancel={handleCancelModal}
       />
+
+      {showConflictModal && conflictInfo !== null ? (
+        <TaskConflictModal
+          isOpen={showConflictModal}
+          taskId={conflictInfo.taskId}
+          reason={conflictInfo.reason}
+          onClose={handleCloseConflictModal}
+          onNavigateToTask={handleNavigateToTask}
+        />
+      ) : null}
     </Layout>
   );
 }

--- a/apps/web/src/services/__tests__/apiClient.test.ts
+++ b/apps/web/src/services/__tests__/apiClient.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Tests for apiClient service.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseConflictError, type ConflictErrorInfo } from '../apiClient';
+
+describe('parseConflictError', () => {
+  describe('Duplicate task pattern', () => {
+    it('extracts task ID from duplicate prompt message', () => {
+      const message = 'Similar task submitted in last 5 minutes: task_fa7666d5-bdf1-4498-b52b-1c12af89a578';
+      const result = parseConflictError(message);
+
+      expect(result).toEqual({
+        taskId: 'task_fa7666d5-bdf1-4498-b52b-1c12af89a578',
+        reason: 'duplicate',
+      } satisfies ConflictErrorInfo);
+    });
+
+    it('extracts task ID with different format', () => {
+      const message = 'Similar task submitted in last 5 minutes: task_abc-123-def-456';
+      const result = parseConflictError(message);
+
+      expect(result).toEqual({
+        taskId: 'task_abc-123-def-456',
+        reason: 'duplicate',
+      } satisfies ConflictErrorInfo);
+    });
+
+    it('handles trailing whitespace in task ID', () => {
+      const message = 'Similar task submitted in last 5 minutes: task_xyz-123 ';
+      const result = parseConflictError(message);
+
+      expect(result).toEqual({
+        taskId: 'task_xyz-123 ', // Whitespace preserved as part of capture
+        reason: 'duplicate',
+      } satisfies ConflictErrorInfo);
+    });
+  });
+
+  describe('Active task pattern', () => {
+    it('extracts task ID from active task message', () => {
+      const message = 'Active task already exists for this Linear issue: task_bb7666d5-bdf1-4498-b52b-1c12af89a579';
+      const result = parseConflictError(message);
+
+      expect(result).toEqual({
+        taskId: 'task_bb7666d5-bdf1-4498-b52b-1c12af89a579',
+        reason: 'active',
+      } satisfies ConflictErrorInfo);
+    });
+
+    it('extracts task ID with different format', () => {
+      const message = 'Active task already exists for this Linear issue: task_active-987';
+      const result = parseConflictError(message);
+
+      expect(result).toEqual({
+        taskId: 'task_active-987',
+        reason: 'active',
+      } satisfies ConflictErrorInfo);
+    });
+  });
+
+  describe('Duplicate approval pattern', () => {
+    it('extracts task ID from duplicate approval message', () => {
+      const message = 'Duplicate: task_cc7666d5-bdf1-4498-b52b-1c12af89a580';
+      const result = parseConflictError(message);
+
+      expect(result).toEqual({
+        taskId: 'task_cc7666d5-bdf1-4498-b52b-1c12af89a580',
+        reason: 'duplicate_approval',
+      } satisfies ConflictErrorInfo);
+    });
+
+    it('extracts task ID with simple format', () => {
+      const message = 'Duplicate: task_simple-123';
+      const result = parseConflictError(message);
+
+      expect(result).toEqual({
+        taskId: 'task_simple-123',
+        reason: 'duplicate_approval',
+      } satisfies ConflictErrorInfo);
+    });
+  });
+
+  describe('Unknown message patterns', () => {
+    it('returns null for completely unknown message', () => {
+      const message = 'Some random error message';
+      const result = parseConflictError(message);
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null for empty string', () => {
+      const message = '';
+      const result = parseConflictError(message);
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null for message without task ID', () => {
+      const message = 'Similar task submitted in last 5 minutes:';
+      const result = parseConflictError(message);
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null for message with similar but different prefix', () => {
+      const message = 'Similar task was submitted: task-123';
+      const result = parseConflictError(message);
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null for duplicate message without "Duplicate:" prefix at start', () => {
+      const message = 'There is a Duplicate: task-123';
+      const result = parseConflictError(message);
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('Pattern matching priority', () => {
+    it('matches duplicate pattern first when message could match multiple', () => {
+      // This message contains both "Duplicate:" and the duplicate pattern
+      const message = 'Similar task submitted in last 5 minutes: task-123 has a Duplicate: something';
+      const result = parseConflictError(message);
+
+      // Should match the first pattern (duplicate) since we check in order
+      expect(result).toEqual({
+        taskId: 'task-123 has a Duplicate: something',
+        reason: 'duplicate',
+      } satisfies ConflictErrorInfo);
+    });
+  });
+});

--- a/apps/web/src/services/apiClient.ts
+++ b/apps/web/src/services/apiClient.ts
@@ -1,5 +1,42 @@
 import type { ApiErrorResponse, ApiResponse } from '@/types';
 
+export type ConflictReason = 'duplicate' | 'active' | 'duplicate_approval';
+
+export interface ConflictErrorInfo {
+  taskId: string;
+  reason: ConflictReason;
+}
+
+/**
+ * Parse a 409 CONFLICT error message to extract task ID and conflict reason.
+ * Returns null if the message doesn't match any known conflict pattern.
+ */
+export function parseConflictError(message: string): ConflictErrorInfo | null {
+  // Pattern 1: "Similar task submitted in last 5 minutes: {taskId}"
+  const duplicatePattern = /Similar task submitted in last 5 minutes: (.+)/;
+  const duplicateMatch = duplicatePattern.exec(message);
+  if (duplicateMatch?.[1]) {
+    return { taskId: duplicateMatch[1], reason: 'duplicate' };
+  }
+
+  // Pattern 2: "Active task already exists for this Linear issue: {taskId}"
+  const activePattern = /Active task already exists for this Linear issue: (.+)/;
+  const activeMatch = activePattern.exec(message);
+  if (activeMatch?.[1]) {
+    return { taskId: activeMatch[1], reason: 'active' };
+  }
+
+  // Pattern 3: "Duplicate: {taskId}"
+  const approvalPattern = /^Duplicate: (.+)/;
+  const approvalMatch = approvalPattern.exec(message);
+  if (approvalMatch?.[1]) {
+    return { taskId: approvalMatch[1], reason: 'duplicate_approval' };
+  }
+
+  // Unknown format - return null to fall back to generic error handling
+  return null;
+}
+
 export class ApiError extends Error {
   constructor(
     public readonly code: string,


### PR DESCRIPTION
## Summary

When submitting a code task that receives a 409 CONFLICT response (duplicate or active task exists), the UI previously showed an unclear error message with a task ID that wasn't clickable.

This PR adds a dedicated conflict modal with clear messaging and navigation to the existing task.

## Changes

- **New**: `TaskConflictModal.tsx` - Modal component with amber/warning styling
- **New**: `parseConflictError()` helper in `apiClient.ts` - Extracts task ID and conflict reason from error messages
- **Modified**: `CodeTaskNewPage.tsx` - Catches 409 errors and shows conflict modal instead of generic error alert

## Test Plan

- 10 new tests for TaskConflictModal component
- 13 new tests for parseConflictError helper
- All 204 tests passing

## Backend Error Formats Handled

1. `Similar task submitted in last 5 minutes: {taskId}` → reason: `duplicate`
2. `Active task already exists for this Linear issue: {taskId}` → reason: `active`
3. `Duplicate: {taskId}` → reason: `duplicate_approval`

Fixes INT-498

🤖 Generated with [Claude Code](https://claude.com/claude-code)