### PR TITLE
feat(orchestrator): raise log cap to 8MB and task timeout to 5h

### DIFF
--- a/migrations/092_execution-memories-stale-pruning-index.mjs
+++ b/migrations/092_execution-memories-stale-pruning-index.mjs
@@ -14,8 +14,7 @@
 export const metadata = {
   id: '092',
   name: 'execution-memories-stale-pruning-index',
-  description:
-    'Composite index for execution_memories stale pruning query (status, applicationCount, createdAt)',
+  description: 'Composite index for execution_memories stale pruning query (status, applicationCount, createdAt)',
   createdAt: '2026-04-12',
 };
 

--- a/migrations/092_execution-memories-stale-pruning-index.mjs
+++ b/migrations/092_execution-memories-stale-pruning-index.mjs
@@ -14,7 +14,8 @@
 export const metadata = {
   id: '092',
   name: 'execution-memories-stale-pruning-index',
-  description: 'Composite index for execution_memories stale pruning query (status, applicationCount, createdAt)',
+  description:
+    'Composite index for execution_memories stale pruning query (status, applicationCount, createdAt)',
   createdAt: '2026-04-12',
 };
 

--- a/workers/orchestrator/src/__tests__/log-forwarder.test.ts
+++ b/workers/orchestrator/src/__tests__/log-forwarder.test.ts
@@ -440,7 +440,7 @@ describe('LogForwarder', () => {
   });
 
   describe('size limits', () => {
-    it('should stop uploading after 4MB total', async () => {
+    it('should stop uploading after 8MB total', async () => {
       const forwarder = createMockForwarder();
       captureUploadedChunks();
 

--- a/workers/orchestrator/src/__tests__/log-forwarder.test.ts
+++ b/workers/orchestrator/src/__tests__/log-forwarder.test.ts
@@ -440,25 +440,44 @@ describe('LogForwarder', () => {
   });
 
   describe('size limits', () => {
-    it('should stop uploading after 8MB total', async () => {
+    it('should stop uploading formatted chunks after 8MB total', async () => {
+      vi.useFakeTimers();
+      const warnSpy = mockLogger.warn as ReturnType<typeof vi.fn>;
+      warnSpy.mockClear();
+
       const forwarder = createMockForwarder();
       captureUploadedChunks();
 
-      const logFile = join(logBasePath, 'task-size.log');
-      forwarder.startForwarding('task-size', logFile);
+      // Use appendChunk (Docker mode) for deterministic control
+      forwarder.registerTask('task-size', 'secret');
+      forwarder.appendChunk('task-size', 'init\n');
+      await forwarder.flush('task-size');
 
-      // Write enough data to create multiple chunks (10KB)
-      const largeContent = 'C'.repeat(10 * 1024);
-      writeFileSync(logFile, largeContent, 'utf-8');
+      // Push totalBytes past the 8MB cap so the next non-force flush
+      // exercises the limit guard in flushBuffer.
+      const forwarders = (forwarder as unknown as Record<string, unknown>)['forwarders'] as Map<
+        string,
+        { totalBytes: number; timer: NodeJS.Timeout | null }
+      >;
+      const state = forwarders.get('task-size');
+      if (state !== undefined) {
+        state.totalBytes = 8 * 1024 * 1024 + 1;
+      }
 
-      // Wait for polling to pick up and chunk the content
-      await new Promise((resolve) => setTimeout(resolve, 200));
+      // Append more content — a timer-triggered (non-force) flush should drop it
+      forwarder.appendChunk('task-size', 'should-be-dropped\n');
+      await vi.advanceTimersByTimeAsync(3100); // CHUNK_INTERVAL_MS = 3000
 
-      await forwarder.stopForwarding('task-size');
+      // Verify the cap was hit: warn logged and chunk dropped
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ taskId: 'task-size' }),
+        'Max total log size reached, stopping uploads'
+      );
+      expect(forwarder.getDroppedChunkCount('task-size')).toBeGreaterThan(0);
 
-      // Should have created chunks
-      const taskUploads = uploadedChunks.filter((u) => u.taskId === 'task-size');
-      expect(taskUploads.length).toBeGreaterThan(0);
+      // Clean up timer
+      if (state?.timer !== null && state?.timer !== undefined) clearInterval(state.timer);
+      vi.useRealTimers();
     });
   });
 

--- a/workers/orchestrator/src/__tests__/task-dispatcher.test.ts
+++ b/workers/orchestrator/src/__tests__/task-dispatcher.test.ts
@@ -725,7 +725,8 @@ describe('TaskDispatcher', () => {
       vi.mocked(mockIsolationProvider.isWorkerRunning).mockResolvedValue(false);
     });
 
-    it('should log warning at 1h 55m', async () => {
+    it('should keep task running and log warning at 4h 55m', async () => {
+      const warnSpy = vi.spyOn(mockLogger, 'warn');
       const request: CreateTaskRequest = {
         taskId: 'timeout-test',
         workerType: 'auto',
@@ -739,10 +740,17 @@ describe('TaskDispatcher', () => {
       await timeoutDispatcher.submitTask(request);
       await vi.advanceTimersByTimeAsync(0);
 
-      // Advance to 4h 55m (295 minutes)
+      // Advance to 4h 55m (295 minutes) — the warning threshold
       await vi.advanceTimersByTimeAsync(295 * 60 * 1000);
 
+      // Task should still be running (not killed yet)
       expect(timeoutDispatcher.getRunningCount()).toBe(1);
+
+      // Warning should have been logged at the 4h 55m mark
+      expect(warnSpy).toHaveBeenCalledWith(
+        { taskId: 'timeout-test' },
+        'Task approaching 5-hour timeout'
+      );
     });
 
     it('should kill container at 5h timeout', async () => {

--- a/workers/orchestrator/src/__tests__/task-dispatcher.test.ts
+++ b/workers/orchestrator/src/__tests__/task-dispatcher.test.ts
@@ -8942,7 +8942,7 @@ describe('TaskDispatcher', () => {
   });
 
   describe('scheduleTimeoutWarning and scheduleTimeoutKill callbacks', () => {
-    it('scheduleTimeoutWarning logs warning for running task at 2h55m', async () => {
+    it('scheduleTimeoutWarning logs warning for running task at 4h55m', async () => {
       vi.useFakeTimers();
       vi.mocked(mockIsolationProvider.isWorkerRunning).mockResolvedValue(true);
       const warnState = createStatePersistence();

--- a/workers/orchestrator/src/__tests__/task-dispatcher.test.ts
+++ b/workers/orchestrator/src/__tests__/task-dispatcher.test.ts
@@ -308,8 +308,9 @@ describe('TaskDispatcher', () => {
   type VerifierMockResult = CompletionVerifierVerdict;
   const dummyTrace = { transcript: '', prompt: '', response: '' };
 
-  // Activity timeout set to 4 hours so it never fires in tests that don't test it explicitly
-  const disabledActivityTimeout = { timeoutMs: 4 * 60 * 60 * 1000, maxRestarts: 3 };
+  // Activity timeout set to 6 hours so it never fires in tests that don't test it explicitly
+  // (must exceed TASK_TIMEOUT_KILL_MS = 5h so tests that advance to kill time don't trip it).
+  const disabledActivityTimeout = { timeoutMs: 6 * 60 * 60 * 1000, maxRestarts: 3 };
 
   const singleAttemptCompletionControl = {
     maxAttempts: 1,
@@ -738,13 +739,13 @@ describe('TaskDispatcher', () => {
       await timeoutDispatcher.submitTask(request);
       await vi.advanceTimersByTimeAsync(0);
 
-      // Advance to 2h 55m (175 minutes)
-      await vi.advanceTimersByTimeAsync(175 * 60 * 1000);
+      // Advance to 4h 55m (295 minutes)
+      await vi.advanceTimersByTimeAsync(295 * 60 * 1000);
 
       expect(timeoutDispatcher.getRunningCount()).toBe(1);
     });
 
-    it('should kill container at 3h timeout', async () => {
+    it('should kill container at 5h timeout', async () => {
       const request: CreateTaskRequest = {
         taskId: 'timeout-kill-test',
         workerType: 'auto',
@@ -759,8 +760,8 @@ describe('TaskDispatcher', () => {
       await vi.advanceTimersByTimeAsync(0);
       vi.clearAllMocks();
 
-      // Advance to 3h (180 minutes)
-      await vi.advanceTimersByTimeAsync(180 * 60 * 1000);
+      // Advance to 5h (300 minutes)
+      await vi.advanceTimersByTimeAsync(300 * 60 * 1000);
 
       expect(mockIsolationProvider.destroyWorker).toHaveBeenCalled();
     });
@@ -780,12 +781,12 @@ describe('TaskDispatcher', () => {
       await timeoutDispatcher.submitTask(request);
       await vi.advanceTimersByTimeAsync(0);
 
-      // Advance to 2h 55m (175 minutes) - warning timeout
-      await vi.advanceTimersByTimeAsync(175 * 60 * 1000);
+      // Advance to 4h 55m (295 minutes) - warning timeout
+      await vi.advanceTimersByTimeAsync(295 * 60 * 1000);
 
       expect(warnSpy).toHaveBeenCalledWith(
         { taskId: 'warning-test' },
-        'Task approaching 3-hour timeout'
+        'Task approaching 5-hour timeout'
       );
     });
 
@@ -804,8 +805,8 @@ describe('TaskDispatcher', () => {
       await vi.advanceTimersByTimeAsync(0);
       vi.clearAllMocks();
 
-      // Advance past 3h timeout
-      await vi.advanceTimersByTimeAsync(180 * 60 * 1000 + 1000);
+      // Advance past 5h timeout
+      await vi.advanceTimersByTimeAsync(300 * 60 * 1000 + 1000);
 
       expect(mockIsolationProvider.destroyWorker).toHaveBeenCalledWith('kill-webhook-test');
       expect(mockWebhookClient.send).toHaveBeenCalledWith(
@@ -830,8 +831,8 @@ describe('TaskDispatcher', () => {
       await timeoutDispatcher.submitTask(request);
       await vi.advanceTimersByTimeAsync(0);
 
-      // Advance past 3h timeout
-      await vi.advanceTimersByTimeAsync(180 * 60 * 1000 + 1000);
+      // Advance past 5h timeout
+      await vi.advanceTimersByTimeAsync(300 * 60 * 1000 + 1000);
 
       const task = await timeoutDispatcher.getTask('interrupted-test');
       expect(task?.status).toBe('interrupted');
@@ -862,8 +863,8 @@ describe('TaskDispatcher', () => {
       // Clear mocks to see what gets called
       vi.clearAllMocks();
 
-      // Advance past 3h timeout - should NOT send interruption webhook since task is already completed
-      await vi.advanceTimersByTimeAsync(180 * 60 * 1000 + 1000);
+      // Advance past 5h timeout - should NOT send interruption webhook since task is already completed
+      await vi.advanceTimersByTimeAsync(300 * 60 * 1000 + 1000);
 
       // Task should still be completed (not interrupted)
       const finalTask = await timeoutDispatcher.getTask('race-test');
@@ -1383,8 +1384,8 @@ describe('TaskDispatcher', () => {
       task.status = 'completed';
       await statePersistence.save(state);
 
-      // Advance past 3h timeout
-      await vi.advanceTimersByTimeAsync(180 * 60 * 1000 + 1000);
+      // Advance past 5h timeout
+      await vi.advanceTimersByTimeAsync(300 * 60 * 1000 + 1000);
 
       // Task should still be completed (not interrupted)
       const finalTask = await dispatcher.getTask('no-timeout-kill-test');
@@ -1589,8 +1590,8 @@ describe('TaskDispatcher', () => {
 
       vi.clearAllMocks();
 
-      // Advance past the 3h kill timeout
-      await vi.advanceTimersByTimeAsync(180 * 60 * 1000 + 1000);
+      // Advance past the 5h kill timeout
+      await vi.advanceTimersByTimeAsync(300 * 60 * 1000 + 1000);
 
       // Task should still be completed (not interrupted)
       const finalTask = await timeoutDispatcher.getTask('status-change-test');
@@ -7580,7 +7581,7 @@ describe('TaskDispatcher', () => {
       await vi.advanceTimersByTimeAsync(0);
       expect(timeoutDispatcher.getRunningCount()).toBe(1);
 
-      await vi.advanceTimersByTimeAsync(180 * 60 * 1000 + 1000);
+      await vi.advanceTimersByTimeAsync(300 * 60 * 1000 + 1000);
       expect(timeoutDispatcher.getRunningCount()).toBe(0);
 
       vi.useRealTimers();
@@ -7706,7 +7707,7 @@ describe('TaskDispatcher', () => {
       (killGuardDispatcher as unknown as { runningCount: number }).runningCount = 0;
 
       // Advance past kill timeout — guard should prevent going to -1
-      await vi.advanceTimersByTimeAsync(180 * 60 * 1000 + 1000);
+      await vi.advanceTimersByTimeAsync(300 * 60 * 1000 + 1000);
       expect(killGuardDispatcher.getRunningCount()).toBe(0);
 
       vi.useRealTimers();
@@ -8963,11 +8964,11 @@ describe('TaskDispatcher', () => {
       await vi.advanceTimersByTimeAsync(0);
 
       const warnSpy = vi.spyOn(mockLogger, 'warn');
-      await vi.advanceTimersByTimeAsync(175 * 60 * 1000);
+      await vi.advanceTimersByTimeAsync(295 * 60 * 1000);
 
       expect(warnSpy).toHaveBeenCalledWith(
         { taskId: 'warn-timer-test' },
-        'Task approaching 3-hour timeout'
+        'Task approaching 5-hour timeout'
       );
 
       vi.useRealTimers();
@@ -9008,7 +9009,7 @@ describe('TaskDispatcher', () => {
       vi.spyOn(errorDispatcher, 'getTask').mockRejectedValue(new Error('DB error'));
       const errorSpy = vi.spyOn(mockLogger, 'error');
 
-      await vi.advanceTimersByTimeAsync(175 * 60 * 1000);
+      await vi.advanceTimersByTimeAsync(295 * 60 * 1000);
 
       expect(errorSpy).toHaveBeenCalledWith(
         { taskId: 'warn-error-test', error: expect.any(Error) },
@@ -9053,7 +9054,7 @@ describe('TaskDispatcher', () => {
       );
       const errorSpy = vi.spyOn(mockLogger, 'error');
 
-      await vi.advanceTimersByTimeAsync(180 * 60 * 1000 + 1000);
+      await vi.advanceTimersByTimeAsync(300 * 60 * 1000 + 1000);
 
       expect(errorSpy).toHaveBeenCalledWith(
         { taskId: 'kill-error-test', error: expect.any(Error) },
@@ -9095,7 +9096,7 @@ describe('TaskDispatcher', () => {
 
       vi.mocked(mockLogForwarder.flushAndStop).mockRejectedValueOnce(new Error('flush failed'));
 
-      await vi.advanceTimersByTimeAsync(180 * 60 * 1000 + 1000);
+      await vi.advanceTimersByTimeAsync(300 * 60 * 1000 + 1000);
 
       expect(mockLogger.error).toHaveBeenCalledWith(
         { taskId: 'kill-flush-fail-test', error: expect.any(Error) },
@@ -9139,11 +9140,11 @@ describe('TaskDispatcher', () => {
       vi.spyOn(nullTaskDispatcher, 'getTask').mockResolvedValue(null);
       const warnSpy = vi.spyOn(mockLogger, 'warn');
 
-      await vi.advanceTimersByTimeAsync(175 * 60 * 1000);
+      await vi.advanceTimersByTimeAsync(295 * 60 * 1000);
 
       expect(warnSpy).not.toHaveBeenCalledWith(
         expect.objectContaining({ taskId: 'warn-null-task-test' }),
-        'Task approaching 3-hour timeout'
+        'Task approaching 5-hour timeout'
       );
 
       vi.useRealTimers();
@@ -9188,11 +9189,11 @@ describe('TaskDispatcher', () => {
 
       const warnSpy = vi.spyOn(mockLogger, 'warn');
 
-      await vi.advanceTimersByTimeAsync(175 * 60 * 1000);
+      await vi.advanceTimersByTimeAsync(295 * 60 * 1000);
 
       expect(warnSpy).not.toHaveBeenCalledWith(
         expect.objectContaining({ taskId: 'warn-completed-task-test' }),
-        'Task approaching 3-hour timeout'
+        'Task approaching 5-hour timeout'
       );
 
       vi.useRealTimers();
@@ -9241,7 +9242,7 @@ describe('TaskDispatcher', () => {
       (earlyReturnDispatcher as unknown as { runningCount: number }).runningCount = 0;
 
       // Advance past kill timeout — early return (task not running) prevents the decrement
-      await vi.advanceTimersByTimeAsync(180 * 60 * 1000 + 1000);
+      await vi.advanceTimersByTimeAsync(300 * 60 * 1000 + 1000);
 
       // runningCount stays at 0 (not -1) because the early return at `task?.status !== 'running'`
       // fires before reaching the `if (this.runningCount > 0) this.runningCount--` guard

--- a/workers/orchestrator/src/services/__tests__/log-forwarder.test.ts
+++ b/workers/orchestrator/src/services/__tests__/log-forwarder.test.ts
@@ -394,7 +394,7 @@ describe('LogForwarder', () => {
       forwarder.appendChunk('task-codex-nocap', 'formatted bootstrap\n');
       const state = forwarders.get('task-codex-nocap');
       if (state !== undefined) {
-        state.totalBytes = 4 * 1024 * 1024 + 1;
+        state.totalBytes = 8 * 1024 * 1024 + 1;
       }
 
       fetchSpy.mockClear();
@@ -456,7 +456,7 @@ describe('LogForwarder', () => {
       >;
       const state = forwarders.get('task-formatted-stop');
       if (state !== undefined) {
-        state.totalBytes = 4 * 1024 * 1024 + 1;
+        state.totalBytes = 8 * 1024 * 1024 + 1;
         state.formattedUploadsStopped = true;
       }
 
@@ -525,14 +525,14 @@ describe('LogForwarder', () => {
       fwd.appendChunk('task-maxsize', 'init\n');
       await fwd.flush('task-maxsize');
 
-      // Manually set totalBytes to exceed 4MB
+      // Manually set totalBytes to exceed 8MB
       const forwarders = (fwd as unknown as Record<string, unknown>)['forwarders'] as Map<
         string,
         { totalBytes: number; timer: NodeJS.Timeout | null }
       >;
       const state = forwarders.get('task-maxsize');
       if (state !== undefined) {
-        state.totalBytes = 4 * 1024 * 1024 + 1;
+        state.totalBytes = 8 * 1024 * 1024 + 1;
       }
 
       // Append content — the non-force flushBuffer path checks totalBytes

--- a/workers/orchestrator/src/services/log-forwarder.ts
+++ b/workers/orchestrator/src/services/log-forwarder.ts
@@ -31,7 +31,7 @@ interface QueuedLogChunk {
 }
 
 const MAX_CHUNK_SIZE = 64 * 1024; // 64KB — must exceed largest single JSON message (hook_response with build output)
-const MAX_TOTAL_LOG_SIZE = 4 * 1024 * 1024; // 4MB
+const MAX_TOTAL_LOG_SIZE = 8 * 1024 * 1024; // 8MB
 const CHUNK_INTERVAL_MS = 3 * 1000; // 3 seconds
 const MAX_BATCH_SIZE = 5;
 

--- a/workers/orchestrator/src/services/task-dispatcher.ts
+++ b/workers/orchestrator/src/services/task-dispatcher.ts
@@ -108,8 +108,8 @@ export function buildMissingFieldsPrompt(
   ].join('\n');
 }
 
-const TASK_TIMEOUT_WARNING_MS = 175 * 60 * 1000; // 2h 55m
-const TASK_TIMEOUT_KILL_MS = 180 * 60 * 1000; // 3h
+const TASK_TIMEOUT_WARNING_MS = 295 * 60 * 1000; // 4h 55m
+const TASK_TIMEOUT_KILL_MS = 300 * 60 * 1000; // 5h
 const COMPLETION_CHECK_INTERVAL_MS = 30 * 1000; // 30s
 const ACTIVITY_HEARTBEAT_THRESHOLD_MS = 30 * 1000; // 30s
 const IMAGE_PULL_TIMEOUT_MS = 900_000; // 15 minutes — image pulls are network-bound
@@ -977,7 +977,7 @@ export class TaskDispatcher {
           const task = await this.getTask(taskId);
           /* v8 ignore start -- source-map: branch inside void async setTimeout callback misattributed by v8 coverage instrumentation even when exercised by fake timer tests @preserve */
           if (task !== null && task.status === 'running') {
-            this.logger.warn({ taskId }, 'Task approaching 3-hour timeout');
+            this.logger.warn({ taskId }, 'Task approaching 5-hour timeout');
           }
           /* v8 ignore stop @preserve */
         } catch (error) {


### PR DESCRIPTION
## Summary

- Bumps `MAX_TOTAL_LOG_SIZE` in the log forwarder from **4MB to 8MB** (`workers/orchestrator/src/services/log-forwarder.ts:34`)
- Extends `TASK_TIMEOUT_KILL_MS` from **3h to 5h** and `TASK_TIMEOUT_WARNING_MS` from **2h 55m to 4h 55m** (`workers/orchestrator/src/services/task-dispatcher.ts:111-112`)
- Test fixture `disabledActivityTimeout` bumped from 4h to 6h so it stays above the new kill threshold

## Why

This PR is **infrastructure-only** and is not tied to any existing Linear issue. Discovered while debugging an unrelated code-task that appeared stuck; investigation surfaced two orchestrator-level issues worth fixing independently:

1. Silent log cap: orchestrator's log forwarder hits 4MB and stops uploading to Firestore, but keeps heartbeating. Users see zero logs while the task is still actively working. Bumping to 8MB buys more headroom for long CI-heavy tasks before the cap triggers.
2. 3h hard kill too aggressive: cross-service migrations that run through many CI iterations need more wall-clock time to converge. Raising to 5h gives the agent room to complete legitimately long work before being reaped.

Neither change addresses the root UX problem (no signal when logs are capped; no circuit breaker for non-converging CI loops) — those are separate follow-ups.

## Endpoint Changes

- Modified: none
- Created: none
- Removed: none
- Unchanged: all endpoints unchanged

## Test plan

- [x] `pnpm run verify:workspace:tracked orchestrator` passes
- [x] `pnpm run ci:tracked` passes
- [ ] Manual: confirm log forwarder's 8MB cap works in prod by observing a long-running task
- [ ] Manual: confirm orchestrator systemd service picks up new constants after deploy

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>