### PR TITLE
[INT-1346] fix(deploy): wire LLM_USAGE_SERVICE_URL into web build via deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -205,6 +205,7 @@ jobs:
             "code-agent:CODE_AGENT"
             "cron-agent:CRON_AGENT"
             "hellscript-agent:HELLSCRIPT_AGENT"
+            "llm-usage-service:LLM_USAGE_SERVICE"
           )
 
           declare -A SERVICE_URLS
@@ -389,6 +390,7 @@ jobs:
                 "code-agent:CODE_AGENT"
                 "cron-agent:CRON_AGENT"
                 "hellscript-agent:HELLSCRIPT_AGENT"
+                "llm-usage-service:LLM_USAGE_SERVICE"
               )
 
               declare -A SERVICE_URLS


### PR DESCRIPTION
## Summary
- Prod web was crashing at module load with `Missing required environment variable: INTEXURAOS_LLM_USAGE_SERVICE_URL` (config.ts:6).
- Root cause: `.github/workflows/deploy.yml` has **two stale copies** of `CLOUD_RUN_SERVICES` (the MONOLITH "Fetch web config" step and the INDIVIDUAL web target case), neither of which included `llm-usage-service`.
- The earlier fix 1584f7813 only touched `apps/web/cloudbuild.yaml`, which is the Cloud Build **fallback** path. The primary deploy path runs on the self-hosted runner via `deploy.yml`, so the earlier fix never took effect in prod (last Cloud Build run was 2026-01-26). When `development` was pushed, deploy.yml ran the stale list, produced a `.env` missing the URL key, Vite baked an empty string into the bundle, and `config.ts`'s `value === ''` check threw in the browser.

## Fix
- Added `"llm-usage-service:LLM_USAGE_SERVICE"` to both `CLOUD_RUN_SERVICES` arrays in `.github/workflows/deploy.yml`, matching ordering of `apps/web/cloudbuild.yaml`.

## Known follow-ups (not in this PR — keeping the fix minimal)
- `CLOUD_RUN_SERVICES` is now duplicated in **three** places (`apps/web/cloudbuild.yaml` + two copies in `deploy.yml`) and drifts independently. Consolidate into a single shared script to prevent the next regression.
- `.claude/reference/env-vars-patterns.md` and CLAUDE.md's "Env Vars (web app)" rule document only three locations — they do not mention `.github/workflows/deploy.yml`, which is why the earlier fix missed these copies. Rule needs updating.
- `gcloud run services describe` in `deploy.yml` has no error handling; a missing service silently writes an empty env var and only surfaces at module load in the browser. Consider `set -euo pipefail` and a non-empty URL assertion after each describe call.

## Test plan
- [x] `pnpm run ci:tracked` — 14883 tests pass, apps/web build passes, lint/typecheck/boundaries/env-vars all pass.
- [x] yaml syntax validated.
- [ ] After merge and deploy: verify prod `intexuraos.cloud` loads without the `Missing required environment variable` error (check DevTools console on `/#/code-tasks`).
- [ ] After deploy: confirm `INTEXURAOS_LLM_USAGE_SERVICE_URL` is baked into the prod JS bundle.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>