### PR TITLE
[INT-1330] Add scaffolding verifier for /create-service

### DIFF
--- a/.claude/commands/create-service.md
+++ b/.claude/commands/create-service.md
@@ -25,6 +25,16 @@ Examples:
 
 ## App Creation Steps
 
+> ## MANDATORY FINAL STEP — READ THIS FIRST
+>
+> **This command is NOT complete until `scripts/verify-service-scaffolding.sh <service-name>` exits 0.**
+>
+> The numbered steps below tell you WHAT to create. Step 14 is the only thing that tells you whether you actually did it. History is unambiguous: previous runs of `/create-service` have silently dropped IAM service accounts, deploy scripts, `docker_services` entries, and per-service `cloudbuild.yaml` files — not because the instructions were missing, but because the executor felt "done" after the visible terraform module was written and skipped the rest.
+>
+> **The verifier is the gate. Not running it = the service is not created.** No exceptions. No "I'm pretty sure I did everything." Run the script. If it exits non-zero, go back and fix what it reports, then re-run until it exits 0.
+>
+> See **Step 14** below for the exact command.
+
 ### 1. Create App Directory Structure
 
 ```
@@ -696,17 +706,15 @@ export function getConfig(): AppConfig {
 
 **Note:** Backend services already get all service URLs via `local.common_service_env_vars` in Terraform, so this step is only needed if the web frontend specifically needs to call your service.
 
-### 12. Add to Root tsconfig.json
+### 12. Verify tsconfig.json Coverage (automatic — nothing to edit)
 
-Edit `tsconfig.json`:
+The root `tsconfig.json` uses a glob include (`apps/*/src/**/*.ts`), so any new service under `apps/<service-name>/src/` is picked up automatically. **Do not edit `tsconfig.json`.** There is no `references[]` array to append to — if you find yourself adding one, you are editing the wrong file.
 
-```json
-{
-  "references": [
-    // ... existing references ...
-    { "path": "./apps/<service-name>" }
-  ]
-}
+Verify the glob is intact (Step 14's verifier also checks this):
+
+```bash
+grep "apps/\*/src" tsconfig.json
+# Expected output: "include": ["packages/*/src/**/*.ts", "apps/*/src/**/*.ts", ...]
 ```
 
 ### 13. Add to Local Dev Setup
@@ -758,13 +766,33 @@ export INTEXURAOS_<SERVICE_NAME>_SERVICE_URL=http://localhost:81XX
 
 This ensures developers can run the service locally with proper configuration.
 
-### 14. Run Verification
+### 14. MANDATORY: Run the Scaffolding Verifier
+
+**This is the gate. Do not claim the service is created until this script exits 0. No exceptions.**
+
+```bash
+bash scripts/verify-service-scaffolding.sh <service-name>
+```
+
+The script checks every required file, terraform block, cloudbuild entry, IAM binding, and GitHub Actions wiring produced by the steps above (25+ checks). **Exit 0 = done. Any other exit = not done.** If it reports missing items, go fix them and re-run the verifier until it passes. Do not proceed to commit, do not mark the task complete, do not move on.
+
+**Why this is mandatory, not optional:** The prose steps above are easy to skim under attention pressure. Previous runs of `/create-service` have silently dropped the IAM service account, the deploy script, the `docker_services` list entry, and the per-service `cloudbuild.yaml` — all because the executor created the terraform module and felt "done." The verifier replaces "I think I did it" with an exit code. Running it is the only way to know.
+
+**Anti-patterns to reject:**
+
+- "I already went through the steps carefully, I don't need to run it" — run it anyway. Past-you was wrong before.
+- "The verifier is flagging something that doesn't apply to my service" — then fix the verifier. Do not bypass it.
+- "I'll run it later" — later never comes. Run it now, before the next action.
+
+**After the verifier exits 0**, run the standard pre-commit checks:
 
 ```bash
 pnpm install
 pnpm run ci
 cd terraform && terraform fmt -recursive && terraform validate
 ```
+
+Only after **both** the verifier AND the CI checks pass is the service considered scaffolded. Only then should you commit.
 
 ### 15. Update Domain Docs Registry (if service has domain layer)
 
@@ -987,35 +1015,34 @@ terraform fmt -check -recursive && terraform validate
 
 ---
 
-## App Requirements Checklist
+## App Scaffolding Verification
 
-- [ ] OpenAPI spec at `/openapi.json`
-- [ ] Swagger UI at `/docs`
-- [ ] Health endpoint at `/health`
-- [ ] CORS enabled
-- [ ] `@intexuraos/infra-otel` in package.json dependencies
-- [ ] Dockerfile includes `COPY otel-register.js`, `ENV OTEL_SERVICE_NAME`, and `--import` in CMD
-- [ ] Added to `local.services` map in Terraform
-- [ ] Added service URL to `local.common_service_env_vars` in Terraform
-- [ ] Terraform module created with `local.common_service_secrets` and `local.common_service_env_vars`
-- [ ] Service account in IAM module
-- [ ] Build steps added to `cloudbuild/cloudbuild.yaml`
-- [ ] Per-service `apps/<service>/cloudbuild.yaml` created
-- [ ] Deploy script `cloudbuild/scripts/deploy-<service>.sh` created
-- [ ] Added to `docker_services` in `terraform/modules/cloud-build/main.tf`
-- [ ] Added to GitHub Actions deploy workflow (`.github/workflows/deploy.yml`) — all 4 places:
-  - [ ] Docker build list (`build-push-monitored.sh` step)
-  - [ ] SERVICES deploy array
-  - [ ] CLOUD_RUN_SERVICES array in "Fetch web config" step (monolith deploy)
-  - [ ] CLOUD_RUN_SERVICES array in individual web deploy (`web)` case block)
-- [ ] Registered in api-docs-hub
-- [ ] Added to `CLOUD_RUN_SERVICES` in Cloud Build files (`cloudbuild/cloudbuild.yaml`, `apps/web/cloudbuild.yaml`)
-- [ ] Added to `.envrc.local.example`
-- [ ] Added to root tsconfig.json
-- [ ] Added to local dev setup (`ecosystem.config.cjs`)
-- [ ] Updated domain docs registry
-- [ ] `pnpm run ci` passes
-- [ ] `terraform validate` passes
+**There is no manual checklist. Run the verifier.**
+
+```bash
+bash scripts/verify-service-scaffolding.sh <service-name>
+```
+
+This **replaces** the decorative `- [ ]` checklist that used to live here. A checklist you tick off from memory is not a gate — it's a wish list. The verifier is the gate: it runs real `grep`/`test` commands against the filesystem and reports observed state, not intention.
+
+### What the verifier enforces
+
+- **App files:** directory, `package.json`, `Dockerfile`, `src/index.ts`, per-service `cloudbuild.yaml`
+- **Dockerfile contents:** `otel-register.js` copy, `OTEL_SERVICE_NAME` env, `--import` in CMD
+- **Deploy script:** exists, has `--cpu-throttling`, does not set `--allow-unauthenticated`
+- **Terraform:** `local.services.<name>` map entry, `module "<name>"` block, `common_service_secrets` wiring, `INTEXURAOS_<NAME>_URL` env var
+- **IAM:** `google_service_account.<name>` resource
+- **Cloud Build trigger list:** `docker_services` array contains the service
+- **cloudbuild.yaml:** `build-push-<name>` and `deploy-<name>` steps
+- **GitHub Actions `deploy.yml`:** docker build line, SERVICES array, 2× `CLOUD_RUN_SERVICES` entries
+- **Monorepo wiring:** `tsconfig.json` glob intact, `ecosystem.config.cjs` (createServiceConfig + URL), `.envrc.local.example` URL
+- **Optional (soft warnings):** api-docs-hub registration, web-facing `CLOUD_RUN_SERVICES` entry
+
+Exit 0 = all required items present. Any other exit = missing items; fix and re-run.
+
+> ## REMINDER: THE VERIFIER IS MANDATORY
+>
+> If you have not run `scripts/verify-service-scaffolding.sh <service-name>` and seen exit 0, **the service is not created** — regardless of how many steps above you followed. This is the third time this document says so. It will not say so a fourth time. Run the script.
 
 ---
 

--- a/scripts/verify-service-scaffolding.sh
+++ b/scripts/verify-service-scaffolding.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+# Verify a service is fully scaffolded per the /create-service checklist.
+#
+# Usage:
+#   bash scripts/verify-service-scaffolding.sh <service-name>
+#
+# Maps 1:1 to the "App Requirements Checklist" in .claude/commands/create-service.md.
+# Exits non-zero if any required item is missing.
+#
+# Checks are HARD (must pass) or SOFT (warn only, e.g. api-docs-hub registration
+# is conditional on the service exposing OpenAPI).
+
+set -uo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <service-name>" >&2
+  echo "Example: $0 user-service" >&2
+  exit 2
+fi
+
+SERVICE="$1"
+# snake_case for terraform locals/modules (e.g. user-service -> user_service)
+SERVICE_SNAKE="${SERVICE//-/_}"
+# UPPER for env vars (e.g. user-service -> USER_SERVICE)
+SERVICE_UPPER="$(echo "$SERVICE_SNAKE" | tr '[:lower:]' '[:upper:]')"
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+FAIL=0
+WARN=0
+PASS=0
+
+red()   { printf '\033[31m%s\033[0m' "$1"; }
+green() { printf '\033[32m%s\033[0m' "$1"; }
+yellow(){ printf '\033[33m%s\033[0m' "$1"; }
+dim()   { printf '\033[2m%s\033[0m' "$1"; }
+
+check() {
+  local label="$1"
+  local ok="$2"
+  local detail="${3:-}"
+  if [[ "$ok" == "1" ]]; then
+    printf '  %s %s' "$(green '✓')" "$label"
+    [[ -n "$detail" ]] && printf ' %s' "$(dim "($detail)")"
+    printf '\n'
+    PASS=$((PASS + 1))
+  else
+    printf '  %s %s' "$(red '✗')" "$label"
+    [[ -n "$detail" ]] && printf ' %s' "$(dim "($detail)")"
+    printf '\n'
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+warn() {
+  local label="$1"
+  local ok="$2"
+  local detail="${3:-}"
+  if [[ "$ok" == "1" ]]; then
+    printf '  %s %s' "$(green '✓')" "$label"
+    [[ -n "$detail" ]] && printf ' %s' "$(dim "($detail)")"
+    printf '\n'
+    PASS=$((PASS + 1))
+  else
+    printf '  %s %s' "$(yellow '!')" "$label"
+    [[ -n "$detail" ]] && printf ' %s' "$(dim "($detail)")"
+    printf '\n'
+    WARN=$((WARN + 1))
+  fi
+}
+
+# --- helpers ----------------------------------------------------------------
+
+file_exists() { [[ -f "$1" ]] && echo 1 || echo 0; }
+
+grep_count() {
+  # grep_count <pattern> <file> -> integer on stdout (0 if no match or no file)
+  local pat="$1" file="$2" n
+  if [[ ! -f "$file" ]]; then echo 0; return; fi
+  # grep -c prints the count but exits 1 on zero matches; swallow the exit code.
+  n="$(grep -cF -- "$pat" "$file" 2>/dev/null || true)"
+  echo "${n:-0}"
+}
+
+grep_any() {
+  # grep_any <pattern> <file> -> 1 if >=1 match
+  local n
+  n="$(grep_count "$1" "$2")"
+  [[ "$n" -gt 0 ]] && echo 1 || echo 0
+}
+
+header() {
+  printf '\n%s %s\n' "$(dim '──')" "$1"
+}
+
+# --- begin ------------------------------------------------------------------
+
+printf 'Verifying service scaffolding for: %s\n' "$(green "$SERVICE")"
+printf '  snake_case: %s   UPPER: %s\n' "$SERVICE_SNAKE" "$SERVICE_UPPER"
+
+header "App files (apps/${SERVICE}/)"
+
+APP_DIR="apps/${SERVICE}"
+check "Directory exists: ${APP_DIR}/"                    "$([[ -d "$APP_DIR" ]] && echo 1 || echo 0)"
+check "package.json"                                     "$(file_exists "${APP_DIR}/package.json")"
+check "Dockerfile"                                       "$(file_exists "${APP_DIR}/Dockerfile")"
+check "src/index.ts"                                     "$(file_exists "${APP_DIR}/src/index.ts")"
+# Checklist line 1003:
+check "Per-service apps/${SERVICE}/cloudbuild.yaml"      "$(file_exists "${APP_DIR}/cloudbuild.yaml")"
+
+# Dockerfile contents per checklist line 997
+DF="${APP_DIR}/Dockerfile"
+check "Dockerfile: COPY otel-register.js"                "$(grep_any "otel-register.js" "$DF")"
+check "Dockerfile: ENV OTEL_SERVICE_NAME"                "$(grep_any "OTEL_SERVICE_NAME" "$DF")"
+check "Dockerfile: CMD uses --import"                    "$(grep_any "\"--import\"" "$DF")"
+
+# package.json infra-otel dependency (checklist line 996)
+PKG="${APP_DIR}/package.json"
+check "package.json: @intexuraos/infra-otel dependency"  "$(grep_any "@intexuraos/infra-otel" "$PKG")"
+
+header "Deploy plumbing"
+
+# Checklist line 1004:
+DEPLOY_SH="cloudbuild/scripts/deploy-${SERVICE}.sh"
+check "Deploy script: ${DEPLOY_SH}"                      "$(file_exists "$DEPLOY_SH")"
+if [[ -f "$DEPLOY_SH" ]]; then
+  check "  deploy.sh: has --cpu-throttling"              "$(grep_any "cpu-throttling" "$DEPLOY_SH")"
+  check "  deploy.sh: does NOT use --allow-unauthenticated" \
+        "$([[ $(grep_count "allow-unauthenticated" "$DEPLOY_SH") == 0 ]] && echo 1 || echo 0)"
+fi
+
+header "Terraform (environments/dev/main.tf)"
+
+DEV_TF="terraform/environments/dev/main.tf"
+# Checklist line 998: Added to local.services map
+check "local.services.${SERVICE_SNAKE} defined"          "$(grep_any "${SERVICE_SNAKE} = {" "$DEV_TF")"
+# Checklist line 1000: module with common_service_secrets/env_vars
+check "module \"${SERVICE_SNAKE}\" block"                "$(grep_any "module \"${SERVICE_SNAKE}\"" "$DEV_TF")"
+# Scope this to within the service's module block (awk picks the block, grep checks for the local).
+MODULE_USES_SECRETS=0
+if grep -qF "module \"${SERVICE_SNAKE}\"" "$DEV_TF" 2>/dev/null; then
+  if awk -v mod="module \"${SERVICE_SNAKE}\"" '
+        $0 ~ mod {in_block=1; brace=0}
+        in_block {
+          for (i=1;i<=length($0);i++) {
+            c=substr($0,i,1)
+            if (c=="{") brace++
+            else if (c=="}") { brace--; if (brace==0) { in_block=0; exit } }
+          }
+          print
+        }
+      ' "$DEV_TF" | grep -qF "local.common_service_secrets"; then
+    MODULE_USES_SECRETS=1
+  fi
+fi
+check "  module uses common_service_secrets"             "$MODULE_USES_SECRETS"
+# Checklist line 999: service URL in common_service_env_vars
+check "INTEXURAOS_${SERVICE_UPPER}_URL in env_vars"      "$(grep_any "INTEXURAOS_${SERVICE_UPPER}_URL" "$DEV_TF")"
+
+header "Terraform (modules/iam + modules/cloud-build)"
+
+IAM_TF="terraform/modules/iam/main.tf"
+# Checklist line 1001:
+check "IAM SA: google_service_account.${SERVICE_SNAKE}"  "$(grep_any "google_service_account\" \"${SERVICE_SNAKE}\"" "$IAM_TF")"
+
+CB_TF="terraform/modules/cloud-build/main.tf"
+# Checklist line 1005:
+check "docker_services list includes \"${SERVICE}\""     "$(grep_any "\"${SERVICE}\"" "$CB_TF")"
+
+header "cloudbuild/cloudbuild.yaml"
+
+CB_YAML="cloudbuild/cloudbuild.yaml"
+# Checklist line 1002:
+check "Build step: build-push-${SERVICE}"                "$(grep_any "build-push-${SERVICE}" "$CB_YAML")"
+check "Deploy step: deploy-${SERVICE}"                   "$(grep_any "deploy-${SERVICE}" "$CB_YAML")"
+# Web config (only if web consumes it) — SOFT:
+warn  "web CLOUD_RUN_SERVICES: ${SERVICE}:${SERVICE_UPPER}" \
+      "$(grep_any "\"${SERVICE}:${SERVICE_UPPER}\"" "$CB_YAML")" \
+      "soft: only required if web frontend calls this service"
+
+header ".github/workflows/deploy.yml (4 required places)"
+
+# Checklist lines 1006-1011:
+DEPLOY_YML=".github/workflows/deploy.yml"
+check "1/4 Docker build line"                            "$(grep_any "build-push-monitored.sh ${SERVICE} apps/${SERVICE}" "$DEPLOY_YML")"
+check "2/4 SERVICES array contains ${SERVICE}"           "$(grep_any " ${SERVICE} " "$DEPLOY_YML")"
+# CLOUD_RUN_SERVICES appears in 2 places in deploy.yml per checklist 1009/1010
+RUN_N="$(grep_count "\"${SERVICE}:${SERVICE_UPPER}\"" "$DEPLOY_YML")"
+check "3/4 + 4/4 CLOUD_RUN_SERVICES (2 entries)"         "$([[ "$RUN_N" -ge 2 ]] && echo 1 || echo 0)" \
+      "found ${RUN_N} / 2 expected"
+
+header "Monorepo wiring"
+
+# Checklist line 1014: repo uses glob include apps/*/src/**/*.ts — automatic for any
+# new service, so we verify the glob is intact rather than a per-service reference.
+# (Note: create-service.md step 12 is stale — it says to add a references[] entry,
+#  but the repo uses include globs.)
+check "tsconfig.json: apps/* glob include intact"        "$(grep_any "apps/*/src/**/*.ts" "tsconfig.json")"
+# Checklist line 1015:
+ECO="ecosystem.config.cjs"
+check "ecosystem.config.cjs: createServiceConfig('${SERVICE}'" \
+      "$(grep_any "createServiceConfig('${SERVICE}'" "$ECO")"
+check "ecosystem.config.cjs: INTEXURAOS_${SERVICE_UPPER}_URL" \
+      "$(grep_any "INTEXURAOS_${SERVICE_UPPER}_URL" "$ECO")"
+# Checklist line 1013:
+check ".envrc.local.example: INTEXURAOS_${SERVICE_UPPER}_URL" \
+      "$(grep_any "INTEXURAOS_${SERVICE_UPPER}_URL" ".envrc.local.example")"
+
+header "Optional registrations"
+
+# Checklist line 1012: api-docs-hub (SOFT — only if service exposes OpenAPI)
+warn  "api-docs-hub: INTEXURAOS_${SERVICE_UPPER}_OPENAPI_URL" \
+      "$(grep_any "INTEXURAOS_${SERVICE_UPPER}_OPENAPI_URL" "apps/api-docs-hub/src/config.ts")" \
+      "soft: only if service exposes /openapi.json"
+
+# --- summary ----------------------------------------------------------------
+
+printf '\n%s\n' "$(dim '────────────────────────────────────────')"
+printf 'Summary for %s: ' "$SERVICE"
+printf '%s passed  '  "$(green "$PASS")"
+printf '%s failed  '  "$([[ $FAIL -gt 0 ]] && red "$FAIL" || green "$FAIL")"
+printf '%s warnings\n' "$([[ $WARN -gt 0 ]] && yellow "$WARN" || green "$WARN")"
+
+if [[ $FAIL -gt 0 ]]; then
+  printf '\n%s %d required item(s) missing. Fix them before shipping.\n' "$(red 'FAIL:')" "$FAIL"
+  exit 1
+fi
+
+printf '\n%s All required scaffolding present.\n' "$(green 'OK:')"
+exit 0

--- a/scripts/verify-service-scaffolding.sh
+++ b/scripts/verify-service-scaffolding.sh
@@ -4,7 +4,7 @@
 # Usage:
 #   bash scripts/verify-service-scaffolding.sh <service-name>
 #
-# Maps 1:1 to the "App Requirements Checklist" in .claude/commands/create-service.md.
+# Maps 1:1 to the "App Scaffolding Verification" in .claude/commands/create-service.md.
 # Exits non-zero if any required item is missing.
 #
 # Checks are HARD (must pass) or SOFT (warn only, e.g. api-docs-hub registration
@@ -31,10 +31,17 @@ FAIL=0
 WARN=0
 PASS=0
 
-red()   { printf '\033[31m%s\033[0m' "$1"; }
-green() { printf '\033[32m%s\033[0m' "$1"; }
-yellow(){ printf '\033[33m%s\033[0m' "$1"; }
-dim()   { printf '\033[2m%s\033[0m' "$1"; }
+if [[ -t 1 ]] && [[ "${NO_COLOR:-}" == "" ]]; then
+  red()   { printf '\033[31m%s\033[0m' "$1"; }
+  green() { printf '\033[32m%s\033[0m' "$1"; }
+  yellow(){ printf '\033[33m%s\033[0m' "$1"; }
+  dim()   { printf '\033[2m%s\033[0m' "$1"; }
+else
+  red()   { printf '%s' "$1"; }
+  green() { printf '%s' "$1"; }
+  yellow(){ printf '%s' "$1"; }
+  dim()   { printf '%s' "$1"; }
+fi
 
 check() {
   local label="$1"
@@ -141,7 +148,7 @@ check "module \"${SERVICE_SNAKE}\" block"                "$(grep_any "module \"$
 MODULE_USES_SECRETS=0
 if grep -qF "module \"${SERVICE_SNAKE}\"" "$DEV_TF" 2>/dev/null; then
   if awk -v mod="module \"${SERVICE_SNAKE}\"" '
-        $0 ~ mod {in_block=1; brace=0}
+        index($0, mod) > 0 {in_block=1; brace=0}
         in_block {
           for (i=1;i<=length($0);i++) {
             c=substr($0,i,1)
@@ -184,7 +191,7 @@ header ".github/workflows/deploy.yml (4 required places)"
 # Checklist lines 1006-1011:
 DEPLOY_YML=".github/workflows/deploy.yml"
 check "1/4 Docker build line"                            "$(grep_any "build-push-monitored.sh ${SERVICE} apps/${SERVICE}" "$DEPLOY_YML")"
-check "2/4 SERVICES array contains ${SERVICE}"           "$(grep_any " ${SERVICE} " "$DEPLOY_YML")"
+check "2/4 SERVICES array contains ${SERVICE}"           "$(grep -qE "(^|[[:space:]])${SERVICE}([[:space:]]|$)" "$DEPLOY_YML" && echo 1 || echo 0)"
 # CLOUD_RUN_SERVICES appears in 2 places in deploy.yml per checklist 1009/1010
 RUN_N="$(grep_count "\"${SERVICE}:${SERVICE_UPPER}\"" "$DEPLOY_YML")"
 check "3/4 + 4/4 CLOUD_RUN_SERVICES (2 entries)"         "$([[ "$RUN_N" -ge 2 ]] && echo 1 || echo 0)" \


### PR DESCRIPTION
## Summary

- Adds `scripts/verify-service-scaffolding.sh` — 25+ checks against a service's scaffolding (app files, Dockerfile, deploy script, terraform, IAM, cloudbuild, deploy.yml, ecosystem.config.cjs, envrc). Exit 0 = fully scaffolded, non-zero = missing items.
- Updates `.claude/commands/create-service.md` with four emphasis blocks making the verifier the mandatory gate, replacing the decorative manual checklist.
- Fixes stale Step 12: the repo's `tsconfig.json` uses glob include `apps/*/src/**/*.ts`, not `references[]` — following the old instruction would have added dead config.

## Why

Past `/create-service` runs silently dropped IAM service accounts, deploy scripts, `docker_services` entries, and per-service `cloudbuild.yaml` files. Every one of those items was already in the manual checklist at the bottom of the command — the checklist just was not enforced. A checklist you tick off from memory is not a gate; it's a wish list. The verifier replaces "I think I did it" with an exit code.

## Test plan

- [x] Run verifier against fully-scaffolded `user-service` → expect exit 0
  - Result: **29 passed, 0 failed, exit 0**
- [x] Run verifier against missing `llm-usage-service` → expect exit 1 with all 4 originally-reported gaps detected
  - Result: **1 passed, 24 failed, exit 1** — catches missing IAM SA, deploy script, `docker_services` entry, and per-service `cloudbuild.yaml` (the 4 originally reported) plus 20 other gaps never previously flagged
- [ ] (Not done in this PR) Run `/create-service` end-to-end on a clean branch and confirm the LLM actually invokes the verifier as a result of the new emphasis

## Not done (follow-ups)

- Wire the verifier into `pnpm run ci:tracked` so CI blocks PRs with incomplete scaffolding
- Extend the same pattern to the Worker checklist
- Add a PreToolUse hook that blocks `git commit` when a newly-added `apps/<name>/` directory fails the verifier

---

Fixes INT-1330

- Linear: [INT-1330](https://linear.app/pbuchman/issue/INT-1330)
- IntexuraOS Code Task: [View task](https://intexuraos.cloud/#/code-tasks/task_35a44991-5fac-4bbb-b764-8ff4aff37099)
- Worker Type: `sonnet`
- Model: `sonnet`

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
