### PR TITLE
INT-491 Add API key prompt handling for interactive mode

### DIFF
--- a/workers/claude-worker/Dockerfile
+++ b/workers/claude-worker/Dockerfile
@@ -53,6 +53,11 @@ RUN addgroup -S claude && adduser -S claude -G claude -u 1001
 RUN mkdir -p /repo /secrets /tmp /home/claude/.claude /home/claude/.config/gcloud \
     && chown -R claude:claude /repo /secrets /tmp /home/claude
 
+# Bake Claude default config to skip onboarding on fresh tmpfs
+# /home/claude is tmpfs so image contents are wiped — entrypoint.sh copies these at startup
+COPY --chown=claude:claude config-defaults/claude.json /opt/claude-defaults/.claude.json
+COPY --chown=claude:claude config-defaults/settings.json /opt/claude-defaults/.claude/settings.json
+
 # Copy entrypoint
 COPY --chown=claude:claude entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/workers/claude-worker/Dockerfile.test
+++ b/workers/claude-worker/Dockerfile.test
@@ -36,6 +36,10 @@ RUN mkdir -p /repo /secrets /tmp /home/claude/.claude \
 COPY test-fixtures/claude-stub.sh /usr/local/bin/claude
 RUN chmod +x /usr/local/bin/claude
 
+# Bake Claude default config to skip onboarding (same as production)
+COPY --chown=claude:claude config-defaults/claude.json /opt/claude-defaults/.claude.json
+COPY --chown=claude:claude config-defaults/settings.json /opt/claude-defaults/.claude/settings.json
+
 # Copy entrypoint (same as production)
 COPY --chown=claude:claude entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/workers/claude-worker/config-defaults/claude.json
+++ b/workers/claude-worker/config-defaults/claude.json
@@ -1,0 +1,12 @@
+{
+  "firstStartTime": "2026-01-01T00:00:00.000Z",
+  "hasCompletedOnboarding": true,
+  "lastOnboardingVersion": "2.1.37",
+  "autoUpdates": false,
+  "sonnet45MigrationComplete": true,
+  "opus45MigrationComplete": true,
+  "opusProMigrationComplete": true,
+  "thinkingMigrationComplete": true,
+  "cachedChromeExtensionInstalled": false,
+  "bypassPermissionsModeAccepted": true
+}

--- a/workers/claude-worker/config-defaults/settings.json
+++ b/workers/claude-worker/config-defaults/settings.json
@@ -1,0 +1,3 @@
+{
+  "preferredNotifChannel": "terminal_bell"
+}

--- a/workers/claude-worker/entrypoint.sh
+++ b/workers/claude-worker/entrypoint.sh
@@ -36,6 +36,14 @@ verify_network_restrictions &
 mkdir -p /home/claude/.config/gcloud /home/claude/.claude
 
 # ------------------------------------------------------------------------------
+# Restore Claude config defaults (skips onboarding on fresh tmpfs)
+# ------------------------------------------------------------------------------
+if [ -d "/opt/claude-defaults" ]; then
+    cp -a /opt/claude-defaults/. /home/claude/
+    echo "[entrypoint] Claude config defaults restored"
+fi
+
+# ------------------------------------------------------------------------------
 # Verify mounts
 # ------------------------------------------------------------------------------
 if [ ! -d "/repo" ]; then

--- a/workers/orchestrator/DEPLOYMENT.md
+++ b/workers/orchestrator/DEPLOYMENT.md
@@ -55,15 +55,15 @@ Or via macOS LaunchAgent (see `workers/orchestrator/README.md` for plist templat
 
 ### Key Files
 
-| File                   | Purpose                                          |
-| ---------------------- | ------------------------------------------------ |
-| `src/index.ts`         | Entry point, env validation, server start        |
-| `src/main.ts`          | Fastify app factory                              |
-| `src/routes.ts`        | HTTP endpoints                                   |
-| `src/services/`        | Business logic (task-dispatcher, worktree, etc.) |
-| `src/services/isolation/docker-provider.ts` | Docker container lifecycle     |
-| `scripts/start.sh`     | Production wrapper (exec node)                   |
-| `dist/index.js`        | Built artifact                                   |
+| File                                        | Purpose                                          |
+| ------------------------------------------- | ------------------------------------------------ |
+| `src/index.ts`                              | Entry point, env validation, server start        |
+| `src/main.ts`                               | Fastify app factory                              |
+| `src/routes.ts`                             | HTTP endpoints                                   |
+| `src/services/`                             | Business logic (task-dispatcher, worktree, etc.) |
+| `src/services/isolation/docker-provider.ts` | Docker container lifecycle                       |
+| `scripts/start.sh`                          | Production wrapper (exec node)                   |
+| `dist/index.js`                             | Built artifact                                   |
 
 ---
 
@@ -105,8 +105,8 @@ Always use `--no-cache` when the entrypoint or any COPY'd file has changed.
 
 ### Key Files
 
-| File                              | Purpose                                     |
-| --------------------------------- | ------------------------------------------- |
+| File                                    | Purpose                                        |
+| --------------------------------------- | ---------------------------------------------- |
 | `workers/claude-worker/Dockerfile`      | Production image (node:22-alpine + Claude CLI) |
 | `workers/claude-worker/Dockerfile.test` | Test image (claude-stub instead of real CLI)   |
 | `workers/claude-worker/entrypoint.sh`   | Container entrypoint (starts Claude)           |
@@ -128,17 +128,17 @@ The orchestrator writes the system prompt to Claude's stdin via the Docker attac
 
 Set by `docker-provider.ts` when creating containers:
 
-| Variable                           | Source                | Purpose                                |
-| ---------------------------------- | --------------------- | -------------------------------------- |
-| `TASK_ID`                          | Task config           | Task identifier                        |
-| `ANTHROPIC_API_KEY`                | Secrets               | Claude API authentication              |
-| `ANTHROPIC_BASE_URL`               | Worker type config    | API endpoint (varies by provider)      |
-| `ANTHROPIC_MODEL`                  | Worker type config    | Model override (optional)              |
-| `LINEAR_API_KEY`                   | Secrets               | Linear MCP integration                 |
-| `SENTRY_AUTH_TOKEN`                | Secrets               | Sentry MCP integration                 |
-| `GOOGLE_APPLICATION_CREDENTIALS`   | Hardcoded `/secrets/` | GCP auth inside container              |
-| `CLAUDE_PROJECT_DIR`               | Hardcoded `/repo`     | Hook path resolution                   |
-| `CLAUDE_CODE_EXIT_AFTER_STOP_DELAY`| Hardcoded `10000`     | Exit 10s after idle                    |
+| Variable                            | Source                | Purpose                           |
+| ----------------------------------- | --------------------- | --------------------------------- |
+| `TASK_ID`                           | Task config           | Task identifier                   |
+| `ANTHROPIC_API_KEY`                 | Secrets               | Claude API authentication         |
+| `ANTHROPIC_BASE_URL`                | Worker type config    | API endpoint (varies by provider) |
+| `ANTHROPIC_MODEL`                   | Worker type config    | Model override (optional)         |
+| `LINEAR_API_KEY`                    | Secrets               | Linear MCP integration            |
+| `SENTRY_AUTH_TOKEN`                 | Secrets               | Sentry MCP integration            |
+| `GOOGLE_APPLICATION_CREDENTIALS`    | Hardcoded `/secrets/` | GCP auth inside container         |
+| `CLAUDE_PROJECT_DIR`                | Hardcoded `/repo`     | Hook path resolution              |
+| `CLAUDE_CODE_EXIT_AFTER_STOP_DELAY` | Hardcoded `10000`     | Exit 10s after idle               |
 
 ---
 
@@ -163,13 +163,13 @@ pnpm --filter orchestrator test:e2e
 
 ### Test Image vs Production Image
 
-| Aspect       | Production (`Dockerfile`)      | Test (`Dockerfile.test`)        |
-| ------------ | ------------------------------ | ------------------------------- |
-| Claude CLI   | Real (`claude.ai/install.sh`)  | Stub (`test-fixtures/claude-stub.sh`) |
-| gcloud CLI   | Installed                      | Not installed                   |
-| Terraform    | Installed                      | Not installed                   |
-| python3      | Installed                      | Not installed                   |
-| `NODE_ENV`   | `production`                   | `test`                          |
+| Aspect     | Production (`Dockerfile`)     | Test (`Dockerfile.test`)              |
+| ---------- | ----------------------------- | ------------------------------------- |
+| Claude CLI | Real (`claude.ai/install.sh`) | Stub (`test-fixtures/claude-stub.sh`) |
+| gcloud CLI | Installed                     | Not installed                         |
+| Terraform  | Installed                     | Not installed                         |
+| python3    | Installed                     | Not installed                         |
+| `NODE_ENV` | `production`                  | `test`                                |
 
 ---
 
@@ -197,14 +197,14 @@ pnpm --filter orchestrator test:e2e
 
 ## Differences from Standard Apps
 
-| Aspect           | Standard App (`apps/*`)           | Orchestrator (`workers/orchestrator`) |
-| ---------------- | --------------------------------- | ------------------------------------- |
-| Deployment       | Cloud Run (Dockerfile)            | Native Node.js (LaunchAgent)          |
-| Cloud Build      | `cloudbuild.yaml` per service     | None — local build only               |
-| Artifact         | Docker image in Artifact Registry | `dist/index.js` bundle               |
-| Terraform        | Cloud Run service module          | Not managed by Terraform              |
-| Push script      | `push-missing-images.sh`          | Not included (apps/ only)             |
-| Docker images    | Self-contained                    | Orchestrator spawns claude-worker     |
+| Aspect        | Standard App (`apps/*`)           | Orchestrator (`workers/orchestrator`) |
+| ------------- | --------------------------------- | ------------------------------------- |
+| Deployment    | Cloud Run (Dockerfile)            | Native Node.js (LaunchAgent)          |
+| Cloud Build   | `cloudbuild.yaml` per service     | None — local build only               |
+| Artifact      | Docker image in Artifact Registry | `dist/index.js` bundle                |
+| Terraform     | Cloud Run service module          | Not managed by Terraform              |
+| Push script   | `push-missing-images.sh`          | Not included (apps/ only)             |
+| Docker images | Self-contained                    | Orchestrator spawns claude-worker     |
 
 ---
 

--- a/workers/orchestrator/src/services/isolation/__tests__/docker-provider.test.ts
+++ b/workers/orchestrator/src/services/isolation/__tests__/docker-provider.test.ts
@@ -148,6 +148,10 @@ class TestableDockerProvider extends DockerProvider {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (this as any).docker = mockDocker;
   }
+
+  protected override async waitForContainerReady(): Promise<void> {
+    return Promise.resolve();
+  }
 }
 
 describe('DockerProvider', () => {

--- a/workers/orchestrator/src/services/isolation/docker-provider.ts
+++ b/workers/orchestrator/src/services/isolation/docker-provider.ts
@@ -225,8 +225,8 @@ export class DockerProvider implements IsolationProvider {
     }
     /* v8 ignore stop @preserve */
 
-    // Write system prompt to worker via stdin
-    // In interactive mode, Claude reads this as the first user message
+    await this.waitForContainerReady(attachStream as unknown as NodeJS.ReadWriteStream, taskId);
+    this.logger.debug({ taskId }, 'Container ready — sending system prompt');
     attachStream.write(systemPrompt + '\n');
 
     const handle: WorkerHandle = {
@@ -261,6 +261,56 @@ export class DockerProvider implements IsolationProvider {
 
     return handle;
   }
+
+  /* v8 ignore start -- test-infra: overridden in TestableDockerProvider, real handshake requires running container with TTY @preserve */
+  protected async waitForContainerReady(
+    attachStream: NodeJS.ReadWriteStream,
+    taskId: string
+  ): Promise<void> {
+    const TOTAL_TIMEOUT_MS = 30_000;
+    const INITIAL_WAIT_MS = 8_000;
+    const SETTLE_MS = 2_000;
+
+    await new Promise<void>((resolve) => {
+      let settled = false;
+      let settleTimer: ReturnType<typeof setTimeout> | null = null;
+      let approvalSent = false;
+
+      const finish = (): void => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(hardTimeout);
+        if (settleTimer) clearTimeout(settleTimer);
+        attachStream.removeListener('data', onData);
+        resolve();
+      };
+
+      const hardTimeout = setTimeout(() => {
+        this.logger.warn({ taskId }, 'Container ready timeout — proceeding anyway');
+        finish();
+      }, TOTAL_TIMEOUT_MS);
+
+      const onData = (): void => {
+        if (approvalSent && !settled) {
+          if (settleTimer) clearTimeout(settleTimer);
+          settleTimer = setTimeout(finish, SETTLE_MS);
+        }
+      };
+
+      attachStream.on('data', onData);
+
+      setTimeout(() => {
+        if (settled) return;
+        approvalSent = true;
+        this.logger.debug({ taskId }, 'Sending API key approval');
+        attachStream.write('\x1b[A');
+        setTimeout(() => {
+          if (!settled) attachStream.write('\r');
+        }, 500);
+      }, INITIAL_WAIT_MS);
+    });
+  }
+  /* v8 ignore stop @preserve */
 
   async destroyWorker(taskId: string, forceKill = false): Promise<void> {
     const worker = this.workers.get(taskId);


### PR DESCRIPTION
## Summary
- Added `waitForContainerReady()` to DockerProvider that handles the API key approval dialog in TTY mode (Up+Enter after 8s, then 2s settle detection, 30s hard timeout)
- Added config defaults (`config-defaults/`) baked into the Docker image and restored by entrypoint.sh to skip onboarding on fresh tmpfs
- Updated Dockerfile, Dockerfile.test, entrypoint.sh, and deployment docs

## Test plan
- [x] `pnpm run ci:tracked` passes (run #27, all phases green)
- [x] E2E tests pass (12 tests including sendInput, timeout, resource usage)
- [x] Unit tests pass with `waitForContainerReady` overridden in TestableDockerProvider
- [ ] Manual E2E: rebuild Docker image, trigger task, verify file creation + `[HOOK-CANARY]` in logs

Fixes INT-491

🤖 Generated with [Claude Code](https://claude.com/claude-code)