### PR TITLE
[INT-1331] feat(deploy): add llm-usage-service to monolith deploy lists

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -161,6 +161,7 @@ jobs:
           bash cloudbuild/scripts/build-push-monitored.sh chat-agent apps/chat-agent/Dockerfile &
           bash cloudbuild/scripts/build-push-monitored.sh cron-agent apps/cron-agent/Dockerfile &
           bash cloudbuild/scripts/build-push-monitored.sh hellscript-agent apps/hellscript-agent/Dockerfile &
+          bash cloudbuild/scripts/build-push-monitored.sh llm-usage-service apps/llm-usage-service/Dockerfile &
           wait
 
       - name: Build workers
@@ -174,6 +175,7 @@ jobs:
             commands-agent actions-agent data-insights-agent notes-agent
             todos-agent bookmarks-agent calendar-agent linear-agent
             web-agent code-agent chat-agent cron-agent hellscript-agent
+            llm-usage-service
           )
           for svc in "${SERVICES[@]}"; do
             bash "cloudbuild/scripts/deploy-${svc}.sh" &

--- a/cloudbuild/cloudbuild.yaml
+++ b/cloudbuild/cloudbuild.yaml
@@ -50,6 +50,7 @@
 # ├─────────────────────────────────────────────────────────────────────────┤
 # │ BATCH 8 - Agents D (add new services HERE)                              │
 # │   1. hellscript-agent                                                   │
+# │   2. llm-usage-service                                                  │
 # ├─────────────────────────────────────────────────────────────────────────┤
 # │ BATCH 9 - Cloud Functions Workers (parallel with Batch 1-8)             │
 # │   1. vm-lifecycle                                                       │
@@ -672,7 +673,7 @@ steps:
       - 'ENVIRONMENT=${_ENVIRONMENT}'
 
   # ===========================================================================
-  # BATCH 8 - Agents D (hellscript-agent)
+  # BATCH 8 - Agents D (hellscript-agent, llm-usage-service)
   # ===========================================================================
 
   # --- Batch 8 Builds (wait for Batch 7 deploys) ---
@@ -692,12 +693,39 @@ steps:
       - 'ARTIFACT_REGISTRY_URL=${_ARTIFACT_REGISTRY_URL}'
       - 'COMMIT_SHA=$COMMIT_SHA'
 
+  - name: 'gcr.io/cloud-builders/docker'
+    id: 'build-push-llm-usage-service'
+    waitFor: ['deploy-code-agent', 'deploy-chat-agent', 'deploy-cron-agent']
+    timeout: 900s
+    entrypoint: 'bash'
+    args:
+      [
+        'cloudbuild/scripts/build-push-monitored.sh',
+        'llm-usage-service',
+        'apps/llm-usage-service/Dockerfile',
+      ]
+    env:
+      - 'DOCKER_BUILDKIT=1'
+      - 'ARTIFACT_REGISTRY_URL=${_ARTIFACT_REGISTRY_URL}'
+      - 'COMMIT_SHA=$COMMIT_SHA'
+
   # --- Batch 8 Deploys ---
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     id: 'deploy-hellscript-agent'
     waitFor: ['build-push-hellscript-agent']
     entrypoint: 'bash'
     args: ['-c', 'bash cloudbuild/scripts/deploy-hellscript-agent.sh']
+    env:
+      - 'COMMIT_SHA=$COMMIT_SHA'
+      - 'REGION=${_REGION}'
+      - 'ARTIFACT_REGISTRY_URL=${_ARTIFACT_REGISTRY_URL}'
+      - 'ENVIRONMENT=${_ENVIRONMENT}'
+
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    id: 'deploy-llm-usage-service'
+    waitFor: ['build-push-llm-usage-service']
+    entrypoint: 'bash'
+    args: ['-c', 'bash cloudbuild/scripts/deploy-llm-usage-service.sh']
     env:
       - 'COMMIT_SHA=$COMMIT_SHA'
       - 'REGION=${_REGION}'
@@ -734,7 +762,7 @@ steps:
 
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     id: 'fetch-web-config'
-    waitFor: ['deploy-hellscript-agent', 'deploy-all-workers']
+    waitFor: ['deploy-hellscript-agent', 'deploy-llm-usage-service', 'deploy-all-workers']
     entrypoint: 'bash'
     args:
       - '-c'


### PR DESCRIPTION
## Summary
- Add `llm-usage-service` to the parallel Docker build and `SERVICES` deploy array in `.github/workflows/deploy.yml` (self-hosted monolith path).
- Add `llm-usage-service` to Batch 8 of `cloudbuild/cloudbuild.yaml` (Cloud Build monolith fallback), including new build and deploy steps and an updated `waitFor` on `fetch-web-config`.

## Context
Finishes the manual step flagged in PR #1738 — that PR's bot author lacked the `workflows` GitHub App permission and couldn't edit `.github/workflows/deploy.yml`. It also missed `cloudbuild/cloudbuild.yaml`, which is the parallel monolith code path used when the self-hosted runner is unavailable.

## Intentionally not included
The bot's PR body also requested adding `"llm-usage-service:LLM_USAGE_SERVICE"` to the `CLOUD_RUN_SERVICES` arrays. Those arrays build `apps/web/.env` — env vars baked into the web frontend bundle. `apps/web/src/config.ts` has **no** reference to `INTEXURAOS_LLM_USAGE_SERVICE_URL`, so adding it would emit a dead env var and cost one extra `gcloud run services describe` call per deploy. The runtime service-to-service URL map in `terraform/environments/dev/main.tf` (`common_service_env_vars`) already includes the URL — that's where it belongs.

## Test plan
- [ ] CI passes
- [ ] Next monolith deploy via self-hosted runner builds and deploys llm-usage-service
- [ ] Next monolith deploy via Cloud Build fallback builds and deploys llm-usage-service

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>