### PR TITLE
[INT-533] Improve bookmark summary prompt focus

### DIFF
--- a/apps/web-agent/src/__tests__/infra/pagesummary/buildSummaryRepairPrompt.test.ts
+++ b/apps/web-agent/src/__tests__/infra/pagesummary/buildSummaryRepairPrompt.test.ts
@@ -47,6 +47,26 @@ describe('buildSummaryPrompt (convenience function)', () => {
     expect(prompt).toContain('NO JSON format');
     expect(prompt).toContain('NO markdown code blocks');
   });
+
+  it('includes content focus instruction', () => {
+    const prompt = buildSummaryPrompt(20, 3);
+    expect(prompt).toContain('Focus on the SPECIFIC CONTENT');
+  });
+
+  it('includes platform ignore instruction', () => {
+    const prompt = buildSummaryPrompt(20, 3);
+    expect(prompt).toContain('Do NOT describe what the platform is');
+  });
+
+  it('includes metadata avoidance instruction', () => {
+    const prompt = buildSummaryPrompt(20, 3);
+    expect(prompt).toContain('Do NOT include platform structural information');
+  });
+
+  it('includes CONTENT FOCUS section header', () => {
+    const prompt = buildSummaryPrompt(20, 3);
+    expect(prompt).toContain('## CONTENT FOCUS');
+  });
 });
 
 describe('summaryPrompt (PromptBuilder)', () => {
@@ -75,6 +95,15 @@ describe('summaryPrompt (PromptBuilder)', () => {
     const prompt = summaryPrompt.build(input);
 
     expect(prompt).toContain('Maximum 400 words'); // 2 * 200
+  });
+
+  it('includes content focus instructions via PromptBuilder', () => {
+    const input: SummaryPromptInput = { maxSentences: 10, maxReadingMinutes: 2 };
+    const prompt = summaryPrompt.build(input);
+
+    expect(prompt).toContain('## CONTENT FOCUS');
+    expect(prompt).toContain('Focus on the SPECIFIC CONTENT');
+    expect(prompt).toContain('Do NOT describe what the platform is');
   });
 });
 
@@ -121,6 +150,13 @@ describe('buildSummaryRepairPrompt (convenience function)', () => {
     expect(prompt).toContain('## INVALID RESPONSE');
     expect(prompt).toContain('## REQUIREMENTS');
     expect(prompt).toContain('## OUTPUT FORMAT');
+  });
+
+  it('includes content focus requirements', () => {
+    const prompt = buildSummaryRepairPrompt('content', 'invalid', 'error');
+
+    expect(prompt).toContain('Focus on the SPECIFIC CONTENT');
+    expect(prompt).toContain('Do NOT describe what the platform is');
   });
 
   it('includes invalid response snippet', () => {

--- a/apps/web-agent/src/infra/pagesummary/buildSummaryRepairPrompt.ts
+++ b/apps/web-agent/src/infra/pagesummary/buildSummaryRepairPrompt.ts
@@ -49,6 +49,18 @@ export interface SummaryRepairPromptDeps extends PromptDeps {
 }
 
 /**
+ * Formats the content focus section for prompts.
+ * Guides LLM to focus on actual content rather than platform descriptions.
+ */
+function formatContentFocus(): string {
+  return `## CONTENT FOCUS
+- Focus on the SPECIFIC CONTENT of this page (the article, post, thread, or message)
+- Do NOT describe what the platform is or how it works (e.g., don't explain "LinkedIn is a professional network" or "Threads is a social media app")
+- Do NOT include platform structural information (usernames, profile details, navigation elements)
+- Summarize WHAT is being said, not WHO said it or WHERE it was posted`;
+}
+
+/**
  * Formats the requirements section for prompts.
  */
 function formatRequirements(
@@ -91,6 +103,8 @@ export const summaryPrompt: PromptBuilder<SummaryPromptInput, SummaryPromptDeps>
 
     return `## Your Task
 Summarize the following web page content.
+
+${formatContentFocus()}
 
 ${formatRequirements(input.maxSentences, maxWords)}
 
@@ -139,6 +153,8 @@ ${input.errorMessage}
 """
 ${truncatedInvalid}
 """
+
+${formatContentFocus()}
 
 ${formatRequirements(maxSentences, maxWords)}
 


### PR DESCRIPTION
## Summary

- Added **CONTENT FOCUS** section to the summary prompt that explicitly instructs the LLM to focus on page-specific content
- Prevents summaries from describing platforms (e.g., "LinkedIn is a professional network") instead of actual content
- Instructions apply to both initial summary and repair prompts

## Changes

- `apps/web-agent/src/infra/pagesummary/buildSummaryRepairPrompt.ts` - Added `formatContentFocus()` function and integrated it into both prompt builders
- `apps/web-agent/src/__tests__/infra/pagesummary/buildSummaryRepairPrompt.test.ts` - Added 6 new tests verifying content focus instructions

## Test plan

- [x] All 175 existing web-agent tests pass
- [x] 6 new tests verify content focus instructions are present
- [x] 100% branch coverage maintained on modified file
- [x] Full CI passes (8023 tests)

Fixes INT-533

🤖 Generated with [Claude Code](https://claude.com/claude-code)