### PR TITLE
Add generic error modal for code task submission

### DIFF
--- a/apps/web/src/components/ConfirmSubmitModal.tsx
+++ b/apps/web/src/components/ConfirmSubmitModal.tsx
@@ -20,18 +20,19 @@ export function ConfirmSubmitModal({
   onCancel,
 }: ConfirmSubmitModalProps): React.JSX.Element | null {
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
 
   if (!isOpen) return null;
 
   const handleConfirm = async (): Promise<void> => {
     setIsSubmitting(true);
-    setError(null);
     try {
       await onConfirm();
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to submit task');
       setIsSubmitting(false);
+      // Close modal and let parent handle error display
+      onCancel();
+      // Re-throw so parent can catch
+      throw err;
     }
   };
 
@@ -88,12 +89,6 @@ export function ConfirmSubmitModal({
                 </span>
                 ?
               </p>
-
-              {error !== null && (
-                <div className="mt-4 rounded-lg border border-red-200 bg-red-50 p-3 dark:border-red-800 dark:bg-red-900/30">
-                  <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
-                </div>
-              )}
             </div>
 
             <div className="flex shrink-0 items-center justify-end gap-2 border-t border-slate-200 p-4 dark:border-slate-700">

--- a/apps/web/src/components/TaskErrorModal.tsx
+++ b/apps/web/src/components/TaskErrorModal.tsx
@@ -1,0 +1,178 @@
+import { useState, useEffect } from 'react';
+import { X, ChevronDown, ChevronUp } from 'lucide-react';
+import { Button } from './ui/Button.js';
+import type { ApiError } from '@/services/apiClient.js';
+import { getErrorConfig } from '@/services/errorConfig.js';
+
+interface TaskErrorModalProps {
+  isOpen: boolean;
+  error: ApiError | null;
+  onClose: () => void;
+  onRetry?: () => void;
+}
+
+export function TaskErrorModal({
+  isOpen,
+  error,
+  onClose,
+  onRetry,
+}: TaskErrorModalProps): React.JSX.Element | null {
+  const [showDetails, setShowDetails] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setShowDetails(false);
+    }
+  }, [isOpen]);
+
+  if (!isOpen || error === null) return null;
+
+  const config = getErrorConfig(error, {
+    onClose,
+    onRetry: onRetry ?? onClose,
+    navigate: (path) => {
+      window.location.href = path;
+    },
+  });
+  const Icon = config.icon;
+  const message = config.getMessage(error);
+
+  const handleBackdropClick = (e: React.MouseEvent<HTMLDivElement>): void => {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  };
+
+  const handlePrimaryAction = (): void => {
+    // For retry action, call the onRetry callback
+    if (config.primaryAction?.label === 'Try Again' && onRetry !== undefined) {
+      onRetry();
+      return;
+    }
+    // For other actions, execute the configured action
+    config.primaryAction?.getAction(error, {
+      onClose,
+      onRetry: onRetry ?? onClose,
+      navigate: (path) => {
+        window.location.href = path;
+      },
+    })();
+  };
+
+  const handleSecondaryAction = (): void => {
+    // For close action, just close the modal
+    if (config.secondaryAction?.label === 'Cancel' || config.secondaryAction?.label === 'Close') {
+      onClose();
+      return;
+    }
+    // For other actions, execute the configured action
+    config.secondaryAction?.getAction(error, {
+      onClose,
+      onRetry: onRetry ?? onClose,
+      navigate: (path) => {
+        window.location.href = path;
+      },
+    })();
+  };
+
+  const details: Record<string, string> = {
+    'Error Code': error.code,
+    'Status': error.status.toString(),
+    'Message': error.message,
+    ...(error.details ?? {}),
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      onClick={handleBackdropClick}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="error-modal-title"
+      aria-describedby="error-modal-description"
+    >
+      <div className="flex max-h-[90vh] w-full max-w-lg flex-col rounded-xl bg-white shadow-2xl dark:bg-slate-800">
+        {/* Header */}
+        <div
+          className={`flex shrink-0 items-start justify-between border-b p-4 ${config.borderColor} dark:border-opacity-50`}
+        >
+          <div className="flex items-start gap-3">
+            <div className={`mt-0.5 rounded-lg p-2 ${config.bgColor} dark:bg-opacity-50`}>
+              <Icon className={`h-5 w-5 ${config.iconColor}`} />
+            </div>
+            <div>
+              <h2 id="error-modal-title" className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+                {config.title}
+              </h2>
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            className="rounded-lg p-2 text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-600 dark:hover:bg-slate-700 dark:hover:text-slate-300"
+            aria-label="Close"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="min-h-0 flex-1 overflow-y-auto p-4">
+          <div className={`rounded-lg border p-4 ${config.bgColor} ${config.borderColor} dark:border-opacity-50`}>
+            <p id="error-modal-description" className={`text-sm ${config.iconColor}`}>
+              {message}
+            </p>
+          </div>
+
+          {/* Collapsible Technical Details */}
+          {config.showDetails && (
+            <div className="mt-4">
+              <button
+                onClick={(): void => {
+                  setShowDetails((prev) => !prev);
+                }}
+                className="flex items-center gap-2 text-sm font-medium text-slate-600 transition-colors hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-200"
+                aria-expanded={showDetails}
+              >
+                {showDetails ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+                Technical Details
+              </button>
+              {showDetails && (
+                <div className="mt-2 overflow-hidden rounded-lg border border-slate-200 bg-slate-50 dark:border-slate-700 dark:bg-slate-900/50">
+                  <table className="w-full text-sm">
+                    <tbody>
+                      {Object.entries(details).map(([key, value]) => (
+                        <tr
+                          key={key}
+                          className="border-b border-slate-200 last:border-b-0 dark:border-slate-700"
+                        >
+                          <td className="px-3 py-2 font-medium text-slate-600 dark:text-slate-400">{key}</td>
+                          <td className="px-3 py-2 font-mono text-slate-900 dark:text-slate-100 break-all">
+                            {value}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Actions */}
+        <div
+          className={`flex shrink-0 items-center justify-end gap-2 border-t p-4 ${config.borderColor} dark:border-opacity-50`}
+        >
+          {config.secondaryAction && (
+            <Button variant="secondary" onClick={handleSecondaryAction}>
+              {config.secondaryAction.label}
+            </Button>
+          )}
+          <Button variant={config.primaryAction?.variant ?? 'secondary'} onClick={handlePrimaryAction}>
+            {config.primaryAction?.label ?? 'Close'}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/index.ts
+++ b/apps/web/src/components/index.ts
@@ -1,6 +1,7 @@
 export { ActionDetailModal } from './ActionDetailModal.js';
 export { ConfirmSubmitModal } from './ConfirmSubmitModal.js';
 export { TaskConflictModal } from './TaskConflictModal.js';
+export { TaskErrorModal } from './TaskErrorModal.js';
 export type { ConflictReason } from './TaskConflictModal.js';
 export { ActionItem } from './ActionItem.js';
 export type { ExecutionState } from './ActionItem.js';

--- a/apps/web/src/pages/CodeTaskNewPage.tsx
+++ b/apps/web/src/pages/CodeTaskNewPage.tsx
@@ -3,7 +3,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import { AlertCircle, Play, Link2, Sparkles } from 'lucide-react';
 import MDEditor from '@uiw/react-md-editor';
 import rehypeSanitize from 'rehype-sanitize';
-import { Button, Card, Layout, ConfirmSubmitModal, TaskConflictModal } from '@/components';
+import { Button, Card, Layout, ConfirmSubmitModal, TaskConflictModal, TaskErrorModal } from '@/components';
 import type { ConflictReason } from '@/components';
 import { LinearIssueCombobox } from '@/components';
 import { useCodeTasks, useLinearIssueOptions, useWorkersStatus } from '@/hooks';
@@ -37,6 +37,8 @@ export function CodeTaskNewPage(): React.JSX.Element {
   const [error, setError] = useState<string | null>(null);
   const [showConflictModal, setShowConflictModal] = useState(false);
   const [conflictInfo, setConflictInfo] = useState<{ taskId: string; reason: ConflictReason } | null>(null);
+  const [showErrorModal, setShowErrorModal] = useState(false);
+  const [taskError, setTaskError] = useState<ApiError | null>(null);
 
   const { status: workersStatus, loading: workersLoading } = useWorkersStatus();
 
@@ -90,6 +92,7 @@ export function CodeTaskNewPage(): React.JSX.Element {
     setSubmitting(true);
     setError(null);
     setShowConflictModal(false);
+    setShowErrorModal(false);
 
     try {
       const requestData: {
@@ -117,14 +120,23 @@ export function CodeTaskNewPage(): React.JSX.Element {
       void navigate(`/code-tasks/${taskId}`);
     } catch (err) {
       setSubmitting(false);
-      if (err instanceof ApiError && err.code === 'CONFLICT') {
-        const parsedConflict = parseConflictError(err.message);
-        if (parsedConflict !== null) {
-          setConflictInfo(parsedConflict);
-          setShowConflictModal(true);
-          return;
+      setShowConfirmModal(false);
+
+      if (err instanceof ApiError) {
+        if (err.code === 'CONFLICT') {
+          const parsedConflict = parseConflictError(err.message);
+          if (parsedConflict !== null) {
+            setConflictInfo(parsedConflict);
+            setShowConflictModal(true);
+            return;
+          }
         }
+        // Show error modal for non-conflict API errors
+        setTaskError(err);
+        setShowErrorModal(true);
+        return;
       }
+
       setError(err instanceof Error ? err.message : 'Failed to submit task');
     }
   };
@@ -140,6 +152,17 @@ export function CodeTaskNewPage(): React.JSX.Element {
   const handleCloseConflictModal = (): void => {
     setShowConflictModal(false);
     setConflictInfo(null);
+  };
+
+  const handleCloseErrorModal = (): void => {
+    setShowErrorModal(false);
+    setTaskError(null);
+  };
+
+  const handleRetrySubmit = (): void => {
+    setShowErrorModal(false);
+    setTaskError(null);
+    void handleConfirmSubmit();
   };
 
   return (
@@ -426,6 +449,13 @@ export function CodeTaskNewPage(): React.JSX.Element {
           onNavigateToTask={handleNavigateToTask}
         />
       ) : null}
+
+      <TaskErrorModal
+        isOpen={showErrorModal}
+        error={taskError}
+        onClose={handleCloseErrorModal}
+        onRetry={handleRetrySubmit}
+      />
     </Layout>
   );
 }

--- a/apps/web/src/services/errorConfig.ts
+++ b/apps/web/src/services/errorConfig.ts
@@ -1,0 +1,200 @@
+import { AlertCircle, Settings, Wrench, Timer, Activity, XCircle, Ban } from 'lucide-react';
+import type { ApiError } from './apiClient.js';
+
+export type ErrorSeverity = 'info' | 'warning' | 'error';
+
+export interface ErrorConfig {
+  icon: React.ComponentType<{ className?: string }>;
+  iconColor: string;
+  bgColor: string;
+  borderColor: string;
+  title: string;
+  getMessage: (error: ApiError) => string;
+  severity: ErrorSeverity;
+  showDetails: boolean;
+  primaryAction?: ErrorAction;
+  secondaryAction?: ErrorAction;
+}
+
+export interface ErrorAction {
+  label: string;
+  variant: 'primary' | 'secondary' | 'danger';
+  getAction: (error: ApiError, helpers: ActionHelpers) => () => void;
+}
+
+export interface ActionHelpers {
+  onClose: () => void;
+  onRetry: () => void;
+  navigate: (path: string) => void;
+}
+
+// Error action types for declarative configuration
+type BuiltAction = 'navigate' | 'retry' | 'close';
+
+// Configuration for each error code
+const ERROR_CONFIGS: Record<
+  string,
+  Omit<ErrorConfig, 'getMessage' | 'primaryAction' | 'secondaryAction'> & {
+    message: string;
+    primaryAction?: Omit<ErrorAction, 'getAction'> & { action: BuiltAction; navigateTo?: string };
+    secondaryAction?: Omit<ErrorAction, 'getAction'> & { action: BuiltAction; navigateTo?: string };
+  }
+> = {
+  WORKER_NOT_CONFIGURED: {
+    icon: Settings,
+    iconColor: 'text-amber-600 dark:text-amber-400',
+    bgColor: 'bg-amber-50 dark:bg-amber-900/30',
+    borderColor: 'border-amber-200 dark:border-amber-800',
+    title: 'Workers Not Configured',
+    message: 'Please configure at least one worker before submitting code tasks.',
+    severity: 'warning',
+    showDetails: false,
+    primaryAction: { label: 'Configure Workers', variant: 'primary', action: 'navigate', navigateTo: '/settings/workers' },
+    secondaryAction: { label: 'Cancel', variant: 'secondary', action: 'close' },
+  },
+  INVALID_WORKER: {
+    icon: Ban,
+    iconColor: 'text-red-600 dark:text-red-400',
+    bgColor: 'bg-red-50 dark:bg-red-900/30',
+    borderColor: 'border-red-200 dark:border-red-800',
+    title: 'Invalid Worker',
+    message: 'The selected worker is not configured or enabled.',
+    severity: 'error',
+    showDetails: true,
+    primaryAction: { label: 'Try Again', variant: 'secondary', action: 'retry' },
+    secondaryAction: { label: 'View Workers', variant: 'secondary', action: 'navigate', navigateTo: '/settings/workers' },
+  },
+  WORKER_UNHEALTHY: {
+    icon: Activity,
+    iconColor: 'text-red-600 dark:text-red-400',
+    bgColor: 'bg-red-50 dark:bg-red-900/30',
+    borderColor: 'border-red-200 dark:border-red-800',
+    title: 'Worker Unhealthy',
+    message: 'The selected worker is currently unavailable.',
+    severity: 'error',
+    showDetails: true,
+    primaryAction: { label: 'Try Again', variant: 'secondary', action: 'retry' },
+    secondaryAction: { label: 'View Workers', variant: 'secondary', action: 'navigate', navigateTo: '/settings/workers' },
+  },
+  MISCONFIGURED: {
+    icon: Wrench,
+    iconColor: 'text-amber-600 dark:text-amber-400',
+    bgColor: 'bg-amber-50 dark:bg-amber-900/30',
+    borderColor: 'border-amber-200 dark:border-amber-800',
+    title: 'Service Unavailable',
+    message: 'The code agent service is temporarily unavailable.',
+    severity: 'warning',
+    showDetails: true,
+    primaryAction: { label: 'Try Again', variant: 'primary', action: 'retry' },
+    secondaryAction: { label: 'Cancel', variant: 'secondary', action: 'close' },
+  },
+  RATE_LIMITED: {
+    icon: Timer,
+    iconColor: 'text-amber-600 dark:text-amber-400',
+    bgColor: 'bg-amber-50 dark:bg-amber-900/30',
+    borderColor: 'border-amber-200 dark:border-amber-800',
+    title: 'Rate Limited',
+    message: 'You have exceeded the rate limit. Please wait before submitting more tasks.',
+    severity: 'warning',
+    showDetails: true,
+    primaryAction: { label: 'Try Again', variant: 'primary', action: 'retry' },
+    secondaryAction: { label: 'Cancel', variant: 'secondary', action: 'close' },
+  },
+  TIMEOUT: {
+    icon: Timer,
+    iconColor: 'text-amber-600 dark:text-amber-400',
+    bgColor: 'bg-amber-50 dark:bg-amber-900/30',
+    borderColor: 'border-amber-200 dark:border-amber-800',
+    title: 'Request Timed Out',
+    message: 'The request took too long to complete. Please check your connection and try again.',
+    severity: 'warning',
+    showDetails: false,
+    primaryAction: { label: 'Try Again', variant: 'primary', action: 'retry' },
+    secondaryAction: { label: 'Cancel', variant: 'secondary', action: 'close' },
+  },
+  INTERNAL_ERROR: {
+    icon: AlertCircle,
+    iconColor: 'text-red-600 dark:text-red-400',
+    bgColor: 'bg-red-50 dark:bg-red-900/30',
+    borderColor: 'border-red-200 dark:border-red-800',
+    title: 'Something Went Wrong',
+    message: 'An unexpected error occurred. Please try again.',
+    severity: 'error',
+    showDetails: true,
+    primaryAction: { label: 'Try Again', variant: 'primary', action: 'retry' },
+    secondaryAction: { label: 'Cancel', variant: 'secondary', action: 'close' },
+  },
+  INVALID_REQUEST: {
+    icon: XCircle,
+    iconColor: 'text-red-600 dark:text-red-400',
+    bgColor: 'bg-red-50 dark:bg-red-900/30',
+    borderColor: 'border-red-200 dark:border-red-800',
+    title: 'Invalid Request',
+    message: 'The request contains invalid data.',
+    severity: 'error',
+    showDetails: true,
+    primaryAction: { label: 'Try Again', variant: 'primary', action: 'retry' },
+    secondaryAction: { label: 'Cancel', variant: 'secondary', action: 'close' },
+  },
+  UNKNOWN: {
+    icon: AlertCircle,
+    iconColor: 'text-red-600 dark:text-red-400',
+    bgColor: 'bg-red-50 dark:bg-red-900/30',
+    borderColor: 'border-red-200 dark:border-red-800',
+    title: 'Error',
+    message: 'An unknown error occurred.',
+    severity: 'error',
+    showDetails: true,
+    primaryAction: { label: 'Try Again', variant: 'primary', action: 'retry' },
+    secondaryAction: { label: 'Cancel', variant: 'secondary', action: 'close' },
+  },
+};
+
+function buildAction(
+  actionDef: Omit<ErrorAction, 'getAction'> & { action: BuiltAction; navigateTo?: string }
+): ErrorAction {
+  return {
+    label: actionDef.label,
+    variant: actionDef.variant,
+    getAction: () =>
+      () => {
+        if (actionDef.action === 'navigate' && actionDef.navigateTo !== undefined) {
+          window.location.href = actionDef.navigateTo;
+        } else if (actionDef.action === 'retry') {
+          // Retry is handled by the caller
+          return;
+        } else if (actionDef.action === 'close') {
+          // Close is handled by the caller
+          return;
+        }
+      },
+  };
+}
+
+export function getErrorConfig(error: ApiError, _helpers: ActionHelpers): ErrorConfig {
+  const config = ERROR_CONFIGS[error.code] ?? ERROR_CONFIGS['UNKNOWN'];
+  if (config === undefined) {
+    // Should never happen since UNKNOWN is always defined
+    throw new Error('No error config found');
+  }
+
+  const result: ErrorConfig = {
+    icon: config.icon,
+    iconColor: config.iconColor,
+    bgColor: config.bgColor,
+    borderColor: config.borderColor,
+    title: config.title,
+    severity: config.severity,
+    showDetails: config.showDetails,
+    getMessage: () => config.message,
+  };
+
+  if (config.primaryAction !== undefined) {
+    result.primaryAction = buildAction(config.primaryAction);
+  }
+  if (config.secondaryAction !== undefined) {
+    result.secondaryAction = buildAction(config.secondaryAction);
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Summary
- Created `TaskErrorModal` component with error configuration registry
- Fixed `ConfirmSubmitModal` to close and re-throw errors instead of swallowing them
- Added error modal to `CodeTaskNewPage` for non-conflict API errors

## Problem
When the code-agent service returned errors during task submission, the `ConfirmSubmitModal` spinner never stopped because the parent's catch block couldn't handle errors that were already caught internally.

## Solution
- Error configuration registry in `errorConfig.ts` maps error codes to UI content
- `TaskErrorModal` displays appropriate icons, messages, and actions per error type
- `ConfirmSubmitModal` now closes and re-throws, letting parent show error modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)