### PR TITLE
docs(plans): INT-1338 Phase 2 execution plans and decisions log

### DIFF
--- a/docs/plans/INT-1338-decisions.md
+++ b/docs/plans/INT-1338-decisions.md
@@ -1,0 +1,268 @@
+# INT-1338 — Phase 2 Decision Log
+
+**Status:** All 17 architectural and scoping decisions captured. This doc is the source of truth; the per-track plan docs (`INT-1339` through `INT-1343`) contain the step-by-step instructions but must be read **together with** this doc because several sections of those plans are now superseded by decisions here.
+
+**Date captured:** 2026-04-10
+**Parent epic:** INT-1338 — LLM Usage Service Phase 2
+**Child tracks:** INT-1339 (pricing), INT-1340 (UI), INT-1341 (orchestrator), INT-1342 (Firestore migration), INT-1343 (pricing UI move)
+
+---
+
+## Part 1 — Scope correction (the big one)
+
+**Original scope error:** The first draft of Track 2 hooked into `workers/orchestrator/src/services/turn-metrics-collector.ts` to parse Claude Code session JSONL files and emit per-call usage events. This tracked **worker-runtime** LLM usage (the Claude Code CLI executing a code task inside a container, making its own API calls) — which is **NOT** in scope.
+
+**Correct scope:** Only track LLM usage from places in IntexuraOS that use the `LLMClient` interface directly (i.e. our own code making LLM calls, not user-facing worker execution).
+
+### Verified LLM-client call sites in the orchestrator (only these are in scope for Track 2)
+
+1. `workers/orchestrator/src/services/agent-compliance-validator.ts:297` — `createOpenRouterClient({... usageSink: new StructuredLogUsageSink({ logger }) })`. Used by `OrchestratorAgentComplianceValidator.validate()` to analyze PR session transcripts post-execution.
+2. `workers/orchestrator/src/services/completion-verifier.ts:810` — `createLlmClient({... usageSink: new StructuredLogUsageSink({ logger }) })` (via `@intexuraos/llm-factory`). Two `.generate()` call sites (`:626` and `:746`) extract structured data from agent completion transcripts.
+
+Both currently use `StructuredLogUsageSink` from `@intexuraos/llm-pricing` — log-only, zero Firestore writes, matches user's prior statement that orchestrator does not write to Firestore.
+
+### Out of scope (explicit)
+
+- Worker-runtime Claude Code / Codex LLM calls (JSONL-derived usage)
+- `workers/orchestrator/src/services/turn-metrics-collector.ts` — stays untouched for this epic (continues to emit per-turn rollups to `code-agent/internal/turn-metrics` as it does today)
+- `workers/orchestrator/src/services/orchestrator-audit-sink.ts` (audit file writer) — unrelated concern
+
+---
+
+## Part 2 — Decisions by track
+
+### Track 2 (INT-1341) — Orchestrator → usage service (fully reframed)
+
+**Architecture:** Orchestrator must **not** call `llm-usage-service` directly. Instead:
+
+1. A new **`HttpWebhookUsageSink`** in `packages/llm-pricing` HMAC-signs usage events and POSTs them to `code-agent`.
+2. A new route **`POST /internal/webhooks/usage-events`** on `code-agent` validates the HMAC (reusing the orchestrator HMAC secret it already has for turn-metrics) and forwards to `llm-usage-service`.
+3. `code-agent` uses `X-Internal-Auth` to call `POST /internal/usage/events` on `llm-usage-service`.
+
+**Rationale:** Code-agent is the single trust boundary between orchestrator and IntexuraOS internal APIs. Orchestrator never learns the internal auth token, keeps its HMAC-only auth model, and llm-usage-service keeps one auth model (X-Internal-Auth).
+
+**Replacement sites:**
+- `agent-compliance-validator.ts:297` — swap `StructuredLogUsageSink` for `HttpWebhookUsageSink`
+- `completion-verifier.ts:810` — same
+
+**New components:**
+- `packages/llm-pricing/src/httpWebhookUsageSink.ts` — signs with HMAC, POSTs to code-agent (new sink)
+- `apps/code-agent/src/routes/internalUsageWebhookRoute.ts` — receives HMAC webhook, forwards to llm-usage-service
+- `apps/code-agent/src/domain/usecases/forwardUsageEvents.ts` — the forwarding logic with HTTP client
+
+**Dropped from original Track 2 plan:**
+- `UsagePublisher` class in orchestrator — not needed, sink injection is enough
+- JSONL parsing in `turn-metrics-collector.ts` — out of scope
+- `extractUsageEvents()`, `selectProvider()`, `deriveEventId()` utilities — not needed
+- Feature flag `INTEXURAOS_USAGE_PUBLISHER_ENABLED` — not needed
+- `session-jsonl-sample.jsonl` fixture — not needed
+- Phase 1 JSONL verification step — not applicable
+
+**Dependency changes:**
+- Track 2 is no longer blocked by Track 4 (orchestrator already has pricing client-side, no server-side cost calc needed)
+- Track 2 moves from Phase 2 to **Phase 1 parallel** (alongside Track 1 and Track 4)
+- Track 3 still depends on Track 2 (reuses the new `HttpUsageSink` primitive)
+
+**Note on `HttpUsageSink` primitives:**
+- Track 2 ships **`HttpWebhookUsageSink`** (HMAC-signed, for orchestrator → code-agent)
+- Track 2 **also** ships **`HttpInternalAuthUsageSink`** (X-Internal-Auth, for in-cluster apps → llm-usage-service directly) — this is what Track 3 reuses to replace `FirestoreUsageSink` across all provider client call sites
+
+### Track 3 (INT-1342) — Firestore writers migration (scope expanded and simplified)
+
+**Core work (unchanged):**
+- Replace `FirestoreUsageSink` with `HttpInternalAuthUsageSink` (shipped by Track 2) across all provider client factories in `packages/infra-{claude,gpt,gemini,perplexity,openrouter}`
+- Update `services.ts` in every consuming app
+- Delete `FirestoreUsageSink` and `llm_usage_stats` collection writes
+
+**Added to scope (significant):**
+
+1. **Remove `user_usage` feature entirely.** The `code-agent` `user_usage` Firestore collection and quota cache are redundant. Cost-based quota enforcement has already been partially dismantled in git history:
+   - `597c23adc fix(code-agent): remove monthly cost limit rate check`
+   - `09a115605 Reorder sidebar menu items and remove daily cost limit`
+   - Original implementation: `8def391d8 INT-367 Implement user rate limiting infrastructure`
+
+   Track 3 finishes this cleanup by deleting `apps/code-agent/src/infra/firestore/userUsageFirestoreRepository.ts`, the `user_usage` collection registration, and any remaining cost-based rate-limiter reads. Keep `rateLimitService.checkLimits()`'s `concurrentTasks`/`tasksThisHour` enforcement — those are correctness-critical.
+
+2. **Remove `packages/llm-audit` entirely.** The `LogAuditSink` → `llm_api_logs` feature is no longer needed (logger output is sufficient for prompt visibility). Track 3 deletes:
+   - The whole `packages/llm-audit` package
+   - The `auditSink` parameter from every `createXxxClient()` factory in `packages/infra-*`
+   - Audit-sink construction in every app's `services.ts`
+   - The `llm_api_logs` Firestore collection usage
+
+3. **Delete `/settings/usage-costs` (`LlmCostsPage`) entirely.** Since it reads the legacy `llm_usage_stats` via `app-settings-service`, and we're deleting that collection, and Track 1's new LLM Usage UI can cover per-user cost views via filter+groupBy, the standalone page is redundant. Track 3 removes:
+   - `apps/web/src/pages/LlmCostsPage.tsx`
+   - `/settings/usage-costs` route in `apps/web/src/App.tsx`
+   - Sidebar entry "Usage Costs" in `apps/web/src/components/Sidebar.tsx`
+   - `getUsageCosts()` from `apps/web/src/services/settingsApi.ts`
+   - `apps/app-settings-service/src/infra/firestore/usageStatsRepository.ts` (the reader)
+   - The `/settings/usage-costs` route handler on `app-settings-service`
+   - Related types (`AggregatedCosts`) from `apps/web/src/types/index.ts`
+
+4. **Remove all `zai` references.** Zai is no longer a supported provider. Track 3 removes references from:
+   - `apps/web/src/types/index.ts`
+   - `apps/app-settings-service/src/routes/internalRoutes.ts`
+   - `apps/app-settings-service/src/index.ts` (REQUIRED_ENV)
+   - `apps/app-settings-service/src/__tests__/routes/publicRoutes.test.ts`
+   - `apps/app-settings-service/src/__tests__/routes/internalRoutes.test.ts`
+   - `apps/linear-agent/src/__tests__/fakes.ts`
+   - `packages/llm-prompts/src/classification/intelligentPromptBuilder.ts`
+   - `packages/llm-pricing/src/__tests__/testFixtures.test.ts`
+   - `packages/llm-pricing/src/__tests__/pricingClient.test.ts`
+   - `packages/llm-factory/src/__tests__/llmClientFactory.test.ts`
+   - `packages/llm-contract/src/__tests__/supportedModels.test.ts`
+   - `packages/llm-contract/src/__tests__/fixtures/pricing.ts`
+   - `LlmProviders` enum if present
+   - Any `ZAI_*` env vars in terraform and ecosystem.config.cjs
+
+**Dropped from original Track 3 plan:**
+- User quota cache webhook fanout (`POST /internal/webhooks/quota-update`) — not needed since `user_usage` is being deleted entirely
+- Dual-write / parity verification period — replaced by atomic delete+migrate approach per Track 4's aggressive deprecation philosophy
+
+### Track 4 (INT-1339) — Pricing ownership (simplified)
+
+**Dropped entirely:**
+- Server-side cost calculation on event ingest — no track requires it (all existing and new callers compute cost client-side)
+- `computeCost` flag in the ingest request
+- Schema `anyOf` for mixed cost/no-cost batches
+- Image-size handling in cost calc
+- `calculateEventCost` use case
+- Image-pricing 1024x1024 default
+
+**Kept:**
+- Move pricing ownership: `app-settings-service` → `llm-usage-service`
+- New `PricingRepository` + `llm_pricing` Firestore collection
+- `POST /internal/pricing` (write) with `X-Internal-Auth`
+- Public `GET /llm-usage/pricing` with Auth0 bearer (for Track 5 UI — see path convention below)
+- One-time migration `086_migrate_pricing_to_llm_usage_service.mjs` at repo root
+- Redirect all `fetchAllPricing()` callers to new endpoint
+- Delete old endpoint in same PR
+
+**Deprecation strategy:** **Atomic delete in the same PR.** No 307 → 410 window. Single PR:
+1. Adds new endpoints on llm-usage-service
+2. Migrates pricing data via the migration script
+3. Updates all 11 consumer apps' `fetchAllPricing()` callers (in-place rename, not a new symbol)
+4. Deletes the old `GET /internal/settings/pricing` route on `app-settings-service`
+
+No feature flag, no special deploy safeguards. Ship it during a low-traffic window with standard rollback readiness.
+
+**Pricing providers:** 5 providers total (drop zai):
+- `google`, `openai`, `anthropic`, `perplexity` — calculated cost from pricing table
+- `openrouter` — **cost comes from provider API response** (`cost.pricingSource = 'provider_reported'`), not from pricing table. Pricing table entries for openrouter may be informational only or absent. Verify during Track 4 implementation.
+
+**Per-provider endpoint:** Not added. Bulk `GET /llm-usage/pricing` only.
+
+### Track 1 (INT-1340) — Web UI (minor updates)
+
+**Confirmed decisions:**
+- `.count()` aggregation included by default on list endpoint
+- **All filter+sort combinations needed in composite indexes.** During plan execution, consult Firestore composite index documentation via context7 MCP to determine the minimal-correct set (Firestore only requires composite indexes for queries combining equality filters on one field with range/sort on a different field — not literal full permutations). Document the chosen index set explicitly in the migration file. Existing `llm_usage_events` collection already has some indexes from Phase 1 — coordinate carefully to avoid conflicts.
+- Track 1's existing `docs/plans/INT-1340-track-1-llm-usage-web-ui.md` remains the source for step-by-step work **except** for path naming and auth model changes below.
+
+**Path convention change:** Per web-app pattern (domain-prefixed paths, service baseURL from `config.{service}ServiceUrl`), all new public routes on llm-usage-service use the `/llm-usage/*` prefix:
+- `POST /llm-usage/events/list` (paginated raw events) — formerly planned as `POST /internal/usage/events/list`
+- `GET /llm-usage/events/:eventId` — formerly planned as `GET /internal/usage/events/:eventId`
+- `POST /llm-usage/query` (aggregate query) — replaces both the internal version and the new public version; there is NO internal query endpoint anymore
+- `GET /llm-usage/pricing` — added by Track 4
+
+All public routes use Auth0 bearer auth validated by the same middleware other user-facing services use. Drop the internal query endpoint (`POST /internal/usage/query`) entirely — only the UI reads usage data, and the read path is public.
+
+**Web API service update:** `apps/web/src/services/llmUsageApi.ts` follows the existing `apiRequest(baseUrl, path, accessToken)` pattern with `config.llmUsageServiceUrl`. Add that config key in the web app's config module.
+
+### Track 5 (INT-1343) — Pricing UI move (minor updates)
+
+**Confirmed decisions:**
+- New path: `/#/llm-usage/pricing`
+- Old URL `/#/settings/llm-pricing`: **remove outright, no redirect shim.** Aligns with atomic deprecation philosophy.
+- Track 5 data source: new public `GET /llm-usage/pricing` on llm-usage-service (delivered by Track 4)
+- Drop 4 of the 4 open decisions from Track 5:
+  1. Old URL handling — decided (404)
+  2. Public endpoint ownership — decided (Track 4 owns it)
+  3. New endpoint path — decided (`/llm-usage/pricing`)
+  4. Response shape for zai/openrouter — decided (drop zai entirely; openrouter stays, cost comes from provider response)
+
+**`LlmCostsPage` deletion moves to Track 3** (since it requires backend reader cleanup to complete meaningfully).
+
+---
+
+## Part 3 — Revised dependency graph
+
+```
+Phase 1 (parallel — start immediately)
+├── INT-1340 (Track 1) — Web UI + new public routes
+├── INT-1341 (Track 2) — Orchestrator sinks + code-agent webhook + HttpUsageSink primitives
+└── INT-1339 (Track 4) — Pricing ownership move + public pricing endpoint
+
+Phase 2 (after Track 2)
+└── INT-1342 (Track 3) — Firestore migration + user_usage removal + llm-audit removal
+                          + LlmCostsPage deletion + zai cleanup
+
+Phase 3 (after Track 1 + Track 4)
+└── INT-1343 (Track 5) — Pricing UI move
+```
+
+**Critical change:** 3 tracks are now parallelizable in Phase 1 (previously 2). Track 2 no longer blocks on Track 4.
+
+---
+
+## Part 4 — Updated llm-usage-service route surface (final)
+
+### Internal routes (X-Internal-Auth)
+- `POST /internal/usage/events` — ingest events (from code-agent, and from other backend services via `HttpInternalAuthUsageSink`)
+- `POST /internal/pricing` — write pricing (for the migration script and future admin operations)
+
+### Public routes (Auth0 bearer)
+- `POST /llm-usage/events/list` — paginated raw event list with `.count()` total (Track 1)
+- `GET /llm-usage/events/:eventId` — single raw event detail (Track 1)
+- `POST /llm-usage/query` — aggregate query with groupBy (Track 1, replaces internal version)
+- `GET /llm-usage/pricing` — full pricing table (Track 4)
+
+### Removed (compared to Phase 1 surface)
+- `POST /internal/webhooks/usage-events` — removed; orchestrator routes via code-agent instead
+- `POST /internal/usage/query` — removed; only public query endpoint exists now
+
+---
+
+## Part 5 — Decisions locked (summary table)
+
+| #   | Decision                                                  | Choice                                                                |
+| --- | --------------------------------------------------------- | --------------------------------------------------------------------- |
+| 1   | Orchestrator → usage service path                         | Via code-agent webhook (HMAC) → code-agent forwards (X-Internal-Auth) |
+| 2   | Server-side cost calculation                              | Dropped entirely                                                      |
+| 3   | Web read auth pattern                                     | Public routes on llm-usage-service with Auth0 bearer                  |
+| 4   | Track 3 scope for `user_usage`                            | Remove feature entirely, no migration                                 |
+| 5   | `app-settings-service` FirestoreUsageStatsRepository fate | Delete the whole `/settings/usage-costs` page + backend               |
+| 6   | `packages/llm-audit` fate                                 | Remove package entirely                                               |
+| 7   | Per-provider pricing endpoint                             | Not added (bulk only)                                                 |
+| 8   | Track 4 deprecation timeline                              | Atomic delete in same PR (no 307/410 window)                          |
+| 9   | Track 1 list endpoint total count                         | Include `.count()` by default                                         |
+| 10  | Track 1 composite index strategy                          | All combinations (research Firestore docs before migration)           |
+| 11  | Track 5 old URL                                           | Remove outright, 404                                                  |
+| 12  | Track 5 new path                                          | `/#/llm-usage/pricing`                                                |
+| 13  | Code-agent webhook path                                   | `POST /internal/webhooks/usage-events`                                |
+| 14  | Internal query endpoint fate                              | Removed; public `POST /llm-usage/query` only                          |
+| 15  | Pricing response shape                                    | 5 providers (drop zai, keep openrouter)                               |
+| 16  | Track 4 deploy safety                                     | None — ship it                                                        |
+| 17  | Path convention for public routes                         | `/llm-usage/*` prefix (domain-based, matches web app pattern)         |
+
+---
+
+## Part 6 — What each original plan doc STILL uses vs what's superseded
+
+| Plan doc                                           | Status                   | Use for                                                                                                                                                                                                                                                                                                              |
+| -------------------------------------------------- | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `INT-1339-track-4-pricing-ownership.md`            | **Partially superseded** | File structure, repository code, migration script skeleton. **Skip:** server-side cost calc sections (phases for `calculateEventCost`, `computeCost` flag, schema `anyOf`). **Update during execution:** endpoint path naming (use `/llm-usage/pricing` for public read), deprecation strategy (atomic not gradual). |
+| `INT-1340-track-1-llm-usage-web-ui.md`             | **Mostly valid**         | Frontend component skeletons, hook patterns, pagination cursor design, Tailwind examples. **Update during execution:** backend route paths use `/llm-usage/*` prefix not `/internal/usage/*`; add `.count()` aggregation; research composite index requirements more rigorously.                                     |
+| `INT-1341-track-2-orchestrator-usage-publisher.md` | **Fully superseded**     | Do not use. The entire plan was written for the wrong scope (JSONL parsing). Rewrite from scratch using Part 2 of this doc as the spec.                                                                                                                                                                              |
+| `INT-1342-track-3-firestore-migration.md`          | **Partially superseded** | Use for: `HttpUsageSink` design (just rename `HttpInternalAuthUsageSink`), the provider client audit, env var wiring pattern. **Skip:** user_usage decision matrix (decided — remove), webhook fanout, dual-write/parity period. **Add:** user_usage removal, llm-audit removal, LlmCostsPage deletion, zai cleanup. |
+| `INT-1343-track-5-move-pricing-ui.md`              | **Mostly valid**         | File rename, swap imports, sidebar updates. **Skip:** the 4 DECISION NEEDED markers (all resolved). **Update during execution:** old URL handling (hard 404, no shim); path naming already matches decision.                                                                                                         |
+
+---
+
+## Part 7 — Action items before Phase 1 starts
+
+1. **Rewrite Track 2 plan doc** (`INT-1341-...md`) from scratch using Part 2 of this document as the specification. This is the only full-rewrite required.
+2. **Research Firestore composite index rules** via context7 MCP and produce the minimal-correct index list for Track 1 before writing the migration.
+3. **Verify the orchestrator already has code-agent's URL and HMAC secret** (it does, based on `webhook-client.ts` usage). Just wire a new target URL for usage webhooks.
+4. **Confirm code-agent has `INTEXURAOS_INTERNAL_AUTH_TOKEN`** — it should since it's a core service, but verify during Track 2 plan rewrite.
+5. **Create new web app config key** `llmUsageServiceUrl` in `apps/web/src/config/index.ts` with dev/prod URLs.
+6. **Audit one more time** for any stragglers: grep for `FirestoreUsageSink`, `llm_usage_stats`, `llm_api_logs`, `user_usage`, `zai`, `ZAI`, `UsageLogger` to make sure the inventories in Tracks 2/3 are complete before coding.

--- a/docs/plans/INT-1339-track-4-pricing-ownership.md
+++ b/docs/plans/INT-1339-track-4-pricing-ownership.md
@@ -4,16 +4,18 @@
 - Linear issue: INT-1339
 - Parent epic: INT-1338
 - Dependencies: none (independent — start immediately)
-- Blocks: INT-1341 (Track 2, orchestrator cost calc), INT-1343 (Track 5, consumer rollout)
-- Plan version: 1.0 (2026-04-10)
+- Blocks: INT-1343 (Track 5, pricing UI move)
+- Plan version: 2.0 (2026-04-10)
 
 ## Executive summary
 
-Today, `app-settings-service` owns the `settings/llm_pricing/providers/{provider}` Firestore sub-collection and exposes `GET /internal/settings/pricing`. Every cost-emitting app (`chat-agent`, `actions-agent`, `web-agent`, `linear-agent`, `commands-agent`, `user-service`, `research-agent`, `image-service`, `todos-agent`, `data-insights-agent`, `calendar-agent`) pulls that payload at boot via `fetchAllPricing()` from `@intexuraos/llm-pricing` and hydrates a `PricingContext`. Track 2 (orchestrator cost calc, INT-1341) wants the same lookup from a worker that has no reason to talk to `app-settings-service` and no business holding an in-memory pricing table. Track 5 (INT-1343) wants to eventually let clients post token-only usage events and have the service fill in `cost.billedUsd` server-side. Both require pricing to live next to usage data.
+Today, `app-settings-service` owns the `settings/llm_pricing/providers/{provider}` Firestore sub-collection and exposes `GET /internal/settings/pricing`. Every cost-emitting app (`chat-agent`, `actions-agent`, `web-agent`, `linear-agent`, `commands-agent`, `user-service`, `research-agent`, `image-service`, `todos-agent`, `data-insights-agent`, `calendar-agent`) pulls that payload at boot via `fetchAllPricing()` from `@intexuraos/llm-pricing` and hydrates a `PricingContext`. Track 5 (INT-1343) wants to surface pricing in the UI via a public endpoint on `llm-usage-service`.
 
-This track transplants pricing ownership from `app-settings-service` into `llm-usage-service` as a new `llm_pricing` Firestore collection, adds a new `GET /internal/pricing` route that returns the existing `AllPricingResponse` shape (so clients can be flipped with a single URL env-var swap), adds server-side cost calculation inside `ingestUsageEvents` (opt-in via a `computeCost: true` flag on the route body, so existing strict-schema callers keep working), extends `@intexuraos/internal-clients/usage-service` with a `fetchAllPricing()` method that returns the same `Result<AllPricingResponse, UsageServiceError>` shape, redirects `fetchAllPricing()` in `@intexuraos/llm-pricing` to use the new URL env var, performs a one-time Firestore migration copying `settings/llm_pricing/providers/*` into `llm_pricing/{provider}`, then rolls consumers over one app at a time.
+This track transplants pricing ownership from `app-settings-service` into `llm-usage-service` as a new `llm_pricing` Firestore collection, adds a new internal `POST /internal/pricing` write route and a public `GET /llm-usage/pricing` read route (Auth0 bearer, for the pricing UI), performs a one-time Firestore migration copying `settings/llm_pricing/providers/*` into `llm_pricing/{provider}`, updates all 11 consumers' `fetchAllPricing()` callers to point at the new endpoint (in-place URL swap, not a new symbol), and **atomically deletes** the old `GET /internal/settings/pricing` endpoint in the same PR.
 
-The end state: `llm-usage-service` owns pricing reads and writes, orchestrator can POST token-only events and get `cost.billedUsd` back, every consumer boots against `INTEXURAOS_LLM_USAGE_SERVICE_URL` for pricing, and the old `app-settings-service` endpoint is behind a 307 redirect for a week before deletion.
+**Server-side cost calculation is NOT in scope for this track.** All existing and new callers compute cost client-side. The `computeCost` flag, `calculateEventCost` use case, schema `anyOf` widening, and image-pricing defaults were dropped per the INT-1338 decisions doc.
+
+The end state: `llm-usage-service` owns pricing reads and writes, the public `GET /llm-usage/pricing` endpoint serves Track 5's UI, every consumer boots against `INTEXURAOS_LLM_USAGE_SERVICE_URL` for pricing, and the old `app-settings-service` endpoint is deleted in the same PR as the consumer migration.
 
 ## Pre-flight checks (do these before writing any code)
 
@@ -22,29 +24,19 @@ The end state: `llm-usage-service` owns pricing reads and writes, orchestrator c
 3. Run `pnpm build` from repo root so `packages/llm-pricing/dist/` and `packages/internal-clients/dist/` exist. Without this, the new imports in llm-usage-service will error with `Cannot find module`.
 4. Grep the whole repo for stragglers this plan may have missed: `rg "settings/llm_pricing|settings\.llm_pricing|/internal/settings/pricing"` — anything that matches must either be updated in Phase 6 or explicitly listed in "Unchanged".
 5. Grep: `rg "fetchAllPricing\("` — verify the list of 11 consumer apps in Phase 6 is still accurate. If new consumers have appeared, add them.
-6. Read `apps/llm-usage-service/src/domain/models/usageEvent.ts:58-63` to confirm the `cost` block shape has not changed. Server-side cost calc must emit exactly this shape.
-7. Read `packages/llm-contract/src/pricing.ts:36-67` (`ModelPricing`) and `packages/llm-contract/src/pricing.ts:75-82` (`ProviderPricing`). These are the types the new repository must return unchanged.
-8. Confirm `firestore-collections.json:252-259` still lists `llm_usage_events` and `llm_usage_daily_aggregates` as owned by `llm-usage-service`. The new `llm_pricing` collection will be added to the same owner.
+6. Read `packages/llm-contract/src/pricing.ts:36-67` (`ModelPricing`) and `packages/llm-contract/src/pricing.ts:75-82` (`ProviderPricing`). These are the types the new repository must return unchanged.
+7. Confirm `firestore-collections.json:252-259` still lists `llm_usage_events` and `llm_usage_daily_aggregates` as owned by `llm-usage-service`. The new `llm_pricing` collection will be added to the same owner.
 
 ## Context files
 
-- `apps/llm-usage-service/src/domain/usecases/ingestUsageEvents.ts:13-80` — existing ingest use case. Server-side cost calc hooks in at line 37 (right after the schema-validated input is cloned into `fullEvent`) and needs read access to a new `pricingRepository` dep.
-- `apps/llm-usage-service/src/routes/internalUsageRoutes.ts:25-195` — route file. Two new handlers will be added here: `GET /internal/pricing` and (optionally) `GET /internal/pricing/:provider`. The existing ingest handler at line 73 also needs to pass `pricingRepository` into the use case.
-- `apps/llm-usage-service/src/routes/schemas/usageEventSchema.ts:120-133` — the strict `cost` block. Currently `required: ['billedUsd', 'providerReportedUsd', 'calculatedUsd', 'pricingSource']`. Phase 3 widens the schema: either (a) add a top-level `computeCost: true` flag on `IngestBody` so omitting `cost` is legal only when `computeCost === true`, or (b) make `cost` optional across the board. See the Phase 3 decision point.
+- `apps/llm-usage-service/src/routes/internalUsageRoutes.ts:25-195` — existing route file. New `POST /internal/pricing` handler goes here (or a new route file alongside it).
 - `apps/llm-usage-service/src/services.ts:6-10` — `ServiceContainer` interface, needs a new `pricingRepository` field. Tests will fail fast because `setServices({...})` calls currently don't provide it.
 - `apps/llm-usage-service/src/infra/firestore/firestoreUsageEventRepository.ts:1-27` — reference pattern for the new `FirestorePricingRepository`. Same style: constant `COLLECTION`, `getFirestore()` inside each method, narrow `try/catch` around Firestore errors, `Result` return type.
-- `packages/llm-pricing/src/pricingClient.ts:125-169` — the current `fetchAllPricing()`. The URL `${baseUrl}/internal/settings/pricing` at line 129 is the only line that changes; its callers already pass a `baseUrl`. The intent in Phase 6 is for each consumer to pass the `llm-usage-service` URL instead of `app-settings-service`. The endpoint path becomes `/internal/pricing` (not `/internal/settings/pricing`). See Phase 5.
+- `packages/llm-pricing/src/pricingClient.ts:125-169` — the current `fetchAllPricing()`. The URL `${baseUrl}/internal/settings/pricing` at line 129 is the only line that changes. The intent in Phase 6 is for each consumer to pass the `llm-usage-service` URL instead of `app-settings-service`. The endpoint path becomes `/internal/pricing` (not `/internal/settings/pricing`). This is an in-place edit of `fetchAllPricing()` — no new symbol is added.
 - `packages/llm-pricing/src/pricingClient.ts:217-285` — `PricingContext` class. Unchanged by this track.
-- `packages/llm-pricing/src/index.ts:17-24` — existing exports. A new `fetchAllPricingFromUsageService()` may be added temporarily during the rollout (Phase 6), or the existing `fetchAllPricing()` may be updated in place. See the Phase 5 decision point.
-- `apps/app-settings-service/src/routes/internalRoutes.ts:12-113` — the old pricing route, to be deprecated in Phase 7 (returns 307 redirect for 1 week, then removed).
-- `apps/app-settings-service/src/infra/firestore/index.ts:20-41` — `FirestorePricingRepository` in the old service. Read-only; provides the migration source shape `settings/llm_pricing/providers/{provider}`. This file is deleted in Phase 7.
-- `apps/app-settings-service/src/services.ts:5-27` — DI container. The `pricingRepository` field here is deleted in Phase 7 along with the route.
-- `packages/internal-clients/src/usage-service/client.ts:19-61` — current usage-service client with `ingestEvents` and `queryUsage`. Phase 4 adds a third method `fetchPricing()` returning `Result<AllPricingResponse, UsageServiceError>`.
-- `packages/internal-clients/src/usage-service/types.ts:171-181` — `UsageServiceClient` interface. Extended in Phase 4.
-- `apps/llm-usage-service/src/index.ts:7-11` — `REQUIRED_ENV`. Unchanged: the service reads its own Firestore, no new env vars for llm-usage-service itself.
-- `terraform/environments/dev/main.tf:302,310,1311` — existing `INTEXURAOS_APP_SETTINGS_SERVICE_URL` and `INTEXURAOS_LLM_USAGE_SERVICE_URL` definitions. No new env vars needed in Phase 6 — consumers swap which of the two existing URLs they pass to `fetchAllPricing()`.
-- `ecosystem.config.cjs:47,57` — PM2 dev-env definitions of the same two URLs. Same: no new vars; only the value each consumer app hands to `fetchAllPricing()` changes.
-- `firestore-collections.json:252-259` — ownership registry. Add a new `llm_pricing` entry owned by `llm-usage-service`.
+- `apps/app-settings-service/src/routes/internalRoutes.ts:12-113` — the old pricing route, **deleted** in Phase 7 (atomic, same PR as consumer migration).
+- `apps/app-settings-service/src/infra/firestore/index.ts:20-41` — `FirestorePricingRepository` in the old service. Deleted in Phase 7.
+- `apps/app-settings-service/src/services.ts:5-27` — DI container. The `pricingRepository` field here is deleted in Phase 7.
 - `migrations/002_initial-llm-pricing.mjs`, `migrations/012_new-pricing-structure.mjs` — reference for how pricing migrations have historically been structured. The new one follows the same pattern but reads from `settings/llm_pricing/providers/*` and writes to `llm_pricing/{provider}`.
 - `scripts/migrate.mjs:29` — migrations directory is the top-level `migrations/` (NOT per-app). The new file goes there as `migrations/086_migrate_pricing_to_llm_usage_service.mjs`.
 - `docs/superpowers/plans/2026-04-09-llm-usage-service-implementation-plan.md` — Phase 1 plan for format reference.
@@ -53,20 +45,18 @@ The end state: `llm-usage-service` owns pricing reads and writes, orchestrator c
 ## Endpoint changes
 
 ### Modified
-- `POST /internal/usage/events` on `llm-usage-service` — body schema widens so `cost` becomes optional when a new top-level `computeCost: true` flag is set. When `cost` is omitted and `computeCost === true`, the service calculates it from tokens + pricing and fills the `cost` block before persisting. Existing strict-schema callers that supply `cost` continue to work unchanged.
+None. `POST /internal/usage/events` on `llm-usage-service` is NOT modified — no `computeCost` flag, no schema widening.
 
 ### Created
-- `GET /internal/pricing` on `llm-usage-service` — returns the `AllPricingResponse` shape (`{ google, openai, anthropic, perplexity }`), wrapped in `{ success, data }`. Requires `X-Internal-Auth`. This replaces `GET /internal/settings/pricing` on `app-settings-service`.
-- `GET /internal/pricing/:provider` on `llm-usage-service` — returns a single `ProviderPricing`. Used by Track 2 workers that only need one provider's table. Requires `X-Internal-Auth`. **⚠ DECISION NEEDED:** do we actually need the per-provider endpoint in v1, or is the bulk endpoint enough? Track 2's orchestrator cost calc can just fetch-all-and-cache; the per-provider endpoint adds a second code path for little benefit. Recommend deferring unless Track 2 explicitly asks for it.
+- `POST /internal/pricing` on `llm-usage-service` — write pricing (for the migration script and future admin operations). Requires `X-Internal-Auth`.
+- `GET /llm-usage/pricing` on `llm-usage-service` — returns the `AllPricingResponse` shape (`{ google, openai, anthropic, perplexity, openrouter }`), wrapped in `{ success, data }`. Requires Auth0 bearer auth. This is the public read endpoint used by Track 5's pricing UI.
 
 ### Removed
-None in this track. `GET /internal/settings/pricing` on `app-settings-service` is DEPRECATED in Phase 7 (returns 307 → usage service) but physical removal is out of scope (happens after 2 weeks of stability, tracked separately).
+- `GET /internal/settings/pricing` on `app-settings-service` — **deleted** in Phase 7 (same PR as the consumer migration). No 307 redirect, no 410 period.
 
 ### Unchanged
-- `POST /internal/usage/events` — behavior unchanged for callers who keep supplying a complete `cost` block.
-- `POST /internal/webhooks/usage-events` — orchestrator webhook. NOT touched in this track; Track 2 (INT-1341) wires it up to use `computeCost: true` once this track lands.
+- `POST /internal/usage/events` — unaffected. Behavior, schema, and callers unchanged.
 - `POST /internal/usage/query` — unaffected.
-- `GET /internal/settings/pricing` — physically still there and still serving the same data during Phases 1-6. Only deprecated (307) in Phase 7.
 
 ## Step-by-step implementation
 
@@ -103,7 +93,7 @@ export class FakePricingRepository implements PricingRepository {
 }
 ```
 
-The Firestore test asserts three things: (a) `getByProvider` returns `null` for a missing doc, (b) `getByProvider` returns a typed `ProviderPricing` for a present doc, (c) `getAll` reads all four providers in parallel and returns a fully-populated `Record<LlmProvider, ProviderPricing>`. Use the repo's Firestore emulator pattern from `apps/llm-usage-service/src/__tests__/infra/firestore/firestoreUsageEventRepository.test.ts` as the template.
+The Firestore test asserts three things: (a) `getByProvider` returns `null` for a missing doc, (b) `getByProvider` returns a typed `ProviderPricing` for a present doc, (c) `getAll` reads all five providers in parallel and returns a fully-populated `Record<LlmProvider, ProviderPricing>`. Use the repo's Firestore emulator pattern from `apps/llm-usage-service/src/__tests__/infra/firestore/firestoreUsageEventRepository.test.ts` as the template.
 
 Expected failure: tests import `../domain/repositories/pricingRepository.js` and `./firestorePricingRepository.js`, neither of which exists yet. Vitest reports `Cannot find module`.
 
@@ -119,7 +109,7 @@ export interface PricingRepository {
   getByProvider(provider: LlmProvider): Promise<ProviderPricing | null>;
 
   /**
-   * Fetch all four provider pricing docs in parallel.
+   * Fetch all five provider pricing docs in parallel.
    * Throws if any required provider is missing - this is a service-level
    * invariant (pricing must be complete or the service is broken).
    */
@@ -161,6 +151,7 @@ export class FirestorePricingRepository implements PricingRepository {
       LlmProviders.OpenAI,
       LlmProviders.Anthropic,
       LlmProviders.Perplexity,
+      LlmProviders.OpenRouter,
     ] as const;
     const results = await Promise.all(providers.map((p) => this.getByProvider(p)));
     const out: Partial<Record<LlmProvider, ProviderPricing>> = {};
@@ -178,6 +169,8 @@ export class FirestorePricingRepository implements PricingRepository {
 ```
 
 Note the collection path: `llm_pricing/{provider}` — **flat, not nested**. The old `app-settings-service` uses `settings/llm_pricing/providers/{provider}` (4 segments) because it shared the `settings` parent doc with other subtrees. The usage service doesn't need that nesting, so we use the simpler flat shape. The migration in Phase 5 does the copy.
+
+Note on providers: 5 providers total — `google`, `openai`, `anthropic`, `perplexity`, `openrouter`. `zai` has been dropped entirely (per INT-1338 decisions). For OpenRouter, pricing table entries may be informational only since cost comes from the provider API response (`cost.pricingSource = 'provider_reported'`). Verify what is actually stored during implementation; do not throw if OpenRouter pricing is absent if the design settles on informational-only.
 
 #### Step 1.4: Wire the repo into `services.ts`
 
@@ -217,7 +210,7 @@ Pre-flight: before editing, `rg "setServices\(" apps/llm-usage-service/src` to e
 ```json
 "llm_pricing": {
   "owner": "llm-usage-service",
-  "description": "LLM pricing per provider (one doc per provider, keyed by provider ID). Read by ingestUsageEvents for server-side cost calc and exposed via GET /internal/pricing."
+  "description": "LLM pricing per provider (one doc per provider, keyed by provider ID). Exposed via GET /llm-usage/pricing for the pricing UI and POST /internal/pricing for admin writes."
 }
 ```
 
@@ -225,37 +218,66 @@ This enforces the one-owner rule. No other service may read or write `llm_pricin
 
 ### Phase 2 — HTTP routes
 
-#### Step 2.1: Failing test for `GET /internal/pricing`
+#### Step 2.1: Failing tests for the new pricing routes
 
-- File: `apps/llm-usage-service/src/__tests__/routes/internalPricingRoutes.test.ts` (new)
+- File: `apps/llm-usage-service/src/__tests__/routes/pricingRoutes.test.ts` (new)
 
-Test cases:
+Test cases for `POST /internal/pricing` (write):
 1. Missing `X-Internal-Auth` → 401 with `error.code === 'UNAUTHORIZED'`.
-2. Valid auth + fake repo populated with all 4 providers → 200 with body `{ success: true, data: { google, openai, anthropic, perplexity } }`, each matching `AllPricingResponse` shape.
+2. Valid auth + valid body → 200, data persisted via `pricingRepository`.
+3. Invalid body (missing required fields) → 400 schema validation error.
+
+Test cases for `GET /llm-usage/pricing` (public read):
+1. Missing Auth0 bearer → 401 with `error.code === 'UNAUTHORIZED'`.
+2. Valid Auth0 bearer + fake repo populated with all 5 providers → 200 with body `{ success: true, data: { google, openai, anthropic, perplexity, openrouter } }`, each matching `AllPricingResponse` shape.
 3. Valid auth + fake repo missing `anthropic` → 500 with `error.code === 'INTERNAL_ERROR'` and the message mentions the missing provider.
 4. Fastify route schema validation: response body is checked against the schema (`additionalProperties: false`) so any accidental leak of extra fields fails the test.
 
 The test uses `app.inject()` per the project testing rules. Use `setServices({ ...defaults, pricingRepository: fake })` in `beforeEach`, `resetServices()` in `afterEach`.
 
-Expected failure: the route does not exist yet, Fastify returns 404.
+Expected failure: the routes do not exist yet, Fastify returns 404.
 
-#### Step 2.2: Implement the route
+#### Step 2.2: Implement the routes
 
-- File: `apps/llm-usage-service/src/routes/internalPricingRoutes.ts` (new)
+- File: `apps/llm-usage-service/src/routes/pricingRoutes.ts` (new)
 
 ```ts
 import type { FastifyPluginCallback, FastifyReply, FastifyRequest } from 'fastify';
-import { validateInternalAuth, logIncomingRequest } from '@intexuraos/common-http';
+import { validateInternalAuth, validateAuth0Bearer, logIncomingRequest } from '@intexuraos/common-http';
 import { getServices } from '../services.js';
 
-export const internalPricingRoutes: FastifyPluginCallback = (app, _opts, done) => {
-  app.get(
+export const pricingRoutes: FastifyPluginCallback = (app, _opts, done) => {
+  // Write: internal only
+  app.post(
     '/internal/pricing',
     {
       schema: {
-        operationId: 'internalGetAllPricing',
-        summary: 'Get all LLM pricing (internal)',
-        description: 'Returns pricing for google, openai, anthropic, and perplexity.',
+        operationId: 'internalWritePricing',
+        summary: 'Write LLM pricing for a provider (internal)',
+        tags: ['pricing'],
+        // body schema: ProviderPricing shape
+      },
+    },
+    async (request: FastifyRequest, reply: FastifyReply) => {
+      logIncomingRequest(request, { message: 'Internal pricing write' });
+      const authResult = validateInternalAuth(request);
+      if (!authResult.valid) {
+        return await reply.fail('UNAUTHORIZED', 'Internal auth failed');
+      }
+      const { pricingRepository } = getServices();
+      // ... persist the body via pricingRepository
+      return await reply.ok({});
+    },
+  );
+
+  // Read: public, Auth0 bearer
+  app.get(
+    '/llm-usage/pricing',
+    {
+      schema: {
+        operationId: 'getAllPricing',
+        summary: 'Get all LLM pricing',
+        description: 'Returns pricing for google, openai, anthropic, perplexity, and openrouter.',
         tags: ['pricing'],
         response: {
           200: {
@@ -264,27 +286,28 @@ export const internalPricingRoutes: FastifyPluginCallback = (app, _opts, done) =
               success: { type: 'boolean', const: true },
               data: {
                 type: 'object',
-                required: ['google', 'openai', 'anthropic', 'perplexity'],
+                required: ['google', 'openai', 'anthropic', 'perplexity', 'openrouter'],
                 properties: {
                   google: { $ref: 'ProviderPricing#' },
                   openai: { $ref: 'ProviderPricing#' },
                   anthropic: { $ref: 'ProviderPricing#' },
                   perplexity: { $ref: 'ProviderPricing#' },
+                  openrouter: { $ref: 'ProviderPricing#' },
                 },
               },
             },
             required: ['success', 'data'],
           },
-          401: { /* same shape as other routes in internalUsageRoutes.ts */ },
+          401: { /* same shape as other routes */ },
           500: { /* same */ },
         },
       },
     },
     async (request: FastifyRequest, reply: FastifyReply) => {
-      logIncomingRequest(request, { message: 'Internal pricing read' });
-      const authResult = validateInternalAuth(request);
+      logIncomingRequest(request, { message: 'Public pricing read' });
+      const authResult = validateAuth0Bearer(request);
       if (!authResult.valid) {
-        return await reply.fail('UNAUTHORIZED', 'Internal auth failed');
+        return await reply.fail('UNAUTHORIZED', 'Auth failed');
       }
       const { pricingRepository } = getServices();
       try {
@@ -315,7 +338,7 @@ export const providerPricingSchema = {
   type: 'object',
   required: ['provider', 'models', 'updatedAt'],
   properties: {
-    provider: { type: 'string', enum: ['google', 'openai', 'anthropic', 'perplexity'] },
+    provider: { type: 'string', enum: ['google', 'openai', 'anthropic', 'perplexity', 'openrouter'] },
     models: {
       type: 'object',
       additionalProperties: {
@@ -349,263 +372,10 @@ export function registerPricingSchemas(app: FastifyInstance): void {
 - Edit `apps/llm-usage-service/src/routes/index.ts:1-9` to add:
 
 ```ts
-import { internalPricingRoutes } from './internalPricingRoutes.js';
+import { pricingRoutes } from './pricingRoutes.js';
 // ...
-await app.register(internalPricingRoutes);
+await app.register(pricingRoutes);
 ```
-
-### Phase 3 — Server-side cost calculation
-
-#### Step 3.1: Decide on the compute flag
-
-**⚠ DECISION NEEDED:** two options for how callers opt into server-side cost calc:
-
-- **Option A — `computeCost` flag on request body.** `IngestBody` gains `computeCost?: boolean`. When true, each event's `cost` block may be omitted (schema becomes `required: ['...', 'usage', 'correlation', 'error']` with `cost` moved out) and the use case fills it in. Existing strict callers keep sending `cost` and are unaffected.
-- **Option B — Always make `cost` optional.** Schema drops `cost` from `required`, use case fills in a zero-cost placeholder if absent. Simpler but silently hides bugs (caller forgot to send cost → we write $0).
-
-Recommend Option A. Option B violates the repo's strict-schema philosophy (see `usageEventSchema.ts:19-20` `additionalProperties: false`).
-
-The rest of this phase assumes Option A.
-
-#### Step 3.2: Failing test for the cost calculator
-
-- File: `apps/llm-usage-service/src/__tests__/domain/usecases/calculateEventCost.test.ts` (new)
-
-Test cases for a new pure function `calculateEventCost(event, pricing): { billedUsd, calculatedUsd, pricingSource }`:
-
-1. Claude with cached reads: `inputTokens=1000, cacheReadTokens=500, outputTokens=200, cacheWriteTokens=0`, pricing from `migrations/012_new-pricing-structure.mjs` (`claude-sonnet-4-5`: `$3/M in`, `$15/M out`, `cacheReadMultiplier=0.1`, `cacheWriteMultiplier=1.25`). Expected billed = `(1000/1e6 * 3) + (500/1e6 * 3 * 0.1) + (200/1e6 * 15)` = `0.003 + 0.00015 + 0.003` = `$0.00615`.
-2. OpenAI `gpt-5.2` simple text: `inputTokens=1000, outputTokens=500`, no cache fields → `(1000/1e6 * 1.75) + (500/1e6 * 14)` = `0.00175 + 0.007` = `$0.00875`.
-3. Perplexity with `useProviderCost=true` and `providerReportedUsd=0.042`: the function returns `{ billedUsd: 0.042, calculatedUsd: null, pricingSource: 'provider_reported' }` (bypasses math).
-4. Model not in pricing table: throws `PricingNotFoundError` with the provider/model in the message.
-5. Image generation: `model=gemini-2.5-flash-image, imageCount=2, imagePricing['1024x1024']=0.03` → `$0.06` and pricingSource `calculated`.
-6. Web search: `model=claude-opus-4-5-20251101, webSearchCalls=3, webSearchCostPerCall=0.03`, plus token cost → billed = token cost + `0.09`.
-7. Grounding enabled for Gemini: `groundingEnabled=true, groundingCostPerRequest=0.035` → billed += `0.035` once (flat per-request).
-
-Expected failure: `calculateEventCost` doesn't exist yet.
-
-#### Step 3.3: Implement `calculateEventCost`
-
-- File: `apps/llm-usage-service/src/domain/usecases/calculateEventCost.ts` (new)
-
-```ts
-import type { LLMModel, ModelPricing, ProviderPricing } from '@intexuraos/llm-contract';
-import type { UsageEventInput } from '../models/usageEvent.js';
-
-export class PricingNotFoundError extends Error {
-  constructor(readonly provider: string, readonly model: string) {
-    super(`Pricing not found for ${provider}/${model}`);
-    this.name = 'PricingNotFoundError';
-  }
-}
-
-export interface CalculatedCost {
-  billedUsd: number;
-  calculatedUsd: number | null;
-  pricingSource: 'calculated' | 'provider_reported';
-}
-
-export function calculateEventCost(
-  event: Pick<UsageEventInput, 'request' | 'usage' | 'cost'>,
-  pricing: Record<string, ProviderPricing>,
-): CalculatedCost {
-  const providerPricing = pricing[event.request.provider];
-  if (providerPricing === undefined) {
-    throw new PricingNotFoundError(event.request.provider, event.request.model);
-  }
-  const model: ModelPricing | undefined = providerPricing.models[event.request.model];
-  if (model === undefined) {
-    throw new PricingNotFoundError(event.request.provider, event.request.model);
-  }
-
-  // Provider-reported bypass (Perplexity)
-  if (model.useProviderCost === true && event.cost?.providerReportedUsd != null) {
-    return {
-      billedUsd: event.cost.providerReportedUsd,
-      calculatedUsd: null,
-      pricingSource: 'provider_reported',
-    };
-  }
-
-  const u = event.usage;
-  let cost = 0;
-  cost += (u.inputTokens / 1_000_000) * model.inputPricePerMillion;
-  cost += (u.outputTokens / 1_000_000) * model.outputPricePerMillion;
-  if (model.cacheReadMultiplier !== undefined) {
-    cost += (u.cacheReadTokens / 1_000_000) * model.inputPricePerMillion * model.cacheReadMultiplier;
-  }
-  if (model.cacheWriteMultiplier !== undefined) {
-    cost += (u.cacheWriteTokens / 1_000_000) * model.inputPricePerMillion * model.cacheWriteMultiplier;
-  }
-  if (model.webSearchCostPerCall !== undefined && u.webSearchCalls > 0) {
-    cost += u.webSearchCalls * model.webSearchCostPerCall;
-  }
-  if (model.groundingCostPerRequest !== undefined && u.groundingEnabled) {
-    cost += model.groundingCostPerRequest;
-  }
-  if (model.imagePricing !== undefined && u.imageCount > 0) {
-    // Default to 1024x1024 for v1; per-size pricing is a follow-up.
-    // ⚠ DECISION NEEDED: do we need a `size` hint on UsageEventUsage, or is 1024x1024 good enough?
-    const perImage = model.imagePricing['1024x1024'] ?? 0;
-    cost += u.imageCount * perImage;
-  }
-
-  return { billedUsd: cost, calculatedUsd: cost, pricingSource: 'calculated' };
-}
-```
-
-The `imagePricing` default-to-1024 is an explicit simplification — note the DECISION NEEDED marker. Current consumers only generate at 1024x1024, so this is a safe default; if/when other sizes are used, add a `request.imageSize` field to the event schema.
-
-#### Step 3.4: Failing test for ingest with `computeCost: true`
-
-- File: `apps/llm-usage-service/src/__tests__/domain/usecases/ingestUsageEvents.test.ts` (extend)
-
-Add a test: when called with `computeCost: true` and an event whose `cost` block is absent, the use case calls `pricingRepository.getAll()` once per batch (cached for the whole batch, not per event), fills in `cost` via `calculateEventCost`, then delegates to `usageEventRepository.createEvent` with the filled event. Assert the persisted event has `cost.pricingSource === 'calculated'` and `cost.billedUsd > 0`.
-
-Also test: `computeCost: true` + model missing from pricing table → event is rejected (not stored), returned in the `rejected` array with `code: 'PRICING_NOT_FOUND'`, but other events in the same batch still process successfully.
-
-Also test: when called with `computeCost: false` (or omitted), the existing code path runs unchanged — no call to `pricingRepository.getAll()`.
-
-#### Step 3.5: Update `ingestUsageEvents` signature and body
-
-- File: `apps/llm-usage-service/src/domain/usecases/ingestUsageEvents.ts:7-80`
-
-```ts
-export interface IngestUsageEventsDeps {
-  logger: Logger;
-  usageEventRepository: UsageEventRepository;
-  usageAggregateRepository: UsageAggregateRepository;
-  pricingRepository: PricingRepository;  // NEW
-}
-
-export async function ingestUsageEvents(
-  deps: IngestUsageEventsDeps,
-  events: (UsageEventInput | TokenOnlyUsageEventInput)[],
-  ingress: 'internal' | 'orchestrator_webhook',
-  options: { computeCost?: boolean } = {},
-): Promise<UsageIngestResponse> {
-  // ...
-  // If computeCost is true, fetch pricing once up front:
-  let pricingSnapshot: Record<LlmProvider, ProviderPricing> | null = null;
-  if (options.computeCost === true) {
-    pricingSnapshot = await deps.pricingRepository.getAll();
-  }
-
-  for (let i = 0; i < events.length; i++) {
-    const input = events[i];
-    if (input === undefined) continue;
-
-    let costBlock = 'cost' in input ? input.cost : undefined;
-    if (costBlock === undefined || options.computeCost === true) {
-      if (pricingSnapshot === null) {
-        rejected.push({ index: i, code: 'INVALID_REQUEST', message: 'cost is required when computeCost is false' });
-        continue;
-      }
-      try {
-        const calculated = calculateEventCost(input as UsageEventInput, pricingSnapshot);
-        costBlock = {
-          billedUsd: calculated.billedUsd,
-          providerReportedUsd: null,
-          calculatedUsd: calculated.calculatedUsd,
-          pricingSource: calculated.pricingSource,
-        };
-      } catch (e) {
-        if (e instanceof PricingNotFoundError) {
-          rejected.push({ index: i, code: 'PRICING_NOT_FOUND', message: e.message });
-          continue;
-        }
-        throw e;
-      }
-    }
-
-    const fullEvent: UsageEvent = { ...input, cost: costBlock, receivedAt, ingress };
-    // ... existing createEvent + aggregate flow
-  }
-}
-```
-
-Note: `TokenOnlyUsageEventInput` is a new type alias: `Omit<UsageEventInput, 'cost'>`. Add it to `apps/llm-usage-service/src/domain/models/usageEvent.ts`.
-
-#### Step 3.6: Widen the Fastify route schema
-
-- File: `apps/llm-usage-service/src/routes/schemas/usageEventSchema.ts:16-164`
-
-Add a second exported schema `$id: 'TokenOnlyUsageEventInput'` that is a copy of `UsageEventInput` with `cost` removed from `required`. The existing strict schema stays. The route body in `internalUsageRoutes.ts` becomes:
-
-```ts
-body: {
-  type: 'object',
-  required: ['schemaVersion', 'events'],
-  properties: {
-    schemaVersion: { type: 'integer', enum: [1] },
-    computeCost: { type: 'boolean', default: false },
-    events: {
-      type: 'array',
-      items: { anyOf: [{ $ref: 'UsageEventInput#' }, { $ref: 'TokenOnlyUsageEventInput#' }] },
-    },
-  },
-}
-```
-
-**⚠ DECISION NEEDED:** the `anyOf` approach allows mixed batches (some events with `cost`, some without) in a single request. If we want stricter behavior — "if `computeCost: true`, ALL events must omit `cost`" — the schema gets more complex (a top-level `if/then/else`). Recommend starting with `anyOf` for simplicity; Track 5 can tighten later if needed.
-
-#### Step 3.7: Pass `pricingRepository` and `computeCost` through the route handler
-
-- File: `apps/llm-usage-service/src/routes/internalUsageRoutes.ts:85-94`
-
-```ts
-const { usageEventRepository, usageAggregateRepository, pricingRepository } = getServices();
-const result = await ingestUsageEvents(
-  { logger: request.log, usageEventRepository, usageAggregateRepository, pricingRepository },
-  body.events,
-  'internal',
-  { computeCost: body.computeCost === true },
-);
-```
-
-Do the same in `apps/llm-usage-service/src/routes/webhookUsageRoutes.ts` so the orchestrator webhook can opt in once Track 2 wires it up. **Default `computeCost: false`** on the webhook for now — Track 2 flips it to `true` when ready.
-
-### Phase 4 — Internal client extension
-
-#### Step 4.1: Failing test for the new client method
-
-- File: `packages/internal-clients/src/usage-service/__tests__/client.test.ts`
-
-Add a test for `fetchPricing()`: mocks a successful `GET /internal/pricing` response via `nock`, asserts the client returns `ok({ google, openai, anthropic, perplexity })`. Add a failure test for 401 → `err({ code: 'API_ERROR' })`. Add a network failure test → `err({ code: 'NETWORK_ERROR' })`.
-
-#### Step 4.2: Extend the client
-
-- File: `packages/internal-clients/src/usage-service/types.ts:171-181`
-
-```ts
-import type { AllPricingResponse } from '@intexuraos/llm-pricing';
-
-export interface UsageServiceClient {
-  ingestEvents(...): Promise<Result<UsageIngestResponse, UsageServiceError>>;
-  queryUsage(...): Promise<Result<UsageQueryResponse, UsageServiceError>>;
-  fetchPricing(options?: { traceId?: string }): Promise<Result<AllPricingResponse, UsageServiceError>>;  // NEW
-}
-```
-
-- File: `packages/internal-clients/src/usage-service/client.ts:19-61`
-
-```ts
-async fetchPricing(
-  options?: { traceId?: string },
-): Promise<Result<AllPricingResponse, UsageServiceError>> {
-  const result = await fetchWithAuth<ApiResponse<AllPricingResponse>>(
-    config,
-    '/internal/pricing',
-    {
-      method: 'GET',
-      ...(options?.traceId !== undefined ? { traceId: options.traceId } : {}),
-    },
-  );
-  if (!result.ok) return err({ code: result.error.code, message: result.error.message });
-  return ok(result.value.data);
-}
-```
-
-Pre-flight: before adding the `AllPricingResponse` import, confirm `@intexuraos/llm-pricing` is already a dependency of `packages/internal-clients`: `rg '"@intexuraos/llm-pricing"' packages/internal-clients/package.json`. If not, add it as a `dependencies` entry. Running `pnpm install` is required before the build will succeed.
 
 ### Phase 5 — One-time migration from `app-settings-service`
 
@@ -620,9 +390,10 @@ Pre-flight: before adding the `AllPricingResponse` import, confirm `@intexuraos/
  * Source: settings/llm_pricing/providers/{provider}     (owner: app-settings-service)
  * Target: llm_pricing/{provider}                         (owner: llm-usage-service)
  *
+ * Providers: google, openai, anthropic, perplexity, openrouter (zai dropped)
+ *
  * Idempotent: re-running this is safe. Overwrites the target doc with the
- * source doc each time. The SOURCE is NOT deleted — that happens in a later
- * cleanup migration after the app-settings-service endpoint is removed.
+ * source doc each time.
  */
 
 export const metadata = {
@@ -633,7 +404,7 @@ export const metadata = {
 };
 
 export async function up(context) {
-  const providers = ['google', 'openai', 'anthropic', 'perplexity'];
+  const providers = ['google', 'openai', 'anthropic', 'perplexity', 'openrouter'];
   const batch = context.firestore.batch();
   let copied = 0;
 
@@ -655,129 +426,114 @@ export async function up(context) {
 
 #### Step 5.2: Test the migration against the emulator
 
-Run `node scripts/migrate.mjs` against the emulator (see Phase 1 instructions in the plan reference) and confirm `llm_pricing/google`, `llm_pricing/openai`, `llm_pricing/anthropic`, `llm_pricing/perplexity` all exist with the same model data as the source. Assert via a spot check: `anthropic.models['claude-sonnet-4-5-20250929'].inputPricePerMillion === 3`.
+Run `node scripts/migrate.mjs` against the emulator (see Phase 1 instructions in the plan reference) and confirm `llm_pricing/google`, `llm_pricing/openai`, `llm_pricing/anthropic`, `llm_pricing/perplexity`, `llm_pricing/openrouter` all exist with the same model data as the source. Assert via a spot check: `anthropic.models['claude-sonnet-4-5-20250929'].inputPricePerMillion === 3`.
 
-#### Step 5.3: Parity verification script
+### Phase 6 — Migrate all consumers and delete old endpoint (atomic)
 
-- File: `apps/llm-usage-service/scripts/verify-pricing-parity.mjs` (new)
+This phase is a **single PR** that:
+1. Updates all 11 consumers' `fetchAllPricing()` callers (in-place URL swap).
+2. Deletes the old `GET /internal/settings/pricing` route on `app-settings-service`.
 
-Standalone node script that starts no server — it opens Firestore directly, reads both `settings/llm_pricing/providers/*` and `llm_pricing/*`, and asserts deep-equality per provider. Prints a diff if mismatch. This script is NOT a migration; it's a manual verification tool, rerun after every pricing update until old endpoint is removed.
+No staged rollout. All consumers flip at once, then the old endpoint is gone. Ship during a low-traffic window with standard rollback readiness.
 
-Run this against dev Firestore after 5.2 lands and before Phase 6 starts.
+#### Step 6.1: Update `fetchAllPricing()` in place
 
-### Phase 6 — Redirect all consumers
+- File: `packages/llm-pricing/src/pricingClient.ts:129`
 
-This phase is mechanical: every consumer that calls `fetchAllPricing(APP_SETTINGS_SERVICE_URL, ...)` is updated to call it with the new URL **and** a different endpoint path. There are two ways to do this:
+Change the URL from `${baseUrl}/internal/settings/pricing` to `${baseUrl}/internal/pricing`. This is an in-place edit of the existing `fetchAllPricing()` — **do not** add a new symbol (`fetchAllPricingFromUsageService` is NOT created).
 
-**Option A — Update `fetchAllPricing()` in place.** Change `packages/llm-pricing/src/pricingClient.ts:129` from `${baseUrl}/internal/settings/pricing` to `${baseUrl}/internal/pricing`. Then update each consumer to pass the llm-usage-service URL instead of app-settings-service URL. PRO: no new symbol, no deprecations. CON: big-bang — all 11 consumers must be updated and deployed together.
+Export is unchanged. Callers change only the URL they pass (from `app-settings-service` URL to `llm-usage-service` URL).
 
-**Option B — Add a new symbol.** Add a second function `fetchAllPricingFromUsageService(baseUrl, token)` that hits `/internal/pricing`, keeping the old `fetchAllPricing()` unchanged. Flip consumers one at a time. PRO: incremental rollout. CON: two functions doing the same thing for the duration of the rollout.
+Update tests in `packages/llm-pricing/src/__tests__/pricingClient.test.ts` to reflect the new path.
 
-**⚠ DECISION NEEDED:** Recommend **Option B** because the repo's dev environment has PM2 restarting services independently and prod has Cloud Run rolling deploys. Big-bang requires all 11 apps to redeploy atomically, which the infrastructure doesn't guarantee. The `fetchAllPricing()` vs `fetchAllPricingFromUsageService()` split is short-lived (1-2 weeks) and deleted in Phase 7.
+#### Step 6.2: Flip all 11 consumers
 
-The rest of this phase assumes Option B.
-
-#### Step 6.1: Add `fetchAllPricingFromUsageService` to `@intexuraos/llm-pricing`
-
-- File: `packages/llm-pricing/src/pricingClient.ts` (append)
-
-```ts
-export async function fetchAllPricingFromUsageService(
-  baseUrl: string,
-  authToken: string,
-): Promise<Result<AllPricingResponse, PricingClientError>> {
-  const url = `${baseUrl}/internal/pricing`;
-  try {
-    const response = await fetch(url, { headers: { 'X-Internal-Auth': authToken } });
-    if (!response.ok) {
-      const body = await response.text().catch(() => '');
-      return err({ code: 'API_ERROR', message: `HTTP ${String(response.status)}: ${body.slice(0, 200)}` });
-    }
-    const data = (await response.json()) as { success: boolean; data: AllPricingResponse };
-    if (!data.success) return err({ code: 'API_ERROR', message: 'Response success is false' });
-    return ok(data.data);
-  } catch (error) {
-    return err({ code: 'NETWORK_ERROR', message: getErrorMessage(error) });
-  }
-}
-```
-
-Export from `packages/llm-pricing/src/index.ts:17-24`. Add a test in `packages/llm-pricing/src/__tests__/pricingClient.test.ts` mirroring the existing `fetchAllPricing` tests.
-
-#### Step 6.2: Flip consumers one at a time
-
-Rollout order (safest first — the services least likely to break if pricing fetch fails):
-
-1. `apps/image-service/src/index.ts:44-48` — image service (narrow blast radius: only affects image generation cost calc).
-2. `apps/research-agent/src/index.ts:64-68` — research agent.
-3. `apps/data-insights-agent/src/index.ts:51-53` — data insights.
-4. `apps/calendar-agent/src/index.ts:43-45` — calendar.
-5. `apps/linear-agent/src/index.ts:45-47` — linear.
-6. `apps/commands-agent/src/services.ts:67` — commands.
-7. `apps/actions-agent/src/services.ts:176-186` — actions.
-8. `apps/todos-agent/src/services.ts:31` — todos.
-9. `apps/user-service/src/index.ts:48-52` — user-service (wider impact: every user login touches it).
-10. `apps/web-agent/src/index.ts:35-45` — web-agent.
-11. `apps/chat-agent/src/services.ts:80-109` — chat-agent (highest traffic; last).
-
-For each, the change is:
+For each consumer, the change is:
 
 ```ts
 // BEFORE
-import { fetchAllPricing, createPricingContext } from '@intexuraos/llm-pricing';
 const appSettingsUrl = process.env['INTEXURAOS_APP_SETTINGS_SERVICE_URL'] ?? '';
 const pricingResult = await fetchAllPricing(appSettingsUrl, internalAuthToken);
 
 // AFTER
-import { fetchAllPricingFromUsageService, createPricingContext } from '@intexuraos/llm-pricing';
 const usageServiceUrl = process.env['INTEXURAOS_LLM_USAGE_SERVICE_URL'] ?? '';
-const pricingResult = await fetchAllPricingFromUsageService(usageServiceUrl, internalAuthToken);
+const pricingResult = await fetchAllPricing(usageServiceUrl, internalAuthToken);
 ```
+
+All 11 consumers:
+
+1. `apps/image-service/src/index.ts:44-48`
+2. `apps/research-agent/src/index.ts:64-68`
+3. `apps/data-insights-agent/src/index.ts:51-53`
+4. `apps/calendar-agent/src/index.ts:43-45`
+5. `apps/linear-agent/src/index.ts:45-47`
+6. `apps/commands-agent/src/services.ts:67`
+7. `apps/actions-agent/src/services.ts:176-186`
+8. `apps/todos-agent/src/services.ts:31`
+9. `apps/user-service/src/index.ts:48-52`
+10. `apps/web-agent/src/index.ts:35-45`
+11. `apps/chat-agent/src/services.ts:80-109`
 
 **Env var check for each consumer:**
 
 - `apps/<name>/src/index.ts` `REQUIRED_ENV` array — if the consumer previously required `INTEXURAOS_APP_SETTINGS_SERVICE_URL` **only for pricing** (not for anything else), remove it from `REQUIRED_ENV` and add `INTEXURAOS_LLM_USAGE_SERVICE_URL`. Run `rg "APP_SETTINGS_SERVICE_URL" apps/<name>` first — if it's still used elsewhere (e.g. todos-agent uses it for saving model preferences), KEEP it.
-- `terraform/environments/dev/main.tf` — add `INTEXURAOS_LLM_USAGE_SERVICE_URL = module.llm_usage_service.service_url` to each consumer's env map IF NOT ALREADY PRESENT (it already is for services that call the usage service for ingest; check before editing).
+- `terraform/environments/dev/main.tf` — add `INTEXURAOS_LLM_USAGE_SERVICE_URL = module.llm_usage_service.service_url` to each consumer's env map IF NOT ALREADY PRESENT.
 - `ecosystem.config.cjs` — same check. `INTEXURAOS_LLM_USAGE_SERVICE_URL` is already defined globally at line 57, so it should flow to every PM2 app that imports the shared env.
 
-**Per-consumer test updates.** Each consumer that mocks pricing in its test suite (e.g. `apps/chat-agent/src/__tests__/services.test.ts:47`) needs its mock updated from `mockFetchAllPricing` → `mockFetchAllPricingFromUsageService`. Grep each consumer's `__tests__/` for `fetchAllPricing` before editing the source.
+**Per-consumer test updates.** Each consumer that mocks pricing in its test suite needs its mock URL updated to point at `/internal/pricing` (new path) rather than `/internal/settings/pricing` (old path). Grep each consumer's `__tests__/` for `fetchAllPricing` and `settings/pricing` before editing the source.
 
-#### Step 6.3: Run `ci:tracked` per consumer after each flip
+#### Step 6.3: Delete the old endpoint on `app-settings-service` (same PR)
 
-Do not batch multiple consumers into one commit. Each commit is:
-1. Flip one consumer.
-2. `pnpm run verify:workspace:tracked -- <app-name>`.
-3. `pnpm run ci:tracked`.
-4. Commit with title like `INT-1339: migrate chat-agent pricing fetch to llm-usage-service`.
-5. Open PR targeting `development`, merge, wait for dev deploy, smoke-test the consumer's health endpoint.
+In the same PR as Step 6.1 and 6.2:
 
-This is slow by design — we're swapping a startup-critical dependency on 11 apps.
-
-### Phase 7 — Deprecate the old endpoint
-
-#### Step 7.1: Return 307 from `app-settings-service`
-
-Only do this after Phase 6 has been stable for 1 week.
-
-- File: `apps/app-settings-service/src/routes/internalRoutes.ts:58-112`
-
-Replace the handler body with a 307 redirect to `${INTEXURAOS_LLM_USAGE_SERVICE_URL}/internal/pricing`. Keep the auth check (so unauthenticated callers still get 401, not a misleading 307). Log a warning on every hit so we can see which caller still uses the old endpoint.
-
-**⚠ DECISION NEEDED:** 307 vs 410-gone. 307 lets any unmigrated caller keep working transparently (fetch follows redirects by default). 410 forces a failure. Recommend 307 for 1 week to catch stragglers, then 410 for 1 week, then delete the route. Aggressive but safer than silently serving stale data.
-
-#### Step 7.2: Delete dead code
-
-After 2 weeks of 307+410 with zero hits in logs:
-
-- Delete `apps/app-settings-service/src/routes/internalRoutes.ts` handler (or the file if nothing else lives there).
-- Delete `apps/app-settings-service/src/infra/firestore/index.ts` `FirestorePricingRepository`.
-- Delete `apps/app-settings-service/src/services.ts` `pricingRepository` field.
-- Delete `apps/app-settings-service/src/__tests__/infra/FirestorePricingRepository.test.ts`.
+- Delete the `GET /internal/settings/pricing` route handler from `apps/app-settings-service/src/routes/internalRoutes.ts`.
+- Delete `apps/app-settings-service/src/infra/firestore/index.ts` `FirestorePricingRepository` (or the whole file if nothing else lives there).
+- Delete `apps/app-settings-service/src/services.ts` `pricingRepository` field and its wiring in `initializeServices()`.
+- Delete `apps/app-settings-service/src/__tests__/infra/FirestorePricingRepository.test.ts` if it exists.
 - Delete `apps/app-settings-service/src/domain/ports/index.ts` `PricingRepository`, `ModelPricing`, `ProviderPricing`, `ImageSize` (keep any usage-stats types still in use).
-- Delete the old `fetchAllPricing()` function from `packages/llm-pricing/src/pricingClient.ts:125-169` (only `fetchAllPricingFromUsageService` remains). Then rename it back to `fetchAllPricing` in a follow-up PR once there's no chance of confusion.
-- Write migration 087 (or whatever is next) to DELETE `settings/llm_pricing/providers/*` from Firestore.
+- Write migration 087 to DELETE `settings/llm_pricing/providers/*` from Firestore (now that the source is no longer needed).
 
-None of the Phase 7 deletions happen inside INT-1339 itself — they are follow-up tickets (e.g. INT-1339a, INT-1339b). This plan leaves the old endpoint in place behind a 307.
+No 307 redirect. No 410. The old endpoint is simply deleted.
+
+#### Step 6.4: Run `ci:tracked` before committing
+
+Run `pnpm run ci:tracked` from repo root. Every workspace must pass. Only then commit and open the PR.
+
+### Phase 7 — Cleanup migration
+
+#### Step 7.1: Write the cleanup migration
+
+- File: `migrations/087_delete_old_pricing_source.mjs` (new)
+
+```js
+/**
+ * Migration 087: Delete the old pricing source docs from app-settings-service.
+ *
+ * Now that llm-usage-service owns pricing and all consumers have been migrated,
+ * the source collection is no longer needed.
+ */
+
+export const metadata = {
+  id: '087',
+  name: 'delete_old_pricing_source',
+  description: 'Delete settings/llm_pricing/providers/* (app-settings-service no longer owns pricing)',
+  createdAt: '2026-04-10',
+};
+
+export async function up(context) {
+  const providers = ['google', 'openai', 'anthropic', 'perplexity', 'openrouter'];
+  const batch = context.firestore.batch();
+
+  for (const p of providers) {
+    batch.delete(context.firestore.doc(`settings/llm_pricing/providers/${p}`));
+  }
+
+  await batch.commit();
+  console.log(`  Deleted ${providers.length} old pricing docs from settings/llm_pricing/providers/*`);
+}
+```
+
+This migration ships in the same PR as Phase 6 (atomic deletion). Migrations 086 and 087 together form the complete move.
 
 ## Test plan
 
@@ -785,77 +541,50 @@ New test files:
 
 - `apps/llm-usage-service/src/__tests__/fakePricingRepository.ts` — in-memory fake used by multiple downstream tests.
 - `apps/llm-usage-service/src/__tests__/infra/firestore/firestorePricingRepository.test.ts` — Firestore integration. Asserts missing-doc returns null, present-doc round-trips, `getAll` throws on partial data.
-- `apps/llm-usage-service/src/__tests__/routes/internalPricingRoutes.test.ts` — route-level tests: 401 on missing auth, 200 on success, 500 on missing provider, schema validation.
-- `apps/llm-usage-service/src/__tests__/domain/usecases/calculateEventCost.test.ts` — pure unit tests for the cost formula. Covers the 7 scenarios in Step 3.2.
-- `apps/llm-usage-service/src/__tests__/domain/usecases/ingestUsageEvents.test.ts` — extended with 3 new cases: `computeCost: true` happy path, `computeCost: true` + unknown model → rejected, `computeCost: false` → no pricing fetch.
-- `packages/internal-clients/src/usage-service/__tests__/client.test.ts` — extended with `fetchPricing()` tests using `nock`.
-- `packages/llm-pricing/src/__tests__/pricingClient.test.ts` — extended with `fetchAllPricingFromUsageService()` tests that mirror the existing `fetchAllPricing()` suite (success, 4xx, 5xx, network error, invalid JSON, `success: false` body).
+- `apps/llm-usage-service/src/__tests__/routes/pricingRoutes.test.ts` — route-level tests: 401 on missing auth (both routes), 200 on success, 500 on missing provider (GET), schema validation.
+
+Updated test files:
+
+- `packages/llm-pricing/src/__tests__/pricingClient.test.ts` — update mocked URL from `/internal/settings/pricing` to `/internal/pricing`. No new test cases needed (same behavior, different path).
+- Per-consumer test updates (11 apps): update mock URLs from `/internal/settings/pricing` to `/internal/pricing`.
 
 Coverage targets:
 
-- `apps/llm-usage-service`: 95% branch coverage including the new files. The image-pricing branch (only-1024) is exercised. The `useProviderCost` branch is exercised.
-- `packages/internal-clients`: 95% branch coverage including `fetchPricing()`.
-- `packages/llm-pricing`: 95% branch coverage including `fetchAllPricingFromUsageService()`.
-- No `v8 ignore` pragmas are needed. If you find yourself writing one, stop and ask — every branch in this track is testable with the in-memory fake or `nock`.
-
-Per-consumer test updates (11 apps, Phase 6):
-
-- For each consumer, update mocks from `fetchAllPricing` to `fetchAllPricingFromUsageService`. No new test files needed.
+- `apps/llm-usage-service`: 95% branch coverage including the new files.
+- `packages/llm-pricing`: 95% branch coverage.
+- No `v8 ignore` pragmas are needed. If you find yourself writing one, stop and ask.
 
 ## Rollout plan
 
-1. **Phases 1-5 ship as one PR** targeting `development`. This adds the new route/repo/migration but does NOT touch any consumer. After merge, dev deploys, migration runs. Parity script from Step 5.3 passes.
-2. **Smoke test**: manually `curl` `https://llm-usage-service.<dev>/internal/pricing` with `X-Internal-Auth`. Confirm response shape matches `AllPricingResponse`. Compare against `GET /internal/settings/pricing` on app-settings-service — they must be byte-for-byte equal.
-3. **Phase 6 ships as 11 separate PRs**, one per consumer, in the order listed in Step 6.2. Each PR:
-   - Waits for previous consumer to be stable in dev for at least 1 hour.
-   - Runs `pnpm run ci:tracked`.
-   - After merge + dev deploy, tail the consumer's logs for startup errors and confirm it boots with pricing loaded.
-4. **Stability window**: after all 11 consumers are on the new endpoint, wait 1 week. During this week both endpoints serve the same data (from different Firestore collections, kept in sync by re-running migration 086 if needed).
-5. **Phase 7.1 ships as a single PR**: flip `GET /internal/settings/pricing` on app-settings-service to return 307. Tail logs for any hits.
-6. **Second stability window**: 1 week of 307. Any hits in logs are investigated — the caller is missing from Phase 6 and must be flipped.
-7. **Phase 7.2** (follow-up ticket): delete dead code and write the cleanup Firestore migration.
+1. **Phases 1-2 + 5 ship as one PR** targeting `development`. This adds the new routes/repo/migration but does NOT touch any consumer. After merge, dev deploys, migration 086 runs. Verify manually: `curl https://llm-usage-service.<dev>/llm-usage/pricing` with Auth0 bearer. Confirm response shape matches `AllPricingResponse` with 5 providers.
+2. **Phase 6 + 7 ship as a single PR** (atomic): flip all 11 consumers + delete old endpoint + run migration 087. Deploy during a low-traffic window. After merge + deploy, tail logs for startup errors on all 11 consumers.
+3. **No stability window needed** — atomic delete eliminates the dual-endpoint drift window entirely.
 
 ## Acceptance criteria
 
 - [ ] `apps/llm-usage-service/src/domain/repositories/pricingRepository.ts` exists and is a domain port.
 - [ ] `apps/llm-usage-service/src/infra/firestore/firestorePricingRepository.ts` exists and reads from `llm_pricing/{provider}`.
-- [ ] `GET /internal/pricing` on llm-usage-service returns `AllPricingResponse` and requires `X-Internal-Auth`.
-- [ ] `POST /internal/usage/events` accepts `computeCost: true` and fills `cost` server-side.
-- [ ] `calculateEventCost` handles cache multipliers, web search, grounding, image generation, and `useProviderCost` bypass.
-- [ ] `migrations/086_migrate_pricing_to_llm_usage_service.mjs` has been applied in dev and parity verified.
+- [ ] `POST /internal/pricing` on llm-usage-service requires `X-Internal-Auth` and writes pricing.
+- [ ] `GET /llm-usage/pricing` on llm-usage-service returns `AllPricingResponse` (5 providers: google, openai, anthropic, perplexity, openrouter) and requires Auth0 bearer auth.
+- [ ] `POST /internal/usage/events` is unmodified — no `computeCost` flag, no schema changes.
+- [ ] `migrations/086_migrate_pricing_to_llm_usage_service.mjs` has been applied in dev (5 providers copied).
+- [ ] `migrations/087_delete_old_pricing_source.mjs` has been applied (old source docs deleted).
 - [ ] `firestore-collections.json` lists `llm_pricing` owned by `llm-usage-service`.
-- [ ] `packages/internal-clients/src/usage-service/client.ts` has `fetchPricing()` method.
-- [ ] `packages/llm-pricing/src/pricingClient.ts` exports `fetchAllPricingFromUsageService`.
-- [ ] All 11 consumer apps have been migrated and each boots cleanly against `INTEXURAOS_LLM_USAGE_SERVICE_URL`.
+- [ ] `packages/llm-pricing/src/pricingClient.ts` `fetchAllPricing()` hits `/internal/pricing` (not `/internal/settings/pricing`).
+- [ ] All 11 consumer apps pass `llm-usage-service` URL to `fetchAllPricing()`.
+- [ ] `GET /internal/settings/pricing` on `app-settings-service` is deleted (no 307, no 410).
+- [ ] `app-settings-service` `pricingRepository` DI wiring is deleted.
 - [ ] `pnpm run ci:tracked` green at repo root.
 - [ ] New backend code has 95% branch coverage with no `v8 ignore` additions.
 - [ ] Every new test was written before its implementation (verifiable in git history).
-- [ ] `GET /internal/settings/pricing` on app-settings-service returns 307 (Phase 7.1 merged).
-- [ ] No consumer code references `fetchAllPricing` directly anymore (only `fetchAllPricingFromUsageService`).
-- [ ] No Firestore read/write to `settings/llm_pricing/providers/*` from any code path outside the migration script.
+- [ ] No Firestore read/write to `settings/llm_pricing/providers/*` from any code path outside the migration scripts.
 
 ## Risks and mitigations
 
-| Risk                                                                                                                                                                                       | Likelihood  | Impact   | Mitigation                                                                                                                                                                                                                   |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Migration 086 runs before llm-usage-service has the new route deployed, leaving a window where pricing is duplicated but not served.                                                       | Low         | Low      | Phases 1-5 ship as one PR so route + repo + migration go live together. The old endpoint keeps serving during this window.                                                                                                   |
-| A consumer silently fails to fetch pricing and boots with a broken `PricingContext`.                                                                                                       | Medium      | High     | Each consumer's bootstrap path already throws on pricing fetch failure (`fetchAllPricing` error → `throw new Error`). Don't relax that — fail loud. Tail logs after each Phase 6 PR.                                         |
-| `calculateEventCost` disagrees with the old client-side calculators (e.g. `infra-claude`), leading to cost drift between Track 2 (server-calc) and Phases 1 consumers (still client-calc). | High        | Medium   | Track 2 is the only caller who uses `computeCost: true` in the near term. Existing consumers keep supplying their own `cost` block. We accept a small Track-2-only drift for now; Track 5 (INT-1343) centralizes everything. |
-| Schema widening (`anyOf` on event item) breaks Fastify's strict validation for some edge case.                                                                                             | Low         | Medium   | Add a regression test in `internalUsageRoutes.test.ts` that posts a mixed batch (1 event with cost, 1 without + `computeCost: true`) and asserts both succeed.                                                               |
-| The new `llm_pricing` Firestore collection drifts from `settings/llm_pricing/providers/*` because the old endpoint keeps getting updates.                                                  | High        | High     | No pricing writes happen during this track. If pricing changes are needed mid-rollout, write a new migration (087) that updates BOTH collections until Phase 7 is done.                                                      |
-| Per-size image pricing (1024x1536, 1536x1024) is ignored — all image calls billed at 1024x1024 price.                                                                                      | Low today   | Medium   | Accepted: `DECISION NEEDED` marker on Step 3.3. Current consumers only use 1024x1024. If that changes, add `request.imageSize` to the event schema in a follow-up.                                                           |
-| The orchestrator (Track 2) starts calling `computeCost: true` before Phase 2 is deployed.                                                                                                  | Low         | High     | Track 2 is explicitly BLOCKED on INT-1339 per the plan header. Do not merge any Track 2 PR until INT-1339 Phase 1-5 is in dev.                                                                                               |
-| Rolling back a consumer mid-rollout leaves it pointing at the wrong URL.                                                                                                                   | Medium      | Low      | Each consumer PR is atomic (one commit, one app, one URL change). Revert = single `git revert`.                                                                                                                              |
-
-## Out of scope
-
-- User-scoped pricing endpoints (pricing stays internal-only).
-- Per-user pricing overrides or promotional pricing.
-- Caching `GET /internal/pricing` in consumers beyond the existing `PricingContext` (that's already per-process in-memory; no Redis).
-- Per-image-size event tracking — all image generation billed at 1024x1024 price in v1.
-- Historical backfill of `cost.billedUsd` on events that were stored with wrong prices before this track landed.
-- Deleting the `settings/llm_pricing/providers/*` Firestore subtree — that's a cleanup migration in a follow-up ticket.
-- Physically removing `GET /internal/settings/pricing` from app-settings-service — Phase 7.2 tracks deletion but ships separately.
-- Migrating the web app's settings UI (`apps/web/src/services/settingsApi.ts`) — the web app reads pricing for display, not calculation, and can stay pointed at `app-settings-service` indefinitely. If it ever needs to move, it's a separate ticket.
-- Track 2 (orchestrator cost calc) work itself — this plan only unblocks it.
-- Track 5 (full client rollout of `computeCost: true`) — this plan only provides the capability.
+| Risk                                                                                                                                 | Likelihood | Impact | Mitigation                                                                                                                                                             |
+| ------------------------------------------------------------------------------------------------------------------------------------ | ---------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Migration 086 runs before llm-usage-service has the new route deployed, leaving a window where pricing is duplicated but not served. | Low        | Low    | Phases 1-2+5 ship as one PR so route + repo + migration go live together. The old endpoint keeps serving during this window.                                           |
+| A consumer silently fails to fetch pricing and boots with a broken `PricingContext`.                                                 | Medium     | High   | Each consumer's bootstrap path already throws on pricing fetch failure. Don't relax that — fail loud. Tail logs after Phase 6 PR.                                      |
+| OpenRouter pricing table is absent from the old `app-settings-service` collection, causing migration 086 to throw.                   | Medium     | Medium | Verify during pre-flight: `rg "openrouter" apps/app-settings-service/src`. If OpenRouter pricing is not stored there, handle gracefully (skip or write a placeholder). |
+| Rolling back Phase 6 mid-deploy — old endpoint is already deleted.                                                                   | Low        | High   | Rollback = revert the PR (restores old endpoint + old consumer URLs in one revert commit). Prepare the revert commit locally before deploying.                         |
+| `fetchAllPricing()` URL change in `packages/llm-pricing` breaks a consumer that still points at `app-settings-service` URL.          | Low        | High   | All 11 consumers are updated in the same PR. There is no window where the old URL is used with the new path.                                                           |

--- a/docs/plans/INT-1339-track-4-pricing-ownership.md
+++ b/docs/plans/INT-1339-track-4-pricing-ownership.md
@@ -1,0 +1,861 @@
+# INT-1339 — Track 4: Move LLM Pricing Ownership into llm-usage-service
+
+## Status
+- Linear issue: INT-1339
+- Parent epic: INT-1338
+- Dependencies: none (independent — start immediately)
+- Blocks: INT-1341 (Track 2, orchestrator cost calc), INT-1343 (Track 5, consumer rollout)
+- Plan version: 1.0 (2026-04-10)
+
+## Executive summary
+
+Today, `app-settings-service` owns the `settings/llm_pricing/providers/{provider}` Firestore sub-collection and exposes `GET /internal/settings/pricing`. Every cost-emitting app (`chat-agent`, `actions-agent`, `web-agent`, `linear-agent`, `commands-agent`, `user-service`, `research-agent`, `image-service`, `todos-agent`, `data-insights-agent`, `calendar-agent`) pulls that payload at boot via `fetchAllPricing()` from `@intexuraos/llm-pricing` and hydrates a `PricingContext`. Track 2 (orchestrator cost calc, INT-1341) wants the same lookup from a worker that has no reason to talk to `app-settings-service` and no business holding an in-memory pricing table. Track 5 (INT-1343) wants to eventually let clients post token-only usage events and have the service fill in `cost.billedUsd` server-side. Both require pricing to live next to usage data.
+
+This track transplants pricing ownership from `app-settings-service` into `llm-usage-service` as a new `llm_pricing` Firestore collection, adds a new `GET /internal/pricing` route that returns the existing `AllPricingResponse` shape (so clients can be flipped with a single URL env-var swap), adds server-side cost calculation inside `ingestUsageEvents` (opt-in via a `computeCost: true` flag on the route body, so existing strict-schema callers keep working), extends `@intexuraos/internal-clients/usage-service` with a `fetchAllPricing()` method that returns the same `Result<AllPricingResponse, UsageServiceError>` shape, redirects `fetchAllPricing()` in `@intexuraos/llm-pricing` to use the new URL env var, performs a one-time Firestore migration copying `settings/llm_pricing/providers/*` into `llm_pricing/{provider}`, then rolls consumers over one app at a time.
+
+The end state: `llm-usage-service` owns pricing reads and writes, orchestrator can POST token-only events and get `cost.billedUsd` back, every consumer boots against `INTEXURAOS_LLM_USAGE_SERVICE_URL` for pricing, and the old `app-settings-service` endpoint is behind a 307 redirect for a week before deletion.
+
+## Pre-flight checks (do these before writing any code)
+
+1. From repo root, establish a green baseline: `pnpm run ci:tracked | tee /tmp/int-1339-baseline.txt`. Do not proceed if anything fails.
+2. Re-verify every context file listed below still exists at the cited line number (files drift between planning and execution). If a line number has shifted by more than a few lines, update the plan before editing.
+3. Run `pnpm build` from repo root so `packages/llm-pricing/dist/` and `packages/internal-clients/dist/` exist. Without this, the new imports in llm-usage-service will error with `Cannot find module`.
+4. Grep the whole repo for stragglers this plan may have missed: `rg "settings/llm_pricing|settings\.llm_pricing|/internal/settings/pricing"` — anything that matches must either be updated in Phase 6 or explicitly listed in "Unchanged".
+5. Grep: `rg "fetchAllPricing\("` — verify the list of 11 consumer apps in Phase 6 is still accurate. If new consumers have appeared, add them.
+6. Read `apps/llm-usage-service/src/domain/models/usageEvent.ts:58-63` to confirm the `cost` block shape has not changed. Server-side cost calc must emit exactly this shape.
+7. Read `packages/llm-contract/src/pricing.ts:36-67` (`ModelPricing`) and `packages/llm-contract/src/pricing.ts:75-82` (`ProviderPricing`). These are the types the new repository must return unchanged.
+8. Confirm `firestore-collections.json:252-259` still lists `llm_usage_events` and `llm_usage_daily_aggregates` as owned by `llm-usage-service`. The new `llm_pricing` collection will be added to the same owner.
+
+## Context files
+
+- `apps/llm-usage-service/src/domain/usecases/ingestUsageEvents.ts:13-80` — existing ingest use case. Server-side cost calc hooks in at line 37 (right after the schema-validated input is cloned into `fullEvent`) and needs read access to a new `pricingRepository` dep.
+- `apps/llm-usage-service/src/routes/internalUsageRoutes.ts:25-195` — route file. Two new handlers will be added here: `GET /internal/pricing` and (optionally) `GET /internal/pricing/:provider`. The existing ingest handler at line 73 also needs to pass `pricingRepository` into the use case.
+- `apps/llm-usage-service/src/routes/schemas/usageEventSchema.ts:120-133` — the strict `cost` block. Currently `required: ['billedUsd', 'providerReportedUsd', 'calculatedUsd', 'pricingSource']`. Phase 3 widens the schema: either (a) add a top-level `computeCost: true` flag on `IngestBody` so omitting `cost` is legal only when `computeCost === true`, or (b) make `cost` optional across the board. See the Phase 3 decision point.
+- `apps/llm-usage-service/src/services.ts:6-10` — `ServiceContainer` interface, needs a new `pricingRepository` field. Tests will fail fast because `setServices({...})` calls currently don't provide it.
+- `apps/llm-usage-service/src/infra/firestore/firestoreUsageEventRepository.ts:1-27` — reference pattern for the new `FirestorePricingRepository`. Same style: constant `COLLECTION`, `getFirestore()` inside each method, narrow `try/catch` around Firestore errors, `Result` return type.
+- `packages/llm-pricing/src/pricingClient.ts:125-169` — the current `fetchAllPricing()`. The URL `${baseUrl}/internal/settings/pricing` at line 129 is the only line that changes; its callers already pass a `baseUrl`. The intent in Phase 6 is for each consumer to pass the `llm-usage-service` URL instead of `app-settings-service`. The endpoint path becomes `/internal/pricing` (not `/internal/settings/pricing`). See Phase 5.
+- `packages/llm-pricing/src/pricingClient.ts:217-285` — `PricingContext` class. Unchanged by this track.
+- `packages/llm-pricing/src/index.ts:17-24` — existing exports. A new `fetchAllPricingFromUsageService()` may be added temporarily during the rollout (Phase 6), or the existing `fetchAllPricing()` may be updated in place. See the Phase 5 decision point.
+- `apps/app-settings-service/src/routes/internalRoutes.ts:12-113` — the old pricing route, to be deprecated in Phase 7 (returns 307 redirect for 1 week, then removed).
+- `apps/app-settings-service/src/infra/firestore/index.ts:20-41` — `FirestorePricingRepository` in the old service. Read-only; provides the migration source shape `settings/llm_pricing/providers/{provider}`. This file is deleted in Phase 7.
+- `apps/app-settings-service/src/services.ts:5-27` — DI container. The `pricingRepository` field here is deleted in Phase 7 along with the route.
+- `packages/internal-clients/src/usage-service/client.ts:19-61` — current usage-service client with `ingestEvents` and `queryUsage`. Phase 4 adds a third method `fetchPricing()` returning `Result<AllPricingResponse, UsageServiceError>`.
+- `packages/internal-clients/src/usage-service/types.ts:171-181` — `UsageServiceClient` interface. Extended in Phase 4.
+- `apps/llm-usage-service/src/index.ts:7-11` — `REQUIRED_ENV`. Unchanged: the service reads its own Firestore, no new env vars for llm-usage-service itself.
+- `terraform/environments/dev/main.tf:302,310,1311` — existing `INTEXURAOS_APP_SETTINGS_SERVICE_URL` and `INTEXURAOS_LLM_USAGE_SERVICE_URL` definitions. No new env vars needed in Phase 6 — consumers swap which of the two existing URLs they pass to `fetchAllPricing()`.
+- `ecosystem.config.cjs:47,57` — PM2 dev-env definitions of the same two URLs. Same: no new vars; only the value each consumer app hands to `fetchAllPricing()` changes.
+- `firestore-collections.json:252-259` — ownership registry. Add a new `llm_pricing` entry owned by `llm-usage-service`.
+- `migrations/002_initial-llm-pricing.mjs`, `migrations/012_new-pricing-structure.mjs` — reference for how pricing migrations have historically been structured. The new one follows the same pattern but reads from `settings/llm_pricing/providers/*` and writes to `llm_pricing/{provider}`.
+- `scripts/migrate.mjs:29` — migrations directory is the top-level `migrations/` (NOT per-app). The new file goes there as `migrations/086_migrate_pricing_to_llm_usage_service.mjs`.
+- `docs/superpowers/plans/2026-04-09-llm-usage-service-implementation-plan.md` — Phase 1 plan for format reference.
+- `.claude/reference/env-vars-patterns.md` — the 3-location env-var rule (not relevant here because we reuse existing vars, but linked for reviewers).
+
+## Endpoint changes
+
+### Modified
+- `POST /internal/usage/events` on `llm-usage-service` — body schema widens so `cost` becomes optional when a new top-level `computeCost: true` flag is set. When `cost` is omitted and `computeCost === true`, the service calculates it from tokens + pricing and fills the `cost` block before persisting. Existing strict-schema callers that supply `cost` continue to work unchanged.
+
+### Created
+- `GET /internal/pricing` on `llm-usage-service` — returns the `AllPricingResponse` shape (`{ google, openai, anthropic, perplexity }`), wrapped in `{ success, data }`. Requires `X-Internal-Auth`. This replaces `GET /internal/settings/pricing` on `app-settings-service`.
+- `GET /internal/pricing/:provider` on `llm-usage-service` — returns a single `ProviderPricing`. Used by Track 2 workers that only need one provider's table. Requires `X-Internal-Auth`. **⚠ DECISION NEEDED:** do we actually need the per-provider endpoint in v1, or is the bulk endpoint enough? Track 2's orchestrator cost calc can just fetch-all-and-cache; the per-provider endpoint adds a second code path for little benefit. Recommend deferring unless Track 2 explicitly asks for it.
+
+### Removed
+None in this track. `GET /internal/settings/pricing` on `app-settings-service` is DEPRECATED in Phase 7 (returns 307 → usage service) but physical removal is out of scope (happens after 2 weeks of stability, tracked separately).
+
+### Unchanged
+- `POST /internal/usage/events` — behavior unchanged for callers who keep supplying a complete `cost` block.
+- `POST /internal/webhooks/usage-events` — orchestrator webhook. NOT touched in this track; Track 2 (INT-1341) wires it up to use `computeCost: true` once this track lands.
+- `POST /internal/usage/query` — unaffected.
+- `GET /internal/settings/pricing` — physically still there and still serving the same data during Phases 1-6. Only deprecated (307) in Phase 7.
+
+## Step-by-step implementation
+
+### Phase 1 — Domain model and repository (server-side)
+
+#### Step 1.1: Failing test for the `PricingRepository` port
+
+Create the test file **before** the interface, using the repo's "test first" rule.
+
+- Test file: `apps/llm-usage-service/src/__tests__/fakePricingRepository.ts`
+- Test file: `apps/llm-usage-service/src/__tests__/infra/firestore/firestorePricingRepository.test.ts`
+
+The fake:
+
+```ts
+// apps/llm-usage-service/src/__tests__/fakePricingRepository.ts
+import type { LlmProvider, ProviderPricing } from '@intexuraos/llm-contract';
+import type { PricingRepository } from '../domain/repositories/pricingRepository.js';
+
+export class FakePricingRepository implements PricingRepository {
+  readonly byProvider: Map<LlmProvider, ProviderPricing> = new Map();
+
+  async getByProvider(provider: LlmProvider): Promise<ProviderPricing | null> {
+    return this.byProvider.get(provider) ?? null;
+  }
+
+  async getAll(): Promise<Record<LlmProvider, ProviderPricing>> {
+    const result: Partial<Record<LlmProvider, ProviderPricing>> = {};
+    for (const [p, pricing] of this.byProvider) {
+      result[p] = pricing;
+    }
+    return result as Record<LlmProvider, ProviderPricing>;
+  }
+}
+```
+
+The Firestore test asserts three things: (a) `getByProvider` returns `null` for a missing doc, (b) `getByProvider` returns a typed `ProviderPricing` for a present doc, (c) `getAll` reads all four providers in parallel and returns a fully-populated `Record<LlmProvider, ProviderPricing>`. Use the repo's Firestore emulator pattern from `apps/llm-usage-service/src/__tests__/infra/firestore/firestoreUsageEventRepository.test.ts` as the template.
+
+Expected failure: tests import `../domain/repositories/pricingRepository.js` and `./firestorePricingRepository.js`, neither of which exists yet. Vitest reports `Cannot find module`.
+
+#### Step 1.2: Implement the `PricingRepository` interface
+
+- File: `apps/llm-usage-service/src/domain/repositories/pricingRepository.ts`
+
+```ts
+import type { LlmProvider, ProviderPricing } from '@intexuraos/llm-contract';
+
+export interface PricingRepository {
+  /** Fetch a single provider's pricing. Returns null if no document exists. */
+  getByProvider(provider: LlmProvider): Promise<ProviderPricing | null>;
+
+  /**
+   * Fetch all four provider pricing docs in parallel.
+   * Throws if any required provider is missing - this is a service-level
+   * invariant (pricing must be complete or the service is broken).
+   */
+  getAll(): Promise<Record<LlmProvider, ProviderPricing>>;
+}
+```
+
+Note: `getAll` throws on missing-provider rather than returning `Result<...>`. Rationale: if pricing is incomplete the service is fundamentally broken and should fast-fail rather than leak a partial response. The route handler converts the thrown error into a 500.
+
+#### Step 1.3: Implement `FirestorePricingRepository`
+
+- File: `apps/llm-usage-service/src/infra/firestore/firestorePricingRepository.ts`
+
+```ts
+import { getFirestore } from '@intexuraos/infra-firestore';
+import { LlmProviders, type LlmProvider, type ProviderPricing } from '@intexuraos/llm-contract';
+import type { PricingRepository } from '../../domain/repositories/pricingRepository.js';
+
+const COLLECTION = 'llm_pricing';
+
+interface ProviderPricingDoc {
+  provider: LlmProvider;
+  models: ProviderPricing['models'];
+  updatedAt: string;
+}
+
+export class FirestorePricingRepository implements PricingRepository {
+  async getByProvider(provider: LlmProvider): Promise<ProviderPricing | null> {
+    const db = getFirestore();
+    const snap = await db.collection(COLLECTION).doc(provider).get();
+    if (!snap.exists) return null;
+    const data = snap.data() as ProviderPricingDoc;
+    return { provider: data.provider, models: data.models, updatedAt: data.updatedAt };
+  }
+
+  async getAll(): Promise<Record<LlmProvider, ProviderPricing>> {
+    const providers = [
+      LlmProviders.Google,
+      LlmProviders.OpenAI,
+      LlmProviders.Anthropic,
+      LlmProviders.Perplexity,
+    ] as const;
+    const results = await Promise.all(providers.map((p) => this.getByProvider(p)));
+    const out: Partial<Record<LlmProvider, ProviderPricing>> = {};
+    for (let i = 0; i < providers.length; i++) {
+      const provider = providers[i];
+      const pricing = results[i];
+      if (provider === undefined || pricing === null || pricing === undefined) {
+        throw new Error(`Missing pricing for provider: ${String(provider)}`);
+      }
+      out[provider] = pricing;
+    }
+    return out as Record<LlmProvider, ProviderPricing>;
+  }
+}
+```
+
+Note the collection path: `llm_pricing/{provider}` — **flat, not nested**. The old `app-settings-service` uses `settings/llm_pricing/providers/{provider}` (4 segments) because it shared the `settings` parent doc with other subtrees. The usage service doesn't need that nesting, so we use the simpler flat shape. The migration in Phase 5 does the copy.
+
+#### Step 1.4: Wire the repo into `services.ts`
+
+- File: `apps/llm-usage-service/src/services.ts:6-40`
+
+```ts
+import type { PricingRepository } from './domain/repositories/pricingRepository.js';
+import { FirestorePricingRepository } from './infra/firestore/firestorePricingRepository.js';
+
+export interface ServiceContainer {
+  usageEventRepository: UsageEventRepository;
+  usageAggregateRepository: UsageAggregateRepository;
+  pricingRepository: PricingRepository;          // NEW
+  orchestratorSecret: string;
+}
+
+// inside initializeServices():
+container = {
+  usageEventRepository: new FirestoreUsageEventRepository(),
+  usageAggregateRepository: new FirestoreUsageAggregateRepository(),
+  pricingRepository: new FirestorePricingRepository(),  // NEW
+  orchestratorSecret,
+};
+```
+
+Pre-flight: before editing, `rg "setServices\(" apps/llm-usage-service/src` to enumerate every test that builds a fake container. Each one currently lacks `pricingRepository` — they MUST all be updated to pass a `FakePricingRepository()` or the test file won't compile. Expected locations:
+
+- `apps/llm-usage-service/src/__tests__/domain/usecases/ingestUsageEvents.test.ts`
+- `apps/llm-usage-service/src/__tests__/routes/internalUsageRoutes.test.ts`
+- `apps/llm-usage-service/src/__tests__/routes/webhookUsageRoutes.test.ts`
+- Any `helpers.ts` in `__tests__/`.
+
+#### Step 1.5: Register the collection in `firestore-collections.json`
+
+- File: `firestore-collections.json:259` (append inside the `collections` object)
+
+```json
+"llm_pricing": {
+  "owner": "llm-usage-service",
+  "description": "LLM pricing per provider (one doc per provider, keyed by provider ID). Read by ingestUsageEvents for server-side cost calc and exposed via GET /internal/pricing."
+}
+```
+
+This enforces the one-owner rule. No other service may read or write `llm_pricing` directly — cross-service reads go through the new HTTP endpoint.
+
+### Phase 2 — HTTP routes
+
+#### Step 2.1: Failing test for `GET /internal/pricing`
+
+- File: `apps/llm-usage-service/src/__tests__/routes/internalPricingRoutes.test.ts` (new)
+
+Test cases:
+1. Missing `X-Internal-Auth` → 401 with `error.code === 'UNAUTHORIZED'`.
+2. Valid auth + fake repo populated with all 4 providers → 200 with body `{ success: true, data: { google, openai, anthropic, perplexity } }`, each matching `AllPricingResponse` shape.
+3. Valid auth + fake repo missing `anthropic` → 500 with `error.code === 'INTERNAL_ERROR'` and the message mentions the missing provider.
+4. Fastify route schema validation: response body is checked against the schema (`additionalProperties: false`) so any accidental leak of extra fields fails the test.
+
+The test uses `app.inject()` per the project testing rules. Use `setServices({ ...defaults, pricingRepository: fake })` in `beforeEach`, `resetServices()` in `afterEach`.
+
+Expected failure: the route does not exist yet, Fastify returns 404.
+
+#### Step 2.2: Implement the route
+
+- File: `apps/llm-usage-service/src/routes/internalPricingRoutes.ts` (new)
+
+```ts
+import type { FastifyPluginCallback, FastifyReply, FastifyRequest } from 'fastify';
+import { validateInternalAuth, logIncomingRequest } from '@intexuraos/common-http';
+import { getServices } from '../services.js';
+
+export const internalPricingRoutes: FastifyPluginCallback = (app, _opts, done) => {
+  app.get(
+    '/internal/pricing',
+    {
+      schema: {
+        operationId: 'internalGetAllPricing',
+        summary: 'Get all LLM pricing (internal)',
+        description: 'Returns pricing for google, openai, anthropic, and perplexity.',
+        tags: ['pricing'],
+        response: {
+          200: {
+            type: 'object',
+            properties: {
+              success: { type: 'boolean', const: true },
+              data: {
+                type: 'object',
+                required: ['google', 'openai', 'anthropic', 'perplexity'],
+                properties: {
+                  google: { $ref: 'ProviderPricing#' },
+                  openai: { $ref: 'ProviderPricing#' },
+                  anthropic: { $ref: 'ProviderPricing#' },
+                  perplexity: { $ref: 'ProviderPricing#' },
+                },
+              },
+            },
+            required: ['success', 'data'],
+          },
+          401: { /* same shape as other routes in internalUsageRoutes.ts */ },
+          500: { /* same */ },
+        },
+      },
+    },
+    async (request: FastifyRequest, reply: FastifyReply) => {
+      logIncomingRequest(request, { message: 'Internal pricing read' });
+      const authResult = validateInternalAuth(request);
+      if (!authResult.valid) {
+        return await reply.fail('UNAUTHORIZED', 'Internal auth failed');
+      }
+      const { pricingRepository } = getServices();
+      try {
+        const all = await pricingRepository.getAll();
+        return await reply.ok(all);
+      } catch (error) {
+        request.log.error({ err: error }, 'Failed to read pricing');
+        return await reply.fail('INTERNAL_ERROR', 'Failed to read pricing');
+      }
+    },
+  );
+
+  done();
+};
+```
+
+#### Step 2.3: Register the `ProviderPricing` schema with the app Ajv instance
+
+The route uses `$ref: 'ProviderPricing#'`, which must be registered before the route is registered.
+
+- File: `apps/llm-usage-service/src/routes/schemas/pricingSchema.ts` (new)
+
+```ts
+import type { FastifyInstance } from 'fastify';
+
+export const providerPricingSchema = {
+  $id: 'ProviderPricing',
+  type: 'object',
+  required: ['provider', 'models', 'updatedAt'],
+  properties: {
+    provider: { type: 'string', enum: ['google', 'openai', 'anthropic', 'perplexity'] },
+    models: {
+      type: 'object',
+      additionalProperties: {
+        type: 'object',
+        required: ['inputPricePerMillion', 'outputPricePerMillion'],
+        properties: {
+          inputPricePerMillion: { type: 'number', minimum: 0 },
+          outputPricePerMillion: { type: 'number', minimum: 0 },
+          cacheReadMultiplier: { type: 'number', minimum: 0 },
+          cacheWriteMultiplier: { type: 'number', minimum: 0 },
+          webSearchCostPerCall: { type: 'number', minimum: 0 },
+          groundingCostPerRequest: { type: 'number', minimum: 0 },
+          imagePricing: { type: 'object', additionalProperties: { type: 'number', minimum: 0 } },
+          useProviderCost: { type: 'boolean' },
+        },
+      },
+    },
+    updatedAt: { type: 'string' },
+  },
+} as const;
+
+export function registerPricingSchemas(app: FastifyInstance): void {
+  app.addSchema(providerPricingSchema);
+}
+```
+
+- Edit `apps/llm-usage-service/src/server.ts:170-171` to call `registerPricingSchemas(app)` right after `registerUsageSchemas(app)`.
+
+#### Step 2.4: Register the route plugin
+
+- Edit `apps/llm-usage-service/src/routes/index.ts:1-9` to add:
+
+```ts
+import { internalPricingRoutes } from './internalPricingRoutes.js';
+// ...
+await app.register(internalPricingRoutes);
+```
+
+### Phase 3 — Server-side cost calculation
+
+#### Step 3.1: Decide on the compute flag
+
+**⚠ DECISION NEEDED:** two options for how callers opt into server-side cost calc:
+
+- **Option A — `computeCost` flag on request body.** `IngestBody` gains `computeCost?: boolean`. When true, each event's `cost` block may be omitted (schema becomes `required: ['...', 'usage', 'correlation', 'error']` with `cost` moved out) and the use case fills it in. Existing strict callers keep sending `cost` and are unaffected.
+- **Option B — Always make `cost` optional.** Schema drops `cost` from `required`, use case fills in a zero-cost placeholder if absent. Simpler but silently hides bugs (caller forgot to send cost → we write $0).
+
+Recommend Option A. Option B violates the repo's strict-schema philosophy (see `usageEventSchema.ts:19-20` `additionalProperties: false`).
+
+The rest of this phase assumes Option A.
+
+#### Step 3.2: Failing test for the cost calculator
+
+- File: `apps/llm-usage-service/src/__tests__/domain/usecases/calculateEventCost.test.ts` (new)
+
+Test cases for a new pure function `calculateEventCost(event, pricing): { billedUsd, calculatedUsd, pricingSource }`:
+
+1. Claude with cached reads: `inputTokens=1000, cacheReadTokens=500, outputTokens=200, cacheWriteTokens=0`, pricing from `migrations/012_new-pricing-structure.mjs` (`claude-sonnet-4-5`: `$3/M in`, `$15/M out`, `cacheReadMultiplier=0.1`, `cacheWriteMultiplier=1.25`). Expected billed = `(1000/1e6 * 3) + (500/1e6 * 3 * 0.1) + (200/1e6 * 15)` = `0.003 + 0.00015 + 0.003` = `$0.00615`.
+2. OpenAI `gpt-5.2` simple text: `inputTokens=1000, outputTokens=500`, no cache fields → `(1000/1e6 * 1.75) + (500/1e6 * 14)` = `0.00175 + 0.007` = `$0.00875`.
+3. Perplexity with `useProviderCost=true` and `providerReportedUsd=0.042`: the function returns `{ billedUsd: 0.042, calculatedUsd: null, pricingSource: 'provider_reported' }` (bypasses math).
+4. Model not in pricing table: throws `PricingNotFoundError` with the provider/model in the message.
+5. Image generation: `model=gemini-2.5-flash-image, imageCount=2, imagePricing['1024x1024']=0.03` → `$0.06` and pricingSource `calculated`.
+6. Web search: `model=claude-opus-4-5-20251101, webSearchCalls=3, webSearchCostPerCall=0.03`, plus token cost → billed = token cost + `0.09`.
+7. Grounding enabled for Gemini: `groundingEnabled=true, groundingCostPerRequest=0.035` → billed += `0.035` once (flat per-request).
+
+Expected failure: `calculateEventCost` doesn't exist yet.
+
+#### Step 3.3: Implement `calculateEventCost`
+
+- File: `apps/llm-usage-service/src/domain/usecases/calculateEventCost.ts` (new)
+
+```ts
+import type { LLMModel, ModelPricing, ProviderPricing } from '@intexuraos/llm-contract';
+import type { UsageEventInput } from '../models/usageEvent.js';
+
+export class PricingNotFoundError extends Error {
+  constructor(readonly provider: string, readonly model: string) {
+    super(`Pricing not found for ${provider}/${model}`);
+    this.name = 'PricingNotFoundError';
+  }
+}
+
+export interface CalculatedCost {
+  billedUsd: number;
+  calculatedUsd: number | null;
+  pricingSource: 'calculated' | 'provider_reported';
+}
+
+export function calculateEventCost(
+  event: Pick<UsageEventInput, 'request' | 'usage' | 'cost'>,
+  pricing: Record<string, ProviderPricing>,
+): CalculatedCost {
+  const providerPricing = pricing[event.request.provider];
+  if (providerPricing === undefined) {
+    throw new PricingNotFoundError(event.request.provider, event.request.model);
+  }
+  const model: ModelPricing | undefined = providerPricing.models[event.request.model];
+  if (model === undefined) {
+    throw new PricingNotFoundError(event.request.provider, event.request.model);
+  }
+
+  // Provider-reported bypass (Perplexity)
+  if (model.useProviderCost === true && event.cost?.providerReportedUsd != null) {
+    return {
+      billedUsd: event.cost.providerReportedUsd,
+      calculatedUsd: null,
+      pricingSource: 'provider_reported',
+    };
+  }
+
+  const u = event.usage;
+  let cost = 0;
+  cost += (u.inputTokens / 1_000_000) * model.inputPricePerMillion;
+  cost += (u.outputTokens / 1_000_000) * model.outputPricePerMillion;
+  if (model.cacheReadMultiplier !== undefined) {
+    cost += (u.cacheReadTokens / 1_000_000) * model.inputPricePerMillion * model.cacheReadMultiplier;
+  }
+  if (model.cacheWriteMultiplier !== undefined) {
+    cost += (u.cacheWriteTokens / 1_000_000) * model.inputPricePerMillion * model.cacheWriteMultiplier;
+  }
+  if (model.webSearchCostPerCall !== undefined && u.webSearchCalls > 0) {
+    cost += u.webSearchCalls * model.webSearchCostPerCall;
+  }
+  if (model.groundingCostPerRequest !== undefined && u.groundingEnabled) {
+    cost += model.groundingCostPerRequest;
+  }
+  if (model.imagePricing !== undefined && u.imageCount > 0) {
+    // Default to 1024x1024 for v1; per-size pricing is a follow-up.
+    // ⚠ DECISION NEEDED: do we need a `size` hint on UsageEventUsage, or is 1024x1024 good enough?
+    const perImage = model.imagePricing['1024x1024'] ?? 0;
+    cost += u.imageCount * perImage;
+  }
+
+  return { billedUsd: cost, calculatedUsd: cost, pricingSource: 'calculated' };
+}
+```
+
+The `imagePricing` default-to-1024 is an explicit simplification — note the DECISION NEEDED marker. Current consumers only generate at 1024x1024, so this is a safe default; if/when other sizes are used, add a `request.imageSize` field to the event schema.
+
+#### Step 3.4: Failing test for ingest with `computeCost: true`
+
+- File: `apps/llm-usage-service/src/__tests__/domain/usecases/ingestUsageEvents.test.ts` (extend)
+
+Add a test: when called with `computeCost: true` and an event whose `cost` block is absent, the use case calls `pricingRepository.getAll()` once per batch (cached for the whole batch, not per event), fills in `cost` via `calculateEventCost`, then delegates to `usageEventRepository.createEvent` with the filled event. Assert the persisted event has `cost.pricingSource === 'calculated'` and `cost.billedUsd > 0`.
+
+Also test: `computeCost: true` + model missing from pricing table → event is rejected (not stored), returned in the `rejected` array with `code: 'PRICING_NOT_FOUND'`, but other events in the same batch still process successfully.
+
+Also test: when called with `computeCost: false` (or omitted), the existing code path runs unchanged — no call to `pricingRepository.getAll()`.
+
+#### Step 3.5: Update `ingestUsageEvents` signature and body
+
+- File: `apps/llm-usage-service/src/domain/usecases/ingestUsageEvents.ts:7-80`
+
+```ts
+export interface IngestUsageEventsDeps {
+  logger: Logger;
+  usageEventRepository: UsageEventRepository;
+  usageAggregateRepository: UsageAggregateRepository;
+  pricingRepository: PricingRepository;  // NEW
+}
+
+export async function ingestUsageEvents(
+  deps: IngestUsageEventsDeps,
+  events: (UsageEventInput | TokenOnlyUsageEventInput)[],
+  ingress: 'internal' | 'orchestrator_webhook',
+  options: { computeCost?: boolean } = {},
+): Promise<UsageIngestResponse> {
+  // ...
+  // If computeCost is true, fetch pricing once up front:
+  let pricingSnapshot: Record<LlmProvider, ProviderPricing> | null = null;
+  if (options.computeCost === true) {
+    pricingSnapshot = await deps.pricingRepository.getAll();
+  }
+
+  for (let i = 0; i < events.length; i++) {
+    const input = events[i];
+    if (input === undefined) continue;
+
+    let costBlock = 'cost' in input ? input.cost : undefined;
+    if (costBlock === undefined || options.computeCost === true) {
+      if (pricingSnapshot === null) {
+        rejected.push({ index: i, code: 'INVALID_REQUEST', message: 'cost is required when computeCost is false' });
+        continue;
+      }
+      try {
+        const calculated = calculateEventCost(input as UsageEventInput, pricingSnapshot);
+        costBlock = {
+          billedUsd: calculated.billedUsd,
+          providerReportedUsd: null,
+          calculatedUsd: calculated.calculatedUsd,
+          pricingSource: calculated.pricingSource,
+        };
+      } catch (e) {
+        if (e instanceof PricingNotFoundError) {
+          rejected.push({ index: i, code: 'PRICING_NOT_FOUND', message: e.message });
+          continue;
+        }
+        throw e;
+      }
+    }
+
+    const fullEvent: UsageEvent = { ...input, cost: costBlock, receivedAt, ingress };
+    // ... existing createEvent + aggregate flow
+  }
+}
+```
+
+Note: `TokenOnlyUsageEventInput` is a new type alias: `Omit<UsageEventInput, 'cost'>`. Add it to `apps/llm-usage-service/src/domain/models/usageEvent.ts`.
+
+#### Step 3.6: Widen the Fastify route schema
+
+- File: `apps/llm-usage-service/src/routes/schemas/usageEventSchema.ts:16-164`
+
+Add a second exported schema `$id: 'TokenOnlyUsageEventInput'` that is a copy of `UsageEventInput` with `cost` removed from `required`. The existing strict schema stays. The route body in `internalUsageRoutes.ts` becomes:
+
+```ts
+body: {
+  type: 'object',
+  required: ['schemaVersion', 'events'],
+  properties: {
+    schemaVersion: { type: 'integer', enum: [1] },
+    computeCost: { type: 'boolean', default: false },
+    events: {
+      type: 'array',
+      items: { anyOf: [{ $ref: 'UsageEventInput#' }, { $ref: 'TokenOnlyUsageEventInput#' }] },
+    },
+  },
+}
+```
+
+**⚠ DECISION NEEDED:** the `anyOf` approach allows mixed batches (some events with `cost`, some without) in a single request. If we want stricter behavior — "if `computeCost: true`, ALL events must omit `cost`" — the schema gets more complex (a top-level `if/then/else`). Recommend starting with `anyOf` for simplicity; Track 5 can tighten later if needed.
+
+#### Step 3.7: Pass `pricingRepository` and `computeCost` through the route handler
+
+- File: `apps/llm-usage-service/src/routes/internalUsageRoutes.ts:85-94`
+
+```ts
+const { usageEventRepository, usageAggregateRepository, pricingRepository } = getServices();
+const result = await ingestUsageEvents(
+  { logger: request.log, usageEventRepository, usageAggregateRepository, pricingRepository },
+  body.events,
+  'internal',
+  { computeCost: body.computeCost === true },
+);
+```
+
+Do the same in `apps/llm-usage-service/src/routes/webhookUsageRoutes.ts` so the orchestrator webhook can opt in once Track 2 wires it up. **Default `computeCost: false`** on the webhook for now — Track 2 flips it to `true` when ready.
+
+### Phase 4 — Internal client extension
+
+#### Step 4.1: Failing test for the new client method
+
+- File: `packages/internal-clients/src/usage-service/__tests__/client.test.ts`
+
+Add a test for `fetchPricing()`: mocks a successful `GET /internal/pricing` response via `nock`, asserts the client returns `ok({ google, openai, anthropic, perplexity })`. Add a failure test for 401 → `err({ code: 'API_ERROR' })`. Add a network failure test → `err({ code: 'NETWORK_ERROR' })`.
+
+#### Step 4.2: Extend the client
+
+- File: `packages/internal-clients/src/usage-service/types.ts:171-181`
+
+```ts
+import type { AllPricingResponse } from '@intexuraos/llm-pricing';
+
+export interface UsageServiceClient {
+  ingestEvents(...): Promise<Result<UsageIngestResponse, UsageServiceError>>;
+  queryUsage(...): Promise<Result<UsageQueryResponse, UsageServiceError>>;
+  fetchPricing(options?: { traceId?: string }): Promise<Result<AllPricingResponse, UsageServiceError>>;  // NEW
+}
+```
+
+- File: `packages/internal-clients/src/usage-service/client.ts:19-61`
+
+```ts
+async fetchPricing(
+  options?: { traceId?: string },
+): Promise<Result<AllPricingResponse, UsageServiceError>> {
+  const result = await fetchWithAuth<ApiResponse<AllPricingResponse>>(
+    config,
+    '/internal/pricing',
+    {
+      method: 'GET',
+      ...(options?.traceId !== undefined ? { traceId: options.traceId } : {}),
+    },
+  );
+  if (!result.ok) return err({ code: result.error.code, message: result.error.message });
+  return ok(result.value.data);
+}
+```
+
+Pre-flight: before adding the `AllPricingResponse` import, confirm `@intexuraos/llm-pricing` is already a dependency of `packages/internal-clients`: `rg '"@intexuraos/llm-pricing"' packages/internal-clients/package.json`. If not, add it as a `dependencies` entry. Running `pnpm install` is required before the build will succeed.
+
+### Phase 5 — One-time migration from `app-settings-service`
+
+#### Step 5.1: Write the migration
+
+- File: `migrations/086_migrate_pricing_to_llm_usage_service.mjs` (new)
+
+```js
+/**
+ * Migration 086: Copy LLM pricing from app-settings-service to llm-usage-service.
+ *
+ * Source: settings/llm_pricing/providers/{provider}     (owner: app-settings-service)
+ * Target: llm_pricing/{provider}                         (owner: llm-usage-service)
+ *
+ * Idempotent: re-running this is safe. Overwrites the target doc with the
+ * source doc each time. The SOURCE is NOT deleted — that happens in a later
+ * cleanup migration after the app-settings-service endpoint is removed.
+ */
+
+export const metadata = {
+  id: '086',
+  name: 'migrate_pricing_to_llm_usage_service',
+  description: 'Copy LLM pricing into the new llm_pricing collection owned by llm-usage-service',
+  createdAt: '2026-04-10',
+};
+
+export async function up(context) {
+  const providers = ['google', 'openai', 'anthropic', 'perplexity'];
+  const batch = context.firestore.batch();
+  let copied = 0;
+
+  for (const p of providers) {
+    const srcSnap = await context.firestore.doc(`settings/llm_pricing/providers/${p}`).get();
+    if (!srcSnap.exists) {
+      throw new Error(`Source pricing missing for provider: ${p}`);
+    }
+    batch.set(context.firestore.doc(`llm_pricing/${p}`), srcSnap.data());
+    copied++;
+  }
+
+  await batch.commit();
+  console.log(`  Copied ${copied} provider pricing docs to llm_pricing/*`);
+}
+```
+
+**Migrations are IMMUTABLE** — if this migration has a bug, you write migration 087 to fix it. Do NOT edit 086 after it has been applied anywhere.
+
+#### Step 5.2: Test the migration against the emulator
+
+Run `node scripts/migrate.mjs` against the emulator (see Phase 1 instructions in the plan reference) and confirm `llm_pricing/google`, `llm_pricing/openai`, `llm_pricing/anthropic`, `llm_pricing/perplexity` all exist with the same model data as the source. Assert via a spot check: `anthropic.models['claude-sonnet-4-5-20250929'].inputPricePerMillion === 3`.
+
+#### Step 5.3: Parity verification script
+
+- File: `apps/llm-usage-service/scripts/verify-pricing-parity.mjs` (new)
+
+Standalone node script that starts no server — it opens Firestore directly, reads both `settings/llm_pricing/providers/*` and `llm_pricing/*`, and asserts deep-equality per provider. Prints a diff if mismatch. This script is NOT a migration; it's a manual verification tool, rerun after every pricing update until old endpoint is removed.
+
+Run this against dev Firestore after 5.2 lands and before Phase 6 starts.
+
+### Phase 6 — Redirect all consumers
+
+This phase is mechanical: every consumer that calls `fetchAllPricing(APP_SETTINGS_SERVICE_URL, ...)` is updated to call it with the new URL **and** a different endpoint path. There are two ways to do this:
+
+**Option A — Update `fetchAllPricing()` in place.** Change `packages/llm-pricing/src/pricingClient.ts:129` from `${baseUrl}/internal/settings/pricing` to `${baseUrl}/internal/pricing`. Then update each consumer to pass the llm-usage-service URL instead of app-settings-service URL. PRO: no new symbol, no deprecations. CON: big-bang — all 11 consumers must be updated and deployed together.
+
+**Option B — Add a new symbol.** Add a second function `fetchAllPricingFromUsageService(baseUrl, token)` that hits `/internal/pricing`, keeping the old `fetchAllPricing()` unchanged. Flip consumers one at a time. PRO: incremental rollout. CON: two functions doing the same thing for the duration of the rollout.
+
+**⚠ DECISION NEEDED:** Recommend **Option B** because the repo's dev environment has PM2 restarting services independently and prod has Cloud Run rolling deploys. Big-bang requires all 11 apps to redeploy atomically, which the infrastructure doesn't guarantee. The `fetchAllPricing()` vs `fetchAllPricingFromUsageService()` split is short-lived (1-2 weeks) and deleted in Phase 7.
+
+The rest of this phase assumes Option B.
+
+#### Step 6.1: Add `fetchAllPricingFromUsageService` to `@intexuraos/llm-pricing`
+
+- File: `packages/llm-pricing/src/pricingClient.ts` (append)
+
+```ts
+export async function fetchAllPricingFromUsageService(
+  baseUrl: string,
+  authToken: string,
+): Promise<Result<AllPricingResponse, PricingClientError>> {
+  const url = `${baseUrl}/internal/pricing`;
+  try {
+    const response = await fetch(url, { headers: { 'X-Internal-Auth': authToken } });
+    if (!response.ok) {
+      const body = await response.text().catch(() => '');
+      return err({ code: 'API_ERROR', message: `HTTP ${String(response.status)}: ${body.slice(0, 200)}` });
+    }
+    const data = (await response.json()) as { success: boolean; data: AllPricingResponse };
+    if (!data.success) return err({ code: 'API_ERROR', message: 'Response success is false' });
+    return ok(data.data);
+  } catch (error) {
+    return err({ code: 'NETWORK_ERROR', message: getErrorMessage(error) });
+  }
+}
+```
+
+Export from `packages/llm-pricing/src/index.ts:17-24`. Add a test in `packages/llm-pricing/src/__tests__/pricingClient.test.ts` mirroring the existing `fetchAllPricing` tests.
+
+#### Step 6.2: Flip consumers one at a time
+
+Rollout order (safest first — the services least likely to break if pricing fetch fails):
+
+1. `apps/image-service/src/index.ts:44-48` — image service (narrow blast radius: only affects image generation cost calc).
+2. `apps/research-agent/src/index.ts:64-68` — research agent.
+3. `apps/data-insights-agent/src/index.ts:51-53` — data insights.
+4. `apps/calendar-agent/src/index.ts:43-45` — calendar.
+5. `apps/linear-agent/src/index.ts:45-47` — linear.
+6. `apps/commands-agent/src/services.ts:67` — commands.
+7. `apps/actions-agent/src/services.ts:176-186` — actions.
+8. `apps/todos-agent/src/services.ts:31` — todos.
+9. `apps/user-service/src/index.ts:48-52` — user-service (wider impact: every user login touches it).
+10. `apps/web-agent/src/index.ts:35-45` — web-agent.
+11. `apps/chat-agent/src/services.ts:80-109` — chat-agent (highest traffic; last).
+
+For each, the change is:
+
+```ts
+// BEFORE
+import { fetchAllPricing, createPricingContext } from '@intexuraos/llm-pricing';
+const appSettingsUrl = process.env['INTEXURAOS_APP_SETTINGS_SERVICE_URL'] ?? '';
+const pricingResult = await fetchAllPricing(appSettingsUrl, internalAuthToken);
+
+// AFTER
+import { fetchAllPricingFromUsageService, createPricingContext } from '@intexuraos/llm-pricing';
+const usageServiceUrl = process.env['INTEXURAOS_LLM_USAGE_SERVICE_URL'] ?? '';
+const pricingResult = await fetchAllPricingFromUsageService(usageServiceUrl, internalAuthToken);
+```
+
+**Env var check for each consumer:**
+
+- `apps/<name>/src/index.ts` `REQUIRED_ENV` array — if the consumer previously required `INTEXURAOS_APP_SETTINGS_SERVICE_URL` **only for pricing** (not for anything else), remove it from `REQUIRED_ENV` and add `INTEXURAOS_LLM_USAGE_SERVICE_URL`. Run `rg "APP_SETTINGS_SERVICE_URL" apps/<name>` first — if it's still used elsewhere (e.g. todos-agent uses it for saving model preferences), KEEP it.
+- `terraform/environments/dev/main.tf` — add `INTEXURAOS_LLM_USAGE_SERVICE_URL = module.llm_usage_service.service_url` to each consumer's env map IF NOT ALREADY PRESENT (it already is for services that call the usage service for ingest; check before editing).
+- `ecosystem.config.cjs` — same check. `INTEXURAOS_LLM_USAGE_SERVICE_URL` is already defined globally at line 57, so it should flow to every PM2 app that imports the shared env.
+
+**Per-consumer test updates.** Each consumer that mocks pricing in its test suite (e.g. `apps/chat-agent/src/__tests__/services.test.ts:47`) needs its mock updated from `mockFetchAllPricing` → `mockFetchAllPricingFromUsageService`. Grep each consumer's `__tests__/` for `fetchAllPricing` before editing the source.
+
+#### Step 6.3: Run `ci:tracked` per consumer after each flip
+
+Do not batch multiple consumers into one commit. Each commit is:
+1. Flip one consumer.
+2. `pnpm run verify:workspace:tracked -- <app-name>`.
+3. `pnpm run ci:tracked`.
+4. Commit with title like `INT-1339: migrate chat-agent pricing fetch to llm-usage-service`.
+5. Open PR targeting `development`, merge, wait for dev deploy, smoke-test the consumer's health endpoint.
+
+This is slow by design — we're swapping a startup-critical dependency on 11 apps.
+
+### Phase 7 — Deprecate the old endpoint
+
+#### Step 7.1: Return 307 from `app-settings-service`
+
+Only do this after Phase 6 has been stable for 1 week.
+
+- File: `apps/app-settings-service/src/routes/internalRoutes.ts:58-112`
+
+Replace the handler body with a 307 redirect to `${INTEXURAOS_LLM_USAGE_SERVICE_URL}/internal/pricing`. Keep the auth check (so unauthenticated callers still get 401, not a misleading 307). Log a warning on every hit so we can see which caller still uses the old endpoint.
+
+**⚠ DECISION NEEDED:** 307 vs 410-gone. 307 lets any unmigrated caller keep working transparently (fetch follows redirects by default). 410 forces a failure. Recommend 307 for 1 week to catch stragglers, then 410 for 1 week, then delete the route. Aggressive but safer than silently serving stale data.
+
+#### Step 7.2: Delete dead code
+
+After 2 weeks of 307+410 with zero hits in logs:
+
+- Delete `apps/app-settings-service/src/routes/internalRoutes.ts` handler (or the file if nothing else lives there).
+- Delete `apps/app-settings-service/src/infra/firestore/index.ts` `FirestorePricingRepository`.
+- Delete `apps/app-settings-service/src/services.ts` `pricingRepository` field.
+- Delete `apps/app-settings-service/src/__tests__/infra/FirestorePricingRepository.test.ts`.
+- Delete `apps/app-settings-service/src/domain/ports/index.ts` `PricingRepository`, `ModelPricing`, `ProviderPricing`, `ImageSize` (keep any usage-stats types still in use).
+- Delete the old `fetchAllPricing()` function from `packages/llm-pricing/src/pricingClient.ts:125-169` (only `fetchAllPricingFromUsageService` remains). Then rename it back to `fetchAllPricing` in a follow-up PR once there's no chance of confusion.
+- Write migration 087 (or whatever is next) to DELETE `settings/llm_pricing/providers/*` from Firestore.
+
+None of the Phase 7 deletions happen inside INT-1339 itself — they are follow-up tickets (e.g. INT-1339a, INT-1339b). This plan leaves the old endpoint in place behind a 307.
+
+## Test plan
+
+New test files:
+
+- `apps/llm-usage-service/src/__tests__/fakePricingRepository.ts` — in-memory fake used by multiple downstream tests.
+- `apps/llm-usage-service/src/__tests__/infra/firestore/firestorePricingRepository.test.ts` — Firestore integration. Asserts missing-doc returns null, present-doc round-trips, `getAll` throws on partial data.
+- `apps/llm-usage-service/src/__tests__/routes/internalPricingRoutes.test.ts` — route-level tests: 401 on missing auth, 200 on success, 500 on missing provider, schema validation.
+- `apps/llm-usage-service/src/__tests__/domain/usecases/calculateEventCost.test.ts` — pure unit tests for the cost formula. Covers the 7 scenarios in Step 3.2.
+- `apps/llm-usage-service/src/__tests__/domain/usecases/ingestUsageEvents.test.ts` — extended with 3 new cases: `computeCost: true` happy path, `computeCost: true` + unknown model → rejected, `computeCost: false` → no pricing fetch.
+- `packages/internal-clients/src/usage-service/__tests__/client.test.ts` — extended with `fetchPricing()` tests using `nock`.
+- `packages/llm-pricing/src/__tests__/pricingClient.test.ts` — extended with `fetchAllPricingFromUsageService()` tests that mirror the existing `fetchAllPricing()` suite (success, 4xx, 5xx, network error, invalid JSON, `success: false` body).
+
+Coverage targets:
+
+- `apps/llm-usage-service`: 95% branch coverage including the new files. The image-pricing branch (only-1024) is exercised. The `useProviderCost` branch is exercised.
+- `packages/internal-clients`: 95% branch coverage including `fetchPricing()`.
+- `packages/llm-pricing`: 95% branch coverage including `fetchAllPricingFromUsageService()`.
+- No `v8 ignore` pragmas are needed. If you find yourself writing one, stop and ask — every branch in this track is testable with the in-memory fake or `nock`.
+
+Per-consumer test updates (11 apps, Phase 6):
+
+- For each consumer, update mocks from `fetchAllPricing` to `fetchAllPricingFromUsageService`. No new test files needed.
+
+## Rollout plan
+
+1. **Phases 1-5 ship as one PR** targeting `development`. This adds the new route/repo/migration but does NOT touch any consumer. After merge, dev deploys, migration runs. Parity script from Step 5.3 passes.
+2. **Smoke test**: manually `curl` `https://llm-usage-service.<dev>/internal/pricing` with `X-Internal-Auth`. Confirm response shape matches `AllPricingResponse`. Compare against `GET /internal/settings/pricing` on app-settings-service — they must be byte-for-byte equal.
+3. **Phase 6 ships as 11 separate PRs**, one per consumer, in the order listed in Step 6.2. Each PR:
+   - Waits for previous consumer to be stable in dev for at least 1 hour.
+   - Runs `pnpm run ci:tracked`.
+   - After merge + dev deploy, tail the consumer's logs for startup errors and confirm it boots with pricing loaded.
+4. **Stability window**: after all 11 consumers are on the new endpoint, wait 1 week. During this week both endpoints serve the same data (from different Firestore collections, kept in sync by re-running migration 086 if needed).
+5. **Phase 7.1 ships as a single PR**: flip `GET /internal/settings/pricing` on app-settings-service to return 307. Tail logs for any hits.
+6. **Second stability window**: 1 week of 307. Any hits in logs are investigated — the caller is missing from Phase 6 and must be flipped.
+7. **Phase 7.2** (follow-up ticket): delete dead code and write the cleanup Firestore migration.
+
+## Acceptance criteria
+
+- [ ] `apps/llm-usage-service/src/domain/repositories/pricingRepository.ts` exists and is a domain port.
+- [ ] `apps/llm-usage-service/src/infra/firestore/firestorePricingRepository.ts` exists and reads from `llm_pricing/{provider}`.
+- [ ] `GET /internal/pricing` on llm-usage-service returns `AllPricingResponse` and requires `X-Internal-Auth`.
+- [ ] `POST /internal/usage/events` accepts `computeCost: true` and fills `cost` server-side.
+- [ ] `calculateEventCost` handles cache multipliers, web search, grounding, image generation, and `useProviderCost` bypass.
+- [ ] `migrations/086_migrate_pricing_to_llm_usage_service.mjs` has been applied in dev and parity verified.
+- [ ] `firestore-collections.json` lists `llm_pricing` owned by `llm-usage-service`.
+- [ ] `packages/internal-clients/src/usage-service/client.ts` has `fetchPricing()` method.
+- [ ] `packages/llm-pricing/src/pricingClient.ts` exports `fetchAllPricingFromUsageService`.
+- [ ] All 11 consumer apps have been migrated and each boots cleanly against `INTEXURAOS_LLM_USAGE_SERVICE_URL`.
+- [ ] `pnpm run ci:tracked` green at repo root.
+- [ ] New backend code has 95% branch coverage with no `v8 ignore` additions.
+- [ ] Every new test was written before its implementation (verifiable in git history).
+- [ ] `GET /internal/settings/pricing` on app-settings-service returns 307 (Phase 7.1 merged).
+- [ ] No consumer code references `fetchAllPricing` directly anymore (only `fetchAllPricingFromUsageService`).
+- [ ] No Firestore read/write to `settings/llm_pricing/providers/*` from any code path outside the migration script.
+
+## Risks and mitigations
+
+| Risk                                                                                                                                                                                       | Likelihood  | Impact   | Mitigation                                                                                                                                                                                                                   |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Migration 086 runs before llm-usage-service has the new route deployed, leaving a window where pricing is duplicated but not served.                                                       | Low         | Low      | Phases 1-5 ship as one PR so route + repo + migration go live together. The old endpoint keeps serving during this window.                                                                                                   |
+| A consumer silently fails to fetch pricing and boots with a broken `PricingContext`.                                                                                                       | Medium      | High     | Each consumer's bootstrap path already throws on pricing fetch failure (`fetchAllPricing` error → `throw new Error`). Don't relax that — fail loud. Tail logs after each Phase 6 PR.                                         |
+| `calculateEventCost` disagrees with the old client-side calculators (e.g. `infra-claude`), leading to cost drift between Track 2 (server-calc) and Phases 1 consumers (still client-calc). | High        | Medium   | Track 2 is the only caller who uses `computeCost: true` in the near term. Existing consumers keep supplying their own `cost` block. We accept a small Track-2-only drift for now; Track 5 (INT-1343) centralizes everything. |
+| Schema widening (`anyOf` on event item) breaks Fastify's strict validation for some edge case.                                                                                             | Low         | Medium   | Add a regression test in `internalUsageRoutes.test.ts` that posts a mixed batch (1 event with cost, 1 without + `computeCost: true`) and asserts both succeed.                                                               |
+| The new `llm_pricing` Firestore collection drifts from `settings/llm_pricing/providers/*` because the old endpoint keeps getting updates.                                                  | High        | High     | No pricing writes happen during this track. If pricing changes are needed mid-rollout, write a new migration (087) that updates BOTH collections until Phase 7 is done.                                                      |
+| Per-size image pricing (1024x1536, 1536x1024) is ignored — all image calls billed at 1024x1024 price.                                                                                      | Low today   | Medium   | Accepted: `DECISION NEEDED` marker on Step 3.3. Current consumers only use 1024x1024. If that changes, add `request.imageSize` to the event schema in a follow-up.                                                           |
+| The orchestrator (Track 2) starts calling `computeCost: true` before Phase 2 is deployed.                                                                                                  | Low         | High     | Track 2 is explicitly BLOCKED on INT-1339 per the plan header. Do not merge any Track 2 PR until INT-1339 Phase 1-5 is in dev.                                                                                               |
+| Rolling back a consumer mid-rollout leaves it pointing at the wrong URL.                                                                                                                   | Medium      | Low      | Each consumer PR is atomic (one commit, one app, one URL change). Revert = single `git revert`.                                                                                                                              |
+
+## Out of scope
+
+- User-scoped pricing endpoints (pricing stays internal-only).
+- Per-user pricing overrides or promotional pricing.
+- Caching `GET /internal/pricing` in consumers beyond the existing `PricingContext` (that's already per-process in-memory; no Redis).
+- Per-image-size event tracking — all image generation billed at 1024x1024 price in v1.
+- Historical backfill of `cost.billedUsd` on events that were stored with wrong prices before this track landed.
+- Deleting the `settings/llm_pricing/providers/*` Firestore subtree — that's a cleanup migration in a follow-up ticket.
+- Physically removing `GET /internal/settings/pricing` from app-settings-service — Phase 7.2 tracks deletion but ships separately.
+- Migrating the web app's settings UI (`apps/web/src/services/settingsApi.ts`) — the web app reads pricing for display, not calculation, and can stay pointed at `app-settings-service` indefinitely. If it ever needs to move, it's a separate ticket.
+- Track 2 (orchestrator cost calc) work itself — this plan only unblocks it.
+- Track 5 (full client rollout of `computeCost: true`) — this plan only provides the capability.

--- a/docs/plans/INT-1340-track-1-llm-usage-web-ui.md
+++ b/docs/plans/INT-1340-track-1-llm-usage-web-ui.md
@@ -5,47 +5,36 @@
 - Parent epic: INT-1338 (LLM Usage Service Phase 2)
 - Dependencies: none (independent; builds directly on Phase 1)
 - Blocks: INT-1343 (Track 5 — pricing UI relocation, which reuses the new `/llm-usage` nav section as the mount point for pricing)
-- Plan version: 1.0
+- Plan version: 2.0 (updated 2026-04-10 — aligned with INT-1338 decisions doc: no BFF, public Auth0 routes on llm-usage-service, `/llm-usage/*` prefix, web app uses `llmUsageServiceUrl` directly)
 
 ## Executive summary
 
 This track delivers the first end-user surface for the new `llm-usage-service`. Phase 1 shipped the ingestion pipeline, daily aggregates, and an internal `POST /internal/usage/query` endpoint, but the web app currently has no way to view or drill into the resulting data. The legacy `LlmCostsPage` reads an old `llm_usage_stats` collection via `app-settings-service` and is completely disconnected from the new `llm_usage_events` / `llm_usage_daily_aggregates` collections owned by `llm-usage-service`. Users therefore cannot answer basic questions like "what did the orchestrator spend on Claude yesterday" without hitting Firestore directly.
 
-Track 1 closes that gap by delivering a new top-level **LLM Usage** nav section with a list view of raw events, a detail view for a single event, and an aggregate/grouping view driven by the existing `/internal/usage/query` endpoint. Because Phase 1 does not expose raw events (the existing query endpoint only returns grouped aggregates), this track **also** adds two new backend endpoints — `POST /internal/usage/events/list` and `GET /internal/usage/events/:eventId` — together with the supporting repository methods, Firestore composite indexes, internal-client extensions, and BFF proxies on `app-settings-service`.
+Track 1 closes that gap by delivering a new top-level **LLM Usage** nav section with a list view of raw events, a detail view for a single event, and an aggregate/grouping view. Because Phase 1 does not expose raw events (the existing query endpoint only returns grouped aggregates), this track **also** adds three new **public** endpoints directly on `llm-usage-service` — `POST /llm-usage/events/list`, `GET /llm-usage/events/:eventId`, and `POST /llm-usage/query` — secured with Auth0 bearer auth (the same middleware all other user-facing services use). The web app calls `llm-usage-service` directly using `config.llmUsageServiceUrl`; there is no BFF layer.
 
 The design mirrors the existing code-tasks list and detail pages as closely as possible: identical Tailwind conventions, identical filter-tab strip, identical localStorage persistence, identical hash routing, identical `*Keyed` detail-page pattern. The intent is that a user landing on `/#/llm-usage` immediately recognizes the UX vocabulary from `/#/code-tasks` and does not need to learn a new mental model.
 
 ## Pre-flight checks
 
-1. Confirm Phase 1 is merged and green: `apps/llm-usage-service` exists and `POST /internal/usage/query` passes its tests.
+1. Confirm Phase 1 is merged and green: `apps/llm-usage-service` exists and its tests pass. Note: `POST /internal/usage/query` from Phase 1 will be removed in this track and replaced by the public `POST /llm-usage/query`.
 2. Confirm `firestore-collections.json` lists `llm_usage_events` with `"owner": "llm-usage-service"` (already present — verified).
-3. Confirm `packages/internal-clients/src/usage-service/client.ts` exports `createUsageServiceClient` and has exactly two methods today (`ingestEvents`, `queryUsage`). Any additional methods already merged mean this plan is stale — stop and re-read.
-4. Confirm the web app uses `HashRouter` and reads service URLs from `apps/web/src/config.ts` (verified: `import.meta.env.INTEXURAOS_*`).
-5. Confirm `app-settings-service` currently serves `/settings/usage-costs` and therefore already has auth, services.ts DI, and public-routes plumbing that can be extended (verified).
-6. Read the `UsageEventInput` TS type in `apps/llm-usage-service/src/domain/models/usageEvent.ts` **before** writing the list-item view model — the event shape is deeply nested (`owner.*`, `source.*`, `request.*`, `usage.*`, `cost.*`, `correlation.*`, `error`) and the detail-view card hierarchy must match.
-7. Run `pnpm run ci:tracked` at the start of the branch to establish a clean baseline.
+3. Confirm the web app uses `HashRouter` and reads service URLs from `apps/web/src/config.ts` (verified: `import.meta.env.INTEXURAOS_*`).
+4. Confirm `apps/web/src/config.ts` does NOT yet have `llmUsageServiceUrl` — this track adds it. If it already exists, check the value and skip the config step in Phase 5.
+5. Read the `UsageEventInput` TS type in `apps/llm-usage-service/src/domain/models/usageEvent.ts` **before** writing the list-item view model — the event shape is deeply nested (`owner.*`, `source.*`, `request.*`, `usage.*`, `cost.*`, `correlation.*`, `error`) and the detail-view card hierarchy must match.
+6. Run `pnpm run ci:tracked` at the start of the branch to establish a clean baseline.
 
 ## Context files
 
 ### Read before touching the backend
-- `apps/llm-usage-service/src/routes/internalUsageRoutes.ts` — both new routes live here alongside `/internal/usage/query`.
+- `apps/llm-usage-service/src/routes/internalUsageRoutes.ts` — read to understand the existing route pattern. The three new public routes go in a new file `publicUsageRoutes.ts` (or alongside the existing routes file — match the naming convention used in that service).
 - `apps/llm-usage-service/src/domain/repositories/usageEventRepository.ts` — interface extended with `list()` and `getById()`.
 - `apps/llm-usage-service/src/infra/firestore/firestoreUsageEventRepository.ts` — Firestore implementation for the new methods.
 - `apps/llm-usage-service/src/domain/models/usageEvent.ts` — canonical `UsageEvent` shape (the list-items return the full event; no projection).
 - `apps/llm-usage-service/src/domain/models/usageQuery.ts` — reuses `AggregateMetrics` / `UsageQueryFilters` vocabulary for the list filters.
-- `apps/llm-usage-service/src/__tests__/routes/internalUsageRoutes.test.ts` — mirror this test layout (beforeAll/beforeEach/afterEach, `app.inject()`, fake repos via `setServices`).
+- `apps/llm-usage-service/src/__tests__/routes/internalUsageRoutes.test.ts` — mirror this test layout (beforeAll/beforeEach/afterEach, `app.inject()`, fake repos via `setServices`). Create a parallel `publicUsageRoutes.test.ts` for the public routes.
 - `apps/llm-usage-service/src/__tests__/fakeUsageEventRepository.ts` — extend with in-memory `list()` and `getById()` for tests.
-
-### Read before touching the internal client
-- `packages/internal-clients/src/usage-service/client.ts` — add two methods next to `queryUsage`.
-- `packages/internal-clients/src/usage-service/types.ts` — add request/response DTOs for list/getById; re-export the full `UsageEvent` shape.
-- `packages/internal-clients/src/usage-service/__tests__/client.test.ts` — extend with `nock`-based tests for the new methods.
-
-### Read before touching the BFF
-- `apps/app-settings-service/src/routes/publicRoutes.ts` — add `GET /settings/llm-usage/events` and `GET /settings/llm-usage/events/:eventId` and `POST /settings/llm-usage/query` alongside `/settings/usage-costs`.
-- `apps/app-settings-service/src/services.ts` — add a `usageServiceClient` to the DI container.
-- `apps/app-settings-service/src/index.ts` — add `INTEXURAOS_LLM_USAGE_SERVICE_URL` + `INTEXURAOS_INTERNAL_AUTH_TOKEN` to `REQUIRED_ENV`.
-- `apps/app-settings-service/src/__tests__/routes/publicRoutes.test.ts` — mirror for new routes with a fake `UsageServiceClient`.
+- Check how `llm-usage-service` registers Auth0 bearer auth middleware — it should already exist from Phase 1 (the service serves public pricing). If Auth0 middleware is not yet wired, look at another service (e.g. `app-settings-service`) for the pattern.
 
 ### Read before touching the web app
 - `apps/web/src/pages/CodeTasksPage.tsx` — design reference for list page. Copy the header, filter-tab strip, sort selector, and localStorage patterns verbatim.
@@ -56,8 +45,8 @@ The design mirrors the existing code-tasks list and detail pages as closely as p
 - `apps/web/src/services/issueGroupsApi.ts` — blueprint for the new `llmUsageApi.ts`.
 - `apps/web/src/services/apiClient.ts` — shared `apiRequest` helper; do not reinvent.
 - `apps/web/src/hooks/useApiClient.ts` — `useApiClient()` hook that wraps `apiRequest` with the current access token.
-- `apps/web/src/config.ts` — the `appSettingsServiceUrl` field already exists; new pages use it (the llm-usage-service is NOT exposed directly to the SPA).
-- `apps/web/vite.config.ts` — the `/api/settings` proxy (port 8122) already exists and is reused as-is. **No new vite proxy entry is needed** because all web traffic goes through `app-settings-service`, which in turn calls `llm-usage-service` server-to-server.
+- `apps/web/src/config.ts` — add a new `llmUsageServiceUrl` config key (the web app calls `llm-usage-service` directly; there is no BFF).
+- `apps/web/vite.config.ts` — add a new proxy entry for `/api/llm-usage` pointing to the `llm-usage-service` dev port. Do NOT reuse the `/api/settings` proxy.
 
 ### Read before touching Firestore indexes
 - `firestore-collections.json` — confirm ownership of `llm_usage_events` stays with `llm-usage-service`.
@@ -69,23 +58,17 @@ The design mirrors the existing code-tasks list and detail pages as closely as p
 - (none — no existing endpoints change contract)
 
 ### Created
-**Backend (`apps/llm-usage-service`)**
-- `POST /internal/usage/events/list` — paginated raw events. Body: `{ timeRange: { from, to }, filters?: UsageEventFilters, sortBy?: { field, direction }, limit?, cursor? }`. Response: `{ events: UsageEvent[], nextCursor?: string, totalMatched: number }`. Auth: `X-Internal-Auth`.
-- `GET /internal/usage/events/:eventId` — single raw event. Response: `{ event: UsageEvent }` or 404. Auth: `X-Internal-Auth`.
-
-**BFF (`apps/app-settings-service`)**
-- `POST /settings/llm-usage/events` — proxies `POST /internal/usage/events/list` on `llm-usage-service`. Auth: user bearer token via `requireAuth`; no user-scoping is applied at the BFF layer in this track (see "Out of scope"). Response mirrors the upstream.
-- `GET /settings/llm-usage/events/:eventId` — proxies `GET /internal/usage/events/:eventId`. Auth: user bearer token.
-- `POST /settings/llm-usage/query` — proxies the existing `POST /internal/usage/query`. Auth: user bearer token. (Added now so the web app has a single BFF entry point per concern; avoids coupling the SPA to two different service URLs.)
+**Public routes (`apps/llm-usage-service`) — Auth0 bearer**
+- `POST /llm-usage/events/list` — paginated raw events. Body: `{ timeRange: { from, to }, filters?: UsageEventFilters, sortBy?: { field, direction }, limit?, cursor? }`. Response: `{ events: UsageEvent[], nextCursor?: string, totalMatched: number }`. Auth: Auth0 bearer token.
+- `GET /llm-usage/events/:eventId` — single raw event. Response: `{ event: UsageEvent }` or 404. Auth: Auth0 bearer token.
+- `POST /llm-usage/query` — aggregate query with groupBy. Replaces both the existing internal query endpoint and the previously planned public version. Auth: Auth0 bearer token.
 
 ### Removed
-- (none)
+- `POST /internal/usage/query` — removed entirely. Only the public `POST /llm-usage/query` exists. The web app calls the public endpoint directly with its Auth0 bearer token.
 
 ### Unchanged
-- `POST /internal/usage/events` (webhook ingest)
-- `POST /internal/usage/events/orchestrator` (orchestrator webhook)
-- `POST /internal/usage/query` (still internal; the BFF above is a thin wrapper, not a replacement)
-- All existing `app-settings-service` public routes (`/settings/pricing`, `/settings/usage-costs`, etc.)
+- `POST /internal/usage/events` (ingest — internal, X-Internal-Auth)
+- All existing `app-settings-service` public routes (no changes to that service in this track)
 
 ## Step-by-step implementation
 
@@ -178,11 +161,11 @@ For `totalMatched`, run a **separate** `.count()` aggregation query with the sam
 
 **`getById` implementation:** `db.collection('llm_usage_events').doc(eventId).get()`; return `ok(null)` on `!snapshot.exists` (NOT `err`); return `ok(snapshot.data() as UsageEvent)` on success.
 
-### Phase 2 — Backend: new list + getById routes (test-first)
+### Phase 2 — Backend: new list, getById, and query public routes (test-first)
 
-Write failing tests first in `apps/llm-usage-service/src/__tests__/routes/internalUsageRoutes.test.ts`. The existing file is the template; add new `describe` blocks:
+Write failing tests first in a new file `apps/llm-usage-service/src/__tests__/routes/publicUsageRoutes.test.ts`. Model it on `internalUsageRoutes.test.ts` but use a valid Auth0 bearer token (use the test auth helper pattern already present in the service) instead of `X-Internal-Auth`. Add new `describe` blocks:
 
-- `POST /internal/usage/events/list`
+- `POST /llm-usage/events/list`
   - returns 200 with paginated events when filters match
   - returns 200 with empty `events` array when no filters match
   - returns 200 with a `nextCursor` when more results exist
@@ -196,24 +179,30 @@ Write failing tests first in `apps/llm-usage-service/src/__tests__/routes/intern
   - returns 400 for invalid `sortBy.field`
   - returns 400 for malformed cursor (decodeCursor returns null)
   - returns 400 when `timeRange.from > timeRange.to`
-  - returns 401 for missing `X-Internal-Auth` header
+  - returns 401 for missing or invalid bearer token
 
-- `GET /internal/usage/events/:eventId`
+- `GET /llm-usage/events/:eventId`
   - returns 200 with full event when found
   - returns 404 when not found
-  - returns 401 for missing `X-Internal-Auth` header
+  - returns 401 for missing or invalid bearer token
 
-Only after all of the above are red, implement the route handlers. Skeleton:
+- `POST /llm-usage/query`
+  - returns 200 with aggregate rows on valid request
+  - returns 400 for invalid groupBy value
+  - returns 401 for missing or invalid bearer token
+
+Only after all of the above are red, implement the route handlers. Create a new file `apps/llm-usage-service/src/routes/publicUsageRoutes.ts`. Skeleton:
 
 ```ts
-// apps/llm-usage-service/src/routes/internalUsageRoutes.ts  (new routes)
+// apps/llm-usage-service/src/routes/publicUsageRoutes.ts
 app.post(
-  '/internal/usage/events/list',
+  '/llm-usage/events/list',
   {
     schema: {
-      operationId: 'internalListUsageEvents',
-      summary: 'List raw usage events (internal, paginated)',
+      operationId: 'listUsageEvents',
+      summary: 'List raw usage events (paginated)',
       tags: ['usage'],
+      security: [{ bearerAuth: [] }],
       body: {
         type: 'object',
         required: ['timeRange'],
@@ -239,16 +228,14 @@ app.post(
           cursor: { type: 'string', minLength: 1 },
         },
       },
-      response: { /* 200, 400, 401 as in existing routes */ },
+      response: { /* 200, 400, 401 as in existing public routes */ },
     },
   },
   async (request, reply) => {
-    logIncomingRequest(request, { message: 'Internal usage events list' });
-    const authResult = validateInternalAuth(request);
-    if (!authResult.valid) {
-      request.log.warn({ reason: authResult.reason }, 'Internal auth failed');
-      return await reply.fail('UNAUTHORIZED', 'Internal auth failed');
-    }
+    logIncomingRequest(request, { message: 'Public usage events list' });
+    // Auth0 bearer auth is applied via the shared requireAuth middleware
+    // registered at the route or plugin level — match the pattern used in
+    // other public routes on this service.
     const body = request.body as ListUsageEventsBody;
     const { usageEventRepository } = getServices();
     const result = await listUsageEvents(
@@ -263,14 +250,10 @@ app.post(
 );
 
 app.get<{ Params: { eventId: string } }>(
-  '/internal/usage/events/:eventId',
+  '/llm-usage/events/:eventId',
   { schema: { /* ... */ } },
   async (request, reply) => {
-    logIncomingRequest(request, { message: 'Internal usage event get' });
-    const authResult = validateInternalAuth(request);
-    if (!authResult.valid) {
-      return await reply.fail('UNAUTHORIZED', 'Internal auth failed');
-    }
+    logIncomingRequest(request, { message: 'Public usage event get' });
     const { usageEventRepository } = getServices();
     const result = await usageEventRepository.getById(request.params.eventId);
     if (!result.ok) {
@@ -282,7 +265,25 @@ app.get<{ Params: { eventId: string } }>(
     return await reply.ok({ event: result.value });
   },
 );
+
+app.post(
+  '/llm-usage/query',
+  { schema: { /* mirror the former /internal/usage/query schema */ } },
+  async (request, reply) => {
+    logIncomingRequest(request, { message: 'Public usage aggregate query' });
+    // delegate to the existing queryUsage use case
+    const body = request.body as UsageQueryBody;
+    const { usageEventRepository } = getServices();
+    const result = await queryUsage({ logger: request.log, usageEventRepository }, body);
+    if (!result.ok) {
+      return await reply.fail('INVALID_REQUEST', result.error.message);
+    }
+    return await reply.ok(result.value);
+  },
+);
 ```
+
+**Remove `POST /internal/usage/query`**: delete the internal query route handler from `internalUsageRoutes.ts` in the same PR. Only the public endpoint above exists going forward.
 
 Create a use case file `apps/llm-usage-service/src/domain/usecases/listUsageEvents.ts` (mirrors `queryUsage.ts`) that does validation, clamping, and delegation to the repo.
 
@@ -388,7 +389,43 @@ export async function down(context) {
 
 Alternative: tell the user they can't combine certain filters. The recommendation above is less user-hostile.
 
-### Phase 4 — Internal client extension
+### Phase 4 — Web app config and Vite proxy
+
+**Web app config (`apps/web/src/config.ts`):** Add `llmUsageServiceUrl` alongside the other service URL keys:
+
+```ts
+// apps/web/src/config.ts
+export const config = {
+  // ... existing keys ...
+  llmUsageServiceUrl: import.meta.env['INTEXURAOS_LLM_USAGE_SERVICE_URL'] ?? '',
+};
+```
+
+Add the env var in the three required locations:
+1. `apps/web/src/index.ts` (or wherever the web app validates required env) — add `'INTEXURAOS_LLM_USAGE_SERVICE_URL'` to the list.
+2. `terraform/environments/dev/main.tf` — add to the web app container's env block. Value: the Cloud Run URL of `llm-usage-service` (already exists as a Terraform output from Phase 1).
+3. `ecosystem.config.cjs` — add to the web app PM2 entry's `env` section with the local dev URL (e.g. `http://localhost:8130` or whatever port llm-usage-service listens on in home-dev).
+
+**Vite proxy (`apps/web/vite.config.ts`):** Add a new proxy entry for `/api/llm-usage`:
+
+```ts
+// vite.config.ts proxy block
+'/api/llm-usage': {
+  target: 'http://localhost:<LLM_USAGE_PORT>',
+  changeOrigin: true,
+  rewrite: (path) => path.replace(/^\/api\/llm-usage/, ''),
+},
+```
+
+Look up the actual port from `ecosystem.config.cjs` for the `llm-usage-service` entry before filling in the value.
+
+### Phase 5 — (Removed — no BFF layer)
+
+The original Phase 5 described BFF proxy routes on `app-settings-service`. Per the decisions doc (Decision #3), all public routes go directly on `llm-usage-service` with Auth0 bearer auth. The web app calls `llm-usage-service` directly. No changes to `app-settings-service` in this track.
+
+### Phase 5a — Internal client extension (backend-to-backend only)
+
+This phase documents what gets added to the internal client for **backend services** (e.g. code-agent forwarding usage events). The web app does NOT use `packages/internal-clients` — it uses `llmUsageApi.ts` with the public endpoints.
 
 Extend `packages/internal-clients/src/usage-service/types.ts`:
 
@@ -437,54 +474,9 @@ export interface UsageServiceClient {
 }
 ```
 
-Note: the client returns `UsageEventInput` rather than `UsageEvent` to avoid leaking the `receivedAt`/`ingress` internals into the BFF DTO. If the UI needs those fields, widen the type — but verify the caller actually uses them first.
+Note: the internal client is used by backend services (e.g. code-agent) calling `POST /internal/usage/events` to ingest events. The web app does NOT use this client — it calls the public `/llm-usage/*` endpoints directly using `llmUsageApi.ts`.
 
-Extend `client.ts` with `listEvents` and `getEvent` methods modeled on `queryUsage`. Add `nock`-based tests to `__tests__/client.test.ts` for all three: happy path, non-2xx, network error.
-
-### Phase 5 — Web app BFF proxy routes
-
-Add to `apps/app-settings-service/src/services.ts`:
-
-```ts
-import { createUsageServiceClient } from '@intexuraos/internal-clients/usage-service';
-import type { UsageServiceClient } from '@intexuraos/internal-clients/usage-service';
-
-export interface ServiceContainer {
-  pricingRepository: PricingRepository;
-  usageStatsRepository: UsageStatsRepository;
-  usageServiceClient: UsageServiceClient;
-}
-
-export function getServices(): ServiceContainer {
-  container ??= {
-    pricingRepository: new FirestorePricingRepository(),
-    usageStatsRepository: new FirestoreUsageStatsRepository(),
-    usageServiceClient: createUsageServiceClient({
-      baseUrl: process.env['INTEXURAOS_LLM_USAGE_SERVICE_URL']!,
-      internalAuthToken: process.env['INTEXURAOS_INTERNAL_AUTH_TOKEN']!,
-      logger: createAppLogger({ name: 'app-settings-service.usageServiceClient' }),
-    }),
-  };
-  return container;
-}
-```
-
-Add to `apps/app-settings-service/src/routes/publicRoutes.ts` (next to `/settings/usage-costs`):
-
-- `POST /settings/llm-usage/events` — validates body with Fastify JSON schema mirroring `ListUsageEventsRequest`, calls `usageServiceClient.listEvents(body, { traceId: request.id })`, returns 200 with `{ events, nextCursor, totalMatched }`. No user-scoping in this track.
-- `GET /settings/llm-usage/events/:eventId` — calls `usageServiceClient.getEvent(eventId)`, returns 200 `{ event }` or 404.
-- `POST /settings/llm-usage/query` — calls `usageServiceClient.queryUsage(body)`. Pass through the response verbatim.
-
-Every new route MUST call `logIncomingRequest(request, { message: '...' })` and `requireAuth(request, reply)` (not `validateInternalAuth` — this is the public-facing BFF).
-
-Add env vars in three places (per CLAUDE.md rules):
-1. `apps/app-settings-service/src/index.ts` — add `'INTEXURAOS_LLM_USAGE_SERVICE_URL'` and `'INTEXURAOS_INTERNAL_AUTH_TOKEN'` to `REQUIRED_ENV` (the second may already be present — check before adding).
-2. `terraform/environments/dev/main.tf` — add the same vars to the `app-settings-service` Cloud Run container's `env` block. The URL should point to the `llm-usage-service` Cloud Run service URL output.
-3. `ecosystem.config.cjs` — add to the `app-settings-service` PM2 entry's `env` section for home-dev.
-
-⚠ **DECISION NEEDED**: `INTEXURAOS_LLM_USAGE_SERVICE_URL` for the dev environment. Look up the actual service URL from `terraform/environments/dev/main.tf` — it likely exists as a Terraform output from the Phase 1 deployment. If it doesn't yet, add the output first.
-
-Write tests in `apps/app-settings-service/src/__tests__/routes/publicRoutes.test.ts` using a `FakeUsageServiceClient` that implements the `UsageServiceClient` interface with in-memory data. Tests must cover: happy path, upstream 404 → BFF 404, upstream 500 → BFF 500, missing auth → BFF 401, invalid body → BFF 400.
+Extend `client.ts` with `listEvents` and `getEvent` methods if needed by backend consumers. Add `nock`-based tests to `__tests__/client.test.ts` for any new methods: happy path, non-2xx, network error.
 
 ### Phase 6 — Web app API service module
 
@@ -506,8 +498,8 @@ export async function listLlmUsageEvents(
   request: ListLlmUsageEventsRequest,
 ): Promise<ListLlmUsageEventsResponse> {
   return await apiRequest<ListLlmUsageEventsResponse>(
-    config.appSettingsServiceUrl,
-    '/settings/llm-usage/events',
+    config.llmUsageServiceUrl,
+    '/llm-usage/events/list',
     accessToken,
     { method: 'POST', body: request },
   );
@@ -518,8 +510,8 @@ export async function getLlmUsageEvent(
   eventId: string,
 ): Promise<{ event: UsageEvent }> {
   return await apiRequest<{ event: UsageEvent }>(
-    config.appSettingsServiceUrl,
-    `/settings/llm-usage/events/${encodeURIComponent(eventId)}`,
+    config.llmUsageServiceUrl,
+    `/llm-usage/events/${encodeURIComponent(eventId)}`,
     accessToken,
   );
 }
@@ -529,8 +521,8 @@ export async function queryLlmUsage(
   request: LlmUsageQueryRequest,
 ): Promise<LlmUsageQueryResponse> {
   return await apiRequest<LlmUsageQueryResponse>(
-    config.appSettingsServiceUrl,
-    '/settings/llm-usage/query',
+    config.llmUsageServiceUrl,
+    '/llm-usage/query',
     accessToken,
     { method: 'POST', body: request },
   );
@@ -847,26 +839,24 @@ Walk through each target scenario end-to-end to prove the UI shape is correct. *
 4. User clicks `claude-worker` in the Component filter strip → `filters.components = ['claude-worker']`.
 5. User clicks `orchestrator` in the Service filter strip → `filters.services = ['orchestrator']`.
 6. User clicks "day" in the Group by selector → UI switches to the `AggregateTable` (driven by `useLlmUsageQuery`).
-7. Under the hood: the web app calls `POST /settings/llm-usage/query` with body `{ timeRange: {from, to}, filters: { providers: ['anthropic'], components: ['claude-worker'], services: ['orchestrator'] }, groupBy: ['day'] }`.
-8. The BFF forwards to `POST /internal/usage/query` on `llm-usage-service`.
-9. Result: a single row with `group.day = '2026-04-10'` and aggregated metrics.
+7. Under the hood: the web app calls `POST /llm-usage/query` directly on `llm-usage-service` with body `{ timeRange: {from, to}, filters: { providers: ['anthropic'], components: ['claude-worker'], services: ['orchestrator'] }, groupBy: ['day'] }`.
+8. Result: a single row with `group.day = '2026-04-10'` and aggregated metrics.
 
 **Use case 2: "Show all Gemini calls without grouping"**
 1. User selects "Last 7 days" time range.
 2. User clicks `google` in the Provider filter strip → `filters.providers = ['google']`.
 3. User confirms Group by is "none" (default).
 4. User confirms Sort is "occurredAt desc" (default).
-5. Under the hood: the web app calls `POST /settings/llm-usage/events` with body `{ timeRange, filters: { providers: ['google'] }, sortBy: { field: 'occurredAt', direction: 'desc' }, limit: 50 }`.
-6. The BFF forwards to `POST /internal/usage/events/list` on `llm-usage-service`.
-7. Result: up to 50 events in a raw list, newest first, with a "Load more" button if `nextCursor` is present.
-8. User clicks any event row → navigates to `/#/llm-usage/{eventId}` → detail page loads via `GET /settings/llm-usage/events/{eventId}`.
+5. Under the hood: the web app calls `POST /llm-usage/events/list` directly on `llm-usage-service` with body `{ timeRange, filters: { providers: ['google'] }, sortBy: { field: 'occurredAt', direction: 'desc' }, limit: 50 }`.
+6. Result: up to 50 events in a raw list, newest first, with a "Load more" button if `nextCursor` is present.
+7. User clicks any event row → navigates to `/#/llm-usage/{eventId}` → detail page loads via `GET /llm-usage/events/{eventId}` directly on `llm-usage-service`.
 
 **Use case 3: "Show cost per LLM from the orchestrator this week, grouped by model"**
 1. User picks "Last 7 days".
 2. User clicks `orchestrator` in the Service filter strip → `filters.services = ['orchestrator']`.
 3. User clicks "model" in the Group by selector → switches to `AggregateTable`.
 4. The sort selector is hidden (grouping defaults to `costUsd desc` for the aggregate endpoint).
-5. Under the hood: `POST /settings/llm-usage/query` body `{ timeRange, filters: { services: ['orchestrator'] }, groupBy: ['request.model'], sortBy: { field: 'costUsd', direction: 'desc' } }`.
+5. Under the hood: the web app calls `POST /llm-usage/query` directly on `llm-usage-service` with body `{ timeRange, filters: { services: ['orchestrator'] }, groupBy: ['request.model'], sortBy: { field: 'costUsd', direction: 'desc' } }`.
 6. Result: one row per model, sorted by cost descending. The `totals` are rendered in a "Grand total" footer row.
 
 All three cases must work on the first deployment of this track. If any of them require extra endpoints or filters not listed in Phase 2/4/5, the plan is incomplete — escalate.
@@ -874,27 +864,13 @@ All three cases must work on the first deployment of this track. If any of them 
 ## Test plan
 
 ### Backend (`apps/llm-usage-service`)
-- `src/__tests__/routes/internalUsageRoutes.test.ts` — extended with 15+ new test cases covering list + getById happy paths, filters, sorting, cursor roundtrip, error cases, auth.
+- `src/__tests__/routes/publicUsageRoutes.test.ts` — new file with 15+ test cases covering list, getById, and query happy paths, filters, sorting, cursor roundtrip, error cases, and Auth0 bearer auth.
 - `src/__tests__/domain/usecases/listUsageEvents.test.ts` — new file, unit tests for validation + limit clamping + cursor encode/decode.
 - `src/__tests__/fakeUsageEventRepository.ts` — extend with in-memory `list()` and `getById()` implementing the same semantics as the Firestore version.
 - `src/__tests__/infra/firestoreUsageEventRepository.test.ts` — if an emulator-backed test already exists, extend it; otherwise rely on the fake-repo tests + manual smoke test in staging.
 
-### Internal client (`packages/internal-clients`)
-- `src/usage-service/__tests__/client.test.ts` — extend with 6 new `nock`-backed tests: listEvents happy, listEvents 404, listEvents network error, getEvent happy, getEvent not-found, getEvent network error.
-
-### BFF (`apps/app-settings-service`)
-- `src/__tests__/routes/publicRoutes.test.ts` — extend with a new `describe('/settings/llm-usage/*')` block:
-  - POST /settings/llm-usage/events happy path
-  - POST /settings/llm-usage/events upstream error
-  - GET /settings/llm-usage/events/:eventId happy path
-  - GET /settings/llm-usage/events/:eventId 404
-  - POST /settings/llm-usage/query happy path
-  - All routes: 401 when no bearer
-  - All routes: 400 when body invalid (Fastify schema)
-- Add `FakeUsageServiceClient` helper in `src/__tests__/fakes/fakeUsageServiceClient.ts`.
-
 ### Web app
-- `src/services/__tests__/llmUsageApi.test.ts` — required (services/ is in the enforced-coverage zone).
+- `src/services/__tests__/llmUsageApi.test.ts` — required (services/ is in the enforced-coverage zone). Tests call `llm-usage-service` directly at `config.llmUsageServiceUrl` — use nock against the llm-usage-service port.
 - `src/hooks/__tests__/useLlmUsageEvents.test.ts` — required (hooks/ is enforced).
 - `src/hooks/__tests__/useLlmUsageQuery.test.ts` — required.
 - `src/hooks/__tests__/useLlmUsageEvent.test.ts` — required.
@@ -908,28 +884,27 @@ All three cases must work on the first deployment of this track. If any of them 
 
 ## Rollout plan
 
-1. **Backend first:** merge the llm-usage-service changes (Phases 1–3) and the new migration alone. Deploy to dev. Verify the new endpoints return correct data against real Firestore.
+1. **Backend first:** merge the llm-usage-service changes (Phases 1–3) and the new migration alone. Deploy to dev. Verify the new public endpoints return correct data using curl with a valid bearer token.
 2. **Run the migration:** `node migrations/086_llm-usage-events-list-indexes.mjs up` from the repo root on dev. Wait for index builds to finish (monitor via `gcloud firestore indexes composite list --project=intexuraos-dev-pbuchman`). This can take 5–30 minutes on non-empty collections.
-3. **Internal client + BFF:** merge Phases 4–5. Redeploy `app-settings-service` to dev. Hit `POST /settings/llm-usage/events` with curl using a fresh bearer token and verify it round-trips.
-4. **Web app:** merge Phases 6–10. Verify in dev UI that all three use cases from Phase 11 work end-to-end.
-5. **Promote to prod** in the same order (backend → BFF → web app) only after dev has soaked for 24h without errors in Sentry or Cloud Run logs.
-6. Update the Linear issue INT-1340 with a link to the merged PR and screenshots of the three use cases.
+3. **Web app:** merge Phases 4–10 (config, vite proxy, API service, hooks, pages, nav). Verify in dev UI that all three use cases from Phase 11 work end-to-end.
+4. **Promote to prod** in the same order (backend → web app) only after dev has soaked for 24h without errors in Sentry or Cloud Run logs.
+5. Update the Linear issue INT-1340 with a link to the merged PR and screenshots of the three use cases.
 
 ## Acceptance criteria
 
-- [ ] `POST /internal/usage/events/list` exists, accepts `{ timeRange, filters, sortBy, limit, cursor }`, returns `{ events, nextCursor, totalMatched }`, has ≥95% branch coverage.
-- [ ] `GET /internal/usage/events/:eventId` exists, returns full `UsageEvent` or 404.
+- [ ] `POST /llm-usage/events/list` exists on `llm-usage-service`, accepts `{ timeRange, filters, sortBy, limit, cursor }`, returns `{ events, nextCursor, totalMatched }`, secured with Auth0 bearer auth, has ≥95% branch coverage.
+- [ ] `GET /llm-usage/events/:eventId` exists on `llm-usage-service`, returns full `UsageEvent` or 404, secured with Auth0 bearer auth.
+- [ ] `POST /llm-usage/query` exists on `llm-usage-service` as the single (public) aggregate query endpoint; `POST /internal/usage/query` is removed.
 - [ ] Firestore composite indexes for the seven filter+sort combinations in Phase 3 exist in `migrations/086_*.mjs` and are deployed to dev.
-- [ ] `UsageServiceClient.listEvents` and `UsageServiceClient.getEvent` are exported and tested with nock.
-- [ ] `app-settings-service` proxies `POST /settings/llm-usage/events`, `GET /settings/llm-usage/events/:eventId`, `POST /settings/llm-usage/query` to `llm-usage-service` via the internal client.
 - [ ] The web app has a new top-level "LLM Usage" nav section with an "Events" sub-item.
 - [ ] `/#/llm-usage` renders the list page with four filter strips (provider, component, service, model), a time-range picker, a group-by selector, and a sort selector.
 - [ ] The list page persists filter/sort/groupBy/timeRange choices to localStorage under `llm-usage-*` keys.
 - [ ] `/#/llm-usage/{eventId}` renders the detail page with cards for request, usage, cost, source+owner, correlation, error, and raw JSON.
 - [ ] Use cases 1, 2, and 3 from Phase 11 work end-to-end against real data in dev.
 - [ ] `pnpm run ci:tracked` passes green.
-- [ ] No existing endpoints change contract.
-- [ ] `INTEXURAOS_LLM_USAGE_SERVICE_URL` is declared in all three required locations.
+- [ ] No existing endpoints change contract (except removal of `POST /internal/usage/query` which is explicitly superseded).
+- [ ] `INTEXURAOS_LLM_USAGE_SERVICE_URL` is declared in all three required locations for the **web app** (not app-settings-service).
+- [ ] `apps/web/src/config.ts` has `llmUsageServiceUrl` and `vite.config.ts` has a proxy entry for `/api/llm-usage`.
 
 ## Risks
 
@@ -939,11 +914,11 @@ All three cases must work on the first deployment of this track. If any of them 
 
 3. **Index count explosion.** Every additional filter-sort combination needs its own composite index. Firestore caps at 200 composite indexes per project. We currently have ~85 migration files, each adding a few. **Mitigation:** Phase 3 limits indexes to single-filter + sort combinations. Multi-filter queries fall back to post-fetch in-memory filtering, which caps at `MAX_LIST_LIMIT` rows per Firestore read. Document this limitation clearly in the list use case.
 
-4. **BFF double-hop latency.** `web → app-settings-service → llm-usage-service → firestore` adds ~30ms over `web → llm-usage-service → firestore`. **Mitigation:** acceptable — matches the existing `/settings/pricing` and `/settings/usage-costs` patterns. Do not optimize prematurely.
+4. **Auth0 JWKS cold-start latency.** On llm-usage-service startup, the first request to a public route triggers JWKS key fetch. Subsequent requests use the cached keys. **Mitigation:** verify the Auth0 middleware has JWKS caching enabled (should already be the case on all other services); no additional work needed.
 
-5. **Schema drift between the stored `UsageEvent` and the client-side type mirror.** The internal client re-defines `UsageEventInput` to avoid cross-app imports. If the llm-usage-service team changes the schema without updating the mirror, the BFF will silently truncate fields. **Mitigation:** add a comment in `packages/internal-clients/src/usage-service/types.ts` pointing at the canonical source (`apps/llm-usage-service/src/domain/models/usageEvent.ts`) and a compile-time assertion via `satisfies` once the types are importable.
+5. **Schema drift between the stored `UsageEvent` and the web app type mirror.** `apps/web/src/types/llmUsage.ts` re-defines types to avoid cross-workspace imports. If the llm-usage-service team changes the schema without updating the mirror, the web app will silently truncate fields. **Mitigation:** add a comment in `apps/web/src/types/llmUsage.ts` pointing at the canonical source (`apps/llm-usage-service/src/domain/models/usageEvent.ts`).
 
-6. **Web app dev proxy assumes `/api/settings`.** The Vite proxy already routes `/api/settings` → port 8122. No change needed, but if a dev forgets to re-build `app-settings-service` after adding the new routes, they'll get 404s in dev. **Mitigation:** document in the PR description that `pnpm --filter app-settings-service build && pnpm dev` must be run in that order on first checkout.
+6. **Vite proxy for `/api/llm-usage` must point to the correct port.** If the port in `vite.config.ts` does not match the port llm-usage-service listens on in `ecosystem.config.cjs`, dev calls will return connection-refused errors. **Mitigation:** cross-check the port in `ecosystem.config.cjs` before writing the proxy entry; document in the PR description that `pnpm --filter llm-usage-service build && pnpm dev` must be run after checkout.
 
 7. **Composite index build time on a non-empty collection.** If `llm_usage_events` already has millions of docs in dev, building 7 new composite indexes can take 30+ minutes. **Mitigation:** run the migration at the start of the backend phase and proceed with web app work in parallel; don't block the PR on index builds.
 
@@ -954,7 +929,7 @@ All three cases must work on the first deployment of this track. If any of them 
 - **Real-time updates / SSE / websockets** — the list page polls every 30s on tab focus, like `CodeTasksPage`. No live stream.
 - **Per-user quota views** — the detail page shows cost but does not compare against a quota.
 - **Export to CSV / JSON** — a "copy raw JSON" button on the detail page is the only export mechanism.
-- **User-scoping in the BFF** — `/settings/llm-usage/*` returns ALL events the caller requests, with no implicit `ownerId = currentUser` filter. This is a deliberate choice because the dashboard is admin-facing (there is only one admin user). If that changes, Track 4 (observability + access control) will add the scoping.
+- **User-scoping on public routes** — `POST /llm-usage/events/list` returns ALL events the caller requests, with no implicit `ownerId = currentUser` filter. This is a deliberate choice because the dashboard is admin-facing (there is only one admin user). If that changes, a future track will add the scoping at the route handler level.
 - **Custom index-aware query planner** — multi-filter queries fall back to post-fetch filtering. A future track can add a proper planner.
 - **Soft delete / archiving of events** — events are immutable once ingested. No archive UI.
 - **Editing pricing on the detail page** — Track 5 handles pricing surface area.
@@ -967,23 +942,24 @@ All three cases must work on the first deployment of this track. If any of them 
 
 ## Appendix A — Open decisions flagged in this plan
 
-All `⚠ DECISION NEEDED` markers:
+All `⚠ DECISION NEEDED` markers have been resolved by the decisions doc (`INT-1338-decisions.md`):
 
-1. **Phase 1:** whether to ship with `.count()` enabled by default on the list endpoint (recommended: yes).
-2. **Phase 3:** whether to index single-filter or multi-filter combinations (recommended: single-filter only, document the limit).
-3. **Phase 5:** the exact value of `INTEXURAOS_LLM_USAGE_SERVICE_URL` for dev — pull from the existing Terraform output or add one if missing.
+1. **Phase 1 / `.count()` default:** ship enabled by default (Decision #9).
+2. **Phase 3 / composite index scope:** single-filter + sort combinations only (Decision #10 — research exact requirements via context7 before writing migration).
+3. **Auth model:** Auth0 bearer on all public routes, no BFF (Decision #3).
+4. **Route prefix:** `/llm-usage/*` (Decision #17).
+5. **Internal query endpoint:** removed; only public `POST /llm-usage/query` exists (Decision #14).
 
 ## Appendix B — Files to be created (summary list)
 
 **Backend:**
+- `apps/llm-usage-service/src/routes/publicUsageRoutes.ts`
 - `apps/llm-usage-service/src/domain/usecases/listUsageEvents.ts`
+- `apps/llm-usage-service/src/__tests__/routes/publicUsageRoutes.test.ts`
 - `apps/llm-usage-service/src/__tests__/domain/usecases/listUsageEvents.test.ts`
 
 **Migrations:**
 - `migrations/086_llm-usage-events-list-indexes.mjs`
-
-**BFF:**
-- `apps/app-settings-service/src/__tests__/fakes/fakeUsageServiceClient.ts`
 
 **Web app:**
 - `apps/web/src/pages/LlmUsagePage.tsx`
@@ -1003,21 +979,15 @@ All `⚠ DECISION NEEDED` markers:
 - `apps/web/src/types/llmUsage.ts`
 
 **Files to be modified (summary list):**
-- `apps/llm-usage-service/src/routes/internalUsageRoutes.ts`
+- `apps/llm-usage-service/src/routes/internalUsageRoutes.ts` (remove `POST /internal/usage/query`)
 - `apps/llm-usage-service/src/domain/repositories/usageEventRepository.ts`
 - `apps/llm-usage-service/src/infra/firestore/firestoreUsageEventRepository.ts`
 - `apps/llm-usage-service/src/domain/models/usageEvent.ts` (add MAX_LIST_LIMIT / DEFAULT_LIST_LIMIT)
-- `apps/llm-usage-service/src/__tests__/routes/internalUsageRoutes.test.ts`
 - `apps/llm-usage-service/src/__tests__/fakeUsageEventRepository.ts`
-- `packages/internal-clients/src/usage-service/client.ts`
-- `packages/internal-clients/src/usage-service/types.ts`
-- `packages/internal-clients/src/usage-service/__tests__/client.test.ts`
-- `apps/app-settings-service/src/services.ts`
-- `apps/app-settings-service/src/routes/publicRoutes.ts`
-- `apps/app-settings-service/src/index.ts` (REQUIRED_ENV)
-- `apps/app-settings-service/src/__tests__/routes/publicRoutes.test.ts`
+- `apps/web/src/config.ts` (add `llmUsageServiceUrl`)
 - `apps/web/src/App.tsx`
 - `apps/web/src/components/Sidebar.tsx`
 - `apps/web/src/pages/index.ts`
-- `terraform/environments/dev/main.tf`
-- `ecosystem.config.cjs`
+- `apps/web/vite.config.ts` (add `/api/llm-usage` proxy)
+- `terraform/environments/dev/main.tf` (add `INTEXURAOS_LLM_USAGE_SERVICE_URL` to web app env)
+- `ecosystem.config.cjs` (add `INTEXURAOS_LLM_USAGE_SERVICE_URL` to web app PM2 entry)

--- a/docs/plans/INT-1340-track-1-llm-usage-web-ui.md
+++ b/docs/plans/INT-1340-track-1-llm-usage-web-ui.md
@@ -1,0 +1,1023 @@
+# INT-1340 — Track 1: LLM Usage Web UI
+
+## Status
+- Linear issue: INT-1340
+- Parent epic: INT-1338 (LLM Usage Service Phase 2)
+- Dependencies: none (independent; builds directly on Phase 1)
+- Blocks: INT-1343 (Track 5 — pricing UI relocation, which reuses the new `/llm-usage` nav section as the mount point for pricing)
+- Plan version: 1.0
+
+## Executive summary
+
+This track delivers the first end-user surface for the new `llm-usage-service`. Phase 1 shipped the ingestion pipeline, daily aggregates, and an internal `POST /internal/usage/query` endpoint, but the web app currently has no way to view or drill into the resulting data. The legacy `LlmCostsPage` reads an old `llm_usage_stats` collection via `app-settings-service` and is completely disconnected from the new `llm_usage_events` / `llm_usage_daily_aggregates` collections owned by `llm-usage-service`. Users therefore cannot answer basic questions like "what did the orchestrator spend on Claude yesterday" without hitting Firestore directly.
+
+Track 1 closes that gap by delivering a new top-level **LLM Usage** nav section with a list view of raw events, a detail view for a single event, and an aggregate/grouping view driven by the existing `/internal/usage/query` endpoint. Because Phase 1 does not expose raw events (the existing query endpoint only returns grouped aggregates), this track **also** adds two new backend endpoints — `POST /internal/usage/events/list` and `GET /internal/usage/events/:eventId` — together with the supporting repository methods, Firestore composite indexes, internal-client extensions, and BFF proxies on `app-settings-service`.
+
+The design mirrors the existing code-tasks list and detail pages as closely as possible: identical Tailwind conventions, identical filter-tab strip, identical localStorage persistence, identical hash routing, identical `*Keyed` detail-page pattern. The intent is that a user landing on `/#/llm-usage` immediately recognizes the UX vocabulary from `/#/code-tasks` and does not need to learn a new mental model.
+
+## Pre-flight checks
+
+1. Confirm Phase 1 is merged and green: `apps/llm-usage-service` exists and `POST /internal/usage/query` passes its tests.
+2. Confirm `firestore-collections.json` lists `llm_usage_events` with `"owner": "llm-usage-service"` (already present — verified).
+3. Confirm `packages/internal-clients/src/usage-service/client.ts` exports `createUsageServiceClient` and has exactly two methods today (`ingestEvents`, `queryUsage`). Any additional methods already merged mean this plan is stale — stop and re-read.
+4. Confirm the web app uses `HashRouter` and reads service URLs from `apps/web/src/config.ts` (verified: `import.meta.env.INTEXURAOS_*`).
+5. Confirm `app-settings-service` currently serves `/settings/usage-costs` and therefore already has auth, services.ts DI, and public-routes plumbing that can be extended (verified).
+6. Read the `UsageEventInput` TS type in `apps/llm-usage-service/src/domain/models/usageEvent.ts` **before** writing the list-item view model — the event shape is deeply nested (`owner.*`, `source.*`, `request.*`, `usage.*`, `cost.*`, `correlation.*`, `error`) and the detail-view card hierarchy must match.
+7. Run `pnpm run ci:tracked` at the start of the branch to establish a clean baseline.
+
+## Context files
+
+### Read before touching the backend
+- `apps/llm-usage-service/src/routes/internalUsageRoutes.ts` — both new routes live here alongside `/internal/usage/query`.
+- `apps/llm-usage-service/src/domain/repositories/usageEventRepository.ts` — interface extended with `list()` and `getById()`.
+- `apps/llm-usage-service/src/infra/firestore/firestoreUsageEventRepository.ts` — Firestore implementation for the new methods.
+- `apps/llm-usage-service/src/domain/models/usageEvent.ts` — canonical `UsageEvent` shape (the list-items return the full event; no projection).
+- `apps/llm-usage-service/src/domain/models/usageQuery.ts` — reuses `AggregateMetrics` / `UsageQueryFilters` vocabulary for the list filters.
+- `apps/llm-usage-service/src/__tests__/routes/internalUsageRoutes.test.ts` — mirror this test layout (beforeAll/beforeEach/afterEach, `app.inject()`, fake repos via `setServices`).
+- `apps/llm-usage-service/src/__tests__/fakeUsageEventRepository.ts` — extend with in-memory `list()` and `getById()` for tests.
+
+### Read before touching the internal client
+- `packages/internal-clients/src/usage-service/client.ts` — add two methods next to `queryUsage`.
+- `packages/internal-clients/src/usage-service/types.ts` — add request/response DTOs for list/getById; re-export the full `UsageEvent` shape.
+- `packages/internal-clients/src/usage-service/__tests__/client.test.ts` — extend with `nock`-based tests for the new methods.
+
+### Read before touching the BFF
+- `apps/app-settings-service/src/routes/publicRoutes.ts` — add `GET /settings/llm-usage/events` and `GET /settings/llm-usage/events/:eventId` and `POST /settings/llm-usage/query` alongside `/settings/usage-costs`.
+- `apps/app-settings-service/src/services.ts` — add a `usageServiceClient` to the DI container.
+- `apps/app-settings-service/src/index.ts` — add `INTEXURAOS_LLM_USAGE_SERVICE_URL` + `INTEXURAOS_INTERNAL_AUTH_TOKEN` to `REQUIRED_ENV`.
+- `apps/app-settings-service/src/__tests__/routes/publicRoutes.test.ts` — mirror for new routes with a fake `UsageServiceClient`.
+
+### Read before touching the web app
+- `apps/web/src/pages/CodeTasksPage.tsx` — design reference for list page. Copy the header, filter-tab strip, sort selector, and localStorage patterns verbatim.
+- `apps/web/src/pages/CodeTaskViewPage.tsx` — design reference for detail page, including the `MemoTaskHeader` / `MemoTaskPromptCard` card hierarchy and the `*Keyed` wrapper.
+- `apps/web/src/components/Sidebar.tsx` — add a new top-level "LLM Usage" collapsible section modeled on the Code Tasks section (lines 427–477).
+- `apps/web/src/App.tsx` — add three new routes (`/llm-usage`, `/llm-usage/:eventId`, plus the `LlmUsageViewPageKeyed` wrapper).
+- `apps/web/src/hooks/useIssueGroups.ts` — blueprint for `useLlmUsageEvents` (server-side filtering, cursor-based pagination, 30s poll, tab-visibility refresh, abort on unmount).
+- `apps/web/src/services/issueGroupsApi.ts` — blueprint for the new `llmUsageApi.ts`.
+- `apps/web/src/services/apiClient.ts` — shared `apiRequest` helper; do not reinvent.
+- `apps/web/src/hooks/useApiClient.ts` — `useApiClient()` hook that wraps `apiRequest` with the current access token.
+- `apps/web/src/config.ts` — the `appSettingsServiceUrl` field already exists; new pages use it (the llm-usage-service is NOT exposed directly to the SPA).
+- `apps/web/vite.config.ts` — the `/api/settings` proxy (port 8122) already exists and is reused as-is. **No new vite proxy entry is needed** because all web traffic goes through `app-settings-service`, which in turn calls `llm-usage-service` server-to-server.
+
+### Read before touching Firestore indexes
+- `firestore-collections.json` — confirm ownership of `llm_usage_events` stays with `llm-usage-service`.
+- `migrations/051_code-tasks-status-createdAt-index.mjs` — template for a composite-index migration file (numbered at the repo root, not inside the app).
+
+## Endpoint changes
+
+### Modified
+- (none — no existing endpoints change contract)
+
+### Created
+**Backend (`apps/llm-usage-service`)**
+- `POST /internal/usage/events/list` — paginated raw events. Body: `{ timeRange: { from, to }, filters?: UsageEventFilters, sortBy?: { field, direction }, limit?, cursor? }`. Response: `{ events: UsageEvent[], nextCursor?: string, totalMatched: number }`. Auth: `X-Internal-Auth`.
+- `GET /internal/usage/events/:eventId` — single raw event. Response: `{ event: UsageEvent }` or 404. Auth: `X-Internal-Auth`.
+
+**BFF (`apps/app-settings-service`)**
+- `POST /settings/llm-usage/events` — proxies `POST /internal/usage/events/list` on `llm-usage-service`. Auth: user bearer token via `requireAuth`; no user-scoping is applied at the BFF layer in this track (see "Out of scope"). Response mirrors the upstream.
+- `GET /settings/llm-usage/events/:eventId` — proxies `GET /internal/usage/events/:eventId`. Auth: user bearer token.
+- `POST /settings/llm-usage/query` — proxies the existing `POST /internal/usage/query`. Auth: user bearer token. (Added now so the web app has a single BFF entry point per concern; avoids coupling the SPA to two different service URLs.)
+
+### Removed
+- (none)
+
+### Unchanged
+- `POST /internal/usage/events` (webhook ingest)
+- `POST /internal/usage/events/orchestrator` (orchestrator webhook)
+- `POST /internal/usage/query` (still internal; the BFF above is a thin wrapper, not a replacement)
+- All existing `app-settings-service` public routes (`/settings/pricing`, `/settings/usage-costs`, etc.)
+
+## Step-by-step implementation
+
+### Phase 1 — Backend: domain model and repository extensions
+
+Write failing tests first (`apps/llm-usage-service/src/__tests__/infra/firestoreUsageEventRepository.test.ts` if it exists, else create; and `apps/llm-usage-service/src/__tests__/fakeUsageEventRepository.ts` needs to implement the new methods).
+
+**Extend the repository interface:**
+
+```ts
+// apps/llm-usage-service/src/domain/repositories/usageEventRepository.ts
+import type { Result } from '@intexuraos/common-core';
+import type { UsageEvent } from '../models/usageEvent.js';
+
+export type CreateEventResult = { status: 'created' } | { status: 'duplicate' };
+
+export interface UsageEventFilters {
+  ownerTypes?: ('user' | 'system')[];
+  ownerIds?: string[];
+  services?: string[];
+  components?: string[];
+  clients?: string[];
+  providers?: string[];
+  models?: string[];
+  operations?: string[];
+  success?: boolean;
+}
+
+export interface ListUsageEventsParams {
+  timeRange: { from: string; to: string };
+  filters?: UsageEventFilters;
+  sortBy?: {
+    field: 'occurredAt' | 'costUsd' | 'totalTokens';
+    direction: 'asc' | 'desc';
+  };
+  limit: number;        // always bounded by MAX_LIST_LIMIT (see below)
+  cursor?: string;      // opaque base64 of { lastOccurredAt, lastEventId }
+}
+
+export interface ListUsageEventsResult {
+  events: UsageEvent[];
+  nextCursor?: string;
+  totalMatched: number; // count of events matching filters in the time range
+}
+
+export interface UsageEventRepository {
+  createEvent(
+    event: UsageEvent,
+  ): Promise<Result<CreateEventResult, { code: string; message: string }>>;
+
+  list(
+    params: ListUsageEventsParams,
+  ): Promise<Result<ListUsageEventsResult, { code: string; message: string }>>;
+
+  getById(
+    eventId: string,
+  ): Promise<Result<UsageEvent | null, { code: string; message: string }>>;
+}
+```
+
+**Constants:** add `MAX_LIST_LIMIT = 200`, `DEFAULT_LIST_LIMIT = 50` to `apps/llm-usage-service/src/domain/models/usageEvent.ts`.
+
+**Cursor design:** opaque, base64-encoded JSON of `{ lastOccurredAt: string, lastEventId: string }`. The repository decodes it and starts the next Firestore query at `.startAfter(lastOccurredAt, lastEventId)`. The `lastEventId` tiebreaker is required because `occurredAt` is not guaranteed unique (a single batch ingest can produce two events with identical `occurredAt` to millisecond precision). Example encoder:
+
+```ts
+function encodeCursor(lastOccurredAt: string, lastEventId: string): string {
+  return Buffer.from(JSON.stringify({ lastOccurredAt, lastEventId }), 'utf8').toString('base64url');
+}
+
+function decodeCursor(cursor: string): { lastOccurredAt: string; lastEventId: string } | null {
+  try {
+    const decoded = JSON.parse(Buffer.from(cursor, 'base64url').toString('utf8')) as unknown;
+    if (
+      typeof decoded === 'object' && decoded !== null
+      && 'lastOccurredAt' in decoded && typeof (decoded as Record<string, unknown>)['lastOccurredAt'] === 'string'
+      && 'lastEventId' in decoded && typeof (decoded as Record<string, unknown>)['lastEventId'] === 'string'
+    ) {
+      return decoded as { lastOccurredAt: string; lastEventId: string };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+```
+
+**Firestore implementation (`firestoreUsageEventRepository.ts`):** use a base query of `.collection('llm_usage_events').where('occurredAt', '>=', from).where('occurredAt', '<=', to)`, then append `.where(...)` clauses for each filter, then `.orderBy(field, direction).orderBy('__name__', direction)` for the tiebreaker, then `.startAfter(...)` if cursor present, then `.limit(limit + 1)` (fetch one extra to compute `nextCursor`). If the `limit+1`-th doc exists, strip it and encode its predecessor's `(occurredAt, eventId)` as the cursor.
+
+For `totalMatched`, run a **separate** `.count()` aggregation query with the same `where` clauses. This costs one extra document read per page of results but is required to render "Showing 50 of 2,341 events". If `.count()` proves too expensive in practice we can gate it behind a `?includeCount=true` query param in a follow-up; ⚠ DECISION NEEDED whether to ship with count enabled by default in this track. Recommendation: **ship with count enabled** because the UX degrades noticeably without it and 1 extra read/page on a collection that currently gets maybe 10k events/day is negligible.
+
+**`getById` implementation:** `db.collection('llm_usage_events').doc(eventId).get()`; return `ok(null)` on `!snapshot.exists` (NOT `err`); return `ok(snapshot.data() as UsageEvent)` on success.
+
+### Phase 2 — Backend: new list + getById routes (test-first)
+
+Write failing tests first in `apps/llm-usage-service/src/__tests__/routes/internalUsageRoutes.test.ts`. The existing file is the template; add new `describe` blocks:
+
+- `POST /internal/usage/events/list`
+  - returns 200 with paginated events when filters match
+  - returns 200 with empty `events` array when no filters match
+  - returns 200 with a `nextCursor` when more results exist
+  - accepts and decodes a cursor from a previous page
+  - filters by `providers`, `components`, `services`, `models`, `ownerIds`
+  - respects `sortBy.field=occurredAt` `direction=desc` (default)
+  - respects `sortBy.field=costUsd` `direction=desc`
+  - respects `sortBy.field=totalTokens` `direction=desc`
+  - clamps `limit` to `MAX_LIST_LIMIT` (200)
+  - uses `DEFAULT_LIST_LIMIT` (50) when `limit` is not supplied
+  - returns 400 for invalid `sortBy.field`
+  - returns 400 for malformed cursor (decodeCursor returns null)
+  - returns 400 when `timeRange.from > timeRange.to`
+  - returns 401 for missing `X-Internal-Auth` header
+
+- `GET /internal/usage/events/:eventId`
+  - returns 200 with full event when found
+  - returns 404 when not found
+  - returns 401 for missing `X-Internal-Auth` header
+
+Only after all of the above are red, implement the route handlers. Skeleton:
+
+```ts
+// apps/llm-usage-service/src/routes/internalUsageRoutes.ts  (new routes)
+app.post(
+  '/internal/usage/events/list',
+  {
+    schema: {
+      operationId: 'internalListUsageEvents',
+      summary: 'List raw usage events (internal, paginated)',
+      tags: ['usage'],
+      body: {
+        type: 'object',
+        required: ['timeRange'],
+        additionalProperties: false,
+        properties: {
+          timeRange: {
+            type: 'object',
+            required: ['from', 'to'],
+            properties: {
+              from: { type: 'string', format: 'date-time' },
+              to: { type: 'string', format: 'date-time' },
+            },
+          },
+          filters: { type: 'object' },
+          sortBy: {
+            type: 'object',
+            properties: {
+              field: { type: 'string', enum: ['occurredAt', 'costUsd', 'totalTokens'] },
+              direction: { type: 'string', enum: ['asc', 'desc'] },
+            },
+          },
+          limit: { type: 'integer', minimum: 1, maximum: 200 },
+          cursor: { type: 'string', minLength: 1 },
+        },
+      },
+      response: { /* 200, 400, 401 as in existing routes */ },
+    },
+  },
+  async (request, reply) => {
+    logIncomingRequest(request, { message: 'Internal usage events list' });
+    const authResult = validateInternalAuth(request);
+    if (!authResult.valid) {
+      request.log.warn({ reason: authResult.reason }, 'Internal auth failed');
+      return await reply.fail('UNAUTHORIZED', 'Internal auth failed');
+    }
+    const body = request.body as ListUsageEventsBody;
+    const { usageEventRepository } = getServices();
+    const result = await listUsageEvents(
+      { logger: request.log, usageEventRepository },
+      body,
+    );
+    if (!result.ok) {
+      return await reply.fail('INVALID_REQUEST', result.error.message);
+    }
+    return await reply.ok(result.value);
+  },
+);
+
+app.get<{ Params: { eventId: string } }>(
+  '/internal/usage/events/:eventId',
+  { schema: { /* ... */ } },
+  async (request, reply) => {
+    logIncomingRequest(request, { message: 'Internal usage event get' });
+    const authResult = validateInternalAuth(request);
+    if (!authResult.valid) {
+      return await reply.fail('UNAUTHORIZED', 'Internal auth failed');
+    }
+    const { usageEventRepository } = getServices();
+    const result = await usageEventRepository.getById(request.params.eventId);
+    if (!result.ok) {
+      return await reply.fail('INTERNAL_ERROR', result.error.message);
+    }
+    if (result.value === null) {
+      return await reply.fail('NOT_FOUND', `Event ${request.params.eventId} not found`);
+    }
+    return await reply.ok({ event: result.value });
+  },
+);
+```
+
+Create a use case file `apps/llm-usage-service/src/domain/usecases/listUsageEvents.ts` (mirrors `queryUsage.ts`) that does validation, clamping, and delegation to the repo.
+
+### Phase 3 — Backend: Firestore composite indexes (migration)
+
+Create `migrations/086_llm-usage-events-list-indexes.mjs` (next available number — verify no one else grabbed 086 first). Content modeled on `051_code-tasks-status-createdAt-index.mjs`:
+
+```js
+export const metadata = {
+  id: '086',
+  name: 'llm-usage-events-list-indexes',
+  description: 'Composite indexes for llm_usage_events list queries (filter + sort combinations)',
+  createdAt: '2026-04-10',
+};
+
+export const indexes = [
+  // Default sort: occurredAt desc, no filter
+  // (single-field; already covered by Firestore's implicit index — no entry needed)
+
+  // Filter by source.service, sort by occurredAt desc
+  {
+    collectionGroup: 'llm_usage_events',
+    queryScope: 'COLLECTION',
+    fields: [
+      { fieldPath: 'source.service', order: 'ASCENDING' },
+      { fieldPath: 'occurredAt', order: 'DESCENDING' },
+      { fieldPath: '__name__', order: 'DESCENDING' },
+    ],
+  },
+  // Filter by source.component, sort by occurredAt desc
+  {
+    collectionGroup: 'llm_usage_events',
+    queryScope: 'COLLECTION',
+    fields: [
+      { fieldPath: 'source.component', order: 'ASCENDING' },
+      { fieldPath: 'occurredAt', order: 'DESCENDING' },
+      { fieldPath: '__name__', order: 'DESCENDING' },
+    ],
+  },
+  // Filter by request.provider, sort by occurredAt desc
+  {
+    collectionGroup: 'llm_usage_events',
+    queryScope: 'COLLECTION',
+    fields: [
+      { fieldPath: 'request.provider', order: 'ASCENDING' },
+      { fieldPath: 'occurredAt', order: 'DESCENDING' },
+      { fieldPath: '__name__', order: 'DESCENDING' },
+    ],
+  },
+  // Filter by request.model, sort by occurredAt desc
+  {
+    collectionGroup: 'llm_usage_events',
+    queryScope: 'COLLECTION',
+    fields: [
+      { fieldPath: 'request.model', order: 'ASCENDING' },
+      { fieldPath: 'occurredAt', order: 'DESCENDING' },
+      { fieldPath: '__name__', order: 'DESCENDING' },
+    ],
+  },
+  // Filter by owner.id, sort by occurredAt desc
+  {
+    collectionGroup: 'llm_usage_events',
+    queryScope: 'COLLECTION',
+    fields: [
+      { fieldPath: 'owner.id', order: 'ASCENDING' },
+      { fieldPath: 'occurredAt', order: 'DESCENDING' },
+      { fieldPath: '__name__', order: 'DESCENDING' },
+    ],
+  },
+  // Sort by cost.billedUsd desc, no filter
+  {
+    collectionGroup: 'llm_usage_events',
+    queryScope: 'COLLECTION',
+    fields: [
+      { fieldPath: 'cost.billedUsd', order: 'DESCENDING' },
+      { fieldPath: '__name__', order: 'DESCENDING' },
+    ],
+  },
+  // Sort by usage.totalTokens desc, no filter
+  {
+    collectionGroup: 'llm_usage_events',
+    queryScope: 'COLLECTION',
+    fields: [
+      { fieldPath: 'usage.totalTokens', order: 'DESCENDING' },
+      { fieldPath: '__name__', order: 'DESCENDING' },
+    ],
+  },
+];
+
+export const collections = ['llm_usage_events'];
+
+export async function up(context) {
+  console.log('  Deploying llm_usage_events list composite indexes...');
+  await context.deployIndexes();
+}
+
+export async function down(context) {
+  console.log('  Removing indexes requires manual deletion via Firebase console');
+}
+```
+
+⚠ **DECISION NEEDED**: multi-field filter combinations (e.g. `provider + service + occurredAt`) will blow up the index count. Recommendation for this track: **only index single-filter + sort combinations**. If the user selects two filters at once, the repository runs one `where` as an index-hit and the other as a post-fetch in-memory filter, accepting that the response may be smaller than `limit` and that pagination may need extra trips. Document this limit in the list use case and add a TODO for a future track if it hurts in practice.
+
+Alternative: tell the user they can't combine certain filters. The recommendation above is less user-hostile.
+
+### Phase 4 — Internal client extension
+
+Extend `packages/internal-clients/src/usage-service/types.ts`:
+
+```ts
+export interface UsageEventFilters {
+  ownerTypes?: ('user' | 'system')[];
+  ownerIds?: string[];
+  services?: string[];
+  components?: string[];
+  clients?: string[];
+  providers?: string[];
+  models?: string[];
+  operations?: string[];
+  success?: boolean;
+}
+
+export interface ListUsageEventsRequest {
+  timeRange: { from: string; to: string };
+  filters?: UsageEventFilters;
+  sortBy?: {
+    field: 'occurredAt' | 'costUsd' | 'totalTokens';
+    direction: 'asc' | 'desc';
+  };
+  limit?: number;
+  cursor?: string;
+}
+
+export interface ListUsageEventsResponse {
+  events: UsageEventInput[]; // full event; occurredAt, receivedAt, ingress included
+  nextCursor?: string;
+  totalMatched: number;
+}
+
+// Extend the UsageServiceClient interface with:
+export interface UsageServiceClient {
+  ingestEvents(/* ... */);
+  queryUsage(/* ... */);
+  listEvents(
+    request: ListUsageEventsRequest,
+    options?: { traceId?: string }
+  ): Promise<Result<ListUsageEventsResponse, UsageServiceError>>;
+  getEvent(
+    eventId: string,
+    options?: { traceId?: string }
+  ): Promise<Result<UsageEventInput | null, UsageServiceError>>;
+}
+```
+
+Note: the client returns `UsageEventInput` rather than `UsageEvent` to avoid leaking the `receivedAt`/`ingress` internals into the BFF DTO. If the UI needs those fields, widen the type — but verify the caller actually uses them first.
+
+Extend `client.ts` with `listEvents` and `getEvent` methods modeled on `queryUsage`. Add `nock`-based tests to `__tests__/client.test.ts` for all three: happy path, non-2xx, network error.
+
+### Phase 5 — Web app BFF proxy routes
+
+Add to `apps/app-settings-service/src/services.ts`:
+
+```ts
+import { createUsageServiceClient } from '@intexuraos/internal-clients/usage-service';
+import type { UsageServiceClient } from '@intexuraos/internal-clients/usage-service';
+
+export interface ServiceContainer {
+  pricingRepository: PricingRepository;
+  usageStatsRepository: UsageStatsRepository;
+  usageServiceClient: UsageServiceClient;
+}
+
+export function getServices(): ServiceContainer {
+  container ??= {
+    pricingRepository: new FirestorePricingRepository(),
+    usageStatsRepository: new FirestoreUsageStatsRepository(),
+    usageServiceClient: createUsageServiceClient({
+      baseUrl: process.env['INTEXURAOS_LLM_USAGE_SERVICE_URL']!,
+      internalAuthToken: process.env['INTEXURAOS_INTERNAL_AUTH_TOKEN']!,
+      logger: createAppLogger({ name: 'app-settings-service.usageServiceClient' }),
+    }),
+  };
+  return container;
+}
+```
+
+Add to `apps/app-settings-service/src/routes/publicRoutes.ts` (next to `/settings/usage-costs`):
+
+- `POST /settings/llm-usage/events` — validates body with Fastify JSON schema mirroring `ListUsageEventsRequest`, calls `usageServiceClient.listEvents(body, { traceId: request.id })`, returns 200 with `{ events, nextCursor, totalMatched }`. No user-scoping in this track.
+- `GET /settings/llm-usage/events/:eventId` — calls `usageServiceClient.getEvent(eventId)`, returns 200 `{ event }` or 404.
+- `POST /settings/llm-usage/query` — calls `usageServiceClient.queryUsage(body)`. Pass through the response verbatim.
+
+Every new route MUST call `logIncomingRequest(request, { message: '...' })` and `requireAuth(request, reply)` (not `validateInternalAuth` — this is the public-facing BFF).
+
+Add env vars in three places (per CLAUDE.md rules):
+1. `apps/app-settings-service/src/index.ts` — add `'INTEXURAOS_LLM_USAGE_SERVICE_URL'` and `'INTEXURAOS_INTERNAL_AUTH_TOKEN'` to `REQUIRED_ENV` (the second may already be present — check before adding).
+2. `terraform/environments/dev/main.tf` — add the same vars to the `app-settings-service` Cloud Run container's `env` block. The URL should point to the `llm-usage-service` Cloud Run service URL output.
+3. `ecosystem.config.cjs` — add to the `app-settings-service` PM2 entry's `env` section for home-dev.
+
+⚠ **DECISION NEEDED**: `INTEXURAOS_LLM_USAGE_SERVICE_URL` for the dev environment. Look up the actual service URL from `terraform/environments/dev/main.tf` — it likely exists as a Terraform output from the Phase 1 deployment. If it doesn't yet, add the output first.
+
+Write tests in `apps/app-settings-service/src/__tests__/routes/publicRoutes.test.ts` using a `FakeUsageServiceClient` that implements the `UsageServiceClient` interface with in-memory data. Tests must cover: happy path, upstream 404 → BFF 404, upstream 500 → BFF 500, missing auth → BFF 401, invalid body → BFF 400.
+
+### Phase 6 — Web app API service module
+
+Create `apps/web/src/services/llmUsageApi.ts`:
+
+```ts
+import { config } from '@/config';
+import { apiRequest } from './apiClient.js';
+import type {
+  ListLlmUsageEventsRequest,
+  ListLlmUsageEventsResponse,
+  UsageEvent,
+  LlmUsageQueryRequest,
+  LlmUsageQueryResponse,
+} from '@/types/llmUsage';
+
+export async function listLlmUsageEvents(
+  accessToken: string,
+  request: ListLlmUsageEventsRequest,
+): Promise<ListLlmUsageEventsResponse> {
+  return await apiRequest<ListLlmUsageEventsResponse>(
+    config.appSettingsServiceUrl,
+    '/settings/llm-usage/events',
+    accessToken,
+    { method: 'POST', body: request },
+  );
+}
+
+export async function getLlmUsageEvent(
+  accessToken: string,
+  eventId: string,
+): Promise<{ event: UsageEvent }> {
+  return await apiRequest<{ event: UsageEvent }>(
+    config.appSettingsServiceUrl,
+    `/settings/llm-usage/events/${encodeURIComponent(eventId)}`,
+    accessToken,
+  );
+}
+
+export async function queryLlmUsage(
+  accessToken: string,
+  request: LlmUsageQueryRequest,
+): Promise<LlmUsageQueryResponse> {
+  return await apiRequest<LlmUsageQueryResponse>(
+    config.appSettingsServiceUrl,
+    '/settings/llm-usage/query',
+    accessToken,
+    { method: 'POST', body: request },
+  );
+}
+```
+
+Create `apps/web/src/types/llmUsage.ts` with the type mirrors. Write **unit tests** for `llmUsageApi.ts` (web app exception says `services/` must have tests). Use nock or the existing `__tests__/` patterns in `apps/web/src/services/__tests__/`.
+
+### Phase 7 — Web app hooks
+
+Create `apps/web/src/hooks/useLlmUsageEvents.ts`. Skeleton mirroring `useIssueGroups.ts`:
+
+```ts
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { getErrorMessage } from '@intexuraos/common-core/errors';
+import { useAuth } from '@/context';
+import { listLlmUsageEvents } from '@/services/llmUsageApi';
+import type {
+  UsageEvent,
+  ListLlmUsageEventsResponse,
+  UsageEventFilters,
+  UsageEventSortField,
+} from '@/types/llmUsage';
+
+const DEFAULT_LIMIT = 50;
+const POLL_INTERVAL_MS = 30000;
+
+export interface UseLlmUsageEventsOptions {
+  timeRange: { from: string; to: string };
+  filters: UsageEventFilters;
+  sortBy: { field: UsageEventSortField; direction: 'asc' | 'desc' };
+}
+
+export interface UseLlmUsageEventsResult {
+  events: UsageEvent[];
+  totalMatched: number;
+  loading: boolean;
+  loadingMore: boolean;
+  refreshing: boolean;
+  error: string | null;
+  hasMore: boolean;
+  loadMore: () => Promise<void>;
+  refresh: (showLoading?: boolean) => Promise<void>;
+}
+
+export function useLlmUsageEvents(
+  options: UseLlmUsageEventsOptions,
+): UseLlmUsageEventsResult {
+  const { getAccessToken } = useAuth();
+  const [events, setEvents] = useState<UsageEvent[]>([]);
+  const [totalMatched, setTotalMatched] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [nextCursor, setNextCursor] = useState<string | undefined>(undefined);
+  const [hasMore, setHasMore] = useState(false);
+  const isMountedRef = useRef(true);
+
+  const refresh = useCallback(/* ... */);
+  const loadMore = useCallback(/* ... */);
+  // initial load effect
+  // tab-visibility refresh effect
+  // polling effect (30s when visible)
+
+  return { events, totalMatched, loading, loadingMore, refreshing, error, hasMore, loadMore, refresh };
+}
+```
+
+Create a second hook `apps/web/src/hooks/useLlmUsageQuery.ts` for the aggregate view (it calls `queryLlmUsage` from `llmUsageApi`). Simpler: no cursor, no polling, just refetch on options change.
+
+Create a third hook `apps/web/src/hooks/useLlmUsageEvent.ts` for the detail view (single event by ID). Mirrors `useTaskView` structure but far simpler — no live log stream.
+
+All three hooks get unit tests (hooks are in the enforced-coverage zone per CLAUDE.md web app exception).
+
+### Phase 8 — Web app list page (LlmUsagePage)
+
+Create `apps/web/src/pages/LlmUsagePage.tsx`. Structure:
+
+```tsx
+export function LlmUsagePage(): React.JSX.Element {
+  const [timeRange, setTimeRange] = useState<TimeRangePreset>(loadTimeRangeFromStorage);
+  const [filters, setFilters] = useState<UsageEventFilters>(loadFiltersFromStorage);
+  const [sortBy, setSortBy] = useState<{ field: UsageEventSortField; direction: 'asc' | 'desc' }>(loadSortFromStorage);
+  const [groupBy, setGroupBy] = useState<GroupByMode>(loadGroupByFromStorage);
+
+  // Two hooks — only one is "active" at a time (the other returns empty state)
+  const listHook = useLlmUsageEvents({
+    timeRange: resolveTimeRange(timeRange),
+    filters,
+    sortBy,
+  });
+  const queryHook = useLlmUsageQuery({
+    timeRange: resolveTimeRange(timeRange),
+    filters,
+    groupBy: resolveGroupByFields(groupBy),
+  });
+
+  return (
+    <Layout>
+      <PageHeader totalMatched={groupBy === 'none' ? listHook.totalMatched : queryHook.totalRows} />
+
+      <TimeRangePicker value={timeRange} onChange={setTimeRange} />
+
+      <FilterTabStrip filters={filters} onChange={setFilters} />
+
+      <GroupBySelector value={groupBy} onChange={setGroupBy} />
+
+      {groupBy !== 'none' ? null : (
+        <SortSelector value={sortBy} onChange={setSortBy} />
+      )}
+
+      {groupBy === 'none' ? (
+        <RawEventsList
+          events={listHook.events}
+          loading={listHook.loading}
+          refreshing={listHook.refreshing}
+          error={listHook.error}
+          hasMore={listHook.hasMore}
+          loadMore={listHook.loadMore}
+        />
+      ) : (
+        <AggregateTable
+          rows={queryHook.rows}
+          totals={queryHook.totals}
+          loading={queryHook.loading}
+          error={queryHook.error}
+          groupBy={groupBy}
+        />
+      )}
+    </Layout>
+  );
+}
+```
+
+**Filter-tab strip styling** — copy these exact Tailwind classes from `CodeTasksPage.tsx` so the two pages look identical:
+
+```tsx
+const INACTIVE_SEGMENT_CLASS =
+  'border-slate-200 bg-white text-slate-600 hover:border-slate-300 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-400 dark:hover:border-slate-500';
+
+// active class examples, one per provider color:
+const PROVIDER_ACTIVE_CLASSES: Record<LlmProvider, string> = {
+  anthropic: 'border-orange-500 bg-orange-50 text-orange-700 dark:border-orange-400 dark:bg-orange-900/30 dark:text-orange-400',
+  openai:    'border-emerald-500 bg-emerald-50 text-emerald-700 dark:border-emerald-400 dark:bg-emerald-900/30 dark:text-emerald-400',
+  google:    'border-blue-500 bg-blue-50 text-blue-700 dark:border-blue-400 dark:bg-blue-900/30 dark:text-blue-400',
+  perplexity:'border-purple-500 bg-purple-50 text-purple-700 dark:border-purple-400 dark:bg-purple-900/30 dark:text-purple-400',
+};
+
+// strip container (copied verbatim from StatusPipeline in CodeTasksPage):
+<div className="mb-4 flex flex-wrap items-center gap-2">
+  {PROVIDERS.map((provider) => {
+    const isActive = filters.providers?.includes(provider) ?? false;
+    return (
+      <button
+        key={provider}
+        onClick={(): void => { toggleProvider(provider); }}
+        className={`inline-flex cursor-pointer items-center gap-2 rounded-full border px-3 py-1.5 text-sm transition-colors ${
+          isActive ? PROVIDER_ACTIVE_CLASSES[provider] : INACTIVE_SEGMENT_CLASS
+        }`}
+      >
+        <span className={`inline-block h-2 w-2 rounded-full ${PROVIDER_DOT_CLASSES[provider]}`} />
+        {provider}
+      </button>
+    );
+  })}
+</div>
+```
+
+The same pattern repeats for filter strips on `component`, `service`, and `model`. All four strips stack vertically above the sort selector.
+
+**Time range presets:** "Today", "Yesterday", "Last 7 days", "Last 30 days", "Custom". Custom opens two `<input type="datetime-local">` fields. Store as `{ preset: 'today' | ... | 'custom', customFrom?, customTo? }`. A pure `resolveTimeRange()` utility in `apps/web/src/utils/llmUsageTimeRange.ts` converts preset → `{ from, to }` ISO strings at call time. This utility is in the `utils/` enforced-coverage zone — write unit tests.
+
+**Group by options:** `none`, `day`, `component`, `service`, `model`. Maps to `groupBy` array passed to `queryLlmUsage`:
+- `none` → uses `useLlmUsageEvents` (raw list), not `useLlmUsageQuery`
+- `day` → `['day']`
+- `component` → `['source.component']`
+- `service` → `['source.service']`
+- `model` → `['request.model']`
+
+**Sort selector:** only visible when `groupBy === 'none'`. Options: `occurredAt desc` (default), `occurredAt asc`, `costUsd desc`, `totalTokens desc`.
+
+**Raw events list row layout:** single-row summary per event, columns: `occurredAt (relative)`, `provider · model`, `component`, `service`, `totalTokens`, `costUsd`, clickable (navigates to `/#/llm-usage/{eventId}`). Use `Link` from `react-router-dom`.
+
+**localStorage keys:** all four filter/sort/groupBy/timeRange states persist to localStorage with keys prefixed `llm-usage-*` (matches `code-tasks-*` convention). Use a small `loadFromStorage<T>(key, validator, fallback)` helper; put it in `apps/web/src/utils/llmUsageStorage.ts` and unit-test it.
+
+### Phase 9 — Web app detail page (LlmUsageViewPage)
+
+Create `apps/web/src/pages/LlmUsageViewPage.tsx`. Follows the `CodeTaskViewPage` card-stack structure:
+
+```tsx
+export function LlmUsageViewPage(): React.JSX.Element {
+  const { eventId } = useParams<{ eventId: string }>();
+  const { event, loading, error } = useLlmUsageEvent(eventId ?? '');
+
+  if (loading) return <Layout><Loader /></Layout>;
+  if (error !== null || event === null) {
+    return <Layout><Card variant="error"><p>{error ?? 'Event not found'}</p></Card></Layout>;
+  }
+
+  return (
+    <Layout>
+      <EventHeader event={event} />
+      <RequestCard request={event.request} />
+      <UsageCard usage={event.usage} />
+      <CostCard cost={event.cost} />
+      <SourceCard source={event.source} owner={event.owner} />
+      <CorrelationCard correlation={event.correlation} />
+      {event.error !== null ? <ErrorCard error={event.error} /> : null}
+      <RawJsonCard event={event} />
+    </Layout>
+  );
+}
+```
+
+Each card uses the existing `Card` component from `@/components` with `text-slate-900 dark:text-slate-100` headings, exactly like `TaskPromptCard` in `CodeTaskViewPage`. The `RawJsonCard` is a `<details><summary>` with a `<pre>` containing `JSON.stringify(event, null, 2)` and a copy-to-clipboard button identical to the one in `MemoTaskPromptCard`.
+
+**`*Keyed` wrapper** — add to `App.tsx` alongside `CodeTaskViewPageKeyed`:
+
+```tsx
+function LlmUsageViewPageKeyed(): React.JSX.Element {
+  const { eventId } = useParams<{ eventId: string }>();
+  return <LlmUsageViewPage key={eventId} />;
+}
+```
+
+This forces the component to remount when the user navigates from one event to another, matching the code-tasks pattern.
+
+### Phase 10 — Web app nav + routing
+
+**`App.tsx` routes:** add next to the code-tasks routes block:
+
+```tsx
+{/* LLM Usage routes */}
+<Route path="/llm-usage" element={<ProtectedRoute><LlmUsagePage /></ProtectedRoute>} />
+<Route path="/llm-usage/:eventId" element={<ProtectedRoute><LlmUsageViewPageKeyed /></ProtectedRoute>} />
+```
+
+Export the two new pages from `apps/web/src/pages/index.ts`.
+
+**`Sidebar.tsx`:** add a new collapsible section between "Code Tasks" and "Cron Agent". Model it on the Code Tasks section (lines 427–477):
+
+```tsx
+const llmUsageItems: NavItem[] = [
+  { to: '/llm-usage', label: 'Events', icon: List },
+  // Track 5 will add { to: '/llm-usage/pricing', label: 'Pricing', icon: DollarSign } here
+];
+
+const [isLlmUsageOpen, setIsLlmUsageOpen] = useState(() =>
+  window.location.hash.includes('/llm-usage'),
+);
+
+// in the render:
+<div className="pt-2">
+  <button
+    onClick={(): void => {
+      if (!isLlmUsageOpen) {
+        void navigate(llmUsageItems[0]?.to ?? '/llm-usage');
+      }
+      setIsLlmUsageOpen(!isLlmUsageOpen);
+    }}
+    className={`flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-colors ${
+      location.pathname.startsWith('/llm-usage')
+        ? 'bg-blue-50 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400'
+        : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900 dark:text-slate-300 dark:hover:bg-slate-700 dark:hover:text-slate-100'
+    }`}
+  >
+    <TrendingUp className="h-5 w-5 shrink-0" />
+    {!isCollapsed ? (
+      <>
+        <span className="flex-1 text-left">LLM Usage</span>
+        {isLlmUsageOpen ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+      </>
+    ) : null}
+  </button>
+  {isLlmUsageOpen && !isCollapsed ? (
+    <div className="ml-4 mt-1 space-y-1 border-l border-slate-200 pl-3 dark:border-slate-600">
+      {llmUsageItems.map((item) => (
+        <NavLink
+          key={item.to}
+          to={item.to}
+          end={item.to === '/llm-usage'}
+          className={/* same pattern as Code Tasks sub-items */}
+        >
+          <item.icon className="h-4 w-4 shrink-0" />
+          <span>{item.label}</span>
+        </NavLink>
+      ))}
+    </div>
+  ) : null}
+</div>
+```
+
+The `TrendingUp` icon is already imported in `Sidebar.tsx` (currently used by the `Usage Costs` settings item). No new lucide import needed.
+
+Also add an auto-expand effect to match the Code Tasks one at line 238–241:
+
+```tsx
+useEffect(() => {
+  if (location.pathname.startsWith('/llm-usage')) {
+    setIsLlmUsageOpen(true);
+  }
+}, [location.pathname]);
+```
+
+### Phase 11 — Use case validation
+
+Walk through each target scenario end-to-end to prove the UI shape is correct. **Do this in the PR description**, not just in tests.
+
+**Use case 1: "Show all orchestrator Claude calls on a specific day, grouped by day"**
+1. User clicks "LLM Usage" → "Events" in the sidebar.
+2. User picks "Custom" time range and enters `2026-04-10T00:00:00Z` → `2026-04-10T23:59:59Z`.
+3. User clicks `anthropic` in the Provider filter strip → `filters.providers = ['anthropic']`.
+4. User clicks `claude-worker` in the Component filter strip → `filters.components = ['claude-worker']`.
+5. User clicks `orchestrator` in the Service filter strip → `filters.services = ['orchestrator']`.
+6. User clicks "day" in the Group by selector → UI switches to the `AggregateTable` (driven by `useLlmUsageQuery`).
+7. Under the hood: the web app calls `POST /settings/llm-usage/query` with body `{ timeRange: {from, to}, filters: { providers: ['anthropic'], components: ['claude-worker'], services: ['orchestrator'] }, groupBy: ['day'] }`.
+8. The BFF forwards to `POST /internal/usage/query` on `llm-usage-service`.
+9. Result: a single row with `group.day = '2026-04-10'` and aggregated metrics.
+
+**Use case 2: "Show all Gemini calls without grouping"**
+1. User selects "Last 7 days" time range.
+2. User clicks `google` in the Provider filter strip → `filters.providers = ['google']`.
+3. User confirms Group by is "none" (default).
+4. User confirms Sort is "occurredAt desc" (default).
+5. Under the hood: the web app calls `POST /settings/llm-usage/events` with body `{ timeRange, filters: { providers: ['google'] }, sortBy: { field: 'occurredAt', direction: 'desc' }, limit: 50 }`.
+6. The BFF forwards to `POST /internal/usage/events/list` on `llm-usage-service`.
+7. Result: up to 50 events in a raw list, newest first, with a "Load more" button if `nextCursor` is present.
+8. User clicks any event row → navigates to `/#/llm-usage/{eventId}` → detail page loads via `GET /settings/llm-usage/events/{eventId}`.
+
+**Use case 3: "Show cost per LLM from the orchestrator this week, grouped by model"**
+1. User picks "Last 7 days".
+2. User clicks `orchestrator` in the Service filter strip → `filters.services = ['orchestrator']`.
+3. User clicks "model" in the Group by selector → switches to `AggregateTable`.
+4. The sort selector is hidden (grouping defaults to `costUsd desc` for the aggregate endpoint).
+5. Under the hood: `POST /settings/llm-usage/query` body `{ timeRange, filters: { services: ['orchestrator'] }, groupBy: ['request.model'], sortBy: { field: 'costUsd', direction: 'desc' } }`.
+6. Result: one row per model, sorted by cost descending. The `totals` are rendered in a "Grand total" footer row.
+
+All three cases must work on the first deployment of this track. If any of them require extra endpoints or filters not listed in Phase 2/4/5, the plan is incomplete — escalate.
+
+## Test plan
+
+### Backend (`apps/llm-usage-service`)
+- `src/__tests__/routes/internalUsageRoutes.test.ts` — extended with 15+ new test cases covering list + getById happy paths, filters, sorting, cursor roundtrip, error cases, auth.
+- `src/__tests__/domain/usecases/listUsageEvents.test.ts` — new file, unit tests for validation + limit clamping + cursor encode/decode.
+- `src/__tests__/fakeUsageEventRepository.ts` — extend with in-memory `list()` and `getById()` implementing the same semantics as the Firestore version.
+- `src/__tests__/infra/firestoreUsageEventRepository.test.ts` — if an emulator-backed test already exists, extend it; otherwise rely on the fake-repo tests + manual smoke test in staging.
+
+### Internal client (`packages/internal-clients`)
+- `src/usage-service/__tests__/client.test.ts` — extend with 6 new `nock`-backed tests: listEvents happy, listEvents 404, listEvents network error, getEvent happy, getEvent not-found, getEvent network error.
+
+### BFF (`apps/app-settings-service`)
+- `src/__tests__/routes/publicRoutes.test.ts` — extend with a new `describe('/settings/llm-usage/*')` block:
+  - POST /settings/llm-usage/events happy path
+  - POST /settings/llm-usage/events upstream error
+  - GET /settings/llm-usage/events/:eventId happy path
+  - GET /settings/llm-usage/events/:eventId 404
+  - POST /settings/llm-usage/query happy path
+  - All routes: 401 when no bearer
+  - All routes: 400 when body invalid (Fastify schema)
+- Add `FakeUsageServiceClient` helper in `src/__tests__/fakes/fakeUsageServiceClient.ts`.
+
+### Web app
+- `src/services/__tests__/llmUsageApi.test.ts` — required (services/ is in the enforced-coverage zone).
+- `src/hooks/__tests__/useLlmUsageEvents.test.ts` — required (hooks/ is enforced).
+- `src/hooks/__tests__/useLlmUsageQuery.test.ts` — required.
+- `src/hooks/__tests__/useLlmUsageEvent.test.ts` — required.
+- `src/utils/__tests__/llmUsageTimeRange.test.ts` — required (utils/ is enforced).
+- `src/utils/__tests__/llmUsageStorage.test.ts` — required.
+- `src/pages/LlmUsagePage.tsx` — optional (UI not enforced).
+- `src/pages/LlmUsageViewPage.tsx` — optional.
+
+### CI gate
+`pnpm run ci:tracked` must pass end-to-end before commit. Backend coverage must be ≥95% branch. Web utils/services/hooks must be ≥95% branch.
+
+## Rollout plan
+
+1. **Backend first:** merge the llm-usage-service changes (Phases 1–3) and the new migration alone. Deploy to dev. Verify the new endpoints return correct data against real Firestore.
+2. **Run the migration:** `node migrations/086_llm-usage-events-list-indexes.mjs up` from the repo root on dev. Wait for index builds to finish (monitor via `gcloud firestore indexes composite list --project=intexuraos-dev-pbuchman`). This can take 5–30 minutes on non-empty collections.
+3. **Internal client + BFF:** merge Phases 4–5. Redeploy `app-settings-service` to dev. Hit `POST /settings/llm-usage/events` with curl using a fresh bearer token and verify it round-trips.
+4. **Web app:** merge Phases 6–10. Verify in dev UI that all three use cases from Phase 11 work end-to-end.
+5. **Promote to prod** in the same order (backend → BFF → web app) only after dev has soaked for 24h without errors in Sentry or Cloud Run logs.
+6. Update the Linear issue INT-1340 with a link to the merged PR and screenshots of the three use cases.
+
+## Acceptance criteria
+
+- [ ] `POST /internal/usage/events/list` exists, accepts `{ timeRange, filters, sortBy, limit, cursor }`, returns `{ events, nextCursor, totalMatched }`, has ≥95% branch coverage.
+- [ ] `GET /internal/usage/events/:eventId` exists, returns full `UsageEvent` or 404.
+- [ ] Firestore composite indexes for the seven filter+sort combinations in Phase 3 exist in `migrations/086_*.mjs` and are deployed to dev.
+- [ ] `UsageServiceClient.listEvents` and `UsageServiceClient.getEvent` are exported and tested with nock.
+- [ ] `app-settings-service` proxies `POST /settings/llm-usage/events`, `GET /settings/llm-usage/events/:eventId`, `POST /settings/llm-usage/query` to `llm-usage-service` via the internal client.
+- [ ] The web app has a new top-level "LLM Usage" nav section with an "Events" sub-item.
+- [ ] `/#/llm-usage` renders the list page with four filter strips (provider, component, service, model), a time-range picker, a group-by selector, and a sort selector.
+- [ ] The list page persists filter/sort/groupBy/timeRange choices to localStorage under `llm-usage-*` keys.
+- [ ] `/#/llm-usage/{eventId}` renders the detail page with cards for request, usage, cost, source+owner, correlation, error, and raw JSON.
+- [ ] Use cases 1, 2, and 3 from Phase 11 work end-to-end against real data in dev.
+- [ ] `pnpm run ci:tracked` passes green.
+- [ ] No existing endpoints change contract.
+- [ ] `INTEXURAOS_LLM_USAGE_SERVICE_URL` is declared in all three required locations.
+
+## Risks
+
+1. **Cursor pagination edge cases.** If two events share the exact same `occurredAt` timestamp (millisecond precision), the `__name__` tiebreaker in the composite index is required for deterministic ordering. Without it, a "Load more" click may skip or duplicate an event at the boundary. **Mitigation:** every composite index in Phase 3 explicitly includes `{ fieldPath: '__name__', order: 'DESCENDING' }` and the Firestore query chains `.orderBy('__name__', direction)` after the primary sort. This must be tested with a fake repo that returns two events with identical `occurredAt`.
+
+2. **`.count()` cost.** Running a `.count()` aggregation per page doubles Firestore reads. At the current volume (10k events/day) this is negligible; at 1M events/day it becomes material. **Mitigation:** hide the total-matched counter behind a `?includeCount=true` flag if cost becomes a problem, defaulting to `true` in Track 1 and reconsidering in Track 4 (observability).
+
+3. **Index count explosion.** Every additional filter-sort combination needs its own composite index. Firestore caps at 200 composite indexes per project. We currently have ~85 migration files, each adding a few. **Mitigation:** Phase 3 limits indexes to single-filter + sort combinations. Multi-filter queries fall back to post-fetch in-memory filtering, which caps at `MAX_LIST_LIMIT` rows per Firestore read. Document this limitation clearly in the list use case.
+
+4. **BFF double-hop latency.** `web → app-settings-service → llm-usage-service → firestore` adds ~30ms over `web → llm-usage-service → firestore`. **Mitigation:** acceptable — matches the existing `/settings/pricing` and `/settings/usage-costs` patterns. Do not optimize prematurely.
+
+5. **Schema drift between the stored `UsageEvent` and the client-side type mirror.** The internal client re-defines `UsageEventInput` to avoid cross-app imports. If the llm-usage-service team changes the schema without updating the mirror, the BFF will silently truncate fields. **Mitigation:** add a comment in `packages/internal-clients/src/usage-service/types.ts` pointing at the canonical source (`apps/llm-usage-service/src/domain/models/usageEvent.ts`) and a compile-time assertion via `satisfies` once the types are importable.
+
+6. **Web app dev proxy assumes `/api/settings`.** The Vite proxy already routes `/api/settings` → port 8122. No change needed, but if a dev forgets to re-build `app-settings-service` after adding the new routes, they'll get 404s in dev. **Mitigation:** document in the PR description that `pnpm --filter app-settings-service build && pnpm dev` must be run in that order on first checkout.
+
+7. **Composite index build time on a non-empty collection.** If `llm_usage_events` already has millions of docs in dev, building 7 new composite indexes can take 30+ minutes. **Mitigation:** run the migration at the start of the backend phase and proceed with web app work in parallel; don't block the PR on index builds.
+
+## Out of scope (explicitly not in this track)
+
+- **Pricing UI relocation** — moved to Track 5 (INT-1343). The `LLM Usage` sidebar section is built with an array that Track 5 can extend.
+- **Charts, timeseries, vega-lite visualizations** — aggregate view is a plain table in Track 1. Visualizations are a potential Phase 3.
+- **Real-time updates / SSE / websockets** — the list page polls every 30s on tab focus, like `CodeTasksPage`. No live stream.
+- **Per-user quota views** — the detail page shows cost but does not compare against a quota.
+- **Export to CSV / JSON** — a "copy raw JSON" button on the detail page is the only export mechanism.
+- **User-scoping in the BFF** — `/settings/llm-usage/*` returns ALL events the caller requests, with no implicit `ownerId = currentUser` filter. This is a deliberate choice because the dashboard is admin-facing (there is only one admin user). If that changes, Track 4 (observability + access control) will add the scoping.
+- **Custom index-aware query planner** — multi-filter queries fall back to post-fetch filtering. A future track can add a proper planner.
+- **Soft delete / archiving of events** — events are immutable once ingested. No archive UI.
+- **Editing pricing on the detail page** — Track 5 handles pricing surface area.
+- **Breadcrumbs / back button wiring beyond the sidebar NavLink** — follow the code-tasks convention (no explicit back button).
+- **Mobile-optimized table layout** — the list renders on mobile but uses a condensed one-line-per-event style; a proper responsive card layout is out of scope.
+- **Integration tests that boot the full stack** — unit + route-level fake-repo tests are sufficient for Track 1.
+- **Metrics/Sentry instrumentation on the new endpoints** — Track 4 (observability) adds structured metrics and alerting.
+
+---
+
+## Appendix A — Open decisions flagged in this plan
+
+All `⚠ DECISION NEEDED` markers:
+
+1. **Phase 1:** whether to ship with `.count()` enabled by default on the list endpoint (recommended: yes).
+2. **Phase 3:** whether to index single-filter or multi-filter combinations (recommended: single-filter only, document the limit).
+3. **Phase 5:** the exact value of `INTEXURAOS_LLM_USAGE_SERVICE_URL` for dev — pull from the existing Terraform output or add one if missing.
+
+## Appendix B — Files to be created (summary list)
+
+**Backend:**
+- `apps/llm-usage-service/src/domain/usecases/listUsageEvents.ts`
+- `apps/llm-usage-service/src/__tests__/domain/usecases/listUsageEvents.test.ts`
+
+**Migrations:**
+- `migrations/086_llm-usage-events-list-indexes.mjs`
+
+**BFF:**
+- `apps/app-settings-service/src/__tests__/fakes/fakeUsageServiceClient.ts`
+
+**Web app:**
+- `apps/web/src/pages/LlmUsagePage.tsx`
+- `apps/web/src/pages/LlmUsageViewPage.tsx`
+- `apps/web/src/services/llmUsageApi.ts`
+- `apps/web/src/services/__tests__/llmUsageApi.test.ts`
+- `apps/web/src/hooks/useLlmUsageEvents.ts`
+- `apps/web/src/hooks/useLlmUsageQuery.ts`
+- `apps/web/src/hooks/useLlmUsageEvent.ts`
+- `apps/web/src/hooks/__tests__/useLlmUsageEvents.test.ts`
+- `apps/web/src/hooks/__tests__/useLlmUsageQuery.test.ts`
+- `apps/web/src/hooks/__tests__/useLlmUsageEvent.test.ts`
+- `apps/web/src/utils/llmUsageTimeRange.ts`
+- `apps/web/src/utils/llmUsageStorage.ts`
+- `apps/web/src/utils/__tests__/llmUsageTimeRange.test.ts`
+- `apps/web/src/utils/__tests__/llmUsageStorage.test.ts`
+- `apps/web/src/types/llmUsage.ts`
+
+**Files to be modified (summary list):**
+- `apps/llm-usage-service/src/routes/internalUsageRoutes.ts`
+- `apps/llm-usage-service/src/domain/repositories/usageEventRepository.ts`
+- `apps/llm-usage-service/src/infra/firestore/firestoreUsageEventRepository.ts`
+- `apps/llm-usage-service/src/domain/models/usageEvent.ts` (add MAX_LIST_LIMIT / DEFAULT_LIST_LIMIT)
+- `apps/llm-usage-service/src/__tests__/routes/internalUsageRoutes.test.ts`
+- `apps/llm-usage-service/src/__tests__/fakeUsageEventRepository.ts`
+- `packages/internal-clients/src/usage-service/client.ts`
+- `packages/internal-clients/src/usage-service/types.ts`
+- `packages/internal-clients/src/usage-service/__tests__/client.test.ts`
+- `apps/app-settings-service/src/services.ts`
+- `apps/app-settings-service/src/routes/publicRoutes.ts`
+- `apps/app-settings-service/src/index.ts` (REQUIRED_ENV)
+- `apps/app-settings-service/src/__tests__/routes/publicRoutes.test.ts`
+- `apps/web/src/App.tsx`
+- `apps/web/src/components/Sidebar.tsx`
+- `apps/web/src/pages/index.ts`
+- `terraform/environments/dev/main.tf`
+- `ecosystem.config.cjs`

--- a/docs/plans/INT-1341-track-2-orchestrator-usage-publisher.md
+++ b/docs/plans/INT-1341-track-2-orchestrator-usage-publisher.md
@@ -1,0 +1,1151 @@
+# INT-1341 — Track 2: Wire Orchestrator to llm-usage-service
+
+## Status
+
+- Linear issue: INT-1341
+- Parent epic: INT-1338 (LLM Usage Service Phase 2)
+- Dependencies: **INT-1339 (Track 4 — server-side cost calculation)** — MUST be merged and deployed to dev before flipping the feature flag on.
+- Blocks: INT-1342 (Track 3 — shares the HMAC webhook HTTP client pattern this track establishes)
+- Plan version: 1.0
+- Author: Claude (agent thread)
+- Target file: `workers/orchestrator/src/services/usage-publisher.ts` (new) and small edits to `turn-metrics-collector.ts` + `start.ts`.
+
+---
+
+## Executive summary
+
+The orchestrator already parses on-disk Claude Code session JSONL files after every turn to produce
+summed-per-turn resource metrics and posts them to `code-agent/internal/turn-metrics`. The per-call
+token usage is aggregated away in that pipeline; nothing is sent to `llm-usage-service`. This track
+adds a parallel code path that extracts the **same** JSONL entries and emits **one
+`UsageEventInput` per entry containing `message.usage`** (preserving per-call granularity), batches
+them into a single HTTP POST to `llm-usage-service/internal/webhooks/usage-events`, and reuses the
+existing `WebhookClient` for HMAC signing, retries, and the pending-queue failover.
+
+Two design points distinguish this from a naive implementation:
+
+1. **No orchestrator-side pricing.** Events are emitted with `cost.billedUsd = 0`,
+   `cost.providerReportedUsd = null`, `cost.calculatedUsd = null`, `cost.pricingSource =
+   'calculated'`. The service (INT-1339) computes the cost server-side from its pricing table.
+   This is why this track is blocked on Track 4.
+2. **Deterministic event IDs.** The same JSONL file is re-read on retry (e.g., adoption) so events
+   must be idempotent: `eventId = sha256("${taskId}:${attempt}:${entryIndex}:${timestamp}").slice(0, 24)`.
+
+The orchestrator is **not** containerized and **not** managed by Terraform — it runs as a systemd
+unit on home-dev and a LaunchAgent on macOS hosts. Env var plumbing therefore touches `start.ts`
+REQUIRED_ENV, the host `.envrc`, and (for future Cloud Run deployment parity) the dev Terraform
+`common_service_env_vars` block. There is **no ecosystem.config.cjs entry to update** — the
+orchestrator is absent from that file (confirmed by grep).
+
+---
+
+## Pre-flight checks
+
+Run these **before** opening a PR branch. Each item is a hard blocker.
+
+1. **Verify INT-1339 is deployed to dev.**
+   ```bash
+   curl -s https://<dev-llm-usage-service-url>/internal/pricing \
+     -H "X-Internal-Auth: $INTEXURAOS_INTERNAL_AUTH_TOKEN" \
+     | jq '.data | keys'
+   ```
+   Must return a non-empty object with at least `claude-sonnet-4-5-20250929` and
+   `claude-opus-4-5-20251101`. If it returns `404` or empty, stop — Track 4 is not ready.
+
+2. **Verify the `/internal/webhooks/usage-events` endpoint is live in dev.** POST an empty events
+   array with a valid HMAC and expect `200 {success: true, data: {accepted: 0, duplicates: 0,
+   rejected: []}}`. If you get `401`, the `INTEXURAOS_ORCHESTRATOR_SECRET` on the orchestrator and
+   the llm-usage-service do not match — fix that before proceeding.
+
+3. **Read an actual JSONL session file from a recent dev task** (see Phase 1 for the exact
+   mechanics). This verifies the `message.model` location hypothesis. **Do not skip this step** —
+   it is the single highest-risk unknown in this plan.
+
+4. **Confirm `pnpm run ci:tracked` currently passes on `development`.** You are about to add a
+   new service that imports from `@intexuraos/llm-contract` — any pre-existing green baseline
+   makes diagnosing new failures trivial.
+
+5. **Locate the orchestrator's runtime environment file.** On home-dev this is typically
+   `~/.code-orchestrator/.envrc` or loaded via `direnv allow` on the repo root `.envrc`. Confirm
+   with `systemctl show --no-pager -p Environment code-orchestrator` (or the LaunchAgent plist on
+   macOS). You need write access before Phase 8 can complete.
+
+---
+
+## Context files (with line numbers)
+
+**Source files to modify:**
+
+- `workers/orchestrator/src/services/turn-metrics-collector.ts` (360 lines)
+  - Lines 41–53: `SessionEntry` interface — needs an optional `message.model` field after Phase 1.
+  - Lines 201–229: `parseSessionJsonl` — already reads all entries; no change needed, but the
+    extraction function will consume the same `entries` array in a sibling method.
+  - Lines 305–330: `aggregateTokens` — **do not modify**; the new `extractUsageEvents` function
+    runs in parallel and operates on the same input.
+  - Lines 77–152: `collectAndPublish` — this is where the new `UsagePublisher.publishTurnUsage()`
+    call is wired in, right after the existing `publish(metrics)` call at line 133.
+  - Lines 146–151: the exact `try/catch` swallow-and-warn pattern to mirror for non-fatal failures.
+
+- `workers/orchestrator/src/services/webhook-client.ts` (274 lines)
+  - Lines 24–27: `signPayload()` — matches exactly the HMAC format validated at
+    `apps/llm-usage-service/src/infra/webhookValidation.ts:60` (`timestamp.body` HMAC-SHA256 hex).
+  - Lines 29–107: `WebhookClient.send()` — **reuse directly**; has retries, 4xx short-circuit,
+    pending-queue failover, Result<void, WebhookError> return type.
+  - Lines 183–219: `deliver()` — already sets `X-Internal-Auth`, `X-Request-Timestamp`,
+    `X-Request-Signature` headers exactly as the service expects.
+
+- `workers/orchestrator/src/services/isolation/types.ts` (249 lines)
+  - Lines 25, 41–107: `WORKER_TYPES` — source of truth for provider mapping. Contains 11 worker
+    types. Note `glm`/`qwen`/`kimi` all share the same DashScope base URL but different models.
+
+- `workers/orchestrator/src/start.ts` (863 lines)
+  - Lines 441–456: REQUIRED_ENV block — add `INTEXURAOS_LLM_USAGE_SERVICE_URL`.
+  - Lines 750–759: `TurnMetricsCollector` construction site — inject the new `UsagePublisher`
+    either as a sibling service passed to the collector, or as a field on
+    `TurnMetricsCollectorConfig`. **Decision: inject as constructor arg #3 on
+    `TurnMetricsCollector`.** See Phase 6.
+
+- `workers/orchestrator/src/main.ts` — no changes needed (wiring happens in `start.ts` only).
+
+**Files to read but not modify:**
+
+- `workers/orchestrator/src/services/runtime/processors/claude-log-processor.ts` (191 lines) —
+  **confirmed wrong hook point**. It only processes the stream-JSON format which contains `type:
+  system/subtype: init` messages with model name, plus `type: result` messages. It has **no**
+  access to `message.usage` per-call data, which lives only in the on-disk JSONL. Stay in
+  `turn-metrics-collector.ts`.
+
+- `workers/orchestrator/src/services/isolation/docker-provider.ts` (1679 lines)
+  - Line 135, 439, 624–716: shows how `workerType` is passed into the container and how
+    `ANTHROPIC_BASE_URL`/`ANTHROPIC_MODEL` are set. The orchestrator knows the worker type at
+    task dispatch time; `TurnMetricsCollector.collectAndPublish` receives `taskId`/`attempt` but
+    **not** `workerType`. Phase 7 must add `workerType` to the `collectAndPublish` params.
+
+- `workers/orchestrator/src/types/task.ts` (157 lines) — `Task.workerType: WorkerType` is the
+  field to plumb through.
+
+- `apps/llm-usage-service/src/routes/schemas/usageEventSchema.ts` (207 lines)
+  - Lines 16–164: **strict** base schema with `additionalProperties: false` at every level.
+  - Lines 176–194: `OrchestratorUsageEventInput` — requires `source.service === 'orchestrator'`
+    and `source.workerLocation` (non-empty string).
+  - Lines 107–117: `usage` object requires **all 11 fields** including ones we cannot populate
+    from JSONL (`reasoningTokens`, `thinkingTokens`, `webSearchCalls`, `groundingEnabled`,
+    `imageCount`). These all become `0`/`false`.
+  - Lines 136–147: `correlation` requires **all 6 fields** with `null` as the default for
+    `requestId`, `traceId`, `researchId`, `sessionId`. We populate `taskId` and `attempt`.
+
+- `apps/llm-usage-service/src/routes/webhookUsageRoutes.ts` (88 lines)
+  - Line 79: ingress tag is `'orchestrator_webhook'` (hardcoded by the route) — we cannot set it
+    from the orchestrator side, and we don't need to.
+
+- `apps/llm-usage-service/src/infra/webhookValidation.ts` (78 lines)
+  - Line 48: **15-minute replay window** — our signature's timestamp must be within 15 minutes
+    of the service's clock. `WebhookClient.deliver()` already generates the timestamp at send
+    time, so this is fine unless pending-queue retries sit longer than 15 minutes. See Risks.
+
+- `packages/internal-clients/src/usage-service/types.ts` (182 lines) — the `UsageEventInput`
+  type we build is exactly this type. Do **not** use `UsageServiceClient.ingestEvents()` — that
+  client targets the `/internal/usage/events` route (without the `webhooks/` prefix) which uses
+  a different auth scheme (`X-Internal-Auth` only, no HMAC). This track uses the HMAC-signed
+  webhook path directly.
+
+- `packages/llm-contract/src/supportedModels.ts:133–139` — `LlmProviders` constants. Note:
+  `'google'`, `'openai'`, `'anthropic'`, `'perplexity'`, `'openrouter'`. **There is no `'zai'`,
+  `'dashscope'`, `'minimax'`, `'mimo'`, or `'xiaomi'` provider.** The schema will reject
+  anything else. Phase 5 handles mapping these to the closest allowed value.
+
+- `workers/orchestrator/src/__tests__/turn-metrics-collector.test.ts` (723 lines) — existing
+  test patterns. Uses `vi.mock('node:fs/promises')` + inline JSONL string fixtures. This plan
+  keeps the same pattern and adds a separate `describe('extractUsageEvents')` block plus a
+  new `describe('UsagePublisher')` block in a new test file.
+
+- `terraform/environments/dev/main.tf:310` — `INTEXURAOS_LLM_USAGE_SERVICE_URL` already defined
+  in `common_service_env_vars` for Cloud Run services. Orchestrator is not Cloud Run, so this
+  block **does not apply to it at runtime**, but the plan must still document where the URL
+  originates for future hosted orchestrator deployment. See Phase 8 for the specific three-place
+  plumbing this orchestrator needs (which is different from the standard apps three-place
+  pattern).
+
+- `ecosystem.config.cjs` — **confirmed absent**: grep for `orchestrator` returns no matches.
+  PM2 does not run the orchestrator. **Skip this file in Phase 8.**
+
+---
+
+## Endpoint changes
+
+### Modified
+- None. No existing endpoint is altered.
+
+### Created
+- None. The orchestrator gains no new incoming routes.
+
+### Outgoing HTTP (new)
+- `POST <INTEXURAOS_LLM_USAGE_SERVICE_URL>/internal/webhooks/usage-events`
+  - Auth: HMAC-SHA256 over `${timestamp}.${rawJsonBody}` using
+    `INTEXURAOS_ORCHESTRATOR_SECRET`, plus the existing `X-Internal-Auth` bearer.
+  - Body: `{ schemaVersion: 1, events: UsageEventInput[] }`.
+  - Retries: 3 attempts, 5s/15s/45s backoff (inherited from `WebhookClient`).
+  - On 4xx: no retry, dropped with `warn` log (matches existing `WebhookClient` behavior).
+  - On 5xx/network/timeout: queued into `pendingWebhooks` state file for background retry.
+
+### Removed
+- None. The existing `POST /internal/turn-metrics` on `code-agent` is **kept as-is**; both
+  posts happen on every turn. No cleanup is part of this track.
+
+### Unchanged
+- `POST <codeAgentUrl>/internal/turn-metrics` — still populated from `aggregateTokens()` summed
+  data, still using the same HMAC pattern.
+
+---
+
+## Step-by-step implementation
+
+### Phase 1 — Verify JSONL shape (DO NOT SKIP)
+
+This is the single highest-risk unknown. The `SessionEntry` interface declares no `message.model`
+field, but the Anthropic SDK format typically includes it. Before writing any code, confirm the
+exact JSON path.
+
+**Steps:**
+
+1. SSH to home-dev (or the dev host running the orchestrator).
+2. Find a recent Claude session directory:
+   ```bash
+   ls -lt ~/.code-orchestrator/secrets/claude-session-* | head -5
+   ```
+3. Pick the most recent task that ran successfully and print one assistant entry:
+   ```bash
+   SESSION=~/.code-orchestrator/secrets/claude-session-task_<id>
+   find "$SESSION/projects" -name '*.jsonl' | head -1 \
+     | xargs -I{} head -100 {} \
+     | jq -c 'select(.message.usage != null) | {type, timestamp, model: .message.model, model_alt: .message.metadata.model, usage: .message.usage}' \
+     | head -5
+   ```
+4. Record the findings in the PR description under a "JSONL shape verification" heading:
+   - Is `message.model` present? (Almost certainly **yes** — confirmed by
+     `claude-log-processor.ts:37` which extracts `model` from the stream init message.)
+   - Is `message.id` (Anthropic request ID) present? If so, we can use it as a more stable
+     `eventId` ingredient.
+   - Is `message.stop_reason` present? Useful for `operation` classification later.
+   - Are there user entries (`type: "user"`) that also have `message.usage`? (Possible for tool
+     results that include cache hits.)
+   - Does GLM produce the same shape, or does it have provider-specific fields? (Verify by
+     submitting a trivial GLM task first.)
+
+5. **⚠ DECISION NEEDED:** if `message.model` is **missing** from JSONL (unlikely but possible if
+   `ANTHROPIC_MODEL=opus` override changes the format), fall back to
+   `WORKER_TYPES[workerType].model ?? 'unknown'` as the model name. Document the fallback in the
+   PR body so reviewers know why the model string may be coarser than expected.
+
+6. **⚠ DECISION NEEDED:** if GLM's JSONL deviates in structure (e.g., nested differently under
+   `message.raw_response`), the `extractUsageEvents` function must branch on `workerType` or
+   operate on a provider-specific normalizer. Prefer branching on `workerType` over sniffing the
+   JSON shape.
+
+Do not proceed to Phase 2 until these decisions are logged in the PR description.
+
+### Phase 2 — Extend SessionEntry type
+
+Given Phase 1 confirms `message.model` exists, extend the interface in
+`workers/orchestrator/src/services/turn-metrics-collector.ts`:
+
+```ts
+interface SessionEntry {
+  type: string;
+  timestamp?: string;
+  subtype?: string;
+  message?: {
+    id?: string;            // Anthropic request ID if present
+    model?: string;         // Model name, e.g. "claude-sonnet-4-5-20250929"
+    stop_reason?: string;   // "end_turn" | "tool_use" | "max_tokens" | ...
+    usage?: {
+      input_tokens?: number;
+      output_tokens?: number;
+      cache_read_input_tokens?: number;
+      cache_creation_input_tokens?: number;
+    };
+  };
+}
+```
+
+Leave all existing consumers untouched — the added fields are optional so
+`classifyTime` and `aggregateTokens` compile without change.
+
+### Phase 3 — Write failing tests FIRST (test-driven)
+
+#### 3a. Create the fixture directory
+
+Check if `workers/orchestrator/src/__tests__/fixtures/` exists. If not, create it with one file:
+
+**Path:** `workers/orchestrator/src/__tests__/fixtures/session-jsonl-sample.jsonl`
+
+**Content:** a realistic two-call sample matching the shape confirmed in Phase 1. Example
+(sanitized; update after Phase 1 verification):
+
+```jsonl
+{"type":"user","timestamp":"2026-04-10T12:00:00.000Z","message":{"role":"user","content":"ping"}}
+{"type":"assistant","timestamp":"2026-04-10T12:00:02.500Z","message":{"id":"msg_01abc","model":"claude-sonnet-4-5-20250929","stop_reason":"end_turn","usage":{"input_tokens":120,"output_tokens":45,"cache_read_input_tokens":1000,"cache_creation_input_tokens":200}}}
+{"type":"user","timestamp":"2026-04-10T12:00:03.000Z","message":{"role":"user","content":"follow up"}}
+{"type":"assistant","timestamp":"2026-04-10T12:00:05.100Z","message":{"id":"msg_02def","model":"claude-sonnet-4-5-20250929","stop_reason":"tool_use","usage":{"input_tokens":85,"output_tokens":12,"cache_read_input_tokens":1100,"cache_creation_input_tokens":0}}}
+```
+
+#### 3b. Add tests to the existing `turn-metrics-collector.test.ts` file
+
+New top-level `describe` block to add (near the end of the file, before the closing `});`):
+
+```ts
+describe('extractUsageEvents', () => {
+  const taskId = 'task_test_123';
+  const attempt = 1;
+  const workerLocation = 'home-dev';
+  const environment = 'dev' as const;
+
+  it('emits one event per entry with message.usage', () => {
+    const entries = [
+      { type: 'user', timestamp: '2026-04-10T12:00:00.000Z' },
+      {
+        type: 'assistant',
+        timestamp: '2026-04-10T12:00:02.500Z',
+        message: {
+          id: 'msg_01',
+          model: 'claude-sonnet-4-5-20250929',
+          usage: {
+            input_tokens: 120,
+            output_tokens: 45,
+            cache_read_input_tokens: 1000,
+            cache_creation_input_tokens: 200,
+          },
+        },
+      },
+    ];
+
+    const events = collector.extractUsageEvents(entries, {
+      taskId, attempt, workerType: 'opus', workerLocation, environment,
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]?.usage.inputTokens).toBe(120);
+    expect(events[0]?.usage.outputTokens).toBe(45);
+    expect(events[0]?.usage.cacheReadTokens).toBe(1000);
+    expect(events[0]?.usage.cacheWriteTokens).toBe(200);
+    expect(events[0]?.usage.totalTokens).toBe(120 + 45 + 1000 + 200);
+    expect(events[0]?.request.provider).toBe('anthropic');
+    expect(events[0]?.request.model).toBe('claude-sonnet-4-5-20250929');
+    expect(events[0]?.request.operation).toBe('other');
+    expect(events[0]?.cost.billedUsd).toBe(0);
+    expect(events[0]?.cost.pricingSource).toBe('calculated');
+    expect(events[0]?.source.service).toBe('orchestrator');
+    expect(events[0]?.source.workerLocation).toBe('home-dev');
+    expect(events[0]?.correlation.taskId).toBe(taskId);
+    expect(events[0]?.correlation.attempt).toBe(attempt);
+  });
+
+  it('skips entries without message.usage', () => {
+    const entries = [
+      { type: 'user', timestamp: '2026-04-10T12:00:00.000Z' },
+      { type: 'system', subtype: 'progress', timestamp: '2026-04-10T12:00:01.000Z' },
+    ];
+    const events = collector.extractUsageEvents(entries, {
+      taskId, attempt, workerType: 'opus', workerLocation, environment,
+    });
+    expect(events).toHaveLength(0);
+  });
+
+  it('handles missing cache tokens as zero', () => {
+    const entries = [{
+      type: 'assistant',
+      timestamp: '2026-04-10T12:00:02.500Z',
+      message: { model: 'claude-sonnet-4-5-20250929', usage: { input_tokens: 50, output_tokens: 25 } },
+    }];
+    const events = collector.extractUsageEvents(entries, {
+      taskId, attempt, workerType: 'opus', workerLocation, environment,
+    });
+    expect(events[0]?.usage.cacheReadTokens).toBe(0);
+    expect(events[0]?.usage.cacheWriteTokens).toBe(0);
+    expect(events[0]?.usage.totalTokens).toBe(75);
+  });
+
+  it('falls back to workerType model when message.model missing', () => {
+    const entries = [{
+      type: 'assistant',
+      timestamp: '2026-04-10T12:00:02.500Z',
+      message: { usage: { input_tokens: 10, output_tokens: 5 } },
+    }];
+    const events = collector.extractUsageEvents(entries, {
+      taskId, attempt, workerType: 'glm', workerLocation, environment,
+    });
+    expect(events[0]?.request.model).toBe('glm-5'); // WORKER_TYPES.glm.model
+  });
+
+  it('falls back to "unknown" when neither message.model nor WORKER_TYPES model is set', () => {
+    const entries = [{
+      type: 'assistant',
+      timestamp: '2026-04-10T12:00:02.500Z',
+      message: { usage: { input_tokens: 10, output_tokens: 5 } },
+    }];
+    const events = collector.extractUsageEvents(entries, {
+      taskId, attempt, workerType: 'auto', workerLocation, environment,
+    });
+    // WORKER_TYPES.auto.model is undefined
+    expect(events[0]?.request.model).toBe('unknown');
+  });
+
+  it('uses occurredAt = entry.timestamp when present', () => {
+    const entries = [{
+      type: 'assistant',
+      timestamp: '2026-04-10T12:00:02.500Z',
+      message: { model: 'claude-sonnet-4-5-20250929', usage: { input_tokens: 1, output_tokens: 1 } },
+    }];
+    const events = collector.extractUsageEvents(entries, {
+      taskId, attempt, workerType: 'opus', workerLocation, environment,
+    });
+    expect(events[0]?.occurredAt).toBe('2026-04-10T12:00:02.500Z');
+  });
+
+  it('falls back to now() when entry.timestamp missing', () => {
+    const before = new Date().toISOString();
+    const entries = [{
+      type: 'assistant',
+      message: { model: 'claude-sonnet-4-5-20250929', usage: { input_tokens: 1, output_tokens: 1 } },
+    }];
+    const events = collector.extractUsageEvents(entries, {
+      taskId, attempt, workerType: 'opus', workerLocation, environment,
+    });
+    const after = new Date().toISOString();
+    expect(events[0]?.occurredAt >= before).toBe(true);
+    expect(events[0]?.occurredAt <= after).toBe(true);
+  });
+
+  it('produces deterministic eventId for the same entry', () => {
+    const entries = [{
+      type: 'assistant',
+      timestamp: '2026-04-10T12:00:02.500Z',
+      message: { model: 'claude-sonnet-4-5-20250929', usage: { input_tokens: 1, output_tokens: 1 } },
+    }];
+    const a = collector.extractUsageEvents(entries, {
+      taskId, attempt, workerType: 'opus', workerLocation, environment,
+    });
+    const b = collector.extractUsageEvents(entries, {
+      taskId, attempt, workerType: 'opus', workerLocation, environment,
+    });
+    expect(a[0]?.eventId).toBe(b[0]?.eventId);
+  });
+
+  it('produces different eventIds for different entries in the same turn', () => {
+    const entries = [
+      {
+        type: 'assistant',
+        timestamp: '2026-04-10T12:00:02.500Z',
+        message: { model: 'claude-sonnet-4-5-20250929', usage: { input_tokens: 1, output_tokens: 1 } },
+      },
+      {
+        type: 'assistant',
+        timestamp: '2026-04-10T12:00:05.100Z',
+        message: { model: 'claude-sonnet-4-5-20250929', usage: { input_tokens: 2, output_tokens: 2 } },
+      },
+    ];
+    const events = collector.extractUsageEvents(entries, {
+      taskId, attempt, workerType: 'opus', workerLocation, environment,
+    });
+    expect(events).toHaveLength(2);
+    expect(events[0]?.eventId).not.toBe(events[1]?.eventId);
+  });
+
+  it.each([
+    ['opus', 'anthropic'],
+    ['auto', 'anthropic'],
+    ['sonnet', 'anthropic'],
+    ['minimax', 'anthropic'],    // see DECISION NEEDED below
+    ['mimo-pro', 'anthropic'],
+    ['glm', 'anthropic'],
+    ['qwen', 'anthropic'],
+    ['kimi', 'anthropic'],
+    ['openrouter-free', 'openrouter'],
+  ] as const)('maps worker type %s to provider %s', (workerType, expectedProvider) => {
+    const entries = [{
+      type: 'assistant',
+      timestamp: '2026-04-10T12:00:02.500Z',
+      message: { model: 'm', usage: { input_tokens: 1, output_tokens: 1 } },
+    }];
+    const events = collector.extractUsageEvents(entries, {
+      taskId, attempt, workerType, workerLocation, environment,
+    });
+    expect(events[0]?.request.provider).toBe(expectedProvider);
+  });
+});
+```
+
+> ⚠ DECISION NEEDED (resolved provisionally above): the llm-usage-service schema hardcodes
+> `PROVIDER_VALUES = Object.values(LlmProviders)` which contains only
+> `google|openai|anthropic|perplexity|openrouter`. There is no provider name that matches GLM,
+> Qwen, Kimi, MiniMax, or MiMo. **Provisional decision: map all Anthropic-compatible proxy
+> providers (i.e., any `WORKER_TYPES[*].apiBaseUrl` that exposes the `/v1/messages` endpoint) to
+> `'anthropic'`**, because the JSONL format and model names are Anthropic-shaped. The service's
+> pricing table will need entries for these model names (`glm-5`, `qwen3.5-plus`, `kimi-k2.5`,
+> `MiniMax-M2.7`, `mimo-v2-pro`) tagged under provider `anthropic`, or fall back to
+> `pricingSource: 'external'` with `billedUsd = 0`. **Confirm with the INT-1339 author before
+> merging.** If the pricing service needs distinct providers, an INT-1338-followup must extend
+> `LlmProviders` first.
+>
+> Codex worker type (`codex`, `codex-xhigh`) is **skipped** by this extractor — Codex uses a
+> different runtime (`runtime: 'codex'`) that does not write the Claude JSONL format.
+> `extractUsageEvents` should return `[]` for Codex worker types and log an info message at the
+> call site. Add a test:
+>
+> ```ts
+> it('returns empty array for codex worker type', () => {
+>   const events = collector.extractUsageEvents(entries, { ...base, workerType: 'codex' });
+>   expect(events).toEqual([]);
+> });
+> ```
+
+Run `pnpm --filter orchestrator test` — **all new tests must fail with "extractUsageEvents is
+not a function"** before you move to Phase 4.
+
+### Phase 4 — Implement `extractUsageEvents`
+
+Add a new public method on `TurnMetricsCollector` (in
+`turn-metrics-collector.ts`). Import the `UsageEventInput` type, the `LlmProviders` constant,
+and the `WORKER_TYPES` lookup.
+
+```ts
+import { createHash, createHmac } from 'node:crypto';
+import type { UsageEventInput } from '@intexuraos/internal-clients/usage-service';
+import { LlmProviders, type LlmProvider } from '@intexuraos/llm-contract';
+import { WORKER_TYPES, type WorkerType } from './isolation/types.js';
+
+export interface ExtractUsageEventsParams {
+  taskId: string;
+  attempt: number;
+  workerType: WorkerType;
+  workerLocation: string;
+  environment: 'dev' | 'prod' | 'test';
+}
+
+/**
+ * Extract one UsageEventInput per JSONL entry that has `message.usage`.
+ * Idempotent: the same (entries, params) input produces the same eventIds.
+ * Returns [] for codex worker type (different runtime, not Claude JSONL).
+ */
+extractUsageEvents(
+  entries: SessionEntry[],
+  params: ExtractUsageEventsParams,
+): UsageEventInput[] {
+  const workerTypeConfig = WORKER_TYPES[params.workerType];
+  if (workerTypeConfig.runtime !== 'claude') {
+    return [];
+  }
+
+  const provider = selectProvider(params.workerType);
+  const fallbackModel = workerTypeConfig.model ?? 'unknown';
+
+  const events: UsageEventInput[] = [];
+  for (let idx = 0; idx < entries.length; idx++) {
+    const entry = entries[idx];
+    /* v8 ignore next -- ts-type: noUncheckedIndexedAccess undefined narrowing */
+    if (entry === undefined) continue;
+    const usage = entry.message?.usage;
+    if (usage === undefined) continue;
+
+    const occurredAt = entry.timestamp ?? new Date().toISOString();
+    const model = entry.message?.model ?? fallbackModel;
+
+    const inputTokens = usage.input_tokens ?? 0;
+    const outputTokens = usage.output_tokens ?? 0;
+    const cacheReadTokens = usage.cache_read_input_tokens ?? 0;
+    const cacheWriteTokens = usage.cache_creation_input_tokens ?? 0;
+    const totalTokens = inputTokens + outputTokens + cacheReadTokens + cacheWriteTokens;
+
+    const eventId = deriveEventId({
+      taskId: params.taskId,
+      attempt: params.attempt,
+      entryIndex: idx,
+      timestamp: occurredAt,
+    });
+
+    events.push({
+      schemaVersion: 1,
+      eventId,
+      occurredAt,
+      owner: {
+        type: 'system',
+        id: `orchestrator:${params.taskId}`,
+      },
+      source: {
+        service: 'orchestrator',
+        component: 'turn-metrics-collector',
+        client: 'claude-code',
+        environment: params.environment,
+        workerLocation: params.workerLocation,
+      },
+      request: {
+        provider,
+        model,
+        operation: 'other',
+        success: true,
+        durationMs: 0,
+      },
+      usage: {
+        inputTokens,
+        outputTokens,
+        totalTokens,
+        cacheReadTokens,
+        cacheWriteTokens,
+        cachedTokens: 0,
+        reasoningTokens: 0,
+        thinkingTokens: 0,
+        webSearchCalls: 0,
+        groundingEnabled: false,
+        imageCount: 0,
+      },
+      cost: {
+        billedUsd: 0,
+        providerReportedUsd: null,
+        calculatedUsd: null,
+        pricingSource: 'calculated',
+      },
+      correlation: {
+        requestId: entry.message?.id ?? null,
+        traceId: null,
+        taskId: params.taskId,
+        researchId: null,
+        attempt: params.attempt,
+        sessionId: null,
+      },
+      error: null,
+    });
+  }
+  return events;
+}
+```
+
+Helper (file-scoped, below the class):
+
+```ts
+function deriveEventId(params: {
+  taskId: string;
+  attempt: number;
+  entryIndex: number;
+  timestamp: string;
+}): string {
+  const input = `${params.taskId}:${String(params.attempt)}:${String(params.entryIndex)}:${params.timestamp}`;
+  return createHash('sha256').update(input).digest('hex').slice(0, 24);
+}
+```
+
+`operation: 'other'` — Phase 1 can revise this to classify `stop_reason === 'tool_use'` as
+`'tool_calling'`, but the first version ships `'other'` for everything to minimize risk. **Do
+not change this without explicit user sign-off.**
+
+`durationMs: 0` — the JSONL does not record per-call latency. The service will need to aggregate
+across events; if we later want per-call duration we must hook `claude-log-processor.ts` on
+`type: result` and pair it with the preceding assistant entry, which is out of scope.
+
+### Phase 5 — Provider selection
+
+Add below the class:
+
+```ts
+function selectProvider(workerType: WorkerType): LlmProvider {
+  switch (workerType) {
+    case 'openrouter-free':
+      return LlmProviders.OpenRouter;
+    case 'opus':
+    case 'auto':
+    case 'sonnet':
+    case 'minimax':
+    case 'mimo-pro':
+    case 'glm':
+    case 'qwen':
+    case 'kimi':
+      // All use the Anthropic /v1/messages wire format (confirmed via WORKER_TYPES apiBaseUrl
+      // suffixes: /anthropic). Map to 'anthropic' so the event passes the schema's provider
+      // enum. Model name (e.g. 'glm-5') carries the disambiguation for the pricing table.
+      return LlmProviders.Anthropic;
+    case 'codex':
+    case 'codex-xhigh':
+      // Unreachable: runtime !== 'claude' check in extractUsageEvents short-circuits.
+      /* v8 ignore next -- auth-guard: codex worker types filtered out upstream @preserve */
+      return LlmProviders.OpenAI;
+  }
+}
+```
+
+Exhaustive switch — TypeScript will fail the build if a new worker type is added to
+`WORKER_TYPES` without updating this function. Do **not** add a `default` branch — that would
+defeat the compile-time safety net.
+
+### Phase 6 — Create the UsagePublisher service
+
+**New file:** `workers/orchestrator/src/services/usage-publisher.ts`
+
+```ts
+import type { Logger } from '@intexuraos/common-core';
+import type { UsageEventInput } from '@intexuraos/internal-clients/usage-service';
+import type { WebhookClient } from './webhook-client.js';
+
+export interface UsagePublisherConfig {
+  usageServiceUrl: string;
+  orchestratorSecret: string;
+  enabled: boolean;
+}
+
+export class UsagePublisher {
+  constructor(
+    private readonly config: UsagePublisherConfig,
+    private readonly webhookClient: WebhookClient,
+    private readonly logger: Logger,
+  ) {}
+
+  async publishTurnUsage(params: {
+    taskId: string;
+    events: UsageEventInput[];
+  }): Promise<void> {
+    if (!this.config.enabled) {
+      this.logger.debug(
+        { taskId: params.taskId, count: params.events.length },
+        'UsagePublisher disabled by feature flag — skipping',
+      );
+      return;
+    }
+
+    if (params.events.length === 0) {
+      return;
+    }
+
+    const url = `${this.config.usageServiceUrl}/internal/webhooks/usage-events`;
+    const payload = {
+      schemaVersion: 1 as const,
+      events: params.events,
+    };
+
+    const result = await this.webhookClient.send({
+      url,
+      secret: this.config.orchestratorSecret,
+      payload,
+      taskId: params.taskId,
+    });
+
+    if (!result.ok) {
+      // WebhookClient.send() already queues non-4xx failures to pendingWebhooks.
+      // 4xx errors are permanent — schema mismatch, invalid provider, etc. — and must surface
+      // in logs loudly so we notice. Non-fatal by design: the turn metrics still landed.
+      this.logger.warn(
+        {
+          taskId: params.taskId,
+          errorType: result.error.type,
+          errorMessage: result.error.message,
+          eventCount: params.events.length,
+        },
+        'UsagePublisher delivery failed (non-fatal, may be queued)',
+      );
+      return;
+    }
+
+    this.logger.info(
+      { taskId: params.taskId, eventCount: params.events.length },
+      'Published per-call usage events to llm-usage-service',
+    );
+  }
+}
+```
+
+**Test file:** `workers/orchestrator/src/__tests__/usage-publisher.test.ts`
+
+Tests to include:
+
+- `publishTurnUsage` returns early when `enabled: false`, does not call `webhookClient.send`.
+- `publishTurnUsage` returns early when `events.length === 0`, does not call `webhookClient.send`.
+- `publishTurnUsage` calls `webhookClient.send` with the expected `url`, `payload`,
+  `taskId`, and `secret` when enabled and events are non-empty.
+- `publishTurnUsage` logs a warn (and does not throw) when `webhookClient.send` returns
+  `{ok: false, error: {type: '5xx', ...}}`.
+- `publishTurnUsage` logs a warn when the error is `4xx` (distinct from 5xx so we see the
+  "permanent schema error" signal separately).
+- `publishTurnUsage` logs an info with correct eventCount on success.
+
+Use a `FakeWebhookClient` implementing `{ send: vi.fn() }` — **do not** instantiate the real
+`WebhookClient`, which requires `StatePersistence`.
+
+### Phase 7 — Wire into `collectAndPublish`
+
+Update `TurnMetricsCollector` constructor signature and `collectAndPublish` method.
+
+1. Add `workerType` and `workerLocation` to `TurnMetricsCollectorConfig`:
+
+```ts
+export interface TurnMetricsCollectorConfig {
+  codeAgentUrl: string;
+  orchestratorSecret: string;
+  internalAuthToken: string;
+  secretsBasePath: string;
+  sharedCredsPath?: string;
+  workerLocation: string;          // NEW — e.g. 'home-dev', 'mac-dev'
+  environment: 'dev' | 'prod' | 'test';  // NEW
+}
+```
+
+2. Inject `UsagePublisher` as a constructor parameter:
+
+```ts
+export class TurnMetricsCollector {
+  constructor(
+    private readonly config: TurnMetricsCollectorConfig,
+    private readonly logger: Logger,
+    private readonly usagePublisher?: UsagePublisher,  // optional for backward-compat in tests
+  ) {}
+```
+
+3. Add `workerType` to `collectAndPublish` params:
+
+```ts
+async collectAndPublish(params: {
+  taskId: string;
+  containerId: string;
+  attempt: number;
+  startedAt: string;
+  completedAt: string;
+  workerType: WorkerType;          // NEW
+}): Promise<void> {
+```
+
+4. At the end of `collectAndPublish`, **after** the existing `await this.publish(metrics)` call
+   (currently line 133), add:
+
+```ts
+      if (this.usagePublisher !== undefined) {
+        try {
+          // Re-read the entries — we don't plumb them out of parseSessionJsonl today.
+          // Cheapest fix: call parseSessionJsonl again? No — expensive I/O. Better:
+          // refactor parseSessionJsonl to return entries alongside timeClassification and tokens.
+          // See step 5 below.
+          const events = this.extractUsageEvents(sessionData.entries, {
+            taskId: params.taskId,
+            attempt: params.attempt,
+            workerType: params.workerType,
+            workerLocation: this.config.workerLocation,
+            environment: this.config.environment,
+          });
+          await this.usagePublisher.publishTurnUsage({
+            taskId: params.taskId,
+            events,
+          });
+        } catch (error) {
+          this.logger.warn(
+            { taskId: params.taskId, error },
+            'UsagePublisher extract/publish failed (non-fatal)',
+          );
+        }
+      }
+```
+
+5. **Refactor `parseSessionJsonl`** to return `entries` alongside existing fields:
+
+```ts
+async parseSessionJsonl(...): Promise<{
+  entries: SessionEntry[];
+  timeClassification: TimeClassification;
+  tokens: TokenAggregation;
+}> {
+  // ... existing code ...
+  return {
+    entries,
+    timeClassification: this.classifyTime(entries),
+    tokens: this.aggregateTokens(entries),
+  };
+}
+```
+
+Update existing tests that destructure `parseSessionJsonl` return — all currently call
+`result.tokens.*` and `result.timeClassification.*`, so adding a third field is additive.
+
+6. Update `task-dispatcher.ts` callers of `collectAndPublish` to pass `workerType: task.workerType`.
+   Grep for `collectAndPublish(` to find call sites — expected to be one location.
+
+### Phase 8 — Env var plumbing
+
+The orchestrator's three-location pattern differs from standard apps because (a) it runs outside
+PM2 and (b) it is outside Terraform management. The actual three locations for this track:
+
+#### Location 1: `workers/orchestrator/src/start.ts`
+
+Add to the REQUIRED_ENV block near line 441–456:
+
+```ts
+const llmUsageServiceUrl = getRequiredEnv('INTEXURAOS_LLM_USAGE_SERVICE_URL');
+const workerLocation = getRequiredEnv('INTEXURAOS_WORKER_LOCATION');
+// environment: reuse existing or add a new required env
+const environment = getRequiredEnv('INTEXURAOS_ENVIRONMENT') as 'dev' | 'prod' | 'test';
+```
+
+Validate `environment` is one of the three allowed values; throw a precondition error otherwise
+(match the existing style that writes to stderr and `process.exit(1)`).
+
+Feature flag (non-required, default off):
+
+```ts
+const usagePublisherEnabled = getOptionalEnv('INTEXURAOS_USAGE_PUBLISHER_ENABLED', '0') === '1';
+```
+
+Wire the service construction after `webhookClient` is created:
+
+```ts
+const usagePublisher = new UsagePublisher(
+  {
+    usageServiceUrl: llmUsageServiceUrl,
+    orchestratorSecret,
+    enabled: usagePublisherEnabled,
+  },
+  webhookClient,
+  logger,
+);
+```
+
+Pass it into `TurnMetricsCollector`:
+
+```ts
+const turnMetricsCollector = new TurnMetricsCollector(
+  {
+    codeAgentUrl: config.codeAgentUrl,
+    orchestratorSecret: config.orchestratorSecret,
+    internalAuthToken: config.internalAuthToken,
+    secretsBasePath,
+    sharedCredsPath,
+    workerLocation,
+    environment,
+  },
+  logger,
+  usagePublisher,
+);
+```
+
+#### Location 2: `.envrc` (repo root + orchestrator host `.envrc`)
+
+Add (with a comment block):
+
+```bash
+# --- Track 2 (INT-1341): orchestrator → llm-usage-service webhook ---
+export INTEXURAOS_LLM_USAGE_SERVICE_URL="http://localhost:8132"  # dev default; override on home-dev
+export INTEXURAOS_WORKER_LOCATION="home-dev"                     # or 'mac-dev', 'office-pc'
+export INTEXURAOS_ENVIRONMENT="dev"
+export INTEXURAOS_USAGE_PUBLISHER_ENABLED="0"                    # flip to 1 after Phase 10 verification
+```
+
+On home-dev, the `.envrc` at `~/` or wherever direnv loads is **the** source of truth. Confirm
+with `ssh home-dev 'direnv exec . printenv | grep INTEXURAOS_LLM_USAGE_SERVICE_URL'` after
+making the change.
+
+For prod orchestrator (future): `INTEXURAOS_LLM_USAGE_SERVICE_URL` should point to the Cloud Run
+URL of `llm-usage-service` (same value as
+`https://${local.services.llm_usage_service.name}-${local.cloud_run_url_suffix}` in
+`terraform/environments/dev/main.tf:310`).
+
+#### Location 3: `terraform/environments/dev/main.tf` — documentation comment only
+
+The orchestrator is not a Terraform-managed service. Do **not** add the orchestrator to the
+Cloud Run service list. Do add a **comment** in the `common_service_env_vars` block noting that
+the orchestrator consumes `INTEXURAOS_LLM_USAGE_SERVICE_URL` from its host `.envrc` and must be
+kept in sync with the Cloud Run value:
+
+```hcl
+    INTEXURAOS_LLM_USAGE_SERVICE_URL            = "https://${local.services.llm_usage_service.name}-${local.cloud_run_url_suffix}"
+    # NOTE: orchestrator (workers/orchestrator) reads the same env var from its host .envrc on
+    # home-dev / mac-dev. Keep in sync — see workers/orchestrator/DEPLOYMENT.md.
+```
+
+**`ecosystem.config.cjs` is NOT touched** — orchestrator is not present in that file
+(verified by grep).
+
+### Phase 9 — Idempotency / eventId strategy
+
+Already covered inline in Phase 4's `deriveEventId`. Reasoning:
+
+- **Why include `taskId`:** isolates different tasks that happen to reuse the same attempt
+  number.
+- **Why include `attempt`:** the same `taskId` can have multiple retry attempts, each with its
+  own JSONL entries at the same index.
+- **Why include `entryIndex`:** the file may contain many entries with the same timestamp (they
+  are written at burst speed). Index disambiguates within a single file read.
+- **Why include `timestamp`:** guards against off-by-one errors in the index if the file is
+  re-read after new lines appended (adoption flow reads the file mid-flight).
+- **Why NOT include `message.id`:** confirmed-present fields are better than optional ones for a
+  primary key. If Phase 1 shows `message.id` is reliable, we can switch to
+  `sha256("${taskId}:${attempt}:${message.id}")` in a follow-up.
+- **Why `sha256(...).slice(0, 24)`:** llm-usage-service schema requires non-empty string; 24 hex
+  chars give 96 bits of entropy (birthday collision floor ≈ 2^48 entries, well above our
+  lifetime volume). Full 64-char hashes work too but bloat the payload.
+
+**Idempotency guarantee:** if the orchestrator restarts mid-turn, adopts a running container,
+and re-parses the JSONL file, it will produce the same eventIds → the service's dedup logic
+(INT-1339 Phase 2) returns `duplicates > 0` and `accepted` reflects only net-new events.
+
+### Phase 10 — Integration test against a real llm-usage-service in dev
+
+**Pre-condition:** Phase 1–9 complete, CI green, feature flag `INTEXURAOS_USAGE_PUBLISHER_ENABLED=1`
+set on one orchestrator instance (home-dev).
+
+1. Restart the orchestrator: `sudo systemctl restart code-orchestrator` (Linux) or
+   `launchctl kickstart -k gui/$(id -u)/com.intexuraos.orchestrator` (macOS).
+2. Verify the new env var was picked up:
+   ```bash
+   journalctl -u code-orchestrator -n 50 | grep -E 'INTEXURAOS_LLM_USAGE_SERVICE_URL|UsagePublisher'
+   ```
+   Expect a log line like `Starting orchestrator` followed by the service construction
+   succeeding (no precondition failures).
+3. Submit a trivial planning task via the web UI or `curl code-agent` — pick the smallest
+   possible task so the session has <5 assistant entries.
+4. Tail orchestrator logs and look for:
+   ```
+   Published per-call usage events to llm-usage-service (eventCount=N)
+   ```
+5. Query llm-usage-service for the events:
+   ```bash
+   curl -sS \
+     -H "X-Internal-Auth: $INTEXURAOS_INTERNAL_AUTH_TOKEN" \
+     -H "Content-Type: application/json" \
+     -d '{"timeRange":{"from":"2026-04-10T00:00:00Z","to":"2026-04-11T00:00:00Z"},"filters":{"services":["orchestrator"]}}' \
+     "$INTEXURAOS_LLM_USAGE_SERVICE_URL/internal/usage/query" | jq
+   ```
+   Expect `rows` count matching the number of assistant turns in the session and `totals.calls`
+   matching the `apiCallCount` from the turn metrics publish.
+6. Verify dedup: submit the same task again. The second submission creates a new session (fresh
+   taskId), so events should all be `accepted`, not `duplicates`. To test dedup specifically,
+   kill-and-restart the orchestrator mid-turn and confirm adoption reuses the same taskId — the
+   next `publishTurnUsage` call should have `duplicates > 0`.
+7. Verify `cost.billedUsd > 0` server-side: the service should compute cost from the pricing
+   table. If all events show `billedUsd = 0`, INT-1339 is missing pricing rows for that model —
+   file a blocker.
+8. Verify schema compliance: check for any `rejected` events in the webhook response logs on the
+   llm-usage-service side:
+   ```bash
+   gcloud logging read 'resource.type="cloud_run_revision" AND resource.labels.service_name="llm-usage-service" AND textPayload:"rejected"' \
+     --project=intexuraos-dev-pbuchman --limit=20 --format=json
+   ```
+   Any rejection with `code: 'FST_ERR_VALIDATION'` means the orchestrator sent a schema
+   violation — fix before flipping the flag globally.
+
+If any step fails, **revert the feature flag** (`INTEXURAOS_USAGE_PUBLISHER_ENABLED=0`) and
+restart. The orchestrator stays functional because the publisher is gated.
+
+---
+
+## Test plan
+
+| File                                                                                 | What it covers                                                                                                                                                                                                                                                                                                                                              |
+| ------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `workers/orchestrator/src/__tests__/turn-metrics-collector.test.ts`                  | Extended with `describe('extractUsageEvents')` — all cases enumerated in Phase 3b (10+ tests). Covers empty entries, missing `message.usage`, all cache-token variants, missing `timestamp`, model fallback chain (`message.model` → `WORKER_TYPES[workerType].model` → `'unknown'`), deterministic eventId, codex early-return, provider selection switch. |
+| `workers/orchestrator/src/__tests__/usage-publisher.test.ts` (NEW)                   | `UsagePublisher.publishTurnUsage` — feature flag gate, empty events short-circuit, webhookClient invocation args, 4xx/5xx warn logs, success info log. Uses a `FakeWebhookClient` matching the interface.                                                                                                                                                   |
+| `workers/orchestrator/src/__tests__/fixtures/session-jsonl-sample.jsonl` (NEW)       | Golden JSONL sample matching Phase 1 verified shape. Loaded by turn-metrics-collector tests via `readFile` mock.                                                                                                                                                                                                                                            |
+| `workers/orchestrator/src/__tests__/turn-metrics-collector.test.ts` (existing tests) | Must continue to pass after adding `workerLocation`/`environment` to `TurnMetricsCollectorConfig`. Update the `const config` fixture at the top of the file to include the new required fields.                                                                                                                                                             |
+| `workers/orchestrator/src/__tests__/start.test.ts` (if it exists)                    | Add assertion that `INTEXURAOS_LLM_USAGE_SERVICE_URL` is required; missing value causes `process.exit(1)`. Likely skip this if the file is covered by `v8 ignore module-init` already.                                                                                                                                                                      |
+
+**Coverage goal:** 95% branch coverage on `extractUsageEvents`, `selectProvider`, and the full
+`UsagePublisher` class. The `codex` early-return branch in `extractUsageEvents` is covered by
+one test; the `workerType` switch in `selectProvider` is covered by the `it.each` table.
+
+**Run locally before PR:**
+
+```bash
+pnpm --filter orchestrator test
+pnpm run verify:workspace:tracked -- orchestrator
+pnpm run ci:tracked
+```
+
+---
+
+## Rollout plan
+
+1. **Merge with flag OFF.** `INTEXURAOS_USAGE_PUBLISHER_ENABLED=0` is the default in `.envrc`.
+   Code ships dark. No behavior change.
+2. **Flip flag on home-dev only.** Edit home-dev's `.envrc`, restart orchestrator. Run Phase 10
+   integration test. Observe for 24 hours. Watch for: (a) increased 5xx from llm-usage-service,
+   (b) pendingWebhooks queue growth, (c) orchestrator memory growth, (d) unexpected `rejected`
+   events in llm-usage-service logs.
+3. **Flip flag on mac-dev (if applicable).** Same verification.
+4. **Flip flag globally** by changing the default in `.envrc.local.example` to `1` and updating
+   team onboarding docs.
+5. **After 1 week of stability**, remove the flag entirely: delete the
+   `INTEXURAOS_USAGE_PUBLISHER_ENABLED` check in `UsagePublisher.publishTurnUsage` and the env
+   var read in `start.ts`. File this cleanup as a separate small PR.
+
+---
+
+## Acceptance criteria
+
+- [ ] Phase 1 JSONL shape verification documented in PR body (model field location, GLM
+      deviation notes).
+- [ ] `extractUsageEvents` function produces valid `UsageEventInput[]` conforming to
+      `OrchestratorUsageEventInput` schema (checked against schema JSON in local Ajv test).
+- [ ] Deterministic `eventId` — two calls with the same input produce the same eventIds
+      (proven by unit test).
+- [ ] `collectAndPublish` invokes `UsagePublisher.publishTurnUsage` after the existing
+      `publish(metrics)` call, inside the same try/catch swallow-and-warn envelope.
+- [ ] `pnpm run ci:tracked` green.
+- [ ] `pnpm --filter orchestrator test` green with 95%+ branch coverage on new code.
+- [ ] `INTEXURAOS_LLM_USAGE_SERVICE_URL` is a hard REQUIRED_ENV in `start.ts`; missing value
+      causes precondition failure at startup.
+- [ ] `INTEXURAOS_USAGE_PUBLISHER_ENABLED=0` by default; the publisher is a no-op when disabled.
+- [ ] Phase 10 integration test passes on home-dev: events visible via
+      `/internal/usage/query`, `cost.billedUsd > 0` (requires INT-1339).
+- [ ] When `llm-usage-service` is down, the orchestrator does NOT crash — confirmed by fault-
+      injection test (temporarily point `INTEXURAOS_LLM_USAGE_SERVICE_URL` at a closed port).
+- [ ] PR title contains `INT-1341`; PR body contains `Fixes INT-1341`.
+
+---
+
+## Risks and mitigations
+
+| Risk                                                                          | Likelihood           | Impact                                                                                                                       | Mitigation                                                                                                                                                                                                   |
+| ----------------------------------------------------------------------------- | -------------------- | ---------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `message.model` field is absent from GLM/Qwen/Kimi JSONL                      | Medium               | Events tagged with fallback `WORKER_TYPES[*].model` (coarser granularity, model name still present)                          | Phase 1 verification; fallback chain `message.model → WORKER_TYPES.model → 'unknown'`                                                                                                                        |
+| Provider enum does not accept `dashscope`/`glm`/`minimax`                     | **High — confirmed** | Schema rejects entire batch with 400                                                                                         | Map to `'anthropic'` in `selectProvider`; **⚠ DECISION NEEDED**: coordinate with INT-1339 pricing table to list these models under provider `anthropic`, or extend `LlmProviders` enum in a prerequisite PR  |
+| Pending webhook queue grows unbounded during llm-usage-service outage         | Low                  | Disk growth; 24h TTL drops events                                                                                            | `WebhookClient.PENDING_WEBHOOK_TTL = 24h` (already implemented at `webhook-client.ts:22`); at high volume, the queue is in-memory + state file so the orchestrator can monitor `getPendingCount()` and alert |
+| Duplicate events on orchestrator restart + container adoption                 | Medium               | Inflated call counts server-side                                                                                             | Deterministic `eventId` — service dedups. Verified by Phase 10 step 6.                                                                                                                                       |
+| 15-minute HMAC replay window expires for pending-queue retries                | Medium               | Retries fail as `401 expired_signature`                                                                                      | `WebhookClient.retryPending` at `webhook-client.ts:131` regenerates `timestamp = Math.floor(now / 1000)` and re-signs — confirmed safe                                                                       |
+| Breaking the existing turn-metrics publish to `code-agent` during refactor    | Low                  | Lost turn metrics visibility                                                                                                 | `publishTurnUsage` is **additive** — the existing `this.publish(metrics)` call is unchanged and runs first; publisher runs after in its own try/catch                                                        |
+| `parseSessionJsonl` now returns a third field, breaks existing tests          | Low                  | Test failures                                                                                                                | Update the 2 existing `parseSessionJsonl` test assertions to destructure `{ entries, timeClassification, tokens }` — covered in Phase 7 step 5                                                               |
+| Env var missing on one host but not another → orchestrator crashes at startup | Medium               | Orchestrator down on that host                                                                                               | Use `getOptionalEnv` for the feature flag only. Use `getRequiredEnv` for `INTEXURAOS_LLM_USAGE_SERVICE_URL` so missing config is loud and fast                                                               |
+| Unknown model string (e.g. future Claude 5) fails pricing lookup              | Medium               | Cost stays 0 for those events                                                                                                | Service-side responsibility (INT-1339); orchestrator sends the raw model string and lets the service decide pricing-source fallback                                                                          |
+| I/O cost of re-reading JSONL                                                  | Low                  | Negligible — already read once per turn in `parseSessionJsonl`; the refactor returns `entries` so no additional read happens | N/A                                                                                                                                                                                                          |
+| Shipping without INT-1339 live                                                | **High**             | Events land but `cost.billedUsd` stays 0                                                                                     | Pre-flight check #1; feature flag default OFF protects against this                                                                                                                                          |
+
+---
+
+## Out of scope
+
+- **Streaming per-call events** (as they arrive in `claude-log-processor.ts`). Post-turn batch
+  only. Real-time streaming is INT-13xx-TBD follow-up.
+- **Backfill of historical sessions.** The orchestrator has `claude-session-*` directories
+  going back weeks — a one-off backfill script is out of scope. If needed, do it as a separate
+  `scripts/backfill-usage-events.ts` PR.
+- **Per-call operation detection** (tool_calling vs generate). All events use `operation:
+  'other'` until we have a use case that requires finer classification. Do not add
+  `stop_reason`-based classification speculatively.
+- **Modifying `code-agent/internal/turn-metrics`.** The existing summed-per-turn publish stays.
+  Track 2 is additive.
+- **Extending `LlmProviders` enum** to add `'zai'`, `'dashscope'`, etc. If Phase 1 shows this
+  is required, file a separate blocker issue under INT-1338 first.
+- **Per-event `durationMs`.** JSONL has no per-call latency. `durationMs: 0` is a known limitation.
+- **Per-event `owner.id` = real user ID.** The orchestrator does not have user context at the
+  turn-metrics collection point. `owner.id = "orchestrator:${taskId}"` is the best we can do
+  without plumbing user IDs through `code-agent → orchestrator → turn-metrics-collector`.
+- **Cloud Run deployment of the orchestrator.** Orchestrator remains a native Node.js process
+  on home-dev/mac-dev for this track.
+- **Deleting the feature flag.** Rollout plan step 5 files a separate cleanup PR after 1 week
+  of stability.
+
+---
+
+## Summary of ⚠ DECISION NEEDED items
+
+1. **Phase 1 — GLM JSONL shape.** If GLM deviates from the Claude format, `extractUsageEvents`
+   must branch on `workerType`. Blocker on verification.
+2. **Phase 3/5 — Provider enum for non-Anthropic proxies.** Provisional decision: map all
+   Anthropic-compatible proxies (`minimax`, `mimo-pro`, `glm`, `qwen`, `kimi`) to
+   `LlmProviders.Anthropic`. Must be confirmed with INT-1339 author before merge, because it
+   implies the pricing table lists `glm-5` etc. under the `anthropic` provider column.
+3. **Phase 4 — Should `operation` classify `stop_reason === 'tool_use'` as `'tool_calling'`?**
+   Provisional decision: **No** — ship `'other'` first, revisit after a week of data.
+4. **Phase 9 — Use `message.id` (Anthropic request ID) as eventId input?** Provisional
+   decision: **No** — use the positional hash first because presence is guaranteed, revisit
+   when Phase 1 confirms `message.id` is always populated.

--- a/docs/plans/INT-1341-track-2-orchestrator-usage-publisher.md
+++ b/docs/plans/INT-1341-track-2-orchestrator-usage-publisher.md
@@ -2,1150 +2,577 @@
 
 ## Status
 
-- Linear issue: INT-1341
-- Parent epic: INT-1338 (LLM Usage Service Phase 2)
-- Dependencies: **INT-1339 (Track 4 — server-side cost calculation)** — MUST be merged and deployed to dev before flipping the feature flag on.
-- Blocks: INT-1342 (Track 3 — shares the HMAC webhook HTTP client pattern this track establishes)
-- Plan version: 1.0
+- Linear issue: **INT-1341**
+- Parent epic: **INT-1338** (LLM Usage Service Phase 2)
+- Dependencies: none — Track 2 is independent and starts in Phase 1 parallel (alongside Track 1 and Track 4)
+- Blocks: **INT-1342** (Track 3 — reuses `HttpInternalAuthUsageSink` shipped here)
+- Plan version: **2.0** (full rewrite — 2026-04-10; supersedes v1.0 which described JSONL parsing)
 - Author: Claude (agent thread)
-- Target file: `workers/orchestrator/src/services/usage-publisher.ts` (new) and small edits to `turn-metrics-collector.ts` + `start.ts`.
+- Authority: `docs/plans/INT-1338-decisions.md` Part 2 is the source of truth for all scope decisions.
 
 ---
 
 ## Executive summary
 
-The orchestrator already parses on-disk Claude Code session JSONL files after every turn to produce
-summed-per-turn resource metrics and posts them to `code-agent/internal/turn-metrics`. The per-call
-token usage is aggregated away in that pipeline; nothing is sent to `llm-usage-service`. This track
-adds a parallel code path that extracts the **same** JSONL entries and emits **one
-`UsageEventInput` per entry containing `message.usage`** (preserving per-call granularity), batches
-them into a single HTTP POST to `llm-usage-service/internal/webhooks/usage-events`, and reuses the
-existing `WebhookClient` for HMAC signing, retries, and the pending-queue failover.
+Two places in the orchestrator make LLM calls using the `LLMClient` interface directly:
 
-Two design points distinguish this from a naive implementation:
+1. `workers/orchestrator/src/services/agent-compliance-validator.ts:297` — `createOpenRouterClient({ usageSink: new StructuredLogUsageSink({ logger }) })`
+2. `workers/orchestrator/src/services/completion-verifier.ts:810` — `createLlmClient({ usageSink: new StructuredLogUsageSink({ logger }) })`
 
-1. **No orchestrator-side pricing.** Events are emitted with `cost.billedUsd = 0`,
-   `cost.providerReportedUsd = null`, `cost.calculatedUsd = null`, `cost.pricingSource =
-   'calculated'`. The service (INT-1339) computes the cost server-side from its pricing table.
-   This is why this track is blocked on Track 4.
-2. **Deterministic event IDs.** The same JSONL file is re-read on retry (e.g., adoption) so events
-   must be idempotent: `eventId = sha256("${taskId}:${attempt}:${entryIndex}:${timestamp}").slice(0, 24)`.
+Both currently use `StructuredLogUsageSink` — log-only, no Firestore writes, no usage tracking. This track replaces both with `HttpWebhookUsageSink`, a new sink in `packages/llm-pricing` that HMAC-signs usage events and POSTs them to `code-agent/internal/webhooks/usage-events`. Code-agent validates the HMAC (using `INTEXURAOS_ORCHESTRATOR_SECRET`, which it already holds), then forwards the events to `llm-usage-service/internal/usage/events` using `X-Internal-Auth`.
 
-The orchestrator is **not** containerized and **not** managed by Terraform — it runs as a systemd
-unit on home-dev and a LaunchAgent on macOS hosts. Env var plumbing therefore touches `start.ts`
-REQUIRED_ENV, the host `.envrc`, and (for future Cloud Run deployment parity) the dev Terraform
-`common_service_env_vars` block. There is **no ecosystem.config.cjs entry to update** — the
-orchestrator is absent from that file (confirmed by grep).
+This track also ships `HttpInternalAuthUsageSink` — a second new sink for in-cluster apps (not the orchestrator) that call `llm-usage-service` directly with `X-Internal-Auth`. Track 3 reuses this sink when migrating all `FirestoreUsageSink` call sites.
+
+**What this track explicitly does NOT do:**
+- Parse JSONL session files or touch `turn-metrics-collector.ts`
+- Add server-side cost calculation (all pricing is client-side, using the existing `PricingContext`)
+- Add a feature flag
+- Add a `UsagePublisher` class
 
 ---
 
 ## Pre-flight checks
 
-Run these **before** opening a PR branch. Each item is a hard blocker.
+Run these before opening a PR branch. Each is a hard blocker.
 
-1. **Verify INT-1339 is deployed to dev.**
+1. **Establish a green CI baseline.**
    ```bash
-   curl -s https://<dev-llm-usage-service-url>/internal/pricing \
-     -H "X-Internal-Auth: $INTEXURAOS_INTERNAL_AUTH_TOKEN" \
-     | jq '.data | keys'
+   pnpm run ci:tracked | tee /tmp/int-1341-baseline.txt
    ```
-   Must return a non-empty object with at least `claude-sonnet-4-5-20250929` and
-   `claude-opus-4-5-20251101`. If it returns `404` or empty, stop — Track 4 is not ready.
+   Do not proceed if anything fails.
 
-2. **Verify the `/internal/webhooks/usage-events` endpoint is live in dev.** POST an empty events
-   array with a valid HMAC and expect `200 {success: true, data: {accepted: 0, duplicates: 0,
-   rejected: []}}`. If you get `401`, the `INTEXURAOS_ORCHESTRATOR_SECRET` on the orchestrator and
-   the llm-usage-service do not match — fix that before proceeding.
+2. **Verify `packages/llm-pricing/dist/` exists.** The new sinks import from this package; `tsc` will fail with `Cannot find module` if dist is stale.
+   ```bash
+   pnpm build
+   ```
 
-3. **Read an actual JSONL session file from a recent dev task** (see Phase 1 for the exact
-   mechanics). This verifies the `message.model` location hypothesis. **Do not skip this step** —
-   it is the single highest-risk unknown in this plan.
+3. **Re-read the two call sites before writing any code** to confirm line numbers have not drifted:
+   - `workers/orchestrator/src/services/agent-compliance-validator.ts` — search for `usageSink: new StructuredLogUsageSink`
+   - `workers/orchestrator/src/services/completion-verifier.ts` — same search
 
-4. **Confirm `pnpm run ci:tracked` currently passes on `development`.** You are about to add a
-   new service that imports from `@intexuraos/llm-contract` — any pre-existing green baseline
-   makes diagnosing new failures trivial.
+4. **Confirm code-agent already has `INTEXURAOS_ORCHESTRATOR_SECRET` in `REQUIRED_ENV`.**
+   Verified at plan time: `apps/code-agent/src/index.ts` line 18 includes `'INTEXURAOS_ORCHESTRATOR_SECRET'`. No env var change needed for code-agent.
 
-5. **Locate the orchestrator's runtime environment file.** On home-dev this is typically
-   `~/.code-orchestrator/.envrc` or loaded via `direnv allow` on the repo root `.envrc`. Confirm
-   with `systemctl show --no-pager -p Environment code-orchestrator` (or the LaunchAgent plist on
-   macOS). You need write access before Phase 8 can complete.
+5. **Confirm code-agent does NOT yet have `INTEXURAOS_LLM_USAGE_SERVICE_URL`.** Verified at plan time — this env var is absent from `apps/code-agent/src/index.ts` and `apps/code-agent/src/services.ts`. Track 2 adds it (see Phase 3 env var wiring).
+
+6. **Check the orchestrator's `INTEXURAOS_INTERNAL_AUTH_TOKEN`.** The orchestrator already reads this env var at `workers/orchestrator/src/start.ts:442`. It is passed to `WebhookClient` at line 541 and forwarded as `X-Internal-Auth` on all webhook calls. No new env var needed for the orchestrator.
 
 ---
 
-## Context files (with line numbers)
+## Context files
 
-**Source files to modify:**
+### Files to create (new)
 
-- `workers/orchestrator/src/services/turn-metrics-collector.ts` (360 lines)
-  - Lines 41–53: `SessionEntry` interface — needs an optional `message.model` field after Phase 1.
-  - Lines 201–229: `parseSessionJsonl` — already reads all entries; no change needed, but the
-    extraction function will consume the same `entries` array in a sibling method.
-  - Lines 305–330: `aggregateTokens` — **do not modify**; the new `extractUsageEvents` function
-    runs in parallel and operates on the same input.
-  - Lines 77–152: `collectAndPublish` — this is where the new `UsagePublisher.publishTurnUsage()`
-    call is wired in, right after the existing `publish(metrics)` call at line 133.
-  - Lines 146–151: the exact `try/catch` swallow-and-warn pattern to mirror for non-fatal failures.
+- `packages/llm-pricing/src/httpWebhookUsageSink.ts` — new `HttpWebhookUsageSink` class implementing `UsageSink`. HMAC-signs usage events in `{timestamp}.{body}` format (matching `signPayload()` in `webhook-client.ts:24-27`) and POSTs to the target URL.
+- `packages/llm-pricing/src/httpInternalAuthUsageSink.ts` — new `HttpInternalAuthUsageSink` class implementing `UsageSink`. Sends usage events to llm-usage-service using `X-Internal-Auth`. Ships here so Track 3 can immediately import it from `@intexuraos/llm-pricing`.
+- `apps/code-agent/src/routes/internalUsageWebhookRoute.ts` — new Fastify plugin exposing `POST /internal/webhooks/usage-events`. Validates `X-Internal-Auth`, validates HMAC with `validateOrchestratorSignature`, delegates to `forwardUsageEvents` use case.
+- `apps/code-agent/src/domain/usecases/forwardUsageEvents.ts` — use case that calls `UsageServiceClient.ingestEvents()` and returns `Result`.
 
-- `workers/orchestrator/src/services/webhook-client.ts` (274 lines)
-  - Lines 24–27: `signPayload()` — matches exactly the HMAC format validated at
-    `apps/llm-usage-service/src/infra/webhookValidation.ts:60` (`timestamp.body` HMAC-SHA256 hex).
-  - Lines 29–107: `WebhookClient.send()` — **reuse directly**; has retries, 4xx short-circuit,
-    pending-queue failover, Result<void, WebhookError> return type.
-  - Lines 183–219: `deliver()` — already sets `X-Internal-Auth`, `X-Request-Timestamp`,
-    `X-Request-Signature` headers exactly as the service expects.
+### Files to modify
 
-- `workers/orchestrator/src/services/isolation/types.ts` (249 lines)
-  - Lines 25, 41–107: `WORKER_TYPES` — source of truth for provider mapping. Contains 11 worker
-    types. Note `glm`/`qwen`/`kimi` all share the same DashScope base URL but different models.
+- `packages/llm-pricing/src/index.ts` — export the two new sink classes and their config types.
+- `workers/orchestrator/src/services/agent-compliance-validator.ts:291-298` — replace `StructuredLogUsageSink` with `HttpWebhookUsageSink`.
+- `workers/orchestrator/src/services/completion-verifier.ts:800-815` — replace `StructuredLogUsageSink` with `HttpWebhookUsageSink`.
+- `apps/code-agent/src/services.ts` — add `usageServiceClient: UsageServiceClient` to `ServiceContainer` and `ServiceConfig`; initialize with `createUsageServiceClient(...)` in the factory; add `INTEXURAOS_LLM_USAGE_SERVICE_URL` to `ServiceConfig`.
+- `apps/code-agent/src/index.ts` — add `INTEXURAOS_LLM_USAGE_SERVICE_URL` to `REQUIRED_ENV`.
+- `apps/code-agent/src/config.ts` (or wherever `loadConfig()` lives) — add `llmUsageServiceUrl: string` from `process.env['INTEXURAOS_LLM_USAGE_SERVICE_URL']`.
+- `apps/code-agent/src/server.ts` (or equivalent route-registration entry point) — register `internalUsageWebhookRoute` plugin.
+- `terraform/environments/dev/main.tf` — add `INTEXURAOS_LLM_USAGE_SERVICE_URL` to code-agent's service env block (already defined as a terraform local at line 310; just add it to code-agent's var map).
+- `ecosystem.config.cjs` — add `INTEXURAOS_LLM_USAGE_SERVICE_URL: 'http://localhost:8132'` to code-agent's PM2 env block.
+- `firestore-collections.json` — no change (no new collections).
 
-- `workers/orchestrator/src/start.ts` (863 lines)
-  - Lines 441–456: REQUIRED_ENV block — add `INTEXURAOS_LLM_USAGE_SERVICE_URL`.
-  - Lines 750–759: `TurnMetricsCollector` construction site — inject the new `UsagePublisher`
-    either as a sibling service passed to the collector, or as a field on
-    `TurnMetricsCollectorConfig`. **Decision: inject as constructor arg #3 on
-    `TurnMetricsCollector`.** See Phase 6.
+### Reference files (read-only)
 
-- `workers/orchestrator/src/main.ts` — no changes needed (wiring happens in `start.ts` only).
-
-**Files to read but not modify:**
-
-- `workers/orchestrator/src/services/runtime/processors/claude-log-processor.ts` (191 lines) —
-  **confirmed wrong hook point**. It only processes the stream-JSON format which contains `type:
-  system/subtype: init` messages with model name, plus `type: result` messages. It has **no**
-  access to `message.usage` per-call data, which lives only in the on-disk JSONL. Stay in
-  `turn-metrics-collector.ts`.
-
-- `workers/orchestrator/src/services/isolation/docker-provider.ts` (1679 lines)
-  - Line 135, 439, 624–716: shows how `workerType` is passed into the container and how
-    `ANTHROPIC_BASE_URL`/`ANTHROPIC_MODEL` are set. The orchestrator knows the worker type at
-    task dispatch time; `TurnMetricsCollector.collectAndPublish` receives `taskId`/`attempt` but
-    **not** `workerType`. Phase 7 must add `workerType` to the `collectAndPublish` params.
-
-- `workers/orchestrator/src/types/task.ts` (157 lines) — `Task.workerType: WorkerType` is the
-  field to plumb through.
-
-- `apps/llm-usage-service/src/routes/schemas/usageEventSchema.ts` (207 lines)
-  - Lines 16–164: **strict** base schema with `additionalProperties: false` at every level.
-  - Lines 176–194: `OrchestratorUsageEventInput` — requires `source.service === 'orchestrator'`
-    and `source.workerLocation` (non-empty string).
-  - Lines 107–117: `usage` object requires **all 11 fields** including ones we cannot populate
-    from JSONL (`reasoningTokens`, `thinkingTokens`, `webSearchCalls`, `groundingEnabled`,
-    `imageCount`). These all become `0`/`false`.
-  - Lines 136–147: `correlation` requires **all 6 fields** with `null` as the default for
-    `requestId`, `traceId`, `researchId`, `sessionId`. We populate `taskId` and `attempt`.
-
-- `apps/llm-usage-service/src/routes/webhookUsageRoutes.ts` (88 lines)
-  - Line 79: ingress tag is `'orchestrator_webhook'` (hardcoded by the route) — we cannot set it
-    from the orchestrator side, and we don't need to.
-
-- `apps/llm-usage-service/src/infra/webhookValidation.ts` (78 lines)
-  - Line 48: **15-minute replay window** — our signature's timestamp must be within 15 minutes
-    of the service's clock. `WebhookClient.deliver()` already generates the timestamp at send
-    time, so this is fine unless pending-queue retries sit longer than 15 minutes. See Risks.
-
-- `packages/internal-clients/src/usage-service/types.ts` (182 lines) — the `UsageEventInput`
-  type we build is exactly this type. Do **not** use `UsageServiceClient.ingestEvents()` — that
-  client targets the `/internal/usage/events` route (without the `webhooks/` prefix) which uses
-  a different auth scheme (`X-Internal-Auth` only, no HMAC). This track uses the HMAC-signed
-  webhook path directly.
-
-- `packages/llm-contract/src/supportedModels.ts:133–139` — `LlmProviders` constants. Note:
-  `'google'`, `'openai'`, `'anthropic'`, `'perplexity'`, `'openrouter'`. **There is no `'zai'`,
-  `'dashscope'`, `'minimax'`, `'mimo'`, or `'xiaomi'` provider.** The schema will reject
-  anything else. Phase 5 handles mapping these to the closest allowed value.
-
-- `workers/orchestrator/src/__tests__/turn-metrics-collector.test.ts` (723 lines) — existing
-  test patterns. Uses `vi.mock('node:fs/promises')` + inline JSONL string fixtures. This plan
-  keeps the same pattern and adds a separate `describe('extractUsageEvents')` block plus a
-  new `describe('UsagePublisher')` block in a new test file.
-
-- `terraform/environments/dev/main.tf:310` — `INTEXURAOS_LLM_USAGE_SERVICE_URL` already defined
-  in `common_service_env_vars` for Cloud Run services. Orchestrator is not Cloud Run, so this
-  block **does not apply to it at runtime**, but the plan must still document where the URL
-  originates for future hosted orchestrator deployment. See Phase 8 for the specific three-place
-  plumbing this orchestrator needs (which is different from the standard apps three-place
-  pattern).
-
-- `ecosystem.config.cjs` — **confirmed absent**: grep for `orchestrator` returns no matches.
-  PM2 does not run the orchestrator. **Skip this file in Phase 8.**
+- `workers/orchestrator/src/services/webhook-client.ts:24-27` — `signPayload()`: `HMAC-SHA256(secret, "${timestamp}.${body}")`, hex-encoded. `HttpWebhookUsageSink` must sign with this exact format.
+- `workers/orchestrator/src/services/webhook-client.ts:183-219` — `deliver()`: sets `X-Internal-Auth`, `X-Request-Timestamp`, `X-Request-Signature` headers.
+- `apps/code-agent/src/infra/webhookValidation.ts:45-95` — `validateOrchestratorSignature()`: validates `X-Request-Timestamp` and `X-Request-Signature` headers using `INTEXURAOS_ORCHESTRATOR_SECRET`. The new route reuses this function exactly.
+- `apps/code-agent/src/routes/webhookRoutes.ts:2045-2103` — turn-metrics webhook: the exact auth + HMAC validation pattern to mirror in the new route.
+- `packages/internal-clients/src/usage-service/client.ts` — `createUsageServiceClient()` and `UsageServiceClient.ingestEvents()`. The forwarding use case calls this.
+- `packages/internal-clients/src/usage-service/types.ts:81-97` — `UsageEventInput` and `UsageIngestRequest` shapes. The webhook body must deserialize to these types.
+- `packages/llm-pricing/src/usageLogger.ts:105-107` — `UsageSink` interface: `log(params: UsageLogParams): Promise<void>`. Both new sinks implement this.
+- `packages/llm-pricing/src/usageLogger.ts:83-107` — `UsageLogParams` fields: `userId`, `provider`, `model`, `callType`, `usage` (NormalizedUsage), `success`, `errorMessage?`. The new sinks map these to `UsageEventInput`.
+- `apps/code-agent/src/routes/internalRoutes.ts:1-10` — reference for how internal routes start (logIncomingRequest, validateInternalAuth pattern).
 
 ---
 
 ## Endpoint changes
 
-### Modified
-- None. No existing endpoint is altered.
-
 ### Created
-- None. The orchestrator gains no new incoming routes.
 
-### Outgoing HTTP (new)
-- `POST <INTEXURAOS_LLM_USAGE_SERVICE_URL>/internal/webhooks/usage-events`
-  - Auth: HMAC-SHA256 over `${timestamp}.${rawJsonBody}` using
-    `INTEXURAOS_ORCHESTRATOR_SECRET`, plus the existing `X-Internal-Auth` bearer.
-  - Body: `{ schemaVersion: 1, events: UsageEventInput[] }`.
-  - Retries: 3 attempts, 5s/15s/45s backoff (inherited from `WebhookClient`).
-  - On 4xx: no retry, dropped with `warn` log (matches existing `WebhookClient` behavior).
-  - On 5xx/network/timeout: queued into `pendingWebhooks` state file for background retry.
-
-### Removed
-- None. The existing `POST /internal/turn-metrics` on `code-agent` is **kept as-is**; both
-  posts happen on every turn. No cleanup is part of this track.
+- `POST /internal/webhooks/usage-events` on `code-agent` — receives HMAC-signed usage events from the orchestrator, validates the shared `INTEXURAOS_ORCHESTRATOR_SECRET`, and forwards to `llm-usage-service`. Body: `UsageIngestRequest` (same schema as `POST /internal/usage/events` on llm-usage-service). Response: `{ success: true, data: { accepted: number, duplicates: number, rejected: RejectedEvent[] } }`. Auth: `X-Internal-Auth` (step 1) + HMAC (step 2, same as turn-metrics webhook).
 
 ### Unchanged
-- `POST <codeAgentUrl>/internal/turn-metrics` — still populated from `aggregateTokens()` summed
-  data, still using the same HMAC pattern.
+
+- `POST /internal/usage/events` on `llm-usage-service` — existing ingest endpoint, called by code-agent after HMAC validation. No schema changes in this track.
+- All other `code-agent` and `llm-usage-service` routes — untouched.
+
+### Removed
+
+None.
 
 ---
 
 ## Step-by-step implementation
 
-### Phase 1 — Verify JSONL shape (DO NOT SKIP)
+### Phase 1 — `HttpWebhookUsageSink` in `packages/llm-pricing`
 
-This is the single highest-risk unknown. The `SessionEntry` interface declares no `message.model`
-field, but the Anthropic SDK format typically includes it. Before writing any code, confirm the
-exact JSON path.
+**Goal:** A `UsageSink` that HMAC-signs events and POSTs them to a configurable URL.
 
-**Steps:**
+#### Step 1.1 — Write a failing test first
 
-1. SSH to home-dev (or the dev host running the orchestrator).
-2. Find a recent Claude session directory:
-   ```bash
-   ls -lt ~/.code-orchestrator/secrets/claude-session-* | head -5
-   ```
-3. Pick the most recent task that ran successfully and print one assistant entry:
-   ```bash
-   SESSION=~/.code-orchestrator/secrets/claude-session-task_<id>
-   find "$SESSION/projects" -name '*.jsonl' | head -1 \
-     | xargs -I{} head -100 {} \
-     | jq -c 'select(.message.usage != null) | {type, timestamp, model: .message.model, model_alt: .message.metadata.model, usage: .message.usage}' \
-     | head -5
-   ```
-4. Record the findings in the PR description under a "JSONL shape verification" heading:
-   - Is `message.model` present? (Almost certainly **yes** — confirmed by
-     `claude-log-processor.ts:37` which extracts `model` from the stream init message.)
-   - Is `message.id` (Anthropic request ID) present? If so, we can use it as a more stable
-     `eventId` ingredient.
-   - Is `message.stop_reason` present? Useful for `operation` classification later.
-   - Are there user entries (`type: "user"`) that also have `message.usage`? (Possible for tool
-     results that include cache hits.)
-   - Does GLM produce the same shape, or does it have provider-specific fields? (Verify by
-     submitting a trivial GLM task first.)
+Create `packages/llm-pricing/src/__tests__/httpWebhookUsageSink.test.ts`.
 
-5. **⚠ DECISION NEEDED:** if `message.model` is **missing** from JSONL (unlikely but possible if
-   `ANTHROPIC_MODEL=opus` override changes the format), fall back to
-   `WORKER_TYPES[workerType].model ?? 'unknown'` as the model name. Document the fallback in the
-   PR body so reviewers know why the model string may be coarser than expected.
+The test must:
+- Use `nock` to intercept the POST request to a fake webhook URL.
+- Assert that `X-Request-Timestamp` and `X-Request-Signature` headers are present.
+- Assert that the signature matches `HMAC-SHA256(secret, "${timestamp}.${body}")` hex-encoded.
+- Assert the request body matches the `UsageIngestRequest` schema (one event per `log()` call).
+- Assert a successful `log()` call resolves without error when the server responds `200 { success: true, data: { accepted: 1, ... } }`.
+- Assert a failed `log()` call (5xx response) logs a warning (using a fake logger) but does **not** throw — non-fatal per existing `StructuredLogUsageSink` behavior.
 
-6. **⚠ DECISION NEEDED:** if GLM's JSONL deviates in structure (e.g., nested differently under
-   `message.raw_response`), the `extractUsageEvents` function must branch on `workerType` or
-   operate on a provider-specific normalizer. Prefer branching on `workerType` over sniffing the
-   JSON shape.
+Run the test, confirm it fails with "module not found".
 
-Do not proceed to Phase 2 until these decisions are logged in the PR description.
+#### Step 1.2 — Implement `httpWebhookUsageSink.ts`
 
-### Phase 2 — Extend SessionEntry type
+```
+packages/llm-pricing/src/httpWebhookUsageSink.ts
+```
 
-Given Phase 1 confirms `message.model` exists, extend the interface in
-`workers/orchestrator/src/services/turn-metrics-collector.ts`:
-
+Config interface:
 ```ts
-interface SessionEntry {
-  type: string;
-  timestamp?: string;
-  subtype?: string;
-  message?: {
-    id?: string;            // Anthropic request ID if present
-    model?: string;         // Model name, e.g. "claude-sonnet-4-5-20250929"
-    stop_reason?: string;   // "end_turn" | "tool_use" | "max_tokens" | ...
-    usage?: {
-      input_tokens?: number;
-      output_tokens?: number;
-      cache_read_input_tokens?: number;
-      cache_creation_input_tokens?: number;
-    };
-  };
+export interface HttpWebhookUsageSinkConfig {
+  webhookUrl: string;
+  webhookSecret: string;
+  service: string;       // fills source.service in UsageEventInput
+  component: string;     // fills source.component
+  logger: Logger;
 }
 ```
 
-Leave all existing consumers untouched — the added fields are optional so
-`classifyTime` and `aggregateTokens` compile without change.
+Implementation notes:
+- Import `createHmac` from `node:crypto`.
+- `log(params: UsageLogParams): Promise<void>` maps `UsageLogParams` → `UsageEventInput`:
+  - `eventId`: generate a random UUID or use `crypto.randomUUID()` — determinism is not required here since these are live calls, not JSONL replays.
+  - `occurredAt`: `new Date().toISOString()`
+  - `owner`: `{ type: 'system', id: params.userId }` (orchestrator calls are system-level; userId here is the task identifier passed through by the infra layer)
+  - `source.service`: from config
+  - `source.component`: from config
+  - `source.client`: `params.model`
+  - `source.environment`: read from `process.env['NODE_ENV'] === 'production' ? 'prod' : 'dev'`
+  - `request.provider`: `params.provider`
+  - `request.model`: `params.model`
+  - `request.operation`: `params.callType` (types overlap exactly — both use the same union)
+  - `request.success`: `params.success`
+  - `request.durationMs`: `0` (not tracked at this level; NormalizedUsage doesn't include duration)
+  - `usage`: map `NormalizedUsage` fields directly (inputTokens, outputTokens, totalTokens, cacheReadTokens, cacheWriteTokens, cachedTokens, reasoningTokens, thinkingTokens, webSearchCalls, groundingEnabled, imageCount)
+  - `cost.billedUsd`: `params.usage.costUsd` (already calculated client-side by PricingContext)
+  - `cost.providerReportedUsd`: `null`
+  - `cost.calculatedUsd`: `params.usage.costUsd`
+  - `cost.pricingSource`: `'calculated'`
+  - `correlation`: all `null` fields; set `sessionId: null`, `taskId: null`, `requestId: null`, `traceId: null`, `attempt: null`, `researchId: null`
+  - `error`: `params.success === false ? { code: null, message: params.errorMessage ?? null } : null`
+- Sign and POST:
+  ```ts
+  const body = JSON.stringify({ schemaVersion: 1, events: [event] });
+  const timestamp = Math.floor(Date.now() / 1000);
+  const message = `${String(timestamp)}.${body}`;
+  const signature = createHmac('sha256', config.webhookSecret).update(message).digest('hex');
+  ```
+  Headers: `X-Request-Timestamp: ${timestamp}`, `X-Request-Signature: ${signature}`, `X-Internal-Auth: ${config.internalAuthToken}`, `Content-Type: application/json`.
 
-### Phase 3 — Write failing tests FIRST (test-driven)
+  Wait — the webhook route on code-agent validates BOTH `X-Internal-Auth` (step 1) and HMAC (step 2). The `HttpWebhookUsageSink` must send both. Add `internalAuthToken: string` to `HttpWebhookUsageSinkConfig`.
 
-#### 3a. Create the fixture directory
+- Failure handling: wrap the fetch in try/catch. On any non-2xx or network error, call `config.logger.warn(...)` and return without throwing. The orchestrator must not fail a compliance validation or completion verification because of a usage reporting side effect.
 
-Check if `workers/orchestrator/src/__tests__/fixtures/` exists. If not, create it with one file:
+#### Step 1.3 — Export from `packages/llm-pricing/src/index.ts`
 
-**Path:** `workers/orchestrator/src/__tests__/fixtures/session-jsonl-sample.jsonl`
-
-**Content:** a realistic two-call sample matching the shape confirmed in Phase 1. Example
-(sanitized; update after Phase 1 verification):
-
-```jsonl
-{"type":"user","timestamp":"2026-04-10T12:00:00.000Z","message":{"role":"user","content":"ping"}}
-{"type":"assistant","timestamp":"2026-04-10T12:00:02.500Z","message":{"id":"msg_01abc","model":"claude-sonnet-4-5-20250929","stop_reason":"end_turn","usage":{"input_tokens":120,"output_tokens":45,"cache_read_input_tokens":1000,"cache_creation_input_tokens":200}}}
-{"type":"user","timestamp":"2026-04-10T12:00:03.000Z","message":{"role":"user","content":"follow up"}}
-{"type":"assistant","timestamp":"2026-04-10T12:00:05.100Z","message":{"id":"msg_02def","model":"claude-sonnet-4-5-20250929","stop_reason":"tool_use","usage":{"input_tokens":85,"output_tokens":12,"cache_read_input_tokens":1100,"cache_creation_input_tokens":0}}}
+Add:
+```ts
+export {
+  HttpWebhookUsageSink,
+  type HttpWebhookUsageSinkConfig,
+} from './httpWebhookUsageSink.js';
 ```
 
-#### 3b. Add tests to the existing `turn-metrics-collector.test.ts` file
+Run the test from Step 1.1 — it must pass. Then run `pnpm run verify:workspace:tracked -- llm-pricing`.
 
-New top-level `describe` block to add (near the end of the file, before the closing `});`):
+---
 
-```ts
-describe('extractUsageEvents', () => {
-  const taskId = 'task_test_123';
-  const attempt = 1;
-  const workerLocation = 'home-dev';
-  const environment = 'dev' as const;
+### Phase 2 — `HttpInternalAuthUsageSink` in `packages/llm-pricing`
 
-  it('emits one event per entry with message.usage', () => {
-    const entries = [
-      { type: 'user', timestamp: '2026-04-10T12:00:00.000Z' },
-      {
-        type: 'assistant',
-        timestamp: '2026-04-10T12:00:02.500Z',
-        message: {
-          id: 'msg_01',
-          model: 'claude-sonnet-4-5-20250929',
-          usage: {
-            input_tokens: 120,
-            output_tokens: 45,
-            cache_read_input_tokens: 1000,
-            cache_creation_input_tokens: 200,
-          },
-        },
-      },
-    ];
+**Goal:** A `UsageSink` for in-cluster apps that call `llm-usage-service` directly using `X-Internal-Auth`. Ships here so Track 3 can import it without waiting.
 
-    const events = collector.extractUsageEvents(entries, {
-      taskId, attempt, workerType: 'opus', workerLocation, environment,
-    });
+#### Step 2.1 — Write a failing test first
 
-    expect(events).toHaveLength(1);
-    expect(events[0]?.usage.inputTokens).toBe(120);
-    expect(events[0]?.usage.outputTokens).toBe(45);
-    expect(events[0]?.usage.cacheReadTokens).toBe(1000);
-    expect(events[0]?.usage.cacheWriteTokens).toBe(200);
-    expect(events[0]?.usage.totalTokens).toBe(120 + 45 + 1000 + 200);
-    expect(events[0]?.request.provider).toBe('anthropic');
-    expect(events[0]?.request.model).toBe('claude-sonnet-4-5-20250929');
-    expect(events[0]?.request.operation).toBe('other');
-    expect(events[0]?.cost.billedUsd).toBe(0);
-    expect(events[0]?.cost.pricingSource).toBe('calculated');
-    expect(events[0]?.source.service).toBe('orchestrator');
-    expect(events[0]?.source.workerLocation).toBe('home-dev');
-    expect(events[0]?.correlation.taskId).toBe(taskId);
-    expect(events[0]?.correlation.attempt).toBe(attempt);
-  });
+Create `packages/llm-pricing/src/__tests__/httpInternalAuthUsageSink.test.ts`.
 
-  it('skips entries without message.usage', () => {
-    const entries = [
-      { type: 'user', timestamp: '2026-04-10T12:00:00.000Z' },
-      { type: 'system', subtype: 'progress', timestamp: '2026-04-10T12:00:01.000Z' },
-    ];
-    const events = collector.extractUsageEvents(entries, {
-      taskId, attempt, workerType: 'opus', workerLocation, environment,
-    });
-    expect(events).toHaveLength(0);
-  });
+Similar to Phase 1 but simpler — no HMAC. Use `nock` to intercept the POST to `llm-usage-service/internal/usage/events`. Assert `X-Internal-Auth` header. Assert body matches `UsageIngestRequest`. Assert non-fatal on 5xx.
 
-  it('handles missing cache tokens as zero', () => {
-    const entries = [{
-      type: 'assistant',
-      timestamp: '2026-04-10T12:00:02.500Z',
-      message: { model: 'claude-sonnet-4-5-20250929', usage: { input_tokens: 50, output_tokens: 25 } },
-    }];
-    const events = collector.extractUsageEvents(entries, {
-      taskId, attempt, workerType: 'opus', workerLocation, environment,
-    });
-    expect(events[0]?.usage.cacheReadTokens).toBe(0);
-    expect(events[0]?.usage.cacheWriteTokens).toBe(0);
-    expect(events[0]?.usage.totalTokens).toBe(75);
-  });
+#### Step 2.2 — Implement `httpInternalAuthUsageSink.ts`
 
-  it('falls back to workerType model when message.model missing', () => {
-    const entries = [{
-      type: 'assistant',
-      timestamp: '2026-04-10T12:00:02.500Z',
-      message: { usage: { input_tokens: 10, output_tokens: 5 } },
-    }];
-    const events = collector.extractUsageEvents(entries, {
-      taskId, attempt, workerType: 'glm', workerLocation, environment,
-    });
-    expect(events[0]?.request.model).toBe('glm-5'); // WORKER_TYPES.glm.model
-  });
-
-  it('falls back to "unknown" when neither message.model nor WORKER_TYPES model is set', () => {
-    const entries = [{
-      type: 'assistant',
-      timestamp: '2026-04-10T12:00:02.500Z',
-      message: { usage: { input_tokens: 10, output_tokens: 5 } },
-    }];
-    const events = collector.extractUsageEvents(entries, {
-      taskId, attempt, workerType: 'auto', workerLocation, environment,
-    });
-    // WORKER_TYPES.auto.model is undefined
-    expect(events[0]?.request.model).toBe('unknown');
-  });
-
-  it('uses occurredAt = entry.timestamp when present', () => {
-    const entries = [{
-      type: 'assistant',
-      timestamp: '2026-04-10T12:00:02.500Z',
-      message: { model: 'claude-sonnet-4-5-20250929', usage: { input_tokens: 1, output_tokens: 1 } },
-    }];
-    const events = collector.extractUsageEvents(entries, {
-      taskId, attempt, workerType: 'opus', workerLocation, environment,
-    });
-    expect(events[0]?.occurredAt).toBe('2026-04-10T12:00:02.500Z');
-  });
-
-  it('falls back to now() when entry.timestamp missing', () => {
-    const before = new Date().toISOString();
-    const entries = [{
-      type: 'assistant',
-      message: { model: 'claude-sonnet-4-5-20250929', usage: { input_tokens: 1, output_tokens: 1 } },
-    }];
-    const events = collector.extractUsageEvents(entries, {
-      taskId, attempt, workerType: 'opus', workerLocation, environment,
-    });
-    const after = new Date().toISOString();
-    expect(events[0]?.occurredAt >= before).toBe(true);
-    expect(events[0]?.occurredAt <= after).toBe(true);
-  });
-
-  it('produces deterministic eventId for the same entry', () => {
-    const entries = [{
-      type: 'assistant',
-      timestamp: '2026-04-10T12:00:02.500Z',
-      message: { model: 'claude-sonnet-4-5-20250929', usage: { input_tokens: 1, output_tokens: 1 } },
-    }];
-    const a = collector.extractUsageEvents(entries, {
-      taskId, attempt, workerType: 'opus', workerLocation, environment,
-    });
-    const b = collector.extractUsageEvents(entries, {
-      taskId, attempt, workerType: 'opus', workerLocation, environment,
-    });
-    expect(a[0]?.eventId).toBe(b[0]?.eventId);
-  });
-
-  it('produces different eventIds for different entries in the same turn', () => {
-    const entries = [
-      {
-        type: 'assistant',
-        timestamp: '2026-04-10T12:00:02.500Z',
-        message: { model: 'claude-sonnet-4-5-20250929', usage: { input_tokens: 1, output_tokens: 1 } },
-      },
-      {
-        type: 'assistant',
-        timestamp: '2026-04-10T12:00:05.100Z',
-        message: { model: 'claude-sonnet-4-5-20250929', usage: { input_tokens: 2, output_tokens: 2 } },
-      },
-    ];
-    const events = collector.extractUsageEvents(entries, {
-      taskId, attempt, workerType: 'opus', workerLocation, environment,
-    });
-    expect(events).toHaveLength(2);
-    expect(events[0]?.eventId).not.toBe(events[1]?.eventId);
-  });
-
-  it.each([
-    ['opus', 'anthropic'],
-    ['auto', 'anthropic'],
-    ['sonnet', 'anthropic'],
-    ['minimax', 'anthropic'],    // see DECISION NEEDED below
-    ['mimo-pro', 'anthropic'],
-    ['glm', 'anthropic'],
-    ['qwen', 'anthropic'],
-    ['kimi', 'anthropic'],
-    ['openrouter-free', 'openrouter'],
-  ] as const)('maps worker type %s to provider %s', (workerType, expectedProvider) => {
-    const entries = [{
-      type: 'assistant',
-      timestamp: '2026-04-10T12:00:02.500Z',
-      message: { model: 'm', usage: { input_tokens: 1, output_tokens: 1 } },
-    }];
-    const events = collector.extractUsageEvents(entries, {
-      taskId, attempt, workerType, workerLocation, environment,
-    });
-    expect(events[0]?.request.provider).toBe(expectedProvider);
-  });
-});
+```
+packages/llm-pricing/src/httpInternalAuthUsageSink.ts
 ```
 
-> ⚠ DECISION NEEDED (resolved provisionally above): the llm-usage-service schema hardcodes
-> `PROVIDER_VALUES = Object.values(LlmProviders)` which contains only
-> `google|openai|anthropic|perplexity|openrouter`. There is no provider name that matches GLM,
-> Qwen, Kimi, MiniMax, or MiMo. **Provisional decision: map all Anthropic-compatible proxy
-> providers (i.e., any `WORKER_TYPES[*].apiBaseUrl` that exposes the `/v1/messages` endpoint) to
-> `'anthropic'`**, because the JSONL format and model names are Anthropic-shaped. The service's
-> pricing table will need entries for these model names (`glm-5`, `qwen3.5-plus`, `kimi-k2.5`,
-> `MiniMax-M2.7`, `mimo-v2-pro`) tagged under provider `anthropic`, or fall back to
-> `pricingSource: 'external'` with `billedUsd = 0`. **Confirm with the INT-1339 author before
-> merging.** If the pricing service needs distinct providers, an INT-1338-followup must extend
-> `LlmProviders` first.
->
-> Codex worker type (`codex`, `codex-xhigh`) is **skipped** by this extractor — Codex uses a
-> different runtime (`runtime: 'codex'`) that does not write the Claude JSONL format.
-> `extractUsageEvents` should return `[]` for Codex worker types and log an info message at the
-> call site. Add a test:
->
-> ```ts
-> it('returns empty array for codex worker type', () => {
->   const events = collector.extractUsageEvents(entries, { ...base, workerType: 'codex' });
->   expect(events).toEqual([]);
-> });
-> ```
-
-Run `pnpm --filter orchestrator test` — **all new tests must fail with "extractUsageEvents is
-not a function"** before you move to Phase 4.
-
-### Phase 4 — Implement `extractUsageEvents`
-
-Add a new public method on `TurnMetricsCollector` (in
-`turn-metrics-collector.ts`). Import the `UsageEventInput` type, the `LlmProviders` constant,
-and the `WORKER_TYPES` lookup.
-
+Config interface:
 ```ts
-import { createHash, createHmac } from 'node:crypto';
-import type { UsageEventInput } from '@intexuraos/internal-clients/usage-service';
-import { LlmProviders, type LlmProvider } from '@intexuraos/llm-contract';
-import { WORKER_TYPES, type WorkerType } from './isolation/types.js';
-
-export interface ExtractUsageEventsParams {
-  taskId: string;
-  attempt: number;
-  workerType: WorkerType;
-  workerLocation: string;
-  environment: 'dev' | 'prod' | 'test';
-}
-
-/**
- * Extract one UsageEventInput per JSONL entry that has `message.usage`.
- * Idempotent: the same (entries, params) input produces the same eventIds.
- * Returns [] for codex worker type (different runtime, not Claude JSONL).
- */
-extractUsageEvents(
-  entries: SessionEntry[],
-  params: ExtractUsageEventsParams,
-): UsageEventInput[] {
-  const workerTypeConfig = WORKER_TYPES[params.workerType];
-  if (workerTypeConfig.runtime !== 'claude') {
-    return [];
-  }
-
-  const provider = selectProvider(params.workerType);
-  const fallbackModel = workerTypeConfig.model ?? 'unknown';
-
-  const events: UsageEventInput[] = [];
-  for (let idx = 0; idx < entries.length; idx++) {
-    const entry = entries[idx];
-    /* v8 ignore next -- ts-type: noUncheckedIndexedAccess undefined narrowing */
-    if (entry === undefined) continue;
-    const usage = entry.message?.usage;
-    if (usage === undefined) continue;
-
-    const occurredAt = entry.timestamp ?? new Date().toISOString();
-    const model = entry.message?.model ?? fallbackModel;
-
-    const inputTokens = usage.input_tokens ?? 0;
-    const outputTokens = usage.output_tokens ?? 0;
-    const cacheReadTokens = usage.cache_read_input_tokens ?? 0;
-    const cacheWriteTokens = usage.cache_creation_input_tokens ?? 0;
-    const totalTokens = inputTokens + outputTokens + cacheReadTokens + cacheWriteTokens;
-
-    const eventId = deriveEventId({
-      taskId: params.taskId,
-      attempt: params.attempt,
-      entryIndex: idx,
-      timestamp: occurredAt,
-    });
-
-    events.push({
-      schemaVersion: 1,
-      eventId,
-      occurredAt,
-      owner: {
-        type: 'system',
-        id: `orchestrator:${params.taskId}`,
-      },
-      source: {
-        service: 'orchestrator',
-        component: 'turn-metrics-collector',
-        client: 'claude-code',
-        environment: params.environment,
-        workerLocation: params.workerLocation,
-      },
-      request: {
-        provider,
-        model,
-        operation: 'other',
-        success: true,
-        durationMs: 0,
-      },
-      usage: {
-        inputTokens,
-        outputTokens,
-        totalTokens,
-        cacheReadTokens,
-        cacheWriteTokens,
-        cachedTokens: 0,
-        reasoningTokens: 0,
-        thinkingTokens: 0,
-        webSearchCalls: 0,
-        groundingEnabled: false,
-        imageCount: 0,
-      },
-      cost: {
-        billedUsd: 0,
-        providerReportedUsd: null,
-        calculatedUsd: null,
-        pricingSource: 'calculated',
-      },
-      correlation: {
-        requestId: entry.message?.id ?? null,
-        traceId: null,
-        taskId: params.taskId,
-        researchId: null,
-        attempt: params.attempt,
-        sessionId: null,
-      },
-      error: null,
-    });
-  }
-  return events;
-}
-```
-
-Helper (file-scoped, below the class):
-
-```ts
-function deriveEventId(params: {
-  taskId: string;
-  attempt: number;
-  entryIndex: number;
-  timestamp: string;
-}): string {
-  const input = `${params.taskId}:${String(params.attempt)}:${String(params.entryIndex)}:${params.timestamp}`;
-  return createHash('sha256').update(input).digest('hex').slice(0, 24);
-}
-```
-
-`operation: 'other'` — Phase 1 can revise this to classify `stop_reason === 'tool_use'` as
-`'tool_calling'`, but the first version ships `'other'` for everything to minimize risk. **Do
-not change this without explicit user sign-off.**
-
-`durationMs: 0` — the JSONL does not record per-call latency. The service will need to aggregate
-across events; if we later want per-call duration we must hook `claude-log-processor.ts` on
-`type: result` and pair it with the preceding assistant entry, which is out of scope.
-
-### Phase 5 — Provider selection
-
-Add below the class:
-
-```ts
-function selectProvider(workerType: WorkerType): LlmProvider {
-  switch (workerType) {
-    case 'openrouter-free':
-      return LlmProviders.OpenRouter;
-    case 'opus':
-    case 'auto':
-    case 'sonnet':
-    case 'minimax':
-    case 'mimo-pro':
-    case 'glm':
-    case 'qwen':
-    case 'kimi':
-      // All use the Anthropic /v1/messages wire format (confirmed via WORKER_TYPES apiBaseUrl
-      // suffixes: /anthropic). Map to 'anthropic' so the event passes the schema's provider
-      // enum. Model name (e.g. 'glm-5') carries the disambiguation for the pricing table.
-      return LlmProviders.Anthropic;
-    case 'codex':
-    case 'codex-xhigh':
-      // Unreachable: runtime !== 'claude' check in extractUsageEvents short-circuits.
-      /* v8 ignore next -- auth-guard: codex worker types filtered out upstream @preserve */
-      return LlmProviders.OpenAI;
-  }
-}
-```
-
-Exhaustive switch — TypeScript will fail the build if a new worker type is added to
-`WORKER_TYPES` without updating this function. Do **not** add a `default` branch — that would
-defeat the compile-time safety net.
-
-### Phase 6 — Create the UsagePublisher service
-
-**New file:** `workers/orchestrator/src/services/usage-publisher.ts`
-
-```ts
-import type { Logger } from '@intexuraos/common-core';
-import type { UsageEventInput } from '@intexuraos/internal-clients/usage-service';
-import type { WebhookClient } from './webhook-client.js';
-
-export interface UsagePublisherConfig {
+export interface HttpInternalAuthUsageSinkConfig {
   usageServiceUrl: string;
-  orchestratorSecret: string;
-  enabled: boolean;
-}
-
-export class UsagePublisher {
-  constructor(
-    private readonly config: UsagePublisherConfig,
-    private readonly webhookClient: WebhookClient,
-    private readonly logger: Logger,
-  ) {}
-
-  async publishTurnUsage(params: {
-    taskId: string;
-    events: UsageEventInput[];
-  }): Promise<void> {
-    if (!this.config.enabled) {
-      this.logger.debug(
-        { taskId: params.taskId, count: params.events.length },
-        'UsagePublisher disabled by feature flag — skipping',
-      );
-      return;
-    }
-
-    if (params.events.length === 0) {
-      return;
-    }
-
-    const url = `${this.config.usageServiceUrl}/internal/webhooks/usage-events`;
-    const payload = {
-      schemaVersion: 1 as const,
-      events: params.events,
-    };
-
-    const result = await this.webhookClient.send({
-      url,
-      secret: this.config.orchestratorSecret,
-      payload,
-      taskId: params.taskId,
-    });
-
-    if (!result.ok) {
-      // WebhookClient.send() already queues non-4xx failures to pendingWebhooks.
-      // 4xx errors are permanent — schema mismatch, invalid provider, etc. — and must surface
-      // in logs loudly so we notice. Non-fatal by design: the turn metrics still landed.
-      this.logger.warn(
-        {
-          taskId: params.taskId,
-          errorType: result.error.type,
-          errorMessage: result.error.message,
-          eventCount: params.events.length,
-        },
-        'UsagePublisher delivery failed (non-fatal, may be queued)',
-      );
-      return;
-    }
-
-    this.logger.info(
-      { taskId: params.taskId, eventCount: params.events.length },
-      'Published per-call usage events to llm-usage-service',
-    );
-  }
-}
-```
-
-**Test file:** `workers/orchestrator/src/__tests__/usage-publisher.test.ts`
-
-Tests to include:
-
-- `publishTurnUsage` returns early when `enabled: false`, does not call `webhookClient.send`.
-- `publishTurnUsage` returns early when `events.length === 0`, does not call `webhookClient.send`.
-- `publishTurnUsage` calls `webhookClient.send` with the expected `url`, `payload`,
-  `taskId`, and `secret` when enabled and events are non-empty.
-- `publishTurnUsage` logs a warn (and does not throw) when `webhookClient.send` returns
-  `{ok: false, error: {type: '5xx', ...}}`.
-- `publishTurnUsage` logs a warn when the error is `4xx` (distinct from 5xx so we see the
-  "permanent schema error" signal separately).
-- `publishTurnUsage` logs an info with correct eventCount on success.
-
-Use a `FakeWebhookClient` implementing `{ send: vi.fn() }` — **do not** instantiate the real
-`WebhookClient`, which requires `StatePersistence`.
-
-### Phase 7 — Wire into `collectAndPublish`
-
-Update `TurnMetricsCollector` constructor signature and `collectAndPublish` method.
-
-1. Add `workerType` and `workerLocation` to `TurnMetricsCollectorConfig`:
-
-```ts
-export interface TurnMetricsCollectorConfig {
-  codeAgentUrl: string;
-  orchestratorSecret: string;
   internalAuthToken: string;
-  secretsBasePath: string;
-  sharedCredsPath?: string;
-  workerLocation: string;          // NEW — e.g. 'home-dev', 'mac-dev'
-  environment: 'dev' | 'prod' | 'test';  // NEW
+  service: string;
+  component: string;
+  logger: Logger;
 }
 ```
 
-2. Inject `UsagePublisher` as a constructor parameter:
+Implementation notes:
+- Same `UsageLogParams` → `UsageEventInput` mapping as `HttpWebhookUsageSink` (extract to a shared private `buildUsageEvent()` helper or inline — fine to duplicate given the files are in the same package).
+- POST to `${config.usageServiceUrl}/internal/usage/events` with `X-Internal-Auth: ${config.internalAuthToken}`.
+- Same non-fatal failure handling (warn and return).
 
+#### Step 2.3 — Export from `packages/llm-pricing/src/index.ts`
+
+Add:
 ```ts
-export class TurnMetricsCollector {
-  constructor(
-    private readonly config: TurnMetricsCollectorConfig,
-    private readonly logger: Logger,
-    private readonly usagePublisher?: UsagePublisher,  // optional for backward-compat in tests
-  ) {}
+export {
+  HttpInternalAuthUsageSink,
+  type HttpInternalAuthUsageSinkConfig,
+} from './httpInternalAuthUsageSink.js';
 ```
 
-3. Add `workerType` to `collectAndPublish` params:
+Run `pnpm run verify:workspace:tracked -- llm-pricing` — must stay green.
 
-```ts
-async collectAndPublish(params: {
-  taskId: string;
-  containerId: string;
-  attempt: number;
-  startedAt: string;
-  completedAt: string;
-  workerType: WorkerType;          // NEW
-}): Promise<void> {
-```
+---
 
-4. At the end of `collectAndPublish`, **after** the existing `await this.publish(metrics)` call
-   (currently line 133), add:
+### Phase 3 — code-agent: add `UsageServiceClient` to service container
 
-```ts
-      if (this.usagePublisher !== undefined) {
-        try {
-          // Re-read the entries — we don't plumb them out of parseSessionJsonl today.
-          // Cheapest fix: call parseSessionJsonl again? No — expensive I/O. Better:
-          // refactor parseSessionJsonl to return entries alongside timeClassification and tokens.
-          // See step 5 below.
-          const events = this.extractUsageEvents(sessionData.entries, {
-            taskId: params.taskId,
-            attempt: params.attempt,
-            workerType: params.workerType,
-            workerLocation: this.config.workerLocation,
-            environment: this.config.environment,
-          });
-          await this.usagePublisher.publishTurnUsage({
-            taskId: params.taskId,
-            events,
-          });
-        } catch (error) {
-          this.logger.warn(
-            { taskId: params.taskId, error },
-            'UsagePublisher extract/publish failed (non-fatal)',
-          );
-        }
-      }
-```
+**Goal:** Wire `createUsageServiceClient` into code-agent's DI container so the forwarding use case can call it.
 
-5. **Refactor `parseSessionJsonl`** to return `entries` alongside existing fields:
+#### Step 3.1 — Add env var to all three required locations
 
-```ts
-async parseSessionJsonl(...): Promise<{
-  entries: SessionEntry[];
-  timeClassification: TimeClassification;
-  tokens: TokenAggregation;
-}> {
-  // ... existing code ...
-  return {
-    entries,
-    timeClassification: this.classifyTime(entries),
-    tokens: this.aggregateTokens(entries),
-  };
-}
-```
+Per CLAUDE.md env-vars rule, a new env var requires changes in three files:
 
-Update existing tests that destructure `parseSessionJsonl` return — all currently call
-`result.tokens.*` and `result.timeClassification.*`, so adding a third field is additive.
+1. `apps/code-agent/src/index.ts` — add `'INTEXURAOS_LLM_USAGE_SERVICE_URL'` to `REQUIRED_ENV` array.
+2. `terraform/environments/dev/main.tf` — add `INTEXURAOS_LLM_USAGE_SERVICE_URL = "https://${local.services.llm_usage_service.name}-${local.cloud_run_url_suffix}"` to code-agent's service env block (the local value is already defined at line 310 and used by other services; just add it to code-agent's map).
+3. `ecosystem.config.cjs` — add `INTEXURAOS_LLM_USAGE_SERVICE_URL: 'http://localhost:8132'` to code-agent's PM2 `env` block.
 
-6. Update `task-dispatcher.ts` callers of `collectAndPublish` to pass `workerType: task.workerType`.
-   Grep for `collectAndPublish(` to find call sites — expected to be one location.
+#### Step 3.2 — Update `ServiceContainer` and `ServiceConfig`
 
-### Phase 8 — Env var plumbing
-
-The orchestrator's three-location pattern differs from standard apps because (a) it runs outside
-PM2 and (b) it is outside Terraform management. The actual three locations for this track:
-
-#### Location 1: `workers/orchestrator/src/start.ts`
-
-Add to the REQUIRED_ENV block near line 441–456:
-
-```ts
-const llmUsageServiceUrl = getRequiredEnv('INTEXURAOS_LLM_USAGE_SERVICE_URL');
-const workerLocation = getRequiredEnv('INTEXURAOS_WORKER_LOCATION');
-// environment: reuse existing or add a new required env
-const environment = getRequiredEnv('INTEXURAOS_ENVIRONMENT') as 'dev' | 'prod' | 'test';
-```
-
-Validate `environment` is one of the three allowed values; throw a precondition error otherwise
-(match the existing style that writes to stderr and `process.exit(1)`).
-
-Feature flag (non-required, default off):
-
-```ts
-const usagePublisherEnabled = getOptionalEnv('INTEXURAOS_USAGE_PUBLISHER_ENABLED', '0') === '1';
-```
-
-Wire the service construction after `webhookClient` is created:
-
-```ts
-const usagePublisher = new UsagePublisher(
-  {
-    usageServiceUrl: llmUsageServiceUrl,
-    orchestratorSecret,
-    enabled: usagePublisherEnabled,
-  },
-  webhookClient,
-  logger,
-);
-```
-
-Pass it into `TurnMetricsCollector`:
-
-```ts
-const turnMetricsCollector = new TurnMetricsCollector(
-  {
-    codeAgentUrl: config.codeAgentUrl,
-    orchestratorSecret: config.orchestratorSecret,
+In `apps/code-agent/src/services.ts`:
+- Add `usageServiceClient: UsageServiceClient` to `ServiceContainer` (not optional — all tests must provide it).
+- Add `llmUsageServiceUrl: string` to `ServiceConfig`.
+- In the factory function (wherever `setServices` is initialized from config), add:
+  ```ts
+  usageServiceClient: createUsageServiceClient({
+    baseUrl: config.llmUsageServiceUrl,
     internalAuthToken: config.internalAuthToken,
-    secretsBasePath,
-    sharedCredsPath,
-    workerLocation,
-    environment,
-  },
-  logger,
-  usagePublisher,
-);
+    logger,
+  }),
+  ```
+- Import `createUsageServiceClient` from `@intexuraos/internal-clients`.
+
+#### Step 3.3 — Update config loading
+
+In `apps/code-agent/src/config.ts` (or equivalent), add `llmUsageServiceUrl: string` field loaded from `process.env['INTEXURAOS_LLM_USAGE_SERVICE_URL']`.
+
+#### Step 3.4 — Update all `setServices()` calls in tests
+
+Search for every `setServices({` call in `apps/code-agent/src/__tests__/`:
+```
+Grep: pattern="setServices\(" path="apps/code-agent/src/__tests__"
+```
+Every call site must add `usageServiceClient: fakeUsageServiceClient`. Create a `fakeUsageServiceClient` helper in the test utilities (a minimal in-memory fake that records calls and returns `ok({ accepted: 1, duplicates: 0, rejected: [] })`).
+
+Run `pnpm run verify:workspace:tracked -- code-agent` after this step — expect TypeScript errors on the `setServices` call sites until all are updated.
+
+---
+
+### Phase 4 — code-agent: `forwardUsageEvents` use case
+
+#### Step 4.1 — Write a failing test first
+
+Create `apps/code-agent/src/__tests__/domain/usecases/forwardUsageEvents.test.ts`.
+
+Test matrix:
+- Happy path: `usageServiceClient.ingestEvents()` returns `ok(...)` → use case returns `ok(...)`.
+- Service error: `usageServiceClient.ingestEvents()` returns `err(...)` → use case returns `err(...)`.
+
+#### Step 4.2 — Implement `forwardUsageEvents.ts`
+
+Create `apps/code-agent/src/domain/usecases/forwardUsageEvents.ts`:
+
+```ts
+import type { Logger, Result } from '@intexuraos/common-core';
+import type { UsageServiceClient, UsageIngestRequest, UsageIngestResponse, UsageServiceError } from '@intexuraos/internal-clients';
+
+export interface ForwardUsageEventsDeps {
+  usageServiceClient: UsageServiceClient;
+  logger: Logger;
+}
+
+export async function forwardUsageEvents(
+  request: UsageIngestRequest,
+  deps: ForwardUsageEventsDeps
+): Promise<Result<UsageIngestResponse, UsageServiceError>> {
+  const result = await deps.usageServiceClient.ingestEvents(request);
+  if (!result.ok) {
+    deps.logger.error({ error: result.error }, 'Failed to forward usage events to llm-usage-service');
+    return result;
+  }
+  deps.logger.info(
+    { accepted: result.value.accepted, duplicates: result.value.duplicates },
+    'Usage events forwarded to llm-usage-service'
+  );
+  return result;
+}
 ```
 
-#### Location 2: `.envrc` (repo root + orchestrator host `.envrc`)
+Run the test from Step 4.1 — it must pass.
 
-Add (with a comment block):
+---
+
+### Phase 5 — code-agent: `internalUsageWebhookRoute`
+
+#### Step 5.1 — Write a failing test first
+
+Create `apps/code-agent/src/__tests__/routes/internalUsageWebhookRoute.test.ts`.
+
+Use `app.inject()` to POST to `/internal/webhooks/usage-events`.
+
+Test matrix:
+- Missing `X-Internal-Auth` → 401.
+- Valid `X-Internal-Auth` but missing `X-Request-Signature` → 401.
+- Valid `X-Internal-Auth` but invalid HMAC → 401.
+- Valid `X-Internal-Auth` + valid HMAC + valid body → 200 `{ success: true, data: { accepted: 1, duplicates: 0, rejected: [] } }`.
+- Valid auth but `usageServiceClient.ingestEvents()` returns error → 500.
+- Valid auth + valid body with zero events → 200 `{ success: true, data: { accepted: 0, duplicates: 0, rejected: [] } }`.
+
+For the HMAC tests, compute the expected signature as `HMAC-SHA256(orchestratorSecret, "${timestamp}.${body}")` in the test setup.
+
+#### Step 5.2 — Implement `internalUsageWebhookRoute.ts`
+
+Create `apps/code-agent/src/routes/internalUsageWebhookRoute.ts`:
+
+```ts
+import type { FastifyPluginCallback } from 'fastify';
+import { logIncomingRequest, validateInternalAuth } from '@intexuraos/common-http';
+import { validateOrchestratorSignature } from '../infra/webhookValidation.js';
+import { loadConfig } from '../config.js';
+import { getServices } from '../services.js';
+import { forwardUsageEvents } from '../domain/usecases/forwardUsageEvents.js';
+
+export const internalUsageWebhookRoute: FastifyPluginCallback = (fastify, _opts, done) => {
+  fastify.post('/internal/webhooks/usage-events', {
+    schema: { /* ... see below */ },
+  }, async (request, reply) => {
+    logIncomingRequest(request);
+
+    // Step 1: Validate X-Internal-Auth
+    const authResult = validateInternalAuth(request);
+    if (!authResult.valid) {
+      request.log.warn({ reason: authResult.reason }, 'Internal auth failed for usage-events webhook');
+      return reply.fail('UNAUTHORIZED', 'Internal authentication failed');
+    }
+
+    // Step 2: Validate orchestrator HMAC signature
+    const signatureResult = validateOrchestratorSignature(request, {
+      orchestratorSecret: loadConfig().orchestratorSecret,
+    });
+    if (!signatureResult.ok) {
+      request.log.warn({ error: signatureResult.error }, 'HMAC validation failed for usage-events webhook');
+      return reply.fail('UNAUTHORIZED', 'Unauthorized');
+    }
+
+    // Step 3: Forward to llm-usage-service
+    const { usageServiceClient, logger } = getServices();
+    const result = await forwardUsageEvents(request.body, { usageServiceClient, logger });
+    if (!result.ok) {
+      return reply.fail('INTERNAL_ERROR', result.error.message);
+    }
+
+    return reply.ok(result.value);
+  });
+
+  done();
+};
+```
+
+Schema for the route: body is `UsageIngestRequest` shape (`schemaVersion: 1`, `events: array`). Response 200 is `{ success: true, data: { accepted: number, duplicates: number, rejected: array } }`. Response 401 and 500 follow the standard error shape.
+
+**Note on `reply.fail` / `reply.ok`:** Use whatever reply helpers code-agent uses in existing routes (`webhookRoutes.ts` uses `reply.fail(code, message)` — use the same).
+
+#### Step 5.3 — Register the route
+
+In `apps/code-agent/src/server.ts` (or wherever routes are registered), add:
+```ts
+import { internalUsageWebhookRoute } from './routes/internalUsageWebhookRoute.js';
+// ...
+server.register(internalUsageWebhookRoute);
+```
+
+Run `pnpm run verify:workspace:tracked -- code-agent` — all tests must pass.
+
+---
+
+### Phase 6 — Orchestrator: swap `StructuredLogUsageSink` for `HttpWebhookUsageSink`
+
+#### Step 6.1 — Confirm orchestrator's env vars
+
+The orchestrator already reads at `workers/orchestrator/src/start.ts`:
+- `INTEXURAOS_CODE_AGENT_URL` (line 441)
+- `INTEXURAOS_ORCHESTRATOR_SECRET` (line 443)
+- `INTEXURAOS_INTERNAL_AUTH_TOKEN` (line 442)
+
+No new env vars needed for the orchestrator itself.
+
+#### Step 6.2 — Update `agent-compliance-validator.ts`
+
+In `workers/orchestrator/src/services/agent-compliance-validator.ts`, update the constructor or factory method that creates the client (around line 291):
+
+Before:
+```ts
+import { StructuredLogUsageSink } from '@intexuraos/llm-pricing';
+// ...
+usageSink: new StructuredLogUsageSink({ logger }),
+```
+
+After:
+```ts
+import { HttpWebhookUsageSink } from '@intexuraos/llm-pricing';
+// ...
+usageSink: new HttpWebhookUsageSink({
+  webhookUrl: `${config.codeAgentUrl}/internal/webhooks/usage-events`,
+  webhookSecret: config.orchestratorSecret,
+  internalAuthToken: config.internalAuthToken,
+  service: 'orchestrator',
+  component: 'agent-compliance-validator',
+  logger,
+}),
+```
+
+Where `config` is the object already available in scope (it contains `codeAgentUrl` and `orchestratorSecret` per `start.ts` wiring).
+
+#### Step 6.3 — Update `completion-verifier.ts`
+
+In `workers/orchestrator/src/services/completion-verifier.ts`, update the `createLlmClient` call (around line 800):
+
+Before:
+```ts
+import { StructuredLogUsageSink } from '@intexuraos/llm-pricing';
+// ...
+usageSink: new StructuredLogUsageSink({ logger: this.logger }),
+```
+
+After:
+```ts
+import { HttpWebhookUsageSink } from '@intexuraos/llm-pricing';
+// ...
+usageSink: new HttpWebhookUsageSink({
+  webhookUrl: `${this.config.codeAgentUrl}/internal/webhooks/usage-events`,
+  webhookSecret: this.config.orchestratorSecret,
+  internalAuthToken: this.config.internalAuthToken,
+  service: 'orchestrator',
+  component: 'completion-verifier',
+  logger: this.logger,
+}),
+```
+
+Verify that `CompletionVerifierConfig` (or its constructor) already holds `codeAgentUrl`, `orchestratorSecret`, and `internalAuthToken`. If not, thread them through from the `start.ts` wiring at lines 752-754.
+
+#### Step 6.4 — Verify orchestrator tests still pass
 
 ```bash
-# --- Track 2 (INT-1341): orchestrator → llm-usage-service webhook ---
-export INTEXURAOS_LLM_USAGE_SERVICE_URL="http://localhost:8132"  # dev default; override on home-dev
-export INTEXURAOS_WORKER_LOCATION="home-dev"                     # or 'mac-dev', 'office-pc'
-export INTEXURAOS_ENVIRONMENT="dev"
-export INTEXURAOS_USAGE_PUBLISHER_ENABLED="0"                    # flip to 1 after Phase 10 verification
+pnpm run verify:workspace:tracked -- orchestrator
 ```
 
-On home-dev, the `.envrc` at `~/` or wherever direnv loads is **the** source of truth. Confirm
-with `ssh home-dev 'direnv exec . printenv | grep INTEXURAOS_LLM_USAGE_SERVICE_URL'` after
-making the change.
+The orchestrator tests use `FakeWebhookClient` for webhook interactions. The new `HttpWebhookUsageSink` is tested separately in `packages/llm-pricing`. Orchestrator tests that construct `AgentComplianceValidator` or `CompletionVerifier` will need a stub `HttpWebhookUsageSink` (use `NoopUsageSink` or a test-specific `HttpWebhookUsageSink` with a `nock`-intercepted URL). If the existing tests pass `usageSink` as a constructor arg, swap them; if the sink is constructed internally, pass a `NoopUsageSink` via config or use `nock`.
 
-For prod orchestrator (future): `INTEXURAOS_LLM_USAGE_SERVICE_URL` should point to the Cloud Run
-URL of `llm-usage-service` (same value as
-`https://${local.services.llm_usage_service.name}-${local.cloud_run_url_suffix}` in
-`terraform/environments/dev/main.tf:310`).
+---
 
-#### Location 3: `terraform/environments/dev/main.tf` — documentation comment only
+### Phase 7 — Final verification
 
-The orchestrator is not a Terraform-managed service. Do **not** add the orchestrator to the
-Cloud Run service list. Do add a **comment** in the `common_service_env_vars` block noting that
-the orchestrator consumes `INTEXURAOS_LLM_USAGE_SERVICE_URL` from its host `.envrc` and must be
-kept in sync with the Cloud Run value:
-
-```hcl
-    INTEXURAOS_LLM_USAGE_SERVICE_URL            = "https://${local.services.llm_usage_service.name}-${local.cloud_run_url_suffix}"
-    # NOTE: orchestrator (workers/orchestrator) reads the same env var from its host .envrc on
-    # home-dev / mac-dev. Keep in sync — see workers/orchestrator/DEPLOYMENT.md.
+```bash
+pnpm run ci:tracked | tee /tmp/int-1341-final.txt
 ```
 
-**`ecosystem.config.cjs` is NOT touched** — orchestrator is not present in that file
-(verified by grep).
-
-### Phase 9 — Idempotency / eventId strategy
-
-Already covered inline in Phase 4's `deriveEventId`. Reasoning:
-
-- **Why include `taskId`:** isolates different tasks that happen to reuse the same attempt
-  number.
-- **Why include `attempt`:** the same `taskId` can have multiple retry attempts, each with its
-  own JSONL entries at the same index.
-- **Why include `entryIndex`:** the file may contain many entries with the same timestamp (they
-  are written at burst speed). Index disambiguates within a single file read.
-- **Why include `timestamp`:** guards against off-by-one errors in the index if the file is
-  re-read after new lines appended (adoption flow reads the file mid-flight).
-- **Why NOT include `message.id`:** confirmed-present fields are better than optional ones for a
-  primary key. If Phase 1 shows `message.id` is reliable, we can switch to
-  `sha256("${taskId}:${attempt}:${message.id}")` in a follow-up.
-- **Why `sha256(...).slice(0, 24)`:** llm-usage-service schema requires non-empty string; 24 hex
-  chars give 96 bits of entropy (birthday collision floor ≈ 2^48 entries, well above our
-  lifetime volume). Full 64-char hashes work too but bloat the payload.
-
-**Idempotency guarantee:** if the orchestrator restarts mid-turn, adopts a running container,
-and re-parses the JSONL file, it will produce the same eventIds → the service's dedup logic
-(INT-1339 Phase 2) returns `duplicates > 0` and `accepted` reflects only net-new events.
-
-### Phase 10 — Integration test against a real llm-usage-service in dev
-
-**Pre-condition:** Phase 1–9 complete, CI green, feature flag `INTEXURAOS_USAGE_PUBLISHER_ENABLED=1`
-set on one orchestrator instance (home-dev).
-
-1. Restart the orchestrator: `sudo systemctl restart code-orchestrator` (Linux) or
-   `launchctl kickstart -k gui/$(id -u)/com.intexuraos.orchestrator` (macOS).
-2. Verify the new env var was picked up:
-   ```bash
-   journalctl -u code-orchestrator -n 50 | grep -E 'INTEXURAOS_LLM_USAGE_SERVICE_URL|UsagePublisher'
-   ```
-   Expect a log line like `Starting orchestrator` followed by the service construction
-   succeeding (no precondition failures).
-3. Submit a trivial planning task via the web UI or `curl code-agent` — pick the smallest
-   possible task so the session has <5 assistant entries.
-4. Tail orchestrator logs and look for:
-   ```
-   Published per-call usage events to llm-usage-service (eventCount=N)
-   ```
-5. Query llm-usage-service for the events:
-   ```bash
-   curl -sS \
-     -H "X-Internal-Auth: $INTEXURAOS_INTERNAL_AUTH_TOKEN" \
-     -H "Content-Type: application/json" \
-     -d '{"timeRange":{"from":"2026-04-10T00:00:00Z","to":"2026-04-11T00:00:00Z"},"filters":{"services":["orchestrator"]}}' \
-     "$INTEXURAOS_LLM_USAGE_SERVICE_URL/internal/usage/query" | jq
-   ```
-   Expect `rows` count matching the number of assistant turns in the session and `totals.calls`
-   matching the `apiCallCount` from the turn metrics publish.
-6. Verify dedup: submit the same task again. The second submission creates a new session (fresh
-   taskId), so events should all be `accepted`, not `duplicates`. To test dedup specifically,
-   kill-and-restart the orchestrator mid-turn and confirm adoption reuses the same taskId — the
-   next `publishTurnUsage` call should have `duplicates > 0`.
-7. Verify `cost.billedUsd > 0` server-side: the service should compute cost from the pricing
-   table. If all events show `billedUsd = 0`, INT-1339 is missing pricing rows for that model —
-   file a blocker.
-8. Verify schema compliance: check for any `rejected` events in the webhook response logs on the
-   llm-usage-service side:
-   ```bash
-   gcloud logging read 'resource.type="cloud_run_revision" AND resource.labels.service_name="llm-usage-service" AND textPayload:"rejected"' \
-     --project=intexuraos-dev-pbuchman --limit=20 --format=json
-   ```
-   Any rejection with `code: 'FST_ERR_VALIDATION'` means the orchestrator sent a schema
-   violation — fix before flipping the flag globally.
-
-If any step fails, **revert the feature flag** (`INTEXURAOS_USAGE_PUBLISHER_ENABLED=0`) and
-restart. The orchestrator stays functional because the publisher is gated.
+Expected: zero failures across all workspaces. Verify:
+- `packages/llm-pricing` — new sink tests pass, coverage ≥ 95%.
+- `apps/code-agent` — new route tests pass, coverage ≥ 95%.
+- `workers/orchestrator` — no regressions.
 
 ---
 
 ## Test plan
 
-| File                                                                                 | What it covers                                                                                                                                                                                                                                                                                                                                              |
-| ------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `workers/orchestrator/src/__tests__/turn-metrics-collector.test.ts`                  | Extended with `describe('extractUsageEvents')` — all cases enumerated in Phase 3b (10+ tests). Covers empty entries, missing `message.usage`, all cache-token variants, missing `timestamp`, model fallback chain (`message.model` → `WORKER_TYPES[workerType].model` → `'unknown'`), deterministic eventId, codex early-return, provider selection switch. |
-| `workers/orchestrator/src/__tests__/usage-publisher.test.ts` (NEW)                   | `UsagePublisher.publishTurnUsage` — feature flag gate, empty events short-circuit, webhookClient invocation args, 4xx/5xx warn logs, success info log. Uses a `FakeWebhookClient` matching the interface.                                                                                                                                                   |
-| `workers/orchestrator/src/__tests__/fixtures/session-jsonl-sample.jsonl` (NEW)       | Golden JSONL sample matching Phase 1 verified shape. Loaded by turn-metrics-collector tests via `readFile` mock.                                                                                                                                                                                                                                            |
-| `workers/orchestrator/src/__tests__/turn-metrics-collector.test.ts` (existing tests) | Must continue to pass after adding `workerLocation`/`environment` to `TurnMetricsCollectorConfig`. Update the `const config` fixture at the top of the file to include the new required fields.                                                                                                                                                             |
-| `workers/orchestrator/src/__tests__/start.test.ts` (if it exists)                    | Add assertion that `INTEXURAOS_LLM_USAGE_SERVICE_URL` is required; missing value causes `process.exit(1)`. Likely skip this if the file is covered by `v8 ignore module-init` already.                                                                                                                                                                      |
+### `packages/llm-pricing`
 
-**Coverage goal:** 95% branch coverage on `extractUsageEvents`, `selectProvider`, and the full
-`UsagePublisher` class. The `codex` early-return branch in `extractUsageEvents` is covered by
-one test; the `workerType` switch in `selectProvider` is covered by the `it.each` table.
+| Test file                           | Scenario                                        | Coverage target                  |
+| ----------------------------------- | ----------------------------------------------- | -------------------------------- |
+| `httpWebhookUsageSink.test.ts`      | Successful POST, correct HMAC headers           | HMAC signing, body serialization |
+| `httpWebhookUsageSink.test.ts`      | 5xx response — non-fatal, logs warning          | Failure path                     |
+| `httpWebhookUsageSink.test.ts`      | Network error — non-fatal, logs warning         | Failure path                     |
+| `httpInternalAuthUsageSink.test.ts` | Successful POST, correct X-Internal-Auth header | Happy path                       |
+| `httpInternalAuthUsageSink.test.ts` | 5xx response — non-fatal, logs warning          | Failure path                     |
 
-**Run locally before PR:**
+### `apps/code-agent`
 
-```bash
-pnpm --filter orchestrator test
-pnpm run verify:workspace:tracked -- orchestrator
-pnpm run ci:tracked
-```
+| Test file                           | Scenario                                          | Coverage target  |
+| ----------------------------------- | ------------------------------------------------- | ---------------- |
+| `forwardUsageEvents.test.ts`        | `ingestEvents` returns ok → use case returns ok   | Happy path       |
+| `forwardUsageEvents.test.ts`        | `ingestEvents` returns err → use case returns err | Error path       |
+| `internalUsageWebhookRoute.test.ts` | Missing X-Internal-Auth → 401                     | Auth guard       |
+| `internalUsageWebhookRoute.test.ts` | Invalid HMAC → 401                                | HMAC guard       |
+| `internalUsageWebhookRoute.test.ts` | Valid auth + valid body → 200                     | Happy path       |
+| `internalUsageWebhookRoute.test.ts` | Valid auth + usageServiceClient error → 500       | Error path       |
+| `internalUsageWebhookRoute.test.ts` | Valid auth + empty events array → 200             | Edge case        |
 
 ---
 
 ## Rollout plan
 
-1. **Merge with flag OFF.** `INTEXURAOS_USAGE_PUBLISHER_ENABLED=0` is the default in `.envrc`.
-   Code ships dark. No behavior change.
-2. **Flip flag on home-dev only.** Edit home-dev's `.envrc`, restart orchestrator. Run Phase 10
-   integration test. Observe for 24 hours. Watch for: (a) increased 5xx from llm-usage-service,
-   (b) pendingWebhooks queue growth, (c) orchestrator memory growth, (d) unexpected `rejected`
-   events in llm-usage-service logs.
-3. **Flip flag on mac-dev (if applicable).** Same verification.
-4. **Flip flag globally** by changing the default in `.envrc.local.example` to `1` and updating
-   team onboarding docs.
-5. **After 1 week of stability**, remove the flag entirely: delete the
-   `INTEXURAOS_USAGE_PUBLISHER_ENABLED` check in `UsagePublisher.publishTurnUsage` and the env
-   var read in `start.ts`. File this cleanup as a separate small PR.
+Track 2 is pure additive — no existing behavior changes until the orchestrator deploys with `HttpWebhookUsageSink` active.
+
+1. **PR merge order:** `packages/llm-pricing` changes (Phases 1-2) must be built and published (or at least built in the monorepo) before the apps that import them. In this monorepo, `pnpm build` handles this — just ensure the build order is correct before opening the PR.
+2. **Deploy code-agent first.** The new `POST /internal/webhooks/usage-events` route is additive. Deploy code-agent with `INTEXURAOS_LLM_USAGE_SERVICE_URL` set. Verify the route returns 401 on an unsigned test request (smoke test).
+3. **Deploy orchestrator second.** Once code-agent is live with the webhook route, deploy the orchestrator with `HttpWebhookUsageSink`. On the next compliance validation or completion verification, a usage event will be POSTed.
+4. **Verify end-to-end.** Trigger a code task to completion (or run a manual compliance validation). Check `llm_usage_events` Firestore collection in `intexuraos-dev-pbuchman` — expect one event per LLM call with `source.service = 'orchestrator'`.
+5. **No rollback complexity.** The only observable change is: usage events from orchestrator start appearing in Firestore. If the webhook route or forwarding fails, `HttpWebhookUsageSink` logs a warning and returns — the orchestrator task continues. Zero user-visible impact on failure.
 
 ---
 
 ## Acceptance criteria
 
-- [ ] Phase 1 JSONL shape verification documented in PR body (model field location, GLM
-      deviation notes).
-- [ ] `extractUsageEvents` function produces valid `UsageEventInput[]` conforming to
-      `OrchestratorUsageEventInput` schema (checked against schema JSON in local Ajv test).
-- [ ] Deterministic `eventId` — two calls with the same input produce the same eventIds
-      (proven by unit test).
-- [ ] `collectAndPublish` invokes `UsagePublisher.publishTurnUsage` after the existing
-      `publish(metrics)` call, inside the same try/catch swallow-and-warn envelope.
-- [ ] `pnpm run ci:tracked` green.
-- [ ] `pnpm --filter orchestrator test` green with 95%+ branch coverage on new code.
-- [ ] `INTEXURAOS_LLM_USAGE_SERVICE_URL` is a hard REQUIRED_ENV in `start.ts`; missing value
-      causes precondition failure at startup.
-- [ ] `INTEXURAOS_USAGE_PUBLISHER_ENABLED=0` by default; the publisher is a no-op when disabled.
-- [ ] Phase 10 integration test passes on home-dev: events visible via
-      `/internal/usage/query`, `cost.billedUsd > 0` (requires INT-1339).
-- [ ] When `llm-usage-service` is down, the orchestrator does NOT crash — confirmed by fault-
-      injection test (temporarily point `INTEXURAOS_LLM_USAGE_SERVICE_URL` at a closed port).
-- [ ] PR title contains `INT-1341`; PR body contains `Fixes INT-1341`.
+- [ ] `packages/llm-pricing` exports `HttpWebhookUsageSink` and `HttpInternalAuthUsageSink`.
+- [ ] `POST /internal/webhooks/usage-events` on code-agent returns 401 for missing/invalid auth/HMAC.
+- [ ] `POST /internal/webhooks/usage-events` on code-agent returns 200 and forwards events to llm-usage-service for valid requests.
+- [ ] `agent-compliance-validator.ts` no longer imports `StructuredLogUsageSink`.
+- [ ] `completion-verifier.ts` no longer imports `StructuredLogUsageSink`.
+- [ ] `pnpm run ci:tracked` passes with zero failures.
+- [ ] A real or simulated compliance validation or completion verification produces a `llm_usage_events` document in Firestore with `source.service = 'orchestrator'`.
+- [ ] No new feature flags added.
+- [ ] `turn-metrics-collector.ts` is not modified.
 
 ---
 
-## Risks and mitigations
+## Risks
 
-| Risk                                                                          | Likelihood           | Impact                                                                                                                       | Mitigation                                                                                                                                                                                                   |
-| ----------------------------------------------------------------------------- | -------------------- | ---------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `message.model` field is absent from GLM/Qwen/Kimi JSONL                      | Medium               | Events tagged with fallback `WORKER_TYPES[*].model` (coarser granularity, model name still present)                          | Phase 1 verification; fallback chain `message.model → WORKER_TYPES.model → 'unknown'`                                                                                                                        |
-| Provider enum does not accept `dashscope`/`glm`/`minimax`                     | **High — confirmed** | Schema rejects entire batch with 400                                                                                         | Map to `'anthropic'` in `selectProvider`; **⚠ DECISION NEEDED**: coordinate with INT-1339 pricing table to list these models under provider `anthropic`, or extend `LlmProviders` enum in a prerequisite PR  |
-| Pending webhook queue grows unbounded during llm-usage-service outage         | Low                  | Disk growth; 24h TTL drops events                                                                                            | `WebhookClient.PENDING_WEBHOOK_TTL = 24h` (already implemented at `webhook-client.ts:22`); at high volume, the queue is in-memory + state file so the orchestrator can monitor `getPendingCount()` and alert |
-| Duplicate events on orchestrator restart + container adoption                 | Medium               | Inflated call counts server-side                                                                                             | Deterministic `eventId` — service dedups. Verified by Phase 10 step 6.                                                                                                                                       |
-| 15-minute HMAC replay window expires for pending-queue retries                | Medium               | Retries fail as `401 expired_signature`                                                                                      | `WebhookClient.retryPending` at `webhook-client.ts:131` regenerates `timestamp = Math.floor(now / 1000)` and re-signs — confirmed safe                                                                       |
-| Breaking the existing turn-metrics publish to `code-agent` during refactor    | Low                  | Lost turn metrics visibility                                                                                                 | `publishTurnUsage` is **additive** — the existing `this.publish(metrics)` call is unchanged and runs first; publisher runs after in its own try/catch                                                        |
-| `parseSessionJsonl` now returns a third field, breaks existing tests          | Low                  | Test failures                                                                                                                | Update the 2 existing `parseSessionJsonl` test assertions to destructure `{ entries, timeClassification, tokens }` — covered in Phase 7 step 5                                                               |
-| Env var missing on one host but not another → orchestrator crashes at startup | Medium               | Orchestrator down on that host                                                                                               | Use `getOptionalEnv` for the feature flag only. Use `getRequiredEnv` for `INTEXURAOS_LLM_USAGE_SERVICE_URL` so missing config is loud and fast                                                               |
-| Unknown model string (e.g. future Claude 5) fails pricing lookup              | Medium               | Cost stays 0 for those events                                                                                                | Service-side responsibility (INT-1339); orchestrator sends the raw model string and lets the service decide pricing-source fallback                                                                          |
-| I/O cost of re-reading JSONL                                                  | Low                  | Negligible — already read once per turn in `parseSessionJsonl`; the refactor returns `entries` so no additional read happens | N/A                                                                                                                                                                                                          |
-| Shipping without INT-1339 live                                                | **High**             | Events land but `cost.billedUsd` stays 0                                                                                     | Pre-flight check #1; feature flag default OFF protects against this                                                                                                                                          |
+| Risk                                                                                                          | Likelihood  | Mitigation                                                                                                                            |
+| ------------------------------------------------------------------------------------------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `HttpWebhookUsageSink` send failure causes orchestrator regression                                            | Low         | Non-fatal by design — failure is logged and swallowed, matching `StructuredLogUsageSink` semantics                                    |
+| `UsageLogParams` fields do not map cleanly to `UsageEventInput` (e.g., missing correlation fields)            | Low         | Verified at plan time: all required fields in `UsageEventInput` are either derivable from `UsageLogParams` or set to `null`/`0`       |
+| Code-agent `ServiceContainer` tests break because `usageServiceClient` is now required                        | Medium      | Fully mitigated in Phase 3.4 — all `setServices()` calls updated with a fake client before any code lands                             |
+| `CompletionVerifier` or `AgentComplianceValidator` config does not expose `codeAgentUrl`/`orchestratorSecret` | Low         | Verified at plan time: `start.ts` lines 561-563 and 752-754 pass both fields to both services                                         |
+| `INTEXURAOS_LLM_USAGE_SERVICE_URL` not set on home-dev code-agent process (PM2)                               | Medium      | Mitigated by adding to `ecosystem.config.cjs`; if process was already running, `pm2 restart code-agent` is needed after config update |
 
 ---
 
 ## Out of scope
 
-- **Streaming per-call events** (as they arrive in `claude-log-processor.ts`). Post-turn batch
-  only. Real-time streaming is INT-13xx-TBD follow-up.
-- **Backfill of historical sessions.** The orchestrator has `claude-session-*` directories
-  going back weeks — a one-off backfill script is out of scope. If needed, do it as a separate
-  `scripts/backfill-usage-events.ts` PR.
-- **Per-call operation detection** (tool_calling vs generate). All events use `operation:
-  'other'` until we have a use case that requires finer classification. Do not add
-  `stop_reason`-based classification speculatively.
-- **Modifying `code-agent/internal/turn-metrics`.** The existing summed-per-turn publish stays.
-  Track 2 is additive.
-- **Extending `LlmProviders` enum** to add `'zai'`, `'dashscope'`, etc. If Phase 1 shows this
-  is required, file a separate blocker issue under INT-1338 first.
-- **Per-event `durationMs`.** JSONL has no per-call latency. `durationMs: 0` is a known limitation.
-- **Per-event `owner.id` = real user ID.** The orchestrator does not have user context at the
-  turn-metrics collection point. `owner.id = "orchestrator:${taskId}"` is the best we can do
-  without plumbing user IDs through `code-agent → orchestrator → turn-metrics-collector`.
-- **Cloud Run deployment of the orchestrator.** Orchestrator remains a native Node.js process
-  on home-dev/mac-dev for this track.
-- **Deleting the feature flag.** Rollout plan step 5 files a separate cleanup PR after 1 week
-  of stability.
-
----
-
-## Summary of ⚠ DECISION NEEDED items
-
-1. **Phase 1 — GLM JSONL shape.** If GLM deviates from the Claude format, `extractUsageEvents`
-   must branch on `workerType`. Blocker on verification.
-2. **Phase 3/5 — Provider enum for non-Anthropic proxies.** Provisional decision: map all
-   Anthropic-compatible proxies (`minimax`, `mimo-pro`, `glm`, `qwen`, `kimi`) to
-   `LlmProviders.Anthropic`. Must be confirmed with INT-1339 author before merge, because it
-   implies the pricing table lists `glm-5` etc. under the `anthropic` provider column.
-3. **Phase 4 — Should `operation` classify `stop_reason === 'tool_use'` as `'tool_calling'`?**
-   Provisional decision: **No** — ship `'other'` first, revisit after a week of data.
-4. **Phase 9 — Use `message.id` (Anthropic request ID) as eventId input?** Provisional
-   decision: **No** — use the positional hash first because presence is guaranteed, revisit
-   when Phase 1 confirms `message.id` is always populated.
+- `workers/orchestrator/src/services/turn-metrics-collector.ts` — untouched.
+- JSONL session file parsing of any kind.
+- `UsagePublisher` class or any orchestrator-level batching abstraction.
+- Server-side cost calculation (Track 4 dropped it entirely; client-side `PricingContext` is sufficient).
+- Feature flag of any kind.
+- Changes to `llm-usage-service` ingest endpoint schema.
+- Migration of `FirestoreUsageSink` call sites in other services — that is Track 3 (INT-1342), which reuses `HttpInternalAuthUsageSink` from this track.
+- `INTEXURAOS_ORCHESTRATOR_SECRET` env var management — already present in orchestrator and code-agent.

--- a/docs/plans/INT-1342-track-3-firestore-migration.md
+++ b/docs/plans/INT-1342-track-3-firestore-migration.md
@@ -1,0 +1,856 @@
+# INT-1342 — Track 3: Migrate All Firestore LLM Usage Writers to HTTP
+
+## Status
+
+- Linear issue: **INT-1342**
+- Parent epic: **INT-1338** (LLM Usage Service Phase 2)
+- Dependencies:
+  - **INT-1341** (Track 2 — proves orchestrator HTTP publisher pattern against `/internal/usage/events`)
+  - **INT-1339** (Track 4 — server-side cost calc lands on `llm-usage-service`, so HTTP callers can omit `calculatedUsd`)
+- Blocks: nothing in this epic — this is the last track that touches Firestore writers.
+- Plan version: **1.0**
+
+## Executive summary
+
+Today every provider client in the monorepo (`infra-claude`, `infra-gpt`, `infra-gemini`, `infra-perplexity`, `infra-openrouter`) logs LLM usage by calling `createUsageLogger({ logger })`, which defaults to `FirestoreUsageSink` and writes directly to the `llm_usage_stats` collection. That collection is owned by the `llm-pricing` package (a package owning a collection is itself a CLAUDE.md architecture smell — see `firestore-collections.json` line 69), and its data is read by `app-settings-service`'s `FirestoreUsageStatsRepository` via `collectionGroup('by_user')` to drive the user cost dashboard. A second writer — `apps/code-agent/src/infra/firestore/userUsageFirestoreRepository.ts` — writes to the `user_usage` collection to enforce per-user rate limits and cost quotas in `rateLimitService`. A third writer — `packages/llm-audit/src/audit.ts` — writes full request/response bodies to `llm_api_logs`; it is explicitly **out of scope** for this track.
+
+After this track lands:
+
+1. The only process in the codebase that writes LLM usage aggregates is `apps/llm-usage-service` via its `POST /internal/usage/events` (internal) and `POST /webhooks/orchestrator-usage-event` (webhook) endpoints.
+2. `FirestoreUsageSink` is deleted. A new `HttpUsageSink` replaces it, built on top of `createUsageServiceClient` from `@intexuraos/internal-clients`.
+3. `app-settings-service`'s `FirestoreUsageStatsRepository` is replaced by an `HttpUsageStatsRepository` that calls `POST /internal/usage/query`. The `collectionGroup('by_user')` read path is retired.
+4. The `llm_usage_stats` collection is manually deleted only after a 7-day dual-write parity window with ≤0.1% mismatch.
+5. `code-agent`'s `user_usage` collection is retained as a **read-only cache** kept hot by a new fanout webhook, `POST /internal/webhooks/quota-update` on `code-agent`, which `llm-usage-service.ingestUsageEvents` fires whenever the `owner.id` matches a known code-agent user and the `source.service === 'code-agent'`. This is the recommended option but requires explicit approval — see `⚠ DECISION NEEDED: user_usage strategy` below.
+6. `firestore-collections.json` is updated: `llm_usage_stats` entry removed, `user_usage` ownership rewritten to `code-agent` with a note that it is a cache populated by `llm-usage-service` webhooks.
+
+Blast radius is huge: there are **41 files** touching `UsageLogger` across packages and apps, every one of the provider clients must change its factory wiring, every consuming app boots a `PricingContext` plus (after this track) an `HttpUsageSink` wired to `INTEXURAOS_LLM_USAGE_SERVICE_URL`, and an `app-settings-service` endpoint that users currently hit is being swapped out underneath them. A mistake here loses cost-tracking data, fails the monthly cost report, or — worst case — breaks `code-agent` rate limiting so one user can burn the whole monthly budget. The rollout plan treats this accordingly with a multi-week dual-write phase and an explicit human gate before collection deletion.
+
+## Pre-flight checks (run before starting Phase 1)
+
+1. **Verify INT-1341 is deployed and green.**
+   - Orchestrator events landing in `llm_usage_events` and `llm_usage_daily_aggregates` collections (check Firestore Studio on `intexuraos-dev-pbuchman`).
+   - `POST /webhooks/orchestrator-usage-event` error rate is <0.1% in dev for 24h.
+2. **Verify INT-1339 is deployed and green.**
+   - `llm-usage-service` `ingestUsageEvents` use case calculates `cost.calculatedUsd` server-side when the client omits it.
+   - Parity check between `cost.providerReportedUsd` and `cost.calculatedUsd` on live events is ≤0.5%.
+3. **Recount `UsageLogger` inventory.**
+   ```bash
+   rg "UsageLogger" apps/ packages/ --files-with-matches | wc -l
+   rg "createUsageLogger\(" apps/ packages/ -n
+   rg "FirestoreUsageSink" apps/ packages/ -n
+   ```
+   If the file count differs from the inventory in the next section, **update this plan before starting**. Drift means a new call site landed between planning and execution — audit it.
+4. **Confirm the env var is already set everywhere.**
+   ```bash
+   rg "INTEXURAOS_LLM_USAGE_SERVICE_URL" terraform/ ecosystem.config.cjs apps/
+   ```
+   Should return matches in `terraform/environments/dev/main.tf` (line ~310), `ecosystem.config.cjs` (line ~57), and — after Phase 3 — every consuming app's `REQUIRED_ENV`.
+5. **Sanity check `firestore-collections.json` hasn't drifted.** The current `llm_usage_stats` entry at line 69 says `"owner": "llm-pricing"`. If someone already changed this, stop and reconcile.
+
+## Complete writer inventory
+
+Verified by `rg "createUsageLogger\(" packages/ apps/` and `rg "FirestoreUsageSink" packages/ apps/` at plan time.
+
+### Primary: `FirestoreUsageSink` (via `UsageLogger` default)
+
+| #   | File                                                                       | Collection                                                         | Trigger                                    | Payload                            | Action                                                                                               |
+| --- | -------------------------------------------------------------------------- | ------------------------------------------------------------------ | ------------------------------------------ | ---------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| 1   | `packages/llm-pricing/src/usageLogger.ts:112` (`FirestoreUsageSink`)       | `llm_usage_stats/{model}/by_call_type/{callType}/by_period/{total\ | YYYY-MM\                                   | YYYY-MM-DD}` + `/by_user/{userId}` | Every LLM call via any provider client                                                               | `totalCalls`, `successfulCalls`, `failedCalls`, `inputTokens`, `outputTokens`, `totalTokens`, `costUsd`, provider+model metadata | **Delete** after Phase 7 |
+| 2   | `packages/llm-pricing/src/usageLogger.ts:314` (`UsageLogger.sink` default) | —                                                                  | —                                          | —                                  | Flip default to `HttpUsageSink` in Phase 6; drop the parameter entirely in Phase 7                   |
+| 3   | `packages/infra-claude/src/client.ts:94`                                   | via #1                                                             | Every `createClaudeClient(...)` call       | —                                  | Change to use HTTP sink via config (Phase 3)                                                         |
+| 4   | `packages/infra-gpt/src/client.ts:97`                                      | via #1                                                             | Every `createGptClient(...)`               | —                                  | Same                                                                                                 |
+| 5   | `packages/infra-gemini/src/client.ts:87`                                   | via #1                                                             | Every `createGeminiClient(...)`            | —                                  | Already accepts `usageSink?` — no signature change, just thread through the new sink from app config |
+| 6   | `packages/infra-gemini/src/toolCallingClient.ts:68`                        | via #1                                                             | Every `createGeminiToolCallingClient(...)` | —                                  | Already accepts `usageSink?` — thread through                                                        |
+| 7   | `packages/infra-perplexity/src/client.ts:222`                              | via #1                                                             | Every `createPerplexityClient(...)`        | —                                  | Change: add `usageSink?` to `PerplexityConfig` and thread through                                    |
+| 8   | `packages/infra-openrouter/src/client.ts:155`                              | via #1                                                             | Every `createOpenRouterClient(...)`        | —                                  | Already accepts `usageSink?` — thread through                                                        |
+
+### Secondary: `userUsageFirestoreRepository`
+
+| #   | File                                                                     | Collection            | Trigger                                                                                                                                                            | Payload                                                                                                                          | Action                                                                                                                                                                                                                                                                                                                           |
+| --- | ------------------------------------------------------------------------ | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 9   | `apps/code-agent/src/infra/firestore/userUsageFirestoreRepository.ts:14` | `user_usage/{userId}` | `rateLimitService.recordTaskStart/Complete` in `apps/code-agent/src/routes/codeRoutes.ts:1894,4543` and `apps/code-agent/src/domain/usecases/startAskAgent.ts:141` | `concurrentTasks`, `tasksThisHour`, `hourStartedAt`, `costToday`, `costThisMonth`, `dayStartedAt`, `monthStartedAt`, `updatedAt` | **See `⚠ DECISION NEEDED` below.** Default recommendation: keep `user_usage` as a read-only cache, hot-loaded by a `POST /internal/webhooks/quota-update` fanout webhook from `llm-usage-service`. Drop local `recordTaskStart` cost writes; keep `concurrentTasks` writes (that's a local ephemeral counter, not billing data). |
+
+### Explicitly OUT OF SCOPE: `llm_api_logs`
+
+| #   | File                                                     | Collection     | Trigger                                    | Payload                                                                                                                                | Action                                                                                                                                                                                                                       |
+| --- | -------------------------------------------------------- | -------------- | ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 10  | `packages/llm-audit/src/audit.ts` (`FirestoreAuditSink`) | `llm_api_logs` | Every LLM request (both success and error) | Full prompt, full response (or error), provider, model, method, token counts, `costUsd`, `durationMs`, optional `researchId`, `userId` | **No change.** Audit logs are a different concern from usage metrics — they store full prompts/responses for compliance and debugging. This track should not touch them. Track it separately if we ever want to consolidate. |
+
+### Final audit grep (Phase 10)
+
+Run these four queries at the end of Phase 10 — **all should return zero production hits**:
+
+```bash
+rg "firestore.*usage" apps/ packages/ -i        # old direct Firestore patterns
+rg "collection\(['\"]llm_usage_stats" apps/ packages/
+rg "\.set\(.*tokens" apps/ packages/
+rg "\.update\(.*costUsd" apps/ packages/
+```
+
+At plan time, these return: one hit in `app-settings-service/src/infra/firestore/usageStatsRepository.ts` (the READER — removed in Phase 8b), plus test fixtures in `packages/llm-pricing/src/__tests__/usageLogger.test.ts` (deleted in Phase 7). No other stragglers were found.
+
+## Decision matrix for `user_usage`
+
+This collection is **not** an LLM analytics aggregate — it is a **per-user quota enforcement state** used at task admission. Deleting it without a replacement breaks `code-agent` rate limiting. Three options:
+
+### Option (a) — Compute quota live via `POST /internal/usage/query`
+
+**How:** Delete `user_usage`. Every call to `rateLimitService.checkLimits(userId, promptLength)` issues `POST /internal/usage/query` with `{ timeRange: { from: startOfHour, to: now }, filters: { ownerIds: [userId], services: ['code-agent'] } }` and reads `totals.calls` / `totals.costUsd`.
+
+**Pros:**
+- Single source of truth (`llm_usage_events`). No cache invalidation.
+- Works immediately after INT-1341/INT-1339 without a new webhook.
+
+**Cons:**
+- Adds **~100–300 ms** latency to every `code-agent` task submission (2 Firestore aggregations + 1 HTTP hop + internal auth).
+- `llm-usage-service` becomes a hard dependency of `code-agent` admission. If it's down, we either block all code tasks or bypass quotas — both bad.
+- `concurrentTasks` is NOT aggregated in `llm_usage_events` (it's a live counter of in-flight tasks, not a sum of past events). We would still need SOME local state.
+- Query pattern (`ownerIds: [userId], services: ['code-agent']`) requires composite Firestore index support in `llm_usage_daily_aggregates` — currently exists, verified at plan time.
+
+### Option (b) — Keep `user_usage` as a read-only cache, updated by webhook fanout ⭐ RECOMMENDED
+
+**How:**
+- `code-agent` keeps `user_usage` but drops its own `costToday`/`costThisMonth` increments from `rateLimitService.recordTaskStart/recordActualCost`.
+- `code-agent` exposes a new endpoint: `POST /internal/webhooks/quota-update` (internal auth via `X-Internal-Auth`).
+- `llm-usage-service.ingestUsageEvents` — after a successful `createEvent` + `incrementAggregate` — does a non-blocking fanout: if `event.source.service === 'code-agent'` AND `event.owner.type === 'user'`, POST `{ userId, costDeltaUsd, dailyCostUsd, monthlyCostUsd, periodKey }` to `code-agent`.
+- `code-agent`'s webhook handler runs a Firestore transaction that increments `costToday` and `costThisMonth` on `user_usage/{userId}`, handling day/month window resets the same way `userUsageFirestoreRepository.recordTaskStart` does today.
+- `concurrentTasks` stays a local counter, written on task dispatch and decremented on completion. This is correct — it's not a billing aggregate.
+- `tasksThisHour` stays a local counter, bumped on `recordTaskStart` with hour-window reset. This is also correct — it's an admission counter, not a cost tracker.
+
+**Pros:**
+- Rate limit checks stay fast (single Firestore read).
+- Resilient to `llm-usage-service` outages: if the webhook fails, `code-agent`'s admission decisions still work — they'll just be slightly stale (already-admitted tasks won't reflect yet-to-land cost).
+- Preserves the existing `user_usage` read path — no changes needed in `rateLimitService.checkLimits`.
+
+**Cons:**
+- Adds a new endpoint, new webhook publisher wiring, new retry semantics.
+- Webhook fanout must be idempotent (we may get duplicate events from retries). Use `eventId` as dedup key in a Firestore doc like `user_usage/{userId}/processed_events/{eventId}`.
+- Two places to reason about quota: the cache and the events collection. If the cache drifts, the UX is wrong.
+
+### Option (c) — Dual-write `user_usage` indefinitely
+
+**How:** `code-agent` keeps calling `userUsageFirestoreRepository.recordTaskStart` AND emits a usage event to `llm-usage-service`. Both Firestore paths stay alive forever.
+
+**Pros:** Zero risk to quota enforcement.
+
+**Cons:** Eternal divergence. Violates the "one writer per collection" rule. Duplicates the data. No consolidation. Defeats the entire point of this epic.
+
+**Not recommended.** Document the rejection and move on.
+
+### ⚠ DECISION NEEDED: `user_usage` strategy
+
+**Default recommendation: Option (b) — cache kept hot by webhook fanout.**
+
+Rationale: it preserves admission-path latency, survives `llm-usage-service` outages, and still consolidates the source of truth to `llm_usage_events`. Option (a) adds a live HTTP dependency on the hot path, which we should not accept. Option (c) is a non-answer.
+
+**User must approve explicitly before starting Phase 8.** If the user picks Option (a) instead, Phase 8 swaps the `user_usage` repo implementation for an `HttpBackedUserUsageRepository` and Phase 9 deletes the `user_usage` collection entirely. If Option (c), cancel Phases 8–9 and document as a known issue.
+
+## Context files
+
+The implementer should read all of these before touching code. Paths are absolute.
+
+1. `/Users/p.buchman/personal/intexuraos-1/packages/llm-pricing/src/usageLogger.ts` — full file (422 lines). Pay attention to:
+   - `UsageSink` interface (line 105)
+   - `FirestoreUsageSink` class (lines 112–214) — this is being deleted
+   - `UsageLogger` class (lines 308–375) and its default `sink` fallback (line 314)
+   - `isUsageLoggingEnabled()` env flag (line 275) — preserve it
+2. `/Users/p.buchman/personal/intexuraos-1/packages/llm-pricing/src/index.ts` — public exports. After Phase 7, `FirestoreUsageSink` is no longer exported; `HttpUsageSink` takes its place.
+3. `/Users/p.buchman/personal/intexuraos-1/packages/llm-pricing/src/types.ts` — `LlmPricing` type (unrelated to usage, keep as-is).
+4. `/Users/p.buchman/personal/intexuraos-1/packages/llm-pricing/src/pricingClient.ts` — unrelated but good context on how `PricingContext` is initialized. Same pattern should be used for `HttpUsageSink` construction.
+5. `/Users/p.buchman/personal/intexuraos-1/packages/llm-audit/src/audit.ts` — read to confirm it is **not** touched.
+6. `/Users/p.buchman/personal/intexuraos-1/packages/infra-claude/src/client.ts:94` — example of provider client factory wiring.
+7. `/Users/p.buchman/personal/intexuraos-1/packages/infra-gpt/src/client.ts:97` — same pattern.
+8. `/Users/p.buchman/personal/intexuraos-1/packages/infra-gemini/src/client.ts:87` — already takes optional `usageSink`, use this as the template.
+9. `/Users/p.buchman/personal/intexuraos-1/packages/infra-gemini/src/toolCallingClient.ts:68` — also already takes `usageSink`.
+10. `/Users/p.buchman/personal/intexuraos-1/packages/infra-perplexity/src/client.ts:222` — does NOT take `usageSink`; add it.
+11. `/Users/p.buchman/personal/intexuraos-1/packages/infra-openrouter/src/client.ts:155` — already takes `usageSink`.
+12. `/Users/p.buchman/personal/intexuraos-1/packages/internal-clients/src/usage-service/client.ts` — reuse `createUsageServiceClient`. Note: it already has `ingestEvents(request, { traceId? })` which is exactly what `HttpUsageSink` needs.
+13. `/Users/p.buchman/personal/intexuraos-1/packages/internal-clients/src/usage-service/types.ts` — full event schema (`UsageEventInput`). `HttpUsageSink` must construct these from `UsageLogParams`.
+14. `/Users/p.buchman/personal/intexuraos-1/apps/code-agent/src/infra/firestore/userUsageFirestoreRepository.ts` — full file (229 lines).
+15. `/Users/p.buchman/personal/intexuraos-1/apps/code-agent/src/domain/services/rateLimitService.ts` — full file (101 lines). Understand what fields it actually reads from `user_usage` (only `concurrentTasks`, `tasksThisHour`, `costToday`).
+16. `/Users/p.buchman/personal/intexuraos-1/apps/code-agent/src/domain/ports/userUsageRepository.ts` — interface.
+17. `/Users/p.buchman/personal/intexuraos-1/apps/code-agent/src/domain/models/userUsage.ts` — `DEFAULT_LIMITS` + `ESTIMATED_COST_PER_TASK`.
+18. `/Users/p.buchman/personal/intexuraos-1/apps/llm-usage-service/src/domain/usecases/ingestUsageEvents.ts` — where the fanout webhook must be added.
+19. `/Users/p.buchman/personal/intexuraos-1/apps/app-settings-service/src/infra/firestore/usageStatsRepository.ts` — `FirestoreUsageStatsRepository` (the READER being replaced).
+20. `/Users/p.buchman/personal/intexuraos-1/apps/app-settings-service/src/routes/publicRoutes.ts:219` — the endpoint currently driven by the above reader.
+21. `/Users/p.buchman/personal/intexuraos-1/terraform/environments/dev/main.tf:310` — confirm `INTEXURAOS_LLM_USAGE_SERVICE_URL` is already set in `common_service_env_vars`.
+22. `/Users/p.buchman/personal/intexuraos-1/ecosystem.config.cjs:57` — same confirmation for PM2.
+23. `/Users/p.buchman/personal/intexuraos-1/firestore-collections.json:69` — current `llm_usage_stats` ownership entry.
+
+### Apps that use provider clients (the `services.ts` files to update)
+
+Verified by `rg "createClaudeClient|createGptClient|createGeminiClient|createPerplexityClient|createOpenRouterClient"` at plan time:
+
+| App                        | Services file / usage                                                                                                                                                                                        | Must update?                                                             |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------ |
+| `apps/research-agent`      | `src/infra/llm/ClaudeAdapter.ts`, `GeminiAdapter.ts`, `GptAdapter.ts`, `PerplexityAdapter.ts`, `OpenRouterAdapter.ts`, `InputValidationAdapter.ts`, `ContextInferenceAdapter.ts` — constructs clients inline | **YES** — add usageSink param to services.ts + pass through all adapters |
+| `apps/user-service`        | `src/infra/llm/LlmValidatorImpl.ts` — constructs clients inline per-validation                                                                                                                               | **YES**                                                                  |
+| `apps/linear-agent`        | `src/services.ts:79` — `createGeminiClient` in DI wiring                                                                                                                                                     | **YES**                                                                  |
+| `apps/hellscript-agent`    | `src/index.ts:38` — `createGeminiClient` at startup                                                                                                                                                          | **YES**                                                                  |
+| `apps/cron-agent`          | `src/index.ts` — creates a client                                                                                                                                                                            | **YES**                                                                  |
+| `apps/image-service`       | `src/infra/llm/GptPromptAdapter.ts`, `GeminiPromptAdapter.ts`, `src/infra/image/GoogleImageGenerator.ts`, `OpenAIImageGenerator.ts`                                                                          | **YES**                                                                  |
+| `apps/commands-agent`      | uses `llm-factory` wrapper; classifier tests mock `createUsageLogger`                                                                                                                                        | **YES** — `services.ts` constructs via `llm-factory`, trace the wrapping |
+| `apps/todos-agent`         | uses `llm-factory` wrapper                                                                                                                                                                                   | **YES**                                                                  |
+| `apps/data-insights-agent` | uses `llm-factory` wrapper                                                                                                                                                                                   | **YES**                                                                  |
+| `apps/calendar-agent`      | uses `llm-factory` wrapper                                                                                                                                                                                   | **YES** (verify)                                                         |
+| `apps/actions-agent`       | uses `llm-factory` wrapper                                                                                                                                                                                   | **YES** (verify)                                                         |
+| `apps/chat-agent`          | uses `llm-factory` wrapper                                                                                                                                                                                   | **YES** (verify)                                                         |
+| `apps/web-agent`           | uses `llm-factory` wrapper                                                                                                                                                                                   | **YES** (verify)                                                         |
+| `apps/code-agent`          | only uses `EmbeddingClient` + `TOOL_CALLING_PRICING` from `infra-gemini`                                                                                                                                     | **NO** — no `createUsageLogger` call sites (verified)                    |
+
+**Important:** `llm-factory` (if it exists as an app-level shared wrapper) must also be audited in Phase 3 — it may be the single funnel that constructs provider clients for many agents. If so, updating it updates them all at once. If it does not funnel all consumers, each agent's `services.ts` or adapter file needs individual treatment.
+
+## Endpoint changes
+
+### Modified
+
+- **`apps/llm-usage-service` — `POST /internal/usage/events`**
+  No API change. Internal behavior change: after `ingestUsageEvents` succeeds, fires a **non-blocking** fanout to `code-agent`'s `/internal/webhooks/quota-update` endpoint for events with `source.service === 'code-agent'` AND `owner.type === 'user'`. Fanout failures must be logged but must NOT roll back the original ingest (events are already safely stored and aggregated). (Only applies if **Option (b)** is chosen — gated on `⚠ DECISION NEEDED` above.)
+
+- **`apps/app-settings-service` — `GET /public/usage/costs` (current `publicRoutes.ts:219`)**
+  No API contract change. Internal behavior: `usageStatsRepository.getUserCosts(userId, days)` now delegates to `createUsageServiceClient(...).queryUsage({ timeRange, filters: { ownerIds: [userId] }, groupBy: ['day', 'model', 'operation'] })` and reshapes the response into the existing `AggregatedCosts` type. The response schema on the public endpoint stays identical so the web UI requires no changes.
+
+### Created
+
+- **`apps/code-agent` — `POST /internal/webhooks/quota-update`** (only if Option (b))
+  - Headers: `X-Internal-Auth: <INTEXURAOS_INTERNAL_AUTH_TOKEN>`
+  - Request body schema (validated by Fastify schema):
+    ```ts
+    {
+      eventId: string,       // idempotency key
+      userId: string,
+      occurredAt: string,    // ISO-8601
+      costDeltaUsd: number,  // positive or negative
+      periodKeys: { day: string, month: string }  // YYYY-MM-DD, YYYY-MM
+    }
+    ```
+  - Response: `{ success: true, applied: boolean }` (applied=false means duplicate eventId, already processed)
+  - Handler uses a Firestore transaction to:
+    1. Check `user_usage/{userId}/processed_events/{eventId}` existence — if present, return `applied: false`.
+    2. Read `user_usage/{userId}`. Reset day/month windows if current `periodKeys` don't match stored `dayStartedAt` / `monthStartedAt`.
+    3. Apply `costToday += costDeltaUsd`, `costThisMonth += costDeltaUsd`.
+    4. Write `user_usage/{userId}/processed_events/{eventId}` sentinel doc with a 7-day TTL (expiration via `receivedAt` field + scheduled cleanup).
+  - `logIncomingRequest()` is called at the top of the handler (CLAUDE.md architecture rule).
+
+### Removed
+
+- `FirestoreUsageSink` class and all its Firestore writes (Phase 7).
+- `apps/app-settings-service/src/infra/firestore/usageStatsRepository.ts` and its `collectionGroup('by_user')` query (Phase 8b).
+- `apps/code-agent/src/infra/firestore/userUsageFirestoreRepository.ts` `recordTaskStart(userId, estimatedCost)` and `recordActualCost(userId, actualCost, estimatedCost)` — the cost-writing parts are dropped. `incrementConcurrent`/`decrementConcurrent` survive because they manage live concurrent task count, not billing data. The `costToday`/`costThisMonth` fields on `user_usage` remain in the schema and are now populated ONLY via the webhook.
+
+### Unchanged
+
+- `apps/llm-usage-service` — `POST /webhooks/orchestrator-usage-event` (already added in INT-1341).
+- All `llm-audit` / `llm_api_logs` paths.
+- All `llm_pricing` Firestore collection paths (`settings/llm_pricing/providers`) — unrelated, owned by `app-settings-service`.
+
+## Step-by-step implementation
+
+### Phase 1 — Create `HttpUsageSink` (test-first)
+
+1.1. Create `packages/llm-pricing/src/httpUsageSink.ts`. Write the failing test FIRST at `packages/llm-pricing/src/__tests__/httpUsageSink.test.ts`:
+   - Test 1: given a fake `UsageServiceClient` and a `UsageLogParams`, `HttpUsageSink.log(params)` calls `client.ingestEvents` exactly once.
+   - Test 2: the `UsageIngestRequest` it builds has `schemaVersion: 1`, `events[0].owner.type === 'user'` when `userId` is non-empty, `'system'` when empty.
+   - Test 3: `events[0].request.operation` is mapped from `CallType` (`'research'` → `'research'`, `'generate'` → `'generate'`, `'image_generation'` → `'image_generation'`, `'tool_calling'` → `'tool_calling'`, `'visualization_insights'` → `'visualization_insights'`, `'visualization_vegalite'` → `'visualization_vegalite'`).
+   - Test 4: `events[0].usage` mirrors `params.usage.inputTokens` / `outputTokens` / `totalTokens`, zero-fills fields `NormalizedUsage` doesn't carry (`cacheReadTokens`, `cacheWriteTokens`, `cachedTokens`, `reasoningTokens`, `thinkingTokens`, `webSearchCalls`, `imageCount`), sets `groundingEnabled: false` unless callers pass it.
+   - Test 5: `events[0].cost.billedUsd === params.usage.costUsd`, `cost.providerReportedUsd === null`, `cost.calculatedUsd === null` (server calculates after INT-1339), `cost.pricingSource === 'external'` (client-side precomputed, now redundant but valid marker).
+   - Test 6: `events[0].eventId` is a fresh UUID per call; `occurredAt` is a valid ISO-8601 string.
+   - Test 7: on `client.ingestEvents` failure, `HttpUsageSink.log` rethrows — the outer `UsageLogger.log` catches and logs (same as `FirestoreUsageSink` failure handling).
+   - Test 8: `source.service`, `source.component`, `source.client`, `source.environment` must all be populated from the constructor deps. Wrong deps → the sink won't compile.
+   - Run all tests — they must all fail (file doesn't exist).
+
+1.2. Implement `HttpUsageSink`:
+   ```ts
+   export interface HttpUsageSinkDeps {
+     usageServiceClient: UsageServiceClient;
+     source: {
+       service: string;      // e.g., 'research-agent'
+       component: string;    // e.g., 'research-use-case'
+       client: string;       // e.g., 'claude' | 'gpt' | 'gemini' | ...
+       environment: 'dev' | 'prod' | 'test';
+     };
+   }
+
+   export class HttpUsageSink implements UsageSink {
+     constructor(private readonly deps: HttpUsageSinkDeps) {}
+
+     async log(params: UsageLogParams): Promise<void> {
+       const event: UsageEventInput = buildUsageEvent(params, this.deps.source);
+       const result = await this.deps.usageServiceClient.ingestEvents({
+         schemaVersion: 1,
+         events: [event],
+       });
+       if (!result.ok) {
+         throw new Error(`HttpUsageSink ingestEvents failed: ${result.error.code} ${result.error.message}`);
+       }
+     }
+   }
+   ```
+   Run tests — all green.
+
+1.3. Export `HttpUsageSink` and `HttpUsageSinkDeps` from `packages/llm-pricing/src/index.ts`.
+
+1.4. Run `pnpm run verify:workspace:tracked -- llm-pricing` — must pass with ≥95% branch coverage on the new file.
+
+### Phase 2 — Add dual-write capability (feature flag)
+
+This phase introduces a `DualWriteUsageSink` that writes to BOTH `FirestoreUsageSink` AND `HttpUsageSink`, gated by an env var `INTEXURAOS_USAGE_SINK_MODE` with values:
+
+- `firestore` (default for Phase 2–4) — `FirestoreUsageSink` only, current behavior
+- `dual` — `DualWriteUsageSink` (Firestore + HTTP, HTTP failures logged but not propagated)
+- `http` — `HttpUsageSink` only (target state for Phase 6 onward)
+
+2.1. Test-first: create `packages/llm-pricing/src/__tests__/dualWriteUsageSink.test.ts`:
+   - Test 1: calls both `primary.log()` and `secondary.log()`.
+   - Test 2: if `secondary.log()` throws, returns successfully (warning is logged via injected logger, primary is considered authoritative).
+   - Test 3: if `primary.log()` throws, propagates the error (since primary is still authoritative during dual-write).
+
+2.2. Implement:
+   ```ts
+   export class DualWriteUsageSink implements UsageSink {
+     constructor(private readonly deps: {
+       primary: UsageSink;
+       secondary: UsageSink;
+       logger: Logger;
+     }) {}
+
+     async log(params: UsageLogParams): Promise<void> {
+       // Run in parallel but handle failures independently
+       const secondaryPromise = this.deps.secondary.log(params).catch((error) => {
+         this.deps.logger.warn({ err: error }, 'Secondary usage sink failed during dual-write');
+       });
+       await this.deps.primary.log(params);
+       await secondaryPromise;
+     }
+   }
+   ```
+
+2.3. Add a factory helper `createUsageSinkFromEnv(deps)` in `packages/llm-pricing/src/usageSinkFactory.ts`:
+   ```ts
+   export function createUsageSinkFromEnv(deps: {
+     logger: Logger;
+     usageServiceClient: UsageServiceClient;
+     source: HttpUsageSinkDeps['source'];
+   }): UsageSink {
+     const mode = process.env['INTEXURAOS_USAGE_SINK_MODE'] ?? 'firestore';
+     switch (mode) {
+       case 'http':
+         return new HttpUsageSink({ usageServiceClient: deps.usageServiceClient, source: deps.source });
+       case 'dual':
+         return new DualWriteUsageSink({
+           primary: new FirestoreUsageSink(),
+           secondary: new HttpUsageSink({ usageServiceClient: deps.usageServiceClient, source: deps.source }),
+           logger: deps.logger,
+         });
+       case 'firestore':
+       default:
+         return new FirestoreUsageSink();
+     }
+   }
+   ```
+
+2.4. Export from `packages/llm-pricing/src/index.ts`. Add tests covering all three branches of the factory (including the default fallthrough for invalid values, which must log a warning and default to `firestore` to avoid accidental data loss).
+
+2.5. `pnpm run verify:workspace:tracked -- llm-pricing` — green.
+
+### Phase 3 — Wire `HttpUsageSink` into every consuming app
+
+For each app in the "Apps that use provider clients" table above, the edit is:
+
+(a) Add `INTEXURAOS_LLM_USAGE_SERVICE_URL` to `REQUIRED_ENV` in `apps/<app>/src/index.ts`.
+(b) In `apps/<app>/src/services.ts` (or the equivalent DI wiring):
+   - Import `createUsageServiceClient` from `@intexuraos/internal-clients`.
+   - Import `createUsageSinkFromEnv` from `@intexuraos/llm-pricing`.
+   - Construct `usageServiceClient` once at service bootstrap:
+     ```ts
+     const usageServiceClient = createUsageServiceClient({
+       baseUrl: process.env['INTEXURAOS_LLM_USAGE_SERVICE_URL']!,
+       internalAuthToken: process.env['INTEXURAOS_INTERNAL_AUTH_TOKEN']!,
+       logger,
+     });
+     ```
+   - Construct a `usageSink` with `source: { service: '<app-name>', component: '<use-case-name>', client: '<provider>', environment: process.env['INTEXURAOS_ENVIRONMENT'] as any }`.
+   - Pass `usageSink` into every `createClaudeClient`/`createGptClient`/`createGeminiClient`/`createPerplexityClient`/`createOpenRouterClient`/`createGeminiToolCallingClient` call via the new config field (see Phase 3.1 below).
+
+3.1. **Add `usageSink?` to provider client configs that don't already have it.**
+   - `packages/infra-claude/src/types.ts` — add `usageSink?: UsageSink` to `ClaudeConfig`.
+   - `packages/infra-gpt/src/types.ts` — add `usageSink?: UsageSink` to `GptConfig`.
+   - `packages/infra-perplexity/src/types.ts` — add `usageSink?: UsageSink` to `PerplexityConfig`.
+   - `packages/infra-gemini/src/types.ts` — already has `usageSink?` (verified).
+   - `packages/infra-openrouter/src/types.ts` — already has `usageSink?` (verified).
+   - Plumb the new field through the factory function:
+     ```ts
+     const usageLogger = createUsageLogger({
+       logger,
+       ...(usageSink !== undefined && { sink: usageSink }),
+     });
+     ```
+   - Test-first for each client that's gaining the new param: add a test like `client.test.ts:871` (openrouter's existing "passes custom usageSink to createUsageLogger" test) — verify the sink is threaded through.
+
+3.2. Apps to update (concrete edits):
+
+   **research-agent** (`apps/research-agent/src/services.ts` + all adapters in `src/infra/llm/`):
+   - Construct one `usageServiceClient` in `services.ts`.
+   - Construct one `usageSink` with `source: { service: 'research-agent', component: 'research', client: '<provider>', environment: ... }`.
+   - Thread through all six adapters (`ClaudeAdapter`, `GeminiAdapter`, `GptAdapter`, `PerplexityAdapter`, `OpenRouterAdapter`, `InputValidationAdapter`, `ContextInferenceAdapter`) — set `client` per adapter.
+   - Each adapter stores the sink in its constructor and passes it into `createXxxClient({ ..., usageSink })`.
+
+   **user-service** (`apps/user-service/src/infra/llm/LlmValidatorImpl.ts`):
+   - `LlmValidatorImpl` constructs client per-validation. Inject `usageSink` via its constructor from `initializeServices`.
+   - Each `createXxxClient` call in the file (six validators × two methods = twelve sites) passes `usageSink`.
+
+   **linear-agent** (`apps/linear-agent/src/services.ts:79`): single `createGeminiClient` call. Single edit.
+
+   **hellscript-agent** (`apps/hellscript-agent/src/index.ts:38`): single `createGeminiClient` call. Construct `usageServiceClient` + `usageSink` inline in `index.ts` right before the `createGeminiClient`.
+
+   **cron-agent** (`apps/cron-agent/src/index.ts`): same pattern.
+
+   **image-service** (`apps/image-service/src/infra/llm/GptPromptAdapter.ts:36`, `GeminiPromptAdapter.ts:36`, `src/infra/image/OpenAIImageGenerator.ts:52`, `GoogleImageGenerator.ts:53`):
+   - Add `usageSink` to the adapter constructors.
+   - `initializeServices(pricingContext)` in `apps/image-service/src/serviceFactory.ts:15` already takes `pricingContext` — extend to take `usageSink` too.
+   - `apps/image-service/src/index.ts:22` already has `INTEXURAOS_APP_SETTINGS_SERVICE_URL` in REQUIRED_ENV — add `INTEXURAOS_LLM_USAGE_SERVICE_URL` next to it.
+
+   **commands-agent, todos-agent, data-insights-agent, calendar-agent, actions-agent, chat-agent, web-agent**:
+   - These use `@intexuraos/llm-factory` as a wrapper. **Audit `llm-factory` in Phase 3.0 before touching these apps.** If `llm-factory.createLlmClient()` is the single funnel, modify it to accept (and thread through) a `usageSink` parameter. Then each app just passes its own sink into the factory once.
+   - If `llm-factory` does NOT exist or does NOT funnel all calls, treat each app like `linear-agent` above.
+
+3.3. Tests for each app's `services.ts` change:
+   - Add a test that verifies the `usageSink` reaches the provider client factory. Pattern: `vi.mock('@intexuraos/llm-pricing', ...)` → spy on `createUsageLogger` → assert it was called with `{ sink: <expected> }`.
+   - Existing tests in `apps/research-agent/src/__tests__/routes.test.ts` (and similar) use `FakePricingContext` — they should keep working because the new `usageSink` is an independent dependency.
+
+3.4. **Do not enable `INTEXURAOS_USAGE_SINK_MODE=dual` yet.** The env var stays unset (defaults to `firestore`) for this phase. All the code is wired, but at runtime it still behaves exactly like today.
+
+3.5. `pnpm run ci:tracked` — green.
+
+### Phase 4 — Deploy dual-write to dev, verify both paths work
+
+4.1. Deploy all touched apps to `dev.intexuraos.cloud` (PM2 reload).
+
+4.2. Flip the env var for ONE app first (`research-agent`) to `INTEXURAOS_USAGE_SINK_MODE=dual`.
+   - Update `apps/research-agent/src/index.ts` REQUIRED_ENV only if you want to make it required; otherwise leave as a runtime-opt-in.
+   - PM2 restart research-agent.
+
+4.3. Issue a known research request via the web UI. Verify:
+   - `llm_usage_stats/<model>/...` got a new entry (Firestore Studio).
+   - `llm_usage_events` got a new entry with matching `eventId`, `occurredAt`, `usage.inputTokens/outputTokens`, `cost.billedUsd`.
+   - `llm_usage_daily_aggregates/<day>-<service>-<model>` got the increment.
+   - Both sinks agree on token counts within exact equality (no floating point surprise; token counts are ints, cost is stored at 6-decimal precision in both paths after INT-1339).
+
+4.4. Repeat for each app one at a time, waiting 1h between flips to watch logs. Roll back any app that starts erroring in `HttpUsageSink`. Watch for:
+   - `llm-usage-service` 4xx responses (schema mismatch — the `HttpUsageSink` is building wrong payloads → fix).
+   - `llm-usage-service` 5xx responses (downstream issue — NOT a reason to flip all apps).
+   - Duplicate event warnings (dedupe is working — expected if you retry).
+
+4.5. Once all apps are in `dual` mode, move to Phase 5.
+
+### Phase 5 — Parity verification script
+
+5.1. Create `scripts/verify-llm-usage-parity.ts`:
+   - Accept `--from=YYYY-MM-DD --to=YYYY-MM-DD` args.
+   - For each day in range:
+     - Read `llm_usage_stats/{model}/by_call_type/{callType}/by_period/{day}` (sum across all models + call types).
+     - Read `llm_usage_daily_aggregates/{day}-*` (sum).
+     - Report: `{ day, firestoreTotal: { calls, inputTokens, outputTokens, costUsd }, httpTotal: { ... }, diffPct: { ... } }`.
+   - Fail with exit code 1 if any `diffPct > 0.1%`.
+   - Run both paths in parallel for efficiency.
+
+5.2. Add to CI as a manual `pnpm run verify:usage-parity --from=<yesterday> --to=<yesterday>` command (not gating — operator-run).
+
+5.3. Add a scheduled daily job (cron in `cron-agent` or manual operator run) that runs the script for "yesterday" and posts to a dev Slack channel on mismatch. This is the canary for the entire dual-write period.
+
+5.4. Run it on day 1, day 3, day 7 of the dev dual-write period. Document the results in this plan's rollout notes. **Do not proceed to Phase 6 until 7 consecutive days show ≤0.1% mismatch.**
+
+### Phase 6 — Flip default to HTTP-only (dev, then prod)
+
+6.1. In dev: flip all apps to `INTEXURAOS_USAGE_SINK_MODE=http` one at a time, 1h apart, watching logs.
+
+6.2. At this point `llm_usage_stats` is receiving zero writes from dev. Verify by watching the collection's write rate in Firestore Studio (should drop to 0 new docs per hour within 1h of the last flip).
+
+6.3. Repeat the parity script one more time (dev → 24h of http-only data → still should match the events path because the events path was already authoritative during dual-write).
+
+6.4. Repeat steps 6.1–6.3 in prod.
+
+### Phase 7 — Remove `FirestoreUsageSink` and `llm_usage_stats` writes
+
+Only do this AFTER Phase 6 is green in prod for 48h.
+
+7.1. Delete `packages/llm-pricing/src/usageLogger.ts` lines 112–214 (`FirestoreUsageSink` class) and the `COLLECTION_NAME = 'llm_usage_stats'` constant.
+
+7.2. Remove the `FirestoreUsageSink` export from `packages/llm-pricing/src/index.ts`.
+
+7.3. Change `UsageLogger` constructor default: instead of `this.sink = deps.sink ?? new FirestoreUsageSink()`, make `sink` a **required** dep. Update the type:
+   ```ts
+   constructor(deps: { logger: Logger; sink: UsageSink }) { ... }
+   ```
+   Update `createUsageLogger` similarly.
+
+7.4. Delete `DualWriteUsageSink` class and `createUsageSinkFromEnv`'s `'firestore'` and `'dual'` branches (or simplify the whole factory to just return `new HttpUsageSink(...)` directly — the env var `INTEXURAOS_USAGE_SINK_MODE` is retired).
+
+7.5. Delete `packages/llm-pricing/src/__tests__/usageLogger.test.ts` lines that reference `FirestoreUsageSink`, `mockFirestore.collection('llm_usage_stats')` (lines 227, 504 at plan time).
+
+7.6. Delete `packages/llm-pricing/src/usageLogger.test.ts` if it still exists (there are two test files at plan time — one in `src/` and one in `src/__tests__/` — audit and consolidate).
+
+7.7. Verify no imports of `FirestoreUsageSink` remain:
+   ```bash
+   rg "FirestoreUsageSink" apps/ packages/
+   ```
+   Only `docs/` should match now.
+
+7.8. Update docs: `docs/packages/llm-pricing/README.md` (lines 111, 130), `docs/packages/llm-pricing/agent.md` (lines 12, 31, 118) — replace `FirestoreUsageSink` references with `HttpUsageSink`.
+
+7.9. Update `scripts/verify-llm-architecture.ts` — it currently references `UsageLogger`; make sure its expectations still pass.
+
+7.10. `pnpm run ci:tracked` — green.
+
+7.11. Commit the removal as a separate PR from Phase 3–6 so the rollback story is clean.
+
+### Phase 8 — Handle `user_usage` per decision
+
+**Only proceed after the `⚠ DECISION NEEDED` above is answered by the user.**
+
+#### Phase 8a — if Option (b) (recommended) — webhook fanout
+
+8a.1. **In `apps/llm-usage-service`:** add a new `QuotaFanoutPublisher` service wired into the container.
+   - Port: `QuotaFanoutPublisher { publish(event: UsageEvent): Promise<void> }`.
+   - HTTP implementation posts to `${INTEXURAOS_CODE_AGENT_URL}/internal/webhooks/quota-update` with `X-Internal-Auth` header.
+   - Fan-out only if `event.source.service === 'code-agent' && event.owner.type === 'user'`.
+   - On failure: log at `warn` with `eventId`, do NOT throw. The events collection is the source of truth — the cache may just be stale until the next event.
+
+8a.2. Modify `apps/llm-usage-service/src/domain/usecases/ingestUsageEvents.ts`:
+   ```ts
+   export interface IngestUsageEventsDeps {
+     logger: Logger;
+     usageEventRepository: UsageEventRepository;
+     usageAggregateRepository: UsageAggregateRepository;
+     quotaFanoutPublisher: QuotaFanoutPublisher;  // NEW
+   }
+   ```
+   After the existing `accepted++` at line 71, add a fanout call:
+   ```ts
+   await deps.quotaFanoutPublisher.publish(fullEvent);
+   ```
+   Test-first: add a test verifying the fanout is called only for matching events, and that publisher failures don't affect the ingest response (failing publish → still accepted++).
+
+8a.3. Wire `quotaFanoutPublisher` into `apps/llm-usage-service/src/services.ts`.
+
+8a.4. **In `apps/code-agent`:** create `apps/code-agent/src/routes/internal/quotaUpdateRoutes.ts` — register `POST /internal/webhooks/quota-update`.
+   - Validate body with Fastify schema matching the contract above.
+   - Use `logIncomingRequest()` (CLAUDE.md rule).
+   - Call a new use case `applyQuotaUpdate(deps, params)` that lives in `apps/code-agent/src/domain/usecases/applyQuotaUpdate.ts`.
+   - Test-first: use case test for (a) first-time event applied, (b) duplicate eventId returns `applied: false`, (c) day-window reset when `periodKeys.day` changes.
+
+8a.5. Modify `apps/code-agent/src/infra/firestore/userUsageFirestoreRepository.ts`:
+   - Remove `recordTaskStart(userId, estimatedCost)` cost-write logic entirely. Keep the function (it still increments `tasksThisHour`), but delete the `costToday`/`costThisMonth` writes — those come from the webhook now.
+   - Remove `recordActualCost(userId, actualCost, estimatedCost)` entirely. `rateLimitService.recordTaskComplete` no longer calls it.
+   - Add a new method `applyCostDelta(eventId, userId, costDeltaUsd, periodKeys)` that is called by the new use case and does the transaction described in the "Created" section above.
+   - Update the `UserUsageRepository` port in `apps/code-agent/src/domain/ports/userUsageRepository.ts` to match.
+
+8a.6. Update `apps/code-agent/src/domain/services/rateLimitService.ts`:
+   - `recordTaskComplete(userId, actualCost?)` — drop the `actualCost` branch (`userUsageRepository.recordActualCost(...)`). The cost comes via webhook now. Keep the `decrementConcurrent`.
+   - Update tests in `apps/code-agent/src/__tests__/domain/services/rateLimitService.test.ts`.
+
+8a.7. Update all `mockServices.ts` / `helpers` test fakes that implement `UserUsageRepository` to reflect the new interface.
+
+8a.8. **Audit: does `code-agent` actually read `costToday`/`costThisMonth` anywhere for rate limit enforcement?**
+   - `rateLimitService.checkLimits` (lines 39–84) currently reads `concurrentTasks` and `tasksThisHour` — NOT `costToday` or `costThisMonth` (verified at plan time, they're only logged for debug).
+   - Conclusion: removing the local write path does NOT break any enforcement. The webhook keeps them accurate for display/analytics purposes only.
+
+8a.9. Update `ecosystem.config.cjs` — no change needed (env var already exists).
+
+8a.10. Update `terraform/environments/dev/main.tf` — `llm-usage-service` needs outbound access to `code-agent`'s internal URL. This should already be covered by `common_service_env_vars`, verify `INTEXURAOS_CODE_AGENT_URL` is in the llm-usage-service Cloud Run env.
+
+8a.11. Deploy, end-to-end test: submit a code task, wait for completion, verify `user_usage/{userId}.costToday` incremented by the right amount and `user_usage/{userId}/processed_events/{eventId}` sentinel exists.
+
+#### Phase 8b — Replace `FirestoreUsageStatsRepository` with HTTP
+
+This is needed regardless of Option (a)/(b)/(c) because `app-settings-service` still reads `llm_usage_stats` via `collectionGroup('by_user')` and after Phase 6 that collection has no writers.
+
+8b.1. Test-first: create `apps/app-settings-service/src/__tests__/infra/httpUsageStatsRepository.test.ts`.
+   - Test 1: `getUserCosts('user-123', 90)` calls `usageServiceClient.queryUsage` with the correct time range (now - 90 days → now), filters `{ ownerIds: ['user-123'] }`, groupBy `['day', 'model', 'operation']`.
+   - Test 2: maps `UsageQueryResponse` → existing `AggregatedCosts` shape (`totalCostUsd`, `totalCalls`, `monthlyBreakdown`, `byModel`, `byCallType`).
+   - Test 3: empty response maps to the empty shape (preserves the existing contract at `usageStatsRepository.ts:126`).
+   - Test 4: usage service error → throws (matches existing behavior).
+
+8b.2. Implement `apps/app-settings-service/src/infra/httpUsageStatsRepository.ts`:
+   ```ts
+   export class HttpUsageStatsRepository implements UsageStatsRepository {
+     constructor(private readonly deps: { usageServiceClient: UsageServiceClient }) {}
+
+     async getUserCosts(userId: string, days = 90): Promise<AggregatedCosts> {
+       const to = new Date().toISOString();
+       const from = new Date(Date.now() - days * 86400 * 1000).toISOString();
+       const result = await this.deps.usageServiceClient.queryUsage({
+         timeRange: { from, to },
+         filters: { ownerIds: [userId] },
+         groupBy: ['day', 'model', 'operation'],
+       });
+       if (!result.ok) throw new Error(`queryUsage failed: ${result.error.message}`);
+       return reshapeToAggregatedCosts(result.value);
+     }
+   }
+   ```
+
+8b.3. Wire `HttpUsageStatsRepository` into `apps/app-settings-service/src/services.ts`. Construct `usageServiceClient` at startup.
+
+8b.4. Add `INTEXURAOS_LLM_USAGE_SERVICE_URL` to `apps/app-settings-service/src/index.ts` REQUIRED_ENV.
+
+8b.5. Delete `apps/app-settings-service/src/infra/firestore/usageStatsRepository.ts` and its tests.
+
+8b.6. Update `apps/app-settings-service/src/infra/firestore/index.ts` — drop the `FirestoreUsageStatsRepository` export.
+
+8b.7. End-to-end test: hit `GET /public/usage/costs?days=30` as a logged-in user, verify the response shape matches what the web UI expects (spot-check `apps/web/src/` for the consumer).
+
+### Phase 9 — Update `firestore-collections.json`
+
+9.1. Remove the `llm_usage_stats` entry from `firestore-collections.json` (lines 69–72 at plan time).
+
+9.2. Update `user_usage` entry: set `owner` to `code-agent` (if not already), add a `notes` field explaining it is a cache written by `code-agent` and the `llm-usage-service` quota-update webhook (the cache pattern is a documented exception to the one-writer rule).
+   Example:
+   ```json
+   "user_usage": {
+     "owner": "code-agent",
+     "description": "Per-user rate limit counters and cost quota cache.",
+     "notes": "Cost fields (costToday, costThisMonth) are populated by the llm-usage-service quota-update webhook; concurrentTasks and tasksThisHour are populated locally by rateLimitService."
+   }
+   ```
+
+9.3. Run `pnpm run ci:tracked` — the firestore validation CI check should still pass.
+
+### Phase 10 — Final audit pass
+
+10.1. Run all five grep queries and confirm zero production hits:
+   ```bash
+   rg "FirestoreUsageSink|new FirestoreUsageSink" apps/ packages/src/
+   rg "llm_usage_stats" apps/ packages/src/
+   rg "firestore.*usage" apps/ packages/ -i | grep -v llm-usage-service | grep -v test
+   rg "collection\(['\"]llm_usage_stats" apps/ packages/
+   rg "\.set\(.*tokens" apps/ packages/ | grep -v test
+   rg "\.update\(.*costUsd" apps/ packages/ | grep -v test
+   ```
+
+10.2. Run full CI: `pnpm run ci:tracked` — must be green end-to-end.
+
+10.3. **MANUAL STEP (gated on explicit user approval):** delete the `llm_usage_stats` Firestore collection.
+   - Use `gcloud firestore bulk-delete --collection-ids=llm_usage_stats --project=intexuraos-dev-pbuchman` first on dev, confirm UI still works, then on prod.
+   - This is irreversible. Do it last, and only after the parity script has shown ≤0.1% mismatch for 7+ days AND Phase 6 has been live in prod for 7+ days.
+   - Record the deletion in the Linear issue as a comment with timestamps.
+
+## Test plan
+
+### Unit tests (must pass in CI before any deploy)
+
+- `packages/llm-pricing/src/__tests__/httpUsageSink.test.ts` — new file, see Phase 1.1 for the 8 test cases. 100% branch coverage.
+- `packages/llm-pricing/src/__tests__/dualWriteUsageSink.test.ts` — new file, 3 test cases.
+- `packages/llm-pricing/src/__tests__/usageSinkFactory.test.ts` — new file, 4 branches (`firestore`, `dual`, `http`, invalid-fallback).
+- Provider client test updates:
+  - `packages/infra-claude/src/__tests__/client.test.ts` — add test that `usageSink` is passed through to `createUsageLogger`.
+  - `packages/infra-gpt/src/__tests__/client.test.ts` — same.
+  - `packages/infra-perplexity/src/__tests__/client.test.ts` — same.
+  - (gemini, openrouter already have this test pattern — verify it still passes.)
+- `apps/app-settings-service/src/__tests__/infra/httpUsageStatsRepository.test.ts` — new file, 4 test cases plus shape reshape coverage.
+- `apps/code-agent/src/__tests__/domain/usecases/applyQuotaUpdate.test.ts` — new file (Option b), 5 test cases: first-apply, duplicate dedupe, day reset, month reset, concurrent-safe transaction.
+- `apps/code-agent/src/__tests__/routes/quotaUpdateRoutes.test.ts` — integration test: valid body → 200, missing auth → 401, invalid schema → 400, duplicate → 200 with `applied: false`.
+- `apps/llm-usage-service/src/__tests__/domain/usecases/ingestUsageEvents.test.ts` — update to cover the new fanout publisher call.
+
+### Integration tests
+
+- Dev environment end-to-end: submit a research request, verify both `llm_usage_stats` (Phase 4 during dual-write) and `llm_usage_events` receive the data. After Phase 6, verify only `llm_usage_events`.
+- Dev environment end-to-end: submit a code task, verify `user_usage` is updated by the webhook (Option b).
+
+### Operator tests (manual, gated on rollout)
+
+- **Daily parity check** — Phase 5 parity script running for 7 days in dev, 7 days in prod, before moving to Phase 7 and then deleting the collection.
+
+### Coverage requirements
+
+- 95% branch coverage on all new files (`httpUsageSink.ts`, `dualWriteUsageSink.ts`, `usageSinkFactory.ts`, `applyQuotaUpdate.ts`, `quotaUpdateRoutes.ts`, `httpUsageStatsRepository.ts`, `quotaFanoutPublisher.ts`).
+- No new `v8 ignore` comments unless blocked by a documented test infrastructure limitation (see `.claude/reference/coverage-exemptions.md`).
+
+## Rollout plan
+
+This is the highest-risk track of the epic. Rollout is deliberately slow.
+
+**Week 0 (code complete, Phase 1–3 merged):**
+- All apps wired with the new sink factory. `INTEXURAOS_USAGE_SINK_MODE` unset everywhere → runtime behavior = today.
+- Parity script exists and is runnable but idle (will show 100% Firestore vs 0% HTTP, expected).
+
+**Week 1 (dev dual-write starts):**
+- Day 1: flip `research-agent` in dev to `INTEXURAOS_USAGE_SINK_MODE=dual`. Watch logs for 2h.
+- Day 2: flip `user-service`, `image-service`, `linear-agent`.
+- Day 3: flip remaining apps (`hellscript-agent`, `cron-agent`, agents using `llm-factory`).
+- Day 4: run parity script. Should be ≤0.1%.
+- Day 5–7: run parity daily. Alert the user if mismatch >0.1%.
+
+**Week 2 (prod dual-write):**
+- Day 1: flip one prod app (lowest-traffic first — `hellscript-agent` or `cron-agent`). Watch for 24h.
+- Day 2–3: flip remaining prod apps.
+- Day 4–7: parity script daily.
+
+**Week 3 (prod dual-write stabilization):**
+- 7 consecutive days of ≤0.1% mismatch in prod before proceeding.
+- Phase 8b (swap `app-settings-service` reader) lands at the end of this week — it's safe because both writers are populating their data stores.
+
+**Week 4 (dev HTTP-only):**
+- Flip all dev apps to `INTEXURAOS_USAGE_SINK_MODE=http`. `llm_usage_stats` in dev stops receiving writes.
+- Monitor `llm-usage-service` error rate. Must stay <0.1%.
+
+**Week 5 (prod HTTP-only):**
+- Flip all prod apps to `http`.
+- 48h soak.
+
+**Week 6 (code removal):**
+- Phase 7 PR: remove `FirestoreUsageSink`, flip `UsageLogger.sink` to required, delete the feature-flag env var.
+- Phase 8a PR (if Option b): webhook fanout end-to-end.
+
+**Week 7 (collection deletion — HUMAN-GATED):**
+- Operator confirms parity history and approves deletion.
+- Delete `llm_usage_stats` from dev. Verify `app-settings-service` dashboard still works (because Phase 8b already swapped the reader).
+- Delete `llm_usage_stats` from prod.
+- Update `firestore-collections.json`.
+
+## Acceptance criteria
+
+All of these must be true before marking INT-1342 as Done:
+
+- [ ] `rg "FirestoreUsageSink" apps/ packages/src/` returns **0** matches (docs excluded).
+- [ ] `rg "llm_usage_stats" apps/ packages/src/` returns **0** matches (docs excluded).
+- [ ] `rg "new FirestoreUsageSink\|FirestoreUsageSink()" apps/ packages/src/` returns **0** matches.
+- [ ] `UsageLogger` constructor no longer accepts an optional `sink` — it's required.
+- [ ] All consuming apps boot with `INTEXURAOS_LLM_USAGE_SERVICE_URL` in their `REQUIRED_ENV`. `validateRequiredEnv` fails fast if missing.
+- [ ] `apps/app-settings-service` uses `HttpUsageStatsRepository` (not `FirestoreUsageStatsRepository`). `FirestoreUsageStatsRepository` is deleted.
+- [ ] (Option b) `POST /internal/webhooks/quota-update` exists on `code-agent`. `llm-usage-service.ingestUsageEvents` fans out to it for matching events.
+- [ ] (Option b) `apps/code-agent/src/infra/firestore/userUsageFirestoreRepository.ts` no longer has `recordActualCost`. `recordTaskStart` no longer writes `costToday`/`costThisMonth`.
+- [ ] `firestore-collections.json` has `llm_usage_stats` removed, `user_usage` updated with cache notes.
+- [ ] Parity script showed ≤0.1% mismatch for 7+ consecutive days in prod before collection deletion.
+- [ ] `llm_usage_stats` Firestore collection deleted in both dev and prod (manual step, logged in Linear).
+- [ ] `pnpm run ci:tracked` passes at every commit in the PR chain. No `v8 ignore` entries added without documented justification in the coverage-exemptions reference.
+- [ ] All existing tests that referenced `FirestoreUsageSink` / `mockFirestore.collection('llm_usage_stats')` are updated or deleted.
+- [ ] Docs updated: `docs/packages/llm-pricing/README.md`, `docs/packages/llm-pricing/agent.md`, `docs/packages/llm-pricing/technical-debt.md`, `docs/services/app-settings-service/technical.md`.
+
+## Risks and mitigations
+
+| #   | Risk                                                                                                                                                                                             | Likelihood | Impact | Mitigation                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | **Data loss during migration** — some writes land in Firestore but not HTTP, or vice versa, during dual-write.                                                                                   | M          | H      | Parity script run daily during Phases 4–6. Alert >0.1% mismatch. Rollback is trivial because both paths stay alive during dual-write.                                                                                                                                                                                                                                                                                       |
+| 2   | **`code-agent` rate limiting breaks** — the `user_usage` migration leaves an edge case where `costToday` stops updating and users can over-spend.                                                | M          | H      | Option (b) webhook design keeps the cache hot. `rateLimitService.checkLimits` does NOT read `costToday`/`costThisMonth` today (verified — they're only in the debug log), so correctness isn't at risk, only observability. Still: Phase 8 has dedicated integration tests.                                                                                                                                                 |
+| 3   | **`llm-usage-service` becomes a single point of failure** — if it's down, dev environment loses usage tracking.                                                                                  | L          | M      | HTTP sink failures are logged but not propagated to the caller — LLM requests still succeed, usage is just unlogged. Events can be backfilled from `llm_api_logs` (still on Firestore) if the outage is recorded.                                                                                                                                                                                                           |
+| 4   | **Audit coverage of 41+ call sites incomplete** — we miss a writer and it keeps writing to `llm_usage_stats` after deletion, causing runtime crashes.                                            | M          | H      | Phase 10 final audit with 5 grep queries. Staging the deletion after 7 days of HTTP-only operation means any missed writer will surface in logs (it'll try to write to a non-existent collection — Firestore accepts this silently, which is the actual danger). Mitigation: after Phase 6 in dev, manually delete `llm_usage_stats` in dev FIRST and watch for crashes in the subsequent 72h. If no crashes, prod is safe. |
+| 5   | **Webhook fanout infinite loop** — llm-usage-service fires webhook → code-agent processes → (if code-agent itself is a provider client consumer) → triggers another usage event → infinite loop. | L          | H      | Code-agent does NOT use provider clients via `createUsageLogger` (verified: only imports `EmbeddingClient` and `TOOL_CALLING_PRICING` from `infra-gemini`). The fanout only fires for `source.service === 'code-agent'`, and code-agent itself doesn't produce those events. Defense-in-depth: rate-limit the fanout endpoint at 10 req/s per userId.                                                                       |
+| 6   | **Event schema drift** — `HttpUsageSink` builds events with wrong types after an `UsageEventInput` type update in `internal-clients`.                                                            | M          | M      | `internal-clients` tests catch type mismatches at compile time (`tsc`). `HttpUsageSink` unit tests validate the shape at runtime. Phase 4 dev deploy catches real mismatches.                                                                                                                                                                                                                                               |
+| 7   | **`INTEXURAOS_USAGE_SINK_MODE` accidentally misconfigured** — e.g., typo `htttp` → factory falls through to default.                                                                             | L          | M      | Factory logs a warning on unknown values; add a test for this branch. Also: rollout plan flips apps ONE AT A TIME so a bad flip is caught before spreading.                                                                                                                                                                                                                                                                 |
+| 8   | **Cost delta in webhook is stale** — `llm-usage-service` retries a failed ingest and the second attempt fans out a duplicate update.                                                             | M          | M      | `POST /internal/webhooks/quota-update` is idempotent via `eventId` sentinel doc. Duplicate calls return `applied: false`.                                                                                                                                                                                                                                                                                                   |
+| 9   | **Web UI for user costs breaks** — `app-settings-service` public endpoint response shape changes when swapping the reader.                                                                       | L          | H      | Phase 8b reshapes the HTTP response to match the existing `AggregatedCosts` contract EXACTLY. Test in phase 8b.7 verifies against the web consumer.                                                                                                                                                                                                                                                                         |
+| 10  | **Firestore composite index missing** — `queryUsage({ ownerIds, services })` needs an index that wasn't created.                                                                                 | L          | M      | Pre-flight: verify the daily aggregate repo supports this query pattern. If not, add an index migration in `migrations/*.mjs` BEFORE Phase 8b (phase dependency).                                                                                                                                                                                                                                                           |
+
+## Out of scope
+
+- **`llm_api_logs`** — The audit trail (`packages/llm-audit`) stays on direct Firestore writes. It stores full prompts/responses, which `llm-usage-service` is not designed to hold. Consolidating audit is a separate concern, maybe a future Phase 3 of this epic.
+- **User-facing migration notifications** — No user-visible change. The `app-settings-service` endpoint contract is preserved.
+- **Historical backfill** — Existing `llm_usage_stats` data is NOT migrated into `llm_usage_events`. The parity script only checks overlap on new writes. Historical dashboards (>90 days) will show a discontinuity. If this is unacceptable, a one-shot migration script is a separate ticket (estimate: 1–2 days).
+- **Orchestrator / worker events** — already handled by INT-1341. This track only touches app-side writers.
+- **Pricing lookup** — `PricingContext` and `fetchAllPricing` are untouched. They still talk to `app-settings-service`. Unrelated.
+- **Changing the public API of `app-settings-service`** — the only internal change is the data source, not the contract.
+- **Deleting `user_usage` entirely** — Option (a) would do this, but we're defaulting to Option (b) which keeps the collection as a cache. Only revisit if Option (a) is approved.
+
+---
+
+## Appendix A — `UsageEventInput` construction from `UsageLogParams`
+
+For the test suite in Phase 1.1, this is the exact mapping `HttpUsageSink.buildUsageEvent` must implement:
+
+```ts
+function buildUsageEvent(
+  params: UsageLogParams,
+  source: HttpUsageSinkDeps['source'],
+): UsageEventInput {
+  const now = new Date();
+  return {
+    schemaVersion: 1,
+    eventId: randomUUID(),
+    occurredAt: now.toISOString(),
+    owner: params.userId !== ''
+      ? { type: 'user', id: params.userId }
+      : { type: 'system', id: source.service },
+    source: {
+      service: source.service,
+      component: source.component,
+      client: source.client,
+      environment: source.environment,
+    },
+    request: {
+      provider: params.provider,
+      model: params.model,
+      operation: mapCallTypeToOperation(params.callType),
+      success: params.success,
+      durationMs: 0,  // UsageLogger doesn't track this; Track 4 adds server-side timing
+    },
+    usage: {
+      inputTokens: params.usage.inputTokens,
+      outputTokens: params.usage.outputTokens,
+      totalTokens: params.usage.inputTokens + params.usage.outputTokens,
+      cacheReadTokens: 0,    // NormalizedUsage doesn't carry these
+      cacheWriteTokens: 0,
+      cachedTokens: 0,
+      reasoningTokens: 0,
+      thinkingTokens: 0,
+      webSearchCalls: params.usage.webSearchCalls ?? 0,
+      groundingEnabled: false,
+      imageCount: 0,
+    },
+    cost: {
+      billedUsd: params.usage.costUsd,
+      providerReportedUsd: null,
+      calculatedUsd: null,
+      pricingSource: 'external',  // pre-calculated client-side; INT-1339 may recompute server-side
+    },
+    correlation: {
+      requestId: null,
+      traceId: null,
+      taskId: null,
+      researchId: null,
+      attempt: null,
+      sessionId: null,
+    },
+    error: params.success
+      ? null
+      : { code: null, message: params.errorMessage ?? null },
+  };
+}
+
+function mapCallTypeToOperation(callType: CallType): UsageEventRequest['operation'] {
+  switch (callType) {
+    case 'research': return 'research';
+    case 'generate': return 'generate';
+    case 'image_generation': return 'image_generation';
+    case 'tool_calling': return 'tool_calling';
+    case 'visualization_insights': return 'visualization_insights';
+    case 'visualization_vegalite': return 'visualization_vegalite';
+    /* v8 ignore next -- ts-type: exhaustive switch, all CallType variants above @preserve */
+    default: return 'other';
+  }
+}
+```
+
+**Note:** `NormalizedUsage` does not currently carry `cacheReadTokens`, `cacheWriteTokens`, `cachedTokens`, `reasoningTokens`, `thinkingTokens`, or `groundingEnabled`. The `HttpUsageSink` zero-fills these. If that's unacceptable (we'd lose cache tracking parity with Firestore), the `UsageLogParams` interface must be extended first — flag this before Phase 1 starts. Verified at plan time: `FirestoreUsageSink` also doesn't track these fields today, so parity is preserved.
+
+## Appendix B — Quick reference for grep queries
+
+```bash
+# Count usage logger call sites
+rg "createUsageLogger\(" apps/ packages/ -n | wc -l          # expect: 6 provider factories + tests
+
+# Find all FirestoreUsageSink references
+rg "FirestoreUsageSink" apps/ packages/ -n                   # expect post-Phase 7: 0 production hits
+
+# Find all llm_usage_stats collection references
+rg "llm_usage_stats" apps/ packages/ firestore-collections.json -n  # expect post-Phase 9: 0 hits
+
+# Find all user_usage collection references
+rg "user_usage" apps/ packages/ -n                           # expect: only code-agent + firestore-collections.json
+
+# Find any direct Firestore writes of token/cost fields
+rg "\.set\(.*tokens\|\.update\(.*costUsd" apps/ packages/ -n  # expect post-Phase 7: only llm-usage-service
+
+# Find HttpUsageSink usage (should grow as we wire it)
+rg "HttpUsageSink" apps/ packages/ -n                        # expect: 1 (definition) + N (wirings)
+```

--- a/docs/plans/INT-1343-track-5-move-pricing-ui.md
+++ b/docs/plans/INT-1343-track-5-move-pricing-ui.md
@@ -10,9 +10,9 @@
 
 ## Executive summary
 
-Pure reorganization + data-source swap. The existing LLM Pricing page lives at `/#/settings/llm-pricing` and fetches from `app-settings-service` (`GET /settings/pricing`). After Track 4 this data is owned by `llm-usage-service` (`GET /internal/pricing`), and after Track 1 the web app has a new `llm-usage` sidebar section. This track moves the page to `/#/llm-usage/pricing`, repoints it at the new service, and leaves a redirect shim at the old URL for one release.
+Pure reorganization + data-source swap. The existing LLM Pricing page lives at `/#/settings/llm-pricing` and fetches from `app-settings-service` (`GET /settings/pricing`). After Track 4 this data is owned by `llm-usage-service` (`GET /llm-usage/pricing`), and after Track 1 the web app has a new `llm-usage` sidebar section. This track moves the page to `/#/llm-usage/pricing`, repoints it at the new service, and removes the old URL outright.
 
-No new UX, no new features. If this track drags out longer than a day of focused work, something is wrong. The only real risks are (a) response-shape drift between the old and new endpoints and (b) Track 1 delivering a differently-named helper module than this plan assumes — both handled in Phase 2.
+No new UX, no new features. If this track drags out longer than a day of focused work, something is wrong. The only real risks are (a) response-shape drift between the old and new endpoints and (b) Track 1 delivering a differently-named helper module than this plan assumes — both handled in Phase 1.
 
 ## Pre-flight checks
 
@@ -20,9 +20,9 @@ Before opening a branch for INT-1343, confirm all of the following:
 
 1. **Track 1 merged.** `/#/llm-usage` renders an LLM Usage nav section and a list page. Confirm the file `apps/web/src/services/llmUsageApi.ts` exists and exposes at least one helper using `config.llmUsageServiceUrl`.
 2. **Track 1 config wired.** `apps/web/src/config.ts` contains a `llmUsageServiceUrl` entry created from `INTEXURAOS_LLM_USAGE_SERVICE_URL` with a `/api/llm-usage` dev fallback, and `apps/web/src/types/index.ts` `AppConfig` has the matching field. `apps/web/vite.config.ts` has a `/api/llm-usage` proxy entry pointing at `llm-usage-service`'s dev port.
-3. **Track 4 merged.** `llm-usage-service` exposes `GET /internal/pricing`, protected by `X-Internal-Auth`. Confirm by grepping `apps/llm-usage-service/src/routes/internalRoutes.ts` (or equivalent) and by running the service locally and calling it.
-4. **Track 4 client shipped.** `packages/internal-clients/src/usage-service/` exports `createUsageServicePricingClient` with a `getAllProvidersPricing()` (or similarly-named) method. Its return type matches the web `AllProvidersPricing` contract (modulo `zai`, see Phase 2 notes).
-5. **Public endpoint decision.** Track 4 delivers an `/internal/*` endpoint for service-to-service use. The web app is a first-party UI that speaks directly to services (no BFF — see "BFF reality" note below), so `llm-usage-service` must ALSO expose a user-auth public endpoint (`GET /settings/pricing` or `GET /pricing`). **⚠ DECISION NEEDED:** confirm whether Track 4 adds this public endpoint too, or whether this track (INT-1343) adds it. Recommendation: add it in Track 4 since the plumbing is right there. If not, Phase 1 of this plan adds it.
+3. **Track 4 merged.** `llm-usage-service` exposes `GET /llm-usage/pricing` (public, Auth0 bearer). Confirm by grepping `apps/llm-usage-service/src/routes/publicRoutes.ts` (or equivalent) and by calling the endpoint with a valid bearer token.
+4. **Track 4 client shipped.** `packages/internal-clients/src/usage-service/` exports `createUsageServicePricingClient` with a `getAllProvidersPricing()` (or similarly-named) method. Its return type covers the 5 providers: `google`, `openai`, `anthropic`, `perplexity`, `openrouter`.
+5. **Public endpoint confirmed.** Track 4 delivers `GET /llm-usage/pricing` (public, Auth0 bearer) — this is the endpoint this track's web app client calls. No Phase 1 work needed in this track.
 6. **Visual baseline.** Navigate to `/#/settings/llm-pricing` in dev, screenshot each provider card, and save to `docs/plans/assets/INT-1343-baseline-*.png`. Used for the Phase 8 parity check.
 
 ## BFF reality (important context)
@@ -40,7 +40,7 @@ This also means the "BFF proxy unit test" requirement from the parent issue simp
 - `apps/web/src/pages/LlmPricingPage.tsx` — the page to move. Self-contained: imports `Card`, `Layout`, `useAuth`, `getLlmPricing`, `formatDateTime`, and `AllProvidersPricing` types. No child components to also move.
 - `apps/web/src/services/settingsApi.ts` — exports `getLlmPricing` (this track removes it) and `getUsageCosts` (this track leaves it alone — that's a different feature used by `LlmCostsPage`, see Out of Scope).
 - `apps/web/src/config.ts` — `getConfig()` and the `getServiceUrl()` dev-fallback helper. Track 1 should have added `llmUsageServiceUrl`.
-- `apps/web/src/types/index.ts` lines 725–754 — `ModelPricing`, `ProviderPricing`, `AllProvidersPricing`. Note the web type already includes `zai` (line 753), but the current `app-settings-service` response only returns `google/openai/anthropic/perplexity` (see `publicRoutes.ts`). This is an **existing bug or forward-compat hack** that Track 4 must decide whether to fix. Phase 2 flags it.
+- `apps/web/src/types/index.ts` lines 725–754 — `ModelPricing`, `ProviderPricing`, `AllProvidersPricing`. The `zai` field will be removed by Track 3 (INT-1342) as part of the full zai cleanup. Track 4 (INT-1339) returns 5 providers (google, openai, anthropic, perplexity, openrouter); no zai.
 - `apps/web/src/App.tsx` — line 223–230 has the current `/settings/llm-pricing` route; line 52 has the `LlmPricingPage` import.
 - `apps/web/src/components/Sidebar.tsx` — line 62 has the current `settingsItems` entry; the `llmUsageItems` array created by Track 1 is where the new entry goes.
 - `apps/web/src/pages/index.ts` line 31 — re-exports `LlmPricingPage`.
@@ -57,12 +57,12 @@ This also means the "BFF proxy unit test" requirement from the parent issue simp
 
 ### Created
 
-- **Web app:** `GET` call from `apps/web/src/services/llmUsageApi.ts#getLlmPricing()` → `llm-usage-service` public endpoint (path TBD by Track 4, likely `/pricing` or `/settings/pricing`).
+- **Web app:** `GET` call from `apps/web/src/services/llmUsageApi.ts#getLlmPricing()` → `llm-usage-service` public endpoint `GET /llm-usage/pricing` (Auth0 bearer, delivered by Track 4).
 - **Web app route:** `/#/llm-usage/pricing` — new React Router route.
 
 ### Removed
 
-- **Web app route:** `/#/settings/llm-pricing` — replaced by a `<Navigate>` redirect to `/#/llm-usage/pricing`. After one release, the redirect is removed (Phase 10 / followup).
+- **Web app route:** `/#/settings/llm-pricing` — **removed outright** (hard 404). No redirect shim, no `<Navigate>`, no followup ticket needed.
 - **Web app service function:** `getLlmPricing` in `apps/web/src/services/settingsApi.ts` — deleted.
 - **Web app sidebar entry:** The `settingsItems` entry for `/settings/llm-pricing` — deleted.
 - **App-settings-service endpoint:** `GET /settings/pricing` — **NOT removed in this track.** That removal belongs to Track 4 (ownership transfer). This track only stops the web app from calling it; Track 4 handles server-side deletion once no callers remain.
@@ -80,22 +80,7 @@ This also means the "BFF proxy unit test" requirement from the parent issue simp
 - Confirm CI baseline: `pnpm run ci:tracked` passes on a fresh `development` pull.
 - For every code change in this plan, write the failing test first. Order: Phase 3 tests → Phase 3 impl → Phase 4-7 (UI, no tests required by web-app exception) → Phase 9 cleanup tests.
 
-### Phase 1 — (Conditional) Add public pricing endpoint to llm-usage-service
-
-**Skip this phase if Pre-flight check #5 confirmed Track 4 already added the public endpoint.**
-
-If Track 4 only shipped `/internal/pricing`, this track must add the user-auth public endpoint:
-
-1. File: `apps/llm-usage-service/src/routes/publicRoutes.ts`.
-2. Add `GET /pricing` (or `GET /settings/pricing` to match the old path — see ⚠ DECISION below).
-3. Handler uses `requireAuth(request, reply)`, calls the same `pricingRepository` that the internal route uses, and returns the same `{ google, openai, anthropic, perplexity }` envelope via `reply.ok(...)`.
-4. Must call `logIncomingRequest(request, {...})` per CLAUDE.md rules.
-5. Wire into the Fastify app in `apps/llm-usage-service/src/index.ts`.
-6. Tests: add a routes test in `apps/llm-usage-service/src/__tests__/routes/publicRoutes.test.ts` with 100% branch coverage (auth fail, missing provider fail path for each of the 4 providers, happy path).
-
-**⚠ DECISION NEEDED:** New path name. `/settings/pricing` preserves the API surface so the client can be a pure URL swap. `/pricing` is cleaner since we're not in a "settings" service anymore. Recommendation: `/pricing`. A public service should own its natural URL, not mirror the old owner's path. The client-side change is a one-liner either way.
-
-### Phase 2 — Add `getLlmPricing` to `llmUsageApi.ts`
+### Phase 1 — Add `getLlmPricing` to `llmUsageApi.ts`
 
 Assume Track 1 created this file with an interface like:
 
@@ -114,7 +99,7 @@ import type { AllProvidersPricing } from '@/types';
 export async function getLlmPricing(accessToken: string): Promise<AllProvidersPricing> {
   return await apiRequest<AllProvidersPricing>(
     config.llmUsageServiceUrl,
-    '/pricing', // or '/settings/pricing' per Phase 1 decision
+    '/llm-usage/pricing',
     accessToken
   );
 }
@@ -122,27 +107,25 @@ export async function getLlmPricing(accessToken: string): Promise<AllProvidersPr
 
 **Shape adapter — is one needed?**
 
-Compare response shapes:
+Track 4 returns 5 providers (zai dropped, openrouter included with cost from provider response). The current `LlmPricingPage` renders `google/openai/anthropic/perplexity` (lines 170–173) and does not render `openrouter`. Compare shapes:
 
-| Field        | app-settings-service today | llm-usage-service (Track 4)  | Web type `AllProvidersPricing`                                          |
-| ------------ | -------------------------- | ---------------------------- | ----------------------------------------------------------------------- |
-| `google`     | `ProviderPricing`          | `ProviderPricing` (expected) | `ProviderPricing`                                                       |
-| `openai`     | `ProviderPricing`          | `ProviderPricing` (expected) | `ProviderPricing`                                                       |
-| `anthropic`  | `ProviderPricing`          | `ProviderPricing` (expected) | `ProviderPricing`                                                       |
-| `perplexity` | `ProviderPricing`          | `ProviderPricing` (expected) | `ProviderPricing`                                                       |
-| `openrouter` | absent                     | **unknown**                  | absent                                                                  |
-| `zai`        | absent                     | **unknown**                  | present (optional in practice; `LlmPricingPage.tsx` does not render it) |
+| Field        | app-settings-service today | llm-usage-service (Track 4) | Web type `AllProvidersPricing` |
+| ------------ | -------------------------- | --------------------------- | ------------------------------ |
+| `google`     | `ProviderPricing`          | `ProviderPricing`           | `ProviderPricing`              |
+| `openai`     | `ProviderPricing`          | `ProviderPricing`           | `ProviderPricing`              |
+| `anthropic`  | `ProviderPricing`          | `ProviderPricing`           | `ProviderPricing`              |
+| `perplexity` | `ProviderPricing`          | `ProviderPricing`           | `ProviderPricing`              |
+| `openrouter` | absent                     | present (provider-reported) | absent (page does not render)  |
+| `zai`        | absent                     | absent (dropped)            | remove from type (Track 3)     |
 
-**⚠ DECISION NEEDED:** What does Track 4's endpoint return for `zai` and `openrouter`? The current `LlmPricingPage` renders exactly `google/openai/anthropic/perplexity` (lines 170–173). If Track 4 returns a superset, no adapter needed — extra fields are ignored. If Track 4 returns a subset (e.g. drops `perplexity`), we need to (a) update the page to render whatever the service returns dynamically, or (b) keep the adapter. Recommendation: **update Track 4 to return the exact four providers** the current page renders, to keep this track a pure move. Escalate to INT-1339 if the shape diverges.
-
-If the shapes match: no adapter. If they don't: add a pure function `adaptPricingResponse(raw: UsageServicePricingResponse): AllProvidersPricing` in `llmUsageApi.ts` and unit-test it.
+No adapter needed — the 4 rendered providers match, and `openrouter` is an extra field the page simply does not render. If Track 4's type definition does not include `openrouter` in `AllProvidersPricing`, just ignore it; if it does, the page renders nothing for it (no existing card block).
 
 **Test (required — `services/` has the web-app exception for required tests):**
 
 File: `apps/web/src/services/__tests__/llmUsageApi.test.ts` (extend if Track 1 created it).
 
 Test cases:
-1. `getLlmPricing(token)` issues a GET to `${config.llmUsageServiceUrl}/pricing` with `Authorization: Bearer <token>`.
+1. `getLlmPricing(token)` issues a GET to `${config.llmUsageServiceUrl}/llm-usage/pricing` with `Authorization: Bearer <token>`.
 2. Returns the `data` field on success.
 3. Throws `ApiError` on 401.
 4. Throws `ApiError` with mapped message on 5xx.
@@ -169,7 +152,7 @@ Mock `fetch` globally (this is how other `*Api.test.ts` files do it — grep `ap
    - Remove `LlmPricingPage` from the import list.
    - Add `LlmUsagePricingPage` in its place.
 2. Route changes (around lines 223–230):
-   - Keep the `/settings/llm-pricing` Route but replace its element with `<Navigate to="/llm-usage/pricing" replace />` (inside a `ProtectedRoute` still so unauth users go through login first). **Placement:** move it down into the "Redirects for old URLs (backward compatibility)" block around line 589, matching the pattern used by `/notion`, `/whatsapp`, etc. The `ProtectedRoute` wrapper is optional for redirects — the existing backward-compat redirects don't use it. Match the existing pattern: `<Route path="/settings/llm-pricing" element={<Navigate to="/llm-usage/pricing" replace />} />`.
+   - **Delete** the `/settings/llm-pricing` route entirely. Do not replace it with a `<Navigate>` redirect. Do not add it to any backward-compat block. The old URL is gone; navigating to it returns a 404 (no route match).
 3. Add the new route in the `/* LLM Usage routes */` block Track 1 created:
    ```tsx
    <Route
@@ -227,44 +210,29 @@ Script (add under `apps/web/e2e/` following the existing Playwright layout; if t
 5. Intercept network: assert a GET went to a URL matching `/api/llm-usage/pricing` (dev) or `llmUsageServiceUrl` prefix (prod).
 6. Assert NO GET went to `/api/settings/pricing` or the `appSettingsServiceUrl` pricing path.
 7. Screenshot and diff against the baseline from Pre-flight #6. Diff threshold: pixel-perfect (we did not change layout).
-8. Navigate to `/#/settings/llm-pricing` and assert the URL resolves to `/#/llm-usage/pricing` (redirect worked).
 
 If a layout difference shows up in step 7, stop and investigate — it means Phase 3's copy introduced an unintended diff.
 
 ### Phase 9 — Final cleanup + verification
 
-1. `rg "/settings/llm-pricing" apps/web` — expect exactly one hit (the `<Navigate>` redirect in `App.tsx`).
+1. `rg "/settings/llm-pricing" apps/web` — expect zero hits (the route is gone, no redirect shim).
 2. `rg "LlmPricingPage" apps/web` — expect zero hits.
 3. `rg "getLlmPricing" apps/web` — expect exactly two hits: the export in `llmUsageApi.ts` and the import in `LlmUsagePricingPage.tsx` (plus any test file).
 4. `pnpm run verify:workspace:tracked -- web` — must pass.
 5. `pnpm run ci:tracked` — must pass completely (Commit Gate).
-6. Manual smoke: `pnpm dev` + open `http://localhost:3000/#/llm-usage/pricing` + confirm data loads + click the redirect URL in the address bar for `/#/settings/llm-pricing` and confirm it redirects.
-
-### Phase 10 — Followup ticket (not part of this PR)
-
-File a followup Linear issue: **"Remove `/settings/llm-pricing` redirect shim"**. Title references INT-1343 in the body ("Followup to INT-1343"). Schedule: one release after INT-1343 ships. The followup deletes the `<Route path="/settings/llm-pricing" element={<Navigate .../>} />` line from `App.tsx`.
-
-Don't create the followup in this PR — create it separately once this PR is merged. User controls; Claude does not auto-file.
+6. Manual smoke: `pnpm dev` + open `http://localhost:3000/#/llm-usage/pricing` + confirm data loads. Navigate to `/#/settings/llm-pricing` and confirm no route matches (404 / not-found page).
 
 ## Test plan
 
 **Unit tests (required by web-app exception for `services/`):**
 - `apps/web/src/services/__tests__/llmUsageApi.test.ts`
-  - `getLlmPricing()` GETs the right URL with the right auth header
+  - `getLlmPricing()` GETs the right URL (`/llm-usage/pricing`) with the right auth header
   - Returns success payload
   - Throws `ApiError` on 401 and 5xx
-  - (If adapter exists) `adaptPricingResponse()` handles all documented shape variations
-
-**Service tests (only if Phase 1 runs):**
-- `apps/llm-usage-service/src/__tests__/routes/publicRoutes.test.ts`
-  - Auth required (401 without bearer)
-  - Happy path returns all 4 providers
-  - Missing provider returns 500 with correct error code (4 variants)
-  - 100% branch coverage
 
 **E2E / Playwright smoke (Phase 8):**
 - `/#/llm-usage/pricing` renders 4 provider cards, hits `llm-usage-service`, screenshot matches baseline
-- `/#/settings/llm-pricing` redirects to `/#/llm-usage/pricing`
+- `/#/settings/llm-pricing` returns no route match (404 / not-found page)
 
 **NOT required (web app coverage exception):**
 - Unit tests for `LlmUsagePricingPage.tsx` itself
@@ -273,18 +241,16 @@ Don't create the followup in this PR — create it separately once this PR is me
 
 1. Merge INT-1340 (Track 1) and INT-1339 (Track 4) first. Hard dependency; do not start this track until both are on `development`.
 2. Open PR for INT-1343 targeting `development`. PR title contains `INT-1343`. PR body: `Fixes INT-1343`.
-3. No feature flag needed. It's a UI move; worst case is a redirect hiccup which is reversible by revert.
+3. No feature flag needed. It's a UI move; worst case is a missing page for users with stale bookmarks (acceptable per atomic deprecation philosophy) — reversible by revert.
 4. After PR merges and deploys to dev:
-   - Check dev analytics/logs for any 404s on `/settings/llm-pricing` (should be rare — redirect handles them).
    - Check logs on `app-settings-service` for `GET /settings/pricing` hits. Should drop to zero within a few minutes of deploy (web-app cache). If any persist >1 hour, investigate stale tabs.
 5. After prod deploy, monitor Sentry for new errors tagged `LlmUsagePricingPage` for 24 hours.
-6. After one release cycle (~1 week), file/execute the Phase 10 followup to remove the redirect shim.
-7. Track 4's server-side deletion of `GET /settings/pricing` on `app-settings-service` happens in INT-1339's own rollout, not this track.
+6. Track 4's server-side deletion of `GET /settings/pricing` on `app-settings-service` happens in INT-1339's own rollout, not this track.
 
 ## Acceptance criteria
 
 - [ ] `/#/llm-usage/pricing` renders the LLM Pricing page with data from `llm-usage-service`
-- [ ] `/#/settings/llm-pricing` redirects to `/#/llm-usage/pricing`
+- [ ] Navigating to `/#/settings/llm-pricing` returns a 404 (no route match — old URL removed outright)
 - [ ] Sidebar has an "LLM Pricing" entry under the LLM Usage section
 - [ ] Sidebar no longer has an "LLM Pricing" entry under Settings
 - [ ] `apps/web/src/services/settingsApi.ts` no longer exports `getLlmPricing`
@@ -292,15 +258,14 @@ Don't create the followup in this PR — create it separately once this PR is me
 - [ ] `apps/web/src/pages/LlmPricingPage.tsx` is deleted; `LlmUsagePricingPage.tsx` exists
 - [ ] `pnpm run ci:tracked` passes
 - [ ] Visual parity confirmed via Phase 8 Playwright smoke
-- [ ] Phase 10 followup issue filed (after merge, not before)
 
 ## Risks
 
-- **Response-shape drift** — Track 4's `/internal/pricing` returns a different shape than `app-settings-service`'s `/settings/pricing`. Mitigation: Pre-flight #4 verifies shape; Phase 2 table compares explicitly; if drift exists, add an adapter or (preferred) escalate to Track 4 to align.
+- **Response-shape drift** — Track 4's `GET /llm-usage/pricing` returns a different shape than `app-settings-service`'s `GET /settings/pricing`. Mitigation: Pre-flight #4 verifies shape; Phase 1 table compares explicitly; if drift exists, add an adapter or (preferred) escalate to Track 4 to align.
 - **Track 1 didn't deliver `llmUsageApi.ts`** — blocker on Pre-flight #1. If Track 1 shipped differently-named helpers, this track extends Track 1 rather than creating a new file. Do not silently create a parallel `pricingApi.ts` — one source of truth per service.
-- **User has old URL bookmarked** — redirect shim handles one release cycle. Phase 10 followup removes it after that.
+- **User has old URL bookmarked** — old URL returns 404. Acceptable per atomic deprecation philosophy; no redirect shim is provided. Users must update their bookmarks.
 - **Visual regression from copy-paste** — Phase 3 is intentionally a byte-identical copy except for the import line + function name. Phase 8 Playwright diff catches any accidental drift.
-- **`zai` / `openrouter` provider mismatch** — flagged in Phase 2 ⚠. If Track 4 returns fewer or more providers, the page either breaks at runtime (undefined access on `pricing.google` etc.) or renders stale data. Mitigation: lock down the Track 4 contract before starting this track.
+- **`openrouter` field in response** — Track 4 returns `openrouter` in the pricing response; the page does not render a card for it. No runtime error expected since the page explicitly renders only the 4 calculated-cost provider cards. Mitigation: Pre-flight #4 confirms the 4 core providers are present in the response.
 - **Deploy ordering** — if the web-app deploys before `llm-usage-service` has the public endpoint live, the page 500s. Mitigation: deploy `llm-usage-service` first, verify, then deploy web.
 - **Dead `appSettingsServiceUrl` — NOT a risk.** It's still used by `getUsageCosts`. Don't remove it.
 
@@ -314,11 +279,9 @@ Don't create the followup in this PR — create it separately once this PR is me
 - **Backfilling `zai` or `openrouter` pricing data** — if they're missing from seeds, that's a data issue, not a UI issue.
 - **Adding new providers to the page** — the current page hardcodes 4 providers; adding more is a feature, not part of this move.
 
-## ⚠ Decision summary (collected from above)
+## Decision summary (resolved via INT-1338-decisions.md)
 
-1. **Old URL handling** — keep a `<Navigate>` redirect for one release, then delete via followup. **Recommended: redirect.** (Phase 4, Phase 10)
-2. **Public endpoint on `llm-usage-service`** — confirm Track 4 adds it; if not, Phase 1 of this track adds it. **Recommended: Track 4 owns it.** (Pre-flight #5, Phase 1)
-3. **New endpoint path name** — `/pricing` vs `/settings/pricing` on the new service. **Recommended: `/pricing`.** (Phase 1)
-4. **Response shape for `zai`/`openrouter`** — align Track 4 to return exactly the 4 providers the current UI renders, OR update the page to render dynamically. **Recommended: align Track 4.** (Phase 2)
-
-All four decisions are cheap to flip if the user disagrees. None block plan approval.
+1. **Old URL handling** — **RESOLVED: remove outright (hard 404).** No `<Navigate>` redirect, no followup ticket. Aligns with atomic deprecation philosophy. (Phase 4)
+2. **Public endpoint on `llm-usage-service`** — **RESOLVED: Track 4 owns it.** Track 4 (INT-1339) delivers `GET /llm-usage/pricing` with Auth0 bearer auth. This track simply calls it. (Pre-flight #5)
+3. **New endpoint path name** — **RESOLVED: `/llm-usage/pricing`.** Domain-prefixed public route convention per INT-1338 decisions. (Phase 1)
+4. **Response shape for `zai`/`openrouter`** — **RESOLVED: drop zai entirely, keep openrouter** (cost from provider response). Track 4 returns 5 providers: `google`, `openai`, `anthropic`, `perplexity`, `openrouter`. Page renders the 4 calculated-cost providers; `openrouter` extra field is ignored. (Phase 1)

--- a/docs/plans/INT-1343-track-5-move-pricing-ui.md
+++ b/docs/plans/INT-1343-track-5-move-pricing-ui.md
@@ -1,0 +1,324 @@
+# INT-1343 — Track 5: Move LLM Pricing UI to LLM Usage Section
+
+## Status
+
+- Linear issue: **INT-1343**
+- Parent epic: **INT-1338** (LLM Usage Service Phase 2)
+- Dependencies: **INT-1340 (Track 1)** and **INT-1339 (Track 4)** — both must be merged before this starts
+- Blocks: nothing
+- Plan version: **1.0**
+
+## Executive summary
+
+Pure reorganization + data-source swap. The existing LLM Pricing page lives at `/#/settings/llm-pricing` and fetches from `app-settings-service` (`GET /settings/pricing`). After Track 4 this data is owned by `llm-usage-service` (`GET /internal/pricing`), and after Track 1 the web app has a new `llm-usage` sidebar section. This track moves the page to `/#/llm-usage/pricing`, repoints it at the new service, and leaves a redirect shim at the old URL for one release.
+
+No new UX, no new features. If this track drags out longer than a day of focused work, something is wrong. The only real risks are (a) response-shape drift between the old and new endpoints and (b) Track 1 delivering a differently-named helper module than this plan assumes — both handled in Phase 2.
+
+## Pre-flight checks
+
+Before opening a branch for INT-1343, confirm all of the following:
+
+1. **Track 1 merged.** `/#/llm-usage` renders an LLM Usage nav section and a list page. Confirm the file `apps/web/src/services/llmUsageApi.ts` exists and exposes at least one helper using `config.llmUsageServiceUrl`.
+2. **Track 1 config wired.** `apps/web/src/config.ts` contains a `llmUsageServiceUrl` entry created from `INTEXURAOS_LLM_USAGE_SERVICE_URL` with a `/api/llm-usage` dev fallback, and `apps/web/src/types/index.ts` `AppConfig` has the matching field. `apps/web/vite.config.ts` has a `/api/llm-usage` proxy entry pointing at `llm-usage-service`'s dev port.
+3. **Track 4 merged.** `llm-usage-service` exposes `GET /internal/pricing`, protected by `X-Internal-Auth`. Confirm by grepping `apps/llm-usage-service/src/routes/internalRoutes.ts` (or equivalent) and by running the service locally and calling it.
+4. **Track 4 client shipped.** `packages/internal-clients/src/usage-service/` exports `createUsageServicePricingClient` with a `getAllProvidersPricing()` (or similarly-named) method. Its return type matches the web `AllProvidersPricing` contract (modulo `zai`, see Phase 2 notes).
+5. **Public endpoint decision.** Track 4 delivers an `/internal/*` endpoint for service-to-service use. The web app is a first-party UI that speaks directly to services (no BFF — see "BFF reality" note below), so `llm-usage-service` must ALSO expose a user-auth public endpoint (`GET /settings/pricing` or `GET /pricing`). **⚠ DECISION NEEDED:** confirm whether Track 4 adds this public endpoint too, or whether this track (INT-1343) adds it. Recommendation: add it in Track 4 since the plumbing is right there. If not, Phase 1 of this plan adds it.
+6. **Visual baseline.** Navigate to `/#/settings/llm-pricing` in dev, screenshot each provider card, and save to `docs/plans/assets/INT-1343-baseline-*.png`. Used for the Phase 8 parity check.
+
+## BFF reality (important context)
+
+There is **no BFF server in this repo**. `apps/web` is a pure SPA. The web app calls individual Cloud Run services directly in production (`INTEXURAOS_<SERVICE>_SERVICE_URL` env vars) and uses `vite.config.ts` `server.proxy` to forward `/api/<service>` → `localhost:<port>` in dev. This means:
+
+- **There is no BFF proxy route to add.** The plan the parent issue sketched ("web-app BFF: `/api/llm-usage/pricing` NEW") does not apply — there's nothing to add a route to.
+- **The web app authenticates with a real user bearer token** (`Authorization: Bearer <auth0>`), not `X-Internal-Auth`. That's why the new service needs a public authenticated endpoint, not just an `/internal/*` one.
+- **The only "proxy route" work** is a one-line addition to `apps/web/vite.config.ts` in the `apiProxy` object — presumed already done by Track 1.
+
+This also means the "BFF proxy unit test" requirement from the parent issue simplifies to "unit test `llmUsageApi.getLlmPricing()` in `services/__tests__/`".
+
+## Context files
+
+- `apps/web/src/pages/LlmPricingPage.tsx` — the page to move. Self-contained: imports `Card`, `Layout`, `useAuth`, `getLlmPricing`, `formatDateTime`, and `AllProvidersPricing` types. No child components to also move.
+- `apps/web/src/services/settingsApi.ts` — exports `getLlmPricing` (this track removes it) and `getUsageCosts` (this track leaves it alone — that's a different feature used by `LlmCostsPage`, see Out of Scope).
+- `apps/web/src/config.ts` — `getConfig()` and the `getServiceUrl()` dev-fallback helper. Track 1 should have added `llmUsageServiceUrl`.
+- `apps/web/src/types/index.ts` lines 725–754 — `ModelPricing`, `ProviderPricing`, `AllProvidersPricing`. Note the web type already includes `zai` (line 753), but the current `app-settings-service` response only returns `google/openai/anthropic/perplexity` (see `publicRoutes.ts`). This is an **existing bug or forward-compat hack** that Track 4 must decide whether to fix. Phase 2 flags it.
+- `apps/web/src/App.tsx` — line 223–230 has the current `/settings/llm-pricing` route; line 52 has the `LlmPricingPage` import.
+- `apps/web/src/components/Sidebar.tsx` — line 62 has the current `settingsItems` entry; the `llmUsageItems` array created by Track 1 is where the new entry goes.
+- `apps/web/src/pages/index.ts` line 31 — re-exports `LlmPricingPage`.
+- `apps/web/src/pages/LlmCostsPage.tsx` — **OUT OF SCOPE.** This is `/settings/usage-costs` (user cost totals aggregated from events), a separate feature that still hits `app-settings-service`'s `/settings/usage-costs`. Do not touch in this track. If it ever moves it's a different follow-up (likely to become part of the LLM Usage section too, but not this issue).
+- `apps/web/vite.config.ts` lines 78–99 — `apiProxy` object. Track 1 should have added `/api/llm-usage`.
+- `apps/app-settings-service/src/routes/publicRoutes.ts` lines 14–141 — the current `GET /settings/pricing` implementation. Useful as a reference for what Track 4's public endpoint should look like if it doesn't already.
+- `packages/internal-clients/src/usage-service/` — after Track 4, the client module. This track does NOT use it (the web app doesn't consume `@intexuraos/internal-clients` — that package is for service-to-service auth). It's only relevant if the public endpoint in Track 4 got skipped and we need to proxy through another service.
+
+## Endpoint changes
+
+### Modified
+
+- None.
+
+### Created
+
+- **Web app:** `GET` call from `apps/web/src/services/llmUsageApi.ts#getLlmPricing()` → `llm-usage-service` public endpoint (path TBD by Track 4, likely `/pricing` or `/settings/pricing`).
+- **Web app route:** `/#/llm-usage/pricing` — new React Router route.
+
+### Removed
+
+- **Web app route:** `/#/settings/llm-pricing` — replaced by a `<Navigate>` redirect to `/#/llm-usage/pricing`. After one release, the redirect is removed (Phase 10 / followup).
+- **Web app service function:** `getLlmPricing` in `apps/web/src/services/settingsApi.ts` — deleted.
+- **Web app sidebar entry:** The `settingsItems` entry for `/settings/llm-pricing` — deleted.
+- **App-settings-service endpoint:** `GET /settings/pricing` — **NOT removed in this track.** That removal belongs to Track 4 (ownership transfer). This track only stops the web app from calling it; Track 4 handles server-side deletion once no callers remain.
+
+### Unchanged
+
+- `GET /settings/usage-costs` on `app-settings-service` — `LlmCostsPage` still uses it.
+- All other `settings/*` routes.
+
+## Step-by-step implementation
+
+### Phase 0 — Branch and TDD setup
+
+- `git checkout -b pbuchman/int-1343-move-pricing-ui`
+- Confirm CI baseline: `pnpm run ci:tracked` passes on a fresh `development` pull.
+- For every code change in this plan, write the failing test first. Order: Phase 3 tests → Phase 3 impl → Phase 4-7 (UI, no tests required by web-app exception) → Phase 9 cleanup tests.
+
+### Phase 1 — (Conditional) Add public pricing endpoint to llm-usage-service
+
+**Skip this phase if Pre-flight check #5 confirmed Track 4 already added the public endpoint.**
+
+If Track 4 only shipped `/internal/pricing`, this track must add the user-auth public endpoint:
+
+1. File: `apps/llm-usage-service/src/routes/publicRoutes.ts`.
+2. Add `GET /pricing` (or `GET /settings/pricing` to match the old path — see ⚠ DECISION below).
+3. Handler uses `requireAuth(request, reply)`, calls the same `pricingRepository` that the internal route uses, and returns the same `{ google, openai, anthropic, perplexity }` envelope via `reply.ok(...)`.
+4. Must call `logIncomingRequest(request, {...})` per CLAUDE.md rules.
+5. Wire into the Fastify app in `apps/llm-usage-service/src/index.ts`.
+6. Tests: add a routes test in `apps/llm-usage-service/src/__tests__/routes/publicRoutes.test.ts` with 100% branch coverage (auth fail, missing provider fail path for each of the 4 providers, happy path).
+
+**⚠ DECISION NEEDED:** New path name. `/settings/pricing` preserves the API surface so the client can be a pure URL swap. `/pricing` is cleaner since we're not in a "settings" service anymore. Recommendation: `/pricing`. A public service should own its natural URL, not mirror the old owner's path. The client-side change is a one-liner either way.
+
+### Phase 2 — Add `getLlmPricing` to `llmUsageApi.ts`
+
+Assume Track 1 created this file with an interface like:
+
+```ts
+// apps/web/src/services/llmUsageApi.ts (created by Track 1)
+import { config } from '@/config';
+import { apiRequest } from './apiClient.js';
+// existing Track 1 exports, e.g. getUsageEvents, getUsageSummary...
+```
+
+Add:
+
+```ts
+import type { AllProvidersPricing } from '@/types';
+
+export async function getLlmPricing(accessToken: string): Promise<AllProvidersPricing> {
+  return await apiRequest<AllProvidersPricing>(
+    config.llmUsageServiceUrl,
+    '/pricing', // or '/settings/pricing' per Phase 1 decision
+    accessToken
+  );
+}
+```
+
+**Shape adapter — is one needed?**
+
+Compare response shapes:
+
+| Field        | app-settings-service today | llm-usage-service (Track 4)  | Web type `AllProvidersPricing`                                          |
+| ------------ | -------------------------- | ---------------------------- | ----------------------------------------------------------------------- |
+| `google`     | `ProviderPricing`          | `ProviderPricing` (expected) | `ProviderPricing`                                                       |
+| `openai`     | `ProviderPricing`          | `ProviderPricing` (expected) | `ProviderPricing`                                                       |
+| `anthropic`  | `ProviderPricing`          | `ProviderPricing` (expected) | `ProviderPricing`                                                       |
+| `perplexity` | `ProviderPricing`          | `ProviderPricing` (expected) | `ProviderPricing`                                                       |
+| `openrouter` | absent                     | **unknown**                  | absent                                                                  |
+| `zai`        | absent                     | **unknown**                  | present (optional in practice; `LlmPricingPage.tsx` does not render it) |
+
+**⚠ DECISION NEEDED:** What does Track 4's endpoint return for `zai` and `openrouter`? The current `LlmPricingPage` renders exactly `google/openai/anthropic/perplexity` (lines 170–173). If Track 4 returns a superset, no adapter needed — extra fields are ignored. If Track 4 returns a subset (e.g. drops `perplexity`), we need to (a) update the page to render whatever the service returns dynamically, or (b) keep the adapter. Recommendation: **update Track 4 to return the exact four providers** the current page renders, to keep this track a pure move. Escalate to INT-1339 if the shape diverges.
+
+If the shapes match: no adapter. If they don't: add a pure function `adaptPricingResponse(raw: UsageServicePricingResponse): AllProvidersPricing` in `llmUsageApi.ts` and unit-test it.
+
+**Test (required — `services/` has the web-app exception for required tests):**
+
+File: `apps/web/src/services/__tests__/llmUsageApi.test.ts` (extend if Track 1 created it).
+
+Test cases:
+1. `getLlmPricing(token)` issues a GET to `${config.llmUsageServiceUrl}/pricing` with `Authorization: Bearer <token>`.
+2. Returns the `data` field on success.
+3. Throws `ApiError` on 401.
+4. Throws `ApiError` with mapped message on 5xx.
+
+Mock `fetch` globally (this is how other `*Api.test.ts` files do it — grep `apps/web/src/services/__tests__/` for patterns).
+
+### Phase 3 — Create `LlmUsagePricingPage.tsx`
+
+**Rename strategy: copy-then-delete, not `git mv`.** Rationale: the page is being reorganized under a new section and will be touched anyway (import updates). A clean copy keeps the diff grep-friendly.
+
+1. Create `apps/web/src/pages/LlmUsagePricingPage.tsx` as a copy of `LlmPricingPage.tsx` with these changes:
+   - Rename the exported function: `LlmPricingPage` → `LlmUsagePricingPage`.
+   - Change import: `import { getLlmPricing } from '@/services/settingsApi';` → `import { getLlmPricing } from '@/services/llmUsageApi';`.
+   - **Everything else identical.** Same `<Layout>`, same `<ProviderBlock>` grid, same heading "LLM Pricing", same description, same loading spinner, same error banner, same empty state. This is a visual-parity move.
+2. Update `apps/web/src/pages/index.ts`:
+   - Remove: `export { LlmPricingPage } from './LlmPricingPage.js';`
+   - Add: `export { LlmUsagePricingPage } from './LlmUsagePricingPage.js';`
+3. Delete `apps/web/src/pages/LlmPricingPage.tsx`.
+4. Grep for any other imports of `LlmPricingPage`: `rg "LlmPricingPage" apps/web`. If any remain (besides the ones updated in Phase 4/5), update them.
+
+### Phase 4 — Update `App.tsx` routing
+
+1. Import change (line 52):
+   - Remove `LlmPricingPage` from the import list.
+   - Add `LlmUsagePricingPage` in its place.
+2. Route changes (around lines 223–230):
+   - Keep the `/settings/llm-pricing` Route but replace its element with `<Navigate to="/llm-usage/pricing" replace />` (inside a `ProtectedRoute` still so unauth users go through login first). **Placement:** move it down into the "Redirects for old URLs (backward compatibility)" block around line 589, matching the pattern used by `/notion`, `/whatsapp`, etc. The `ProtectedRoute` wrapper is optional for redirects — the existing backward-compat redirects don't use it. Match the existing pattern: `<Route path="/settings/llm-pricing" element={<Navigate to="/llm-usage/pricing" replace />} />`.
+3. Add the new route in the `/* LLM Usage routes */` block Track 1 created:
+   ```tsx
+   <Route
+     path="/llm-usage/pricing"
+     element={
+       <ProtectedRoute>
+         <LlmUsagePricingPage />
+       </ProtectedRoute>
+     }
+   />
+   ```
+   If Track 1 didn't add a comment block yet, add `{/* LLM Usage routes */}` above the block.
+
+### Phase 5 — Update `Sidebar.tsx`
+
+1. Line 62: Remove `{ to: '/settings/llm-pricing', label: 'LLM Pricing', icon: DollarSign },` from `settingsItems`.
+2. Check if `DollarSign` is still imported/used elsewhere in `Sidebar.tsx`. If only the deleted line used it, remove the `DollarSign` entry from the `lucide-react` import block (line 19). `rg "DollarSign" apps/web/src/components/Sidebar.tsx` after the edit to confirm.
+3. In the `llmUsageItems` array that Track 1 created, add:
+   ```ts
+   { to: '/llm-usage/pricing', label: 'LLM Pricing', icon: DollarSign },
+   ```
+   Position: after whatever Track 1 put first (likely the list/summary page). Re-add `DollarSign` to the `lucide-react` import if Phase 5 step 2 removed it.
+
+### Phase 6 — Delete `getLlmPricing` from `settingsApi.ts`
+
+1. Remove the `getLlmPricing` export (lines 5–11).
+2. Remove the now-unused `AllProvidersPricing` import if this was its only user (check: `getUsageCosts` imports `AggregatedCosts`, not `AllProvidersPricing`, so the type import for `AllProvidersPricing` can drop).
+3. `rg "getLlmPricing" apps/web` — should only hit `llmUsageApi.ts` and the new page after this phase.
+4. Do NOT delete `settingsApi.ts` itself — `getUsageCosts` still lives there.
+
+### Phase 7 — Config/env cleanup review
+
+No env-var changes needed in this track if Track 1 already added `INTEXURAOS_LLM_USAGE_SERVICE_URL` to all three required locations (index.ts REQUIRED_ENV on the service, terraform dev env, ecosystem.config.cjs).
+
+**Verify, don't assume:**
+- `apps/web/src/config.ts` has `llmUsageServiceUrl: getServiceUrl('INTEXURAOS_LLM_USAGE_SERVICE_URL', '/api/llm-usage'),`
+- `apps/web/src/types/index.ts` `AppConfig` has `llmUsageServiceUrl: string;`
+- `apps/web/vite.config.ts` has `/api/llm-usage` in the `apiProxy` object
+- `apps/web/cloudbuild.yaml` (or wherever web env is injected in prod) has the new `INTEXURAOS_LLM_USAGE_SERVICE_URL` secret/var wired in
+
+If any of the above are missing, file a blocker comment on Track 1 — do not silently add them in this track.
+
+**`appSettingsServiceUrl` retention:** `config.appSettingsServiceUrl` is still used by `getUsageCosts` (`LlmCostsPage` at `/settings/usage-costs`). Do NOT remove it.
+
+### Phase 8 — Playwright visual parity smoke test
+
+Login per CLAUDE.md Playwright credentials. Run against dev environment or a local `pnpm dev` build.
+
+Script (add under `apps/web/e2e/` following the existing Playwright layout; if the repo doesn't have one, run manually with the Playwright MCP):
+
+1. Navigate to `/#/llm-usage/pricing`.
+2. Assert `h2` text is `"LLM Pricing"`.
+3. Assert four provider cards render: `"Google"`, `"OpenAI"`, `"Anthropic"`, `"Perplexity"` (exact header match).
+4. Assert at least one model row is visible per provider card.
+5. Intercept network: assert a GET went to a URL matching `/api/llm-usage/pricing` (dev) or `llmUsageServiceUrl` prefix (prod).
+6. Assert NO GET went to `/api/settings/pricing` or the `appSettingsServiceUrl` pricing path.
+7. Screenshot and diff against the baseline from Pre-flight #6. Diff threshold: pixel-perfect (we did not change layout).
+8. Navigate to `/#/settings/llm-pricing` and assert the URL resolves to `/#/llm-usage/pricing` (redirect worked).
+
+If a layout difference shows up in step 7, stop and investigate — it means Phase 3's copy introduced an unintended diff.
+
+### Phase 9 — Final cleanup + verification
+
+1. `rg "/settings/llm-pricing" apps/web` — expect exactly one hit (the `<Navigate>` redirect in `App.tsx`).
+2. `rg "LlmPricingPage" apps/web` — expect zero hits.
+3. `rg "getLlmPricing" apps/web` — expect exactly two hits: the export in `llmUsageApi.ts` and the import in `LlmUsagePricingPage.tsx` (plus any test file).
+4. `pnpm run verify:workspace:tracked -- web` — must pass.
+5. `pnpm run ci:tracked` — must pass completely (Commit Gate).
+6. Manual smoke: `pnpm dev` + open `http://localhost:3000/#/llm-usage/pricing` + confirm data loads + click the redirect URL in the address bar for `/#/settings/llm-pricing` and confirm it redirects.
+
+### Phase 10 — Followup ticket (not part of this PR)
+
+File a followup Linear issue: **"Remove `/settings/llm-pricing` redirect shim"**. Title references INT-1343 in the body ("Followup to INT-1343"). Schedule: one release after INT-1343 ships. The followup deletes the `<Route path="/settings/llm-pricing" element={<Navigate .../>} />` line from `App.tsx`.
+
+Don't create the followup in this PR — create it separately once this PR is merged. User controls; Claude does not auto-file.
+
+## Test plan
+
+**Unit tests (required by web-app exception for `services/`):**
+- `apps/web/src/services/__tests__/llmUsageApi.test.ts`
+  - `getLlmPricing()` GETs the right URL with the right auth header
+  - Returns success payload
+  - Throws `ApiError` on 401 and 5xx
+  - (If adapter exists) `adaptPricingResponse()` handles all documented shape variations
+
+**Service tests (only if Phase 1 runs):**
+- `apps/llm-usage-service/src/__tests__/routes/publicRoutes.test.ts`
+  - Auth required (401 without bearer)
+  - Happy path returns all 4 providers
+  - Missing provider returns 500 with correct error code (4 variants)
+  - 100% branch coverage
+
+**E2E / Playwright smoke (Phase 8):**
+- `/#/llm-usage/pricing` renders 4 provider cards, hits `llm-usage-service`, screenshot matches baseline
+- `/#/settings/llm-pricing` redirects to `/#/llm-usage/pricing`
+
+**NOT required (web app coverage exception):**
+- Unit tests for `LlmUsagePricingPage.tsx` itself
+
+## Rollout plan
+
+1. Merge INT-1340 (Track 1) and INT-1339 (Track 4) first. Hard dependency; do not start this track until both are on `development`.
+2. Open PR for INT-1343 targeting `development`. PR title contains `INT-1343`. PR body: `Fixes INT-1343`.
+3. No feature flag needed. It's a UI move; worst case is a redirect hiccup which is reversible by revert.
+4. After PR merges and deploys to dev:
+   - Check dev analytics/logs for any 404s on `/settings/llm-pricing` (should be rare — redirect handles them).
+   - Check logs on `app-settings-service` for `GET /settings/pricing` hits. Should drop to zero within a few minutes of deploy (web-app cache). If any persist >1 hour, investigate stale tabs.
+5. After prod deploy, monitor Sentry for new errors tagged `LlmUsagePricingPage` for 24 hours.
+6. After one release cycle (~1 week), file/execute the Phase 10 followup to remove the redirect shim.
+7. Track 4's server-side deletion of `GET /settings/pricing` on `app-settings-service` happens in INT-1339's own rollout, not this track.
+
+## Acceptance criteria
+
+- [ ] `/#/llm-usage/pricing` renders the LLM Pricing page with data from `llm-usage-service`
+- [ ] `/#/settings/llm-pricing` redirects to `/#/llm-usage/pricing`
+- [ ] Sidebar has an "LLM Pricing" entry under the LLM Usage section
+- [ ] Sidebar no longer has an "LLM Pricing" entry under Settings
+- [ ] `apps/web/src/services/settingsApi.ts` no longer exports `getLlmPricing`
+- [ ] `apps/web/src/services/llmUsageApi.ts` exports a tested `getLlmPricing`
+- [ ] `apps/web/src/pages/LlmPricingPage.tsx` is deleted; `LlmUsagePricingPage.tsx` exists
+- [ ] `pnpm run ci:tracked` passes
+- [ ] Visual parity confirmed via Phase 8 Playwright smoke
+- [ ] Phase 10 followup issue filed (after merge, not before)
+
+## Risks
+
+- **Response-shape drift** — Track 4's `/internal/pricing` returns a different shape than `app-settings-service`'s `/settings/pricing`. Mitigation: Pre-flight #4 verifies shape; Phase 2 table compares explicitly; if drift exists, add an adapter or (preferred) escalate to Track 4 to align.
+- **Track 1 didn't deliver `llmUsageApi.ts`** — blocker on Pre-flight #1. If Track 1 shipped differently-named helpers, this track extends Track 1 rather than creating a new file. Do not silently create a parallel `pricingApi.ts` — one source of truth per service.
+- **User has old URL bookmarked** — redirect shim handles one release cycle. Phase 10 followup removes it after that.
+- **Visual regression from copy-paste** — Phase 3 is intentionally a byte-identical copy except for the import line + function name. Phase 8 Playwright diff catches any accidental drift.
+- **`zai` / `openrouter` provider mismatch** — flagged in Phase 2 ⚠. If Track 4 returns fewer or more providers, the page either breaks at runtime (undefined access on `pricing.google` etc.) or renders stale data. Mitigation: lock down the Track 4 contract before starting this track.
+- **Deploy ordering** — if the web-app deploys before `llm-usage-service` has the public endpoint live, the page 500s. Mitigation: deploy `llm-usage-service` first, verify, then deploy web.
+- **Dead `appSettingsServiceUrl` — NOT a risk.** It's still used by `getUsageCosts`. Don't remove it.
+
+## Out of scope
+
+- **`/#/settings/usage-costs` (`LlmCostsPage`)** — different feature (user cost totals aggregated from events). Stays in `app-settings-service` for now. Any future migration to the LLM Usage section is a separate issue.
+- **Editing pricing values from the UI** — page is read-only today, stays read-only. Pricing is seeded/updated via migrations.
+- **Changing the layout, copy, colors, or card structure of the pricing page** — pure move, zero design changes. If the user wants a redesign, separate ticket.
+- **Removing `GET /settings/pricing` from `app-settings-service`** — owned by Track 4 (INT-1339).
+- **Deprecating the whole Settings section** — unrelated.
+- **Backfilling `zai` or `openrouter` pricing data** — if they're missing from seeds, that's a data issue, not a UI issue.
+- **Adding new providers to the page** — the current page hardcodes 4 providers; adding more is a feature, not part of this move.
+
+## ⚠ Decision summary (collected from above)
+
+1. **Old URL handling** — keep a `<Navigate>` redirect for one release, then delete via followup. **Recommended: redirect.** (Phase 4, Phase 10)
+2. **Public endpoint on `llm-usage-service`** — confirm Track 4 adds it; if not, Phase 1 of this track adds it. **Recommended: Track 4 owns it.** (Pre-flight #5, Phase 1)
+3. **New endpoint path name** — `/pricing` vs `/settings/pricing` on the new service. **Recommended: `/pricing`.** (Phase 1)
+4. **Response shape for `zai`/`openrouter`** — align Track 4 to return exactly the 4 providers the current UI renders, OR update the page to render dynamically. **Recommended: align Track 4.** (Phase 2)
+
+All four decisions are cheap to flip if the user disagrees. None block plan approval.


### PR DESCRIPTION
## Summary
- Adds 6 plan documents for [INT-1338](https://linear.app/pbuchman/issue/INT-1338) (LLM Usage Service Phase 2 epic) and its 5 child tracks
- No code changes — plan documentation only
- Includes a decisions log capturing 17 architectural decisions made during planning

## Plan structure
- `docs/plans/INT-1338-decisions.md` — source of truth for the epic (17 decisions, 7 parts)
- `docs/plans/INT-1339-track-4-pricing-ownership.md` — Track 4 (pricing ownership)
- `docs/plans/INT-1340-track-1-llm-usage-web-ui.md` — Track 1 (web UI)
- `docs/plans/INT-1341-track-2-orchestrator-usage-publisher.md` — Track 2 (**fully superseded** by decisions doc per scope correction — rewrite before executing)
- `docs/plans/INT-1342-track-3-firestore-migration.md` — Track 3 (Firestore migration + feature deletions)
- `docs/plans/INT-1343-track-5-move-pricing-ui.md` — Track 5 (pricing UI move)

## Phase execution order
- **Phase 1 (parallel):** Tracks 1, 2, 4
- **Phase 2 (after Track 2):** Track 3
- **Phase 3 (after Tracks 1 + 4):** Track 5

## Key architectural decisions (from decisions doc Part 5)
1. Orchestrator routes usage via code-agent gateway, never directly to llm-usage-service
2. Scope is strictly LLMClient callers (worker-runtime Claude Code / Codex JSONL is out of scope)
3. Server-side cost calculation dropped entirely
4. Public routes on llm-usage-service with Auth0 bearer (no BFF layer)
5. Track 3 adds feature deletions: user_usage cache, packages/llm-audit, /settings/usage-costs page
6. Zai provider removed; 5 providers remain
7. Atomic deprecation for Track 4 (single PR, no 307/410 window)

## Test plan
- [ ] Read `docs/plans/INT-1338-decisions.md` as the source of truth for architectural decisions
- [ ] Verify each child Linear issue (INT-1339, INT-1340, INT-1341, INT-1342, INT-1343) matches its plan doc cross-references
- [ ] Confirm Track 2 plan is rewritten from the decisions doc spec before starting Phase 1
- [ ] Research Firestore composite index rules before Track 1 migration

Refs INT-1338

Architected with love by 🤖 <a href="mailto:intex@intexuraos.cloud">Intex</a>