### PR TITLE
[INT-1366] fix: LLM usage event shape — slash crash, OpenRouter cost, user-scoped events

### DIFF
--- a/apps/llm-usage-service/src/__tests__/infra/firestore/aggregateKeyUtils.test.ts
+++ b/apps/llm-usage-service/src/__tests__/infra/firestore/aggregateKeyUtils.test.ts
@@ -48,7 +48,7 @@ describe('aggregateKeyUtils', () => {
       expect(parts[2]).toBe(sha256Truncated('user_abc'));
       expect(parts[3]).toBe('orchestrator');
       expect(parts[4]).toBe('research');
-      expect(parts[5]).toBe('web');
+      expect(parts[5]).toBe(sha256Truncated('web'));
       expect(parts[6]).toBe('dev');
       expect(parts[7]).toBe(LlmProviders.Anthropic);
       expect(parts[8]).toBe(sha256Truncated('claude-sonnet-4-20250514'));
@@ -62,6 +62,32 @@ describe('aggregateKeyUtils', () => {
       });
       const id = computeAggregateId(event);
       expect(id).toContain('__false');
+    });
+
+    describe('source.client slash safety', () => {
+      it('produces an id with no "/" even when source.client contains slashes', () => {
+        const event = createTestEvent({
+          source: { service: 'orchestrator', component: 'compliance', client: 'xiaomi/mimo-v2-pro', environment: 'dev' },
+        });
+        expect(computeAggregateId(event)).not.toMatch(/\//);
+      });
+
+      it('is deterministic for the same input', () => {
+        const event = createTestEvent({
+          source: { service: 'orchestrator', component: 'compliance', client: 'xiaomi/mimo-v2-pro', environment: 'dev' },
+        });
+        expect(computeAggregateId(event)).toBe(computeAggregateId(event));
+      });
+
+      it('differs when source.client differs (hash distinguishes clients)', () => {
+        const a = computeAggregateId(createTestEvent({
+          source: { service: 'orchestrator', component: 'compliance', client: 'client-a', environment: 'dev' },
+        }));
+        const b = computeAggregateId(createTestEvent({
+          source: { service: 'orchestrator', component: 'compliance', client: 'client-b', environment: 'dev' },
+        }));
+        expect(a).not.toBe(b);
+      });
     });
   });
 });

--- a/apps/llm-usage-service/src/__tests__/infra/firestore/firestoreUsageAggregateRepository.test.ts
+++ b/apps/llm-usage-service/src/__tests__/infra/firestore/firestoreUsageAggregateRepository.test.ts
@@ -115,6 +115,22 @@ describe('FirestoreUsageAggregateRepository', () => {
     });
   });
 
+  describe('incrementAggregate — does not throw on bad doc-id', () => {
+    it('returns err Result instead of throwing when Firestore rejects the doc id', async () => {
+      mockDoc.mockImplementationOnce(() => {
+        throw new Error('Value for argument "documentPath" must point to a document');
+      });
+
+      const repo = new FirestoreUsageAggregateRepository();
+      const result = await repo.incrementAggregate(createTestEvent());
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.message).toMatch(/documentPath/);
+      }
+    });
+  });
+
   describe('queryAggregates', () => {
     it('returns aggregates from Firestore query', async () => {
       const docData = {

--- a/apps/llm-usage-service/src/infra/firestore/aggregateKeyUtils.ts
+++ b/apps/llm-usage-service/src/infra/firestore/aggregateKeyUtils.ts
@@ -18,11 +18,15 @@ export function toDateString(isoTimestamp: string): string {
 /**
  * Compute the aggregate document ID from event dimensions.
  *
- * Format: {date}__{ownerType}__{ownerIdHash}__{service}__{component}__{client}__{environment}__{provider}__{modelHash}__{operation}__{success}
+ * Format: {date}__{ownerType}__{ownerIdHash}__{service}__{component}__{clientHash}__{environment}__{provider}__{modelHash}__{operation}__{success}
+ *
+ * Position 5 is `clientHash` (sha256Truncated of source.client) rather than the raw value so that
+ * any client string containing "/" cannot produce an invalid Firestore document path segment.
  */
 export function computeAggregateId(event: UsageEvent): string {
   const date = toDateString(event.occurredAt);
   const ownerIdHash = sha256Truncated(event.owner.id);
+  const clientHash = sha256Truncated(event.source.client);
   const modelHash = sha256Truncated(event.request.model);
   const success = String(event.request.success);
 
@@ -32,7 +36,7 @@ export function computeAggregateId(event: UsageEvent): string {
     ownerIdHash,
     event.source.service,
     event.source.component,
-    event.source.client,
+    clientHash,
     event.source.environment,
     event.request.provider,
     modelHash,

--- a/apps/llm-usage-service/src/infra/firestore/firestoreUsageAggregateRepository.ts
+++ b/apps/llm-usage-service/src/infra/firestore/firestoreUsageAggregateRepository.ts
@@ -12,10 +12,10 @@ export class FirestoreUsageAggregateRepository implements UsageAggregateReposito
   async incrementAggregate(event: UsageEvent): Promise<Result<void, { code: string; message: string }>> {
     const db = getFirestore();
     const aggregateId = computeAggregateId(event);
-    const docRef = db.collection(COLLECTION).doc(aggregateId);
     const now = new Date().toISOString();
 
     try {
+      const docRef = db.collection(COLLECTION).doc(aggregateId);
       const doc = await docRef.get();
 
       const counterFields = {

--- a/docs/plans/2026-04-13-llm-usage-event-shape-fix.md
+++ b/docs/plans/2026-04-13-llm-usage-event-shape-fix.md
@@ -1,0 +1,1175 @@
+# LLM Usage Event Shape Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix structural bugs in the shared LLM usage event pipeline so that (a) Firestore writes never crash on OpenRouter-style model IDs, (b) user-initiated LLM calls show up as user-scoped events, (c) OpenRouter's per-call cost from the API response is the source of truth, and (d) missing pricing never drops events.
+
+**Architecture:** All fixes land in `packages/llm-pricing/`, `packages/infra-openrouter/`, `packages/internal-clients/`, and `apps/llm-usage-service/`. Zero changes to `workers/orchestrator/*` files (orchestrator inherits the improved event shape via the shared package). Backwards-compatible: every new field is optional with a default that preserves current behavior.
+
+**Tech Stack:** TypeScript strict mode, Vitest, Fastify (llm-usage-service), Firestore Admin SDK.
+
+---
+
+## Background — Verified Evidence
+
+These are the bugs being fixed. Each was confirmed against production logs, Firestore data, and source files.
+
+| #   | Symptom                                                                             | Root Cause                                                                                                              | File:Line                                                                            |
+| --- | ----------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| 1   | Recurring 500 on `/internal/webhooks/usage-events` (20:03:17, 20:54:16)             | `source.client = "xiaomi/mimo-v2-pro"` propagates into Firestore aggregate doc-ID; `/` makes the path-segment count odd | `packages/llm-pricing/src/buildUsageEvent.ts:46`                                     |
+| 2   | Sync throw kills the request; aggregate lost                                        | `db.collection(C).doc(id)` is **outside** the try/catch                                                                 | `apps/llm-usage-service/src/infra/firestore/firestoreUsageAggregateRepository.ts:15` |
+| 3   | User dashboard shows zero usage even when user-initiated calls happen               | `owner.type` hardcoded to `'system'` for every event                                                                    | `packages/llm-pricing/src/buildUsageEvent.ts:42`                                     |
+| 4   | OpenRouter cost computed via static allowlist instead of API-reported value         | `extractUsage` hardcodes `undefined` for `providerCost`                                                                 | `packages/infra-openrouter/src/client.ts:160`                                        |
+| 5   | Dynamic model selection (user picks unpriced model) throws → no LLM call → no event | `pricingContext.getPricing(model)` throws on missing                                                                    | `packages/llm-pricing/src/pricingClient.ts:374-379`                                  |
+
+---
+
+## File Structure
+
+**Modify:**
+- `packages/llm-pricing/src/usageLogger.ts` — add 3 optional fields to `UsageLogParams`
+- `packages/llm-pricing/src/buildUsageEvent.ts` — consume new fields with safe defaults
+- `packages/llm-pricing/src/pricingClient.ts` — make `getPricing` no-throw with warn-on-miss; `validateModels` keeps strict for startup
+- `packages/llm-pricing/src/__tests__/usageLogger.test.ts` — add cases for new fields
+- `packages/llm-pricing/src/__tests__/pricingClient.test.ts` — add no-throw test
+- `packages/llm-pricing/src/__tests__/httpInternalAuthUsageSink.test.ts` — update assertion of `client === <model>` → `client === <component>`
+- `packages/llm-pricing/src/__tests__/httpWebhookUsageSink.test.ts` — update assertion of `client === <model>` → `client === <component>`
+- `packages/infra-openrouter/src/client.ts` — capture `usage.cost`, pass as `providerCost`
+- `packages/infra-openrouter/src/types.ts` — add optional `cost?: number` to `OpenRouterUsage`
+- `packages/infra-openrouter/src/__tests__/client.test.ts` — add provider-cost passthrough tests (generate AND research)
+- `packages/llm-factory/src/llmClientFactory.ts` — add `ownerType` to `LlmClientConfig`, propagate
+- `packages/llm-factory/src/openRouterGenerateClient.ts` — propagate `ownerType` to inner client
+- `packages/infra-claude/src/client.ts` — accept `ownerType` in config, forward in `trackUsage`
+- `packages/infra-gemini/src/client.ts` — accept `ownerType` in config, forward in `trackUsage`
+- `packages/infra-gpt/src/client.ts` — accept `ownerType` in config, forward in `trackUsage`
+- `packages/infra-perplexity/src/client.ts` — accept `ownerType` in config, forward in `trackUsage`
+- `packages/internal-clients/src/user-service/client.ts` — pass `ownerType: 'user'` when creating per-user clients
+- `apps/llm-usage-service/src/infra/firestore/aggregateKeyUtils.ts` — hash `source.client`
+- `apps/llm-usage-service/src/infra/firestore/firestoreUsageAggregateRepository.ts` — widen try/catch around `doc()` call
+- `apps/llm-usage-service/src/__tests__/infra/firestore/aggregateKeyUtils.test.ts` — UPDATE existing `parts[5]` assertion (line 51) and add slash-safety test
+- `apps/llm-usage-service/src/__tests__/infra/firestore/firestoreUsageAggregateRepository.test.ts` — add error-path test
+
+**Buildup contract:** The new fields are added to `UsageLogParams` first (Task 1) so subsequent tasks have something to consume. Each subsequent task is independently committable.
+
+---
+
+## Task 1: Add optional fields to `UsageLogParams`
+
+**Files:**
+- Modify: `packages/llm-pricing/src/usageLogger.ts`
+- Test: `packages/llm-pricing/src/__tests__/usageLogger.test.ts`
+
+- [ ] **Step 1: Read the current `UsageLogParams` interface**
+
+Read `packages/llm-pricing/src/usageLogger.ts:42-59` to confirm field structure.
+
+- [ ] **Step 2: Add a failing test that the logger forwards new optional fields to the sink**
+
+Append to `packages/llm-pricing/src/__tests__/usageLogger.test.ts` inside the existing `describe('usageLogger', ...)` block:
+
+```ts
+  describe('UsageLogger.log forwarding new optional fields', () => {
+    it('forwards ownerType, clientName, providerReportedUsd to the sink when provided', async () => {
+      const fakeSink = { log: vi.fn().mockResolvedValue(undefined) };
+      const logger = createUsageLogger({ logger: fakeLogger, sink: fakeSink });
+
+      await logger.log({
+        ...baseParams,
+        ownerType: 'user',
+        clientName: 'linear-agent-title-gen',
+        providerReportedUsd: 0.0042,
+      });
+
+      expect(fakeSink.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ownerType: 'user',
+          clientName: 'linear-agent-title-gen',
+          providerReportedUsd: 0.0042,
+        }),
+      );
+    });
+
+    it('omits new optional fields from the sink call when not provided', async () => {
+      const fakeSink = { log: vi.fn().mockResolvedValue(undefined) };
+      const logger = createUsageLogger({ logger: fakeLogger, sink: fakeSink });
+
+      await logger.log(baseParams);
+
+      const callArg = fakeSink.log.mock.calls[0]?.[0] as Record<string, unknown>;
+      expect(callArg.ownerType).toBeUndefined();
+      expect(callArg.clientName).toBeUndefined();
+      expect(callArg.providerReportedUsd).toBeUndefined();
+    });
+  });
+```
+
+- [ ] **Step 3: Run the test to verify it fails (TypeScript error or assertion)**
+
+```bash
+cd /Users/p.buchman/personal/intexuraos-1
+pnpm --filter @intexuraos/llm-pricing test usageLogger.test.ts
+```
+
+Expected: TypeScript error — `ownerType`/`clientName`/`providerReportedUsd` are not in `UsageLogParams`.
+
+- [ ] **Step 4: Add the optional fields to `UsageLogParams`**
+
+In `packages/llm-pricing/src/usageLogger.ts`, locate the `UsageLogParams` interface (around line 42). Add three optional fields with JSDoc:
+
+```ts
+export interface UsageLogParams {
+  /** User ID for per-user tracking */
+  userId: string;
+  /** LLM provider (anthropic, openai, google, perplexity) */
+  provider: LlmProvider;
+  /** Model identifier (e.g., 'claude-sonnet-4-5') */
+  model: string;
+  /** Type of LLM operation performed */
+  callType: CallType;
+  /** Normalized usage with token counts and calculated cost */
+  usage: NormalizedUsage;
+  /** Whether the LLM call succeeded */
+  success: boolean;
+  /** Error message if success is false */
+  errorMessage?: string;
+  /** Optional pino logger for structured logging */
+  logger?: Logger;
+  /** Owner scope of the call. Defaults to 'system' when omitted to preserve legacy behavior. */
+  ownerType?: 'user' | 'system';
+  /** Slash-safe label identifying the calling client/transport (e.g. 'openrouter-generate'). Defaults to source.component when omitted. */
+  clientName?: string;
+  /** Cost reported by the provider (e.g. OpenRouter usage.cost). When set, the receiver records pricingSource: 'provider'. */
+  providerReportedUsd?: number | null;
+}
+```
+
+- [ ] **Step 5: Re-run the test to verify it passes**
+
+```bash
+pnpm --filter @intexuraos/llm-pricing test usageLogger.test.ts
+```
+
+Expected: PASS for both new tests; pre-existing tests still PASS.
+
+- [ ] **Step 6: Run the package's full type-check + tests**
+
+```bash
+pnpm --filter @intexuraos/llm-pricing run ci:tracked
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/llm-pricing/src/usageLogger.ts packages/llm-pricing/src/__tests__/usageLogger.test.ts
+git commit -m "feat(llm-pricing): add optional ownerType, clientName, providerReportedUsd to UsageLogParams"
+```
+
+---
+
+## Task 2: Update `buildUsageEvent` to consume the new fields
+
+**Files:**
+- Modify: `packages/llm-pricing/src/buildUsageEvent.ts`
+- Test: `packages/llm-pricing/src/__tests__/buildUsageEvent.test.ts` (NEW FILE)
+
+- [ ] **Step 1: Create a new test file with failing tests**
+
+Create `packages/llm-pricing/src/__tests__/buildUsageEvent.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { LlmModels, LlmProviders } from '@intexuraos/llm-contract';
+import { buildUsageEvent } from '../buildUsageEvent.js';
+import type { UsageLogParams } from '../usageLogger.js';
+
+const baseParams: UsageLogParams = {
+  userId: 'user-123',
+  provider: LlmProviders.OpenRouter,
+  model: 'or:nvidia/nemotron-3-super-120b-a12b:free',
+  callType: 'generate',
+  usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30, costUsd: 0.001 },
+  success: true,
+};
+
+const baseSource = { service: 'linear-agent', component: 'title-gen' };
+
+describe('buildUsageEvent', () => {
+  it('defaults owner.type to "system" when ownerType not provided', () => {
+    const event = buildUsageEvent(baseParams, baseSource) as Record<string, any>;
+    expect(event.owner).toEqual({ type: 'system', id: 'user-123' });
+  });
+
+  it('uses owner.type "user" when ownerType: "user" passed', () => {
+    const event = buildUsageEvent(
+      { ...baseParams, ownerType: 'user' },
+      baseSource,
+    ) as Record<string, any>;
+    expect(event.owner).toEqual({ type: 'user', id: 'user-123' });
+  });
+
+  it('defaults source.client to source.component when clientName not provided', () => {
+    const event = buildUsageEvent(baseParams, baseSource) as Record<string, any>;
+    expect(event.source.client).toBe('title-gen');
+  });
+
+  it('uses source.client = clientName when provided', () => {
+    const event = buildUsageEvent(
+      { ...baseParams, clientName: 'openrouter-generate' },
+      baseSource,
+    ) as Record<string, any>;
+    expect(event.source.client).toBe('openrouter-generate');
+  });
+
+  it('source.client never contains "/" even when model id contains it', () => {
+    const event = buildUsageEvent(baseParams, baseSource) as Record<string, any>;
+    expect(event.source.client).not.toMatch(/\//);
+  });
+
+  it('cost.providerReportedUsd is null and pricingSource is "calculated" by default', () => {
+    const event = buildUsageEvent(baseParams, baseSource) as Record<string, any>;
+    expect(event.cost.providerReportedUsd).toBeNull();
+    expect(event.cost.pricingSource).toBe('calculated');
+    expect(event.cost.billedUsd).toBe(0.001);
+    expect(event.cost.calculatedUsd).toBe(0.001);
+  });
+
+  it('cost uses providerReportedUsd as billedUsd when provided; pricingSource = "provider_reported"', () => {
+    const event = buildUsageEvent(
+      { ...baseParams, providerReportedUsd: 0.0042 },
+      baseSource,
+    ) as Record<string, any>;
+    expect(event.cost.providerReportedUsd).toBe(0.0042);
+    expect(event.cost.billedUsd).toBe(0.0042);
+    expect(event.cost.calculatedUsd).toBe(0.001); // params.usage.costUsd retained
+    expect(event.cost.pricingSource).toBe('provider_reported');
+  });
+
+  it('clamps a negative providerReportedUsd to 0 (schema requires billedUsd >= 0)', () => {
+    const event = buildUsageEvent(
+      { ...baseParams, providerReportedUsd: -0.001 },
+      baseSource,
+    ) as Record<string, any>;
+    expect(event.cost.billedUsd).toBeGreaterThanOrEqual(0);
+  });
+
+  it('treats providerReportedUsd: null as "no provider cost"', () => {
+    const event = buildUsageEvent(
+      { ...baseParams, providerReportedUsd: null },
+      baseSource,
+    ) as Record<string, any>;
+    expect(event.cost.providerReportedUsd).toBeNull();
+    expect(event.cost.pricingSource).toBe('calculated');
+    expect(event.cost.billedUsd).toBe(0.001);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify failures**
+
+```bash
+pnpm --filter @intexuraos/llm-pricing test buildUsageEvent.test.ts
+```
+
+Expected: Multiple FAIL — `owner.type` always 'system', `source.client` is the model id, etc.
+
+- [ ] **Step 3: Implement the changes in `buildUsageEvent.ts`**
+
+Replace the body of `buildUsageEvent` in `packages/llm-pricing/src/buildUsageEvent.ts`:
+
+```ts
+export function buildUsageEvent(
+  params: UsageLogParams,
+  source: { service: string; component: string },
+  correlationOverrides?: CorrelationOverrides
+): UsageEventPayload {
+  const environment: 'dev' | 'prod' = process.env['NODE_ENV'] === 'production' ? 'prod' : 'dev';
+
+  const ownerType = params.ownerType ?? 'system';
+  const clientName = params.clientName ?? source.component;
+  const providerReportedUsd = params.providerReportedUsd ?? null;
+  const useProviderCost = providerReportedUsd !== null;
+  // Schema requires billedUsd >= 0; clamp defensively so a misbehaving provider can't 400 the receiver.
+  const billedUsd = useProviderCost
+    ? Math.max(0, providerReportedUsd)
+    : params.usage.costUsd;
+  const pricingSource = useProviderCost ? 'provider_reported' : 'calculated';
+
+  return {
+    schemaVersion: 1,
+    eventId: crypto.randomUUID(),
+    occurredAt: new Date().toISOString(),
+    owner: { type: ownerType, id: params.userId },
+    source: {
+      service: source.service,
+      component: source.component,
+      client: clientName,
+      environment,
+    },
+    request: {
+      provider: params.provider,
+      model: params.model,
+      operation: params.callType,
+      success: params.success,
+      durationMs: 0,
+    },
+    usage: {
+      inputTokens: params.usage.inputTokens,
+      outputTokens: params.usage.outputTokens,
+      totalTokens: params.usage.totalTokens,
+      cacheReadTokens: params.usage.cacheTokens ?? 0,
+      cacheWriteTokens: 0,
+      cachedTokens: 0,
+      reasoningTokens: params.usage.reasoningTokens ?? 0,
+      thinkingTokens: params.usage.thinkingTokens ?? 0,
+      webSearchCalls: params.usage.webSearchCalls ?? 0,
+      groundingEnabled: params.usage.groundingEnabled ?? false,
+      imageCount: 0,
+    },
+    cost: {
+      billedUsd,
+      providerReportedUsd,
+      calculatedUsd: params.usage.costUsd,
+      pricingSource,
+    },
+    correlation: {
+      requestId: correlationOverrides?.requestId ?? null,
+      traceId: null,
+      taskId: correlationOverrides?.taskId ?? null,
+      researchId: null,
+      attempt: null,
+      sessionId: correlationOverrides?.sessionId ?? null,
+    },
+    error: params.success ? null : { code: null, message: params.errorMessage ?? null },
+  };
+}
+```
+
+- [ ] **Step 4: Run buildUsageEvent tests to verify they pass**
+
+```bash
+pnpm --filter @intexuraos/llm-pricing test buildUsageEvent.test.ts
+```
+
+Expected: All PASS.
+
+- [ ] **Step 5: Run sibling sink tests to confirm no regression**
+
+```bash
+pnpm --filter @intexuraos/llm-pricing test
+```
+
+Expected: All PASS (httpInternalAuthUsageSink + httpWebhookUsageSink tests still green because they don't pass the new fields and defaults match prior behavior — `client = source.component`, not `client = model`).
+
+If `httpInternalAuthUsageSink.test.ts` or `httpWebhookUsageSink.test.ts` asserts `client === <model>`, **update those tests to assert `client === <component>`** (this matches the new, correct semantic). Cite each test that changes.
+
+- [ ] **Step 6: Run the receiver service tests to ensure aggregate doc-ID schema still validates**
+
+```bash
+pnpm --filter @intexuraos/llm-usage-service test
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/llm-pricing/src/buildUsageEvent.ts packages/llm-pricing/src/__tests__/
+git commit -m "feat(llm-pricing): consume ownerType/clientName/providerReportedUsd in buildUsageEvent"
+```
+
+---
+
+## Task 3: Make `pricingContext.getPricing` no-throw
+
+**Files:**
+- Modify: `packages/llm-pricing/src/pricingClient.ts`
+- Test: `packages/llm-pricing/src/__tests__/pricingClient.test.ts`
+
+- [ ] **Step 1: Add a failing test for the no-throw contract**
+
+Append to `packages/llm-pricing/src/__tests__/pricingClient.test.ts` inside the existing PricingContext describe block:
+
+```ts
+  describe('getPricing no-throw on missing model', () => {
+    it('returns zero pricing instead of throwing when the model is unknown', () => {
+      const ctx = new PricingContext({
+        google: { models: {}, updatedAt: '' },
+        openai: { models: {}, updatedAt: '' },
+        anthropic: { models: {}, updatedAt: '' },
+        perplexity: { models: {}, updatedAt: '' },
+        openrouter: { models: {}, updatedAt: '' },
+      });
+
+      const pricing = ctx.getPricing('or:some/unpriced-model' as LLMModel);
+
+      expect(pricing).toEqual({ inputPricePerMillion: 0, outputPricePerMillion: 0 });
+    });
+
+    it('still returns the real pricing for a known model', () => {
+      const ctx = new PricingContext({
+        google: { models: {}, updatedAt: '' },
+        openai: { models: {}, updatedAt: '' },
+        anthropic: {
+          models: {
+            'claude-sonnet-4-5': { inputPricePerMillion: 3, outputPricePerMillion: 15 },
+          },
+          updatedAt: '',
+        },
+        perplexity: { models: {}, updatedAt: '' },
+        openrouter: { models: {}, updatedAt: '' },
+      });
+
+      expect(ctx.getPricing('claude-sonnet-4-5' as LLMModel)).toEqual({
+        inputPricePerMillion: 3,
+        outputPricePerMillion: 15,
+      });
+    });
+  });
+
+  describe('validateModels still throws on missing — fail-fast preserved for startup', () => {
+    it('validateModels throws when a required model is missing', () => {
+      const ctx = new PricingContext({
+        google: { models: {}, updatedAt: '' },
+        openai: { models: {}, updatedAt: '' },
+        anthropic: { models: {}, updatedAt: '' },
+        perplexity: { models: {}, updatedAt: '' },
+        openrouter: { models: {}, updatedAt: '' },
+      });
+
+      expect(() => ctx.validateModels(['claude-sonnet-4-5' as LLMModel])).toThrow(
+        /Missing pricing/,
+      );
+    });
+  });
+```
+
+- [ ] **Step 2: Run the test to verify failure**
+
+```bash
+pnpm --filter @intexuraos/llm-pricing test pricingClient.test.ts
+```
+
+Expected: FAIL — `getPricing` currently throws on unknown model.
+
+- [ ] **Step 3: Implement the no-throw change**
+
+In `packages/llm-pricing/src/pricingClient.ts`, replace the body of `getPricing`:
+
+```ts
+  /**
+   * Get pricing for a model.
+   *
+   * Returns zero pricing for unknown models so producers can still emit a
+   * usage event with cost=$0 instead of crashing. Use validateModels() at
+   * startup if you need fail-fast for known-static dependencies.
+   */
+  getPricing(model: LLMModel): ModelPricing {
+    const pricing = this.pricing.get(model);
+    if (pricing === undefined) {
+      // Audit trail: ops needs to know which models leak through unpriced.
+      // Use console.warn (no Logger dep in PricingContext) — Cloud Logging picks it up as severity=WARNING.
+      console.warn(`[llm-pricing] No pricing for model ${String(model)} — falling back to $0; emit-don't-skip policy`);
+      return { inputPricePerMillion: 0, outputPricePerMillion: 0 };
+    }
+    return pricing;
+  }
+```
+
+Update the JSDoc on `IPricingContext.getPricing` (line ~308) to match — remove "throws if not found" and replace with "returns zero pricing for unknown models, emits a warn for ops audit".
+
+- [ ] **Step 4: Re-run the package tests**
+
+```bash
+pnpm --filter @intexuraos/llm-pricing test
+```
+
+Expected: New tests PASS. Existing tests assert no throw on known models — should still pass. If any pre-existing test asserts `expect(() => ctx.getPricing('unknown')).toThrow(...)`, **delete that assertion** (the contract changed). Cite each removed assertion.
+
+- [ ] **Step 5: Run dependent packages' tests to catch any caller that relied on throw**
+
+```bash
+pnpm --filter @intexuraos/internal-clients test
+pnpm --filter @intexuraos/llm-factory test
+```
+
+Expected: PASS. If a test in `internal-clients` was asserting `getLlmClient` throws on unknown model, change it to assert the LLM call now succeeds with cost=0. Cite the test.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/llm-pricing/src/pricingClient.ts packages/llm-pricing/src/__tests__/pricingClient.test.ts
+git commit -m "feat(llm-pricing): make getPricing no-throw; preserve fail-fast in validateModels"
+```
+
+---
+
+## Task 4: Capture OpenRouter `usage.cost` in the API response
+
+**Files:**
+- Modify: `packages/infra-openrouter/src/client.ts`
+- Test: `packages/infra-openrouter/src/__tests__/client.test.ts`
+
+**Background:** Per OpenRouter docs (verified via context7 against `openrouter.ai`), `/chat/completions` always returns `usage.cost` (number, USD). The current code at line 156-160 hardcodes `undefined` and back-computes via static pricing. We will read `usage.cost`, populate `NormalizedUsage.costUsd` from it when present, and pass it through to `usageLogger.log` as `providerReportedUsd`.
+
+- [ ] **Step 1: Read the current `extractUsage` and `trackUsage` functions**
+
+Read `packages/infra-openrouter/src/client.ts:131-163`. Note the `OpenRouterUsage` interface lives in **`packages/infra-openrouter/src/types.ts:100-104`** (NOT in client.ts). It currently models `prompt_tokens`, `completion_tokens`, `total_tokens`. We need to add `cost?: number`. Also note that `extractUsage` is declared as a **closure inside `createOpenRouterClient`** that captures `pricing` from the outer scope — keep it as a closure, do not extract it to module scope.
+
+- [ ] **Step 2: Add a failing test for cost passthrough**
+
+In `packages/infra-openrouter/src/__tests__/client.test.ts`, add:
+
+```ts
+  describe('OpenRouter usage.cost passthrough', () => {
+    it('uses usage.cost from API response and forwards it to the sink as providerReportedUsd', async () => {
+      const fakeSink = { log: vi.fn().mockResolvedValue(undefined) };
+
+      // Use nock or whatever the existing test infra uses to fake the OpenRouter response
+      // (mirror an existing test in this file — copy its setup pattern).
+      // The faked response body MUST include:
+      //   usage: { prompt_tokens: 100, completion_tokens: 50, cost: 0.0042 }
+
+      const client = createOpenRouterClient({
+        apiKey: 'test',
+        model: 'xiaomi/mimo-v2-pro',
+        userId: 'test-user',
+        pricing: { inputPricePerMillion: 0, outputPricePerMillion: 0, useProviderCost: true },
+        logger: fakeLogger,
+        usageSink: fakeSink,
+      });
+
+      const result = await client.generate('hello');
+      expect(result.ok).toBe(true);
+
+      expect(fakeSink.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          providerReportedUsd: 0.0042,
+        }),
+      );
+    });
+
+    it('omits providerReportedUsd when usage.cost absent and falls back to token-based costUsd', async () => {
+      const fakeSink = { log: vi.fn().mockResolvedValue(undefined) };
+      // Mirror the existing response-mocking idiom from this file's first test.
+      // The faked response body MUST include:
+      //   usage: { prompt_tokens: 100, completion_tokens: 50, total_tokens: 150 }   // NO cost field
+      const client = createOpenRouterClient({
+        apiKey: 'test',
+        model: 'xiaomi/mimo-v2-pro',
+        userId: 'test-user',
+        pricing: { inputPricePerMillion: 1, outputPricePerMillion: 2 },
+        logger: fakeLogger,
+        usageSink: fakeSink,
+      });
+      await client.generate('hello');
+
+      const callArg = fakeSink.log.mock.calls[0]?.[0] as Record<string, any>;
+      expect(callArg.providerReportedUsd).toBeUndefined();
+      // Sanity: token-based fallback still produces a non-zero cost when token prices > 0.
+      expect(callArg.usage.costUsd).toBeGreaterThan(0);
+    });
+
+    it('forwards providerReportedUsd on the research callType too', async () => {
+      const fakeSink = { log: vi.fn().mockResolvedValue(undefined) };
+      // Faked response body for research: same shape with usage.cost = 0.011
+      const client = createOpenRouterClient({
+        apiKey: 'test',
+        model: 'xiaomi/mimo-v2-pro',
+        userId: 'test-user',
+        pricing: { inputPricePerMillion: 0, outputPricePerMillion: 0, useProviderCost: true },
+        logger: fakeLogger,
+        usageSink: fakeSink,
+      });
+      await client.research('hello');
+
+      expect(fakeSink.log).toHaveBeenCalledWith(
+        expect.objectContaining({ callType: 'research', providerReportedUsd: 0.011 }),
+      );
+    });
+  });
+```
+
+(Adapt the response-mocking idiom to what's already in this file — read the first test in `client.test.ts` and mirror its `nock` or `vi.spyOn(global, 'fetch')` setup.)
+
+- [ ] **Step 3: Run the test to verify failure**
+
+```bash
+pnpm --filter @intexuraos/infra-openrouter test
+```
+
+Expected: FAIL — `cost` not in the parsed `OpenRouterUsage`, not forwarded.
+
+- [ ] **Step 4: Update the `OpenRouterUsage` type**
+
+In `packages/infra-openrouter/src/types.ts:100-104`, add `cost`:
+
+```ts
+export interface OpenRouterUsage {
+  prompt_tokens: number;
+  completion_tokens: number;
+  total_tokens: number;
+  cost?: number; // OpenRouter reports USD cost per request (always present per docs, optional for back-compat)
+}
+```
+
+- [ ] **Step 5: Refactor `extractUsage` and `trackUsage` in `client.ts`**
+
+In `packages/infra-openrouter/src/client.ts`, **keep `extractUsage` as a closure** inside `createOpenRouterClient` so it retains access to `pricing`. Change its return shape and update all call sites:
+
+1. Replace `extractUsage` (current lines 150-163):
+
+   ```ts
+   function extractUsage(usage: OpenRouterUsage | undefined): {
+     normalized: NormalizedUsage;
+     providerReportedUsd: number | null;
+   } {
+     /* v8 ignore start -- upstream: cannot verify usage is present in all API responses @preserve */
+     if (usage === undefined) {
+       return {
+         normalized: { inputTokens: 0, outputTokens: 0, totalTokens: 0, costUsd: 0 },
+         providerReportedUsd: null,
+       };
+     }
+     /* v8 ignore stop @preserve */
+     const providerReportedUsd = typeof usage.cost === 'number' ? usage.cost : null;
+     const normalized = normalizeUsage(
+       usage.prompt_tokens,
+       usage.completion_tokens,
+       providerReportedUsd ?? undefined,
+       pricing,
+     );
+     return { normalized, providerReportedUsd };
+   }
+   ```
+
+2. Update `trackUsage` signature to accept the optional provider cost:
+
+   ```ts
+   function trackUsage(
+     callType: CallType,
+     usage: NormalizedUsage,
+     success: boolean,
+     errorMessage?: string,
+     providerReportedUsd?: number | null,
+   ): void {
+     void usageLogger.log({
+       userId,
+       provider: LlmProviders.OpenRouter,
+       model,
+       callType,
+       usage,
+       success,
+       ...(errorMessage !== undefined && { errorMessage }),
+       ...(providerReportedUsd !== undefined && providerReportedUsd !== null && { providerReportedUsd }),
+     });
+   }
+   ```
+
+3. **Refactor every call site of `extractUsage`** — there are TWO success paths (research and generate) and FOUR error paths:
+
+| Line                   | Path                  | Refactor                                                                                                                                                                                        |
+| ---------------------- | --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ~218                   | `research` success    | `const { normalized, providerReportedUsd } = extractUsage(data.usage); trackUsage('research', normalized, true, undefined, providerReportedUsd);`                                               |
+| ~316                   | `generate` success    | `const { normalized, providerReportedUsd } = extractUsage(data.usage); trackUsage('generate', normalized, true, undefined, providerReportedUsd);`                                               |
+| ~210, ~249, ~298, ~327 | error paths (4 sites) | Leave the existing `emptyUsage` literal as-is and call `trackUsage(callType, emptyUsage, false, errorMsg)` — `providerReportedUsd` is omitted (defaults to undefined → omitted from sink call). |
+
+   Read each call site before editing to confirm the surrounding variables.
+
+4. Delete the obsolete comment at the old line 156 ("OpenRouter doesn't provide per-request cost in the response").
+
+- [ ] **Step 6: Run the package tests**
+
+```bash
+pnpm --filter @intexuraos/infra-openrouter test
+```
+
+Expected: New tests PASS. Pre-existing tests still PASS (back-compat — when response has no `cost`, behavior matches today).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/infra-openrouter/src/client.ts packages/infra-openrouter/src/types.ts packages/infra-openrouter/src/__tests__/client.test.ts
+git commit -m "feat(infra-openrouter): capture usage.cost from API response and forward as providerReportedUsd"
+```
+
+---
+
+## Task 5: Plumb `ownerType` through `LlmClientConfig` and the OpenRouter generate client
+
+**Files:**
+- Modify: `packages/llm-factory/src/llmClientFactory.ts`
+- Modify: `packages/llm-factory/src/openRouterGenerateClient.ts`
+- Test: `packages/llm-factory/src/__tests__/llmClientFactory.test.ts`
+- Test: `packages/llm-factory/src/__tests__/openRouterGenerateClient.test.ts`
+
+- [ ] **Step 1: Read `LlmClientConfig` and locate the call to underlying clients**
+
+Read `packages/llm-factory/src/llmClientFactory.ts` and `packages/llm-factory/src/openRouterGenerateClient.ts`. Identify where `usageSink`/`usageLogger` is wired.
+
+- [ ] **Step 2: Add a failing test asserting ownerType propagates to the underlying sink**
+
+In `packages/llm-factory/src/__tests__/llmClientFactory.test.ts`, add:
+
+```ts
+  describe('LlmClientConfig.ownerType propagation', () => {
+    it('forwards ownerType to the usage sink when passed', async () => {
+      const fakeSink = { log: vi.fn().mockResolvedValue(undefined) };
+      const client = createLlmClient({
+        apiKey: 'test',
+        model: 'gpt-4o-mini',
+        userId: 'user-123',
+        pricing: { inputPricePerMillion: 1, outputPricePerMillion: 1 },
+        logger: fakeLogger,
+        usageSink: fakeSink,
+        ownerType: 'user',
+      });
+      // Trigger the generate path — mock the underlying provider call to succeed cheaply.
+      // (Mirror the existing test pattern in this file for HTTP mocking.)
+      await client.generate('hello');
+
+      expect(fakeSink.log).toHaveBeenCalledWith(
+        expect.objectContaining({ ownerType: 'user' }),
+      );
+    });
+
+    it('omits ownerType from the sink call when not configured (defaults to system downstream)', async () => {
+      const fakeSink = { log: vi.fn().mockResolvedValue(undefined) };
+      const client = createLlmClient({
+        apiKey: 'test',
+        model: 'gpt-4o-mini',
+        userId: 'user-123',
+        pricing: { inputPricePerMillion: 1, outputPricePerMillion: 1 },
+        logger: fakeLogger,
+        usageSink: fakeSink,
+      });
+      await client.generate('hello');
+
+      const callArg = fakeSink.log.mock.calls[0]?.[0] as Record<string, unknown>;
+      expect(callArg.ownerType).toBeUndefined();
+    });
+  });
+```
+
+Add a parallel test in `openRouterGenerateClient.test.ts`.
+
+- [ ] **Step 3: Run the test to verify failure**
+
+```bash
+pnpm --filter @intexuraos/llm-factory test
+```
+
+Expected: TypeScript error — `ownerType` is not in `LlmClientConfig`.
+
+- [ ] **Step 4: Add `ownerType` to `LlmClientConfig`**
+
+In `packages/llm-factory/src/llmClientFactory.ts`, locate the `LlmClientConfig` interface and add:
+
+```ts
+export interface LlmClientConfig {
+  // ...existing fields...
+  /** Owner scope for emitted usage events. Defaults to undefined → 'system' downstream. */
+  ownerType?: 'user' | 'system';
+}
+```
+
+In every `createLlmClient` provider branch (Claude, Gemini, GPT, Perplexity, OpenRouter), find where the inner client is constructed and pass `ownerType` through into the `usageSink` payload. Concretely, each infra-* client's `trackUsage` helper needs to forward `ownerType`.
+
+**Pattern (apply to each infra-* client called from llm-factory):**
+
+In the infra client's `trackUsage` helper (e.g., `packages/infra-claude/src/client.ts`, similar pattern in others):
+
+```ts
+function trackUsage(
+  callType: CallType,
+  usage: NormalizedUsage,
+  success: boolean,
+  errorMessage?: string,
+): void {
+  void usageLogger.log({
+    userId,
+    provider: LlmProviders.Anthropic,
+    model,
+    callType,
+    usage,
+    success,
+    ...(errorMessage !== undefined && { errorMessage }),
+    ...(ownerType !== undefined && { ownerType }),
+  });
+}
+```
+
+Add `ownerType` to each infra client's `Config` interface (just pass-through). Read `ownerType` from `config` in the factory function. **Do this for all 5 infra-* clients (`infra-claude`, `infra-gemini`, `infra-gpt`, `infra-openrouter`, `infra-perplexity`)** so they all support the new field.
+
+- [ ] **Step 5: Update `openRouterGenerateClient.ts` to forward `ownerType`**
+
+In `packages/llm-factory/src/openRouterGenerateClient.ts`, the call to `createOpenRouterClient` (around line 12) — add `ownerType: config.ownerType` to the constructor argument.
+
+- [ ] **Step 6: Run all dependent package tests**
+
+```bash
+pnpm --filter @intexuraos/llm-factory test
+pnpm --filter @intexuraos/infra-openrouter test
+pnpm --filter @intexuraos/infra-claude test
+pnpm --filter @intexuraos/infra-gemini test
+pnpm --filter @intexuraos/infra-gpt test
+pnpm --filter @intexuraos/infra-perplexity test
+```
+
+Expected: All PASS (back-compat — when `ownerType` is not passed, behavior is unchanged).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/llm-factory packages/infra-claude packages/infra-gemini packages/infra-gpt packages/infra-openrouter packages/infra-perplexity
+git commit -m "feat(llm-factory,infra-*): plumb ownerType through every LLM client construction"
+```
+
+---
+
+## Task 6: User-context callers pass `ownerType: 'user'`
+
+**Files:**
+- Modify: `packages/internal-clients/src/user-service/client.ts`
+- Test: `packages/internal-clients/src/user-service/__tests__/client.test.ts`
+
+The `getLlmClient(userId)` function is called specifically when the system acts on behalf of a user. Every client created here MUST be tagged `ownerType: 'user'`.
+
+- [ ] **Step 1: Add a failing test**
+
+In `packages/internal-clients/src/user-service/__tests__/client.test.ts`, add:
+
+```ts
+  describe('getLlmClient sets ownerType to "user"', () => {
+    it('passes ownerType: "user" into the underlying LlmClient config', async () => {
+      // Spy on createLlmClient (or whatever it's wired through) to capture the config.
+      const captured: any[] = [];
+      vi.spyOn(llmFactoryModule, 'createLlmClient').mockImplementation((cfg: any) => {
+        captured.push(cfg);
+        return { generate: vi.fn().mockResolvedValue({ ok: true, value: { content: '' } }) } as any;
+      });
+
+      // Stub the user-service /settings + /llm-keys responses.
+      // (Mirror the pattern used in the existing client.test.ts.)
+
+      const client = createUserServiceClient({/* ... */});
+      const result = await client.getLlmClient('user-123');
+      expect(result.ok).toBe(true);
+
+      expect(captured.at(-1)).toEqual(expect.objectContaining({ ownerType: 'user' }));
+    });
+  });
+```
+
+- [ ] **Step 2: Run the test to verify failure**
+
+```bash
+pnpm --filter @intexuraos/internal-clients test
+```
+
+Expected: FAIL — `ownerType` not in the captured config.
+
+- [ ] **Step 3: Implement: pass `ownerType: 'user'` in every `createLlmClient` call inside `getLlmClient`**
+
+In `packages/internal-clients/src/user-service/client.ts`, locate the three places `createLlmClient(...)` is invoked inside the `getLlmClient` async method (lines ~208, ~259, ~282). Add `ownerType: 'user'` to each `LlmClientConfig` literal.
+
+Also update the inner `buildClientForModel` helper (line ~250-267) to pass `ownerType: 'user'`.
+
+- [ ] **Step 4: Re-run tests**
+
+```bash
+pnpm --filter @intexuraos/internal-clients test
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/internal-clients
+git commit -m "feat(internal-clients): tag user-service getLlmClient calls with ownerType: 'user'"
+```
+
+---
+
+## Task 7: Hash `source.client` in aggregate doc-ID (defense-in-depth)
+
+**Files:**
+- Modify: `apps/llm-usage-service/src/infra/firestore/aggregateKeyUtils.ts`
+- Test: `apps/llm-usage-service/src/__tests__/infra/firestore/aggregateKeyUtils.test.ts`
+
+After Task 2, `source.client` will no longer contain slashes from any IntexuraOS or orchestrator producer. This task adds a belt to the existing suspenders so any future producer that goes rogue can't crash the aggregate write.
+
+- [ ] **Step 1: Update the existing test, then add new slash-safety cases**
+
+The test file `apps/llm-usage-service/src/__tests__/infra/firestore/aggregateKeyUtils.test.ts` ALREADY EXISTS. At ~line 51 it asserts `expect(parts[5]).toBe('web')` (raw client). After hashing, `parts[5]` will be `sha256Truncated('web')`. Update that single assertion FIRST:
+
+```ts
+// Before (line ~51):
+expect(parts[5]).toBe('web');
+// After:
+expect(parts[5]).toBe(sha256Truncated('web'));
+```
+
+Then APPEND the slash-safety cases (don't replace the file):
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { computeAggregateId } from '../../../infra/firestore/aggregateKeyUtils.js';
+import type { UsageEvent } from '../../../domain/models/usageEvent.js';
+
+const baseEvent: UsageEvent = {
+  schemaVersion: 1,
+  eventId: 'evt-1',
+  occurredAt: '2026-04-13T20:00:00.000Z',
+  receivedAt: '2026-04-13T20:00:00.001Z',
+  ingress: 'orchestrator_webhook',
+  owner: { type: 'system', id: 'sys-1' },
+  source: { service: 'orchestrator', component: 'compliance', client: 'xiaomi/mimo-v2-pro', environment: 'dev' },
+  request: { provider: 'openrouter', model: 'xiaomi/mimo-v2-pro', operation: 'generate', success: true, durationMs: 0 },
+  usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0, cachedTokens: 0, reasoningTokens: 0, thinkingTokens: 0, webSearchCalls: 0, groundingEnabled: false, imageCount: 0 },
+  cost: { billedUsd: 0, providerReportedUsd: null, calculatedUsd: 0, pricingSource: 'calculated' },
+  correlation: { requestId: null, traceId: null, taskId: null, researchId: null, attempt: null, sessionId: null },
+  error: null,
+};
+
+describe('computeAggregateId — slash safety', () => {
+  it('produces an id with no "/" even when source.client contains slashes', () => {
+    const id = computeAggregateId(baseEvent);
+    expect(id).not.toMatch(/\//);
+  });
+
+  it('is deterministic for the same input', () => {
+    expect(computeAggregateId(baseEvent)).toBe(computeAggregateId(baseEvent));
+  });
+
+  it('differs when source.client differs (hash distinguishes clients)', () => {
+    const idA = computeAggregateId(baseEvent);
+    const idB = computeAggregateId({
+      ...baseEvent,
+      source: { ...baseEvent.source, client: 'different-client' },
+    });
+    expect(idA).not.toBe(idB);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify the slash-safety case fails**
+
+```bash
+pnpm --filter @intexuraos/llm-usage-service test aggregateKeyUtils.test.ts
+```
+
+Expected: First test FAILS (id contains the raw `xiaomi/mimo-v2-pro`).
+
+- [ ] **Step 3: Update `computeAggregateId` to hash `source.client`**
+
+In `apps/llm-usage-service/src/infra/firestore/aggregateKeyUtils.ts`, replace the `computeAggregateId` body:
+
+```ts
+export function computeAggregateId(event: UsageEvent): string {
+  const date = toDateString(event.occurredAt);
+  const ownerIdHash = sha256Truncated(event.owner.id);
+  const clientHash = sha256Truncated(event.source.client);
+  const modelHash = sha256Truncated(event.request.model);
+  const success = String(event.request.success);
+
+  return [
+    date,
+    event.owner.type,
+    ownerIdHash,
+    event.source.service,
+    event.source.component,
+    clientHash,
+    event.source.environment,
+    event.request.provider,
+    modelHash,
+    event.request.operation,
+    success,
+  ].join('__');
+}
+```
+
+Update the JSDoc on the function to reflect the new format string.
+
+- [ ] **Step 4: Re-run tests**
+
+```bash
+pnpm --filter @intexuraos/llm-usage-service test aggregateKeyUtils.test.ts
+```
+
+Expected: All PASS.
+
+- [ ] **Step 5: Run the full app test suite**
+
+```bash
+pnpm --filter @intexuraos/llm-usage-service test
+```
+
+Expected: All PASS (other tests don't assert specific aggregate id strings; if any does, update it to the new format).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/llm-usage-service/src/infra/firestore/aggregateKeyUtils.ts apps/llm-usage-service/src/__tests__/infra/firestore/aggregateKeyUtils.test.ts
+git commit -m "fix(llm-usage-service): hash source.client in aggregate doc-id for slash safety"
+```
+
+---
+
+## Task 8: Wrap `db.collection().doc()` in try/catch in the aggregate repository
+
+**Files:**
+- Modify: `apps/llm-usage-service/src/infra/firestore/firestoreUsageAggregateRepository.ts`
+- Test: `apps/llm-usage-service/src/__tests__/infra/firestore/firestoreUsageAggregateRepository.test.ts`
+
+Even after Task 7, `db.collection(C).doc(badId)` will throw synchronously if Firestore validates anything else. Move the doc reference construction inside the try block so any failure becomes a logged `err` Result instead of a 500.
+
+- [ ] **Step 1: Add a failing test using the EXISTING mock pattern in this file**
+
+Read the top of `apps/llm-usage-service/src/__tests__/infra/firestore/firestoreUsageAggregateRepository.test.ts`. The file already uses `vi.mock('@intexuraos/infra-firestore', ...)` at the top with named mock functions like `mockDoc`, `mockCollection`. **Reuse those — do NOT introduce `vi.spyOn(firestoreModule, ...)` (mixing mock strategies on the same module is fragile).**
+
+Add a test that reuses the existing mock infrastructure to make `mockDoc` throw synchronously on a single call:
+
+```ts
+  describe('incrementAggregate — does not throw on bad doc-id', () => {
+    it('returns err Result instead of throwing when Firestore rejects the doc id', async () => {
+      mockDoc.mockImplementationOnce(() => {
+        throw new Error('Value for argument "documentPath" must point to a document');
+      });
+
+      const repo = new FirestoreUsageAggregateRepository();
+      const result = await repo.incrementAggregate(makeFakeEvent());
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.message).toMatch(/documentPath/);
+      }
+    });
+  });
+```
+
+(Use the existing `makeFakeEvent` helper in this file, or copy its body if it doesn't exist as a helper. The point is to reuse the pre-existing mock plumbing rather than swap strategies.)
+
+- [ ] **Step 2: Run the test to verify failure**
+
+```bash
+pnpm --filter @intexuraos/llm-usage-service test firestoreUsageAggregateRepository.test.ts
+```
+
+Expected: FAIL — the throw escapes (test expects `result.ok === false`, gets thrown error).
+
+- [ ] **Step 3: Move the doc construction into the try block**
+
+In `apps/llm-usage-service/src/infra/firestore/firestoreUsageAggregateRepository.ts`, refactor `incrementAggregate`:
+
+```ts
+  async incrementAggregate(event: UsageEvent): Promise<Result<void, { code: string; message: string }>> {
+    const db = getFirestore();
+    const aggregateId = computeAggregateId(event);
+    const now = new Date().toISOString();
+
+    try {
+      const docRef = db.collection(COLLECTION).doc(aggregateId);
+      const doc = await docRef.get();
+
+      const counterFields = {
+        // ... existing counter fields ...
+      };
+
+      if (doc.exists) {
+        await docRef.update({
+          ...counterFields,
+          lastOccurredAt: event.occurredAt,
+          updatedAt: now,
+        });
+      } else {
+        await docRef.set({
+          // ... existing set payload ...
+        });
+      }
+
+      return ok(undefined);
+    } catch (error: unknown) {
+      const firestoreError = error as { code?: number; message?: string };
+      return err({
+        code: String(firestoreError.code ?? 'UNKNOWN'),
+        message: firestoreError.message ?? 'Unknown Firestore error',
+      });
+    }
+  }
+```
+
+The single-line move: `const docRef = db.collection(COLLECTION).doc(aggregateId);` was at line 15 (before try). Now it lives inside the try, BEFORE `await docRef.get()`.
+
+- [ ] **Step 4: Re-run tests**
+
+```bash
+pnpm --filter @intexuraos/llm-usage-service test firestoreUsageAggregateRepository.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/llm-usage-service/src/infra/firestore/firestoreUsageAggregateRepository.ts apps/llm-usage-service/src/__tests__/infra/firestore/firestoreUsageAggregateRepository.test.ts
+git commit -m "fix(llm-usage-service): widen try/catch to cover doc-ref construction in incrementAggregate"
+```
+
+---
+
+## Task 9: End-to-end repo CI
+
+**Files:** none
+
+- [ ] **Step 1: Run the repo-wide CI from root**
+
+```bash
+cd /Users/p.buchman/personal/intexuraos-1
+pnpm run ci:tracked 2>&1 | tee /tmp/ci-output-llm-fix.txt
+```
+
+Expected: PASS for every workspace touched. Coverage 100% branch.
+
+- [ ] **Step 2: If CI fails — diagnose and fix per CLAUDE.md**
+
+Per CLAUDE.md: any failure in any workspace is mine to fix. Read `/tmp/ci-output-llm-fix.txt`, find the failure, fix it, re-run.
+
+- [ ] **Step 3: After CI passes, proceed to simplification (handled by the orchestrating session, not this plan).**
+
+Per-task commits already exist. The simplify pass runs over the cumulative diff before the PR is opened.
+
+---
+
+## Endpoint Changes
+
+Per CLAUDE.md "Plan Documentation: Plans with HTTP endpoints MUST include 'Endpoint Changes' section":
+
+- **Modified:** none (no route signatures change)
+- **Created:** none
+- **Removed:** none
+- **Unchanged routes, but wire-payload semantics shift (verified safe):**
+  - `POST /internal/webhooks/usage-events` (orchestrator → llm-usage-service)
+  - `POST /internal/usage/events` (apps/* via HttpInternalAuthUsageSink)
+
+**Wire-payload semantic changes** (relative to today, all schema-compatible — verified against `apps/llm-usage-service/src/routes/schemas/usageEventSchema.ts:118-130`):
+- `source.client` now carries the component label (e.g. `"agent-compliance-validator"`, `"title-gen"`) instead of the model id. Same string type, no slashes — schema accepts.
+- `cost.providerReportedUsd` becomes a real number for OpenRouter calls (was always `null`). Schema already allows `number | null`.
+- `cost.pricingSource` may now be `"provider_reported"` (was always `"calculated"`). Both values are in the existing enum `['provider_reported', 'calculated', 'mixed', 'external']`.
+- `owner.type` may now be `"user"` for LLM calls executed on behalf of a real user (was always `"system"`). Schema already allows both via the existing enum.
+
+**Behavioral side effects worth flagging to dashboards/ops:**
+- Existing on-disk Firestore aggregates in `llm_usage_daily_aggregates` are keyed today by the model id at position 5 of the doc-id (e.g. `..__claude-sonnet-4-5__..`). After Task 7, position 5 becomes `sha256Truncated(source.client)`. New writes will land in NEW aggregate documents; historical aggregates stop accumulating. Effect: dashboards that group "by client" see a data discontinuity at deploy time. No data is lost — the underlying `llm_usage_events` collection is unaffected.
+- This is acceptable because today's `sourceClient` field is semantically wrong (it equals the model id, redundant with `request.model`). The discontinuity restores correct semantics.
+
+---
+
+## Self-Review Checklist (run after writing the plan, before execution)
+
+1. **Spec coverage:** Each of the 5 verified bugs in the Background table maps to at least one task: Bug 1 → Task 2 + Task 7 (defense), Bug 2 → Task 8, Bug 3 → Task 1+2+5+6, Bug 4 → Task 4, Bug 5 → Task 3. ✅
+2. **No placeholders:** Every test step includes complete code. Step 4 of Task 4 says "mirror the test pattern" but explicitly tells the implementer where to look — acceptable for HTTP-mock idiom that varies by package. ✅
+3. **Type consistency:** `ownerType: 'user' | 'system'`, `clientName: string`, `providerReportedUsd: number | null` consistent across Tasks 1, 2, 5, 6. ✅
+4. **Backwards compat:** All new fields optional, defaults preserve current behavior — confirmed at every interface change. ✅
+5. **Orchestrator untouched:** No `workers/orchestrator/*` files in the modify list. Side-effect on event shape via shared package is the *desired* behavior. ✅

--- a/packages/infra-claude/src/__tests__/client.test.ts
+++ b/packages/infra-claude/src/__tests__/client.test.ts
@@ -428,4 +428,24 @@ describe('createClaudeClient', () => {
       }
     });
   });
+
+  it('passes ownerType to usage logger when provided', async () => {
+    mockMessagesCreate.mockResolvedValue({
+      content: [{ type: 'text', text: 'ok' }],
+      usage: { input_tokens: 10, output_tokens: 5 },
+    });
+
+    const client = createClaudeClient({
+      apiKey: 'test-key',
+      model: TEST_MODEL,
+      userId: 'test-user',
+      pricing: createTestPricing(),
+      logger: mockLogger,
+      usageSink: mockUsageSink,
+      ownerType: 'user',
+    });
+    await client.generate('hello');
+
+    expect(mockUsageLoggerLog).toHaveBeenCalledWith(expect.objectContaining({ ownerType: 'user' }));
+  });
 });

--- a/packages/infra-claude/src/client.ts
+++ b/packages/infra-claude/src/client.ts
@@ -88,7 +88,7 @@ const MAX_TOKENS = 8192;
  */
 export function createClaudeClient(config: ClaudeConfig): ClaudeClient {
   const client = new Anthropic({ apiKey: config.apiKey });
-  const { model, userId, pricing, logger, usageSink } = config;
+  const { model, userId, pricing, logger, usageSink, ownerType } = config;
   const usageLogger = createUsageLogger({ logger, sink: usageSink });
 
   function trackUsage(
@@ -105,6 +105,7 @@ export function createClaudeClient(config: ClaudeConfig): ClaudeClient {
       usage,
       success,
       ...(errorMessage !== undefined && { errorMessage }),
+      ...(ownerType !== undefined && { ownerType }),
     });
   }
 

--- a/packages/infra-claude/src/types.ts
+++ b/packages/infra-claude/src/types.ts
@@ -54,4 +54,6 @@ export interface ClaudeConfig {
   logger: Logger;
   /** Usage sink. Required — pass NoopUsageSink to explicitly opt out. */
   usageSink: UsageSink;
+  /** Owner scope of the call. When omitted, the usage sink defaults to 'system'. */
+  ownerType?: 'user' | 'system';
 }

--- a/packages/infra-claude/src/types.ts
+++ b/packages/infra-claude/src/types.ts
@@ -7,6 +7,8 @@
 import type { Logger } from '@intexuraos/common-core';
 import type { UsageSink } from '@intexuraos/llm-pricing';
 
+import type { OwnerType } from '@intexuraos/llm-contract';
+
 export type {
   LLMError as ClaudeError,
   ResearchResult,
@@ -55,5 +57,5 @@ export interface ClaudeConfig {
   /** Usage sink. Required — pass NoopUsageSink to explicitly opt out. */
   usageSink: UsageSink;
   /** Owner scope of the call. When omitted, the usage sink defaults to 'system'. */
-  ownerType?: 'user' | 'system';
+  ownerType?: OwnerType;
 }

--- a/packages/infra-gemini/src/__tests__/client.test.ts
+++ b/packages/infra-gemini/src/__tests__/client.test.ts
@@ -1105,4 +1105,24 @@ describe('createGeminiClient', () => {
       }
     });
   });
+
+  it('passes ownerType to usage logger when provided', async () => {
+    mockGenerateContent.mockResolvedValue({
+      text: 'ok',
+      usageMetadata: { promptTokenCount: 5, candidatesTokenCount: 5 },
+    });
+
+    const client = createGeminiClient({
+      apiKey: 'test-key',
+      model: TEST_MODEL,
+      userId: 'test-user',
+      pricing: createTestPricing(),
+      logger: mockLogger,
+      usageSink: mockUsageSink,
+      ownerType: 'user',
+    });
+    await client.generate('hello');
+
+    expect(mockUsageLoggerLog).toHaveBeenCalledWith(expect.objectContaining({ ownerType: 'user' }));
+  });
 });

--- a/packages/infra-gemini/src/client.ts
+++ b/packages/infra-gemini/src/client.ts
@@ -56,7 +56,7 @@ const DEFAULT_IMAGE_SIZE: ImageSize = '1024x1024';
 
 export function createGeminiClient(config: GeminiConfig): GeminiClient {
   const ai = new GoogleGenAI({ apiKey: config.apiKey });
-  const { model, userId, pricing, imagePricing, logger, usageSink } = config;
+  const { model, userId, pricing, imagePricing, logger, usageSink, ownerType } = config;
   const usageLogger = createUsageLogger({ logger, sink: usageSink });
 
   function trackUsage(
@@ -73,6 +73,7 @@ export function createGeminiClient(config: GeminiConfig): GeminiClient {
       usage,
       success,
       ...(errorMessage !== undefined && { errorMessage }),
+      ...(ownerType !== undefined && { ownerType }),
     });
   }
 

--- a/packages/infra-gemini/src/types.ts
+++ b/packages/infra-gemini/src/types.ts
@@ -7,6 +7,8 @@
 import type { Logger } from '@intexuraos/common-core';
 import type { UsageSink } from '@intexuraos/llm-pricing';
 
+import type { OwnerType } from '@intexuraos/llm-contract';
+
 export type {
   LLMError as GeminiError,
   ResearchResult,
@@ -58,5 +60,5 @@ export interface GeminiConfig {
   /** Usage sink. Required — pass NoopUsageSink to explicitly opt out. */
   usageSink: UsageSink;
   /** Owner scope of the call. When omitted, the usage sink defaults to 'system'. */
-  ownerType?: 'user' | 'system';
+  ownerType?: OwnerType;
 }

--- a/packages/infra-gemini/src/types.ts
+++ b/packages/infra-gemini/src/types.ts
@@ -57,4 +57,6 @@ export interface GeminiConfig {
   logger: Logger;
   /** Usage sink. Required — pass NoopUsageSink to explicitly opt out. */
   usageSink: UsageSink;
+  /** Owner scope of the call. When omitted, the usage sink defaults to 'system'. */
+  ownerType?: 'user' | 'system';
 }

--- a/packages/infra-gpt/src/__tests__/client.test.ts
+++ b/packages/infra-gpt/src/__tests__/client.test.ts
@@ -877,4 +877,24 @@ describe('createGptClient', () => {
       }
     });
   });
+
+  it('passes ownerType to usage logger when provided', async () => {
+    mockChatCompletionsCreate.mockResolvedValue({
+      choices: [{ message: { content: 'ok' } }],
+      usage: { prompt_tokens: 5, completion_tokens: 5 },
+    });
+
+    const client = createGptClient({
+      apiKey: 'test-key',
+      model: TEST_MODEL,
+      userId: 'test-user',
+      pricing: createTestPricing(),
+      logger: mockLogger,
+      usageSink: mockUsageSink,
+      ownerType: 'user',
+    });
+    await client.generate('hello');
+
+    expect(mockUsageLoggerLog).toHaveBeenCalledWith(expect.objectContaining({ ownerType: 'user' }));
+  });
 });

--- a/packages/infra-gpt/src/client.ts
+++ b/packages/infra-gpt/src/client.ts
@@ -91,7 +91,7 @@ const DEFAULT_IMAGE_SIZE: ImageSize = '1024x1024';
  */
 export function createGptClient(config: GptConfig): GptClient {
   const client = new OpenAI({ apiKey: config.apiKey });
-  const { model, userId, pricing, imagePricing, logger, usageSink } = config;
+  const { model, userId, pricing, imagePricing, logger, usageSink, ownerType } = config;
   const usageLogger = createUsageLogger({ logger, sink: usageSink });
 
   function trackUsage(
@@ -108,6 +108,7 @@ export function createGptClient(config: GptConfig): GptClient {
       usage,
       success,
       ...(errorMessage !== undefined && { errorMessage }),
+      ...(ownerType !== undefined && { ownerType }),
     });
   }
 

--- a/packages/infra-gpt/src/types.ts
+++ b/packages/infra-gpt/src/types.ts
@@ -7,6 +7,8 @@
 import type { Logger } from '@intexuraos/common-core';
 import type { UsageSink } from '@intexuraos/llm-pricing';
 
+import type { OwnerType } from '@intexuraos/llm-contract';
+
 export type {
   LLMError as GptError,
   ResearchResult,
@@ -66,5 +68,5 @@ export interface GptConfig {
   /** Usage sink. Required — pass NoopUsageSink to explicitly opt out. */
   usageSink: UsageSink;
   /** Owner scope of the call. When omitted, the usage sink defaults to 'system'. */
-  ownerType?: 'user' | 'system';
+  ownerType?: OwnerType;
 }

--- a/packages/infra-gpt/src/types.ts
+++ b/packages/infra-gpt/src/types.ts
@@ -65,4 +65,6 @@ export interface GptConfig {
   logger: Logger;
   /** Usage sink. Required — pass NoopUsageSink to explicitly opt out. */
   usageSink: UsageSink;
+  /** Owner scope of the call. When omitted, the usage sink defaults to 'system'. */
+  ownerType?: 'user' | 'system';
 }

--- a/packages/infra-openrouter/src/__tests__/client.test.ts
+++ b/packages/infra-openrouter/src/__tests__/client.test.ts
@@ -843,7 +843,7 @@ describe('createOpenRouterClient', () => {
       expect(result.ok).toBe(true);
 
       expect(mockUsageLoggerLog).toHaveBeenCalledWith(
-        expect.objectContaining({ providerReportedUsd: 0.0042 }),
+        expect.objectContaining({ providerReportedUsd: 0.0042 })
       );
     });
 
@@ -911,7 +911,7 @@ describe('createOpenRouterClient', () => {
       await client.research('hello');
 
       expect(mockUsageLoggerLog).toHaveBeenCalledWith(
-        expect.objectContaining({ callType: 'research', providerReportedUsd: 0.011 }),
+        expect.objectContaining({ callType: 'research', providerReportedUsd: 0.011 })
       );
     });
   });
@@ -1059,5 +1059,37 @@ describe('createOpenRouterClient', () => {
         expect(result.error.code).toBe('API_ERROR');
       }
     });
+  });
+
+  it('passes ownerType to usage logger when provided', async () => {
+    nock(API_BASE_URL)
+      .post('/chat/completions')
+      .reply(200, {
+        id: 'test-id',
+        model: TEST_MODEL,
+        created: Date.now(),
+        object: 'chat.completion',
+        choices: [
+          {
+            index: 0,
+            message: { content: 'ok', role: 'assistant' },
+            finish_reason: 'stop',
+          },
+        ],
+        usage: { prompt_tokens: 5, completion_tokens: 5, total_tokens: 10 },
+      });
+
+    const client = createOpenRouterClient({
+      apiKey: 'test-key',
+      model: TEST_MODEL,
+      userId: 'test-user',
+      pricing: createTestPricing(),
+      logger: mockLogger,
+      usageSink: mockUsageSink,
+      ownerType: 'user',
+    });
+    await client.generate('hello');
+
+    expect(mockUsageLoggerLog).toHaveBeenCalledWith(expect.objectContaining({ ownerType: 'user' }));
   });
 });

--- a/packages/infra-openrouter/src/__tests__/client.test.ts
+++ b/packages/infra-openrouter/src/__tests__/client.test.ts
@@ -811,6 +811,111 @@ describe('createOpenRouterClient', () => {
     });
   });
 
+  describe('OpenRouter usage.cost passthrough', () => {
+    it('uses usage.cost from API response and forwards it to the sink as providerReportedUsd', async () => {
+      nock(API_BASE_URL)
+        .post('/chat/completions')
+        .reply(200, {
+          id: 'test-id',
+          model: TEST_MODEL,
+          created: Date.now(),
+          object: 'chat.completion',
+          choices: [
+            {
+              index: 0,
+              message: { content: 'Generated text.', role: 'assistant' },
+              finish_reason: 'stop',
+            },
+          ],
+          usage: { prompt_tokens: 100, completion_tokens: 50, total_tokens: 150, cost: 0.0042 },
+        });
+
+      const client = createOpenRouterClient({
+        apiKey: 'test-key',
+        model: TEST_MODEL,
+        userId: 'test-user',
+        pricing: createTestPricing({ useProviderCost: true }),
+        logger: mockLogger,
+        usageSink: mockUsageSink,
+      });
+
+      const result = await client.generate('hello');
+      expect(result.ok).toBe(true);
+
+      expect(mockUsageLoggerLog).toHaveBeenCalledWith(
+        expect.objectContaining({ providerReportedUsd: 0.0042 }),
+      );
+    });
+
+    it('omits providerReportedUsd when usage.cost absent and falls back to token-based costUsd', async () => {
+      nock(API_BASE_URL)
+        .post('/chat/completions')
+        .reply(200, {
+          id: 'test-id',
+          model: TEST_MODEL,
+          created: Date.now(),
+          object: 'chat.completion',
+          choices: [
+            {
+              index: 0,
+              message: { content: 'Generated text.', role: 'assistant' },
+              finish_reason: 'stop',
+            },
+          ],
+          usage: { prompt_tokens: 100, completion_tokens: 50, total_tokens: 150 }, // NO cost field
+        });
+
+      const client = createOpenRouterClient({
+        apiKey: 'test-key',
+        model: TEST_MODEL,
+        userId: 'test-user',
+        pricing: createTestPricing({ inputPricePerMillion: 1, outputPricePerMillion: 2 }),
+        logger: mockLogger,
+        usageSink: mockUsageSink,
+      });
+
+      await client.generate('hello');
+
+      const callArg = mockUsageLoggerLog.mock.calls[0]?.[0] as Record<string, unknown>;
+      expect(callArg['providerReportedUsd']).toBeUndefined();
+      expect((callArg['usage'] as { costUsd: number }).costUsd).toBeGreaterThan(0); // token-fallback still produces non-zero cost
+    });
+
+    it('forwards providerReportedUsd on the research callType too', async () => {
+      nock(API_BASE_URL)
+        .post('/chat/completions')
+        .reply(200, {
+          id: 'test-id',
+          model: `${TEST_MODEL}:online`,
+          created: Date.now(),
+          object: 'chat.completion',
+          choices: [
+            {
+              index: 0,
+              message: { content: 'Research findings.', role: 'assistant' },
+              finish_reason: 'stop',
+            },
+          ],
+          usage: { prompt_tokens: 100, completion_tokens: 50, total_tokens: 150, cost: 0.011 },
+        });
+
+      const client = createOpenRouterClient({
+        apiKey: 'test-key',
+        model: TEST_MODEL,
+        userId: 'test-user',
+        pricing: createTestPricing({ useProviderCost: true }),
+        logger: mockLogger,
+        usageSink: mockUsageSink,
+      });
+
+      await client.research('hello');
+
+      expect(mockUsageLoggerLog).toHaveBeenCalledWith(
+        expect.objectContaining({ callType: 'research', providerReportedUsd: 0.011 }),
+      );
+    });
+  });
+
   describe('usageSink', () => {
     it('passes custom usageSink to createUsageLogger', async () => {
       const { createUsageLogger } = await import('@intexuraos/llm-pricing');

--- a/packages/infra-openrouter/src/__tests__/client.test.ts
+++ b/packages/infra-openrouter/src/__tests__/client.test.ts
@@ -862,7 +862,7 @@ describe('createOpenRouterClient', () => {
               finish_reason: 'stop',
             },
           ],
-          usage: { prompt_tokens: 100, completion_tokens: 50, total_tokens: 150 }, // NO cost field
+          usage: { prompt_tokens: 100, completion_tokens: 50, total_tokens: 150 },
         });
 
       const client = createOpenRouterClient({

--- a/packages/infra-openrouter/src/client.ts
+++ b/packages/infra-openrouter/src/client.ts
@@ -136,7 +136,7 @@ export function createOpenRouterClient(config: OpenRouterConfig): OpenRouterClie
     usage: NormalizedUsage,
     success: boolean,
     errorMessage?: string,
-    providerReportedUsd?: number | null,
+    providerReportedUsd?: number | null
   ): void {
     void usageLogger.log({
       userId,
@@ -146,7 +146,8 @@ export function createOpenRouterClient(config: OpenRouterConfig): OpenRouterClie
       usage,
       success,
       ...(errorMessage !== undefined && { errorMessage }),
-      ...(providerReportedUsd !== undefined && providerReportedUsd !== null && { providerReportedUsd }),
+      ...(providerReportedUsd !== undefined &&
+        providerReportedUsd !== null && { providerReportedUsd }),
       ...(ownerType !== undefined && { ownerType }),
     });
   }
@@ -168,7 +169,7 @@ export function createOpenRouterClient(config: OpenRouterConfig): OpenRouterClie
       usage.prompt_tokens,
       usage.completion_tokens,
       providerReportedUsd ?? undefined,
-      pricing,
+      pricing
     );
     return { normalized, providerReportedUsd };
   }

--- a/packages/infra-openrouter/src/client.ts
+++ b/packages/infra-openrouter/src/client.ts
@@ -126,6 +126,7 @@ export function createOpenRouterClient(config: OpenRouterConfig): OpenRouterClie
     timeoutMs = DEFAULT_TIMEOUT_MS,
     logger,
     usageSink,
+    ownerType,
   } = config;
 
   const usageLogger = createUsageLogger({ logger, sink: usageSink });
@@ -146,6 +147,7 @@ export function createOpenRouterClient(config: OpenRouterConfig): OpenRouterClie
       success,
       ...(errorMessage !== undefined && { errorMessage }),
       ...(providerReportedUsd !== undefined && providerReportedUsd !== null && { providerReportedUsd }),
+      ...(ownerType !== undefined && { ownerType }),
     });
   }
 

--- a/packages/infra-openrouter/src/client.ts
+++ b/packages/infra-openrouter/src/client.ts
@@ -134,7 +134,8 @@ export function createOpenRouterClient(config: OpenRouterConfig): OpenRouterClie
     callType: CallType,
     usage: NormalizedUsage,
     success: boolean,
-    errorMessage?: string
+    errorMessage?: string,
+    providerReportedUsd?: number | null,
   ): void {
     void usageLogger.log({
       userId,
@@ -144,22 +145,30 @@ export function createOpenRouterClient(config: OpenRouterConfig): OpenRouterClie
       usage,
       success,
       ...(errorMessage !== undefined && { errorMessage }),
+      ...(providerReportedUsd !== undefined && providerReportedUsd !== null && { providerReportedUsd }),
     });
   }
 
-  function extractUsage(usage: OpenRouterUsage | undefined): NormalizedUsage {
+  function extractUsage(usage?: OpenRouterUsage): {
+    normalized: NormalizedUsage;
+    providerReportedUsd: number | null;
+  } {
     /* v8 ignore start -- upstream: cannot verify usage is present in all API responses @preserve */
     if (usage === undefined) {
-      return { inputTokens: 0, outputTokens: 0, totalTokens: 0, costUsd: 0 };
+      return {
+        normalized: { inputTokens: 0, outputTokens: 0, totalTokens: 0, costUsd: 0 },
+        providerReportedUsd: null,
+      };
     }
     /* v8 ignore stop @preserve */
-    // OpenRouter doesn't provide per-request cost in the response like Perplexity does
-    return normalizeUsage(
+    const providerReportedUsd = typeof usage.cost === 'number' ? usage.cost : null;
+    const normalized = normalizeUsage(
       usage.prompt_tokens,
       usage.completion_tokens,
-      undefined, // No provider cost in response
-      pricing
+      providerReportedUsd ?? undefined,
+      pricing,
     );
+    return { normalized, providerReportedUsd };
   }
 
   return {
@@ -215,7 +224,7 @@ export function createOpenRouterClient(config: OpenRouterConfig): OpenRouterClie
 
         const data = (await response.json()) as OpenRouterResponse;
         const content = data.choices[0]?.message.content ?? '';
-        const usage = extractUsage(data.usage);
+        const { normalized, providerReportedUsd } = extractUsage(data.usage);
 
         // Extract sources from annotations (OpenRouter returns web search citations as annotations)
         const sources: string[] = [];
@@ -237,9 +246,9 @@ export function createOpenRouterClient(config: OpenRouterConfig): OpenRouterClie
           }
         }
 
-        trackUsage('research', usage, true);
+        trackUsage('research', normalized, true, undefined, providerReportedUsd);
 
-        return ok({ content, sources, usage });
+        return ok({ content, sources, usage: normalized });
       } catch (error) {
         const errorMsg = getErrorMessage(error);
         const emptyUsage: NormalizedUsage = {
@@ -313,11 +322,11 @@ export function createOpenRouterClient(config: OpenRouterConfig): OpenRouterClie
           /* v8 ignore stop @preserve */
         }
         const content = firstChoice.message.content;
-        const usage = extractUsage(data.usage);
+        const { normalized, providerReportedUsd } = extractUsage(data.usage);
 
-        trackUsage('generate', usage, true);
+        trackUsage('generate', normalized, true, undefined, providerReportedUsd);
 
-        return ok({ content, usage });
+        return ok({ content, usage: normalized });
       } catch (error) {
         const errorMsg = getErrorMessage(error);
         const emptyUsage: NormalizedUsage = {

--- a/packages/infra-openrouter/src/types.ts
+++ b/packages/infra-openrouter/src/types.ts
@@ -6,6 +6,7 @@
 
 import type { Logger } from '@intexuraos/common-core';
 import type { UsageSink } from '@intexuraos/llm-pricing';
+import type { OwnerType } from '@intexuraos/llm-contract';
 
 export type {
   LLMError as OpenRouterError,
@@ -63,7 +64,7 @@ export interface OpenRouterConfig {
   /** Usage sink. Required — pass NoopUsageSink to explicitly opt out. */
   usageSink: UsageSink;
   /** Owner scope of the call. When omitted, the usage sink defaults to 'system'. */
-  ownerType?: 'user' | 'system';
+  ownerType?: OwnerType;
 }
 
 /**

--- a/packages/infra-openrouter/src/types.ts
+++ b/packages/infra-openrouter/src/types.ts
@@ -101,6 +101,7 @@ export interface OpenRouterUsage {
   prompt_tokens: number;
   completion_tokens: number;
   total_tokens: number;
+  cost?: number; // OpenRouter reports USD cost per request (always present per docs, optional for back-compat)
 }
 
 /**

--- a/packages/infra-openrouter/src/types.ts
+++ b/packages/infra-openrouter/src/types.ts
@@ -62,6 +62,8 @@ export interface OpenRouterConfig {
   logger: Logger;
   /** Usage sink. Required — pass NoopUsageSink to explicitly opt out. */
   usageSink: UsageSink;
+  /** Owner scope of the call. When omitted, the usage sink defaults to 'system'. */
+  ownerType?: 'user' | 'system';
 }
 
 /**

--- a/packages/infra-perplexity/src/__tests__/client.test.ts
+++ b/packages/infra-perplexity/src/__tests__/client.test.ts
@@ -1059,4 +1059,26 @@ describe('createPerplexityClient', () => {
       }
     });
   });
+
+  it('passes ownerType to usage logger when provided', async () => {
+    nock(API_BASE_URL)
+      .post('/chat/completions')
+      .reply(200, {
+        choices: [{ message: { content: 'ok' } }],
+        usage: { prompt_tokens: 5, completion_tokens: 5, total_tokens: 10 },
+      });
+
+    const client = createPerplexityClient({
+      apiKey: 'test-key',
+      model: TEST_MODEL,
+      userId: 'test-user',
+      pricing: createTestPricing({ useProviderCost: false }),
+      logger: mockLogger,
+      usageSink: mockUsageSink,
+      ownerType: 'user',
+    });
+    await client.generate('hello');
+
+    expect(mockUsageLoggerLog).toHaveBeenCalledWith(expect.objectContaining({ ownerType: 'user' }));
+  });
 });

--- a/packages/infra-perplexity/src/client.ts
+++ b/packages/infra-perplexity/src/client.ts
@@ -195,6 +195,7 @@ export function createPerplexityClient(config: PerplexityConfig): PerplexityClie
     timeoutMs = DEFAULT_TIMEOUT_MS,
     logger,
     usageSink,
+    ownerType,
   } = config;
   const usageLogger = createUsageLogger({ logger, sink: usageSink });
 
@@ -212,6 +213,7 @@ export function createPerplexityClient(config: PerplexityConfig): PerplexityClie
       usage,
       success,
       ...(errorMessage !== undefined && { errorMessage }),
+      ...(ownerType !== undefined && { ownerType }),
     });
   }
 

--- a/packages/infra-perplexity/src/types.ts
+++ b/packages/infra-perplexity/src/types.ts
@@ -6,6 +6,7 @@
 
 import type { Logger } from '@intexuraos/common-core';
 import type { UsageSink } from '@intexuraos/llm-pricing';
+import type { OwnerType } from '@intexuraos/llm-contract';
 
 export type {
   LLMError as PerplexityError,
@@ -54,7 +55,7 @@ export interface PerplexityConfig {
   /** Usage sink. Required — pass NoopUsageSink to explicitly opt out. */
   usageSink: UsageSink;
   /** Owner scope of the call. When omitted, the usage sink defaults to 'system'. */
-  ownerType?: 'user' | 'system';
+  ownerType?: OwnerType;
 }
 
 /** Search context size for Perplexity requests */

--- a/packages/infra-perplexity/src/types.ts
+++ b/packages/infra-perplexity/src/types.ts
@@ -53,6 +53,8 @@ export interface PerplexityConfig {
   logger: Logger;
   /** Usage sink. Required — pass NoopUsageSink to explicitly opt out. */
   usageSink: UsageSink;
+  /** Owner scope of the call. When omitted, the usage sink defaults to 'system'. */
+  ownerType?: 'user' | 'system';
 }
 
 /** Search context size for Perplexity requests */

--- a/packages/internal-clients/src/user-service/__tests__/client-fallback.test.ts
+++ b/packages/internal-clients/src/user-service/__tests__/client-fallback.test.ts
@@ -8,6 +8,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import nock from 'nock';
 import { LlmModels } from '@intexuraos/llm-contract';
 import { createFakePricingContext, createFakeUsageSink } from '@intexuraos/llm-pricing';
+import type { LlmClientConfig } from '@intexuraos/llm-factory';
 import type { LlmGenerateClient, GenerateResult } from '@intexuraos/llm-factory';
 import type { Result } from '@intexuraos/common-core';
 import { err, ok } from '@intexuraos/common-core';
@@ -301,5 +302,103 @@ describe('getLlmClient fallback behavior', () => {
       expect.objectContaining({ userId: 'user123', fallbackModel: ANTHROPIC_FALLBACK }),
       'No API key for fallback model'
     );
+  });
+});
+
+describe('getLlmClient ownerType tagging', () => {
+  beforeEach(() => {
+    nock.cleanAll();
+    vi.clearAllMocks();
+  });
+
+  it('passes ownerType: "user" to createLlmClient for the main client (call site 3)', async () => {
+    // Normal path: user has a key for their default model
+    setupNocks(PRIMARY_MODEL);
+
+    const fakeClient: LlmGenerateClient = {
+      generate: vi.fn().mockResolvedValue(makeSuccessResult('ok')),
+    };
+    mockCreateLlmClient.mockReturnValue(fakeClient);
+
+    const serviceClient = createUserServiceClient(config);
+    const result = await serviceClient.getLlmClient('user123');
+
+    if (!result.ok) expect.fail(`Expected ok, got ${JSON.stringify(result.error)}`);
+
+    // One createLlmClient call for the main client
+    expect(mockCreateLlmClient).toHaveBeenCalledTimes(1);
+    const capturedConfig = mockCreateLlmClient.mock.calls[0]?.[0] as LlmClientConfig;
+    expect(capturedConfig).toMatchObject({ ownerType: 'user' });
+  });
+
+  it('passes ownerType: "user" to createLlmClient for the buildClientForModel helper (call site 2)', async () => {
+    // Fallback retry path: primary fails, buildClientForModel creates fallback client
+    setupNocks(PRIMARY_MODEL, FALLBACK_MODEL);
+
+    const primaryGenerate = vi.fn().mockResolvedValue(makeErrorResult());
+    const primaryClient: LlmGenerateClient = { generate: primaryGenerate };
+
+    const fallbackGenerate = vi.fn().mockResolvedValue(makeSuccessResult('fallback ok'));
+    const fallbackClient: LlmGenerateClient = { generate: fallbackGenerate };
+
+    mockCreateLlmClient.mockReturnValueOnce(primaryClient).mockReturnValueOnce(fallbackClient);
+
+    const serviceClient = createUserServiceClient(config);
+    const result = await serviceClient.getLlmClient('user123');
+
+    if (!result.ok) expect.fail(`Expected ok, got ${JSON.stringify(result.error)}`);
+
+    // Trigger fallback so buildClientForModel is invoked
+    await result.value.generate('test prompt');
+
+    // Two calls: primary (call site 3) and fallback (call site 2 inside buildClientForModel)
+    expect(mockCreateLlmClient).toHaveBeenCalledTimes(2);
+    const primaryConfig = mockCreateLlmClient.mock.calls[0]?.[0] as LlmClientConfig;
+    const fallbackConfig = mockCreateLlmClient.mock.calls[1]?.[0] as LlmClientConfig;
+    expect(primaryConfig).toMatchObject({ ownerType: 'user' });
+    expect(fallbackConfig).toMatchObject({ ownerType: 'user' });
+  });
+
+  it('passes ownerType: "user" to createLlmClient for the platform Gemini fallback (call site 1)', async () => {
+    // Platform Gemini path: user has no key for their preferred model
+    // and the service has a platform Gemini key configured
+    const configWithPlatformKey = {
+      ...config,
+      platformGeminiApiKey: 'platform-gemini-key',
+    };
+
+    // User wants ClaudeHaiku35 but has no anthropic key
+    nock('http://localhost:3000')
+      .get('/internal/users/user123/settings')
+      .matchHeader('X-Internal-Auth', 'test-token')
+      .reply(200, {
+        success: true,
+        data: {
+          llmPreferences: { defaultModel: LlmModels.ClaudeHaiku35 },
+        },
+      });
+
+    nock('http://localhost:3000')
+      .get('/internal/users/user123/llm-keys')
+      .matchHeader('X-Internal-Auth', 'test-token')
+      .reply(200, {
+        success: true,
+        data: { openai: 'openai-key' }, // no anthropic key
+      });
+
+    const fakeClient: LlmGenerateClient = {
+      generate: vi.fn().mockResolvedValue(makeSuccessResult('gemini ok')),
+    };
+    mockCreateLlmClient.mockReturnValue(fakeClient);
+
+    const serviceClient = createUserServiceClient(configWithPlatformKey);
+    const result = await serviceClient.getLlmClient('user123');
+
+    if (!result.ok) expect.fail(`Expected ok, got ${JSON.stringify(result.error)}`);
+
+    // Platform Gemini fallback: one call via call site 1
+    expect(mockCreateLlmClient).toHaveBeenCalledTimes(1);
+    const capturedConfig = mockCreateLlmClient.mock.calls[0]?.[0] as LlmClientConfig;
+    expect(capturedConfig).toMatchObject({ ownerType: 'user' });
   });
 });

--- a/packages/internal-clients/src/user-service/client.ts
+++ b/packages/internal-clients/src/user-service/client.ts
@@ -212,6 +212,7 @@ export function createUserServiceClient(config: UserServiceConfig): UserServiceC
               pricing: fallbackPricing,
               logger: config.logger,
               usageSink: config.usageSink,
+              ownerType: 'user',
             });
 
             logger.info(
@@ -263,6 +264,7 @@ export function createUserServiceClient(config: UserServiceConfig): UserServiceC
             pricing: resolvePricing(model),
             logger: config.logger,
             usageSink: config.usageSink,
+            ownerType: 'user',
           });
         }
 
@@ -277,6 +279,7 @@ export function createUserServiceClient(config: UserServiceConfig): UserServiceC
           pricing,
           logger: config.logger,
           usageSink: config.usageSink,
+          ownerType: 'user',
         };
 
         const client: LlmGenerateClient = createLlmClient(clientConfig);

--- a/packages/llm-contract/src/index.ts
+++ b/packages/llm-contract/src/index.ts
@@ -16,6 +16,7 @@ export type {
   LLMErrorCode,
   LLMError,
   LLMClient,
+  OwnerType,
 } from './types.js';
 
 export {

--- a/packages/llm-contract/src/types.ts
+++ b/packages/llm-contract/src/types.ts
@@ -10,6 +10,14 @@ import type { Result } from '@intexuraos/common-core';
 import type { LLMModel } from './supportedModels.js';
 
 /**
+ * Owner scope for emitted LLM usage events.
+ *
+ * - `'user'`: the call was made on behalf of a real user (their dashboard should show it).
+ * - `'system'`: the call was an internal/system action (e.g. orchestrator validators, execution-memory).
+ */
+export type OwnerType = 'user' | 'system';
+
+/**
  * Base configuration for LLM clients.
  *
  * Extended by provider-specific configs (e.g., {@link ClaudeConfig}, {@link GptConfig})

--- a/packages/llm-factory/src/__tests__/llmClientFactory.test.ts
+++ b/packages/llm-factory/src/__tests__/llmClientFactory.test.ts
@@ -191,6 +191,61 @@ describe('llmClientFactory', () => {
     });
   });
 
+  describe('LlmClientConfig.ownerType propagation', () => {
+    it('forwards ownerType to createOpenRouterGenerateClient when passed', async () => {
+      const { createOpenRouterGenerateClient } = await import('../openRouterGenerateClient.js');
+
+      createLlmClient({
+        apiKey: 'test-key',
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        model: 'or:google/gemma-4-31b-it:free' as any,
+        userId: 'user-123',
+        pricing: createTestPricing(),
+        logger: mockLogger,
+        usageSink: mockUsageSink,
+        ownerType: 'user',
+      });
+
+      expect(vi.mocked(createOpenRouterGenerateClient)).toHaveBeenCalledWith(
+        expect.objectContaining({ ownerType: 'user' })
+      );
+    });
+
+    it('forwards ownerType to createGeminiClient when passed', async () => {
+      const { createGeminiClient } = await import('@intexuraos/infra-gemini');
+
+      createLlmClient({
+        apiKey: 'test-key',
+        model: LlmModels.Gemini25Flash,
+        userId: 'user-123',
+        pricing: createTestPricing(),
+        logger: mockLogger,
+        usageSink: mockUsageSink,
+        ownerType: 'user',
+      });
+
+      expect(vi.mocked(createGeminiClient)).toHaveBeenCalledWith(
+        expect.objectContaining({ ownerType: 'user' })
+      );
+    });
+
+    it('omits ownerType from config when not provided', async () => {
+      const { createGeminiClient } = await import('@intexuraos/infra-gemini');
+
+      createLlmClient({
+        apiKey: 'test-key',
+        model: LlmModels.Gemini25Flash,
+        userId: 'user-123',
+        pricing: createTestPricing(),
+        logger: mockLogger,
+        usageSink: mockUsageSink,
+      });
+
+      const callArg = vi.mocked(createGeminiClient).mock.calls[0]?.[0] as unknown as Record<string, unknown>;
+      expect(callArg?.['ownerType']).toBeUndefined();
+    });
+  });
+
   describe('isSupportedProvider', () => {
     it('returns true for Google provider', () => {
       expect(isSupportedProvider(LlmProviders.Google)).toBe(true);

--- a/packages/llm-factory/src/__tests__/llmClientFactory.test.ts
+++ b/packages/llm-factory/src/__tests__/llmClientFactory.test.ts
@@ -241,7 +241,10 @@ describe('llmClientFactory', () => {
         usageSink: mockUsageSink,
       });
 
-      const callArg = vi.mocked(createGeminiClient).mock.calls[0]?.[0] as unknown as Record<string, unknown>;
+      const callArg = vi.mocked(createGeminiClient).mock.calls[0]?.[0] as unknown as Record<
+        string,
+        unknown
+      >;
       expect(callArg?.['ownerType']).toBeUndefined();
     });
   });

--- a/packages/llm-factory/src/__tests__/openRouterGenerateClient.test.ts
+++ b/packages/llm-factory/src/__tests__/openRouterGenerateClient.test.ts
@@ -145,4 +145,34 @@ describe('createOpenRouterGenerateClient', () => {
       expect(result.error.code).toBe('OVERLOADED');
     }
   });
+
+  describe('ownerType propagation', () => {
+    it('forwards ownerType to createOpenRouterClient when set to user', async () => {
+      const { createOpenRouterClient } = await import('@intexuraos/infra-openrouter');
+      mockOrGenerate.mockResolvedValue(
+        ok({ content: '', usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0, costUsd: 0 } })
+      );
+
+      createOpenRouterGenerateClient({ ...baseConfig, ownerType: 'user' });
+
+      expect(createOpenRouterClient).toHaveBeenCalledWith(
+        expect.objectContaining({ ownerType: 'user' })
+      );
+    });
+
+    it('omits ownerType from createOpenRouterClient call when not configured', async () => {
+      const { createOpenRouterClient } = await import('@intexuraos/infra-openrouter');
+      mockOrGenerate.mockResolvedValue(
+        ok({ content: '', usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0, costUsd: 0 } })
+      );
+
+      createOpenRouterGenerateClient(baseConfig);
+
+      const callArg = vi.mocked(createOpenRouterClient).mock.calls[0]?.[0] as unknown as Record<
+        string,
+        unknown
+      >;
+      expect(callArg?.['ownerType']).toBeUndefined();
+    });
+  });
 });

--- a/packages/llm-factory/src/llmClientFactory.ts
+++ b/packages/llm-factory/src/llmClientFactory.ts
@@ -43,6 +43,7 @@ import {
   type LLMModel,
   type ModelPricing,
   type ToolCallingClient,
+  type OwnerType,
 } from '@intexuraos/llm-contract';
 import { createOpenRouterGenerateClient } from './openRouterGenerateClient.js';
 import type { Logger, Result } from '@intexuraos/common-core';
@@ -68,7 +69,7 @@ export interface LlmClientConfig {
    * When omitted, downstream defaults to 'system' to preserve legacy behavior.
    * Pass 'user' for calls initiated directly by a human (e.g. chat, code tasks).
    */
-  ownerType?: 'user' | 'system';
+  ownerType?: OwnerType;
 }
 
 /**

--- a/packages/llm-factory/src/llmClientFactory.ts
+++ b/packages/llm-factory/src/llmClientFactory.ts
@@ -63,6 +63,12 @@ export interface LlmClientConfig {
   logger: Logger;
   /** Usage sink. Required — pass NoopUsageSink to explicitly opt out. */
   usageSink: UsageSink;
+  /**
+   * Owner scope of the call.
+   * When omitted, downstream defaults to 'system' to preserve legacy behavior.
+   * Pass 'user' for calls initiated directly by a human (e.g. chat, code tasks).
+   */
+  ownerType?: 'user' | 'system';
 }
 
 /**

--- a/packages/llm-factory/src/openRouterGenerateClient.ts
+++ b/packages/llm-factory/src/openRouterGenerateClient.ts
@@ -16,6 +16,7 @@ export function createOpenRouterGenerateClient(config: LlmClientConfig): LlmGene
     pricing: config.pricing,
     logger: config.logger,
     usageSink: config.usageSink,
+    ...(config.ownerType !== undefined && { ownerType: config.ownerType }),
   });
 
   return {

--- a/packages/llm-pricing/src/__tests__/buildUsageEvent.test.ts
+++ b/packages/llm-pricing/src/__tests__/buildUsageEvent.test.ts
@@ -1,7 +1,19 @@
 import { describe, expect, it } from 'vitest';
-import { LlmModels, LlmProviders } from '@intexuraos/llm-contract';
+import { LlmProviders } from '@intexuraos/llm-contract';
 import { buildUsageEvent } from '../buildUsageEvent.js';
 import type { UsageLogParams } from '../usageLogger.js';
+
+interface EventForTests {
+  owner: { type: string; id: string };
+  source: { service: string; component: string; client: string; environment: string };
+  cost: {
+    billedUsd: number;
+    providerReportedUsd: number | null;
+    calculatedUsd: number;
+    pricingSource: string;
+  };
+  [k: string]: unknown;
+}
 
 const baseParams: UsageLogParams = {
   userId: 'user-123',
@@ -16,38 +28,38 @@ const baseSource = { service: 'linear-agent', component: 'title-gen' };
 
 describe('buildUsageEvent', () => {
   it('defaults owner.type to "system" when ownerType not provided', () => {
-    const event = buildUsageEvent(baseParams, baseSource) as Record<string, any>;
+    const event = buildUsageEvent(baseParams, baseSource) as EventForTests;
     expect(event.owner).toEqual({ type: 'system', id: 'user-123' });
   });
 
   it('uses owner.type "user" when ownerType: "user" passed', () => {
     const event = buildUsageEvent(
       { ...baseParams, ownerType: 'user' },
-      baseSource,
-    ) as Record<string, any>;
+      baseSource
+    ) as EventForTests;
     expect(event.owner).toEqual({ type: 'user', id: 'user-123' });
   });
 
   it('defaults source.client to source.component when clientName not provided', () => {
-    const event = buildUsageEvent(baseParams, baseSource) as Record<string, any>;
+    const event = buildUsageEvent(baseParams, baseSource) as EventForTests;
     expect(event.source.client).toBe('title-gen');
   });
 
   it('uses source.client = clientName when provided', () => {
     const event = buildUsageEvent(
       { ...baseParams, clientName: 'openrouter-generate' },
-      baseSource,
-    ) as Record<string, any>;
+      baseSource
+    ) as EventForTests;
     expect(event.source.client).toBe('openrouter-generate');
   });
 
   it('source.client never contains "/" even when model id contains it', () => {
-    const event = buildUsageEvent(baseParams, baseSource) as Record<string, any>;
+    const event = buildUsageEvent(baseParams, baseSource) as EventForTests;
     expect(event.source.client).not.toMatch(/\//);
   });
 
   it('cost.providerReportedUsd is null and pricingSource is "calculated" by default', () => {
-    const event = buildUsageEvent(baseParams, baseSource) as Record<string, any>;
+    const event = buildUsageEvent(baseParams, baseSource) as EventForTests;
     expect(event.cost.providerReportedUsd).toBeNull();
     expect(event.cost.pricingSource).toBe('calculated');
     expect(event.cost.billedUsd).toBe(0.001);
@@ -57,8 +69,8 @@ describe('buildUsageEvent', () => {
   it('cost uses providerReportedUsd as billedUsd when provided; pricingSource = "provider_reported"', () => {
     const event = buildUsageEvent(
       { ...baseParams, providerReportedUsd: 0.0042 },
-      baseSource,
-    ) as Record<string, any>;
+      baseSource
+    ) as EventForTests;
     expect(event.cost.providerReportedUsd).toBe(0.0042);
     expect(event.cost.billedUsd).toBe(0.0042);
     expect(event.cost.calculatedUsd).toBe(0.001);
@@ -68,8 +80,8 @@ describe('buildUsageEvent', () => {
   it('treats providerReportedUsd: null as "no provider cost"', () => {
     const event = buildUsageEvent(
       { ...baseParams, providerReportedUsd: null },
-      baseSource,
-    ) as Record<string, any>;
+      baseSource
+    ) as EventForTests;
     expect(event.cost.providerReportedUsd).toBeNull();
     expect(event.cost.pricingSource).toBe('calculated');
     expect(event.cost.billedUsd).toBe(0.001);
@@ -78,8 +90,8 @@ describe('buildUsageEvent', () => {
   it('clamps a negative providerReportedUsd to 0 (schema requires billedUsd >= 0)', () => {
     const event = buildUsageEvent(
       { ...baseParams, providerReportedUsd: -0.001 },
-      baseSource,
-    ) as Record<string, any>;
+      baseSource
+    ) as EventForTests;
     expect(event.cost.billedUsd).toBeGreaterThanOrEqual(0);
   });
 });

--- a/packages/llm-pricing/src/__tests__/buildUsageEvent.test.ts
+++ b/packages/llm-pricing/src/__tests__/buildUsageEvent.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import { LlmModels, LlmProviders } from '@intexuraos/llm-contract';
+import { buildUsageEvent } from '../buildUsageEvent.js';
+import type { UsageLogParams } from '../usageLogger.js';
+
+const baseParams: UsageLogParams = {
+  userId: 'user-123',
+  provider: LlmProviders.OpenRouter,
+  model: 'or:nvidia/nemotron-3-super-120b-a12b:free',
+  callType: 'generate',
+  usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30, costUsd: 0.001 },
+  success: true,
+};
+
+const baseSource = { service: 'linear-agent', component: 'title-gen' };
+
+describe('buildUsageEvent', () => {
+  it('defaults owner.type to "system" when ownerType not provided', () => {
+    const event = buildUsageEvent(baseParams, baseSource) as Record<string, any>;
+    expect(event.owner).toEqual({ type: 'system', id: 'user-123' });
+  });
+
+  it('uses owner.type "user" when ownerType: "user" passed', () => {
+    const event = buildUsageEvent(
+      { ...baseParams, ownerType: 'user' },
+      baseSource,
+    ) as Record<string, any>;
+    expect(event.owner).toEqual({ type: 'user', id: 'user-123' });
+  });
+
+  it('defaults source.client to source.component when clientName not provided', () => {
+    const event = buildUsageEvent(baseParams, baseSource) as Record<string, any>;
+    expect(event.source.client).toBe('title-gen');
+  });
+
+  it('uses source.client = clientName when provided', () => {
+    const event = buildUsageEvent(
+      { ...baseParams, clientName: 'openrouter-generate' },
+      baseSource,
+    ) as Record<string, any>;
+    expect(event.source.client).toBe('openrouter-generate');
+  });
+
+  it('source.client never contains "/" even when model id contains it', () => {
+    const event = buildUsageEvent(baseParams, baseSource) as Record<string, any>;
+    expect(event.source.client).not.toMatch(/\//);
+  });
+
+  it('cost.providerReportedUsd is null and pricingSource is "calculated" by default', () => {
+    const event = buildUsageEvent(baseParams, baseSource) as Record<string, any>;
+    expect(event.cost.providerReportedUsd).toBeNull();
+    expect(event.cost.pricingSource).toBe('calculated');
+    expect(event.cost.billedUsd).toBe(0.001);
+    expect(event.cost.calculatedUsd).toBe(0.001);
+  });
+
+  it('cost uses providerReportedUsd as billedUsd when provided; pricingSource = "provider_reported"', () => {
+    const event = buildUsageEvent(
+      { ...baseParams, providerReportedUsd: 0.0042 },
+      baseSource,
+    ) as Record<string, any>;
+    expect(event.cost.providerReportedUsd).toBe(0.0042);
+    expect(event.cost.billedUsd).toBe(0.0042);
+    expect(event.cost.calculatedUsd).toBe(0.001);
+    expect(event.cost.pricingSource).toBe('provider_reported');
+  });
+
+  it('treats providerReportedUsd: null as "no provider cost"', () => {
+    const event = buildUsageEvent(
+      { ...baseParams, providerReportedUsd: null },
+      baseSource,
+    ) as Record<string, any>;
+    expect(event.cost.providerReportedUsd).toBeNull();
+    expect(event.cost.pricingSource).toBe('calculated');
+    expect(event.cost.billedUsd).toBe(0.001);
+  });
+
+  it('clamps a negative providerReportedUsd to 0 (schema requires billedUsd >= 0)', () => {
+    const event = buildUsageEvent(
+      { ...baseParams, providerReportedUsd: -0.001 },
+      baseSource,
+    ) as Record<string, any>;
+    expect(event.cost.billedUsd).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/packages/llm-pricing/src/__tests__/httpInternalAuthUsageSink.test.ts
+++ b/packages/llm-pricing/src/__tests__/httpInternalAuthUsageSink.test.ts
@@ -156,7 +156,7 @@ describe('HttpInternalAuthUsageSink', () => {
       expect(event?.source).toEqual({
         service: 'research-agent',
         component: 'llm-client',
-        client: LlmModels.Gemini25Flash,
+        client: 'llm-client',
         environment: 'dev',
       });
       expect(event?.request).toEqual({

--- a/packages/llm-pricing/src/__tests__/httpWebhookUsageSink.test.ts
+++ b/packages/llm-pricing/src/__tests__/httpWebhookUsageSink.test.ts
@@ -150,7 +150,7 @@ describe('HttpWebhookUsageSink', () => {
       expect(event?.source).toEqual({
         service: 'orchestrator',
         component: 'agent-loop',
-        client: LlmModels.ClaudeSonnet46,
+        client: 'agent-loop',
         environment: 'dev',
       });
       expect(event?.request).toEqual({

--- a/packages/llm-pricing/src/__tests__/pricingClient.test.ts
+++ b/packages/llm-pricing/src/__tests__/pricingClient.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
-import { type ProviderPricing, type Gemini25Pro } from '@intexuraos/llm-contract';
+import { type ProviderPricing, type Gemini25Pro, type LLMModel } from '@intexuraos/llm-contract';
 import { LlmModels, LlmProviders } from '@intexuraos/llm-contract';
 import {
   PricingContext,
@@ -265,12 +265,6 @@ describe('pricingClient', () => {
       expect(pricing.inputPricePerMillion).toBe(1.25);
       expect(pricing.outputPricePerMillion).toBe(10.0);
       expect(pricing.groundingCostPerRequest).toBe(0.035);
-    });
-
-    it('throws when getting pricing for unknown model', () => {
-      const context = new PricingContext(completeAllPricing);
-
-      expect(() => context.getPricing('unknown-model' as Gemini25Pro)).toThrow('Pricing not found');
     });
 
     it('validates that specified models have pricing', () => {
@@ -689,6 +683,58 @@ describe('pricingClient', () => {
       expect(result.ok).toBe(true);
       expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('attempt 1/4'));
       stderrSpy.mockRestore();
+    });
+  });
+
+  describe('getPricing no-throw on missing model', () => {
+    it('returns zero pricing instead of throwing when the model is unknown', () => {
+      const ctx = new PricingContext({
+        google: { models: {}, updatedAt: '' },
+        openai: { models: {}, updatedAt: '' },
+        anthropic: { models: {}, updatedAt: '' },
+        perplexity: { models: {}, updatedAt: '' },
+        openrouter: { models: {}, updatedAt: '' },
+      });
+
+      const pricing = ctx.getPricing('or:some/unpriced-model' as LLMModel);
+
+      expect(pricing).toEqual({ inputPricePerMillion: 0, outputPricePerMillion: 0 });
+    });
+
+    it('still returns the real pricing for a known model', () => {
+      const ctx = new PricingContext({
+        google: { models: {}, updatedAt: '' },
+        openai: { models: {}, updatedAt: '' },
+        anthropic: {
+          models: {
+            [LlmModels.ClaudeSonnet46]: { inputPricePerMillion: 3, outputPricePerMillion: 15 },
+          },
+          updatedAt: '',
+        },
+        perplexity: { models: {}, updatedAt: '' },
+        openrouter: { models: {}, updatedAt: '' },
+      });
+
+      expect(ctx.getPricing(LlmModels.ClaudeSonnet46)).toEqual({
+        inputPricePerMillion: 3,
+        outputPricePerMillion: 15,
+      });
+    });
+  });
+
+  describe('validateModels still throws on missing — fail-fast preserved for startup', () => {
+    it('validateModels throws when a required model is missing', () => {
+      const ctx = new PricingContext({
+        google: { models: {}, updatedAt: '' },
+        openai: { models: {}, updatedAt: '' },
+        anthropic: { models: {}, updatedAt: '' },
+        perplexity: { models: {}, updatedAt: '' },
+        openrouter: { models: {}, updatedAt: '' },
+      });
+
+      expect(() => ctx.validateModels([LlmModels.ClaudeSonnet46])).toThrow(
+        /Missing pricing/,
+      );
     });
   });
 });

--- a/packages/llm-pricing/src/__tests__/pricingClient.test.ts
+++ b/packages/llm-pricing/src/__tests__/pricingClient.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
-import { type ProviderPricing, type Gemini25Pro, type LLMModel } from '@intexuraos/llm-contract';
+import { type ProviderPricing, type LLMModel } from '@intexuraos/llm-contract';
 import { LlmModels, LlmProviders } from '@intexuraos/llm-contract';
 import {
   PricingContext,
@@ -687,32 +687,46 @@ describe('pricingClient', () => {
   });
 
   describe('getPricing no-throw on missing model', () => {
+    let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      stderrSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+    });
+
+    afterEach(() => {
+      stderrSpy.mockRestore();
+    });
+
     it('returns zero pricing instead of throwing when the model is unknown', () => {
       const ctx = new PricingContext({
-        google: { models: {}, updatedAt: '' },
-        openai: { models: {}, updatedAt: '' },
-        anthropic: { models: {}, updatedAt: '' },
-        perplexity: { models: {}, updatedAt: '' },
-        openrouter: { models: {}, updatedAt: '' },
+        google: { provider: LlmProviders.Google, models: {}, updatedAt: '' },
+        openai: { provider: LlmProviders.OpenAI, models: {}, updatedAt: '' },
+        anthropic: { provider: LlmProviders.Anthropic, models: {}, updatedAt: '' },
+        perplexity: { provider: LlmProviders.Perplexity, models: {}, updatedAt: '' },
+        openrouter: { provider: LlmProviders.OpenRouter, models: {}, updatedAt: '' },
       });
 
       const pricing = ctx.getPricing('or:some/unpriced-model' as LLMModel);
 
       expect(pricing).toEqual({ inputPricePerMillion: 0, outputPricePerMillion: 0 });
+      expect(stderrSpy).toHaveBeenCalledWith(
+        expect.stringContaining('No pricing for model or:some/unpriced-model')
+      );
     });
 
     it('still returns the real pricing for a known model', () => {
       const ctx = new PricingContext({
-        google: { models: {}, updatedAt: '' },
-        openai: { models: {}, updatedAt: '' },
+        google: { provider: LlmProviders.Google, models: {}, updatedAt: '' },
+        openai: { provider: LlmProviders.OpenAI, models: {}, updatedAt: '' },
         anthropic: {
+          provider: LlmProviders.Anthropic,
           models: {
             [LlmModels.ClaudeSonnet46]: { inputPricePerMillion: 3, outputPricePerMillion: 15 },
           },
           updatedAt: '',
         },
-        perplexity: { models: {}, updatedAt: '' },
-        openrouter: { models: {}, updatedAt: '' },
+        perplexity: { provider: LlmProviders.Perplexity, models: {}, updatedAt: '' },
+        openrouter: { provider: LlmProviders.OpenRouter, models: {}, updatedAt: '' },
       });
 
       expect(ctx.getPricing(LlmModels.ClaudeSonnet46)).toEqual({
@@ -725,16 +739,14 @@ describe('pricingClient', () => {
   describe('validateModels still throws on missing — fail-fast preserved for startup', () => {
     it('validateModels throws when a required model is missing', () => {
       const ctx = new PricingContext({
-        google: { models: {}, updatedAt: '' },
-        openai: { models: {}, updatedAt: '' },
-        anthropic: { models: {}, updatedAt: '' },
-        perplexity: { models: {}, updatedAt: '' },
-        openrouter: { models: {}, updatedAt: '' },
+        google: { provider: LlmProviders.Google, models: {}, updatedAt: '' },
+        openai: { provider: LlmProviders.OpenAI, models: {}, updatedAt: '' },
+        anthropic: { provider: LlmProviders.Anthropic, models: {}, updatedAt: '' },
+        perplexity: { provider: LlmProviders.Perplexity, models: {}, updatedAt: '' },
+        openrouter: { provider: LlmProviders.OpenRouter, models: {}, updatedAt: '' },
       });
 
-      expect(() => ctx.validateModels([LlmModels.ClaudeSonnet46])).toThrow(
-        /Missing pricing/,
-      );
+      expect(() => ctx.validateModels([LlmModels.ClaudeSonnet46])).toThrow(/Missing pricing/);
     });
   });
 });

--- a/packages/llm-pricing/src/__tests__/usageLogger.test.ts
+++ b/packages/llm-pricing/src/__tests__/usageLogger.test.ts
@@ -199,4 +199,38 @@ describe('usageLogger', () => {
       expect(usageLogger.sink).toBe(customSink);
     });
   });
+
+  describe('UsageLogger.log forwarding new optional fields', () => {
+    it('forwards ownerType, clientName, providerReportedUsd to the sink when provided', async () => {
+      const fakeSink = { log: vi.fn().mockResolvedValue(undefined) };
+      const logger = createUsageLogger({ logger: fakeLogger, sink: fakeSink });
+
+      await logger.log({
+        ...baseParams,
+        ownerType: 'user',
+        clientName: 'linear-agent-title-gen',
+        providerReportedUsd: 0.0042,
+      });
+
+      expect(fakeSink.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ownerType: 'user',
+          clientName: 'linear-agent-title-gen',
+          providerReportedUsd: 0.0042,
+        }),
+      );
+    });
+
+    it('omits new optional fields from the sink call when not provided', async () => {
+      const fakeSink = { log: vi.fn().mockResolvedValue(undefined) };
+      const logger = createUsageLogger({ logger: fakeLogger, sink: fakeSink });
+
+      await logger.log(baseParams);
+
+      const callArg = fakeSink.log.mock.calls[0]?.[0] as Record<string, unknown>;
+      expect(callArg['ownerType']).toBeUndefined();
+      expect(callArg['clientName']).toBeUndefined();
+      expect(callArg['providerReportedUsd']).toBeUndefined();
+    });
+  });
 });

--- a/packages/llm-pricing/src/__tests__/usageLogger.test.ts
+++ b/packages/llm-pricing/src/__tests__/usageLogger.test.ts
@@ -217,7 +217,7 @@ describe('usageLogger', () => {
           ownerType: 'user',
           clientName: 'linear-agent-title-gen',
           providerReportedUsd: 0.0042,
-        }),
+        })
       );
     });
 

--- a/packages/llm-pricing/src/buildUsageEvent.ts
+++ b/packages/llm-pricing/src/buildUsageEvent.ts
@@ -40,9 +40,7 @@ export function buildUsageEvent(
   const providerReportedUsd = params.providerReportedUsd ?? null;
   const useProviderCost = providerReportedUsd !== null;
   // Schema requires billedUsd >= 0; clamp defensively so a misbehaving provider can't 400 the receiver.
-  const billedUsd = useProviderCost
-    ? Math.max(0, providerReportedUsd)
-    : params.usage.costUsd;
+  const billedUsd = useProviderCost ? Math.max(0, providerReportedUsd) : params.usage.costUsd;
   const pricingSource = useProviderCost ? 'provider_reported' : 'calculated';
 
   return {

--- a/packages/llm-pricing/src/buildUsageEvent.ts
+++ b/packages/llm-pricing/src/buildUsageEvent.ts
@@ -35,15 +35,25 @@ export function buildUsageEvent(
 ): UsageEventPayload {
   const environment: 'dev' | 'prod' = process.env['NODE_ENV'] === 'production' ? 'prod' : 'dev';
 
+  const ownerType = params.ownerType ?? 'system';
+  const clientName = params.clientName ?? source.component;
+  const providerReportedUsd = params.providerReportedUsd ?? null;
+  const useProviderCost = providerReportedUsd !== null;
+  // Schema requires billedUsd >= 0; clamp defensively so a misbehaving provider can't 400 the receiver.
+  const billedUsd = useProviderCost
+    ? Math.max(0, providerReportedUsd)
+    : params.usage.costUsd;
+  const pricingSource = useProviderCost ? 'provider_reported' : 'calculated';
+
   return {
     schemaVersion: 1,
     eventId: crypto.randomUUID(),
     occurredAt: new Date().toISOString(),
-    owner: { type: 'system', id: params.userId },
+    owner: { type: ownerType, id: params.userId },
     source: {
       service: source.service,
       component: source.component,
-      client: params.model,
+      client: clientName,
       environment,
     },
     request: {
@@ -67,10 +77,10 @@ export function buildUsageEvent(
       imageCount: 0,
     },
     cost: {
-      billedUsd: params.usage.costUsd,
-      providerReportedUsd: null,
+      billedUsd,
+      providerReportedUsd,
       calculatedUsd: params.usage.costUsd,
-      pricingSource: 'calculated',
+      pricingSource,
     },
     correlation: {
       requestId: correlationOverrides?.requestId ?? null,

--- a/packages/llm-pricing/src/pricingClient.ts
+++ b/packages/llm-pricing/src/pricingClient.ts
@@ -305,7 +305,7 @@ export async function fetchAllPricingWithRetry(
  * Implemented by {@link PricingContext}.
  */
 export interface IPricingContext {
-  /** Get pricing for a model, throws if not found */
+  /** Get pricing for a model; returns zero pricing for unknown models with a warn for ops audit */
   getPricing(model: LLMModel): ModelPricing;
   /** Check if pricing exists for a model */
   hasPricing(model: LLMModel): boolean;
@@ -369,12 +369,20 @@ export class PricingContext implements IPricingContext {
 
   /**
    * Get pricing for a model.
-   * @throws Error if model pricing not found
+   *
+   * Returns zero pricing for unknown models so producers can still emit a
+   * usage event with cost=$0 instead of crashing. Use validateModels() at
+   * startup if you need fail-fast for known-static dependencies.
    */
   getPricing(model: LLMModel): ModelPricing {
     const pricing = this.pricing.get(model);
     if (pricing === undefined) {
-      throw new Error(`Pricing not found for model: ${model}`);
+      // Audit trail: ops needs to know which models leak through unpriced.
+      // console.warn (no Logger dep in PricingContext) — Cloud Logging picks it up as severity=WARNING.
+      console.warn(
+        `[llm-pricing] No pricing for model ${String(model)} — falling back to $0; emit-don't-skip policy`,
+      );
+      return { inputPricePerMillion: 0, outputPricePerMillion: 0 };
     }
     return pricing;
   }

--- a/packages/llm-pricing/src/pricingClient.ts
+++ b/packages/llm-pricing/src/pricingClient.ts
@@ -378,9 +378,9 @@ export class PricingContext implements IPricingContext {
     const pricing = this.pricing.get(model);
     if (pricing === undefined) {
       // Audit trail: ops needs to know which models leak through unpriced.
-      // console.warn (no Logger dep in PricingContext) — Cloud Logging picks it up as severity=WARNING.
-      console.warn(
-        `[llm-pricing] No pricing for model ${String(model)} — falling back to $0; emit-don't-skip policy`,
+      // process.stderr.write (no Logger dep in PricingContext) — Cloud Logging picks it up as severity=WARNING.
+      process.stderr.write(
+        `[llm-pricing] No pricing for model ${model} — falling back to $0; emit-don't-skip policy\n`
       );
       return { inputPricePerMillion: 0, outputPricePerMillion: 0 };
     }

--- a/packages/llm-pricing/src/pricingClient.ts
+++ b/packages/llm-pricing/src/pricingClient.ts
@@ -377,7 +377,6 @@ export class PricingContext implements IPricingContext {
   getPricing(model: LLMModel): ModelPricing {
     const pricing = this.pricing.get(model);
     if (pricing === undefined) {
-      // Audit trail: ops needs to know which models leak through unpriced.
       // process.stderr.write (no Logger dep in PricingContext) — Cloud Logging picks it up as severity=WARNING.
       process.stderr.write(
         `[llm-pricing] No pricing for model ${model} — falling back to $0; emit-don't-skip policy\n`

--- a/packages/llm-pricing/src/usageLogger.ts
+++ b/packages/llm-pricing/src/usageLogger.ts
@@ -56,6 +56,12 @@ export interface UsageLogParams {
   errorMessage?: string;
   /** Optional pino logger for structured logging */
   logger?: Logger;
+  /** Owner scope of the call. Defaults to 'system' when omitted to preserve legacy behavior. */
+  ownerType?: 'user' | 'system';
+  /** Slash-safe label identifying the calling client/transport (e.g. 'openrouter-generate'). Defaults to source.component when omitted. */
+  clientName?: string;
+  /** Cost reported by the provider (e.g. OpenRouter usage.cost). When set, the receiver records pricingSource: 'provider_reported'. */
+  providerReportedUsd?: number | null;
 }
 
 /**

--- a/packages/llm-pricing/src/usageLogger.ts
+++ b/packages/llm-pricing/src/usageLogger.ts
@@ -10,7 +10,7 @@
  */
 
 import { getErrorMessage } from '@intexuraos/common-core';
-import type { NormalizedUsage } from '@intexuraos/llm-contract';
+import type { NormalizedUsage, OwnerType } from '@intexuraos/llm-contract';
 import type { LlmProvider } from './types.js';
 import type { Logger } from '@intexuraos/common-core';
 
@@ -57,8 +57,8 @@ export interface UsageLogParams {
   /** Optional pino logger for structured logging */
   logger?: Logger;
   /** Owner scope of the call. Defaults to 'system' when omitted to preserve legacy behavior. */
-  ownerType?: 'user' | 'system';
-  /** Slash-safe label identifying the calling client/transport (e.g. 'openrouter-generate'). Defaults to source.component when omitted. */
+  ownerType?: OwnerType;
+  /** Label identifying the calling client/transport (e.g. 'openrouter-generate'). Defaults to source.component when omitted. */
   clientName?: string;
   /** Cost reported by the provider (e.g. OpenRouter usage.cost). When set, the receiver records pricingSource: 'provider_reported'. */
   providerReportedUsd?: number | null;


### PR DESCRIPTION
## Summary

Fixes recurring 500s on the LLM usage event ingest pipeline plus three structural bugs that surfaced once user-selectable OpenRouter models landed in production. Verified against live Firestore + Cloud Logging during investigation.

- **Slash crash**: `source.client` carried the model id (`xiaomi/mimo-v2-pro`), which Firestore parsed as a path separator inside the aggregate doc id and 500'd `incrementAggregate`. Now `source.client` defaults to `source.component` (slash-safe) and the aggregate doc id additionally hashes it as defense-in-depth.
- **OpenRouter cost passthrough**: OpenRouter's `/chat/completions` returns `usage.cost` per request. The producer was hardcoding `undefined` and back-computing via static allowlist prices. Now the API-reported cost flows through `providerReportedUsd` and lands as `cost.billedUsd` with `cost.pricingSource: 'provider_reported'`.
- **User-scoped events**: `owner.type` was hardcoded to `'system'` for every event. Added `OwnerType` to `llm-contract`, plumbed through `LlmClientConfig` and 5 infra clients; `internal-clients/getLlmClient` (the per-user code path used by linear-agent title gen, etc.) tags its 3 client construction sites with `ownerType: 'user'`.
- **Never-skip on missing pricing**: `PricingContext.getPricing` no longer throws on unknown models — returns zero pricing with a `process.stderr.write` audit line. `validateModels` keeps fail-fast for startup callers. Producers always emit, never drop.
- **Defense-in-depth**: `db.collection().doc()` construction moved inside the try/catch in `firestoreUsageAggregateRepository.ts` so any future producer-side garbage logs and returns err rather than crashing the request.

## Architecture

All fixes land in shared packages and the receiver. **Zero changes to workers/orchestrator/* files** per scope constraint — orchestrator's hardcoded xiaomi/mimo-v2-pro compliance-validator model is preserved; it inherits the improved event shape via the shared package import. Backwards compatible: every new field is optional with a default that preserves prior behavior.

Plan document: docs/plans/2026-04-13-llm-usage-event-shape-fix.md

## Endpoint Changes
- **Modified**: none (no route signatures change)
- **Created**: none
- **Removed**: none
- **Unchanged routes, but wire-payload semantics shift** (all schema-compatible against usageEventSchema.ts:118-130):
  - POST /internal/webhooks/usage-events — source.client carries the component label instead of the model id; cost.providerReportedUsd may now be a real number; cost.pricingSource may now be 'provider_reported'; owner.type may now be 'user'. Schema accepts all of these.
  - POST /internal/usage/events — same wire-shape changes as above.

## Behavioral note for ops/dashboards

Existing on-disk Firestore aggregates are keyed today by the model id at position 5 of the doc id. After this PR, position 5 becomes sha256Truncated(source.client) and source.client itself shifts from model id to component label. New writes land in NEW aggregate documents; historical aggregates stop accumulating. Effect: dashboards that group "by client" see a discontinuity at deploy. No data is lost — llm_usage_events is unaffected. The discontinuity restores correct semantics (client is now meaningfully a transport label, not a duplicate of request.model).

## Test plan
- [x] pnpm run ci:tracked — 14560 tests pass, lint clean, typecheck clean, all 21 static validations green
- [x] New tests across packages/llm-pricing, packages/infra-*, packages/internal-clients, apps/llm-usage-service — TDD per-task
- [x] Existing tests updated where they asserted the old buggy semantic
- [x] Merged latest development (incl. INT-1366 OpenRouter Model group-by) — no logical conflicts; the new UI's request.model grouping continues to work and now displays accurate per-call costs from OpenRouter

Architected with love by 🤖 <a href="mailto:intex@intexuraos.cloud">Intex</a>