### PR TITLE
[INT-1368] fix(cloudbuild): rename claude-worker build step to code-worker

### DIFF
--- a/cloudbuild/cloudbuild.yaml
+++ b/cloudbuild/cloudbuild.yaml
@@ -83,17 +83,17 @@ steps:
         npm install -g pnpm@10
         pnpm install --frozen-lockfile
 
-  # Build claude-worker Docker image (no deploy, runs in parallel with pnpm-install)
+  # Build code-worker Docker image (no deploy, runs in parallel with pnpm-install)
   - name: 'gcr.io/cloud-builders/docker'
-    id: 'build-push-claude-worker'
+    id: 'build-push-code-worker'
     waitFor: ['-'] # Start immediately, no dependencies
     timeout: 900s
     entrypoint: 'bash'
     args:
       [
         'cloudbuild/scripts/build-push-monitored.sh',
-        'claude-worker',
-        'workers/claude-worker/Dockerfile',
+        'code-worker',
+        'workers/code-worker/Dockerfile',
       ]
     env:
       - 'DOCKER_BUILDKIT=1'


### PR DESCRIPTION
## Summary
- Cloud Build `intexuraos-dev-deploy` trigger was failing at step `build-push-claude-worker` with `lstat workers/claude-worker: no such file` ([build 06d04598](https://console.cloud.google.com/cloud-build/builds;region=europe-central2/06d04598-2f27-4f0d-a6b7-bb5be7c2d406?project=intexuraos-dev-pbuchman)).
- The worker directory was renamed `workers/claude-worker` → `workers/code-worker` everywhere (orchestrator image pull path, standalone `workers/code-worker/cloudbuild.yaml`, Terraform), but the main `cloudbuild/cloudbuild.yaml` build step still referenced the old path.
- This also aligns the image published to Artifact Registry (`intexuraos-dev/code-worker:latest`) with what the orchestrator actually pulls in `workers/orchestrator/src/start.ts:53` and `docker-provider.ts:39`. The previous `:latest` tag was being written to `claude-worker`, which no consumer read.

## Changes
- `cloudbuild/cloudbuild.yaml` step `build-push-claude-worker` → `build-push-code-worker`
- Build script arg `claude-worker` → `code-worker` (image name)
- Dockerfile path `workers/claude-worker/Dockerfile` → `workers/code-worker/Dockerfile`

No Terraform changes needed — `terraform/` already has zero references to `claude-worker`. No downstream `waitFor` dependencies on the renamed step.

## Test plan
- [x] `pnpm run ci:tracked` passes (type/lint/test/static/build/format all green)
- [x] YAML syntax validated with `js-yaml`
- [x] Confirmed no remaining `claude-worker` references in `cloudbuild/` or `terraform/`
- [ ] Cloud Build re-run on development after merge should succeed through the `build-push-code-worker` step

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

---

- Linear: [INT-1368](https://linear.app/pbuchman/issue/INT-1368)
- IntexuraOS Code Task: [View task](https://intexuraos.cloud/#/code-tasks/task_6aec0e1c-9dfb-4428-a920-82100c24da4b)
- Worker Type: `codex`
- Model: `default`
