### PR TITLE
[INT-1370] Apply deploy.yml patch — remove retired data-insights-agent

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -150,7 +150,6 @@ jobs:
           bash cloudbuild/scripts/build-push-monitored.sh research-agent apps/research-agent/Dockerfile &
           bash cloudbuild/scripts/build-push-monitored.sh commands-agent apps/commands-agent/Dockerfile &
           bash cloudbuild/scripts/build-push-monitored.sh actions-agent apps/actions-agent/Dockerfile &
-          bash cloudbuild/scripts/build-push-monitored.sh data-insights-agent apps/data-insights-agent/Dockerfile &
           bash cloudbuild/scripts/build-push-monitored.sh notes-agent apps/notes-agent/Dockerfile &
           bash cloudbuild/scripts/build-push-monitored.sh todos-agent apps/todos-agent/Dockerfile &
           bash cloudbuild/scripts/build-push-monitored.sh bookmarks-agent apps/bookmarks-agent/Dockerfile &
@@ -172,7 +171,7 @@ jobs:
           SERVICES=(
             image-service api-docs-hub notion-service user-service whatsapp-service
             app-settings-service mobile-notifications-service research-agent
-            commands-agent actions-agent data-insights-agent notes-agent
+            commands-agent actions-agent notes-agent
             todos-agent bookmarks-agent calendar-agent linear-agent
             web-agent code-agent chat-agent cron-agent hellscript-agent
             llm-usage-service
@@ -194,7 +193,6 @@ jobs:
             "research-agent:RESEARCH_AGENT"
             "commands-agent:COMMANDS_AGENT"
             "actions-agent:ACTIONS_AGENT"
-            "data-insights-agent:DATA_INSIGHTS_AGENT"
             "notes-agent:NOTES_AGENT"
             "todos-agent:TODOS_AGENT"
             "bookmarks-agent:BOOKMARKS_AGENT"
@@ -379,7 +377,6 @@ jobs:
                 "research-agent:RESEARCH_AGENT"
                 "commands-agent:COMMANDS_AGENT"
                 "actions-agent:ACTIONS_AGENT"
-                "data-insights-agent:DATA_INSIGHTS_AGENT"
                 "notes-agent:NOTES_AGENT"
                 "todos-agent:TODOS_AGENT"
                 "bookmarks-agent:BOOKMARKS_AGENT"


### PR DESCRIPTION
## Summary
- Applies `docs/evidence/INT-1370-deploy-fix.patch` (merged via PR #1803) to `.github/workflows/deploy.yml` itself
- Removes all 4 `data-insights-agent` references that cause deployment failures (`Cannot find service [intexuraos-data-insights-agent]`)
- PR #1803 merged the patch file but could not modify `deploy.yml` directly — the GitHub App token lacked the `workflows` permission. This PR completes the fix using a local token with the `workflow` scope.

## What this removes (net 4 deletions, 1 modified line)
1. Docker image build command for `data-insights-agent`
2. `data-insights-agent` entry in the `SERVICES` array
3. `"data-insights-agent:DATA_INSIGHTS_AGENT"` from monolith `CLOUD_RUN_SERVICES`
4. `"data-insights-agent:DATA_INSIGHTS_AGENT"` from individual target `CLOUD_RUN_SERVICES`

## Verification
- [x] `pnpm run ci:tracked` passed — 14560 tests, all validators green
- [x] `grep data-insights-agent .github/workflows/deploy.yml` returns zero matches
- [x] Diff matches `docs/evidence/INT-1370-deploy-fix.patch` exactly
- [x] Migration 092 formatting reverted during staging (Prettier re-wrapped the description; git history shows it must stay on one line to preserve the migration checksum)

## Test plan
- [ ] CI green on this PR
- [ ] After merge, trigger a deploy and confirm no `Cannot find service` error for `intexuraos-data-insights-agent`

Fixes INT-1370

Architected with love by 🤖 <a href="mailto:intex@intexuraos.cloud">Intex</a>