### PR TITLE
fix: unblock development CI — usage client mocks + utc time range

### DIFF
--- a/apps/code-agent/src/__tests__/domain/usecases/forwardUsageEvents.test.ts
+++ b/apps/code-agent/src/__tests__/domain/usecases/forwardUsageEvents.test.ts
@@ -28,6 +28,9 @@ function createMockUsageServiceClient(
   return {
     ingestEvents: vi.fn().mockResolvedValue(ingestResult),
     queryUsage: vi.fn(),
+    fetchPricing: vi.fn(),
+    listUsageEvents: vi.fn(),
+    getUsageEvent: vi.fn(),
   };
 }
 

--- a/apps/code-agent/src/__tests__/routes/internalUsageWebhookRoute.test.ts
+++ b/apps/code-agent/src/__tests__/routes/internalUsageWebhookRoute.test.ts
@@ -71,6 +71,9 @@ function createMockUsageServiceClient(): UsageServiceClient {
   return {
     ingestEvents: vi.fn<UsageServiceClient['ingestEvents']>(),
     queryUsage: vi.fn<UsageServiceClient['queryUsage']>(),
+    fetchPricing: vi.fn<UsageServiceClient['fetchPricing']>(),
+    listUsageEvents: vi.fn<UsageServiceClient['listUsageEvents']>(),
+    getUsageEvent: vi.fn<UsageServiceClient['getUsageEvent']>(),
   };
 }
 

--- a/apps/web/src/utils/llmUsageTimeRange.ts
+++ b/apps/web/src/utils/llmUsageTimeRange.ts
@@ -11,37 +11,41 @@ export interface ResolvedTimeRange {
   to: string;
 }
 
-function startOfDay(d: Date): string {
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+function startOfUtcDay(d: Date): string {
   const c = new Date(d);
-  c.setHours(0, 0, 0, 0);
+  c.setUTCHours(0, 0, 0, 0);
   return c.toISOString();
 }
 
-function endOfDay(d: Date): string {
+function endOfUtcDay(d: Date): string {
   const c = new Date(d);
-  c.setHours(23, 59, 59, 999);
+  c.setUTCHours(23, 59, 59, 999);
   return c.toISOString();
 }
 
-/** Resolves a preset to { from, to } ISO strings at call time */
+/**
+ * Resolves a preset to { from, to } ISO strings at call time.
+ *
+ * All day boundaries and offsets are computed in UTC so results are
+ * deterministic across host timezones and DST transitions.
+ */
 export function resolveTimeRange(state: TimeRangeState): ResolvedTimeRange {
   const now = new Date();
   switch (state.preset) {
     case 'today':
-      return { from: startOfDay(now), to: now.toISOString() };
+      return { from: startOfUtcDay(now), to: now.toISOString() };
     case 'yesterday': {
-      const y = new Date(now);
-      y.setDate(y.getDate() - 1);
-      return { from: startOfDay(y), to: endOfDay(y) };
+      const y = new Date(now.getTime() - MS_PER_DAY);
+      return { from: startOfUtcDay(y), to: endOfUtcDay(y) };
     }
     case 'last7days': {
-      const d = new Date(now);
-      d.setDate(d.getDate() - 7);
+      const d = new Date(now.getTime() - 7 * MS_PER_DAY);
       return { from: d.toISOString(), to: now.toISOString() };
     }
     case 'last30days': {
-      const d = new Date(now);
-      d.setDate(d.getDate() - 30);
+      const d = new Date(now.getTime() - 30 * MS_PER_DAY);
       return { from: d.toISOString(), to: now.toISOString() };
     }
     case 'custom':


### PR DESCRIPTION
## Summary

- Fixes two independent failures that were breaking CI on `development`.
- Adds the missing `fetchPricing`, `listUsageEvents`, and `getUsageEvent` stubs to the hand-rolled `UsageServiceClient` mocks in `apps/code-agent` tests — the interface grew but the mocks did not, so `tsc --project tsconfig.tests-check.json` failed with `TS2739`.
- Rewrites `apps/web/src/utils/llmUsageTimeRange.ts` to compute day boundaries and N-day offsets in UTC (`setUTCHours`, millisecond arithmetic). The previous implementation used local-time `setHours`/`setDate`, which was deterministic in UTC (so GH Actions stayed green) but drifted by 1–2 h on any CET/CEST dev machine and would hit DST bugs for real users near the 7-/30-day boundary.

## Background

The CI failure that prompted this was the `Type Check` step on GH Actions run [24277209771](https://github.com/) — only the two code-agent mocks. While running `pnpm run ci:tracked` locally to verify, the timezone-dependent tests in `apps/web/src/utils/__tests__/llmUsageTimeRange.test.ts` surfaced a latent bug: the assertions already asserted UTC-shaped values, so the test was correct about the *intended* behavior; the implementation was the one with the local-time footgun. Fixed the implementation rather than the tests.

## Test plan

- [x] `pnpm run typecheck:tests` passes locally
- [x] `pnpm run ci:tracked` passes locally (including coverage, lint, static validation, build/format)
- [ ] GH Actions CI green on this PR
- [ ] `LlmUsagePage` preset buttons (today/yesterday/7d/30d) still produce sane ranges in the UI

## Notes

- No Linear ID — this is a direct unblock of the `development` branch, not tied to an existing issue.
- Only one caller of `resolveTimeRange` (`apps/web/src/pages/LlmUsagePage.tsx`), which consumes the `from`/`to` ISO strings opaquely, so the UTC switch is transparent to the query layer.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>