### PR TITLE
[INT-1336] feat(llm-usage-service): strict JSON schema validation at route layer

### DIFF
--- a/apps/llm-usage-service/src/__tests__/domain/usecases/ingestUsageEvents.test.ts
+++ b/apps/llm-usage-service/src/__tests__/domain/usecases/ingestUsageEvents.test.ts
@@ -1,11 +1,32 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { LlmProviders } from '@intexuraos/llm-contract';
 import { ingestUsageEvents } from '../../../domain/usecases/ingestUsageEvents.js';
 import { FakeUsageEventRepository } from '../../fakeUsageEventRepository.js';
 import { FakeUsageAggregateRepository } from '../../fakeUsageAggregateRepository.js';
 import { createTestEventInput } from '../../helpers.js';
 import type { UsageEventInput } from '../../../domain/models/usageEvent.js';
 
+/**
+ * Use-case-layer tests for `ingestUsageEvents`.
+ *
+ * As of the strict-schema refactor, structural validation (schemaVersion, field
+ * presence/types/enums, additionalProperties, orchestrator constraint) is performed
+ * by the Fastify route schemas `UsageEventInput` / `OrchestratorUsageEventInput`
+ * BEFORE this use case runs. Malformed events never reach the use case, so the
+ * ~46 field-level rejection tests that previously lived in this file have been
+ * deleted — they exercised branches of `validateEvent()` that no longer exist.
+ *
+ * The tests below cover the remaining use-case responsibilities:
+ *   1. Happy path: valid events are stored and aggregates incremented.
+ *   2. Deduplication: same eventId is counted as `duplicate`, not `accepted`.
+ *   3. Repository failures: Firestore `createEvent` errors are surfaced as rejected entries.
+ *   4. Aggregate failures: aggregate increment errors do not block event storage.
+ *   5. Sparse arrays: `undefined` holes in the events array are skipped.
+ *   6. Mixed batch: valid + duplicate events are handled correctly in a single call.
+ *
+ * Field-level rejection behavior is now tested at the route layer in
+ * `src/__tests__/routes/internalUsageRoutes.test.ts` and
+ * `src/__tests__/routes/webhookUsageRoutes.test.ts`.
+ */
 describe('ingestUsageEvents', () => {
   let eventRepo: FakeUsageEventRepository;
   let aggregateRepo: FakeUsageAggregateRepository;
@@ -45,329 +66,6 @@ describe('ingestUsageEvents', () => {
     expect(aggregateRepo.getIncrementCallCount()).toBe(1);
   });
 
-  it('rejects events with invalid schemaVersion', async () => {
-    const events = [{ ...createTestEventInput(), schemaVersion: 2 as unknown as 1 }];
-    const result = await ingestUsageEvents(
-      { logger, usageEventRepository: eventRepo, usageAggregateRepository: aggregateRepo },
-      events,
-      'internal',
-    );
-
-    expect(result.rejected).toHaveLength(1);
-    expect(result.rejected[0]?.code).toBe('INVALID_SCHEMA_VERSION');
-  });
-
-  it('rejects events with empty eventId', async () => {
-    const events = [createTestEventInput({ eventId: '' })];
-    const result = await ingestUsageEvents(
-      { logger, usageEventRepository: eventRepo, usageAggregateRepository: aggregateRepo },
-      events,
-      'internal',
-    );
-
-    expect(result.rejected).toHaveLength(1);
-    expect(result.rejected[0]?.code).toBe('INVALID_EVENT_ID');
-  });
-
-  it('rejects events with empty occurredAt', async () => {
-    const events = [createTestEventInput({ occurredAt: '' })];
-    const result = await ingestUsageEvents(
-      { logger, usageEventRepository: eventRepo, usageAggregateRepository: aggregateRepo },
-      events,
-      'internal',
-    );
-
-    expect(result.rejected).toHaveLength(1);
-    expect(result.rejected[0]?.code).toBe('INVALID_OCCURRED_AT');
-  });
-
-  it('rejects events with missing owner', async () => {
-    const events = [{ ...createTestEventInput(), owner: null } as unknown as UsageEventInput];
-    const result = await ingestUsageEvents(
-      { logger, usageEventRepository: eventRepo, usageAggregateRepository: aggregateRepo },
-      events,
-      'internal',
-    );
-
-    expect(result.rejected).toHaveLength(1);
-    expect(result.rejected[0]?.code).toBe('INVALID_OWNER');
-  });
-
-  it('rejects events with invalid owner type', async () => {
-    const events = [createTestEventInput({ owner: { type: 'invalid' as 'user', id: 'x' } })];
-    const result = await ingestUsageEvents(
-      { logger, usageEventRepository: eventRepo, usageAggregateRepository: aggregateRepo },
-      events,
-      'internal',
-    );
-
-    expect(result.rejected).toHaveLength(1);
-    expect(result.rejected[0]?.code).toBe('INVALID_OWNER_TYPE');
-  });
-
-  it('rejects events with empty owner id', async () => {
-    const events = [createTestEventInput({ owner: { type: 'user', id: '' } })];
-    const result = await ingestUsageEvents(
-      { logger, usageEventRepository: eventRepo, usageAggregateRepository: aggregateRepo },
-      events,
-      'internal',
-    );
-
-    expect(result.rejected).toHaveLength(1);
-    expect(result.rejected[0]?.code).toBe('INVALID_OWNER_ID');
-  });
-
-  it('rejects events with missing source', async () => {
-    const events = [{ ...createTestEventInput(), source: undefined } as unknown as UsageEventInput];
-    const result = await ingestUsageEvents(
-      { logger, usageEventRepository: eventRepo, usageAggregateRepository: aggregateRepo },
-      events,
-      'internal',
-    );
-
-    expect(result.rejected).toHaveLength(1);
-    expect(result.rejected[0]?.code).toBe('INVALID_SOURCE');
-  });
-
-  it('rejects events with empty source.service', async () => {
-    const events = [createTestEventInput({
-      source: { service: '', component: 'x', client: 'y', environment: 'dev' },
-    })];
-    const result = await ingestUsageEvents(
-      { logger, usageEventRepository: eventRepo, usageAggregateRepository: aggregateRepo },
-      events,
-      'internal',
-    );
-
-    expect(result.rejected).toHaveLength(1);
-    expect(result.rejected[0]?.code).toBe('INVALID_SOURCE_SERVICE');
-  });
-
-  it('rejects events with empty source.component', async () => {
-    const events = [createTestEventInput({
-      source: { service: 'svc', component: '', client: 'y', environment: 'dev' },
-    })];
-    const result = await ingestUsageEvents(
-      { logger, usageEventRepository: eventRepo, usageAggregateRepository: aggregateRepo },
-      events,
-      'internal',
-    );
-
-    expect(result.rejected).toHaveLength(1);
-    expect(result.rejected[0]?.code).toBe('INVALID_SOURCE_COMPONENT');
-  });
-
-  it('rejects events with empty source.client', async () => {
-    const events = [createTestEventInput({
-      source: { service: 'svc', component: 'comp', client: '', environment: 'dev' },
-    })];
-    const result = await ingestUsageEvents(
-      { logger, usageEventRepository: eventRepo, usageAggregateRepository: aggregateRepo },
-      events,
-      'internal',
-    );
-
-    expect(result.rejected).toHaveLength(1);
-    expect(result.rejected[0]?.code).toBe('INVALID_SOURCE_CLIENT');
-  });
-
-  it('rejects events with invalid source.environment', async () => {
-    const events = [createTestEventInput({
-      source: { service: 'svc', component: 'comp', client: 'web', environment: 'staging' as 'dev' },
-    })];
-    const result = await ingestUsageEvents(
-      { logger, usageEventRepository: eventRepo, usageAggregateRepository: aggregateRepo },
-      events,
-      'internal',
-    );
-
-    expect(result.rejected).toHaveLength(1);
-    expect(result.rejected[0]?.code).toBe('INVALID_SOURCE_ENVIRONMENT');
-  });
-
-  it('rejects events with missing request', async () => {
-    const events = [{ ...createTestEventInput(), request: null } as unknown as UsageEventInput];
-    const result = await ingestUsageEvents(
-      { logger, usageEventRepository: eventRepo, usageAggregateRepository: aggregateRepo },
-      events,
-      'internal',
-    );
-
-    expect(result.rejected).toHaveLength(1);
-    expect(result.rejected[0]?.code).toBe('INVALID_REQUEST');
-  });
-
-  it('rejects events with invalid provider', async () => {
-    const events = [createTestEventInput({
-      request: { provider: 'invalid' as typeof LlmProviders.OpenAI, model: 'x', operation: 'generate', success: true, durationMs: 100 },
-    })];
-    const result = await ingestUsageEvents(
-      { logger, usageEventRepository: eventRepo, usageAggregateRepository: aggregateRepo },
-      events,
-      'internal',
-    );
-
-    expect(result.rejected).toHaveLength(1);
-    expect(result.rejected[0]?.code).toBe('INVALID_PROVIDER');
-  });
-
-  it('rejects events with empty model', async () => {
-    const events = [createTestEventInput({
-      request: { provider: LlmProviders.OpenAI, model: '', operation: 'generate', success: true, durationMs: 100 },
-    })];
-    const result = await ingestUsageEvents(
-      { logger, usageEventRepository: eventRepo, usageAggregateRepository: aggregateRepo },
-      events,
-      'internal',
-    );
-
-    expect(result.rejected).toHaveLength(1);
-    expect(result.rejected[0]?.code).toBe('INVALID_MODEL');
-  });
-
-  it('rejects events with invalid operation', async () => {
-    const events = [createTestEventInput({
-      request: { provider: LlmProviders.OpenAI, model: 'gpt-4o', operation: 'invalid' as 'generate', success: true, durationMs: 100 },
-    })];
-    const result = await ingestUsageEvents(
-      { logger, usageEventRepository: eventRepo, usageAggregateRepository: aggregateRepo },
-      events,
-      'internal',
-    );
-
-    expect(result.rejected).toHaveLength(1);
-    expect(result.rejected[0]?.code).toBe('INVALID_OPERATION');
-  });
-
-  it('rejects events with non-boolean success', async () => {
-    const events = [createTestEventInput({
-      request: { provider: LlmProviders.OpenAI, model: 'gpt-4o', operation: 'generate', success: 'true' as unknown as boolean, durationMs: 100 },
-    })];
-    const result = await ingestUsageEvents(
-      { logger, usageEventRepository: eventRepo, usageAggregateRepository: aggregateRepo },
-      events,
-      'internal',
-    );
-
-    expect(result.rejected).toHaveLength(1);
-    expect(result.rejected[0]?.code).toBe('INVALID_SUCCESS');
-  });
-
-  it('rejects events with negative durationMs', async () => {
-    const events = [createTestEventInput({
-      request: { provider: LlmProviders.OpenAI, model: 'gpt-4o', operation: 'generate', success: true, durationMs: -1 },
-    })];
-    const result = await ingestUsageEvents(
-      { logger, usageEventRepository: eventRepo, usageAggregateRepository: aggregateRepo },
-      events,
-      'internal',
-    );
-
-    expect(result.rejected).toHaveLength(1);
-    expect(result.rejected[0]?.code).toBe('INVALID_DURATION');
-  });
-
-  it('rejects events with missing usage', async () => {
-    const events = [{ ...createTestEventInput(), usage: null } as unknown as UsageEventInput];
-    const result = await ingestUsageEvents(
-      { logger, usageEventRepository: eventRepo, usageAggregateRepository: aggregateRepo },
-      events,
-      'internal',
-    );
-
-    expect(result.rejected).toHaveLength(1);
-    expect(result.rejected[0]?.code).toBe('INVALID_USAGE');
-  });
-
-  it('rejects events with negative inputTokens', async () => {
-    const input = createTestEventInput();
-    const events = [{ ...input, usage: { ...input.usage, inputTokens: -1 } }];
-    const result = await ingestUsageEvents(
-      { logger, usageEventRepository: eventRepo, usageAggregateRepository: aggregateRepo },
-      events,
-      'internal',
-    );
-
-    expect(result.rejected).toHaveLength(1);
-    expect(result.rejected[0]?.code).toBe('INVALID_INPUT_TOKENS');
-  });
-
-  it('rejects events with negative outputTokens', async () => {
-    const input = createTestEventInput();
-    const events = [{ ...input, usage: { ...input.usage, outputTokens: -1 } }];
-    const result = await ingestUsageEvents(
-      { logger, usageEventRepository: eventRepo, usageAggregateRepository: aggregateRepo },
-      events,
-      'internal',
-    );
-
-    expect(result.rejected).toHaveLength(1);
-    expect(result.rejected[0]?.code).toBe('INVALID_OUTPUT_TOKENS');
-  });
-
-  it('rejects events with negative totalTokens', async () => {
-    const input = createTestEventInput();
-    const events = [{ ...input, usage: { ...input.usage, totalTokens: -1 } }];
-    const result = await ingestUsageEvents(
-      { logger, usageEventRepository: eventRepo, usageAggregateRepository: aggregateRepo },
-      events,
-      'internal',
-    );
-
-    expect(result.rejected).toHaveLength(1);
-    expect(result.rejected[0]?.code).toBe('INVALID_TOTAL_TOKENS');
-  });
-
-  it('rejects events with missing cost', async () => {
-    const events = [{ ...createTestEventInput(), cost: undefined } as unknown as UsageEventInput];
-    const result = await ingestUsageEvents(
-      { logger, usageEventRepository: eventRepo, usageAggregateRepository: aggregateRepo },
-      events,
-      'internal',
-    );
-
-    expect(result.rejected).toHaveLength(1);
-    expect(result.rejected[0]?.code).toBe('INVALID_COST');
-  });
-
-  it('rejects events with negative billedUsd', async () => {
-    const input = createTestEventInput();
-    const events = [{ ...input, cost: { ...input.cost, billedUsd: -0.01 } }];
-    const result = await ingestUsageEvents(
-      { logger, usageEventRepository: eventRepo, usageAggregateRepository: aggregateRepo },
-      events,
-      'internal',
-    );
-
-    expect(result.rejected).toHaveLength(1);
-    expect(result.rejected[0]?.code).toBe('INVALID_BILLED_USD');
-  });
-
-  it('rejects events with invalid pricingSource', async () => {
-    const input = createTestEventInput();
-    const events = [{ ...input, cost: { ...input.cost, pricingSource: 'invalid' as 'calculated' } }];
-    const result = await ingestUsageEvents(
-      { logger, usageEventRepository: eventRepo, usageAggregateRepository: aggregateRepo },
-      events,
-      'internal',
-    );
-
-    expect(result.rejected).toHaveLength(1);
-    expect(result.rejected[0]?.code).toBe('INVALID_PRICING_SOURCE');
-  });
-
-  it('rejects events with missing correlation', async () => {
-    const events = [{ ...createTestEventInput(), correlation: null } as unknown as UsageEventInput];
-    const result = await ingestUsageEvents(
-      { logger, usageEventRepository: eventRepo, usageAggregateRepository: aggregateRepo },
-      events,
-      'internal',
-    );
-
-    expect(result.rejected).toHaveLength(1);
-    expect(result.rejected[0]?.code).toBe('INVALID_CORRELATION');
-  });
-
   it('handles repository create failure', async () => {
     eventRepo.setFailure({ code: 'FIRESTORE_ERROR', message: 'connection failed' });
     const events = [createTestEventInput({ eventId: 'evt_fail' })];
@@ -405,256 +103,7 @@ describe('ingestUsageEvents', () => {
     expect(result.accepted).toBe(1);
   });
 
-  it('rejects events with non-string eventId', async () => {
-    const events = [{ ...createTestEventInput(), eventId: 123 as unknown as string }];
-    const result = await ingestUsageEvents(
-      { logger, usageEventRepository: eventRepo, usageAggregateRepository: aggregateRepo },
-      events,
-      'internal',
-    );
-
-    expect(result.rejected).toHaveLength(1);
-    expect(result.rejected[0]?.code).toBe('INVALID_EVENT_ID');
-  });
-
-  it('rejects events with non-string occurredAt', async () => {
-    const events = [{ ...createTestEventInput(), occurredAt: 123 as unknown as string }];
-    const result = await ingestUsageEvents(
-      { logger, usageEventRepository: eventRepo, usageAggregateRepository: aggregateRepo },
-      events,
-      'internal',
-    );
-
-    expect(result.rejected).toHaveLength(1);
-    expect(result.rejected[0]?.code).toBe('INVALID_OCCURRED_AT');
-  });
-
-  it('rejects events with non-string owner.id', async () => {
-    const events = [createTestEventInput({ owner: { type: 'user', id: 123 as unknown as string } })];
-    const result = await ingestUsageEvents(
-      { logger, usageEventRepository: eventRepo, usageAggregateRepository: aggregateRepo },
-      events,
-      'internal',
-    );
-
-    expect(result.rejected).toHaveLength(1);
-    expect(result.rejected[0]?.code).toBe('INVALID_OWNER_ID');
-  });
-
-  it('rejects events with non-string source.service', async () => {
-    const events = [createTestEventInput({
-      source: { service: 123 as unknown as string, component: 'c', client: 'web', environment: 'dev' },
-    })];
-    const result = await ingestUsageEvents(
-      { logger, usageEventRepository: eventRepo, usageAggregateRepository: aggregateRepo },
-      events,
-      'internal',
-    );
-
-    expect(result.rejected).toHaveLength(1);
-    expect(result.rejected[0]?.code).toBe('INVALID_SOURCE_SERVICE');
-  });
-
-  it('rejects events with non-string source.component', async () => {
-    const events = [createTestEventInput({
-      source: { service: 'svc', component: 123 as unknown as string, client: 'web', environment: 'dev' },
-    })];
-    const result = await ingestUsageEvents(
-      { logger, usageEventRepository: eventRepo, usageAggregateRepository: aggregateRepo },
-      events,
-      'internal',
-    );
-
-    expect(result.rejected).toHaveLength(1);
-    expect(result.rejected[0]?.code).toBe('INVALID_SOURCE_COMPONENT');
-  });
-
-  it('rejects events with non-string source.client', async () => {
-    const events = [createTestEventInput({
-      source: { service: 'svc', component: 'comp', client: 123 as unknown as string, environment: 'dev' },
-    })];
-    const result = await ingestUsageEvents(
-      { logger, usageEventRepository: eventRepo, usageAggregateRepository: aggregateRepo },
-      events,
-      'internal',
-    );
-
-    expect(result.rejected).toHaveLength(1);
-    expect(result.rejected[0]?.code).toBe('INVALID_SOURCE_CLIENT');
-  });
-
-  it('rejects events with non-string request.model', async () => {
-    const events = [createTestEventInput({
-      request: { provider: LlmProviders.OpenAI, model: 123 as unknown as string, operation: 'generate', success: true, durationMs: 100 },
-    })];
-    const result = await ingestUsageEvents(
-      { logger, usageEventRepository: eventRepo, usageAggregateRepository: aggregateRepo },
-      events,
-      'internal',
-    );
-
-    expect(result.rejected).toHaveLength(1);
-    expect(result.rejected[0]?.code).toBe('INVALID_MODEL');
-  });
-
-  it('rejects events with non-number durationMs', async () => {
-    const events = [createTestEventInput({
-      request: { provider: LlmProviders.OpenAI, model: 'gpt-4o', operation: 'generate', success: true, durationMs: 'fast' as unknown as number },
-    })];
-    const result = await ingestUsageEvents(
-      { logger, usageEventRepository: eventRepo, usageAggregateRepository: aggregateRepo },
-      events,
-      'internal',
-    );
-
-    expect(result.rejected).toHaveLength(1);
-    expect(result.rejected[0]?.code).toBe('INVALID_DURATION');
-  });
-
-  it('rejects events with non-number inputTokens', async () => {
-    const input = createTestEventInput();
-    const events = [{ ...input, usage: { ...input.usage, inputTokens: 'many' as unknown as number } }];
-    const result = await ingestUsageEvents(
-      { logger, usageEventRepository: eventRepo, usageAggregateRepository: aggregateRepo },
-      events,
-      'internal',
-    );
-
-    expect(result.rejected).toHaveLength(1);
-    expect(result.rejected[0]?.code).toBe('INVALID_INPUT_TOKENS');
-  });
-
-  it('rejects events with non-number outputTokens', async () => {
-    const input = createTestEventInput();
-    const events = [{ ...input, usage: { ...input.usage, outputTokens: 'many' as unknown as number } }];
-    const result = await ingestUsageEvents(
-      { logger, usageEventRepository: eventRepo, usageAggregateRepository: aggregateRepo },
-      events,
-      'internal',
-    );
-
-    expect(result.rejected).toHaveLength(1);
-    expect(result.rejected[0]?.code).toBe('INVALID_OUTPUT_TOKENS');
-  });
-
-  it('rejects events with non-number totalTokens', async () => {
-    const input = createTestEventInput();
-    const events = [{ ...input, usage: { ...input.usage, totalTokens: 'many' as unknown as number } }];
-    const result = await ingestUsageEvents(
-      { logger, usageEventRepository: eventRepo, usageAggregateRepository: aggregateRepo },
-      events,
-      'internal',
-    );
-
-    expect(result.rejected).toHaveLength(1);
-    expect(result.rejected[0]?.code).toBe('INVALID_TOTAL_TOKENS');
-  });
-
-  it('rejects events with invalid occurredAt timestamp', async () => {
-    const events = [createTestEventInput({ occurredAt: 'not-a-date' })];
-    const result = await ingestUsageEvents(
-      { logger, usageEventRepository: eventRepo, usageAggregateRepository: aggregateRepo },
-      events,
-      'internal',
-    );
-
-    expect(result.rejected).toHaveLength(1);
-    expect(result.rejected[0]?.code).toBe('INVALID_OCCURRED_AT');
-    expect(result.rejected[0]?.message).toBe('occurredAt must be a valid ISO timestamp');
-  });
-
-  it('rejects events with negative cacheReadTokens', async () => {
-    const input = createTestEventInput();
-    const events = [{ ...input, usage: { ...input.usage, cacheReadTokens: -1 } }];
-    const result = await ingestUsageEvents(
-      { logger, usageEventRepository: eventRepo, usageAggregateRepository: aggregateRepo },
-      events,
-      'internal',
-    );
-
-    expect(result.rejected).toHaveLength(1);
-    expect(result.rejected[0]?.code).toBe('INVALID_CACHE_READ_TOKENS');
-  });
-
-  it('rejects events with negative cacheWriteTokens', async () => {
-    const input = createTestEventInput();
-    const events = [{ ...input, usage: { ...input.usage, cacheWriteTokens: -1 } }];
-    const result = await ingestUsageEvents(
-      { logger, usageEventRepository: eventRepo, usageAggregateRepository: aggregateRepo },
-      events,
-      'internal',
-    );
-
-    expect(result.rejected).toHaveLength(1);
-    expect(result.rejected[0]?.code).toBe('INVALID_CACHE_WRITE_TOKENS');
-  });
-
-  it('rejects events with negative cachedTokens', async () => {
-    const input = createTestEventInput();
-    const events = [{ ...input, usage: { ...input.usage, cachedTokens: -1 } }];
-    const result = await ingestUsageEvents(
-      { logger, usageEventRepository: eventRepo, usageAggregateRepository: aggregateRepo },
-      events,
-      'internal',
-    );
-
-    expect(result.rejected).toHaveLength(1);
-    expect(result.rejected[0]?.code).toBe('INVALID_CACHED_TOKENS');
-  });
-
-  it('rejects events with negative reasoningTokens', async () => {
-    const input = createTestEventInput();
-    const events = [{ ...input, usage: { ...input.usage, reasoningTokens: -1 } }];
-    const result = await ingestUsageEvents(
-      { logger, usageEventRepository: eventRepo, usageAggregateRepository: aggregateRepo },
-      events,
-      'internal',
-    );
-
-    expect(result.rejected).toHaveLength(1);
-    expect(result.rejected[0]?.code).toBe('INVALID_REASONING_TOKENS');
-  });
-
-  it('rejects events with negative thinkingTokens', async () => {
-    const input = createTestEventInput();
-    const events = [{ ...input, usage: { ...input.usage, thinkingTokens: -1 } }];
-    const result = await ingestUsageEvents(
-      { logger, usageEventRepository: eventRepo, usageAggregateRepository: aggregateRepo },
-      events,
-      'internal',
-    );
-
-    expect(result.rejected).toHaveLength(1);
-    expect(result.rejected[0]?.code).toBe('INVALID_THINKING_TOKENS');
-  });
-
-  it('rejects events with negative webSearchCalls', async () => {
-    const input = createTestEventInput();
-    const events = [{ ...input, usage: { ...input.usage, webSearchCalls: -1 } }];
-    const result = await ingestUsageEvents(
-      { logger, usageEventRepository: eventRepo, usageAggregateRepository: aggregateRepo },
-      events,
-      'internal',
-    );
-
-    expect(result.rejected).toHaveLength(1);
-    expect(result.rejected[0]?.code).toBe('INVALID_WEB_SEARCH_CALLS');
-  });
-
-  it('rejects events with negative imageCount', async () => {
-    const input = createTestEventInput();
-    const events = [{ ...input, usage: { ...input.usage, imageCount: -1 } }];
-    const result = await ingestUsageEvents(
-      { logger, usageEventRepository: eventRepo, usageAggregateRepository: aggregateRepo },
-      events,
-      'internal',
-    );
-
-    expect(result.rejected).toHaveLength(1);
-    expect(result.rejected[0]?.code).toBe('INVALID_IMAGE_COUNT');
-  });
-
-  it('handles mixed batch (valid + duplicate + invalid)', async () => {
+  it('handles mixed batch (valid + duplicate)', async () => {
     // Pre-seed the duplicate
     await ingestUsageEvents(
       { logger, usageEventRepository: eventRepo, usageAggregateRepository: aggregateRepo },
@@ -662,50 +111,21 @@ describe('ingestUsageEvents', () => {
       'internal',
     );
 
-    // Reset aggregate counter after pre-seed
     const preIncrementCount = aggregateRepo.getIncrementCallCount();
 
     const result = await ingestUsageEvents(
       { logger, usageEventRepository: eventRepo, usageAggregateRepository: aggregateRepo },
       [
-        createTestEventInput({ eventId: 'evt_new' }),  // valid
-        createTestEventInput({ eventId: 'evt_dup' }),  // duplicate
-        createTestEventInput({ eventId: '' }),          // invalid
+        createTestEventInput({ eventId: 'evt_new' }), // valid
+        createTestEventInput({ eventId: 'evt_dup' }), // duplicate (pre-seeded above)
       ],
       'internal',
     );
 
     expect(result.accepted).toBe(1);
     expect(result.duplicates).toBe(1);
-    expect(result.rejected).toHaveLength(1);
-    expect(result.rejected[0]?.code).toBe('INVALID_EVENT_ID');
-    // Only the valid event should have incremented the aggregate
+    expect(result.rejected).toHaveLength(0);
+    // Only the new valid event should have incremented the aggregate
     expect(aggregateRepo.getIncrementCallCount()).toBe(preIncrementCount + 1);
-  });
-
-  it('rejects events with non-boolean groundingEnabled', async () => {
-    const input = createTestEventInput();
-    const events = [{ ...input, usage: { ...input.usage, groundingEnabled: 'yes' as unknown as boolean } }];
-    const result = await ingestUsageEvents(
-      { logger, usageEventRepository: eventRepo, usageAggregateRepository: aggregateRepo },
-      events,
-      'internal',
-    );
-
-    expect(result.rejected).toHaveLength(1);
-    expect(result.rejected[0]?.code).toBe('INVALID_GROUNDING_ENABLED');
-  });
-
-  it('rejects events with non-number billedUsd', async () => {
-    const input = createTestEventInput();
-    const events = [{ ...input, cost: { ...input.cost, billedUsd: 'cheap' as unknown as number } }];
-    const result = await ingestUsageEvents(
-      { logger, usageEventRepository: eventRepo, usageAggregateRepository: aggregateRepo },
-      events,
-      'internal',
-    );
-
-    expect(result.rejected).toHaveLength(1);
-    expect(result.rejected[0]?.code).toBe('INVALID_BILLED_USD');
   });
 });

--- a/apps/llm-usage-service/src/__tests__/helpers.ts
+++ b/apps/llm-usage-service/src/__tests__/helpers.ts
@@ -15,6 +15,7 @@ export function createTestEventInput(overrides?: Partial<UsageEventInput>): Usag
       component: 'research',
       client: 'web',
       environment: 'dev',
+      workerLocation: 'home-dev',
     },
     request: {
       provider: LlmProviders.Anthropic,

--- a/apps/llm-usage-service/src/__tests__/routes/internalUsageRoutes.test.ts
+++ b/apps/llm-usage-service/src/__tests__/routes/internalUsageRoutes.test.ts
@@ -82,6 +82,107 @@ describe('internalUsageRoutes', () => {
 
       expect(response.statusCode).toBe(400);
     });
+
+    it('rejects events missing source.environment', async () => {
+      const validEvent = createTestEventInput({ eventId: 'evt_missing_env' });
+      const { environment: _omitted, ...sourceWithoutEnv } = validEvent.source;
+      const response = await app.inject({
+        method: 'POST',
+        url: '/internal/usage/events',
+        headers: { 'x-internal-auth': AUTH_TOKEN },
+        payload: {
+          schemaVersion: 1,
+          events: [{ ...validEvent, source: sourceWithoutEnv }],
+        },
+      });
+
+      expect(response.statusCode).toBe(400);
+      const body = JSON.parse(response.body) as {
+        success: boolean;
+        error: {
+          code: string;
+          message: string;
+          details?: { errors?: { path: string; message: string }[] };
+        };
+      };
+      expect(body.success).toBe(false);
+      expect(body.error.code).toBe('INVALID_REQUEST');
+      const errors = body.error.details?.errors ?? [];
+      expect(
+        errors.some((e) => e.path.includes('source/environment') || e.path.includes('environment') || e.path.endsWith('source'))
+      ).toBe(true);
+      expect(eventRepo.getStoredEvents()).toHaveLength(0);
+    });
+
+    it('rejects events with invalid source.environment enum value', async () => {
+      const validEvent = createTestEventInput({ eventId: 'evt_bad_env' });
+      const response = await app.inject({
+        method: 'POST',
+        url: '/internal/usage/events',
+        headers: { 'x-internal-auth': AUTH_TOKEN },
+        payload: {
+          schemaVersion: 1,
+          events: [{
+            ...validEvent,
+            source: { ...validEvent.source, environment: 'staging' },
+          }],
+        },
+      });
+
+      expect(response.statusCode).toBe(400);
+      const body = JSON.parse(response.body) as {
+        success: boolean;
+        error: { code: string; details?: { errors?: { path: string }[] } };
+      };
+      expect(body.success).toBe(false);
+      expect(body.error.code).toBe('INVALID_REQUEST');
+      expect(eventRepo.getStoredEvents()).toHaveLength(0);
+    });
+
+    it('rejects events with unknown top-level field (additionalProperties: false)', async () => {
+      const validEvent = createTestEventInput({ eventId: 'evt_bogus' });
+      const response = await app.inject({
+        method: 'POST',
+        url: '/internal/usage/events',
+        headers: { 'x-internal-auth': AUTH_TOKEN },
+        payload: {
+          schemaVersion: 1,
+          events: [{ ...validEvent, bogus: 1 }],
+        },
+      });
+
+      expect(response.statusCode).toBe(400);
+      const body = JSON.parse(response.body) as {
+        success: boolean;
+        error: { code: string };
+      };
+      expect(body.success).toBe(false);
+      expect(body.error.code).toBe('INVALID_REQUEST');
+      expect(eventRepo.getStoredEvents()).toHaveLength(0);
+    });
+
+    it('rejects entire batch when any single event is malformed (full-batch rejection)', async () => {
+      const validEvent1 = createTestEventInput({ eventId: 'evt_batch_1' });
+      const validEvent3 = createTestEventInput({ eventId: 'evt_batch_3' });
+      const malformedEvent = {
+        ...validEvent1,
+        eventId: 'evt_batch_2_bad',
+        usage: { ...validEvent1.usage, inputTokens: -5 },
+      };
+      const response = await app.inject({
+        method: 'POST',
+        url: '/internal/usage/events',
+        headers: { 'x-internal-auth': AUTH_TOKEN },
+        payload: {
+          schemaVersion: 1,
+          events: [validEvent1, malformedEvent, validEvent3],
+        },
+      });
+
+      expect(response.statusCode).toBe(400);
+      // Full-batch rejection: zero events persisted even though events[0] and events[2] were valid
+      expect(eventRepo.getStoredEvents()).toHaveLength(0);
+    });
   });
 
   describe('POST /internal/usage/query', () => {

--- a/apps/llm-usage-service/src/__tests__/routes/webhookUsageRoutes.test.ts
+++ b/apps/llm-usage-service/src/__tests__/routes/webhookUsageRoutes.test.ts
@@ -48,12 +48,11 @@ describe('webhookUsageRoutes', () => {
 
   describe('POST /internal/webhooks/usage-events', () => {
     it('returns 200 for valid signed request with orchestrator events', async () => {
+      // Factory default already produces an orchestrator event with workerLocation,
+      // so no source override needed.
       const payload = {
         schemaVersion: 1,
-        events: [createTestEventInput({
-          eventId: 'evt_wh_1',
-          source: { service: 'orchestrator', component: 'research', client: 'web', environment: 'dev' },
-        })],
+        events: [createTestEventInput({ eventId: 'evt_wh_1' })],
       };
       const { timestamp, signature } = signPayload(payload);
 
@@ -102,11 +101,18 @@ describe('webhookUsageRoutes', () => {
     });
 
     it('rejects events with non-orchestrator source.service', async () => {
+      // workerLocation is included so the ONLY violation is the const: 'orchestrator' constraint
       const payload = {
         schemaVersion: 1,
         events: [createTestEventInput({
           eventId: 'evt_wh_bad',
-          source: { service: 'other-service', component: 'research', client: 'web', environment: 'dev' },
+          source: {
+            service: 'other-service',
+            component: 'research',
+            client: 'web',
+            environment: 'dev',
+            workerLocation: 'home-dev',
+          },
         })],
       };
       const { timestamp, signature } = signPayload(payload);
@@ -122,8 +128,57 @@ describe('webhookUsageRoutes', () => {
       });
 
       expect(response.statusCode).toBe(400);
-      const body = JSON.parse(response.body) as { error: { message: string } };
-      expect(body.error.message).toContain('orchestrator');
+      const body = JSON.parse(response.body) as {
+        success: boolean;
+        error: {
+          code: string;
+          message: string;
+          details?: { errors?: { path: string; message: string }[] };
+        };
+      };
+      expect(body.success).toBe(false);
+      expect(body.error.code).toBe('INVALID_REQUEST');
+      // Assertion on the envelope-shaped error path; 'source/service' indicates the const constraint fired
+      const errors = body.error.details?.errors ?? [];
+      expect(errors.some((e) => e.path.includes('source/service') || e.path.includes('service'))).toBe(true);
+      expect(eventRepo.getStoredEvents()).toHaveLength(0);
+    });
+
+    it('rejects orchestrator webhook payload missing source.workerLocation', async () => {
+      // orchestrator event but source override drops workerLocation
+      const payload = {
+        schemaVersion: 1,
+        events: [createTestEventInput({
+          eventId: 'evt_wh_no_loc',
+          source: {
+            service: 'orchestrator',
+            component: 'research',
+            client: 'web',
+            environment: 'dev',
+            // workerLocation intentionally omitted
+          },
+        })],
+      };
+      const { timestamp, signature } = signPayload(payload);
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/internal/webhooks/usage-events',
+        headers: {
+          'x-request-timestamp': timestamp,
+          'x-request-signature': signature,
+        },
+        payload,
+      });
+
+      expect(response.statusCode).toBe(400);
+      const body = JSON.parse(response.body) as {
+        success: boolean;
+        error: { code: string; details?: { errors?: { path: string }[] } };
+      };
+      expect(body.success).toBe(false);
+      expect(body.error.code).toBe('INVALID_REQUEST');
+      expect(eventRepo.getStoredEvents()).toHaveLength(0);
     });
 
     it('returns 400 for invalid schemaVersion', async () => {

--- a/apps/llm-usage-service/src/domain/models/usageEvent.ts
+++ b/apps/llm-usage-service/src/domain/models/usageEvent.ts
@@ -18,6 +18,12 @@ export interface UsageEvent {
     component: string;
     client: string;
     environment: 'dev' | 'prod' | 'test';
+    /**
+     * Physical location identifier of the orchestrator that produced this event
+     * (e.g. 'home-dev', 'mac-dev', 'office-pc'). Required at the webhook endpoint
+     * (enforced by OrchestratorUsageEventInput schema); optional on the internal endpoint.
+     */
+    workerLocation?: string;
   };
 
   request: {

--- a/apps/llm-usage-service/src/domain/usecases/ingestUsageEvents.ts
+++ b/apps/llm-usage-service/src/domain/usecases/ingestUsageEvents.ts
@@ -1,155 +1,8 @@
 import type { Logger } from '@intexuraos/common-core';
 import { isErr } from '@intexuraos/common-core';
-import { LlmProviders } from '@intexuraos/llm-contract';
 import type { UsageEventInput, UsageIngestResponse, RejectedEvent, UsageEvent } from '../models/usageEvent.js';
 import type { UsageEventRepository } from '../repositories/usageEventRepository.js';
 import type { UsageAggregateRepository } from '../repositories/usageAggregateRepository.js';
-
-const VALID_PROVIDERS = [LlmProviders.Google, LlmProviders.OpenAI, LlmProviders.Anthropic, LlmProviders.Perplexity, LlmProviders.OpenRouter] as const;
-const VALID_OPERATIONS = [
-  'research', 'generate', 'image_generation', 'tool_calling',
-  'visualization_insights', 'visualization_vegalite', 'other',
-] as const;
-const VALID_OWNER_TYPES = ['user', 'system'] as const;
-const VALID_ENVIRONMENTS = ['dev', 'prod', 'test'] as const;
-const VALID_PRICING_SOURCES = ['provider_reported', 'calculated', 'mixed', 'external'] as const;
-
-/**
- * Validates untrusted JSON input that has been cast to UsageEventInput.
- * The runtime checks guard against malformed payloads that bypass TypeScript's
- * compile-time guarantees.
- */
-function validateEvent(typedInput: UsageEventInput, index: number): RejectedEvent | null {
-  // Cast to unknown to perform runtime validation on untrusted JSON
-  const input = typedInput as unknown as Record<string, unknown>;
-
-  if (input['schemaVersion'] !== 1) {
-    return { index, code: 'INVALID_SCHEMA_VERSION', message: 'schemaVersion must be 1' };
-  }
-
-  if (typeof input['eventId'] !== 'string' || input['eventId'].length === 0) {
-    return { index, code: 'INVALID_EVENT_ID', message: 'eventId is required and must be a non-empty string' };
-  }
-
-  if (typeof input['occurredAt'] !== 'string' || input['occurredAt'].length === 0) {
-    return { index, code: 'INVALID_OCCURRED_AT', message: 'occurredAt is required and must be a non-empty ISO timestamp' };
-  }
-
-  const parsedDate = new Date(input['occurredAt']);
-  if (Number.isNaN(parsedDate.getTime())) {
-    return { index, code: 'INVALID_OCCURRED_AT', message: 'occurredAt must be a valid ISO timestamp' };
-  }
-
-  // Validate owner
-  const owner = input['owner'] as Record<string, unknown> | undefined | null;
-  if (owner === undefined || owner === null) {
-    return { index, code: 'INVALID_OWNER', message: 'owner is required' };
-  }
-  if (!VALID_OWNER_TYPES.includes(owner['type'] as typeof VALID_OWNER_TYPES[number])) {
-    return { index, code: 'INVALID_OWNER_TYPE', message: `owner.type must be one of: ${VALID_OWNER_TYPES.join(', ')}` };
-  }
-  if (typeof owner['id'] !== 'string' || owner['id'].length === 0) {
-    return { index, code: 'INVALID_OWNER_ID', message: 'owner.id is required and must be a non-empty string' };
-  }
-
-  // Validate source
-  const source = input['source'] as Record<string, unknown> | undefined | null;
-  if (source === undefined || source === null) {
-    return { index, code: 'INVALID_SOURCE', message: 'source is required' };
-  }
-  if (typeof source['service'] !== 'string' || source['service'].length === 0) {
-    return { index, code: 'INVALID_SOURCE_SERVICE', message: 'source.service is required' };
-  }
-  if (typeof source['component'] !== 'string' || source['component'].length === 0) {
-    return { index, code: 'INVALID_SOURCE_COMPONENT', message: 'source.component is required' };
-  }
-  if (typeof source['client'] !== 'string' || source['client'].length === 0) {
-    return { index, code: 'INVALID_SOURCE_CLIENT', message: 'source.client is required' };
-  }
-  if (!VALID_ENVIRONMENTS.includes(source['environment'] as typeof VALID_ENVIRONMENTS[number])) {
-    return { index, code: 'INVALID_SOURCE_ENVIRONMENT', message: `source.environment must be one of: ${VALID_ENVIRONMENTS.join(', ')}` };
-  }
-
-  // Validate request
-  const request = input['request'] as Record<string, unknown> | undefined | null;
-  if (request === undefined || request === null) {
-    return { index, code: 'INVALID_REQUEST', message: 'request is required' };
-  }
-  if (!VALID_PROVIDERS.includes(request['provider'] as typeof VALID_PROVIDERS[number])) {
-    return { index, code: 'INVALID_PROVIDER', message: `request.provider must be one of: ${VALID_PROVIDERS.join(', ')}` };
-  }
-  if (typeof request['model'] !== 'string' || request['model'].length === 0) {
-    return { index, code: 'INVALID_MODEL', message: 'request.model is required' };
-  }
-  if (!VALID_OPERATIONS.includes(request['operation'] as typeof VALID_OPERATIONS[number])) {
-    return { index, code: 'INVALID_OPERATION', message: `request.operation must be one of: ${VALID_OPERATIONS.join(', ')}` };
-  }
-  if (typeof request['success'] !== 'boolean') {
-    return { index, code: 'INVALID_SUCCESS', message: 'request.success must be a boolean' };
-  }
-  if (typeof request['durationMs'] !== 'number' || request['durationMs'] < 0) {
-    return { index, code: 'INVALID_DURATION', message: 'request.durationMs must be a non-negative number' };
-  }
-
-  // Validate usage
-  const usage = input['usage'] as Record<string, unknown> | undefined | null;
-  if (usage === undefined || usage === null) {
-    return { index, code: 'INVALID_USAGE', message: 'usage is required' };
-  }
-  if (typeof usage['inputTokens'] !== 'number' || usage['inputTokens'] < 0) {
-    return { index, code: 'INVALID_INPUT_TOKENS', message: 'usage.inputTokens must be a non-negative number' };
-  }
-  if (typeof usage['outputTokens'] !== 'number' || usage['outputTokens'] < 0) {
-    return { index, code: 'INVALID_OUTPUT_TOKENS', message: 'usage.outputTokens must be a non-negative number' };
-  }
-  if (typeof usage['totalTokens'] !== 'number' || usage['totalTokens'] < 0) {
-    return { index, code: 'INVALID_TOTAL_TOKENS', message: 'usage.totalTokens must be a non-negative number' };
-  }
-  if (typeof usage['cacheReadTokens'] !== 'number' || usage['cacheReadTokens'] < 0) {
-    return { index, code: 'INVALID_CACHE_READ_TOKENS', message: 'usage.cacheReadTokens must be >= 0' };
-  }
-  if (typeof usage['cacheWriteTokens'] !== 'number' || usage['cacheWriteTokens'] < 0) {
-    return { index, code: 'INVALID_CACHE_WRITE_TOKENS', message: 'usage.cacheWriteTokens must be >= 0' };
-  }
-  if (typeof usage['cachedTokens'] !== 'number' || usage['cachedTokens'] < 0) {
-    return { index, code: 'INVALID_CACHED_TOKENS', message: 'usage.cachedTokens must be >= 0' };
-  }
-  if (typeof usage['reasoningTokens'] !== 'number' || usage['reasoningTokens'] < 0) {
-    return { index, code: 'INVALID_REASONING_TOKENS', message: 'usage.reasoningTokens must be >= 0' };
-  }
-  if (typeof usage['thinkingTokens'] !== 'number' || usage['thinkingTokens'] < 0) {
-    return { index, code: 'INVALID_THINKING_TOKENS', message: 'usage.thinkingTokens must be >= 0' };
-  }
-  if (typeof usage['webSearchCalls'] !== 'number' || usage['webSearchCalls'] < 0) {
-    return { index, code: 'INVALID_WEB_SEARCH_CALLS', message: 'usage.webSearchCalls must be >= 0' };
-  }
-  if (typeof usage['groundingEnabled'] !== 'boolean') {
-    return { index, code: 'INVALID_GROUNDING_ENABLED', message: 'usage.groundingEnabled must be a boolean' };
-  }
-  if (typeof usage['imageCount'] !== 'number' || usage['imageCount'] < 0) {
-    return { index, code: 'INVALID_IMAGE_COUNT', message: 'usage.imageCount must be >= 0' };
-  }
-
-  // Validate cost
-  const cost = input['cost'] as Record<string, unknown> | undefined | null;
-  if (cost === undefined || cost === null) {
-    return { index, code: 'INVALID_COST', message: 'cost is required' };
-  }
-  if (typeof cost['billedUsd'] !== 'number' || cost['billedUsd'] < 0) {
-    return { index, code: 'INVALID_BILLED_USD', message: 'cost.billedUsd must be a non-negative number' };
-  }
-  if (!VALID_PRICING_SOURCES.includes(cost['pricingSource'] as typeof VALID_PRICING_SOURCES[number])) {
-    return { index, code: 'INVALID_PRICING_SOURCE', message: `cost.pricingSource must be one of: ${VALID_PRICING_SOURCES.join(', ')}` };
-  }
-
-  // Validate correlation
-  const correlation = input['correlation'];
-  if (correlation === undefined || correlation === null) {
-    return { index, code: 'INVALID_CORRELATION', message: 'correlation is required' };
-  }
-
-  return null;
-}
 
 export interface IngestUsageEventsDeps {
   logger: Logger;
@@ -176,11 +29,10 @@ export async function ingestUsageEvents(
       continue;
     }
 
-    const validationError = validateEvent(input, i);
-    if (validationError !== null) {
-      rejected.push(validationError);
-      continue;
-    }
+    // Structural validation (schemaVersion, field presence/types/enums, additionalProperties)
+    // is performed by the Fastify route schema (UsageEventInput / OrchestratorUsageEventInput)
+    // before this use case runs. Malformed events never reach here; the only rejection path
+    // remaining is Firestore createEvent failures below.
 
     const fullEvent: UsageEvent = {
       ...input,

--- a/apps/llm-usage-service/src/routes/internalUsageRoutes.ts
+++ b/apps/llm-usage-service/src/routes/internalUsageRoutes.ts
@@ -38,7 +38,7 @@ export const internalUsageRoutes: FastifyPluginCallback = (app, _opts, done) => 
             schemaVersion: { type: 'integer', enum: [1] },
             events: {
               type: 'array',
-              items: { type: 'object' },
+              items: { $ref: 'UsageEventInput#' },
             },
           },
         },

--- a/apps/llm-usage-service/src/routes/schemas/usageEventSchema.ts
+++ b/apps/llm-usage-service/src/routes/schemas/usageEventSchema.ts
@@ -1,0 +1,207 @@
+import type { FastifyInstance } from 'fastify';
+import { LlmProviders } from '@intexuraos/llm-contract';
+
+const PROVIDER_VALUES = Object.values(LlmProviders);
+
+/**
+ * Base usage event input JSON Schema. Mirrors the UsageEventInput TypeScript
+ * type in apps/llm-usage-service/src/domain/models/usageEvent.ts exactly.
+ *
+ * Used as the body.items schema for POST /internal/usage/events. The webhook
+ * endpoint references the stricter OrchestratorUsageEventInput below.
+ *
+ * `additionalProperties: false` is set at every object level so unknown fields
+ * are rejected with a 400, not silently accepted.
+ */
+export const usageEventInputSchema = {
+  $id: 'UsageEventInput',
+  type: 'object',
+  additionalProperties: false,
+  required: [
+    'schemaVersion',
+    'eventId',
+    'occurredAt',
+    'owner',
+    'source',
+    'request',
+    'usage',
+    'cost',
+    'correlation',
+    'error',
+  ],
+  properties: {
+    schemaVersion: { type: 'integer', enum: [1] },
+    eventId: { type: 'string', minLength: 1 },
+    occurredAt: { type: 'string', format: 'date-time' },
+    owner: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['type', 'id'],
+      properties: {
+        type: { type: 'string', enum: ['user', 'system'] },
+        id: { type: 'string', minLength: 1 },
+      },
+    },
+    source: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['service', 'component', 'client', 'environment'],
+      properties: {
+        service: { type: 'string', minLength: 1 },
+        component: { type: 'string', minLength: 1 },
+        client: { type: 'string', minLength: 1 },
+        environment: {
+          type: 'string',
+          enum: ['dev', 'prod', 'test'],
+          description:
+            'The intexuraos environment of the caller that originated this usage. For events emitted by the orchestrator, this is the environment of the code-agent that dispatched the task, NOT the orchestrator\'s own environment (the orchestrator has no environment, only a location).',
+        },
+        workerLocation: {
+          type: 'string',
+          minLength: 1,
+          description:
+            "Physical location identifier of the orchestrator that produced this event (e.g. 'home-dev', 'mac-dev', 'office-pc'). Required at the webhook endpoint (via OrchestratorUsageEventInput); optional on the internal endpoint.",
+        },
+      },
+    },
+    request: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['provider', 'model', 'operation', 'success', 'durationMs'],
+      properties: {
+        provider: { type: 'string', enum: PROVIDER_VALUES },
+        model: { type: 'string', minLength: 1 },
+        operation: {
+          type: 'string',
+          enum: [
+            'research',
+            'generate',
+            'image_generation',
+            'tool_calling',
+            'visualization_insights',
+            'visualization_vegalite',
+            'other',
+          ],
+        },
+        success: { type: 'boolean' },
+        durationMs: { type: 'number', minimum: 0 },
+      },
+    },
+    usage: {
+      type: 'object',
+      additionalProperties: false,
+      required: [
+        'inputTokens',
+        'outputTokens',
+        'totalTokens',
+        'cacheReadTokens',
+        'cacheWriteTokens',
+        'cachedTokens',
+        'reasoningTokens',
+        'thinkingTokens',
+        'webSearchCalls',
+        'groundingEnabled',
+        'imageCount',
+      ],
+      properties: {
+        inputTokens: { type: 'number', minimum: 0 },
+        outputTokens: { type: 'number', minimum: 0 },
+        totalTokens: { type: 'number', minimum: 0 },
+        cacheReadTokens: { type: 'number', minimum: 0 },
+        cacheWriteTokens: { type: 'number', minimum: 0 },
+        cachedTokens: { type: 'number', minimum: 0 },
+        reasoningTokens: { type: 'number', minimum: 0 },
+        thinkingTokens: { type: 'number', minimum: 0 },
+        webSearchCalls: { type: 'number', minimum: 0 },
+        groundingEnabled: { type: 'boolean' },
+        imageCount: { type: 'number', minimum: 0 },
+      },
+    },
+    cost: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['billedUsd', 'providerReportedUsd', 'calculatedUsd', 'pricingSource'],
+      properties: {
+        billedUsd: { type: 'number', minimum: 0 },
+        providerReportedUsd: { type: ['number', 'null'] },
+        calculatedUsd: { type: ['number', 'null'] },
+        pricingSource: {
+          type: 'string',
+          enum: ['provider_reported', 'calculated', 'mixed', 'external'],
+        },
+      },
+    },
+    correlation: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['requestId', 'traceId', 'taskId', 'researchId', 'attempt', 'sessionId'],
+      properties: {
+        requestId: { type: ['string', 'null'] },
+        traceId: { type: ['string', 'null'] },
+        taskId: { type: ['string', 'null'] },
+        researchId: { type: ['string', 'null'] },
+        // Widened to number|null to match the TypeScript type; the schema does not
+        // enforce integer semantics because the TS interface declares plain `number | null`.
+        attempt: { type: ['number', 'null'] },
+        sessionId: { type: ['string', 'null'] },
+      },
+    },
+    error: {
+      anyOf: [
+        { type: 'null' },
+        {
+          type: 'object',
+          additionalProperties: false,
+          required: ['code', 'message'],
+          properties: {
+            code: { type: ['string', 'null'] },
+            message: { type: ['string', 'null'] },
+          },
+        },
+      ],
+    },
+  },
+} as const;
+
+/**
+ * Orchestrator-specific usage event input schema. Extends the base via `allOf`:
+ *
+ *   1. Pins `source.service` to the literal `'orchestrator'` (was previously
+ *      enforced by an imperative for-loop in webhookUsageRoutes.ts).
+ *   2. Makes `source.workerLocation` a required field (was previously not
+ *      validated anywhere).
+ *
+ * Used as the body.items schema for POST /internal/webhooks/usage-events.
+ */
+export const orchestratorUsageEventInputSchema = {
+  $id: 'OrchestratorUsageEventInput',
+  allOf: [
+    { $ref: 'UsageEventInput#' },
+    {
+      type: 'object',
+      required: ['source'],
+      properties: {
+        source: {
+          type: 'object',
+          required: ['service', 'workerLocation'],
+          properties: {
+            service: { const: 'orchestrator' },
+          },
+        },
+      },
+    },
+  ],
+} as const;
+
+/**
+ * Registers both usage event schemas with the Fastify app's Ajv instance.
+ *
+ * Must be called AFTER `registerCoreSchemas(app)` and BEFORE any route is
+ * registered that references these schemas via `$ref`. Order within this
+ * function matters: the base schema must be added before the orchestrator
+ * schema resolves its `$ref`.
+ */
+export function registerUsageSchemas(app: FastifyInstance): void {
+  app.addSchema(usageEventInputSchema);
+  app.addSchema(orchestratorUsageEventInputSchema);
+}

--- a/apps/llm-usage-service/src/routes/webhookUsageRoutes.ts
+++ b/apps/llm-usage-service/src/routes/webhookUsageRoutes.ts
@@ -26,7 +26,7 @@ export const webhookUsageRoutes: FastifyPluginCallback = (app, _opts, done) => {
             schemaVersion: { type: 'integer', enum: [1] },
             events: {
               type: 'array',
-              items: { type: 'object' },
+              items: { $ref: 'OrchestratorUsageEventInput#' },
             },
           },
         },
@@ -69,19 +69,9 @@ export const webhookUsageRoutes: FastifyPluginCallback = (app, _opts, done) => {
         return await reply.fail('UNAUTHORIZED', authResult.error.message);
       }
 
-      // schemaVersion and events are validated by Fastify schema (enum: [1], type: array)
+      // schemaVersion, event shapes, and source.service === 'orchestrator' constraint
+      // are all validated by the Fastify route schema (OrchestratorUsageEventInput).
       const body = request.body as WebhookIngestBody;
-
-      // Enforce: all events must have source.service === 'orchestrator'
-      for (let i = 0; i < body.events.length; i++) {
-        const event = body.events[i];
-        if (event !== undefined && event.source.service !== 'orchestrator') {
-          return await reply.fail(
-            'INVALID_REQUEST',
-            `Event at index ${String(i)} has source.service '${event.source.service}' — webhook endpoint only accepts events from 'orchestrator'`,
-          );
-        }
-      }
 
       const result = await ingestUsageEvents(
         { logger: request.log, usageEventRepository, usageAggregateRepository },

--- a/apps/llm-usage-service/src/server.ts
+++ b/apps/llm-usage-service/src/server.ts
@@ -18,6 +18,7 @@ import {
 } from '@intexuraos/http-server';
 import { createLogStream, setupSentryErrorHandler } from '@intexuraos/infra-sentry';
 import { registerRoutes } from './routes/index.js';
+import { registerUsageSchemas } from './routes/schemas/usageEventSchema.js';
 
 const SERVICE_NAME = 'llm-usage-service';
 const SERVICE_VERSION = '0.0.1';
@@ -138,6 +139,17 @@ export async function buildServer(): Promise<FastifyInstance> {
             stream: createLogStream(),
           },
     disableRequestLogging: true,
+    // Override Fastify's default `removeAdditional: true` so that
+    // `additionalProperties: false` on the UsageEventInput schema actually
+    // rejects unknown fields with a 400, rather than silently stripping them.
+    // All other body schemas in this service use the default additionalProperties: true
+    // (e.g. query `filters: { type: 'object' }`), so this change only affects schemas
+    // that explicitly opt into strict mode.
+    ajv: {
+      customOptions: {
+        removeAdditional: false,
+      },
+    },
   });
 
   registerQuietHealthCheckLogging(app);
@@ -155,6 +167,7 @@ export async function buildServer(): Promise<FastifyInstance> {
   setupSentryErrorHandler(app as unknown as FastifyInstance);
 
   registerCoreSchemas(app);
+  registerUsageSchemas(app);
 
   await app.register(fastifySwagger, buildOpenApiOptions());
   await app.register(fastifySwaggerUi, {

--- a/docs/superpowers/specs/2026-04-09-usage-service-api-design.md
+++ b/docs/superpowers/specs/2026-04-09-usage-service-api-design.md
@@ -119,12 +119,12 @@ It is **not** responsible for:
 
 ## API Surface
 
-| Method | Path                               | Auth                    | Purpose |
-| ------ | ---------------------------------- | ----------------------- | ------- |
-| POST   | `/internal/usage/events`           | `X-Internal-Auth`       | Ingest usage events from normal services |
+| Method | Path                               | Auth                    | Purpose                                                                        |
+| ------ | ---------------------------------- | ----------------------- | ------------------------------------------------------------------------------ |
+| POST   | `/internal/usage/events`           | `X-Internal-Auth`       | Ingest usage events from normal services                                       |
 | POST   | `/internal/webhooks/usage-events`  | Orchestrator HMAC       | Ingest usage events from orchestrator without exposing the internal auth token |
-| POST   | `/internal/usage/query`            | `X-Internal-Auth`       | Query aggregated usage and cost concentration |
-| GET    | `/health`                          | none                    | Standard service health endpoint |
+| POST   | `/internal/usage/query`            | `X-Internal-Auth`       | Query aggregated usage and cost concentration                                  |
+| GET    | `/health`                          | none                    | Standard service health endpoint                                               |
 
 There must be **no** user-scoped public endpoint in this stage.
 

--- a/packages/internal-clients/src/usage-service/types.ts
+++ b/packages/internal-clients/src/usage-service/types.ts
@@ -20,6 +20,12 @@ export interface UsageEventSource {
   component: string;
   client: string;
   environment: 'dev' | 'prod' | 'test';
+  /**
+   * Physical location identifier of the orchestrator that produced this event
+   * (e.g. 'home-dev', 'mac-dev', 'office-pc'). Required at the webhook endpoint
+   * (enforced by the OrchestratorUsageEventInput schema); optional on the internal endpoint.
+   */
+  workerLocation?: string;
 }
 
 export interface UsageEventRequest {


### PR DESCRIPTION
## Summary
- Replace loose `items: { type: 'object' }` on both ingest endpoints with strict `UsageEventInput` / `OrchestratorUsageEventInput` JSON Schemas compiled by Ajv. Delete the 130-line hand-rolled `validateEvent()` function and its `VALID_*` constants.
- Add `source.workerLocation` as a new optional field on the base `UsageEventInput`. `OrchestratorUsageEventInput` extends the base via `allOf`, pins `source.service: { const: 'orchestrator' }`, and requires `workerLocation`. The webhook route references the stricter schema; the imperative `source.service === 'orchestrator'` loop in `webhookUsageRoutes.ts` is deleted.
- Delete ~46 use-case rejection tests that exercised `validateEvent` branches no longer reachable (validation now runs at the route layer, so malformed events never reach the use case). Net diff: feat commit is +431/-780 (net −349 lines).

## Breaking Contract Changes
Both ingest endpoints move from **partial per-event acceptance** to **full-batch rejection**.

- **Before:** a batch of 10 with 1 malformed event returns 200 + `{accepted: 9, rejected: [{index: 3, ...}]}`
- **After:** the same batch returns 400 for the entire batch; zero events are persisted

This is a deliberate contract tightening. It's safe today because grep confirms zero external callers of either endpoint exist in the monorepo (no app in `apps/`, no worker in `workers/`, no package besides `packages/internal-clients/src/usage-service/` itself). The change kills the three-sources-of-truth smell — TypeScript type + runtime `validateEvent` + absent edge schema — by collapsing all three into a single Ajv-compiled schema.

## Sentry error envelope
Schema violations now flow through `setupSentryErrorHandler` (`packages/infra-sentry/src/fastify.ts:82-97`) which reshapes Fastify validation errors to the IntexuraOS envelope:

```json
{
  "success": false,
  "error": {
    "code": "INVALID_REQUEST",
    "message": "Validation failed",
    "details": { "errors": [{ "path": "body/events/0/source/environment", "message": "..." }] }
  }
}
```

All new and updated tests assert on `body.error.details.errors[N].path`, not on free-text `body.error.message`. The previously-existing webhook test at `webhookUsageRoutes.test.ts:104` — which asserted `body.error.message.toContain('orchestrator')` against the imperative loop's custom error string — is updated to assert on the envelope path instead.

Additionally, Fastify's default `ajv.removeAdditional: true` option was overridden to `false` on this service so that `additionalProperties: false` on the `UsageEventInput` schema actually rejects unknown fields with 400 rather than silently stripping them. Only the new usage event schemas use `additionalProperties: false`; other body schemas in this service use the default (`true`) and are unaffected.

## Test plan
- [x] New route-level rejection tests: missing `source.environment`, invalid enum value, `additionalProperties: false` unknown field, explicit full-batch rejection (batch of 3, event[1] with `usage.inputTokens: -5`, asserts zero events persisted)
- [x] Updated webhook test at line 104 — asserts envelope path `source/service` instead of the deleted imperative loop's custom error string
- [x] New webhook test — rejects orchestrator payload missing `source.workerLocation`
- [x] `ingestUsageEvents.test.ts` pruned from 711 → 131 lines. 6 tests kept: `accepts valid events`, `detects duplicate events`, `handles repository create failure`, `handles aggregate increment failure gracefully`, `skips undefined events in the array`, `handles mixed batch (valid + duplicate)` (reframed; the `invalid` leg is unreachable now)
- [x] `node scripts/verify-workspace-tracked.mjs llm-usage-service` — 14,908 tests pass across 729 files
- [x] `pnpm run ci:tracked` — all 20 static-validation gates + build + format pass
- [x] Grep sanity checks: zero `validateEvent` code references (1 doc-comment mention in the test file header only), zero `VALID_PROVIDERS|VALID_OPERATIONS|VALID_OWNER_TYPES|VALID_ENVIRONMENTS|VALID_PRICING_SOURCES` matches anywhere in `apps/llm-usage-service/src`

## Producer follow-up — lesson from commit 95eb9a64c
This PR only tightens the **receiver** side. The orchestrator does not yet emit usage events; wiring that emission is a separate follow-up.

When that follow-up happens, it must add `callerEnvironment: 'dev' | 'prod'` to the `Task` type (threaded from code-agent's `INTEXURAOS_ENVIRONMENT` via a new field on `CreateTaskRequest`), AND a new `INTEXURAOS_ORCHESTRATOR_WORKER_LOCATION` env var on the orchestrator for `source.workerLocation`. **Critically**, that PR must ALSO update `DispatchMetadataSchema` in `workers/orchestrator/src/services/dispatch-metadata-client.ts`, the `GET /internal/tasks/:id/dispatch-metadata` response in `apps/code-agent/src/routes/internalRoutes.ts`, and `tryRecoverMissingTask` in `workers/orchestrator/src/services/task-dispatcher.ts` — with an explicit recovery-path test that seeds metadata and asserts the recovered task carries the new field through to the emission site.

Commit `95eb9a64c` is a direct template for why this matters: it widened a guard on `runtimeSessionId` without updating `tryRecoverMissingTask`, silently breaking every dispatch-metadata-recovered task in production because `failAcceptedResume` swallows the generic error. Tests passed because they matched both failure paths without distinguishing which fired. With this PR's strict schema, the same field-drop bug class would turn into "recovered tasks emit events rejected with 400", silently mis-attributing cost across every recovered task. Forcing the producer follow-up into a shape where the recovery path is tested up front prevents the recurrence.

## Commits
- `44f3ee99c` feat(llm-usage-service): strict JSON schema validation at route layer — the refactor
- `831eed57c` chore(docs): align usage-service API design table columns — narrow formatter cleanup from `pnpm run format:docs-tables`, bundled here because it was in the working tree on this branch

## Not linked to Linear
Per explicit user decision at plan approval time, this internal refactor skips the CLAUDE.md `INT-XXX` cross-linking rule. Zero callers + receiver-only scope + deliberate semantics change = no ticket tracking needed.

Architected with love by 🤖 <a href="mailto:intex@intexuraos.cloud">Intex</a>
---
- Linear: [INT-1336](https://linear.app/pbuchman/issue/INT-1336)
- IntexuraOS Code Task: [View task](https://intexuraos.cloud/#/code-tasks/task_3ed86f79-fa9e-49d7-a65c-aacceec286bc)
- Worker Type: `sonnet`
- Model: `sonnet`