### PR TITLE
[INT-1344] fix(terraform): enable server-side delete protection on firestore db

### DIFF
--- a/terraform/modules/firestore/main.tf
+++ b/terraform/modules/firestore/main.tf
@@ -10,6 +10,10 @@ resource "google_firestore_database" "database" {
   # ABANDON: database survives even if removed from Terraform state or on destroy
   deletion_policy = "ABANDON"
 
+  # Server-side delete protection: GCP refuses delete API calls regardless of caller
+  # (terraform, gcloud, console). Third layer on top of prevent_destroy + ABANDON.
+  delete_protection_state = "DELETE_PROTECTION_ENABLED"
+
   # Point-in-time recovery (disabled — see follow-up task for PITR decision)
   point_in_time_recovery_enablement = "POINT_IN_TIME_RECOVERY_DISABLED"
 


### PR DESCRIPTION
## Summary
- Adds `delete_protection_state = "DELETE_PROTECTION_ENABLED"` to `terraform/modules/firestore/main.tf`.
- Third layer of defense on top of `deletion_policy = "ABANDON"` and `lifecycle.prevent_destroy = true`. Unlike those two (which only bind Terraform's own behavior), this flag is enforced **server-side by GCP** — the Firestore Admin API will refuse delete calls from any caller (Terraform, `gcloud`, console).
- **Already applied to dev** via `terraform apply -target=module.firestore` before this PR was opened. Verified with `gcloud firestore databases describe --database='(default)'` — returns `DELETE_PROTECTION_ENABLED`.

## Why three layers?
| Layer | Scope | What it blocks |
|---|---|---|
| `deletion_policy = "ABANDON"` | Terraform-virtual | If Terraform decides to stop managing the resource, GCP keeps it |
| `lifecycle.prevent_destroy = true` | Terraform plan-time | Any plan containing a destroy/replace on this resource fails at plan time |
| `delete_protection_state = "DELETE_PROTECTION_ENABLED"` | GCP server-side | API refuses delete regardless of caller — the only layer that survives someone editing the Terraform config to bypass the other two |

## Plan output (from targeted apply)
```
~ resource "google_firestore_database" "database" {
    ~ delete_protection_state = "DELETE_PROTECTION_DISABLED" -> "DELETE_PROTECTION_ENABLED"
      id                      = "projects/intexuraos-dev-pbuchman/databases/(default)"
      name                    = "(default)"
  }
Plan: 0 to add, 1 to change, 0 to destroy.
Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```

## Test plan
- [x] `terraform plan -target=module.firestore` — in-place update, 0 to destroy
- [x] `terraform apply -target=module.firestore` — applied successfully
- [x] `gcloud firestore databases describe` — confirms `DELETE_PROTECTION_ENABLED` on the GCP side
- [x] `pnpm run ci:tracked` — passes
- [ ] CI green on GitHub Actions

## Note
During `ci:tracked` I initially hit 9 pre-existing lint errors in `apps/code-agent` (present on `development`, not caused by this change) — root cause was stale `packages/*/dist/`. A clean `pnpm install && pnpm build` cleared them. Worth knowing if someone else hits it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)