### PR TITLE
[INT-1328] fix(nitpick-nuker): use GraphQL viewer for actor identity

### DIFF
--- a/.claude/skills/nitpick-nuker/reference/gh-api-endpoints.md
+++ b/.claude/skills/nitpick-nuker/reference/gh-api-endpoints.md
@@ -176,8 +176,10 @@ query (
 ## Useful CLI Commands
 
 ```bash
-# Get current user
-gh api user --jq '.login'
+# Get the authenticated actor's login (works for user PATs AND GitHub App
+# installation tokens). Avoid `gh api user` — it returns 403 "Resource not
+# accessible by integration" on installation tokens (ghs_*).
+gh api graphql -f query='query { viewer { login } }' --jq '.data.viewer.login'
 
 # Get PR details
 gh pr view {pr_number} --json number,headRefName,baseRefName,url

--- a/.claude/skills/nitpick-nuker/scripts/fetch-unprocessed-comments.sh
+++ b/.claude/skills/nitpick-nuker/scripts/fetch-unprocessed-comments.sh
@@ -29,8 +29,20 @@ REPO_INFO=$(gh repo view --json owner,name --jq '"\(.owner.login) \(.name)"')
 OWNER=$(echo "$REPO_INFO" | cut -d' ' -f1)
 REPO=$(echo "$REPO_INFO" | cut -d' ' -f2)
 
-# Get bot username (current authenticated user)
-BOT_USERNAME=$(gh api user --jq '.login')
+# Get the authenticated actor's login.
+#
+# We cannot use `gh api user` because GitHub App installation tokens (ghs_*)
+# return 403 "Resource not accessible by integration" on /user — installations
+# have no associated user. GraphQL `viewer` works for every token type gh
+# supports: user PATs (ghp_), fine-grained PATs (github_pat_), OAuth (gho_),
+# user-to-server (ghu_), and installation tokens (ghs_). The login string is
+# "<user>" for humans and "<app-slug>[bot]" for installations — both are safe
+# inside the jq --arg filters used below.
+BOT_USERNAME=$(gh api graphql -f query='query { viewer { login } }' --jq '.data.viewer.login')
+if [[ -z "$BOT_USERNAME" || "$BOT_USERNAME" == "null" ]]; then
+  echo "ERROR: could not determine authenticated actor via GraphQL viewer" >&2
+  exit 2
+fi
 
 # Function to check if comment has bot's laugh reaction
 has_bot_laugh() {


### PR DESCRIPTION
## Summary

- `gh api user` returns HTTP 403 **"Resource not accessible by integration"** when authenticated with a GitHub App installation token (`ghs_*`), which is the token class used inside `code-worker` containers spawned by the orchestrator. Combined with `set -euo pipefail`, this killed `fetch-unprocessed-comments.sh` at line 33 *before* the REST fallback path could run, silently breaking every `/nitpick-nuker` invocation from within a worker.
- Replace the `gh api user` call with `gh api graphql -f query='query { viewer { login } }'`, which works for every token kind `gh` supports (`ghp_`, `github_pat_`, `gho_`, `ghu_`, `ghs_`) because GraphQL `viewer` resolves to the *authenticated actor* regardless of auth type — a `User` node for humans, a `User` node representing the installation for App tokens.
- Add a defensive empty/`null` guard so `set -euo pipefail` fails loudly on any future regression instead of silently letting `BOT_USERNAME=""` corrupt the duplicate-detection filter and cause every comment to be reprocessed forever.
- Update the matching reference doc (`reference/gh-api-endpoints.md`) so it stops teaching the broken `gh api user` pattern.

## Why GraphQL `viewer` instead of parsing `gh auth status`

Both candidates were evaluated empirically in a live worker container:

| | `gh auth status` + sed | `gh api graphql viewer` |
|---|---|---|
| Works across token kinds | yes | yes |
| Latency (10 iters) | 5.27 s (~527 ms/call) | 3.30 s (~330 ms/call) |
| Output format | text, regex-parsed | structured JSON |
| Contract stability | `gh` CLI text (historically unstable) | GitHub GraphQL schema (`X-Github-Media-Type: github.v4`) |
| Subprocess forks | 3 (`gh`+`sed`+`head`) | 1 (`gh`) |
| Failure mode under `pipefail` | silent empty string on format change | non-zero exit, structured error |

`gh auth status` is **not** purely local — it performs a live token-verification network call per invocation, so both candidates pay one round trip. GraphQL `viewer` is faster, has a stable contract, and fails loudly.

## Test plan

- [x] **Local Mac** (`gho_` user OAuth token) → `gh api graphql viewer` returns `"pbuchman"` (verified)
- [x] **home-dev direct** (`ghs_` installation token via `GH_TOKEN` env) → returns `"intexuraos-code-worker[bot]"` (verified) — this proves the fix is a GitHub API contract, not a container runtime artifact
- [x] **Live `code-worker` container** (`ghs_` installation token at `/secrets/github-token`, `gh` wrapper shim at `/usr/local/bin/gh`) — **ran the pushed script end-to-end against PR #1736**, same PR and same container class as the original failure in the transcript. Script sailed past the previously-fatal line 33, hit the intended GraphQL-complexity-limit fallback path, fell back to REST successfully, and produced a valid JSON array of issue comments from PR #1736. No 403 anywhere. (verified)
- [x] `bash -n fetch-unprocessed-comments.sh` → `SYNTAX OK`
- [x] `pnpm run ci:tracked` → all phases green (Type & Lint, Tests, 23 Static Validators, Build & Format)
- [x] Audited `.claude/skills/` tree for any other `gh api user` references — found exactly two (the script and the reference doc), both fixed in this PR

## Notes

- No orchestrator changes, no Dockerfile changes, no new env vars, no new secrets.
- Changes are `.sh` + `.md` only. TypeScript CI is unaffected (all 23 static validators pass unchanged).
- Commit parent is `fc0425545` (merge of PR #1736), so the fix applies directly to the state of `development` that saw the original failure.

Architected with love by 🤖 <a href="mailto:intex@intexuraos.cloud">Intex</a>

---
- Linear: [INT-1328](https://linear.app/pbuchman/issue/INT-1328)
- IntexuraOS Code Task: [View task](https://intexuraos.cloud/#/code-tasks/task_01b2abcd-afb8-4239-9645-b531f7c94e1a)
- Worker Type: `sonnet`
- Model: `sonnet`