### PR TITLE
Fix code-agent Pub/Sub permissions for whatsapp-send topic

### DIFF
--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -761,7 +761,7 @@ module "pubsub_llm_call" {
   ]
 }
 
-# Topic for sending WhatsApp messages (actions-agent, research-agent -> whatsapp-service)
+# Topic for sending WhatsApp messages (actions-agent, research-agent, code-agent -> whatsapp-service)
 module "pubsub_whatsapp_send" {
   source = "../../modules/pubsub-push"
 
@@ -778,6 +778,7 @@ module "pubsub_whatsapp_send" {
     actions_agent   = module.iam.service_accounts["actions_agent"]
     research_agent  = module.iam.service_accounts["research_agent"]
     bookmarks_agent = module.iam.service_accounts["bookmarks_agent"]
+    code_agent      = module.iam.service_accounts["code_agent"]
   }
 
   depends_on = [


### PR DESCRIPTION
## Summary
- Add `code_agent` service account to `publisher_service_accounts` for the `whatsapp-send` Pub/Sub topic
- Fixes PERMISSION_DENIED errors when code-agent publishes WhatsApp notifications for code task events

## Context
The code-agent publishes to the `intexuraos-whatsapp-send-dev` Pub/Sub topic to send WhatsApp notifications, but its service account (`intexuraos-code-dev@intexuraos-dev-pbuchman.iam.gserviceaccount.com`) was missing from the `publisher_service_accounts` list in Terraform. This caused all WhatsApp notifications from code-agent to fail with PERMISSION_DENIED in production.

## Test plan
- [x] Terraform plan shows one new resource: `google_pubsub_topic_iam_member.publisher["code_agent"]`
- [x] Terraform apply completed successfully
- [x] IAM binding verified: `code_agent` now has `roles/pubsub.publisher` on the `whatsapp-send` topic

🤖 Generated with [Claude Code](https://claude.com/claude-code)