### PR TITLE
chore(claude): add conciseness rule, disable Explanatory output style

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -2,6 +2,10 @@
 
 All rules verified by `pnpm run ci:tracked`. If CI passes, rules are satisfied. Keep this file compact — add references to `.claude/reference/`, don't inline details.
 
+# Communication
+
+**Be concise.** Output the answer, the diff, or the result. Do not write elaborations, rationales, summaries of what you just did, or educational asides unless the user explicitly asks for reasoning. If a question has a one-line answer, give a one-line answer. This rule takes precedence over any output style that encourages elaboration.
+
 # Gates
 
 **Commit Gate:** Before commit: (1) `pnpm run ci:tracked` passed completely? (2) Not saying "other services/workspaces"? (3) Not saying "unrelated to my changes" or "not caused by my code"? All YES = commit. Any NO = STOP.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -156,7 +156,7 @@
     "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/statusline.sh",
     "padding": 0
   },
-  "outputStyle": "Explanatory",
+  "outputStyle": "default",
   "enabledPlugins": {
     "superpowers@superpowers-marketplace": true,
     "context7@claude-plugins-official": true,


### PR DESCRIPTION
## Summary
- Adds a top-level **Communication** section to `.claude/CLAUDE.md` requiring concise output (no elaborations, rationales, or educational asides unless the user asks for reasoning). Explicitly notes it overrides elaborative output styles.
- Flips `.claude/settings.json` `outputStyle` from `Explanatory` to `default` — the previous pin was actively producing the elaborations the new rule forbids.

## Test plan
- [x] `pnpm run ci:tracked` passes locally (14560 tests, all phases green)
- [ ] Reviewer sanity-checks the wording in `.claude/CLAUDE.md` Communication section
- [ ] After merge, contributors will pick up the new default style on their next session

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>