### PR TITLE
Fix planning branch merge logs missing from task output

### DIFF
--- a/workers/orchestrator/src/services/task-dispatcher.ts
+++ b/workers/orchestrator/src/services/task-dispatcher.ts
@@ -216,6 +216,8 @@ export class TaskDispatcher {
         return;
       }
 
+      this.logForwarder.registerTask(taskId, request.webhookSecret);
+
       if (request.agentType === 'execution' && request.planningPrBranch !== undefined) {
         const mergeResult = await this.worktreeManager.mergePlanningBranch(
           worktreePath,
@@ -227,9 +229,9 @@ export class TaskDispatcher {
             'Failed to merge planning branch — proceeding without plan files'
           );
         }
+      } else if (request.agentType === 'execution') {
+        this.logger.info({ taskId }, 'No planning branch to merge — dispatched without planningPrBranch');
       }
-
-      this.logForwarder.registerTask(taskId, request.webhookSecret);
 
       const workerTypeConfig = WORKER_TYPES[request.workerType as WorkerType];
       if (workerTypeConfig.apiKeyEnvVar === 'ANTHROPIC_API_KEY') {


### PR DESCRIPTION
## Summary
- Moved `logForwarder.registerTask()` before the planning branch merge so merge success/failure logs appear in the task's forwarded log stream
- Added explicit log when execution tasks are dispatched without a `planningPrBranch`, making the absence visible in task logs

## Test plan
- [x] `pnpm --filter orchestrator build` passes
- [x] `pnpm --filter orchestrator test` passes (656 tests)
- [ ] Next execution task with planning branch shows merge log in task console
- [ ] Next execution task without planning branch shows "No planning branch to merge" in task console

Architected with love by 🤖 <a href="mailto:intex@intexuraos.cloud">Intex</a>