### PR TITLE
Allow retry for interrupted tasks

### DIFF
--- a/apps/code-agent/src/__tests__/usecases/retryTask.test.ts
+++ b/apps/code-agent/src/__tests__/usecases/retryTask.test.ts
@@ -3,7 +3,7 @@
  *
  * Test Requirements from INT-520:
  * 1. Returns error when original task not found
- * 2. Returns error when task status is not 'failed' or 'cancelled'
+ * 2. Returns error when task status is not 'failed', 'cancelled', or 'interrupted'
  * 3. Returns error when task failed less than 5 minutes ago (cool-off period)
  * 4. Successfully creates retry task with retriedFrom set
  * 5. Updates Linear issue state to In Progress
@@ -175,8 +175,8 @@ describe('retryTask use case', () => {
       }
     });
 
-    it('should return error when task status is not failed or cancelled', async () => {
-      const nonRetryableStatuses: TaskStatus[] = ['dispatched', 'running', 'completed', 'interrupted'];
+    it('should return error when task status is not failed, cancelled, or interrupted', async () => {
+      const nonRetryableStatuses: TaskStatus[] = ['dispatched', 'running', 'completed'];
 
       for (const status of nonRetryableStatuses) {
         vi.clearAllMocks();
@@ -192,7 +192,7 @@ describe('retryTask use case', () => {
         expect(result.ok).toBe(false);
         if (!result.ok) {
           expect(result.error.code).toBe('invalid_status');
-          expect(result.error.message).toContain('Only failed or cancelled tasks can be retried');
+          expect(result.error.message).toContain('Only failed, cancelled, or interrupted tasks can be retried');
         }
       }
     });
@@ -350,6 +350,83 @@ describe('retryTask use case', () => {
       if (result.ok) {
         expect(result.value.codeTaskId).toBe(retryTaskId);
       }
+    });
+
+    it('should successfully retry an interrupted task and bypass cool-off', async () => {
+      const retryTaskId = 'task_retry_interrupted';
+      const twoMinutesAgo = Timestamp.fromDate(new Date(Date.now() - 2 * 60 * 1000));
+      const mockInterruptedTask = createMockTask({
+        status: 'interrupted',
+        completedAt: twoMinutesAgo,
+      }) as unknown as Record<string, unknown>;
+      delete mockInterruptedTask['error'];
+      mockCodeTaskRepo.findByIdForUser.mockResolvedValue(ok(mockInterruptedTask as unknown as CodeTask));
+
+      mockCodeTaskRepo.create.mockImplementation((input) => {
+        const newTask: CodeTask = {
+          id: retryTaskId,
+          userId: input.userId,
+          traceId: input.traceId,
+          prompt: input.prompt,
+          sanitizedPrompt: input.sanitizedPrompt,
+          systemPromptHash: input.systemPromptHash,
+          workerType: input.workerType,
+          workerLocation: input.workerLocation,
+          repository: input.repository,
+          baseBranch: input.baseBranch,
+          status: 'dispatched',
+          dedupKey: 'new-dedup-key',
+          callbackReceived: false,
+          createdAt: Timestamp.now(),
+          updatedAt: Timestamp.now(),
+          retriedFrom: originalTaskId,
+          webhookSecret: input.webhookSecret ?? 'whsec_secret',
+          linearIssueId,
+          linearIssueTitle: 'Retry mechanism test',
+        };
+        return Promise.resolve(ok(newTask));
+      });
+
+      mockTaskDispatcher.dispatch.mockResolvedValue(
+        ok({ orchestratorTaskId: 'orch-123', workerLocation: 'home-mac' })
+      );
+      mockLinearAgentClient.updateIssueState.mockResolvedValue(ok(undefined));
+      mockLinearAgentClient.addComment.mockResolvedValue(ok(undefined));
+      mockCodeTaskRepo.hasActiveTaskForLinearIssue.mockResolvedValue(ok({ hasActive: false }));
+      mockWorkerSettingsRepo.getSettings.mockResolvedValue(
+        ok({
+          workers: [{
+            name: 'home-mac',
+            url: 'https://worker.example.com',
+            enabled: true,
+            cfAccessClientId: 'client-id',
+            cfAccessClientSecret: 'client-secret',
+            dispatchSigningSecret: 'webhook-secret',
+          }],
+        })
+      );
+      mockWhatsAppNotifier.notifyTaskStarted.mockResolvedValue(ok(undefined));
+      mockCodeTaskRepo.update.mockResolvedValue(
+        ok(createMockTask({ id: retryTaskId }) as unknown as CodeTask)
+      );
+      mockMetricsClient.incrementTasksSubmitted.mockResolvedValue(undefined);
+
+      const deps = createDeps();
+      const result = await retryTask(deps, { originalTaskId, userId });
+
+      // Should succeed despite completedAt being only 2 minutes ago (bypasses cool-off)
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.codeTaskId).toBe(retryTaskId);
+        expect(result.value.retriedFrom).toBe(originalTaskId);
+      }
+
+      // Verify Linear comment uses dynamic status text
+      expect(mockLinearAgentClient.addComment).toHaveBeenCalledWith({
+        userId,
+        issueId: linearIssueId,
+        body: expect.stringContaining('Retrying interrupted task'),
+      });
     });
 
     it('should allow retry when task has no completedAt timestamp', async () => {

--- a/apps/code-agent/src/domain/usecases/retryTask.ts
+++ b/apps/code-agent/src/domain/usecases/retryTask.ts
@@ -1,5 +1,5 @@
 /**
- * Use case: Retry a failed or cancelled code task.
+ * Use case: Retry a failed, cancelled, or interrupted code task.
  *
  * Creates a new task with the same prompt, optionally with additional context.
  * Links the new task to the original via retriedFrom field.
@@ -45,7 +45,7 @@ const CANCEL_NONCE_TTL_MS = 15 * 60 * 1000;
  * Request to retry a failed task.
  */
 export interface RetryTaskRequest {
-  /** The ID of the failed or cancelled task to retry */
+  /** The ID of the failed, cancelled, or interrupted task to retry */
   originalTaskId: string;
   /** User ID requesting the retry */
   userId: string;
@@ -93,11 +93,11 @@ export interface RetryTaskDeps {
 }
 
 /**
- * Retry a failed or cancelled code task use case.
+ * Retry a failed, cancelled, or interrupted code task use case.
  *
  * Workflow:
  * 1. Fetch original task and validate it belongs to user
- * 2. Validate status is 'failed' or 'cancelled'
+ * 2. Validate status is 'failed', 'cancelled', or 'interrupted'
  * 3. Validate cool-off period has elapsed (5 minutes)
  * 4. Check for active tasks on same Linear issue
  * 5. Reconstruct prompt with additional context if provided
@@ -127,20 +127,21 @@ export async function retryTask(
 
   const originalTask = originalTaskResult.value;
 
-  // Step 2: Validate status is failed or cancelled
-  if (!['failed', 'cancelled'].includes(originalTask.status)) {
+  // Step 2: Validate status is failed, cancelled, or interrupted
+  if (!['failed', 'cancelled', 'interrupted'].includes(originalTask.status)) {
     logger.warn({ taskId: originalTask.id, status: originalTask.status }, 'Attempted to retry non-retryable task');
     return err({
       code: 'invalid_status',
-      message: `Cannot retry task with status "${originalTask.status}". Only failed or cancelled tasks can be retried.`,
+      message: `Cannot retry task with status "${originalTask.status}". Only failed, cancelled, or interrupted tasks can be retried.`,
     });
   }
 
   // Step 3: Validate cool-off period
-  // Cancelled tasks bypass cool-off — cancellation is user-initiated so immediate retry is appropriate
+  // Cancelled and interrupted tasks bypass cool-off — cancellation is user-initiated and
+  // interruption is infrastructure-related, so immediate retry is appropriate for both
   const completedAt = originalTask.completedAt;
 
-  if (originalTask.status !== 'cancelled' && completedAt !== undefined) {
+  if (originalTask.status === 'failed' && completedAt !== undefined) {
     const now = Date.now();
     let completedAtTime: number;
 

--- a/apps/web/src/pages/CodeTaskDetailPage.tsx
+++ b/apps/web/src/pages/CodeTaskDetailPage.tsx
@@ -129,7 +129,7 @@ export function CodeTaskDetailPage(): React.JSX.Element {
   const StatusIcon = status.icon;
   const isRunning = task.status === 'running' || task.status === 'dispatched';
   const canCancel = isRunning;
-  const canRetry = task.status === 'failed' || task.status === 'cancelled';
+  const canRetry = task.status === 'failed' || task.status === 'cancelled' || task.status === 'interrupted';
 
   // Build links array - Linear and PR
   const links: { label: string; url: string | undefined; text: string; type?: string }[] = [];


### PR DESCRIPTION
## Summary
- Interrupted tasks (worker died / zombie detected) are now retryable alongside failed and cancelled tasks
- Cool-off period is bypassed for interrupted tasks since the failure is infrastructure-related, not task-logic-related
- Retry button now appears on the task detail page for interrupted tasks

## Test plan
- [x] Existing retry tests for failed/cancelled tasks still pass (21 tests)
- [x] New test: interrupted task retries successfully with cool-off bypass
- [x] Non-retryable statuses test updated (interrupted removed from blocked list)
- [x] Full CI passes (`pnpm run ci:tracked`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)