### PR TITLE
fix(web): wire INTEXURAOS_LLM_USAGE_SERVICE_URL into web prod build

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -35,7 +35,9 @@ All rules verified by `pnpm run ci:tracked`. If CI passes, rules are satisfied. 
 
 **Apps & Packages:** Apps: `getServices()`, `getFirestore()`, `INTEXURAOS_*` env vars, `validateRequiredEnv()`. New service: `/create-service`. Packages: `common-*` (leaf), `infra-*` (wrappers), no domain logic. Pub/Sub publishers MUST extend `BasePubSubPublisher`, topic names from env vars.
 
-**Env Vars:** Three locations required: (1) `apps/<service>/src/index.ts` `REQUIRED_ENV`, (2) `terraform/environments/dev/main.tf`, (3) `ecosystem.config.cjs`. Reference: `.claude/reference/env-vars-patterns.md`.
+**Env Vars (services):** Three locations required: (1) `apps/<service>/src/index.ts` `REQUIRED_ENV`, (2) `terraform/environments/dev/main.tf`, (3) `ecosystem.config.cjs`. Reference: `.claude/reference/env-vars-patterns.md`.
+
+**Env Vars (web app):** Web app is a static Vite bundle, not a Cloud Run service — env vars are **baked in at build time**, no runtime env surface exists. When a new `INTEXURAOS_*_URL` is consumed by the web app, it MUST be wired in THREE web-specific locations: (1) `apps/web/src/config.ts` `getConfig()` — add a `getServiceUrl()` entry with the dev proxy path, (2) `apps/web/cloudbuild.yaml` `CLOUD_RUN_SERVICES` array — add `"<service>:<SUFFIX>"` so the prod build fetches the URL and writes it to `/workspace/apps/web/.env`, (3) `apps/web/vite.config.ts` proxy + `ecosystem.config.cjs` — so dev shells can route `/api/<path>` to the local process. Skipping (2) produces a clean build, green tests, and a prod bundle that throws `Missing required environment variable` at module load.
 
 **Web App:** Hash routing only (`/#/path`). TailwindCSS, `@auth0/auth0-react`, `useApiClient`, SRP ~150 lines, `import.meta.env.INTEXURAOS_*`. Dev: Vite proxies `/api/*`. Prod: absolute Cloud Run URLs.
 

--- a/.claude/reference/env-vars-patterns.md
+++ b/.claude/reference/env-vars-patterns.md
@@ -71,3 +71,57 @@ const SERVICE_ENV_MAPPINGS = {
   },
 };
 ```
+
+---
+
+## Web App Patterns
+
+The web app is a static Vite bundle (deployed to GCS + CDN, NOT Cloud Run). Env vars are
+baked into the bundle at build time — there is no runtime env surface. Skipping any of
+the three locations below produces a bundle that throws `Missing required environment
+variable: <name>` at module-load time in prod.
+
+### 1. `apps/web/src/config.ts` — consumer declaration
+
+```typescript
+// apps/web/src/config.ts - getConfig()
+export function getConfig(): AppConfig {
+  return {
+    // ...
+    // Dev: Vite proxy /api/<path> → local process
+    // Prod: absolute Cloud Run URL baked in from .env at build time
+    myServiceUrl: getServiceUrl('INTEXURAOS_MY_SERVICE_URL', '/api/my-service'),
+  };
+}
+```
+
+### 2. `apps/web/cloudbuild.yaml` — prod build-time injection
+
+```yaml
+# apps/web/cloudbuild.yaml - fetch-config step
+CLOUD_RUN_SERVICES=(
+  # Format: "<cloud-run-service-name>:<ENV_VAR_SUFFIX>"
+  # Produces INTEXURAOS_<SUFFIX>_URL in /workspace/apps/web/.env before Vite builds
+  "my-service:MY_SERVICE"
+)
+```
+
+### 3. `apps/web/vite.config.ts` + `ecosystem.config.cjs` — dev proxy
+
+```typescript
+// apps/web/vite.config.ts - server.proxy
+export default defineConfig({
+  server: {
+    proxy: {
+      '/api/my-service': {
+        target: 'http://localhost:8XXX',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api\/my-service/, ''),
+      },
+    },
+  },
+});
+```
+
+The backing service must also be declared in `ecosystem.config.cjs` so PM2 starts
+it on the expected port in dev.

--- a/apps/web/cloudbuild.yaml
+++ b/apps/web/cloudbuild.yaml
@@ -32,6 +32,7 @@ steps:
           "app-settings-service:APP_SETTINGS_SERVICE"
           "cron-agent:CRON_AGENT"
           "hellscript-agent:HELLSCRIPT_AGENT"
+          "llm-usage-service:LLM_USAGE_SERVICE"
         )
 
         # Fetch service URLs from Cloud Run API (not secrets)

--- a/packages/llm-pricing/src/buildUsageEvent.ts
+++ b/packages/llm-pricing/src/buildUsageEvent.ts
@@ -1,5 +1,3 @@
-// IMPORTANT: Must remain `import type` — @intexuraos/internal-clients is a devDependency (type-checking only).
-import type { UsageEventInput } from '@intexuraos/internal-clients';
 import type { UsageLogParams } from './usageLogger.js';
 
 /**
@@ -14,7 +12,18 @@ export interface CorrelationOverrides {
 }
 
 /**
- * Shared helper that maps UsageLogParams to a UsageEventInput payload.
+ * Structural payload produced by buildUsageEvent — intentionally opaque
+ * (`Record<string, unknown>`) to break the circular type reference with
+ * @intexuraos/internal-clients' UsageEventInput. Sinks only JSON.stringify
+ * the result, so no field-level access is needed at this layer; shape is
+ * validated by the receiving service's Zod schema.
+ *
+ * @internal
+ */
+export type UsageEventPayload = Record<string, unknown>;
+
+/**
+ * Shared helper that maps UsageLogParams to a usage event payload.
  * Used by both HttpWebhookUsageSink and HttpInternalAuthUsageSink to avoid duplication.
  *
  * @internal
@@ -23,7 +32,7 @@ export function buildUsageEvent(
   params: UsageLogParams,
   source: { service: string; component: string },
   correlationOverrides?: CorrelationOverrides
-): UsageEventInput {
+): UsageEventPayload {
   const environment: 'dev' | 'prod' = process.env['NODE_ENV'] === 'production' ? 'prod' : 'dev';
 
   return {


### PR DESCRIPTION
## Summary
- **Web prod outage fix.** `apps/web/cloudbuild.yaml` missed `llm-usage-service` in `CLOUD_RUN_SERVICES`, so Vite never got `INTEXURAOS_LLM_USAGE_SERVICE_URL` in `.env` at build time. Runtime threw `Missing required environment variable` at module load from `apps/web/src/config.ts:41` (`llmUsageServiceUrl: getServiceUrl('INTEXURAOS_LLM_USAGE_SERVICE_URL', '/api/llm-usage')`) because `import.meta.env.DEV === false` in prod.
- **`pnpm build` unblocked.** `packages/internal-clients` build was failing with `TS2307: Cannot find module '@intexuraos/internal-clients'` from `packages/llm-pricing/src/buildUsageEvent.ts` — circular type reference (`internal-clients` depends on `llm-pricing` for `IPricingContext`; `llm-pricing` imported `UsageEventInput` back from `internal-clients`). `buildUsageEvent` now returns a local `Record<string, unknown>` type alias; the sinks only `JSON.stringify` the payload so no field-level type is needed and the receiving service's Zod schema still enforces shape at the boundary.

## Test plan
- [x] `pnpm run ci:tracked` — all phases green (typecheck, 49-workspace lint, 15062 tests, 22 static validators, build, format)
- [x] Verified `apps/web` Vite build completes (`built in 7.50s`)
- [x] Verified `packages/internal-clients` `tsc` build completes
- [ ] After merge: trigger `apps/web/cloudbuild.yaml` manual build on prod and verify the generated `.env` contains `INTEXURAOS_LLM_USAGE_SERVICE_URL=https://intexuraos-llm-usage-service-…`
- [ ] After redeploy: confirm `https://intexuraos.cloud` loads without the `Missing required environment variable` crash

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>