### PR TITLE
[INT-1326] Add llm-usage-service API spec and implementation plan

### DIFF
--- a/docs/superpowers/plans/2026-04-09-llm-usage-service-implementation-plan.md
+++ b/docs/superpowers/plans/2026-04-09-llm-usage-service-implementation-plan.md
@@ -1,0 +1,363 @@
+# LLM Usage Service Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to execute this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement a new internal-only `llm-usage-service` that accepts LLM usage events from internal services and orchestrator, stores immutable raw events, maintains daily aggregates, and exposes an internal aggregate query API plus a shared internal service client.
+
+**Architecture:** Create a new Cloud Run app using `/create-service llm-usage-service`. The service uses two authenticated ingest routes, one internal query route, and Firestore-backed raw event plus daily aggregate repositories. Normal services call it through `@intexuraos/internal-clients`. Orchestrator support is only the webhook-compatible endpoint in this stage, not consumer rollout.
+
+**Tech Stack:** TypeScript, Fastify, Firestore, `@intexuraos/common-http`, `@intexuraos/http-contracts`, `@intexuraos/internal-clients`, Vitest
+
+**Spec:** `docs/superpowers/specs/2026-04-09-usage-service-api-design.md`
+
+**Out of Scope:** migration, replacing current callers, dashboards, user-scoped endpoints, Claude/Codex runtime turn metrics
+
+---
+
+### Task 1: Scaffold `llm-usage-service` with the standard service command
+
+**Files:**
+- Create: `apps/llm-usage-service/*`
+
+- [ ] **Step 1: Run the standard scaffold command**
+
+Use:
+
+```text
+/create-service llm-usage-service
+```
+
+- [ ] **Step 2: Verify the scaffold instead of rebuilding it manually**
+
+Double-check that the generated service matches `.claude/commands/create-service.md`:
+
+- `apps/llm-usage-service/package.json`
+- `apps/llm-usage-service/Dockerfile`
+- `apps/llm-usage-service/src/index.ts`
+- `apps/llm-usage-service/src/services.ts`
+- `apps/llm-usage-service/src/domain/`
+- `apps/llm-usage-service/src/infra/`
+- `apps/llm-usage-service/src/routes/`
+
+If the command succeeded, do not replace the scaffold with a custom layout.
+
+- [ ] **Step 3: Update service metadata and required env vars**
+
+Adjust the scaffold so the new service validates the env vars it actually needs in stage 1:
+
+- `INTEXURAOS_GCP_PROJECT_ID`
+- `INTEXURAOS_INTERNAL_AUTH_TOKEN`
+- `INTEXURAOS_ORCHESTRATOR_SECRET`
+- standard Sentry/environment vars already used by the repo
+
+- [ ] **Step 4: Verify the service still boots with the scaffolded health route**
+
+Expected outcome:
+
+- `/health` remains available
+- service name is `llm-usage-service`
+- no missing-import or missing-config errors remain from scaffold cleanup
+
+---
+
+### Task 2: Define the domain model and use-case boundaries
+
+**Files:**
+- Create: `apps/llm-usage-service/src/domain/models/usageEvent.ts`
+- Create: `apps/llm-usage-service/src/domain/models/usageQuery.ts`
+- Create: `apps/llm-usage-service/src/domain/repositories/usageEventRepository.ts`
+- Create: `apps/llm-usage-service/src/domain/usecases/ingestUsageEvents.ts`
+- Create: `apps/llm-usage-service/src/domain/usecases/queryUsage.ts`
+
+- [ ] **Step 1: Add canonical type definitions matching the spec**
+
+Define domain types for:
+
+- `UsageEventInput`
+- `UsageEvent`
+- `UsageIngestRequest`
+- `UsageIngestResponse`
+- `UsageQueryRequest`
+- `UsageQueryResponse`
+- aggregate metric types
+
+- [ ] **Step 2: Add repository interfaces in the domain layer**
+
+Define ports for:
+
+- creating raw events idempotently
+- incrementing daily aggregates
+- querying aggregate documents by time range and filters
+
+- [ ] **Step 3: Implement domain use cases without Firestore imports**
+
+Required use cases:
+
+- `ingestUsageEvents`
+- `queryUsage`
+
+The use cases should:
+
+- validate allowed `groupBy` and `sortBy` values
+- handle duplicate events correctly
+- keep route/controller logic thin
+
+---
+
+### Task 3: Implement Firestore persistence for raw events and daily aggregates
+
+**Files:**
+- Create: `apps/llm-usage-service/src/infra/firestore/firestoreUsageEventRepository.ts`
+- Create: `apps/llm-usage-service/src/infra/firestore/firestoreUsageQueryRepository.ts`
+- Create any small helper modules needed for aggregate keys or date partitioning
+
+- [ ] **Step 1: Implement raw event persistence using `llm_usage_events/{eventId}`**
+
+Requirements:
+
+- document ID is `eventId`
+- writes must be immutable create operations
+- duplicate `eventId` must be detected cleanly
+
+- [ ] **Step 2: Implement daily aggregate upserts using `llm_usage_daily_aggregates/{aggregateId}`**
+
+Requirements:
+
+- aggregate dimensions match the spec exactly
+- counters increment only for newly accepted raw events
+- date granularity is daily
+
+- [ ] **Step 3: Keep idempotency correct**
+
+The aggregate update must only happen after raw event creation succeeds.
+
+This is the key correctness rule for the whole service.
+
+- [ ] **Step 4: Add repository tests for duplicate handling and aggregate increments**
+
+Required test cases:
+
+- first insert creates raw event and aggregate
+- duplicate insert does not change aggregate counters
+- multiple events on same day and same dimensions increment one aggregate doc
+- same day but different component or model creates separate aggregate docs
+
+---
+
+### Task 4: Implement the authenticated ingest endpoints
+
+**Files:**
+- Create: `apps/llm-usage-service/src/routes/internalUsageRoutes.ts`
+- Create: `apps/llm-usage-service/src/routes/webhookUsageRoutes.ts`
+- Update: service route registration files created by scaffold
+
+- [ ] **Step 1: Implement `POST /internal/usage/events`**
+
+Requirements:
+
+- authenticate with `validateInternalAuth(...)`
+- validate request body against the spec
+- return partial acceptance information
+- accept optional `X-Trace-Id`
+
+- [ ] **Step 2: Implement `POST /internal/webhooks/usage-events`**
+
+Requirements:
+
+- use the existing orchestrator webhook signature pattern
+- validate `X-Request-Timestamp`
+- validate `X-Request-Signature`
+- reject callers trying to use internal auth instead of webhook auth
+
+- [ ] **Step 3: Enforce ingress-specific business rules**
+
+Required rules:
+
+- webhook endpoint only accepts `source.service === "orchestrator"`
+- service sets `ingress` to `internal` or `orchestrator_webhook`
+- `receivedAt` is generated by the service, never trusted from caller payload
+
+- [ ] **Step 4: Add route tests**
+
+Required test cases:
+
+- internal auth missing -> `401`
+- webhook signature missing or expired -> `401`
+- valid internal batch with one duplicate and one invalid event -> partial success response
+- valid orchestrator payload accepted
+
+---
+
+### Task 5: Implement the internal aggregate query endpoint
+
+**Files:**
+- Update: `apps/llm-usage-service/src/routes/internalUsageRoutes.ts`
+- Update: query use case and repositories from Tasks 2-3
+
+- [ ] **Step 1: Implement `POST /internal/usage/query`**
+
+Requirements:
+
+- internal auth only
+- validate `timeRange`, `filters`, `groupBy`, `sortBy`, and `limit`
+- reject unsupported dimensions clearly
+
+- [ ] **Step 2: Query aggregate documents, not raw events**
+
+The implementation should:
+
+- fetch matching daily aggregate docs
+- regroup in memory according to `groupBy`
+- compute `rows` and `totals`
+- support sort descending by `costUsd` for “where is the spend” questions
+
+- [ ] **Step 3: Add query tests**
+
+Required test cases:
+
+- no `groupBy` returns totals only
+- grouping by `source.service` and `source.component` returns ranked rows
+- filters by owner, model, and success work together
+- limit is enforced
+
+---
+
+### Task 6: Add OpenAPI schemas and route registration
+
+**Files:**
+- Update: `apps/llm-usage-service/src/server.ts`
+- Update: route modules
+- Update: any schema registration helpers created by scaffold
+
+- [ ] **Step 1: Register core schemas and endpoint schemas**
+
+Every new route must expose:
+
+- request body schema
+- success response schema
+- error response schema
+- correct `security` declaration for internal endpoints
+
+- [ ] **Step 2: Keep the route layout aligned with repo conventions**
+
+Use:
+
+- `/internal/...` for normal internal routes
+- `/internal/webhooks/...` for orchestrator webhook route
+- `/health` for the unauthenticated health endpoint
+
+---
+
+### Task 7: Add the shared internal client
+
+**Files:**
+- Create: `packages/internal-clients/src/usage-service/client.ts`
+- Create: `packages/internal-clients/src/usage-service/types.ts`
+- Create: `packages/internal-clients/src/usage-service/index.ts`
+- Update: `packages/internal-clients/src/index.ts`
+- Create: `packages/internal-clients/src/usage-service/__tests__/client.test.ts`
+
+- [ ] **Step 1: Implement `createUsageServiceClient(...)`**
+
+Mirror the shape of the user-service client and reuse `fetchWithAuth(...)`.
+
+- [ ] **Step 2: Implement typed methods**
+
+Required methods:
+
+- `ingestEvents(...)`
+- `queryUsage(...)`
+
+- [ ] **Step 3: Add client tests**
+
+Required test cases:
+
+- internal auth header is sent
+- `traceId` is forwarded
+- success response is parsed correctly
+- HTTP error maps to `API_ERROR`
+- network failure maps to `NETWORK_ERROR`
+
+---
+
+### Task 8: Wire dependencies and keep clean architecture boundaries
+
+**Files:**
+- Update: `apps/llm-usage-service/src/services.ts`
+- Update: any route/use-case wiring files created by scaffold
+
+- [ ] **Step 1: Instantiate Firestore-backed repositories in `services.ts`**
+
+Keep Firestore dependencies in `infra`, not in domain or route modules.
+
+- [ ] **Step 2: Inject use cases into routes through the service container**
+
+Routes should call use cases, not repository implementations directly.
+
+- [ ] **Step 3: Verify ESLint architecture boundaries are respected**
+
+Specifically confirm:
+
+- domain does not import infra
+- routes do not implement business logic
+- Firestore code stays in infra
+
+---
+
+### Task 9: Final verification before PR
+
+**Files:**
+- All changed files
+
+- [ ] **Step 1: Run targeted tests for the new app and internal client**
+
+At minimum, run:
+
+- `pnpm vitest run apps/llm-usage-service`
+- `pnpm vitest run packages/internal-clients/src/usage-service/__tests__/client.test.ts`
+
+If the service uses named Vitest projects instead of direct paths, use the matching repo command.
+
+- [ ] **Step 2: Run local typecheck and lint for touched workspaces**
+
+At minimum:
+
+- service typecheck
+- service lint
+- internal-clients typecheck
+- internal-clients tests
+
+- [ ] **Step 3: Run the required final repo verification**
+
+Before commit and PR, run:
+
+```bash
+pnpm run ci:tracked
+```
+
+If this is too heavy for the environment, document exactly what was run and what remains.
+
+- [ ] **Step 4: Confirm stage-1 boundaries were preserved**
+
+Double-check that the implementation did **not**:
+
+- migrate old data
+- wire all callers to the new service
+- add user endpoints
+- include Claude/Codex runtime turn metrics
+
+---
+
+### Delivery Checklist
+
+- [ ] `llm-usage-service` exists as a new app
+- [ ] `/internal/usage/events` implemented
+- [ ] `/internal/webhooks/usage-events` implemented
+- [ ] `/internal/usage/query` implemented
+- [ ] `/health` implemented and working
+- [ ] Firestore raw event store implemented
+- [ ] Firestore daily aggregate store implemented
+- [ ] Shared usage-service internal client implemented
+- [ ] Auth and deduplication tests implemented
+- [ ] Query grouping tests implemented
+- [ ] Final verification completed

--- a/docs/superpowers/plans/2026-04-09-llm-usage-service-implementation-plan.md
+++ b/docs/superpowers/plans/2026-04-09-llm-usage-service-implementation-plan.md
@@ -12,6 +12,20 @@
 
 **Out of Scope:** migration, replacing current callers, dashboards, user-scoped endpoints, Claude/Codex runtime turn metrics
 
+## Endpoint Changes
+
+**Created:**
+- `POST /internal/usage/events` — internal service ingest
+- `POST /internal/webhooks/usage-events` — orchestrator webhook ingest
+- `POST /internal/usage/query` — internal aggregate query
+
+**Modified:** none
+
+**Removed:** none
+
+**Unchanged:**
+- `GET /health` — standard scaffolded health endpoint remains in place
+
 ---
 
 ### Task 1: Scaffold `llm-usage-service` with the standard service command
@@ -49,6 +63,8 @@ Adjust the scaffold so the new service validates the env vars it actually needs 
 - `INTEXURAOS_INTERNAL_AUTH_TOKEN`
 - `INTEXURAOS_ORCHESTRATOR_SECRET`
 - standard Sentry/environment vars already used by the repo
+- register the new service and required env-var wiring in `ecosystem.config.cjs`
+- update `terraform/environments/dev/main.tf` alongside `apps/llm-usage-service/src/index.ts` when new service env vars are introduced, per repo convention
 
 - [ ] **Step 4: Verify the service still boots with the scaffolded health route**
 
@@ -98,6 +114,7 @@ Required use cases:
 
 The use cases should:
 
+- accept `logger: Logger` as a required dependency
 - validate allowed `groupBy` and `sortBy` values
 - handle duplicate events correctly
 - keep route/controller logic thin
@@ -124,6 +141,7 @@ Requirements:
 Requirements:
 
 - aggregate dimensions match the spec exactly
+- `ownerIdHash` and `modelHash` use lowercase hex SHA-256 truncated to 32 characters
 - counters increment only for newly accepted raw events
 - date granularity is daily
 
@@ -142,6 +160,13 @@ Required test cases:
 - multiple events on same day and same dimensions increment one aggregate doc
 - same day but different component or model creates separate aggregate docs
 
+- [ ] **Step 5: Register Firestore collection ownership**
+
+Requirements:
+
+- add `llm_usage_events` to `firestore-collections.json` with `owner: "llm-usage-service"`
+- add `llm_usage_daily_aggregates` to `firestore-collections.json` with `owner: "llm-usage-service"`
+
 ---
 
 ### Task 4: Implement the authenticated ingest endpoints
@@ -155,6 +180,7 @@ Required test cases:
 
 Requirements:
 
+- call `logIncomingRequest()` before auth and request validation
 - authenticate with `validateInternalAuth(...)`
 - validate request body against the spec
 - return partial acceptance information
@@ -164,6 +190,7 @@ Requirements:
 
 Requirements:
 
+- call `logIncomingRequest()` before auth and request validation
 - use the existing orchestrator webhook signature pattern
 - validate `X-Request-Timestamp`
 - validate `X-Request-Signature`
@@ -198,6 +225,7 @@ Required test cases:
 
 Requirements:
 
+- call `logIncomingRequest()` before auth and request validation
 - internal auth only
 - validate `timeRange`, `filters`, `groupBy`, `sortBy`, and `limit`
 - reject unsupported dimensions clearly
@@ -210,6 +238,7 @@ The implementation should:
 - regroup in memory according to `groupBy`
 - compute `rows` and `totals`
 - support sort descending by `costUsd` for “where is the spend” questions
+- prefer this in-memory regrouping path over multi-field Firestore queries; if the final query strategy needs composite indexes, add the required migration in `migrations/*.mjs`
 
 - [ ] **Step 3: Add query tests**
 
@@ -259,7 +288,7 @@ Use:
 
 - [ ] **Step 1: Implement `createUsageServiceClient(...)`**
 
-Mirror the shape of the user-service client and reuse `fetchWithAuth(...)`.
+Mirror the shape of the user-service client, but use `fetchWithAuth(...)` as the preferred shared implementation pattern even though the older user-service client still uses inline `fetch()`.
 
 - [ ] **Step 2: Implement typed methods**
 
@@ -351,6 +380,7 @@ Double-check that the implementation did **not**:
 ### Delivery Checklist
 
 - [ ] `llm-usage-service` exists as a new app
+- [ ] `firestore-collections.json` registers `llm_usage_events` and `llm_usage_daily_aggregates` to `llm-usage-service`
 - [ ] `/internal/usage/events` implemented
 - [ ] `/internal/webhooks/usage-events` implemented
 - [ ] `/internal/usage/query` implemented

--- a/docs/superpowers/plans/2026-04-09-llm-usage-service-implementation-plan.md
+++ b/docs/superpowers/plans/2026-04-09-llm-usage-service-implementation-plan.md
@@ -191,10 +191,11 @@ Requirements:
 Requirements:
 
 - call `logIncomingRequest()` before auth and request validation
-- use the existing orchestrator webhook signature pattern
+- implement the existing orchestrator webhook signature pattern locally inside `llm-usage-service`; do not import from `apps/code-agent`
 - validate `X-Request-Timestamp`
 - validate `X-Request-Signature`
 - reject callers trying to use internal auth instead of webhook auth
+- keep any shared-package extraction explicitly out of scope for this task
 
 - [ ] **Step 3: Enforce ingress-specific business rules**
 

--- a/docs/superpowers/specs/2026-04-09-usage-service-api-design.md
+++ b/docs/superpowers/specs/2026-04-09-usage-service-api-design.md
@@ -60,7 +60,9 @@ The implementation must reuse existing repo patterns instead of inventing new on
 - Orchestrator webhook auth: current `validateOrchestratorSignature(...)` pattern
 - Internal client style: `packages/internal-clients/src/user-service/*`
 - Response envelope style: `reply.ok(...)` and `reply.fail(...)`
+- Route logging: `logIncomingRequest()` on every endpoint before auth and use-case execution
 - Service structure: routes + domain + infra with clean architecture boundaries
+- Firestore registry: `firestore-collections.json` ownership registration for every new collection
 
 ## Required Service Scaffolding Command
 
@@ -125,6 +127,17 @@ It is **not** responsible for:
 | GET    | `/health`                          | none                    | Standard service health endpoint |
 
 There must be **no** user-scoped public endpoint in this stage.
+
+## Route Conventions
+
+Every route in this service must call `logIncomingRequest()` before authentication and before invoking the use case.
+
+This applies to:
+
+- `POST /internal/usage/events`
+- `POST /internal/webhooks/usage-events`
+- `POST /internal/usage/query`
+- `GET /health`
 
 ## Authentication Design
 
@@ -448,6 +461,8 @@ This endpoint exists so internal systems can answer questions like:
 - `sortBy.field` must be one of the returned metric fields
 - query must run against aggregate documents, not by scanning raw events directly
 - if `groupBy` is empty, return one totals row only
+- prefer a date-range aggregate fetch plus in-memory regrouping so the first implementation does not depend on multi-field Firestore queries
+- if later filtering requires multi-field Firestore queries, add the required composite index migration in `migrations/*.mjs`
 
 ## Canonical Event Schema
 
@@ -470,7 +485,7 @@ interface UsageEvent {
     service: string;
     component: string;
     client: string;
-    environment: 'local' | 'dev' | 'prod' | 'test';
+    environment: 'dev' | 'prod' | 'test';
   };
 
   request: {
@@ -525,6 +540,10 @@ interface UsageEvent {
 }
 ```
 
+### Provider Values
+
+`request.provider` stays a closed union in stage 1. Unknown providers should be rejected instead of silently accepted, and adding a new provider is a deliberate schema update rather than an implicit string expansion.
+
 ## Concrete Firestore Data Model
 
 Use Firestore in stage 1 because it matches existing repo infrastructure and avoids inventing a new storage dependency.
@@ -543,6 +562,7 @@ Rules:
 - document is immutable after successful create
 - if create fails because the document already exists, treat as duplicate
 - this collection is the source of truth for ingestion history and deduplication
+- register `llm_usage_events` in `firestore-collections.json` with `owner: "llm-usage-service"`
 
 Required stored fields:
 
@@ -578,7 +598,14 @@ Recommended `aggregateId` shape:
 {date}__{ownerType}__{ownerIdHash}__{service}__{component}__{client}__{provider}__{modelHash}__{operation}__{success}
 ```
 
-The exact encoding is implementation detail, but it must be deterministic and collision-safe.
+Deterministic encoding rules:
+
+- normalize `owner.id` and `request.model` exactly as received
+- compute `ownerIdHash` as lowercase hex SHA-256 truncated to 32 characters
+- compute `modelHash` as lowercase hex SHA-256 truncated to 32 characters
+- keep the unhashed dimensions human-readable in the aggregate ID
+
+This keeps the key deterministic, avoids delimiter collisions from values like `auth0|abc123`, and still leaves enough readable context for debugging.
 
 Required aggregate fields:
 
@@ -618,6 +645,8 @@ interface DailyUsageAggregate {
   updatedAt: string;
 }
 ```
+
+Register `llm_usage_daily_aggregates` in `firestore-collections.json` with `owner: "llm-usage-service"`.
 
 ### Aggregate Write Rule
 
@@ -736,7 +765,8 @@ interface UsageServiceError {
 
 ### Client Implementation Rules
 
-- reuse `fetchWithAuth(...)` from `packages/internal-clients/src/shared/errors.ts`
+- mirror the method surface and error envelope of the user-service client
+- use `fetchWithAuth(...)` from `packages/internal-clients/src/shared/errors.ts` even though the older user-service client still uses inline `fetch()`; `fetchWithAuth` is the newer preferred shared pattern
 - keep the success envelope consistent with existing internal clients
 - support optional `traceId`
 - do not add orchestrator webhook auth to this package

--- a/docs/superpowers/specs/2026-04-09-usage-service-api-design.md
+++ b/docs/superpowers/specs/2026-04-09-usage-service-api-design.md
@@ -57,7 +57,7 @@ The implementation must reuse existing repo patterns instead of inventing new on
 
 - Service scaffolding: `.claude/commands/create-service.md`
 - Internal auth: `validateInternalAuth(...)` from `@intexuraos/common-http`
-- Orchestrator webhook auth: current `validateOrchestratorSignature(...)` pattern
+- Orchestrator webhook auth: current `validateOrchestratorSignature(...)` pattern, implemented locally in `llm-usage-service` because apps cannot import from `apps/code-agent`
 - Internal client style: `packages/internal-clients/src/user-service/*`
 - Response envelope style: `reply.ok(...)` and `reply.fail(...)`
 - Route logging: `logIncomingRequest()` on every endpoint before auth and use-case execution
@@ -171,6 +171,7 @@ Headers:
 Validation:
 
 - reuse the existing orchestrator webhook signing model
+- implement the HMAC validation locally inside `llm-usage-service` by following the existing `code-agent` pattern; do not import from `apps/code-agent`
 - signature input must match the existing repo pattern: `${timestamp}.${JSON.stringify(body)}`
 - reject requests older than 15 minutes
 - use `INTEXURAOS_ORCHESTRATOR_SECRET`
@@ -785,6 +786,12 @@ Recommended orchestrator implementation when rollout happens later:
 
 - create a small local sender that posts to `/internal/webhooks/usage-events`
 - reuse the existing HMAC signing helper pattern
+
+Implementation note for stage 1:
+
+- keep the webhook validator local to `llm-usage-service/src/infra/` even if the logic mirrors `apps/code-agent/src/infra/webhookValidation.ts`
+- do not introduce a cross-app import
+- do not expand scope by extracting the validator to a shared package in this task; that cleanup can happen later if multiple services need the same helper
 
 ## Future `LLMClient` Integration Contract
 

--- a/docs/superpowers/specs/2026-04-09-usage-service-api-design.md
+++ b/docs/superpowers/specs/2026-04-09-usage-service-api-design.md
@@ -1,0 +1,810 @@
+# LLM Usage Service API and Data Model Specification
+
+**Date:** 2026-04-09  
+**Status:** Draft for review  
+**Service Name:** `llm-usage-service`  
+**Audience:** Implementation worker creating the service and the shared internal client  
+**Out of Scope:** migration, rollout, consumer replacement, Terraform, dashboards, billing policy
+
+## Purpose
+
+Define the first implementation stage of a new internal-only service that becomes the authoritative ingestion point for LLM usage events across IntexuraOS.
+
+This stage is intentionally limited to:
+
+- the HTTP API shape
+- the authentication model
+- the event and aggregate data model
+- the shared internal client contract
+- the delivery checkpoints needed to create the service cleanly
+
+This stage does **not** include replacing existing usage storage or wiring every caller to the new service yet.
+
+## Why This Service Exists
+
+LLM usage is currently fragmented:
+
+- shared provider clients write aggregated usage to `llm_usage_stats`
+- audit logging writes detailed request metadata to `llm_api_logs`
+- `code-agent` keeps a separate `user_usage` store for quota and estimated spend
+- orchestrator verifier and compliance-validator usage is only structured-logged
+
+That split creates four concrete failures:
+
+1. There is no single authoritative ingestion API for LLM usage.
+2. Important token subtypes are lost in the current shared aggregate path.
+3. Orchestrator usage is not captured in the same analytics system as other services.
+4. Spend concentration by service, component, model, and client implementation is hard to answer reliably.
+
+The new service exists to fix those design problems with one internal contract.
+
+## Decision Summary
+
+Build a new Cloud Run app named `llm-usage-service` with:
+
+- one internal ingest endpoint for normal services authenticated by `X-Internal-Auth`
+- one webhook-style ingest endpoint for orchestrator authenticated by HMAC headers
+- one internal aggregate query endpoint for cost and usage analysis
+- one canonical immutable `UsageEvent` record shape
+- one Firestore-backed raw-event store plus one Firestore-backed daily aggregate store
+- one new `@intexuraos/internal-clients` usage-service client for normal services
+
+Do **not** add any user-scoped public endpoint in this stage.
+
+## Existing Repo Patterns To Reuse
+
+The implementation must reuse existing repo patterns instead of inventing new ones:
+
+- Service scaffolding: `.claude/commands/create-service.md`
+- Internal auth: `validateInternalAuth(...)` from `@intexuraos/common-http`
+- Orchestrator webhook auth: current `validateOrchestratorSignature(...)` pattern
+- Internal client style: `packages/internal-clients/src/user-service/*`
+- Response envelope style: `reply.ok(...)` and `reply.fail(...)`
+- Service structure: routes + domain + infra with clean architecture boundaries
+
+## Required Service Scaffolding Command
+
+Use the standard service creation command:
+
+```text
+/create-service llm-usage-service
+```
+
+The command already includes the scaffold checklist. The implementation worker must only add one mandatory verification step after running it:
+
+- confirm that the generated app structure matches `.claude/commands/create-service.md`
+
+Do not hand-roll the initial service skeleton if the command succeeds.
+
+## Scope
+
+### In Scope
+
+- `llm-usage-service` API contract
+- auth model for internal services and orchestrator
+- request and response schemas
+- canonical event shape
+- Firestore data model for raw events and aggregates
+- shared usage-service internal client
+- internal aggregate query endpoint needed to answer cost concentration questions
+
+### Out of Scope
+
+- migration from `llm_usage_stats`, `llm_api_logs`, or `user_usage`
+- replacing current provider usage logging in this same task
+- consumer rollout across all services
+- public or user JWT endpoints
+- orchestrator turn metrics unrelated to LLM usage events
+- dashboards or UI
+
+## Service Boundary
+
+`llm-usage-service` is an internal infrastructure service. Its only job is:
+
+1. validate incoming usage events
+2. deduplicate them by `eventId`
+3. persist immutable raw events
+4. maintain aggregate usage counters
+5. expose internal-only aggregate queries
+
+It is **not** responsible for:
+
+- prompt or response auditing
+- end-user settings
+- quota decisions
+- pricing model configuration
+- user-facing reporting pages
+
+## API Surface
+
+| Method | Path                               | Auth                    | Purpose |
+| ------ | ---------------------------------- | ----------------------- | ------- |
+| POST   | `/internal/usage/events`           | `X-Internal-Auth`       | Ingest usage events from normal services |
+| POST   | `/internal/webhooks/usage-events`  | Orchestrator HMAC       | Ingest usage events from orchestrator without exposing the internal auth token |
+| POST   | `/internal/usage/query`            | `X-Internal-Auth`       | Query aggregated usage and cost concentration |
+| GET    | `/health`                          | none                    | Standard service health endpoint |
+
+There must be **no** user-scoped public endpoint in this stage.
+
+## Authentication Design
+
+### 1. Internal Service Calls
+
+Used by normal services inside IntexuraOS.
+
+Headers:
+
+- `X-Internal-Auth: <token>`
+- `X-Trace-Id: <optional-trace-id>`
+
+Validation:
+
+- use the existing `validateInternalAuth(...)` pattern
+
+Applies to:
+
+- `POST /internal/usage/events`
+- `POST /internal/usage/query`
+
+### 2. Orchestrator Webhook Calls
+
+Used only by orchestrator.
+
+Headers:
+
+- `X-Request-Timestamp: <unix-seconds>`
+- `X-Request-Signature: <hex-hmac>`
+
+Validation:
+
+- reuse the existing orchestrator webhook signing model
+- signature input must match the existing repo pattern: `${timestamp}.${JSON.stringify(body)}`
+- reject requests older than 15 minutes
+- use `INTEXURAOS_ORCHESTRATOR_SECRET`
+
+Applies to:
+
+- `POST /internal/webhooks/usage-events`
+
+### 3. Separation Rules
+
+These rules are mandatory:
+
+- the webhook endpoint must not accept `X-Internal-Auth` as its authentication mechanism
+- the internal endpoint must not accept unsigned orchestrator traffic
+- orchestrator must not be given the internal service auth token
+
+## Common Response Envelope
+
+All authenticated endpoints must follow the normal internal response shape:
+
+Successful response:
+
+```json
+{
+  "success": true,
+  "data": {}
+}
+```
+
+Failure response:
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": "INVALID_REQUEST",
+    "message": "Human-readable message"
+  }
+}
+```
+
+Recommended failure codes for this service:
+
+- `UNAUTHORIZED`
+- `INVALID_REQUEST`
+- `NOT_FOUND`
+- `INTERNAL_ERROR`
+
+## Ingest API Contract
+
+### Endpoint
+
+`POST /internal/usage/events`  
+`POST /internal/webhooks/usage-events`
+
+Both endpoints accept the same payload shape. The only difference is authentication.
+
+### Request Body
+
+```json
+{
+  "schemaVersion": 1,
+  "events": [
+    {
+      "eventId": "14bb54ff-0fb7-4f4f-bab0-a6c63a0ad329",
+      "occurredAt": "2026-04-09T13:45:00.000Z",
+      "owner": {
+        "type": "user",
+        "id": "auth0|abc123"
+      },
+      "source": {
+        "service": "research-agent",
+        "component": "summary-generator",
+        "client": "infra-gemini",
+        "environment": "dev"
+      },
+      "request": {
+        "provider": "google",
+        "model": "gemini-2.5-flash",
+        "operation": "generate",
+        "success": true,
+        "durationMs": 1840
+      },
+      "usage": {
+        "inputTokens": 1000,
+        "outputTokens": 240,
+        "totalTokens": 1240,
+        "cacheReadTokens": 0,
+        "cacheWriteTokens": 0,
+        "cachedTokens": 0,
+        "reasoningTokens": 0,
+        "thinkingTokens": 50,
+        "webSearchCalls": 0,
+        "groundingEnabled": false,
+        "imageCount": 0
+      },
+      "cost": {
+        "billedUsd": 0.00132,
+        "providerReportedUsd": null,
+        "calculatedUsd": 0.00132,
+        "pricingSource": "calculated"
+      },
+      "correlation": {
+        "requestId": "req_123",
+        "traceId": "trace_123",
+        "taskId": null,
+        "researchId": "res_456",
+        "attempt": null,
+        "sessionId": null
+      },
+      "error": null
+    }
+  ]
+}
+```
+
+### Ingest Response
+
+```json
+{
+  "success": true,
+  "data": {
+    "accepted": 1,
+    "duplicates": 0,
+    "rejected": []
+  }
+}
+```
+
+Rejected items must be reported per index:
+
+```json
+{
+  "success": true,
+  "data": {
+    "accepted": 1,
+    "duplicates": 1,
+    "rejected": [
+      {
+        "index": 2,
+        "code": "INVALID_REQUEST",
+        "message": "usage.totalTokens must be >= 0"
+      }
+    ]
+  }
+}
+```
+
+### Ingest Validation Rules
+
+- `schemaVersion` is required and must be `1`
+- `events` is required and must be non-empty
+- `eventId` is required
+- `occurredAt` must be a valid ISO timestamp
+- `owner.type` must be `user` or `system`
+- `owner.id` is required
+- `source.service`, `source.component`, `source.client`, and `source.environment` are required
+- `request.provider`, `request.model`, `request.operation`, `request.success`, and `request.durationMs` are required
+- all numeric usage fields must be integers `>= 0`
+- `cost.billedUsd` is required and must be `>= 0`
+- `providerReportedUsd` and `calculatedUsd` are optional and may be `null`
+- `error` may be `null` even when `success=false`
+- `success=false` events may still have non-zero usage and cost
+
+### Ingest Semantics
+
+- event ingestion must be idempotent by `eventId`
+- duplicates are treated as successful no-op events
+- partial acceptance inside a batch is allowed
+- the service sets `receivedAt`; callers do not send it
+- the service records which ingress path accepted the event: `internal` or `orchestrator_webhook`
+
+### Orchestrator-Specific Rules
+
+For `POST /internal/webhooks/usage-events`:
+
+- `source.service` must equal `orchestrator`
+- `owner.type` will usually be `system`
+- `correlation.taskId` and `correlation.attempt` are strongly recommended when the event came from a task execution
+
+## Query API Contract
+
+### Endpoint
+
+`POST /internal/usage/query`
+
+### Purpose
+
+This endpoint exists so internal systems can answer questions like:
+
+- which service is generating the most cost
+- which component within a service is the most expensive
+- how much spend belongs to a given user or system owner
+- which models and providers dominate usage
+
+### Request Body
+
+```json
+{
+  "timeRange": {
+    "from": "2026-04-01T00:00:00.000Z",
+    "to": "2026-04-30T23:59:59.999Z"
+  },
+  "filters": {
+    "ownerTypes": ["user", "system"],
+    "ownerIds": ["auth0|abc123", "orchestrator-completion-verifier"],
+    "services": ["research-agent", "orchestrator"],
+    "components": ["summary-generator", "completion-verifier"],
+    "clients": ["infra-gemini", "infra-openrouter"],
+    "providers": ["google", "openrouter"],
+    "models": ["gemini-2.5-flash"],
+    "operations": ["generate", "tool_calling"],
+    "success": true
+  },
+  "groupBy": ["source.service", "source.component", "request.model"],
+  "sortBy": {
+    "field": "costUsd",
+    "direction": "desc"
+  },
+  "limit": 50
+}
+```
+
+### Allowed `groupBy` Dimensions
+
+- `day`
+- `owner.type`
+- `owner.id`
+- `source.service`
+- `source.component`
+- `source.client`
+- `request.provider`
+- `request.model`
+- `request.operation`
+- `request.success`
+
+### Query Response
+
+```json
+{
+  "success": true,
+  "data": {
+    "rows": [
+      {
+        "group": {
+          "source.service": "research-agent",
+          "source.component": "summary-generator",
+          "request.model": "gemini-2.5-flash"
+        },
+        "metrics": {
+          "calls": 1200,
+          "costUsd": 18.45,
+          "inputTokens": 800000,
+          "outputTokens": 125000,
+          "totalTokens": 925000,
+          "cacheReadTokens": 0,
+          "cacheWriteTokens": 0,
+          "cachedTokens": 0,
+          "reasoningTokens": 0,
+          "thinkingTokens": 42000,
+          "webSearchCalls": 0,
+          "imageCount": 0
+        }
+      }
+    ],
+    "totals": {
+      "calls": 1200,
+      "costUsd": 18.45,
+      "inputTokens": 800000,
+      "outputTokens": 125000,
+      "totalTokens": 925000,
+      "cacheReadTokens": 0,
+      "cacheWriteTokens": 0,
+      "cachedTokens": 0,
+      "reasoningTokens": 0,
+      "thinkingTokens": 42000,
+      "webSearchCalls": 0,
+      "imageCount": 0
+    }
+  }
+}
+```
+
+### Query Rules
+
+- `timeRange.from` and `timeRange.to` are required
+- `limit` defaults to `100` and must be capped to a safe maximum such as `500`
+- `sortBy.field` must be one of the returned metric fields
+- query must run against aggregate documents, not by scanning raw events directly
+- if `groupBy` is empty, return one totals row only
+
+## Canonical Event Schema
+
+This is the authoritative logical model stored after ingestion.
+
+```ts
+interface UsageEvent {
+  schemaVersion: 1;
+  eventId: string;
+  occurredAt: string;
+  receivedAt: string;
+  ingress: 'internal' | 'orchestrator_webhook';
+
+  owner: {
+    type: 'user' | 'system';
+    id: string;
+  };
+
+  source: {
+    service: string;
+    component: string;
+    client: string;
+    environment: 'local' | 'dev' | 'prod' | 'test';
+  };
+
+  request: {
+    provider: 'google' | 'openai' | 'anthropic' | 'perplexity' | 'openrouter';
+    model: string;
+    operation:
+      | 'research'
+      | 'generate'
+      | 'image_generation'
+      | 'tool_calling'
+      | 'visualization_insights'
+      | 'visualization_vegalite'
+      | 'other';
+    success: boolean;
+    durationMs: number;
+  };
+
+  usage: {
+    inputTokens: number;
+    outputTokens: number;
+    totalTokens: number;
+    cacheReadTokens: number;
+    cacheWriteTokens: number;
+    cachedTokens: number;
+    reasoningTokens: number;
+    thinkingTokens: number;
+    webSearchCalls: number;
+    groundingEnabled: boolean;
+    imageCount: number;
+  };
+
+  cost: {
+    billedUsd: number;
+    providerReportedUsd: number | null;
+    calculatedUsd: number | null;
+    pricingSource: 'provider_reported' | 'calculated' | 'mixed' | 'external';
+  };
+
+  correlation: {
+    requestId: string | null;
+    traceId: string | null;
+    taskId: string | null;
+    researchId: string | null;
+    attempt: number | null;
+    sessionId: string | null;
+  };
+
+  error: {
+    code: string | null;
+    message: string | null;
+  } | null;
+}
+```
+
+## Concrete Firestore Data Model
+
+Use Firestore in stage 1 because it matches existing repo infrastructure and avoids inventing a new storage dependency.
+
+### Collection 1: Raw Events
+
+Collection:
+
+```text
+llm_usage_events/{eventId}
+```
+
+Rules:
+
+- document ID is `eventId`
+- document is immutable after successful create
+- if create fails because the document already exists, treat as duplicate
+- this collection is the source of truth for ingestion history and deduplication
+
+Required stored fields:
+
+- the full canonical `UsageEvent`
+- optional `ingestMetadata.requestIp` if easy to capture
+- optional `ingestMetadata.traceId` copied from headers for debugging
+
+### Collection 2: Daily Aggregates
+
+Collection:
+
+```text
+llm_usage_daily_aggregates/{aggregateId}
+```
+
+One document represents one day and one exact dimension tuple:
+
+- `date`
+- `owner.type`
+- `owner.id`
+- `source.service`
+- `source.component`
+- `source.client`
+- `source.environment`
+- `request.provider`
+- `request.model`
+- `request.operation`
+- `request.success`
+
+Recommended `aggregateId` shape:
+
+```text
+{date}__{ownerType}__{ownerIdHash}__{service}__{component}__{client}__{provider}__{modelHash}__{operation}__{success}
+```
+
+The exact encoding is implementation detail, but it must be deterministic and collision-safe.
+
+Required aggregate fields:
+
+```ts
+interface DailyUsageAggregate {
+  aggregateId: string;
+  date: string; // YYYY-MM-DD
+
+  ownerType: 'user' | 'system';
+  ownerId: string;
+
+  sourceService: string;
+  sourceComponent: string;
+  sourceClient: string;
+  sourceEnvironment: string;
+
+  provider: string;
+  model: string;
+  operation: string;
+  success: boolean;
+
+  calls: number;
+  costUsd: number;
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+  cachedTokens: number;
+  reasoningTokens: number;
+  thinkingTokens: number;
+  webSearchCalls: number;
+  imageCount: number;
+
+  firstOccurredAt: string;
+  lastOccurredAt: string;
+  updatedAt: string;
+}
+```
+
+### Aggregate Write Rule
+
+Aggregate updates must happen **only** after the raw event create succeeds.
+
+That means:
+
+- new raw event -> update aggregate
+- duplicate raw event -> do not update aggregate
+
+This is what keeps idempotency correct.
+
+## Data Modeling Rules
+
+### Owner Attribution
+
+Owner is mandatory and must be explicit in the payload.
+
+Examples:
+
+- `{ "type": "user", "id": "auth0|abc123" }`
+- `{ "type": "system", "id": "orchestrator-completion-verifier" }`
+- `{ "type": "system", "id": "orchestrator-compliance-validator" }`
+
+The service must not infer owner from auth headers.
+
+### Source Attribution
+
+Every event must include:
+
+- `source.service`
+- `source.component`
+- `source.client`
+
+This is mandatory because the business requirement is to answer where costs are concentrated.
+
+Examples:
+
+- `research-agent` / `summary-generator` / `infra-gemini`
+- `image-service` / `prompt-adapter` / `infra-openrouter`
+- `orchestrator` / `completion-verifier` / `infra-gpt`
+
+### Token Modeling
+
+Keep token subtypes as first-class fields.
+
+Rules:
+
+- `cacheReadTokens` and `cacheWriteTokens` stay separate
+- `cachedTokens` stays separate for providers that only expose cached input tokens
+- `reasoningTokens` and `thinkingTokens` stay separate
+- `totalTokens` is stored exactly as reported by the caller
+
+`cacheWriteTokens` is the canonical cross-provider field for values currently represented in some clients as cache creation tokens.
+
+### Cost Modeling
+
+`cost.billedUsd` is the authoritative reporting value.
+
+Use:
+
+- `providerReportedUsd` when the upstream provider directly reports cost
+- `calculatedUsd` when cost was derived from pricing tables
+- `pricingSource` to explain how `billedUsd` was chosen
+
+This is required because some providers expose direct API call cost while others do not.
+
+## Shared Internal Client Design
+
+Add a new client to `@intexuraos/internal-clients` that mirrors the style of the existing user-service client.
+
+Recommended package layout:
+
+```text
+packages/internal-clients/src/
+  usage-service/
+    client.ts
+    types.ts
+    index.ts
+```
+
+### `UsageServiceConfig`
+
+```ts
+interface UsageServiceConfig {
+  baseUrl: string;
+  internalAuthToken: string;
+  logger: Logger;
+}
+```
+
+### `UsageServiceClient`
+
+```ts
+interface UsageServiceClient {
+  ingestEvents(
+    request: UsageIngestRequest,
+    options?: { traceId?: string }
+  ): Promise<Result<UsageIngestResponse, UsageServiceError>>;
+
+  queryUsage(
+    request: UsageQueryRequest,
+    options?: { traceId?: string }
+  ): Promise<Result<UsageQueryResponse, UsageServiceError>>;
+}
+```
+
+### `UsageServiceError`
+
+```ts
+interface UsageServiceError {
+  code: 'NETWORK_ERROR' | 'API_ERROR' | 'VALIDATION_ERROR';
+  message: string;
+}
+```
+
+### Client Implementation Rules
+
+- reuse `fetchWithAuth(...)` from `packages/internal-clients/src/shared/errors.ts`
+- keep the success envelope consistent with existing internal clients
+- support optional `traceId`
+- do not add orchestrator webhook auth to this package
+
+## Orchestrator Position
+
+Do **not** make orchestrator depend on `@intexuraos/internal-clients` in this stage.
+
+Reason:
+
+- orchestrator does not currently depend on that package
+- orchestrator uses a different auth model
+- coupling low-level webhook delivery to the internal client package does not simplify the design
+
+Recommended orchestrator implementation when rollout happens later:
+
+- create a small local sender that posts to `/internal/webhooks/usage-events`
+- reuse the existing HMAC signing helper pattern
+
+## Future `LLMClient` Integration Contract
+
+This stage does not implement the rollout, but the API must support the planned integration shape.
+
+The future direction should be:
+
+```ts
+interface LlmUsageReporter {
+  report(event: UsageEventInput): Promise<void>;
+}
+```
+
+Important design rule:
+
+- low-level `LLMClient` implementations should depend on a required reporter interface
+- they should **not** depend directly on `@intexuraos/internal-clients`
+
+That keeps provider packages transport-agnostic while still allowing:
+
+- normal services to use an HTTP reporter backed by `UsageServiceClient`
+- orchestrator to use a webhook reporter with HMAC signing
+
+## Required Delivery Checkpoints
+
+The implementation worker must deliver all of the following:
+
+1. New app scaffolded with `/create-service llm-usage-service` and scaffold verified.
+2. Authenticated internal ingest endpoint implemented.
+3. Authenticated orchestrator webhook ingest endpoint implemented.
+4. Internal aggregate query endpoint implemented.
+5. Firestore raw-event and daily-aggregate repositories implemented.
+6. OpenAPI schemas for all endpoints implemented.
+7. Shared `@intexuraos/internal-clients` usage-service client implemented.
+8. Tests for auth, ingestion, deduplication, aggregate writes, and query grouping implemented.
+9. Health endpoint preserved and working.
+10. Final verification completed before PR creation.
+
+## What The Worker Must Not Do In This Stage
+
+- do not migrate old usage data
+- do not delete old usage paths
+- do not update all existing LLM clients to point to this service
+- do not add end-user endpoints
+- do not include Claude/Codex runtime turn metrics
+
+## Implementation Plan Reference
+
+Detailed execution steps live in:
+
+`docs/superpowers/plans/2026-04-09-llm-usage-service-implementation-plan.md`
+
+That plan is the operational handoff for the Claude worker.

--- a/workers/orchestrator/src/services/isolation/__tests__/docker-provider.test.ts
+++ b/workers/orchestrator/src/services/isolation/__tests__/docker-provider.test.ts
@@ -1381,7 +1381,7 @@ describe('DockerProvider', () => {
       const baseUrlEntry = envArr.find((e: string) => e.startsWith('ANTHROPIC_BASE_URL='));
       expect(baseUrlEntry).toBe('ANTHROPIC_BASE_URL=https://openrouter.ai/api');
       const modelEntry = envArr.find((e: string) => e.startsWith('ANTHROPIC_MODEL='));
-      expect(modelEntry).toBe('ANTHROPIC_MODEL=qwen/qwen3.6-plus:free');
+      expect(modelEntry).toBe('ANTHROPIC_MODEL=google/gemma-4-31b-it:free');
       const effortEntry = envArr.find((e: string) => e.startsWith('CLAUDE_CODE_EFFORT_LEVEL='));
       expect(effortEntry).toBe('CLAUDE_CODE_EFFORT_LEVEL=high');
       const betasEntry = envArr.find((e: string) =>


### PR DESCRIPTION
Fixes INT-1326

## What

- add a detailed API and data-model specification for the new internal-only `llm-usage-service`
- add a worker-oriented implementation plan optimized for a less specialized Claude worker
- define the shared `@intexuraos/internal-clients` usage-service client contract and the orchestrator webhook-auth path

## Why

LLM usage tracking is currently fragmented across multiple incompatible paths. Shared provider clients write aggregate usage into `llm_usage_stats`, audit logging writes detailed request metadata into `llm_api_logs`, `code-agent` keeps separate quota and estimated-cost data in `user_usage`, and orchestrator verifier/compliance-validator usage is only emitted to structured logs. That split means there is no single authoritative ingestion contract for LLM usage.

The practical consequence is that we cannot answer cost concentration questions reliably. We lose important token subtype detail in the shared aggregate path, orchestrator usage is not stored alongside normal service usage, and the current data model does not consistently attribute spend by service, component, model, and client implementation. The new service is meant to become the clean replacement boundary for those concerns.

This PR defines the first implementation stage only: a dedicated internal-only `llm-usage-service` with explicit auth rules for both internal services and orchestrator, a canonical immutable usage event schema, a Firestore-backed raw-event and daily-aggregate model, and a shared usage-service client in `@intexuraos/internal-clients`. It intentionally does not include migration or consumer rollout.

## Key Decisions Captured

- normal services ingest usage through `POST /internal/usage/events` with `X-Internal-Auth`
- orchestrator ingests usage through `POST /internal/webhooks/usage-events` with the existing HMAC webhook auth pattern
- there is no user-scoped endpoint in stage 1; the read path is internal-only via `POST /internal/usage/query`
- the service stores immutable raw events plus daily aggregates so cost concentration can be queried without rescanning raw events
- token subtype tracking includes cache variants, reasoning/thinking tokens, and optional direct provider-reported cost
- the shared internal client lives in `@intexuraos/internal-clients`, while orchestrator stays decoupled from that package in stage 1
- the implementation plan explicitly requires `/create-service llm-usage-service` and a scaffold verification checkpoint

## Files

- `docs/superpowers/specs/2026-04-09-usage-service-api-design.md`
- `docs/superpowers/plans/2026-04-09-llm-usage-service-implementation-plan.md`

## Verification

- `git diff --check`

## Notes

- docs-only PR
- no migration or consumer integration is included here
- stage 1 excludes Claude/Codex runtime turn metrics