### PR TITLE
Remove redundant elapsed time from code task page header

### DIFF
--- a/apps/web/src/pages/CodeTaskDetailPage.tsx
+++ b/apps/web/src/pages/CodeTaskDetailPage.tsx
@@ -160,15 +160,6 @@ export function CodeTaskDetailPage(): React.JSX.Element {
   return (
     <Layout>
       <div className="mb-6">
-        <div className="flex flex-wrap items-center gap-2">
-          {isRunning && elapsedTime > 0 ? (
-            <span className="inline-flex items-center gap-1.5 rounded-full bg-blue-100 px-2.5 py-1 text-sm font-medium text-blue-700 dark:bg-blue-900/50 dark:text-blue-300">
-              <Clock className="h-4 w-4" />
-              {formatElapsedTime(elapsedTime)}
-            </span>
-          ) : null}
-        </div>
-
         <div className="mt-1 flex flex-wrap items-center gap-2">
           {task.linearIssueId !== undefined ? (
             <span className="text-lg font-medium text-blue-600 dark:text-blue-400">{task.linearIssue?.identifier ?? task.linearIssueId}</span>


### PR DESCRIPTION
## Summary
- Removed redundant elapsed time badge from the top of the code task detail page
- The elapsed time is already displayed in the "Active Task Progress" card, so showing it twice was unnecessary visual noise

## Test plan
- [x] View a running code task
- [x] Verify elapsed time still appears in the progress card
- [x] Confirm no duplicate time display above the title

🤖 Generated with [Claude Code](https://claude.com/claude-code)