### PR TITLE
Add webhook secret configuration UI to Linear settings

### DIFF
--- a/apps/web/src/pages/LinearConnectionPage.tsx
+++ b/apps/web/src/pages/LinearConnectionPage.tsx
@@ -1,8 +1,17 @@
 import { type FormEvent, useCallback, useEffect, useState } from 'react';
 import { Button, Card, Input, Layout } from '@/components';
 import { useAuth } from '@/context';
-import { ApiError, disconnectLinear, getLinearConnection, saveLinearConnection, validateLinearApiKey } from '@/services';
-import type { LinearConnectionStatus, LinearTeam } from '@/types';
+import {
+  ApiError,
+  disconnectLinear,
+  getLinearConnection,
+  saveLinearConnection,
+  validateLinearApiKey,
+  getWebhookConfig,
+  saveWebhookSecret,
+  removeWebhookSecret,
+} from '@/services';
+import type { LinearConnectionStatus, LinearTeam, LinearWebhookConfig } from '@/types';
 
 type ConnectionState = 'loading' | 'disconnected' | 'connected' | 'configuring';
 
@@ -21,6 +30,16 @@ export function LinearConnectionPage(): React.JSX.Element {
   const [isSaving, setIsSaving] = useState(false);
   const [isDisconnecting, setIsDisconnecting] = useState(false);
 
+  // Webhook config state
+  const [webhookConfig, setWebhookConfig] = useState<LinearWebhookConfig | null>(null);
+  const [webhookSecret, setWebhookSecret] = useState('');
+  const [isSavingWebhook, setIsSavingWebhook] = useState(false);
+  const [isRemovingWebhook, setIsRemovingWebhook] = useState(false);
+  const [webhookError, setWebhookError] = useState<string | null>(null);
+  const [webhookSuccess, setWebhookSuccess] = useState<string | null>(null);
+  const [isEditingWebhook, setIsEditingWebhook] = useState(false);
+  const [copiedToClipboard, setCopiedToClipboard] = useState(false);
+
   const fetchStatus = useCallback(async (): Promise<void> => {
     try {
       const token = await getAccessToken();
@@ -28,12 +47,24 @@ export function LinearConnectionPage(): React.JSX.Element {
       setConnection(status);
       if (status?.connected === true) {
         setState('connected');
+        // Fetch webhook config when connected
+        try {
+          const config = await getWebhookConfig(token);
+          setWebhookConfig(config);
+        } catch (e) {
+          // Webhook config might fail (403 if not set up yet), but don't fail entire page load
+          if (!(e instanceof ApiError && e.status === 403)) {
+            setWebhookError(e instanceof ApiError ? e.message : 'Failed to fetch webhook configuration');
+          }
+        }
       } else {
         setState('disconnected');
+        setWebhookConfig(null);
       }
     } catch (e) {
       setError(e instanceof ApiError ? e.message : 'Failed to fetch connection status');
       setState('disconnected');
+      setWebhookConfig(null);
     }
   }, [getAccessToken]);
 
@@ -108,9 +139,20 @@ export function LinearConnectionPage(): React.JSX.Element {
     try {
       setIsDisconnecting(true);
       const token = await getAccessToken();
+
+      // Clear webhook secret if configured
+      if (webhookConfig?.hasWebhookSecret === true) {
+        try {
+          await removeWebhookSecret(token);
+        } catch {
+          // Don't fail disconnect if webhook removal fails
+        }
+      }
+
       await disconnectLinear(token);
       setSuccessMessage('Linear disconnected successfully');
       setConnection(null);
+      setWebhookConfig(null);
       setState('disconnected');
     } catch (e) {
       setError(e instanceof ApiError ? e.message : 'Failed to disconnect');
@@ -134,6 +176,93 @@ export function LinearConnectionPage(): React.JSX.Element {
     setTeams([]);
     setSelectedTeamId('');
     setError(null);
+  };
+
+  const handleCopyWebhookUrl = async (): Promise<void> => {
+    if (webhookConfig?.webhookUrl) {
+      try {
+        await navigator.clipboard.writeText(webhookConfig.webhookUrl);
+        setCopiedToClipboard(true);
+        setTimeout(() => {
+          setCopiedToClipboard(false);
+        }, 2000);
+      } catch {
+        // Fallback for browsers that don't support clipboard API
+        setWebhookError('Failed to copy to clipboard');
+      }
+    }
+  };
+
+  const handleSaveWebhookSecret = async (): Promise<void> => {
+    setWebhookError(null);
+    setWebhookSuccess(null);
+
+    const secret = webhookSecret.trim();
+    if (secret === '') {
+      setWebhookError('Please enter a webhook signing secret');
+      return;
+    }
+
+    try {
+      setIsSavingWebhook(true);
+      const token = await getAccessToken();
+      await saveWebhookSecret(token, secret);
+      setWebhookSuccess('Webhook configured successfully');
+      setWebhookSecret('');
+      setIsEditingWebhook(false);
+      try {
+        const refreshed = await getWebhookConfig(token);
+        setWebhookConfig(refreshed);
+      } catch {
+        // Save succeeded — don't mask success with a refresh error
+        setWebhookConfig((prev) =>
+          prev !== null ? { ...prev, hasWebhookSecret: true } : prev
+        );
+      }
+    } catch (e) {
+      setWebhookError(e instanceof ApiError ? e.message : 'Failed to save webhook secret');
+    } finally {
+      setIsSavingWebhook(false);
+    }
+  };
+
+  const handleRemoveWebhookSecret = async (): Promise<void> => {
+    setWebhookError(null);
+    setWebhookSuccess(null);
+
+    try {
+      setIsRemovingWebhook(true);
+      const token = await getAccessToken();
+      await removeWebhookSecret(token);
+      setWebhookSuccess('Webhook secret removed');
+      setIsEditingWebhook(false);
+      try {
+        const refreshed = await getWebhookConfig(token);
+        setWebhookConfig(refreshed);
+      } catch {
+        // Remove succeeded — optimistically update local state
+        setWebhookConfig((prev) =>
+          prev !== null ? { ...prev, hasWebhookSecret: false } : prev
+        );
+      }
+    } catch (e) {
+      setWebhookError(e instanceof ApiError ? e.message : 'Failed to remove webhook secret');
+    } finally {
+      setIsRemovingWebhook(false);
+    }
+  };
+
+  const handleStartEditingWebhook = (): void => {
+    setIsEditingWebhook(true);
+    setWebhookError(null);
+    setWebhookSuccess(null);
+    setWebhookSecret('');
+  };
+
+  const handleCancelEditingWebhook = (): void => {
+    setIsEditingWebhook(false);
+    setWebhookSecret('');
+    setWebhookError(null);
   };
 
   if (state === 'loading') {
@@ -167,7 +296,8 @@ export function LinearConnectionPage(): React.JSX.Element {
         ) : null}
 
         {state === 'connected' && connection !== null ? (
-          <Card title="Connected Account" variant="success">
+          <>
+            <Card title="Connected Account" variant="success">
             <dl className="space-y-2 text-sm">
               <div className="flex justify-between">
                 <dt className="text-slate-600 dark:text-slate-400">Status</dt>
@@ -221,6 +351,136 @@ export function LinearConnectionPage(): React.JSX.Element {
               </Button>
             </div>
           </Card>
+
+          <Card title="Real-time Sync">
+            <div className="space-y-4">
+              <p className="text-sm text-slate-500 dark:text-slate-400">
+                Enable near real-time sync with Linear by configuring a webhook. When enabled, issue
+                changes in Linear are reflected instantly instead of waiting for periodic sync.
+              </p>
+
+              <details className="bg-slate-50 rounded-lg dark:bg-slate-700">
+                <summary className="p-4 text-sm font-medium text-slate-900 dark:text-slate-100 cursor-pointer hover:bg-slate-100 dark:hover:bg-slate-600 rounded-lg">
+                  How to set up Linear webhook
+                </summary>
+                <ol className="px-4 pb-4 text-sm text-slate-600 dark:text-slate-300 space-y-1 list-decimal list-inside">
+                  <li>Go to Linear Settings → API → Webhooks</li>
+                  <li>Click &quot;New webhook&quot;</li>
+                  <li>Set URL to the webhook URL below</li>
+                  <li>Select &quot;Issues&quot; under Data changes</li>
+                  <li>Copy the signing secret shown</li>
+                  <li>Paste the secret in the field below</li>
+                </ol>
+              </details>
+
+              {webhookConfig !== null && (
+                <div className="bg-slate-50 rounded-lg p-4 dark:bg-slate-700">
+                  <label className="block text-sm font-medium text-slate-900 dark:text-slate-100 mb-2">
+                    Webhook URL
+                  </label>
+                  <div className="flex items-center">
+                    <input
+                      type="text"
+                      readOnly
+                      value={webhookConfig.webhookUrl}
+                      className="flex-1 text-xs bg-slate-100 dark:bg-slate-800 px-3 py-2 rounded-l border border-r-0 border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-300 overflow-hidden text-ellipsis whitespace-nowrap"
+                      onClick={(e) => {
+                        e.currentTarget.select();
+                      }}
+                    />
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => void handleCopyWebhookUrl()}
+                      className="rounded-l-none border border-l-0 border-slate-300 dark:border-slate-600 whitespace-nowrap"
+                    >
+                      {copiedToClipboard ? 'Copied!' : 'Copy'}
+                    </Button>
+                  </div>
+                </div>
+              )}
+
+              <div>
+                {(isEditingWebhook || webhookConfig?.hasWebhookSecret !== true) && (
+                  <Input
+                    type="password"
+                    label="Webhook Signing Secret"
+                    placeholder="Enter the signing secret from Linear"
+                    value={webhookSecret}
+                    onChange={(e) => {
+                      setWebhookSecret(e.target.value);
+                      if (webhookError !== null) {
+                        setWebhookError(null);
+                      }
+                    }}
+                  />
+                )}
+                <div className="mt-3">
+                  {isEditingWebhook || webhookConfig?.hasWebhookSecret !== true ? (
+                    <div className="flex gap-3">
+                      <Button
+                        type="button"
+                        isLoading={isSavingWebhook}
+                        onClick={() => void handleSaveWebhookSecret()}
+                        disabled={webhookSecret.trim() === '' || isSavingWebhook}
+                      >
+                        Save
+                      </Button>
+                      {isEditingWebhook && (
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          onClick={handleCancelEditingWebhook}
+                        >
+                          Cancel
+                        </Button>
+                      )}
+                    </div>
+                  ) : (
+                    <div className="flex gap-3">
+                      <Button
+                        type="button"
+                        variant="secondary"
+                        onClick={handleStartEditingWebhook}
+                      >
+                        Update Secret
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="danger"
+                        isLoading={isRemovingWebhook}
+                        onClick={() => void handleRemoveWebhookSecret()}
+                      >
+                        Remove
+                      </Button>
+                    </div>
+                  )}
+                </div>
+              </div>
+
+              {webhookError !== null && (
+                <div className="rounded-md border border-red-200 bg-red-50 p-3 dark:border-red-800 dark:bg-red-900/30">
+                  <p className="text-sm text-red-700 dark:text-red-400">{webhookError}</p>
+                </div>
+              )}
+
+              {webhookSuccess !== null && (
+                <div className="rounded-md border border-green-200 bg-green-50 p-3 dark:border-green-800 dark:bg-green-900/30">
+                  <p className="text-sm text-green-700 dark:text-green-400">{webhookSuccess}</p>
+                </div>
+              )}
+
+              {webhookConfig?.hasWebhookSecret === true && !isEditingWebhook && (
+                <div className="rounded-md border border-green-200 bg-green-50 p-4 dark:border-green-800 dark:bg-green-900/30">
+                  <p className="text-sm text-green-700 dark:text-green-400">
+                    <span className="font-medium">✓ Configured:</span> Real-time sync is active
+                  </p>
+                </div>
+              )}
+            </div>
+          </Card>
+          </>
         ) : null}
 
         {state === 'disconnected' && (

--- a/apps/web/src/services/linearApi.ts
+++ b/apps/web/src/services/linearApi.ts
@@ -5,6 +5,7 @@ import type {
   ListIssuesResponse,
   LinearTeam,
   FailedLinearIssue,
+  LinearWebhookConfig,
 } from '@/types';
 
 interface ValidateResponse {
@@ -206,6 +207,55 @@ export async function syncFromLinear(
     '/linear/sync',
     accessToken,
     { method: 'POST' }
+  );
+}
+
+interface WebhookConfigSaveResponse {
+  configured: boolean;
+}
+
+/**
+ * Get webhook configuration (URL and secret status)
+ */
+export async function getWebhookConfig(
+  accessToken: string
+): Promise<LinearWebhookConfig> {
+  return await apiRequest<LinearWebhookConfig>(
+    config.linearAgentUrl,
+    '/linear/webhook-config',
+    accessToken
+  );
+}
+
+/**
+ * Save or update webhook signing secret
+ */
+export async function saveWebhookSecret(
+  accessToken: string,
+  secret: string
+): Promise<WebhookConfigSaveResponse> {
+  return await apiRequest<WebhookConfigSaveResponse>(
+    config.linearAgentUrl,
+    '/linear/webhook-config',
+    accessToken,
+    {
+      method: 'POST',
+      body: { secret },
+    }
+  );
+}
+
+/**
+ * Remove webhook signing secret
+ */
+export async function removeWebhookSecret(
+  accessToken: string
+): Promise<WebhookConfigSaveResponse> {
+  return await apiRequest<WebhookConfigSaveResponse>(
+    config.linearAgentUrl,
+    '/linear/webhook-config',
+    accessToken,
+    { method: 'DELETE' }
   );
 }
 

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -990,6 +990,15 @@ export interface LinearConnectionStatus {
 }
 
 /**
+ * Linear webhook configuration from linear-agent
+ */
+export interface LinearWebhookConfig {
+  webhookUrl: string;
+  hasWebhookSecret: boolean;
+  teamId: string;
+}
+
+/**
  * Grouped issues by dashboard column
  */
 export interface GroupedIssues {


### PR DESCRIPTION
## Summary
- Adds "Real-time Sync" card to Settings → Linear page for configuring Linear webhook signing secret
- Follows existing NotionConnectionPage pattern (optional config card visible only when connected)
- Includes webhook URL display with copy button, secret input, update/remove actions
- Clears webhook secret on disconnect; optimistic state updates on refresh failures

## Files Changed
- `apps/web/src/types/index.ts` — Added `LinearWebhookConfig` interface
- `apps/web/src/services/linearApi.ts` — Added `getWebhookConfig`, `saveWebhookSecret`, `removeWebhookSecret`
- `apps/web/src/pages/LinearConnectionPage.tsx` — Added Real-time Sync card with full UI

## Test plan
- [ ] Verify card appears only when Linear is connected
- [ ] Verify webhook URL displays and copy button works
- [ ] Verify saving a webhook secret shows success confirmation
- [ ] Verify "Update Secret" and "Remove" buttons appear when configured
- [ ] Verify disconnecting Linear also removes the webhook secret
- [ ] Verify page loads correctly when webhook config endpoint returns 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)