### PR TITLE
Switch default LLM to Gemini 2.5 Flash + increase title gen timeout

### DIFF
--- a/apps/actions-agent/src/services.ts
+++ b/apps/actions-agent/src/services.ts
@@ -205,6 +205,7 @@ export async function initServices(config: ServiceConfig): Promise<void> {
     pricingContext,
     logger: createAppLogger({ name: 'userServiceClient' }),
     platformZaiApiKey: process.env['INTEXURAOS_GUEST_ZAI_API_KEY'],
+    platformGeminiApiKey: process.env['INTEXURAOS_GEMINI_APP_API_KEY'],
   });
 
   const commandsAgentClient = createCommandsAgentHttpClient({

--- a/apps/calendar-agent/src/services.ts
+++ b/apps/calendar-agent/src/services.ts
@@ -46,6 +46,7 @@ export function initServices(config: ServiceConfig): void {
     pricingContext: config.pricingContext,
     logger: logger,
     platformZaiApiKey: process.env['INTEXURAOS_GUEST_ZAI_API_KEY'],
+    platformGeminiApiKey: process.env['INTEXURAOS_GEMINI_APP_API_KEY'],
   });
 
   const calendarActionExtractionService = createCalendarActionExtractionService(userServiceClient, logger);

--- a/apps/chat-agent/src/services.ts
+++ b/apps/chat-agent/src/services.ts
@@ -144,6 +144,7 @@ export async function initializeServices(): Promise<void> {
       pricingContext,
       logger,
       platformZaiApiKey: process.env['INTEXURAOS_GUEST_ZAI_API_KEY'],
+      platformGeminiApiKey: process.env['INTEXURAOS_GEMINI_APP_API_KEY'],
     }),
     logger,
     guestRateLimiter: createGuestRateLimiter(),

--- a/apps/code-agent/src/services.ts
+++ b/apps/code-agent/src/services.ts
@@ -180,7 +180,7 @@ export function initServices(config: ServiceConfig): void {
     : createLinearAgentHttpClient({
         baseUrl: config.linearAgentUrl,
         internalAuthToken: config.internalAuthToken,
-        timeoutMs: 10000,
+        timeoutMs: 30000,
       }, logger);
 
   const linearIssueService = createLinearIssueService({

--- a/apps/commands-agent/src/services.ts
+++ b/apps/commands-agent/src/services.ts
@@ -76,6 +76,7 @@ export async function initServices(config: ServiceConfig): Promise<void> {
     pricingContext,
     logger: createAppLogger({ name: 'userServiceClient' }),
     platformZaiApiKey: process.env['INTEXURAOS_GUEST_ZAI_API_KEY'],
+    platformGeminiApiKey: process.env['INTEXURAOS_GEMINI_APP_API_KEY'],
   });
   const eventPublisher = createActionEventPublisher({
     projectId: config.gcpProjectId,

--- a/apps/data-insights-agent/src/index.ts
+++ b/apps/data-insights-agent/src/index.ts
@@ -64,6 +64,7 @@ async function main(): Promise<void> {
     pricingContext,
     logger,
     platformZaiApiKey: process.env['INTEXURAOS_GUEST_ZAI_API_KEY'],
+    platformGeminiApiKey: process.env['INTEXURAOS_GEMINI_APP_API_KEY'],
   });
 
   initServices({

--- a/apps/image-service/src/services.ts
+++ b/apps/image-service/src/services.ts
@@ -69,6 +69,7 @@ export function initializeServices(pricingContext: IPricingContext): void {
     pricingContext,
     logger: createAppLogger({ name: 'user-service-client' }),
     platformZaiApiKey: process.env['INTEXURAOS_GUEST_ZAI_API_KEY'],
+    platformGeminiApiKey: process.env['INTEXURAOS_GEMINI_APP_API_KEY'],
   });
 
   // Get pricing for prompt generation models

--- a/apps/linear-agent/src/services.ts
+++ b/apps/linear-agent/src/services.ts
@@ -52,6 +52,7 @@ export function initServices(config: ServiceConfig): void {
     pricingContext: config.pricingContext,
     logger: logger,
     platformZaiApiKey: process.env['INTEXURAOS_GUEST_ZAI_API_KEY'],
+    platformGeminiApiKey: process.env['INTEXURAOS_GEMINI_APP_API_KEY'],
   });
 
   const extractionService = createLinearActionExtractionService(userServiceClient, logger);

--- a/apps/research-agent/src/services.ts
+++ b/apps/research-agent/src/services.ts
@@ -221,6 +221,7 @@ export function initializeServices(pricingContext: IPricingContext): void {
     pricingContext,
     logger: createAppLogger({ name: 'user-service-client' }),
     platformZaiApiKey: process.env['INTEXURAOS_GUEST_ZAI_API_KEY'],
+    platformGeminiApiKey: process.env['INTEXURAOS_GEMINI_APP_API_KEY'],
   });
 
   const notificationSender = createNotificationSender();

--- a/apps/todos-agent/src/services.ts
+++ b/apps/todos-agent/src/services.ts
@@ -50,6 +50,7 @@ export async function initServices(config: ServiceConfig): Promise<void> {
     pricingContext,
     logger: createAppLogger({ name: 'userServiceClient' }),
     platformZaiApiKey: process.env['INTEXURAOS_GUEST_ZAI_API_KEY'],
+    platformGeminiApiKey: process.env['INTEXURAOS_GEMINI_APP_API_KEY'],
   });
 
   container = {

--- a/apps/web-agent/src/services.ts
+++ b/apps/web-agent/src/services.ts
@@ -45,6 +45,7 @@ export function initServices(dependencies: ServiceDependencies): void {
       pricingContext: dependencies.pricingContext,
       logger: createAppLogger({ name: 'userServiceClient' }),
       platformZaiApiKey: process.env['INTEXURAOS_GUEST_ZAI_API_KEY'],
+      platformGeminiApiKey: process.env['INTEXURAOS_GEMINI_APP_API_KEY'],
     }),
   };
 }

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -21,6 +21,7 @@ const COMMON_SERVICE_ENV = {
   INTEXURAOS_GCP_PROJECT_ID: process.env.INTEXURAOS_GCP_PROJECT_ID,
   INTEXURAOS_WEB_APP_URL: process.env.INTEXURAOS_WEB_APP_URL ?? 'http://localhost:3000',
   INTEXURAOS_GUEST_ZAI_API_KEY: process.env.INTEXURAOS_GUEST_ZAI_API_KEY,
+  INTEXURAOS_GEMINI_APP_API_KEY: process.env.INTEXURAOS_GEMINI_APP_API_KEY,
 };
 
 // All service URLs - mirrors Terraform local.common_service_env_vars

--- a/packages/internal-clients/src/user-service/__tests__/client.test.ts
+++ b/packages/internal-clients/src/user-service/__tests__/client.test.ts
@@ -251,7 +251,7 @@ describe('createUserServiceClient', () => {
       };
 
       const mockKeys = {
-        zai: 'zai-key',
+        google: 'google-key',
       };
 
       nock('http://localhost:3000')
@@ -270,7 +270,7 @@ describe('createUserServiceClient', () => {
       if (result.ok) {
         expect(result.value).toBeDefined();
         expect(mockLogger.info).toHaveBeenCalledWith(
-          expect.objectContaining({ model: LlmModels.Glm47Flash }),
+          expect.objectContaining({ model: LlmModels.Gemini25Flash }),
           'LLM client created successfully'
         );
       } else {
@@ -583,8 +583,56 @@ describe('createUserServiceClient', () => {
       }
     });
 
-    it('falls back to platform Glm47Flash when user has no API key and platformZaiApiKey is configured', async () => {
-      const configWithPlatformKey = {
+    it('falls back to platform Gemini25Flash when user has no API key and platformGeminiApiKey is configured', async () => {
+      const configWithGeminiKey = {
+        ...config,
+        platformGeminiApiKey: 'platform-gemini-key',
+      };
+
+      const mockSettings = {
+        llmPreferences: {
+          defaultModel: LlmModels.Glm47Flash,
+        },
+      };
+
+      const mockKeys = {
+        openai: 'openai-key',
+      };
+
+      nock('http://localhost:3000')
+        .get('/internal/users/user123/settings')
+        .matchHeader('X-Internal-Auth', 'test-token')
+        .reply(200, { success: true, data: mockSettings });
+
+      nock('http://localhost:3000')
+        .get('/internal/users/user123/llm-keys')
+        .matchHeader('X-Internal-Auth', 'test-token')
+        .reply(200, { success: true, data: mockKeys });
+
+      const client = createUserServiceClient(configWithGeminiKey);
+      const result = await client.getLlmClient('user123');
+
+      if (result.ok) {
+        expect(result.value).toBeDefined();
+        expect(mockLogger.warn).toHaveBeenCalledWith(
+          {
+            userId: 'user123',
+            provider: LlmProviders.Zai,
+            requestedModel: LlmModels.Glm47Flash,
+          },
+          'No API key for provider, falling back to platform Gemini25Flash'
+        );
+        expect(mockLogger.info).toHaveBeenCalledWith(
+          { userId: 'user123', model: LlmModels.Gemini25Flash, provider: LlmProviders.Google },
+          'LLM client created successfully'
+        );
+      } else {
+        expect.fail('Expected successful result');
+      }
+    });
+
+    it('falls back to platform Glm47Flash when no Gemini key and platformZaiApiKey is configured', async () => {
+      const configWithZaiKey = {
         ...config,
         platformZaiApiKey: 'platform-zai-key',
       };
@@ -609,7 +657,7 @@ describe('createUserServiceClient', () => {
         .matchHeader('X-Internal-Auth', 'test-token')
         .reply(200, { success: true, data: mockKeys });
 
-      const client = createUserServiceClient(configWithPlatformKey);
+      const client = createUserServiceClient(configWithZaiKey);
       const result = await client.getLlmClient('user123');
 
       if (result.ok) {
@@ -631,7 +679,54 @@ describe('createUserServiceClient', () => {
       }
     });
 
-    it('returns NO_API_KEY when user has no key and no platformZaiApiKey configured', async () => {
+    it('prefers Gemini fallback over ZAI when both platform keys are configured', async () => {
+      const configWithBothKeys = {
+        ...config,
+        platformGeminiApiKey: 'platform-gemini-key',
+        platformZaiApiKey: 'platform-zai-key',
+      };
+
+      const mockSettings = {
+        llmPreferences: {
+          defaultModel: LlmModels.Gemini25Flash,
+        },
+      };
+
+      const mockKeys = {};
+
+      nock('http://localhost:3000')
+        .get('/internal/users/user123/settings')
+        .matchHeader('X-Internal-Auth', 'test-token')
+        .reply(200, { success: true, data: mockSettings });
+
+      nock('http://localhost:3000')
+        .get('/internal/users/user123/llm-keys')
+        .matchHeader('X-Internal-Auth', 'test-token')
+        .reply(200, { success: true, data: mockKeys });
+
+      const client = createUserServiceClient(configWithBothKeys);
+      const result = await client.getLlmClient('user123');
+
+      if (result.ok) {
+        expect(result.value).toBeDefined();
+        expect(mockLogger.warn).toHaveBeenCalledWith(
+          {
+            userId: 'user123',
+            provider: LlmProviders.Google,
+            requestedModel: LlmModels.Gemini25Flash,
+          },
+          'No API key for provider, falling back to platform Gemini25Flash'
+        );
+        expect(mockLogger.info).toHaveBeenCalledWith(
+          { userId: 'user123', model: LlmModels.Gemini25Flash, provider: LlmProviders.Google },
+          'LLM client created successfully'
+        );
+      } else {
+        expect.fail('Expected successful result');
+      }
+    });
+
+    it('returns NO_API_KEY when user has no key and no platform keys configured', async () => {
       const mockSettings = {
         llmPreferences: {
           defaultModel: LlmModels.Gemini25Flash,
@@ -660,48 +755,6 @@ describe('createUserServiceClient', () => {
         expect(result.error.message).toContain('google');
       } else {
         expect.fail('Expected error result');
-      }
-    });
-
-    it('falls back even when user preferred model is non-Zai provider', async () => {
-      const configWithPlatformKey = {
-        ...config,
-        platformZaiApiKey: 'platform-zai-key',
-      };
-
-      const mockSettings = {
-        llmPreferences: {
-          defaultModel: LlmModels.Gemini25Flash,
-        },
-      };
-
-      const mockKeys = {};
-
-      nock('http://localhost:3000')
-        .get('/internal/users/user123/settings')
-        .matchHeader('X-Internal-Auth', 'test-token')
-        .reply(200, { success: true, data: mockSettings });
-
-      nock('http://localhost:3000')
-        .get('/internal/users/user123/llm-keys')
-        .matchHeader('X-Internal-Auth', 'test-token')
-        .reply(200, { success: true, data: mockKeys });
-
-      const client = createUserServiceClient(configWithPlatformKey);
-      const result = await client.getLlmClient('user123');
-
-      if (result.ok) {
-        expect(result.value).toBeDefined();
-        expect(mockLogger.warn).toHaveBeenCalledWith(
-          {
-            userId: 'user123',
-            provider: LlmProviders.Google,
-            requestedModel: LlmModels.Gemini25Flash,
-          },
-          'No API key for provider, falling back to platform Glm47Flash'
-        );
-      } else {
-        expect.fail('Expected successful result');
       }
     });
 

--- a/packages/internal-clients/src/user-service/client.ts
+++ b/packages/internal-clients/src/user-service/client.ts
@@ -156,7 +156,7 @@ export function createUserServiceClient(config: UserServiceConfig): UserServiceC
         };
 
         // Step 2: Determine model (use user's preference or default)
-        const rawModel = settingsBody.data.llmPreferences?.defaultModel ?? LlmModels.Glm47Flash;
+        const rawModel = settingsBody.data.llmPreferences?.defaultModel ?? LlmModels.Gemini25Flash;
 
         // Validate that the model is supported
         if (!isValidModel(rawModel)) {
@@ -198,6 +198,29 @@ export function createUserServiceClient(config: UserServiceConfig): UserServiceC
         const apiKey = keysBody.data[keyField];
 
         if (apiKey === null || apiKey === undefined) {
+          if (config.platformGeminiApiKey !== undefined) {
+            logger.warn(
+              { userId, provider, requestedModel: defaultModel },
+              'No API key for provider, falling back to platform Gemini25Flash'
+            );
+            const fallbackModel = LlmModels.Gemini25Flash;
+            const fallbackPricing = config.pricingContext.getPricing(fallbackModel);
+            const fallbackClient = createLlmClient({
+              apiKey: config.platformGeminiApiKey,
+              model: fallbackModel,
+              userId,
+              pricing: fallbackPricing,
+              logger: config.logger,
+            });
+
+            logger.info(
+              { userId, model: fallbackModel, provider: LlmProviders.Google },
+              'LLM client created successfully'
+            );
+
+            return ok(fallbackClient);
+          }
+
           if (config.platformZaiApiKey !== undefined) {
             logger.warn(
               { userId, provider, requestedModel: defaultModel },

--- a/packages/internal-clients/src/user-service/types.ts
+++ b/packages/internal-clients/src/user-service/types.ts
@@ -12,6 +12,7 @@ export interface UserServiceConfig {
   pricingContext: IPricingContext;
   logger: Logger;
   platformZaiApiKey?: string | undefined;
+  platformGeminiApiKey?: string | undefined;
 }
 
 /**

--- a/scripts/verify-env-vars.mjs
+++ b/scripts/verify-env-vars.mjs
@@ -60,6 +60,8 @@ const COMMON_OPTIONAL_ENV = new Set([
   'INTEXURAOS_AUTH_JWKS_URL',
   // Platform-wide Zai API key (optional fallback for services using user-service client)
   'INTEXURAOS_GUEST_ZAI_API_KEY',
+  // Platform-wide Gemini API key (primary fallback for services using user-service client)
+  'INTEXURAOS_GEMINI_APP_API_KEY',
 ]);
 
 /**
@@ -298,6 +300,7 @@ function isCommonServiceVar(varName) {
     'INTEXURAOS_AUTH0_CLIENT_ID',
     'INTEXURAOS_INTERNAL_AUTH_TOKEN',
     'INTEXURAOS_GUEST_ZAI_API_KEY',
+    'INTEXURAOS_GEMINI_APP_API_KEY',
     // Global infrastructure vars (set once, used by all services)
     'INTEXURAOS_GCP_PROJECT_ID',
     'INTEXURAOS_WEB_APP_URL',

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -555,6 +555,7 @@ locals {
     INTEXURAOS_INTERNAL_AUTH_TOKEN = module.secret_manager.secret_ids["INTEXURAOS_INTERNAL_AUTH_TOKEN"]
     INTEXURAOS_SENTRY_DSN          = module.secret_manager.secret_ids["INTEXURAOS_SENTRY_DSN"]
     INTEXURAOS_GUEST_ZAI_API_KEY   = module.secret_manager.secret_ids["INTEXURAOS_GUEST_ZAI_API_KEY"]
+    INTEXURAOS_GEMINI_APP_API_KEY  = module.secret_manager.secret_ids["INTEXURAOS_GEMINI_APP_API_KEY"]
   }
 }
 


### PR DESCRIPTION
## Summary
- **Switch default LLM** from `glm-4.7-flash` (ZAI) to `gemini-2.5-flash` — faster response times for title generation and other LLM tasks
- **Add Gemini fallback chain**: when user has no API key for their provider, try platform Gemini key first, then ZAI key, then error
- **Increase code-agent title generation timeout** from 10s to 30s as safety net
- **Propagate `INTEXURAOS_GEMINI_APP_API_KEY`** to all 10 services via Terraform common secrets + ecosystem.config.cjs

## Context
Task `task_8a0bea39` showed that `glm-4.7-flash` took 29s for a simple Linear issue title, exceeding the 10s HTTP timeout. The fallback used the raw prompt as the title instead of an LLM-generated one.

## Changes
- `packages/internal-clients`: New `platformGeminiApiKey` config, default model → Gemini, Gemini-first fallback chain
- `apps/code-agent`: Title generation timeout 10s → 30s
- `terraform/environments/dev/main.tf`: Add `INTEXURAOS_GEMINI_APP_API_KEY` to common secrets
- `ecosystem.config.cjs`: Add to `COMMON_SERVICE_ENV`
- 10 service `services.ts` files: Pass `platformGeminiApiKey`
- `scripts/verify-env-vars.mjs`: Register new common env var

## Test plan
- [x] All 8305 tests pass (54 in internal-clients, 3 new fallback tests)
- [x] Full CI green (`pnpm run ci:tracked`)
- [x] Terraform `fmt -check` passes
- [ ] After deploy: verify linear-agent logs show `model: "gemini-2.5-flash"` for title generation
- [ ] After deploy: verify title generation completes within a few seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)