### PR TITLE
[INT-465] PR Comment Auto-Response - Resume/Start Claude Task

### DIFF
--- a/apps/code-agent/src/__tests__/infra/github-event-parser.test.ts
+++ b/apps/code-agent/src/__tests__/infra/github-event-parser.test.ts
@@ -7,6 +7,7 @@ import {
   parsePullRequestEvent,
   parsePullRequestReviewEvent,
   parsePullRequestReviewCommentEvent,
+  parseIssueCommentEvent,
   parsePushEvent,
   parseGitHubWebhookEvent,
   shouldProcessRepository,
@@ -847,6 +848,357 @@ describe('github-event-parser', () => {
     });
   });
 
+  describe('parseIssueCommentEvent', () => {
+    const validIssueCommentPayload = {
+      id: 12345,
+      action: 'created',
+      repository: {
+        id: 456,
+        full_name: 'intexuraos/code-agent',
+      },
+      issue: {
+        id: 101,
+        number: 42,
+        title: 'Test PR',
+        state: 'open',
+        pull_request: {
+          url: 'https://api.github.com/repos/intexuraos/code-agent/pulls/42',
+        },
+      },
+      comment: {
+        id: 789,
+        body: 'Great work on this PR!',
+      },
+      sender: {
+        login: 'commenter',
+        id: 111,
+        type: 'User',
+      },
+    };
+
+    it('should parse valid issue_comment on a PR', () => {
+      const result = parseIssueCommentEvent(validIssueCommentPayload);
+
+      expect(result.ok).toBe(true);
+      if (result.ok && result.value !== null) {
+        expect(result.value).toMatchObject({
+          githubEventId: 12345,
+          repository: 'intexuraos/code-agent',
+          pullRequestNumber: 42,
+          pullRequestId: 101,
+          eventType: 'issue_comment',
+          action: 'created',
+          senderLogin: 'commenter',
+          body: 'Great work on this PR!',
+          title: 'Test PR',
+          state: 'open',
+        });
+      }
+    });
+
+    it('should return null for comments on issues (not PRs)', () => {
+      const issueOnlyPayload = {
+        id: 12345,
+        action: 'created',
+        repository: {
+          id: 456,
+          full_name: 'intexuraos/code-agent',
+        },
+        issue: {
+          id: 101,
+          number: 42,
+          title: 'Bug report',
+          state: 'open',
+          // No pull_request field - this is a regular issue
+        },
+        comment: {
+          id: 789,
+          body: 'Thanks for reporting!',
+        },
+        sender: {
+          login: 'maintainer',
+          id: 111,
+        },
+      };
+
+      const result = parseIssueCommentEvent(issueOnlyPayload);
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value).toBeNull();
+      }
+    });
+
+    it('should handle missing comment body', () => {
+      const payloadWithoutCommentBody = {
+        ...validIssueCommentPayload,
+        comment: {
+          id: 789,
+        },
+      };
+
+      const result = parseIssueCommentEvent(payloadWithoutCommentBody);
+
+      expect(result.ok).toBe(true);
+      if (result.ok && result.value !== null) {
+        expect(result.value.body).toBeNull();
+      }
+    });
+
+    it('should handle missing comment object entirely', () => {
+      const payloadWithoutComment = {
+        id: 12345,
+        action: 'created',
+        repository: {
+          id: 456,
+          full_name: 'intexuraos/code-agent',
+        },
+        issue: {
+          id: 101,
+          number: 42,
+          pull_request: { url: 'https://api.github.com/...' },
+        },
+        sender: {
+          login: 'commenter',
+          id: 111,
+        },
+      };
+
+      const result = parseIssueCommentEvent(payloadWithoutComment);
+
+      expect(result.ok).toBe(true);
+      if (result.ok && result.value !== null) {
+        expect(result.value.body).toBeNull();
+      }
+    });
+
+    it('should return error for non-object payload', () => {
+      const result = parseIssueCommentEvent(null);
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe('INVALID_PAYLOAD');
+        expect(result.error.message).toBe('Payload is not an object');
+      }
+    });
+
+    it('should return error for missing issue', () => {
+      const payload = {
+        id: 12345,
+        action: 'created',
+        repository: {
+          id: 456,
+          full_name: 'intexuraos/code-agent',
+        },
+        comment: {
+          id: 789,
+          body: 'Hello!',
+        },
+        sender: {
+          login: 'commenter',
+          id: 111,
+        },
+      };
+
+      const result = parseIssueCommentEvent(payload);
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe('INVALID_PAYLOAD');
+        expect(result.error.message).toBe('Missing issue');
+      }
+    });
+
+    it('should return error for missing sender', () => {
+      const payload = {
+        id: 12345,
+        action: 'created',
+        repository: {
+          id: 456,
+          full_name: 'intexuraos/code-agent',
+        },
+        issue: {
+          id: 101,
+          number: 42,
+          pull_request: { url: 'https://...' },
+        },
+        comment: {
+          id: 789,
+          body: 'Hello!',
+        },
+      };
+
+      const result = parseIssueCommentEvent(payload);
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe('INVALID_PAYLOAD');
+        expect(result.error.message).toBe('Missing or invalid sender');
+      }
+    });
+
+    it('should return error for missing repository', () => {
+      const payload = {
+        id: 12345,
+        action: 'created',
+        issue: {
+          id: 101,
+          number: 42,
+          pull_request: { url: 'https://...' },
+        },
+        comment: {
+          id: 789,
+          body: 'Hello!',
+        },
+        sender: {
+          login: 'commenter',
+          id: 111,
+        },
+      };
+
+      const result = parseIssueCommentEvent(payload);
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe('INVALID_PAYLOAD');
+        expect(result.error.message).toBe('Missing repository');
+      }
+    });
+
+    it('should return error for invalid repository data', () => {
+      const payload = {
+        id: 12345,
+        action: 'created',
+        repository: {
+          id: 'not-a-number',
+          full_name: 'intexuraos/code-agent',
+        },
+        issue: {
+          id: 101,
+          number: 42,
+          pull_request: { url: 'https://...' },
+        },
+        sender: {
+          login: 'commenter',
+          id: 111,
+        },
+      };
+
+      const result = parseIssueCommentEvent(payload);
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe('INVALID_PAYLOAD');
+        expect(result.error.message).toBe('Invalid repository data');
+      }
+    });
+
+    it('should return error for invalid issue data', () => {
+      const payload = {
+        id: 12345,
+        action: 'created',
+        repository: {
+          id: 456,
+          full_name: 'intexuraos/code-agent',
+        },
+        issue: {
+          id: 'not-a-number',
+          number: 42,
+          pull_request: { url: 'https://...' },
+        },
+        sender: {
+          login: 'commenter',
+          id: 111,
+        },
+      };
+
+      const result = parseIssueCommentEvent(payload);
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe('INVALID_PAYLOAD');
+        expect(result.error.message).toBe('Invalid issue data');
+      }
+    });
+
+    it('should filter unknown actions to null', () => {
+      const payloadWithUnknownAction = {
+        ...validIssueCommentPayload,
+        action: 'unknown_action',
+      };
+
+      const result = parseIssueCommentEvent(payloadWithUnknownAction);
+
+      expect(result.ok).toBe(true);
+      if (result.ok && result.value !== null) {
+        expect(result.value.action).toBeNull();
+      }
+    });
+
+    it('should handle deleted action', () => {
+      const payloadWithDeleted = {
+        ...validIssueCommentPayload,
+        action: 'deleted',
+      };
+
+      const result = parseIssueCommentEvent(payloadWithDeleted);
+
+      expect(result.ok).toBe(true);
+      if (result.ok && result.value !== null) {
+        expect(result.value.action).toBe('deleted');
+      }
+    });
+
+    it('should handle Date instance for created_at', () => {
+      const createdDate = new Date('2024-01-15T12:00:00Z');
+      const payloadWithDateObject = {
+        ...validIssueCommentPayload,
+        created_at: createdDate,
+      };
+
+      const result = parseIssueCommentEvent(payloadWithDateObject);
+
+      expect(result.ok).toBe(true);
+      if (result.ok && result.value !== null) {
+        expect(result.value.createdAt).toBeInstanceOf(Date);
+        expect(result.value.createdAt).toEqual(createdDate);
+      }
+    });
+
+    it('should use Date.now() when event id is missing', () => {
+      const payloadWithoutId = {
+        action: 'created',
+        repository: {
+          id: 456,
+          full_name: 'intexuraos/code-agent',
+        },
+        issue: {
+          id: 101,
+          number: 42,
+          pull_request: { url: 'https://...' },
+        },
+        comment: {
+          id: 789,
+          body: 'Hello!',
+        },
+        sender: {
+          login: 'commenter',
+          id: 111,
+        },
+      };
+
+      const beforeTime = Date.now();
+      const result = parseIssueCommentEvent(payloadWithoutId);
+      const afterTime = Date.now();
+
+      expect(result.ok).toBe(true);
+      if (result.ok && result.value !== null) {
+        expect(result.value.githubEventId).toBeGreaterThanOrEqual(beforeTime);
+        expect(result.value.githubEventId).toBeLessThanOrEqual(afterTime);
+      }
+    });
+  });
+
   describe('parseGitHubWebhookEvent', () => {
     it('should parse pull_request events', () => {
       const payload = {
@@ -953,6 +1305,69 @@ describe('github-event-parser', () => {
       if (result.ok) {
         expect(result.value).not.toBeNull(); // @allow-result-access -- narrowed by result.ok
         expect(result.value?.eventType).toBe('push'); // @allow-result-access -- narrowed by result.ok
+      }
+    });
+
+    it('should parse issue_comment events on PRs', () => {
+      const payload = {
+        id: 12345,
+        action: 'created',
+        repository: {
+          id: 456,
+          full_name: 'intexuraos/code-agent',
+        },
+        issue: {
+          id: 101,
+          number: 42,
+          pull_request: { url: 'https://api.github.com/...' },
+        },
+        comment: {
+          id: 789,
+          body: 'Great work!',
+        },
+        sender: {
+          login: 'commenter',
+          id: 111,
+        },
+      };
+
+      const result = parseGitHubWebhookEvent('issue_comment', payload);
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value).not.toBeNull(); // @allow-result-access -- narrowed by result.ok
+        expect(result.value?.eventType).toBe('issue_comment'); // @allow-result-access -- narrowed by result.ok
+      }
+    });
+
+    it('should return null for issue_comment on non-PR issues', () => {
+      const payload = {
+        id: 12345,
+        action: 'created',
+        repository: {
+          id: 456,
+          full_name: 'intexuraos/code-agent',
+        },
+        issue: {
+          id: 101,
+          number: 42,
+          // No pull_request field - this is a regular issue
+        },
+        comment: {
+          id: 789,
+          body: 'Thanks for reporting!',
+        },
+        sender: {
+          login: 'commenter',
+          id: 111,
+        },
+      };
+
+      const result = parseGitHubWebhookEvent('issue_comment', payload);
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value).toBeNull(); // @allow-result-access -- ignored for non-PR issues
       }
     });
 

--- a/apps/code-agent/src/domain/models/gitHubPREvent.ts
+++ b/apps/code-agent/src/domain/models/gitHubPREvent.ts
@@ -8,6 +8,7 @@ export type GitHubEventType =
   | 'pull_request'
   | 'pull_request_review'
   | 'pull_request_review_comment'
+  | 'issue_comment'
   | 'push'
   | 'ping';
 

--- a/apps/code-agent/src/infra/github-event-parser.ts
+++ b/apps/code-agent/src/infra/github-event-parser.ts
@@ -360,6 +360,98 @@ export function parsePullRequestReviewCommentEvent(
 }
 
 /**
+ * Parse an issue_comment event payload.
+ * These are general comments on PRs (not inline diff comments).
+ * Returns null if the comment is on an issue (not a PR).
+ */
+export function parseIssueCommentEvent(
+  payload: unknown
+): Result<CreateGitHubPREventInput | null, { code: 'INVALID_PAYLOAD'; message: string }> {
+  if (!payload || typeof payload !== 'object') {
+    return err({ code: 'INVALID_PAYLOAD', message: 'Payload is not an object' });
+  }
+
+  const p = payload as Record<string, unknown>;
+
+  // Check if this is a comment on a PR (not an issue)
+  const issue = p['issue'];
+  if (!issue || typeof issue !== 'object') {
+    return err({ code: 'INVALID_PAYLOAD', message: 'Missing issue' });
+  }
+
+  const issueObj = issue as Record<string, unknown>;
+
+  // issue_comment events for PRs have a 'pull_request' field in the issue object
+  // If it's missing or null, this is a comment on an issue, not a PR
+  if (!issueObj['pull_request']) {
+    return ok(null);
+  }
+
+  const senderResult = extractSender(payload);
+  if (!senderResult.ok) {
+    return senderResult;
+  }
+
+  const action = p['action'];
+  const repository = p['repository'];
+  const comment = p['comment'];
+
+  if (!repository || typeof repository !== 'object') {
+    return err({ code: 'INVALID_PAYLOAD', message: 'Missing repository' });
+  }
+
+  const repo = repository as Record<string, unknown>;
+  const repoName = repo['full_name'];
+  const repoId = repo['id'];
+
+  if (typeof repoName !== 'string' || typeof repoId !== 'number') {
+    return err({ code: 'INVALID_PAYLOAD', message: 'Invalid repository data' });
+  }
+
+  // Get PR number and ID from the issue object
+  const prNumber = issueObj['number'];
+  const prId = issueObj['id'];
+  const prTitle = issueObj['title'] ?? null;
+  const prState = issueObj['state'] ?? null;
+
+  if (typeof prNumber !== 'number' || typeof prId !== 'number') {
+    return err({ code: 'INVALID_PAYLOAD', message: 'Invalid issue data' });
+  }
+
+  // Extract comment body if available
+  let commentBody: unknown = null;
+  if (comment && typeof comment === 'object') {
+    const commentObj = comment as Record<string, unknown>;
+    commentBody = commentObj['body'] ?? null;
+  }
+
+  const createdAt = p['created_at'] ?? new Date().toISOString();
+
+  // Validate action is a known GitHubPRAction or null
+  const validatedAction =
+    typeof action === 'string' && isValidGitHubPRAction(action) ? action : null;
+
+  return ok({
+    githubEventId: (p as { id?: number })['id'] ?? Date.now(),
+    repository: repoName,
+    repositoryId: repoId,
+    pullRequestNumber: prNumber,
+    pullRequestId: prId,
+    eventType: 'issue_comment' as GitHubEventType,
+    action: validatedAction,
+    senderLogin: senderResult.value.login,
+    senderId: senderResult.value.id,
+    senderType: senderResult.value.type,
+    title: typeof prTitle === 'string' ? prTitle : null,
+    body: typeof commentBody === 'string' ? commentBody : null,
+    state: typeof prState === 'string' ? prState : null,
+    mergedAt: null,
+    createdAt: createdAt instanceof Date ? createdAt : new Date(String(createdAt)),
+    payload,
+  });
+}
+
+/**
  * Parse a push event payload.
  * Push events are optional for context, so we return null if not PR-related.
  */
@@ -430,6 +522,8 @@ export function parseGitHubWebhookEvent(
       return parsePullRequestReviewEvent(payload);
     case 'pull_request_review_comment':
       return parsePullRequestReviewCommentEvent(payload);
+    case 'issue_comment':
+      return parseIssueCommentEvent(payload);
     case 'push':
       return parsePushEvent(payload);
     case 'ping':

--- a/apps/web/src/hooks/useGitHubPREvents.ts
+++ b/apps/web/src/hooks/useGitHubPREvents.ts
@@ -95,8 +95,11 @@ export function useGitHubPREvents(options?: UseGitHubPREventsOptions): {
   }, [fetchEvents]);
 
   // Group events by pull request number
+  // Filter out PR #0 (push events that aren't PR-specific)
+  const prEvents = events.filter((event) => event.pullRequestNumber !== 0);
+
   const groupedEvents: GroupedPREvents[] = Array.from(
-    events.reduce((map, event) => {
+    prEvents.reduce((map, event) => {
       const key = event.pullRequestNumber;
       if (!map.has(key)) {
         map.set(key, {

--- a/apps/web/src/pages/PREventsPage.tsx
+++ b/apps/web/src/pages/PREventsPage.tsx
@@ -32,6 +32,20 @@ function PREventItem({ eventType, action, senderLogin, createdAt }: PREventItemP
         color: 'text-purple-700 dark:text-purple-400',
       };
     }
+    if (eventType === 'pull_request_review_comment') {
+      return {
+        icon: '📝',
+        label: 'Inline Comment',
+        color: 'text-orange-700 dark:text-orange-400',
+      };
+    }
+    if (eventType === 'issue_comment') {
+      return {
+        icon: '💭',
+        label: 'Comment',
+        color: 'text-cyan-700 dark:text-cyan-400',
+      };
+    }
     if (eventType === 'push') {
       return {
         icon: '📤',


### PR DESCRIPTION
## Summary

- **Phase 0 Complete:** Bug fixes for PR events
  - Filter out PR #0 from UI display (push events)
  - Add `issue_comment` parser for general PR comments
  - Update UI to display different comment types with distinct icons

## Implementation Progress

| Phase | Description | Status |
|-------|-------------|--------|
| 0 | Bug fixes (prerequisites) | ✅ Complete |
| 1 | Data model & locking | 🔲 Pending |
| 2 | PR comment handler | 🔲 Pending |
| 3 | Task context & prompt | 🔲 Pending |
| 4 | UI direct feedback | 🔲 Pending |
| 5 | Testing & polish | 🔲 Pending |

## Test plan

- [x] `issue_comment` events on PRs are parsed correctly
- [x] `issue_comment` events on issues (not PRs) return null
- [x] PR #0 (push events) filtered from UI
- [x] All 80 github-event-parser tests pass
- [x] Full CI passes

Fixes INT-465

🤖 Generated with [Claude Code](https://claude.com/claude-code)