### PR TITLE
Switch PM2 ecosystem to pnpm --filter with start:local scripts

### DIFF
--- a/.claude/commands/create-service.md
+++ b/.claude/commands/create-service.md
@@ -97,6 +97,7 @@ Avoid redundant paths like `/internal/todos/todos` — use simple `/internal/tod
     "typecheck": "tsc --noEmit",
     "lint:local": "eslint src --max-warnings 0",
     "start": "node dist/index.js",
+    "start:local": "node --experimental-strip-types src/index.ts",
     "dev": "node --watch --experimental-strip-types src/index.ts"
   },
   "dependencies": {

--- a/apps/actions-agent/package.json
+++ b/apps/actions-agent/package.json
@@ -11,6 +11,7 @@
     "typecheck": "tsc --noEmit",
     "lint:local": "eslint src --max-warnings 0",
     "start": "node dist/index.js",
+    "start:local": "node --experimental-strip-types src/index.ts",
     "dev": "node --watch --experimental-strip-types src/index.ts"
   },
   "dependencies": {

--- a/apps/api-docs-hub/package.json
+++ b/apps/api-docs-hub/package.json
@@ -11,6 +11,7 @@
     "typecheck": "tsc --noEmit",
     "lint:local": "eslint src --max-warnings 0",
     "start": "node dist/index.js",
+    "start:local": "node --experimental-strip-types src/index.ts",
     "dev": "node --watch --experimental-strip-types src/index.ts"
   },
   "dependencies": {

--- a/apps/app-settings-service/package.json
+++ b/apps/app-settings-service/package.json
@@ -12,6 +12,7 @@
     "lint:local": "eslint src --max-warnings 0",
     "test": "vitest run",
     "start": "node dist/index.js",
+    "start:local": "node --experimental-strip-types src/index.ts",
     "dev": "node --watch --experimental-strip-types src/index.ts"
   },
   "dependencies": {

--- a/apps/bookmarks-agent/package.json
+++ b/apps/bookmarks-agent/package.json
@@ -11,6 +11,7 @@
     "typecheck": "tsc --noEmit",
     "lint:local": "eslint src --max-warnings 0",
     "start": "node dist/index.js",
+    "start:local": "node --experimental-strip-types src/index.ts",
     "dev": "node --watch --experimental-strip-types src/index.ts",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/apps/calendar-agent/package.json
+++ b/apps/calendar-agent/package.json
@@ -11,6 +11,7 @@
     "typecheck": "tsc --noEmit",
     "lint:local": "eslint src --max-warnings 0",
     "start": "node dist/index.js",
+    "start:local": "node --experimental-strip-types src/index.ts",
     "dev": "node --watch --experimental-strip-types src/index.ts"
   },
   "dependencies": {

--- a/apps/chat-agent/package.json
+++ b/apps/chat-agent/package.json
@@ -11,6 +11,7 @@
     "typecheck": "tsc --noEmit",
     "lint:local": "eslint src --max-warnings 0",
     "start": "node dist/index.js",
+    "start:local": "node --experimental-strip-types src/index.ts",
     "dev": "node --watch --experimental-strip-types src/index.ts",
     "test": "vitest run"
   },

--- a/apps/code-agent/package.json
+++ b/apps/code-agent/package.json
@@ -11,6 +11,7 @@
     "typecheck": "tsc --noEmit",
     "lint:local": "eslint src --max-warnings 0",
     "start": "node dist/index.js",
+    "start:local": "node --experimental-strip-types src/index.ts",
     "dev": "node --watch --experimental-strip-types src/index.ts"
   },
   "dependencies": {

--- a/apps/commands-agent/package.json
+++ b/apps/commands-agent/package.json
@@ -11,6 +11,7 @@
     "typecheck": "tsc --noEmit",
     "lint:local": "eslint src --max-warnings 0",
     "start": "node dist/index.js",
+    "start:local": "node --experimental-strip-types src/index.ts",
     "dev": "node --watch --experimental-strip-types src/index.ts"
   },
   "dependencies": {

--- a/apps/data-insights-agent/package.json
+++ b/apps/data-insights-agent/package.json
@@ -11,6 +11,7 @@
     "typecheck": "tsc --noEmit",
     "lint:local": "eslint src --max-warnings 0",
     "start": "node dist/index.js",
+    "start:local": "node --experimental-strip-types src/index.ts",
     "dev": "node --watch --experimental-strip-types src/index.ts"
   },
   "dependencies": {

--- a/apps/image-service/package.json
+++ b/apps/image-service/package.json
@@ -11,6 +11,7 @@
     "typecheck": "tsc --noEmit",
     "lint:local": "eslint src --max-warnings 0",
     "start": "node dist/index.js",
+    "start:local": "node --experimental-strip-types src/index.ts",
     "dev": "node --watch --experimental-strip-types src/index.ts"
   },
   "dependencies": {

--- a/apps/linear-agent/package.json
+++ b/apps/linear-agent/package.json
@@ -11,6 +11,7 @@
     "typecheck": "tsc --noEmit",
     "lint:local": "eslint src --max-warnings 0",
     "start": "node dist/index.js",
+    "start:local": "node --experimental-strip-types src/index.ts",
     "dev": "node --watch --experimental-strip-types src/index.ts"
   },
   "dependencies": {

--- a/apps/mobile-notifications-service/package.json
+++ b/apps/mobile-notifications-service/package.json
@@ -11,6 +11,7 @@
     "typecheck": "tsc --noEmit",
     "lint:local": "eslint src --max-warnings 0",
     "start": "node dist/index.js",
+    "start:local": "node --experimental-strip-types src/index.ts",
     "dev": "node --watch --experimental-strip-types src/index.ts"
   },
   "dependencies": {

--- a/apps/notes-agent/package.json
+++ b/apps/notes-agent/package.json
@@ -11,6 +11,7 @@
     "typecheck": "tsc --noEmit",
     "lint:local": "eslint src --max-warnings 0",
     "start": "node dist/index.js",
+    "start:local": "node --experimental-strip-types src/index.ts",
     "dev": "node --watch --experimental-strip-types src/index.ts",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/apps/notion-service/package.json
+++ b/apps/notion-service/package.json
@@ -11,6 +11,7 @@
     "typecheck": "tsc --noEmit",
     "lint:local": "eslint src --max-warnings 0",
     "start": "node dist/index.js",
+    "start:local": "node --experimental-strip-types src/index.ts",
     "dev": "node --watch --experimental-strip-types src/index.ts"
   },
   "dependencies": {

--- a/apps/research-agent/package.json
+++ b/apps/research-agent/package.json
@@ -11,6 +11,7 @@
     "typecheck": "tsc --noEmit",
     "lint:local": "eslint src --max-warnings 0",
     "start": "node dist/index.js",
+    "start:local": "node --experimental-strip-types src/index.ts",
     "dev": "node --watch --experimental-strip-types src/index.ts"
   },
   "dependencies": {

--- a/apps/todos-agent/package.json
+++ b/apps/todos-agent/package.json
@@ -11,6 +11,7 @@
     "typecheck": "tsc --noEmit",
     "lint:local": "eslint src --max-warnings 0",
     "start": "node dist/index.js",
+    "start:local": "node --experimental-strip-types src/index.ts",
     "dev": "node --watch --experimental-strip-types src/index.ts",
     "test": "vitest run",
     "test:watch": "vitest"

--- a/apps/user-service/package.json
+++ b/apps/user-service/package.json
@@ -11,6 +11,7 @@
     "typecheck": "tsc --noEmit",
     "lint:local": "eslint src --max-warnings 0",
     "start": "node dist/index.js",
+    "start:local": "node --experimental-strip-types src/index.ts",
     "dev": "node --watch --experimental-strip-types src/index.ts"
   },
   "dependencies": {

--- a/apps/web-agent/package.json
+++ b/apps/web-agent/package.json
@@ -8,6 +8,7 @@
     "build": "node ../../scripts/build-service.mjs web-agent",
     "dev": "npx tsx watch src/index.ts",
     "start": "node dist/index.js",
+    "start:local": "node --experimental-strip-types src/index.ts",
     "test": "pnpm run --filter @intexuraos/root test -- apps/web-agent",
     "typecheck": "tsc --noEmit",
     "lint:local": "eslint src --max-warnings 0"

--- a/apps/whatsapp-service/package.json
+++ b/apps/whatsapp-service/package.json
@@ -11,6 +11,7 @@
     "typecheck": "tsc --noEmit",
     "lint:local": "eslint src --max-warnings 0",
     "start": "node dist/index.js",
+    "start:local": "node --experimental-strip-types src/index.ts",
     "dev": "node --watch --experimental-strip-types src/index.ts"
   },
   "dependencies": {

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -152,7 +152,6 @@ function createServiceConfig(name, port, options = {}) {
 
   const baseConfig = {
     name,
-    cwd: `./apps/${name}`,
     env: {
       ...process.env,
       ...COMMON_SERVICE_ENV,
@@ -163,7 +162,7 @@ function createServiceConfig(name, port, options = {}) {
     },
     autorestart: true,
     restart_delay: 5000,
-    watch: ['src', '../../packages'],
+    watch: [`apps/${name}/src`, 'packages'],
     watch_delay: 1000,
     ignore_watch: ['node_modules', '__tests__', '**/*.test.ts', '**/*.spec.ts', 'dist'],
     log_date_format: 'YYYY-MM-DD HH:mm:ss',
@@ -173,7 +172,7 @@ function createServiceConfig(name, port, options = {}) {
     return {
       ...baseConfig,
       script: 'bash',
-      args: ['-c', `sleep ${startupDelay} && pnpm exec tsx src/index.ts`],
+      args: ['-c', `sleep ${startupDelay} && pnpm --filter ${name} start:local`],
       interpreter: 'none',
     };
   }
@@ -181,7 +180,7 @@ function createServiceConfig(name, port, options = {}) {
   return {
     ...baseConfig,
     script: 'pnpm',
-    args: ['exec', 'tsx', 'src/index.ts'],
+    args: ['--filter', name, 'start:local'],
     interpreter: 'none',
   };
 }
@@ -217,8 +216,9 @@ module.exports = {
     {
       name: 'web',
       script: 'pnpm',
-      args: process.env.PREDEV_ENVIRONMENT === 'true' ? ['run', 'preview'] : ['run', 'dev'],
-      cwd: './apps/web',
+      args: process.env.PREDEV_ENVIRONMENT === 'true'
+        ? ['--filter', 'web', 'preview']
+        : ['--filter', 'web', 'dev'],
       interpreter: 'none',
       env: {
         ...process.env,


### PR DESCRIPTION
## Summary

- Added `start:local` script (`node --experimental-strip-types src/index.ts`) to all 19 backend service `package.json` files — services now declare how to start themselves for local dev
- Updated `ecosystem.config.cjs` to use `pnpm --filter <name> start:local` from repo root instead of `pnpm exec tsx src/index.ts` from per-service `cwd`
- Updated watch paths from relative (`src`, `../../packages`) to repo-root-relative (`apps/<name>/src`, `packages`)
- Web app now uses `pnpm --filter web preview/dev` instead of `pnpm run preview/dev` with `cwd`
- Updated create-service command template to include `start:local` for new services

## Test plan

- [ ] Run `pm2 delete all && pm2 start ecosystem.config.cjs` and verify all services come online
- [ ] Health check all backend ports (8110-8129)
- [ ] Kill a service process and verify PM2 detects the crash and restarts it
- [ ] Verify `pnpm run ci:tracked` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)