### PR TITLE
[INT-1386] Consolidated: Centralize LLM pricing in llm-usage-service

### DIFF
--- a/apps/actions-agent/src/services.ts
+++ b/apps/actions-agent/src/services.ts
@@ -106,10 +106,8 @@ import {
 import { createUserServiceClient, type UserServiceClient } from '@intexuraos/internal-clients';
 import {
   fetchAllPricingWithRetry,
-  createPricingContext,
   HttpInternalAuthUsageSink,
 } from '@intexuraos/llm-pricing';
-import { LlmModels } from '@intexuraos/llm-contract';
 
 export interface Services {
   actionServiceClient: ActionServiceClient;
@@ -186,15 +184,6 @@ export async function initServices(config: ServiceConfig): Promise<void> {
     throw new Error(`Failed to fetch pricing: ${pricingResult.error.message}`);
   }
 
-  // Support common models for approval intent classification
-  const pricingContext = createPricingContext(pricingResult.value, [
-    LlmModels.Gemini25Flash,
-    LlmModels.Gemini25Pro,
-    LlmModels.ClaudeSonnet46,
-    LlmModels.GPT54,
-    LlmModels.SonarPro,
-  ]);
-
   const actionRepository = createFirestoreActionRepository({
     logger: createAppLogger({ name: 'actionRepository' }),
   });
@@ -206,7 +195,6 @@ export async function initServices(config: ServiceConfig): Promise<void> {
   const userServiceClient = createUserServiceClient({
     baseUrl: config.userServiceUrl,
     internalAuthToken: config.internalAuthToken,
-    pricingContext,
     logger: userServiceClientLogger,
     usageSink: new HttpInternalAuthUsageSink({
       usageServiceUrl: config.llmUsageServiceUrl,

--- a/apps/calendar-agent/src/services.ts
+++ b/apps/calendar-agent/src/services.ts
@@ -44,7 +44,6 @@ export function initServices(config: ServiceConfig): void {
   const userServiceClient = createUserServiceClient({
     baseUrl: config.userServiceUrl,
     internalAuthToken: config.internalAuthToken,
-    pricingContext: config.pricingContext,
     logger: logger,
     usageSink: new HttpInternalAuthUsageSink({
       usageServiceUrl: config.llmUsageServiceUrl,

--- a/apps/chat-agent/src/__tests__/services.test.ts
+++ b/apps/chat-agent/src/__tests__/services.test.ts
@@ -14,22 +14,11 @@ import {
 import { ok } from '@intexuraos/common-core';
 
 const {
-  mockCreatePricingContext,
-  mockFetchAllPricing,
   mockCreateUserServiceClient,
   mockCreateLlmClient,
   mockGuestRateLimiter,
 } = vi.hoisted(() => {
-  const mockPricingContext = {
-    getPricing: vi.fn().mockReturnValue({
-      inputPricePerMillion: 0,
-      outputPricePerMillion: 0,
-    }),
-  };
-
   return {
-    mockCreatePricingContext: vi.fn().mockReturnValue(mockPricingContext),
-    mockFetchAllPricing: vi.fn().mockResolvedValue({ ok: true, value: { models: [] } }),
     mockCreateUserServiceClient: vi.fn().mockReturnValue({
       getLlmClient: vi.fn().mockResolvedValue({ ok: true, value: { generate: vi.fn() } }),
       getApiKeys: vi.fn().mockResolvedValue({ ok: true, value: {} }),
@@ -44,8 +33,6 @@ const {
 });
 
 vi.mock('@intexuraos/llm-pricing', () => ({
-  fetchAllPricingWithRetry: mockFetchAllPricing,
-  createPricingContext: mockCreatePricingContext,
   HttpInternalAuthUsageSink: vi.fn().mockImplementation(function FakeSink() {
     return { log: vi.fn().mockResolvedValue(undefined) };
   }),
@@ -88,8 +75,6 @@ describe('chat-agent services', () => {
     process.env['INTEXURAOS_LLM_USAGE_SERVICE_URL'] = 'http://localhost:8081';
     process.env['INTEXURAOS_GEMINI_APP_API_KEY'] = 'test-gemini-key';
     process.env['INTEXURAOS_DASHSCOPE_APP_API_KEY'] = 'test-dashscope-key';
-    mockCreatePricingContext.mockClear();
-    mockFetchAllPricing.mockClear();
     mockCreateUserServiceClient.mockClear();
     mockCreateLlmClient.mockClear();
   });
@@ -201,8 +186,8 @@ describe('chat-agent services', () => {
   });
 
   describe('initializeServices', () => {
-    it('uses the Gemini platform key for guest access and user-service fallbacks', async () => {
-      await initializeServices();
+    it('uses the Gemini platform key for guest access and user-service fallbacks', () => {
+      initializeServices();
 
       expect(mockCreateLlmClient).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -217,10 +202,10 @@ describe('chat-agent services', () => {
       );
     });
 
-    it('fails fast when the Gemini guest key is missing', async () => {
+    it('fails fast when the Gemini guest key is missing', () => {
       delete process.env['INTEXURAOS_GEMINI_APP_API_KEY'];
 
-      await expect(initializeServices()).rejects.toThrow(
+      expect(() => initializeServices()).toThrow(
         'INTEXURAOS_GEMINI_APP_API_KEY environment variable is required for guest access'
       );
     });

--- a/apps/chat-agent/src/index.ts
+++ b/apps/chat-agent/src/index.ts
@@ -32,7 +32,7 @@ const PORT = Number(process.env['PORT'] ?? 8080);
 const HOST = process.env['HOST'] ?? '0.0.0.0';
 
 async function main(): Promise<void> {
-  await initializeServices();
+  initializeServices();
 
   const app = await buildServer();
 

--- a/apps/chat-agent/src/services.ts
+++ b/apps/chat-agent/src/services.ts
@@ -5,11 +5,7 @@
 
 import { createAppLogger } from '@intexuraos/infra-sentry';
 import { createUserServiceClient, type UserServiceClient } from '@intexuraos/internal-clients';
-import {
-  fetchAllPricingWithRetry,
-  createPricingContext,
-  HttpInternalAuthUsageSink,
-} from '@intexuraos/llm-pricing';
+import { HttpInternalAuthUsageSink } from '@intexuraos/llm-pricing';
 import { LlmModels } from '@intexuraos/llm-contract';
 import { createLlmClient, type LlmGenerateClient } from '@intexuraos/llm-factory';
 import { FirestoreEmbeddingRepository } from './infra/firestore/embeddingRepository.js';
@@ -24,14 +20,6 @@ import type { Logger } from 'pino';
 
 // Re-export createChatClient for use in routes (via services layer)
 export { createChatClient };
-
-/**
- * Models supported for chat responses.
- * These are validated at startup to ensure pricing is available.
- */
-const CHAT_MODELS = [
-  LlmModels.Gemini25Flash,
-] as const;
 
 /**
  * Service container holding all adapter instances.
@@ -75,9 +63,8 @@ export function resetServices(): void {
 
 /**
  * Initialize the service container with all dependencies.
- * Fetches pricing data from llm-usage-service at startup.
  */
-export async function initializeServices(): Promise<void> {
+export function initializeServices(): void {
   const openaiApiKey = process.env['INTEXURAOS_OPENAI_APP_API_KEY'];
   const userServiceUrl = process.env['INTEXURAOS_USER_SERVICE_URL'];
   const internalAuthToken = process.env['INTEXURAOS_INTERNAL_AUTH_TOKEN'];
@@ -109,18 +96,6 @@ export async function initializeServices(): Promise<void> {
     level: (process.env['LOG_LEVEL'] ?? 'info') as 'error' | 'info' | 'warn' | 'debug' | 'silent',
   });
 
-  // Fetch pricing data from llm-usage-service
-  const pricingResult = await fetchAllPricingWithRetry(llmUsageServiceUrl, internalAuthToken);
-
-  if (!pricingResult.ok) {
-    throw new Error(`Failed to fetch pricing: ${pricingResult.error.message}`);
-  }
-
-  const pricingContext = createPricingContext(
-    pricingResult.value,
-    [...CHAT_MODELS] as unknown as (typeof LlmModels.Gemini25Flash)[]
-  );
-
   // Create OpenAI instance for embeddings
   const openai = new OpenAI({ apiKey: openaiApiKey });
 
@@ -145,7 +120,6 @@ export async function initializeServices(): Promise<void> {
     apiKey: guestGeminiApiKey,
     model: LlmModels.Gemini25Flash,
     userId: 'guest',
-    pricing: pricingContext.getPricing(LlmModels.Gemini25Flash),
     logger,
     usageSink: guestUsageSink,
   });
@@ -160,7 +134,6 @@ export async function initializeServices(): Promise<void> {
     userServiceClient: createUserServiceClient({
       baseUrl: userServiceUrl,
       internalAuthToken,
-      pricingContext,
       logger,
       usageSink: userServiceUsageSink,
       platformGeminiApiKey: process.env['INTEXURAOS_GEMINI_APP_API_KEY'],

--- a/apps/chat-agent/src/services.ts
+++ b/apps/chat-agent/src/services.ts
@@ -7,7 +7,6 @@ import { createAppLogger } from '@intexuraos/infra-sentry';
 import { createUserServiceClient, type UserServiceClient } from '@intexuraos/internal-clients';
 import {
   fetchAllPricingWithRetry,
-  createPricingContext,
   HttpInternalAuthUsageSink,
 } from '@intexuraos/llm-pricing';
 import { LlmModels } from '@intexuraos/llm-contract';
@@ -24,14 +23,6 @@ import type { Logger } from 'pino';
 
 // Re-export createChatClient for use in routes (via services layer)
 export { createChatClient };
-
-/**
- * Models supported for chat responses.
- * These are validated at startup to ensure pricing is available.
- */
-const CHAT_MODELS = [
-  LlmModels.Gemini25Flash,
-] as const;
 
 /**
  * Service container holding all adapter instances.
@@ -116,11 +107,6 @@ export async function initializeServices(): Promise<void> {
     throw new Error(`Failed to fetch pricing: ${pricingResult.error.message}`);
   }
 
-  const pricingContext = createPricingContext(
-    pricingResult.value,
-    [...CHAT_MODELS] as unknown as (typeof LlmModels.Gemini25Flash)[]
-  );
-
   // Create OpenAI instance for embeddings
   const openai = new OpenAI({ apiKey: openaiApiKey });
 
@@ -145,7 +131,6 @@ export async function initializeServices(): Promise<void> {
     apiKey: guestGeminiApiKey,
     model: LlmModels.Gemini25Flash,
     userId: 'guest',
-    pricing: pricingContext.getPricing(LlmModels.Gemini25Flash),
     logger,
     usageSink: guestUsageSink,
   });
@@ -160,7 +145,6 @@ export async function initializeServices(): Promise<void> {
     userServiceClient: createUserServiceClient({
       baseUrl: userServiceUrl,
       internalAuthToken,
-      pricingContext,
       logger,
       usageSink: userServiceUsageSink,
       platformGeminiApiKey: process.env['INTEXURAOS_GEMINI_APP_API_KEY'],

--- a/apps/code-agent/src/services.ts
+++ b/apps/code-agent/src/services.ts
@@ -8,7 +8,6 @@ import type { Logger } from 'pino';
 import type { Firestore } from '@google-cloud/firestore';
 import { ok, type Result } from '@intexuraos/common-core';
 import { getFirestore } from '@intexuraos/infra-firestore';
-import { TOOL_CALLING_PRICING } from '@intexuraos/infra-gemini';
 import { createWhatsAppSendPublisher, type WhatsAppSendPublisher } from '@intexuraos/infra-pubsub';
 import { LlmModels, type ToolCallingClient } from '@intexuraos/llm-contract';
 import { createToolCallingClient } from '@intexuraos/llm-factory';
@@ -93,7 +92,6 @@ import { createTaskGroupSummaryFirestoreRepository } from './infra/firestore/tas
 import { withGroupUpdates } from './infra/repositories/codeTaskRepositoryWithGroupUpdates.js';
 
 const GEMINI_TOOL_CALLING_MODEL = LlmModels.Gemini25Flash;
-const GEMINI_TOOL_CALLING_PRICING = TOOL_CALLING_PRICING[LlmModels.Gemini25Flash];
 export interface ServiceContainer {
   firestore: Firestore;
   logger: Logger;
@@ -360,13 +358,6 @@ export function initServices(config: ServiceConfig): void {
     internalAuthToken: config.internalAuthToken,
     logger,
     usageSink: buildUsageSink('user-service-client'),
-    pricingContext: {
-      getPricing() { throw new Error('code-agent does not use LLM pricing'); },
-      hasPricing() { return false; },
-      validateModels() { throw new Error('code-agent does not use LLM pricing'); },
-      validateAllModels() { throw new Error('code-agent does not use LLM pricing'); },
-      getModelsWithPricing() { return []; },
-    },
   });
 
   const usageServiceClient = config.llmUsageServiceUrl !== ''
@@ -435,7 +426,6 @@ export function initServices(config: ServiceConfig): void {
         apiKey: config.geminiAppApiKey,
         model: GEMINI_TOOL_CALLING_MODEL,
         userId: 'system:github-agent',
-        pricing: GEMINI_TOOL_CALLING_PRICING,
         logger,
         usageSink: buildUsageSink('github-agent'),
       })

--- a/apps/commands-agent/src/services.ts
+++ b/apps/commands-agent/src/services.ts
@@ -1,10 +1,8 @@
 import { createAppLogger } from '@intexuraos/infra-sentry';
 import {
   fetchAllPricingWithRetry,
-  createPricingContext,
   HttpInternalAuthUsageSink,
 } from '@intexuraos/llm-pricing';
-import { LlmModels } from '@intexuraos/llm-contract';
 import type { CommandRepository } from './domain/ports/commandRepository.js';
 import type { ClassifierFactory } from './domain/ports/classifier.js';
 import type { EventPublisherPort } from './domain/ports/eventPublisher.js';
@@ -57,13 +55,6 @@ export interface ServiceConfig {
 
 let container: Services | null = null;
 
-/**
- * Models supported for classification.
- */
-const CLASSIFIER_MODELS = [
-  LlmModels.Gemini25Flash,
-] as const;
-
 export async function initServices(config: ServiceConfig): Promise<void> {
   const logger = createAppLogger({ name: 'commands-agent' });
 
@@ -77,8 +68,6 @@ export async function initServices(config: ServiceConfig): Promise<void> {
     throw new Error(`Failed to fetch pricing: ${pricingResult.error.message}`);
   }
 
-  const pricingContext = createPricingContext(pricingResult.value, [...CLASSIFIER_MODELS] as unknown as typeof LlmModels.Gemini25Flash[]);
-
   const commandRepository = createFirestoreCommandRepository();
   const actionsAgentClient = createActionsAgentClient({
     baseUrl: config.actionsAgentUrl,
@@ -91,7 +80,6 @@ export async function initServices(config: ServiceConfig): Promise<void> {
   const userServiceClient = createUserServiceClient({
     baseUrl: config.userServiceUrl,
     internalAuthToken: config.internalAuthToken,
-    pricingContext,
     logger: userServiceClientLogger,
     usageSink: new HttpInternalAuthUsageSink({
       usageServiceUrl: config.llmUsageServiceUrl,

--- a/apps/cron-agent/src/index.ts
+++ b/apps/cron-agent/src/index.ts
@@ -8,7 +8,7 @@ import { createAppLogger } from '@intexuraos/infra-sentry';
 import { FirestoreScheduleRepository } from './infra/firestore-schedule-repository.js';
 import { FirestoreExecutionRepository } from './infra/firestore-execution-repository.js';
 import { OpenApiToolRegistry } from './infra/openapi-tool-registry.js';
-import { createGeminiClient, createGeminiToolCallingClient, TOOL_CALLING_PRICING } from '@intexuraos/infra-gemini';
+import { createGeminiClient, createGeminiToolCallingClient } from '@intexuraos/infra-gemini';
 import { LlmModels } from '@intexuraos/llm-contract';
 import { HttpInternalAuthUsageSink } from '@intexuraos/llm-pricing';
 
@@ -70,7 +70,6 @@ async function main(): Promise<void> {
     apiKey: config.geminiApiKey,
     model: LlmModels.Gemini25Flash,
     userId: 'cron-agent-system',
-    pricing: TOOL_CALLING_PRICING[LlmModels.Gemini25Flash],
     logger: createAppLogger({ name: 'tool-calling' }),
     usageSink: buildUsageSink('tool-calling'),
   });
@@ -79,7 +78,6 @@ async function main(): Promise<void> {
     apiKey: config.geminiApiKey,
     model: LlmModels.Gemini25Flash,
     userId: 'cron-agent-system',
-    pricing: TOOL_CALLING_PRICING[LlmModels.Gemini25Flash],
     logger: createAppLogger({ name: 'gemini-client' }),
     usageSink: buildUsageSink('gemini-client'),
   });

--- a/apps/image-service/src/serviceFactory.ts
+++ b/apps/image-service/src/serviceFactory.ts
@@ -36,7 +36,6 @@ export function initializeServices(pricingContext: IPricingContext): void {
   const userServiceClient = createUserServiceClient({
     baseUrl: process.env['INTEXURAOS_USER_SERVICE_URL'] ?? 'http://localhost:8110',
     internalAuthToken,
-    pricingContext,
     logger: createAppLogger({ name: 'user-service-client' }),
     usageSink: buildUsageSink('user-service-client'),
     platformGeminiApiKey: process.env['INTEXURAOS_GEMINI_APP_API_KEY'],

--- a/apps/linear-agent/src/__tests__/routes/internalIssuesRoutes.test.ts
+++ b/apps/linear-agent/src/__tests__/routes/internalIssuesRoutes.test.ts
@@ -3,7 +3,6 @@ import { err } from '@intexuraos/common-core';
 
 vi.mock('@intexuraos/infra-gemini', () => ({
   createGeminiClient: vi.fn(),
-  TOOL_CALLING_PRICING: {},
 }));
 
 import { buildServer } from '../../server.js';

--- a/apps/linear-agent/src/services.ts
+++ b/apps/linear-agent/src/services.ts
@@ -70,7 +70,6 @@ export function initServices(config: ServiceConfig): void {
   const userServiceClient = createUserServiceClient({
     baseUrl: config.userServiceUrl,
     internalAuthToken: config.internalAuthToken,
-    pricingContext: config.pricingContext,
     logger: logger,
     usageSink: buildUsageSink('user-service-client'),
     platformGeminiApiKey: process.env['INTEXURAOS_GEMINI_APP_API_KEY'],

--- a/apps/llm-usage-service/src/__tests__/domain/services/costCalculation.test.ts
+++ b/apps/llm-usage-service/src/__tests__/domain/services/costCalculation.test.ts
@@ -161,6 +161,47 @@ describe('calculateCost', () => {
       const pricing = makePricing({ inputPricePerMillion: 0, outputPricePerMillion: 0 });
       expect(calculateCost(LlmProviders.Google, usage, pricing)).toBe(0);
     });
+
+    it('includes image cost when imageCount > 0 and imagePricing is set', () => {
+      const usage = makeUsage({ imageCount: 2 });
+      const pricing = makePricing({
+        inputPricePerMillion: 0,
+        outputPricePerMillion: 0,
+        imagePricing: { '1024x1024': 0.04, '1536x1024': 0.08, '1024x1536': 0.08 },
+      });
+      // imageCost = 2 * 0.04 = 0.08
+      expect(calculateCost(LlmProviders.Google, usage, pricing)).toBe(0.08);
+    });
+
+    it('returns 0 image cost when imagePricing is undefined', () => {
+      const usage = makeUsage({ imageCount: 3 });
+      const pricing = makePricing({ inputPricePerMillion: 0, outputPricePerMillion: 0 });
+      expect(calculateCost(LlmProviders.Google, usage, pricing)).toBe(0);
+    });
+
+    it('adds image cost to token cost', () => {
+      const usage = makeUsage({ inputTokens: 1000, outputTokens: 500, imageCount: 1 });
+      const pricing = makePricing({
+        inputPricePerMillion: 1.25,
+        outputPricePerMillion: 10.0,
+        imagePricing: { '1024x1024': 0.03 },
+      });
+      // tokenCost = (1000*1.25 + 500*10) / 1_000_000 = 6250/1_000_000 = 0.00625
+      // imageCost = 1 * 0.03 = 0.03
+      // total = 0.03625
+      expect(calculateCost(LlmProviders.Google, usage, pricing)).toBe(0.03625);
+    });
+
+    it('returns 0 image cost when imagePricing has no default size entry', () => {
+      const usage = makeUsage({ imageCount: 2 });
+      const pricing = makePricing({
+        inputPricePerMillion: 0,
+        outputPricePerMillion: 0,
+        imagePricing: { '1536x1024': 0.08 },
+      });
+      // Default size 1024x1024 is not in imagePricing → perImagePrice = 0
+      expect(calculateCost(LlmProviders.Google, usage, pricing)).toBe(0);
+    });
   });
 
   // =========================================================================
@@ -234,6 +275,30 @@ describe('calculateCost', () => {
       const usage = makeUsage();
       const pricing = makePricing({ inputPricePerMillion: 0, outputPricePerMillion: 0 });
       expect(calculateCost(LlmProviders.OpenAI, usage, pricing)).toBe(0);
+    });
+
+    it('includes image cost when imageCount > 0 and imagePricing is set', () => {
+      const usage = makeUsage({ imageCount: 3 });
+      const pricing = makePricing({
+        inputPricePerMillion: 0,
+        outputPricePerMillion: 0,
+        imagePricing: { '1024x1024': 0.04, '1536x1024': 0.08, '1024x1536': 0.08 },
+      });
+      // imageCost = 3 * 0.04 = 0.12
+      expect(calculateCost(LlmProviders.OpenAI, usage, pricing)).toBe(0.12);
+    });
+
+    it('adds image cost to token cost', () => {
+      const usage = makeUsage({ inputTokens: 1000, outputTokens: 500, imageCount: 2 });
+      const pricing = makePricing({
+        inputPricePerMillion: 2.5,
+        outputPricePerMillion: 10.0,
+        imagePricing: { '1024x1024': 0.04 },
+      });
+      // tokenCost = (1000*2.5 + 500*10) / 1_000_000 = 7500/1_000_000 = 0.0075
+      // imageCost = 2 * 0.04 = 0.08
+      // total = 0.0875
+      expect(calculateCost(LlmProviders.OpenAI, usage, pricing)).toBe(0.0875);
     });
   });
 

--- a/apps/llm-usage-service/src/__tests__/domain/services/costCalculation.test.ts
+++ b/apps/llm-usage-service/src/__tests__/domain/services/costCalculation.test.ts
@@ -1,0 +1,328 @@
+import { describe, it, expect } from 'vitest';
+import { LlmProviders } from '@intexuraos/llm-contract';
+import type { ModelPricing } from '@intexuraos/llm-contract';
+import { calculateCost, type UsageTokens } from '../../../domain/services/costCalculation.js';
+
+function makeUsage(overrides?: Partial<UsageTokens>): UsageTokens {
+  return {
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    cachedTokens: 0,
+    reasoningTokens: 0,
+    thinkingTokens: 0,
+    webSearchCalls: 0,
+    groundingEnabled: false,
+    imageCount: 0,
+    ...overrides,
+  };
+}
+
+function makePricing(overrides?: Partial<ModelPricing>): ModelPricing {
+  return {
+    inputPricePerMillion: 3.0,
+    outputPricePerMillion: 15.0,
+    ...overrides,
+  };
+}
+
+describe('calculateCost', () => {
+  // =========================================================================
+  // Anthropic
+  // =========================================================================
+  describe('anthropic', () => {
+    it('calculates basic input/output cost', () => {
+      const usage = makeUsage({ inputTokens: 1000, outputTokens: 500 });
+      const pricing = makePricing({
+        inputPricePerMillion: 3.0,
+        outputPricePerMillion: 15.0,
+      });
+      // regularCost = 1000 * 3 = 3000
+      // outputCost = 500 * 15 = 7500
+      // total = (3000 + 7500) / 1_000_000 = 0.0105
+      expect(calculateCost(LlmProviders.Anthropic, usage, pricing)).toBe(0.0105);
+    });
+
+    it('applies cache read multiplier (default 0.1)', () => {
+      const usage = makeUsage({ inputTokens: 1000, cacheReadTokens: 2000, outputTokens: 0 });
+      const pricing = makePricing({ inputPricePerMillion: 10.0, outputPricePerMillion: 0 });
+      // regularCost = 1000 * 10 = 10000
+      // readCost = 2000 * 10 * 0.1 = 2000
+      // total = 12000 / 1_000_000 = 0.012
+      expect(calculateCost(LlmProviders.Anthropic, usage, pricing)).toBe(0.012);
+    });
+
+    it('applies custom cache read multiplier from pricing', () => {
+      const usage = makeUsage({ inputTokens: 0, cacheReadTokens: 1000, outputTokens: 0 });
+      const pricing = makePricing({
+        inputPricePerMillion: 10.0,
+        outputPricePerMillion: 0,
+        cacheReadMultiplier: 0.2,
+      });
+      // readCost = 1000 * 10 * 0.2 = 2000
+      // total = 2000 / 1_000_000 = 0.002
+      expect(calculateCost(LlmProviders.Anthropic, usage, pricing)).toBe(0.002);
+    });
+
+    it('applies cache write multiplier (default 1.25)', () => {
+      const usage = makeUsage({ inputTokens: 0, cacheWriteTokens: 1000, outputTokens: 0 });
+      const pricing = makePricing({ inputPricePerMillion: 10.0, outputPricePerMillion: 0 });
+      // writeCost = 1000 * 10 * 1.25 = 12500
+      // total = 12500 / 1_000_000 = 0.0125
+      expect(calculateCost(LlmProviders.Anthropic, usage, pricing)).toBe(0.0125);
+    });
+
+    it('applies custom cache write multiplier from pricing', () => {
+      const usage = makeUsage({ inputTokens: 0, cacheWriteTokens: 1000, outputTokens: 0 });
+      const pricing = makePricing({
+        inputPricePerMillion: 10.0,
+        outputPricePerMillion: 0,
+        cacheWriteMultiplier: 1.5,
+      });
+      // writeCost = 1000 * 10 * 1.5 = 15000
+      // total = 15000 / 1_000_000 = 0.015
+      expect(calculateCost(LlmProviders.Anthropic, usage, pricing)).toBe(0.015);
+    });
+
+    it('includes web search cost', () => {
+      const usage = makeUsage({ inputTokens: 0, outputTokens: 0, webSearchCalls: 2 });
+      const pricing = makePricing({
+        inputPricePerMillion: 0,
+        outputPricePerMillion: 0,
+        webSearchCostPerCall: 0.005,
+      });
+      // searchCostScaled = 2 * 0.005 * 1_000_000 = 10000
+      // total = 10000 / 1_000_000 = 0.01
+      expect(calculateCost(LlmProviders.Anthropic, usage, pricing)).toBe(0.01);
+    });
+
+    it('returns 0 for zero usage', () => {
+      const usage = makeUsage();
+      const pricing = makePricing();
+      expect(calculateCost(LlmProviders.Anthropic, usage, pricing)).toBe(0);
+    });
+  });
+
+  // =========================================================================
+  // Google
+  // =========================================================================
+  describe('google', () => {
+    it('calculates basic input/output cost', () => {
+      const usage = makeUsage({ inputTokens: 1000, outputTokens: 500 });
+      const pricing = makePricing({
+        inputPricePerMillion: 1.25,
+        outputPricePerMillion: 10.0,
+      });
+      // inputCost = 1000 * 1.25 = 1250
+      // outputCost = 500 * 10 = 5000
+      // total = 6250 / 1_000_000 = 0.00625
+      expect(calculateCost(LlmProviders.Google, usage, pricing)).toBe(0.00625);
+    });
+
+    it('includes thinking tokens at output price', () => {
+      const usage = makeUsage({ inputTokens: 0, outputTokens: 100, thinkingTokens: 500 });
+      const pricing = makePricing({
+        inputPricePerMillion: 0,
+        outputPricePerMillion: 10.0,
+      });
+      // outputCost = 100 * 10 = 1000
+      // thinkingCost = 500 * 10 = 5000
+      // total = 6000 / 1_000_000 = 0.006
+      expect(calculateCost(LlmProviders.Google, usage, pricing)).toBe(0.006);
+    });
+
+    it('includes grounding cost when enabled', () => {
+      const usage = makeUsage({ inputTokens: 0, outputTokens: 0, groundingEnabled: true });
+      const pricing = makePricing({
+        inputPricePerMillion: 0,
+        outputPricePerMillion: 0,
+        groundingCostPerRequest: 0.035,
+      });
+      // groundingCostScaled = 0.035 * 1_000_000 = 35000
+      // total = 35000 / 1_000_000 = 0.035
+      expect(calculateCost(LlmProviders.Google, usage, pricing)).toBe(0.035);
+    });
+
+    it('does not include grounding cost when disabled', () => {
+      const usage = makeUsage({ inputTokens: 100, outputTokens: 100, groundingEnabled: false });
+      const pricing = makePricing({
+        inputPricePerMillion: 1.0,
+        outputPricePerMillion: 1.0,
+        groundingCostPerRequest: 0.035,
+      });
+      // inputCost = 100, outputCost = 100
+      // total = 200 / 1_000_000 = 0.0002
+      expect(calculateCost(LlmProviders.Google, usage, pricing)).toBe(0.0002);
+    });
+
+    it('returns 0 for zero usage', () => {
+      const usage = makeUsage();
+      const pricing = makePricing({ inputPricePerMillion: 0, outputPricePerMillion: 0 });
+      expect(calculateCost(LlmProviders.Google, usage, pricing)).toBe(0);
+    });
+  });
+
+  // =========================================================================
+  // OpenAI
+  // =========================================================================
+  describe('openai', () => {
+    it('calculates basic input/output cost', () => {
+      const usage = makeUsage({ inputTokens: 1000, outputTokens: 500 });
+      const pricing = makePricing({
+        inputPricePerMillion: 2.5,
+        outputPricePerMillion: 10.0,
+      });
+      // regularInputCost = 1000 * 2.5 = 2500
+      // outputCost = 500 * 10 = 5000
+      // total = 7500 / 1_000_000 = 0.0075
+      expect(calculateCost(LlmProviders.OpenAI, usage, pricing)).toBe(0.0075);
+    });
+
+    it('applies cached token discount (default 0.5)', () => {
+      const usage = makeUsage({ inputTokens: 1000, cachedTokens: 400, outputTokens: 0 });
+      const pricing = makePricing({
+        inputPricePerMillion: 10.0,
+        outputPricePerMillion: 0,
+      });
+      // regularInput = max(0, 1000 - 400) = 600
+      // regularCost = 600 * 10 = 6000
+      // cachedCost = 400 * 10 * 0.5 = 2000
+      // total = 8000 / 1_000_000 = 0.008
+      expect(calculateCost(LlmProviders.OpenAI, usage, pricing)).toBe(0.008);
+    });
+
+    it('applies custom cache multiplier from pricing', () => {
+      const usage = makeUsage({ inputTokens: 1000, cachedTokens: 500, outputTokens: 0 });
+      const pricing = makePricing({
+        inputPricePerMillion: 10.0,
+        outputPricePerMillion: 0,
+        cacheReadMultiplier: 0.25,
+      });
+      // regularInput = max(0, 1000 - 500) = 500
+      // regularCost = 500 * 10 = 5000
+      // cachedCost = 500 * 10 * 0.25 = 1250
+      // total = 6250 / 1_000_000 = 0.00625
+      expect(calculateCost(LlmProviders.OpenAI, usage, pricing)).toBe(0.00625);
+    });
+
+    it('clamps regularInput to 0 if cachedTokens > inputTokens', () => {
+      const usage = makeUsage({ inputTokens: 100, cachedTokens: 200, outputTokens: 0 });
+      const pricing = makePricing({
+        inputPricePerMillion: 10.0,
+        outputPricePerMillion: 0,
+      });
+      // regularInput = max(0, 100 - 200) = 0
+      // cachedCost = 200 * 10 * 0.5 = 1000
+      // total = 1000 / 1_000_000 = 0.001
+      expect(calculateCost(LlmProviders.OpenAI, usage, pricing)).toBe(0.001);
+    });
+
+    it('includes web search cost', () => {
+      const usage = makeUsage({ inputTokens: 0, outputTokens: 0, webSearchCalls: 3 });
+      const pricing = makePricing({
+        inputPricePerMillion: 0,
+        outputPricePerMillion: 0,
+        webSearchCostPerCall: 0.0025,
+      });
+      // searchCostScaled = 3 * 0.0025 * 1_000_000 = 7500
+      // total = 7500 / 1_000_000 = 0.0075
+      expect(calculateCost(LlmProviders.OpenAI, usage, pricing)).toBe(0.0075);
+    });
+
+    it('returns 0 for zero usage', () => {
+      const usage = makeUsage();
+      const pricing = makePricing({ inputPricePerMillion: 0, outputPricePerMillion: 0 });
+      expect(calculateCost(LlmProviders.OpenAI, usage, pricing)).toBe(0);
+    });
+  });
+
+  // =========================================================================
+  // Perplexity
+  // =========================================================================
+  describe('perplexity', () => {
+    it('calculates token-based cost with request fee', () => {
+      const usage = makeUsage({ inputTokens: 1000, outputTokens: 500, webSearchCalls: 1 });
+      const pricing = makePricing({
+        inputPricePerMillion: 1.0,
+        outputPricePerMillion: 1.0,
+        webSearchCostPerCall: 0.005,
+      });
+      // inputCost = 1000 * 1 = 1000
+      // outputCost = 500 * 1 = 500
+      // requestCostScaled = 1 * 0.005 * 1_000_000 = 5000
+      // total = 6500 / 1_000_000 = 0.0065
+      expect(calculateCost(LlmProviders.Perplexity, usage, pricing)).toBe(0.0065);
+    });
+
+    it('defaults webSearchCalls to 1 for request fee', () => {
+      const usage = makeUsage({ inputTokens: 0, outputTokens: 0, webSearchCalls: 0 });
+      const pricing = makePricing({
+        inputPricePerMillion: 0,
+        outputPricePerMillion: 0,
+        webSearchCostPerCall: 0.005,
+      });
+      // requests = max(webSearchCalls, 1) = 1 (Perplexity always charges at least 1 request)
+      // requestCostScaled = 1 * 0.005 * 1_000_000 = 5000
+      // total = 5000 / 1_000_000 = 0.005
+      expect(calculateCost(LlmProviders.Perplexity, usage, pricing)).toBe(0.005);
+    });
+
+    it('uses multiple webSearchCalls when > 0', () => {
+      const usage = makeUsage({ inputTokens: 0, outputTokens: 0, webSearchCalls: 3 });
+      const pricing = makePricing({
+        inputPricePerMillion: 0,
+        outputPricePerMillion: 0,
+        webSearchCostPerCall: 0.005,
+      });
+      // requests = 3 (> 0 so use actual value)
+      // requestCostScaled = 3 * 0.005 * 1_000_000 = 15000
+      // total = 15000 / 1_000_000 = 0.015
+      expect(calculateCost(LlmProviders.Perplexity, usage, pricing)).toBe(0.015);
+    });
+
+    it('returns 0 when no request fee and no tokens', () => {
+      const usage = makeUsage();
+      const pricing = makePricing({ inputPricePerMillion: 0, outputPricePerMillion: 0 });
+      // requests defaults to 1, but requestFee is 0
+      expect(calculateCost(LlmProviders.Perplexity, usage, pricing)).toBe(0);
+    });
+  });
+
+  // =========================================================================
+  // OpenRouter
+  // =========================================================================
+  describe('openrouter', () => {
+    it('calculates token-based cost with per-million prices', () => {
+      const usage = makeUsage({ inputTokens: 1000, outputTokens: 500 });
+      const pricing = makePricing({
+        inputPricePerMillion: 0.26,
+        outputPricePerMillion: 1.56,
+      });
+      // inputCost = 1000 * (0.26 / 1_000_000) = 0.00026
+      // outputCost = 500 * (1.56 / 1_000_000) = 0.00078
+      // total = round((0.00026 + 0.00078) * 1_000_000) / 1_000_000
+      //       = round(1040) / 1_000_000 = 0.00104
+      expect(calculateCost(LlmProviders.OpenRouter, usage, pricing)).toBe(0.00104);
+    });
+
+    it('returns 0 for zero usage', () => {
+      const usage = makeUsage();
+      const pricing = makePricing({ inputPricePerMillion: 0, outputPricePerMillion: 0 });
+      expect(calculateCost(LlmProviders.OpenRouter, usage, pricing)).toBe(0);
+    });
+  });
+
+  // =========================================================================
+  // Unknown provider
+  // =========================================================================
+  describe('unknown provider', () => {
+    it('throws for unsupported provider', () => {
+      const usage = makeUsage();
+      const pricing = makePricing();
+      expect(() =>
+        calculateCost('unknown' as never, usage, pricing)
+      ).toThrow('Unsupported provider: unknown');
+    });
+  });
+});

--- a/apps/llm-usage-service/src/__tests__/domain/services/pricingCache.test.ts
+++ b/apps/llm-usage-service/src/__tests__/domain/services/pricingCache.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { LlmProviders } from '@intexuraos/llm-contract';
+import type { ProviderPricing } from '@intexuraos/llm-contract';
+import { createPricingCache } from '../../../domain/services/pricingCache.js';
+import { FakePricingRepository } from '../../fakePricingRepository.js';
+
+const mockAnthropicPricing: ProviderPricing = {
+  provider: LlmProviders.Anthropic,
+  models: {
+    'claude-sonnet-4-20250514': {
+      inputPricePerMillion: 3.0,
+      outputPricePerMillion: 15.0,
+    },
+  },
+  updatedAt: '2026-04-10T12:00:00Z',
+};
+
+const mockGooglePricing: ProviderPricing = {
+  provider: LlmProviders.Google,
+  models: {
+    'gemini-2.5-pro': {
+      inputPricePerMillion: 1.25,
+      outputPricePerMillion: 10.0,
+    },
+  },
+  updatedAt: '2026-04-10T12:00:00Z',
+};
+
+const mockOpenaiPricing: ProviderPricing = {
+  provider: LlmProviders.OpenAI,
+  models: {},
+  updatedAt: '2026-04-10T12:00:00Z',
+};
+
+const mockPerplexityPricing: ProviderPricing = {
+  provider: LlmProviders.Perplexity,
+  models: {},
+  updatedAt: '2026-04-10T12:00:00Z',
+};
+
+const mockOpenRouterPricing: ProviderPricing = {
+  provider: LlmProviders.OpenRouter,
+  models: {},
+  updatedAt: '2026-04-10T12:00:00Z',
+};
+
+function populateRepo(repo: FakePricingRepository): void {
+  repo.byProvider.set(LlmProviders.Anthropic, mockAnthropicPricing);
+  repo.byProvider.set(LlmProviders.Google, mockGooglePricing);
+  repo.byProvider.set(LlmProviders.OpenAI, mockOpenaiPricing);
+  repo.byProvider.set(LlmProviders.Perplexity, mockPerplexityPricing);
+  repo.byProvider.set(LlmProviders.OpenRouter, mockOpenRouterPricing);
+}
+
+describe('pricingCache', () => {
+  let repo: FakePricingRepository;
+  const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), child: vi.fn() } as never;
+
+  beforeEach(() => {
+    repo = new FakePricingRepository();
+    populateRepo(repo);
+  });
+
+  it('returns model pricing on first access (loads from repo)', async () => {
+    const cache = createPricingCache(repo);
+
+    const pricing = await cache.getModelPricing(LlmProviders.Anthropic, 'claude-sonnet-4-20250514', logger);
+
+    expect(pricing).not.toBeNull();
+    expect(pricing?.inputPricePerMillion).toBe(3.0);
+    expect(pricing?.outputPricePerMillion).toBe(15.0);
+  });
+
+  it('returns null for unknown model', async () => {
+    const cache = createPricingCache(repo);
+
+    const pricing = await cache.getModelPricing(LlmProviders.Anthropic, 'unknown-model', logger);
+
+    expect(pricing).toBeNull();
+  });
+
+  it('caches data and does not call repo on subsequent access within TTL', async () => {
+    const getAllSpy = vi.spyOn(repo, 'getAll');
+    const cache = createPricingCache(repo, 60_000);
+
+    await cache.getModelPricing(LlmProviders.Anthropic, 'claude-sonnet-4-20250514', logger);
+    await cache.getModelPricing(LlmProviders.Google, 'gemini-2.5-pro', logger);
+
+    expect(getAllSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('reloads from repo after TTL expires', async () => {
+    const getAllSpy = vi.spyOn(repo, 'getAll');
+    // Use a very short TTL
+    const cache = createPricingCache(repo, 1);
+
+    await cache.getModelPricing(LlmProviders.Anthropic, 'claude-sonnet-4-20250514', logger);
+    expect(getAllSpy).toHaveBeenCalledTimes(1);
+
+    // Wait for TTL to expire
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    await cache.getModelPricing(LlmProviders.Anthropic, 'claude-sonnet-4-20250514', logger);
+    expect(getAllSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('invalidate() forces reload on next access', async () => {
+    const getAllSpy = vi.spyOn(repo, 'getAll');
+    const cache = createPricingCache(repo, 60_000);
+
+    await cache.getModelPricing(LlmProviders.Anthropic, 'claude-sonnet-4-20250514', logger);
+    expect(getAllSpy).toHaveBeenCalledTimes(1);
+
+    cache.invalidate();
+
+    await cache.getModelPricing(LlmProviders.Anthropic, 'claude-sonnet-4-20250514', logger);
+    expect(getAllSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('concurrent calls trigger only one repo fetch', async () => {
+    const getAllSpy = vi.spyOn(repo, 'getAll');
+    const cache = createPricingCache(repo, 60_000);
+
+    // Fire multiple concurrent requests
+    const [r1, r2, r3] = await Promise.all([
+      cache.getModelPricing(LlmProviders.Anthropic, 'claude-sonnet-4-20250514', logger),
+      cache.getModelPricing(LlmProviders.Google, 'gemini-2.5-pro', logger),
+      cache.getModelPricing(LlmProviders.Anthropic, 'claude-sonnet-4-20250514', logger),
+    ]);
+
+    expect(getAllSpy).toHaveBeenCalledTimes(1);
+    expect(r1?.inputPricePerMillion).toBe(3.0);
+    expect(r2?.inputPricePerMillion).toBe(1.25);
+    expect(r3?.inputPricePerMillion).toBe(3.0);
+  });
+
+  it('propagates repo errors and allows retry', async () => {
+    const failingRepo = new FakePricingRepository();
+    // Don't populate — getAll() will throw because providers are missing
+    const cache = createPricingCache(failingRepo, 60_000);
+
+    await expect(
+      cache.getModelPricing(LlmProviders.Anthropic, 'claude-sonnet-4-20250514', logger),
+    ).rejects.toThrow();
+
+    // After failure, next call should retry (loadingPromise cleared)
+    populateRepo(failingRepo);
+    const pricing = await cache.getModelPricing(LlmProviders.Anthropic, 'claude-sonnet-4-20250514', logger);
+    expect(pricing?.inputPricePerMillion).toBe(3.0);
+  });
+});

--- a/apps/llm-usage-service/src/__tests__/domain/services/pricingCache.test.ts
+++ b/apps/llm-usage-service/src/__tests__/domain/services/pricingCache.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { LlmProviders } from '@intexuraos/llm-contract';
+import { LlmProviders, LlmModels } from '@intexuraos/llm-contract';
 import type { ProviderPricing } from '@intexuraos/llm-contract';
 import { createPricingCache } from '../../../domain/services/pricingCache.js';
 import { FakePricingRepository } from '../../fakePricingRepository.js';
@@ -18,7 +18,7 @@ const mockAnthropicPricing: ProviderPricing = {
 const mockGooglePricing: ProviderPricing = {
   provider: LlmProviders.Google,
   models: {
-    'gemini-2.5-pro': {
+    [LlmModels.Gemini25Pro]: {
       inputPricePerMillion: 1.25,
       outputPricePerMillion: 10.0,
     },
@@ -84,7 +84,7 @@ describe('pricingCache', () => {
     const cache = createPricingCache(repo, 60_000);
 
     await cache.getModelPricing(LlmProviders.Anthropic, 'claude-sonnet-4-20250514', logger);
-    await cache.getModelPricing(LlmProviders.Google, 'gemini-2.5-pro', logger);
+    await cache.getModelPricing(LlmProviders.Google, LlmModels.Gemini25Pro, logger);
 
     expect(getAllSpy).toHaveBeenCalledTimes(1);
   });
@@ -124,7 +124,7 @@ describe('pricingCache', () => {
     // Fire multiple concurrent requests
     const [r1, r2, r3] = await Promise.all([
       cache.getModelPricing(LlmProviders.Anthropic, 'claude-sonnet-4-20250514', logger),
-      cache.getModelPricing(LlmProviders.Google, 'gemini-2.5-pro', logger),
+      cache.getModelPricing(LlmProviders.Google, LlmModels.Gemini25Pro, logger),
       cache.getModelPricing(LlmProviders.Anthropic, 'claude-sonnet-4-20250514', logger),
     ]);
 

--- a/apps/llm-usage-service/src/__tests__/domain/usecases/ingestUsageEvents.test.ts
+++ b/apps/llm-usage-service/src/__tests__/domain/usecases/ingestUsageEvents.test.ts
@@ -1,131 +1,254 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { LlmProviders } from '@intexuraos/llm-contract';
+import type { ModelPricing } from '@intexuraos/llm-contract';
 import { ingestUsageEvents } from '../../../domain/usecases/ingestUsageEvents.js';
 import { FakeUsageEventRepository } from '../../fakeUsageEventRepository.js';
 import { FakeUsageAggregateRepository } from '../../fakeUsageAggregateRepository.js';
-import { createTestEventInput } from '../../helpers.js';
-import type { UsageEventInput } from '../../../domain/models/usageEvent.js';
+import { FakePricingCache } from '../../fakePricingCache.js';
+import { createTestEventInput, createTestEventInputV2 } from '../../helpers.js';
+import type { UsageEventInputAny } from '../../../domain/models/usageEvent.js';
 
 /**
  * Use-case-layer tests for `ingestUsageEvents`.
  *
- * As of the strict-schema refactor, structural validation (schemaVersion, field
- * presence/types/enums, additionalProperties, orchestrator constraint) is performed
- * by the Fastify route schemas `UsageEventInput` / `OrchestratorUsageEventInput`
- * BEFORE this use case runs. Malformed events never reach the use case, so the
- * ~46 field-level rejection tests that previously lived in this file have been
- * deleted — they exercised branches of `validateEvent()` that no longer exist.
- *
- * The tests below cover the remaining use-case responsibilities:
- *   1. Happy path: valid events are stored and aggregates incremented.
- *   2. Deduplication: same eventId is counted as `duplicate`, not `accepted`.
- *   3. Repository failures: Firestore `createEvent` errors are surfaced as rejected entries.
- *   4. Aggregate failures: aggregate increment errors do not block event storage.
- *   5. Sparse arrays: `undefined` holes in the events array are skipped.
- *   6. Mixed batch: valid + duplicate events are handled correctly in a single call.
- *
- * Field-level rejection behavior is now tested at the route layer in
- * `src/__tests__/routes/internalUsageRoutes.test.ts` and
- * `src/__tests__/routes/webhookUsageRoutes.test.ts`.
+ * Tests cover:
+ *   1. V1 backward compatibility (happy path, dedup, repo failure, aggregate failure, sparse arrays, mixed batch)
+ *   2. V2 pending pricing source with pricing found (calculated cost)
+ *   3. V2 pending pricing source with unknown model (default to 0)
+ *   4. V2 provider_reported pricing source
+ *   5. V2 provider_reported with negative providerReportedUsd (clamping)
  */
 describe('ingestUsageEvents', () => {
   let eventRepo: FakeUsageEventRepository;
   let aggregateRepo: FakeUsageAggregateRepository;
+  let pricingCache: FakePricingCache;
   const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), child: vi.fn() } as never;
+
+  const anthropicPricing: ModelPricing = {
+    inputPricePerMillion: 3.0,
+    outputPricePerMillion: 15.0,
+  };
 
   beforeEach(() => {
     eventRepo = new FakeUsageEventRepository();
     aggregateRepo = new FakeUsageAggregateRepository();
+    pricingCache = new FakePricingCache();
   });
 
-  it('accepts valid events', async () => {
-    const events = [createTestEventInput({ eventId: 'evt_1' })];
-    const result = await ingestUsageEvents(
-      { logger, usageEventRepository: eventRepo, usageAggregateRepository: aggregateRepo },
-      events,
-      'internal',
-    );
+  function makeDeps(): { logger: typeof logger; usageEventRepository: FakeUsageEventRepository; usageAggregateRepository: FakeUsageAggregateRepository; pricingCache: FakePricingCache } {
+    return { logger, usageEventRepository: eventRepo, usageAggregateRepository: aggregateRepo, pricingCache };
+  }
 
-    expect(result.accepted).toBe(1);
-    expect(result.duplicates).toBe(0);
-    expect(result.rejected).toHaveLength(0);
+  // ---------------------------------------------------------------------------
+  // V1 backward compatibility
+  // ---------------------------------------------------------------------------
+  describe('v1 backward compatibility', () => {
+    it('accepts valid events', async () => {
+      const events = [createTestEventInput({ eventId: 'evt_1' })];
+      const result = await ingestUsageEvents(makeDeps(), events, 'internal');
+
+      expect(result.accepted).toBe(1);
+      expect(result.duplicates).toBe(0);
+      expect(result.rejected).toHaveLength(0);
+    });
+
+    it('detects duplicate events and does not double-increment aggregate', async () => {
+      const events = [
+        createTestEventInput({ eventId: 'evt_dup' }),
+        createTestEventInput({ eventId: 'evt_dup' }),
+      ];
+      const result = await ingestUsageEvents(makeDeps(), events, 'internal');
+
+      expect(result.accepted).toBe(1);
+      expect(result.duplicates).toBe(1);
+      expect(aggregateRepo.getIncrementCallCount()).toBe(1);
+    });
+
+    it('handles repository create failure', async () => {
+      eventRepo.setFailure({ code: 'FIRESTORE_ERROR', message: 'connection failed' });
+      const events = [createTestEventInput({ eventId: 'evt_fail' })];
+      const result = await ingestUsageEvents(makeDeps(), events, 'internal');
+
+      expect(result.rejected).toHaveLength(1);
+      expect(result.rejected[0]?.code).toBe('FIRESTORE_ERROR');
+    });
+
+    it('handles aggregate increment failure gracefully (event still stored)', async () => {
+      aggregateRepo.setFailure({ code: 'AGG_ERROR', message: 'aggregate failed' });
+      const events = [createTestEventInput({ eventId: 'evt_agg_fail' })];
+      const result = await ingestUsageEvents(makeDeps(), events, 'internal');
+
+      expect(result.accepted).toBe(1);
+    });
+
+    it('skips undefined events in the array', async () => {
+      const events = [undefined as unknown as UsageEventInputAny, createTestEventInput({ eventId: 'evt_ok' })];
+      const result = await ingestUsageEvents(makeDeps(), events, 'internal');
+
+      expect(result.accepted).toBe(1);
+    });
+
+    it('handles mixed batch (valid + duplicate)', async () => {
+      await ingestUsageEvents(makeDeps(), [createTestEventInput({ eventId: 'evt_dup' })], 'internal');
+      const preIncrementCount = aggregateRepo.getIncrementCallCount();
+
+      const result = await ingestUsageEvents(
+        makeDeps(),
+        [
+          createTestEventInput({ eventId: 'evt_new' }),
+          createTestEventInput({ eventId: 'evt_dup' }),
+        ],
+        'internal',
+      );
+
+      expect(result.accepted).toBe(1);
+      expect(result.duplicates).toBe(1);
+      expect(result.rejected).toHaveLength(0);
+      expect(aggregateRepo.getIncrementCallCount()).toBe(preIncrementCount + 1);
+    });
+
+    it('stores v1 events with schemaVersion 1 as-is', async () => {
+      const events = [createTestEventInput({ eventId: 'evt_v1_check' })];
+      await ingestUsageEvents(makeDeps(), events, 'internal');
+
+      const stored = eventRepo.getStoredEvents();
+      expect(stored).toHaveLength(1);
+      expect(stored[0]?.schemaVersion).toBe(1);
+      expect(stored[0]?.cost.billedUsd).toBe(0.003);
+      expect(stored[0]?.cost.pricingSource).toBe('calculated');
+    });
   });
 
-  it('detects duplicate events and does not double-increment aggregate', async () => {
-    const events = [
-      createTestEventInput({ eventId: 'evt_dup' }),
-      createTestEventInput({ eventId: 'evt_dup' }),
-    ];
-    const result = await ingestUsageEvents(
-      { logger, usageEventRepository: eventRepo, usageAggregateRepository: aggregateRepo },
-      events,
-      'internal',
-    );
+  // ---------------------------------------------------------------------------
+  // V2 events
+  // ---------------------------------------------------------------------------
+  describe('v2 events', () => {
+    it('enriches pending events with calculated cost when pricing is found', async () => {
+      pricingCache.setPricing(LlmProviders.Anthropic, 'claude-sonnet-4-20250514', anthropicPricing);
 
-    expect(result.accepted).toBe(1);
-    expect(result.duplicates).toBe(1);
-    expect(aggregateRepo.getIncrementCallCount()).toBe(1);
-  });
+      const events = [createTestEventInputV2({
+        eventId: 'evt_v2_pending',
+        cost: { providerReportedUsd: null, pricingSource: 'pending' },
+      })];
 
-  it('handles repository create failure', async () => {
-    eventRepo.setFailure({ code: 'FIRESTORE_ERROR', message: 'connection failed' });
-    const events = [createTestEventInput({ eventId: 'evt_fail' })];
-    const result = await ingestUsageEvents(
-      { logger, usageEventRepository: eventRepo, usageAggregateRepository: aggregateRepo },
-      events,
-      'internal',
-    );
+      const result = await ingestUsageEvents(makeDeps(), events, 'internal');
 
-    expect(result.rejected).toHaveLength(1);
-    expect(result.rejected[0]?.code).toBe('FIRESTORE_ERROR');
-  });
+      expect(result.accepted).toBe(1);
 
-  it('handles aggregate increment failure gracefully (event still stored)', async () => {
-    aggregateRepo.setFailure({ code: 'AGG_ERROR', message: 'aggregate failed' });
-    const events = [createTestEventInput({ eventId: 'evt_agg_fail' })];
-    const result = await ingestUsageEvents(
-      { logger, usageEventRepository: eventRepo, usageAggregateRepository: aggregateRepo },
-      events,
-      'internal',
-    );
+      const stored = eventRepo.getStoredEvents();
+      expect(stored).toHaveLength(1);
+      const event = stored[0];
+      expect(event).toBeDefined();
+      expect(event?.schemaVersion).toBe(1);
+      expect(event?.cost.pricingSource).toBe('calculated');
+      expect(event?.cost.providerReportedUsd).toBeNull();
+      expect(event?.cost.calculatedUsd).toBeGreaterThan(0);
+      expect(event?.cost.billedUsd).toBe(event?.cost.calculatedUsd);
+    });
 
-    // Event was still accepted even though aggregation failed
-    expect(result.accepted).toBe(1);
-  });
+    it('defaults cost to 0 when pricing is not found for model', async () => {
+      // No pricing seeded for model — cache returns null
 
-  it('skips undefined events in the array', async () => {
-    const events = [undefined as unknown as UsageEventInput, createTestEventInput({ eventId: 'evt_ok' })];
-    const result = await ingestUsageEvents(
-      { logger, usageEventRepository: eventRepo, usageAggregateRepository: aggregateRepo },
-      events,
-      'internal',
-    );
+      const events = [createTestEventInputV2({
+        eventId: 'evt_v2_unknown',
+        cost: { providerReportedUsd: null, pricingSource: 'pending' },
+      })];
 
-    expect(result.accepted).toBe(1);
-  });
+      const result = await ingestUsageEvents(makeDeps(), events, 'internal');
 
-  it('handles mixed batch (valid + duplicate)', async () => {
-    // Pre-seed the duplicate
-    await ingestUsageEvents(
-      { logger, usageEventRepository: eventRepo, usageAggregateRepository: aggregateRepo },
-      [createTestEventInput({ eventId: 'evt_dup' })],
-      'internal',
-    );
+      expect(result.accepted).toBe(1);
 
-    const preIncrementCount = aggregateRepo.getIncrementCallCount();
+      const stored = eventRepo.getStoredEvents();
+      expect(stored).toHaveLength(1);
+      const event = stored[0];
+      expect(event?.cost.billedUsd).toBe(0);
+      expect(event?.cost.calculatedUsd).toBe(0);
+      expect(event?.cost.pricingSource).toBe('calculated');
+      expect(event?.cost.providerReportedUsd).toBeNull();
+    });
 
-    const result = await ingestUsageEvents(
-      { logger, usageEventRepository: eventRepo, usageAggregateRepository: aggregateRepo },
-      [
-        createTestEventInput({ eventId: 'evt_new' }), // valid
-        createTestEventInput({ eventId: 'evt_dup' }), // duplicate (pre-seeded above)
-      ],
-      'internal',
-    );
+    it('uses provider_reported cost when pricingSource is provider_reported and providerReportedUsd is non-null', async () => {
+      const events = [createTestEventInputV2({
+        eventId: 'evt_v2_reported',
+        cost: { providerReportedUsd: 0.0042, pricingSource: 'provider_reported' },
+      })];
 
-    expect(result.accepted).toBe(1);
-    expect(result.duplicates).toBe(1);
-    expect(result.rejected).toHaveLength(0);
-    // Only the new valid event should have incremented the aggregate
-    expect(aggregateRepo.getIncrementCallCount()).toBe(preIncrementCount + 1);
+      const result = await ingestUsageEvents(makeDeps(), events, 'internal');
+
+      expect(result.accepted).toBe(1);
+
+      const stored = eventRepo.getStoredEvents();
+      expect(stored).toHaveLength(1);
+      const event = stored[0];
+      expect(event?.cost.billedUsd).toBe(0.0042);
+      expect(event?.cost.providerReportedUsd).toBe(0.0042);
+      expect(event?.cost.calculatedUsd).toBeNull();
+      expect(event?.cost.pricingSource).toBe('provider_reported');
+    });
+
+    it('clamps negative providerReportedUsd to 0 for billedUsd', async () => {
+      const events = [createTestEventInputV2({
+        eventId: 'evt_v2_negative',
+        cost: { providerReportedUsd: -0.005, pricingSource: 'provider_reported' },
+      })];
+
+      const result = await ingestUsageEvents(makeDeps(), events, 'internal');
+
+      expect(result.accepted).toBe(1);
+
+      const stored = eventRepo.getStoredEvents();
+      const event = stored[0];
+      expect(event?.cost.billedUsd).toBe(0);
+      expect(event?.cost.providerReportedUsd).toBe(-0.005);
+      expect(event?.cost.pricingSource).toBe('provider_reported');
+    });
+
+    it('falls back to calculated pricing when provider_reported has null USD', async () => {
+      pricingCache.setPricing(LlmProviders.Anthropic, 'claude-sonnet-4-20250514', anthropicPricing);
+
+      const events = [createTestEventInputV2({
+        eventId: 'evt_v2_reported_null',
+        cost: { providerReportedUsd: null, pricingSource: 'provider_reported' },
+      })];
+
+      const result = await ingestUsageEvents(makeDeps(), events, 'internal');
+
+      expect(result.accepted).toBe(1);
+
+      const stored = eventRepo.getStoredEvents();
+      const event = stored[0];
+      expect(event?.cost.pricingSource).toBe('calculated');
+      expect(event?.cost.calculatedUsd).toBeGreaterThan(0);
+      expect(event?.cost.billedUsd).toBe(event?.cost.calculatedUsd);
+      expect(event?.cost.providerReportedUsd).toBeNull();
+    });
+
+    it('stores v2 events as schemaVersion 1', async () => {
+      pricingCache.setPricing(LlmProviders.Anthropic, 'claude-sonnet-4-20250514', anthropicPricing);
+
+      const events = [createTestEventInputV2({ eventId: 'evt_v2_stored_v1' })];
+      await ingestUsageEvents(makeDeps(), events, 'internal');
+
+      const stored = eventRepo.getStoredEvents();
+      expect(stored[0]?.schemaVersion).toBe(1);
+    });
+
+    it('handles mixed v1 and v2 events in the same batch', async () => {
+      pricingCache.setPricing(LlmProviders.Anthropic, 'claude-sonnet-4-20250514', anthropicPricing);
+
+      const events: UsageEventInputAny[] = [
+        createTestEventInput({ eventId: 'evt_mix_v1' }),
+        createTestEventInputV2({ eventId: 'evt_mix_v2' }),
+      ];
+
+      const result = await ingestUsageEvents(makeDeps(), events, 'internal');
+
+      expect(result.accepted).toBe(2);
+      const stored = eventRepo.getStoredEvents();
+      expect(stored).toHaveLength(2);
+      // Both stored as schemaVersion 1
+      expect(stored[0]?.schemaVersion).toBe(1);
+      expect(stored[1]?.schemaVersion).toBe(1);
+    });
   });
 });

--- a/apps/llm-usage-service/src/__tests__/fakePricingCache.ts
+++ b/apps/llm-usage-service/src/__tests__/fakePricingCache.ts
@@ -1,0 +1,29 @@
+import type { LlmProvider, ModelPricing } from '@intexuraos/llm-contract';
+import type { Logger } from '@intexuraos/common-core';
+import type { PricingCache } from '../domain/services/pricingCache.js';
+
+/**
+ * In-memory fake for PricingCache, used in tests.
+ *
+ * Callers seed pricing via `setPricing(provider, model, pricing)` and the cache
+ * returns it immediately without any TTL behavior.
+ */
+export class FakePricingCache implements PricingCache {
+  private readonly data = new Map<string, ModelPricing>();
+
+  private makeKey(provider: LlmProvider, model: string): string {
+    return `${provider}::${model}`;
+  }
+
+  setPricing(provider: LlmProvider, model: string, pricing: ModelPricing): void {
+    this.data.set(this.makeKey(provider, model), pricing);
+  }
+
+  async getModelPricing(provider: LlmProvider, model: string, _logger: Logger): Promise<ModelPricing | null> {
+    return this.data.get(this.makeKey(provider, model)) ?? null;
+  }
+
+  invalidate(): void {
+    this.data.clear();
+  }
+}

--- a/apps/llm-usage-service/src/__tests__/helpers.ts
+++ b/apps/llm-usage-service/src/__tests__/helpers.ts
@@ -99,7 +99,7 @@ export function createTestEventInputV2(
       imageCount: 0,
     },
     cost: {
-      providerReportedUsd: 0.003,
+      providerReportedUsd: null,
       pricingSource: 'pending',
     },
     correlation: {

--- a/apps/llm-usage-service/src/__tests__/helpers.ts
+++ b/apps/llm-usage-service/src/__tests__/helpers.ts
@@ -1,5 +1,9 @@
 import { LlmProviders } from '@intexuraos/llm-contract';
-import type { UsageEvent, UsageEventInput } from '../domain/models/usageEvent.js';
+import type {
+  UsageEvent,
+  UsageEventInput,
+  UsageEventInputV2,
+} from '../domain/models/usageEvent.js';
 
 /**
  * Creates a valid UsageEventInput for testing.
@@ -42,6 +46,61 @@ export function createTestEventInput(overrides?: Partial<UsageEventInput>): Usag
       providerReportedUsd: null,
       calculatedUsd: null,
       pricingSource: 'calculated',
+    },
+    correlation: {
+      requestId: 'req_123',
+      traceId: null,
+      taskId: null,
+      researchId: null,
+      attempt: null,
+      sessionId: null,
+    },
+    error: null,
+    ...overrides,
+  };
+}
+
+/**
+ * Creates a valid UsageEventInputV2 for testing.
+ */
+export function createTestEventInputV2(
+  overrides?: Partial<UsageEventInputV2>,
+): UsageEventInputV2 {
+  return {
+    schemaVersion: 2,
+    eventId: `evt_${String(Date.now())}`,
+    occurredAt: '2026-04-10T12:00:00.000Z',
+    owner: { type: 'user', id: 'user_123' },
+    source: {
+      service: 'orchestrator',
+      component: 'research',
+      client: 'web',
+      environment: 'dev',
+      workerLocation: 'home-dev',
+    },
+    request: {
+      provider: LlmProviders.Anthropic,
+      model: 'claude-sonnet-4-20250514',
+      operation: 'generate',
+      success: true,
+      durationMs: 1500,
+    },
+    usage: {
+      inputTokens: 100,
+      outputTokens: 200,
+      totalTokens: 300,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      cachedTokens: 0,
+      reasoningTokens: 0,
+      thinkingTokens: 0,
+      webSearchCalls: 0,
+      groundingEnabled: false,
+      imageCount: 0,
+    },
+    cost: {
+      providerReportedUsd: 0.003,
+      pricingSource: 'pending',
     },
     correlation: {
       requestId: 'req_123',

--- a/apps/llm-usage-service/src/__tests__/routes/internalUsageRoutes.test.ts
+++ b/apps/llm-usage-service/src/__tests__/routes/internalUsageRoutes.test.ts
@@ -206,6 +206,38 @@ describe('internalUsageRoutes', () => {
       expect(eventRepo.getStoredEvents()).toHaveLength(0);
     });
 
+    it('rejects mismatched envelope — v1 schemaVersion with v2 events', async () => {
+      const v2Event = createTestEventInputV2({ eventId: 'evt_mismatch_1' });
+      const response = await app.inject({
+        method: 'POST',
+        url: '/internal/usage/events',
+        headers: { 'x-internal-auth': AUTH_TOKEN },
+        payload: {
+          schemaVersion: 1,
+          events: [v2Event],
+        },
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(eventRepo.getStoredEvents()).toHaveLength(0);
+    });
+
+    it('rejects mismatched envelope — v2 schemaVersion with v1 events', async () => {
+      const v1Event = createTestEventInput({ eventId: 'evt_mismatch_2' });
+      const response = await app.inject({
+        method: 'POST',
+        url: '/internal/usage/events',
+        headers: { 'x-internal-auth': AUTH_TOKEN },
+        payload: {
+          schemaVersion: 2,
+          events: [v1Event],
+        },
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(eventRepo.getStoredEvents()).toHaveLength(0);
+    });
+
     it('rejects entire batch when any single event is malformed (full-batch rejection)', async () => {
       const validEvent1 = createTestEventInput({ eventId: 'evt_batch_1' });
       const validEvent3 = createTestEventInput({ eventId: 'evt_batch_3' });

--- a/apps/llm-usage-service/src/__tests__/routes/internalUsageRoutes.test.ts
+++ b/apps/llm-usage-service/src/__tests__/routes/internalUsageRoutes.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeAll, beforeEach, afterAll, afterEach } from 'vitest';
 import type { FastifyInstance } from 'fastify';
+import { LlmProviders } from '@intexuraos/llm-contract';
 import { buildServer } from '../../server.js';
 import { setServices, resetServices, type ServiceContainer } from '../../services.js';
 import { FakeUsageEventRepository } from '../fakeUsageEventRepository.js';
@@ -86,7 +87,20 @@ describe('internalUsageRoutes', () => {
       expect(response.statusCode).toBe(400);
     });
 
-    it('returns 200 for v2 events', async () => {
+    it('accepts v2 events and stores enriched cost in Firestore', async () => {
+      const pricingCache = new FakePricingCache();
+      pricingCache.setPricing(LlmProviders.Anthropic, 'claude-sonnet-4-20250514', {
+        inputPricePerMillion: 3.0,
+        outputPricePerMillion: 15.0,
+      });
+      setServices({
+        usageEventRepository: eventRepo,
+        usageAggregateRepository: aggregateRepo,
+        pricingRepository: new FakePricingRepository(),
+        pricingCache,
+        orchestratorSecret: 'test-secret',
+      } satisfies ServiceContainer);
+
       const response = await app.inject({
         method: 'POST',
         url: '/internal/usage/events',
@@ -101,6 +115,17 @@ describe('internalUsageRoutes', () => {
       const body = JSON.parse(response.body) as { success: boolean; data: { accepted: number } };
       expect(body.success).toBe(true);
       expect(body.data.accepted).toBe(1);
+
+      // Verify Firestore round-trip: stored event has enriched cost shape
+      const stored = eventRepo.getStoredEvents();
+      expect(stored).toHaveLength(1);
+      const event = stored[0];
+      expect(event).toBeDefined();
+      expect(event?.schemaVersion).toBe(1);
+      expect(event?.cost.pricingSource).toBe('calculated');
+      expect(event?.cost.calculatedUsd).toBeGreaterThan(0);
+      expect(event?.cost.billedUsd).toBe(event?.cost.calculatedUsd);
+      expect(event?.cost.providerReportedUsd).toBeNull();
     });
 
     it('rejects events missing source.environment', async () => {

--- a/apps/llm-usage-service/src/__tests__/routes/internalUsageRoutes.test.ts
+++ b/apps/llm-usage-service/src/__tests__/routes/internalUsageRoutes.test.ts
@@ -5,7 +5,8 @@ import { setServices, resetServices, type ServiceContainer } from '../../service
 import { FakeUsageEventRepository } from '../fakeUsageEventRepository.js';
 import { FakeUsageAggregateRepository } from '../fakeUsageAggregateRepository.js';
 import { FakePricingRepository } from '../fakePricingRepository.js';
-import { createTestEventInput } from '../helpers.js';
+import { FakePricingCache } from '../fakePricingCache.js';
+import { createTestEventInput, createTestEventInputV2 } from '../helpers.js';
 
 describe('internalUsageRoutes', () => {
   let app: FastifyInstance;
@@ -26,6 +27,7 @@ describe('internalUsageRoutes', () => {
       usageEventRepository: eventRepo,
       usageAggregateRepository: aggregateRepo,
       pricingRepository: new FakePricingRepository(),
+      pricingCache: new FakePricingCache(),
       orchestratorSecret: 'test-secret',
     } satisfies ServiceContainer);
   });
@@ -76,12 +78,29 @@ describe('internalUsageRoutes', () => {
         url: '/internal/usage/events',
         headers: { 'x-internal-auth': AUTH_TOKEN },
         payload: {
-          schemaVersion: 2,
+          schemaVersion: 3,
           events: [],
         },
       });
 
       expect(response.statusCode).toBe(400);
+    });
+
+    it('returns 200 for v2 events', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/internal/usage/events',
+        headers: { 'x-internal-auth': AUTH_TOKEN },
+        payload: {
+          schemaVersion: 2,
+          events: [createTestEventInputV2({ eventId: 'evt_v2_1' })],
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body) as { success: boolean; data: { accepted: number } };
+      expect(body.success).toBe(true);
+      expect(body.data.accepted).toBe(1);
     });
 
     it('rejects events missing source.environment', async () => {

--- a/apps/llm-usage-service/src/__tests__/routes/pricingRoutes.test.ts
+++ b/apps/llm-usage-service/src/__tests__/routes/pricingRoutes.test.ts
@@ -7,6 +7,7 @@ import { setServices, resetServices, type ServiceContainer } from '../../service
 import { FakeUsageEventRepository } from '../fakeUsageEventRepository.js';
 import { FakeUsageAggregateRepository } from '../fakeUsageAggregateRepository.js';
 import { FakePricingRepository } from '../fakePricingRepository.js';
+import { FakePricingCache } from '../fakePricingCache.js';
 
 // Mock requireAuth for Auth0 bearer tests — validateInternalAuth is NOT mocked
 // so POST /internal/pricing still validates against env var.
@@ -133,6 +134,7 @@ describe('pricingRoutes', () => {
       usageEventRepository: new FakeUsageEventRepository(),
       usageAggregateRepository: new FakeUsageAggregateRepository(),
       pricingRepository: pricingRepo,
+      pricingCache: new FakePricingCache(),
       orchestratorSecret: 'test-secret',
     } satisfies ServiceContainer);
   });

--- a/apps/llm-usage-service/src/__tests__/routes/publicUsageRoutes.test.ts
+++ b/apps/llm-usage-service/src/__tests__/routes/publicUsageRoutes.test.ts
@@ -5,6 +5,7 @@ import { setServices, resetServices, type ServiceContainer } from '../../service
 import { FakeUsageEventRepository } from '../fakeUsageEventRepository.js';
 import { FakeUsageAggregateRepository } from '../fakeUsageAggregateRepository.js';
 import { FakePricingRepository } from '../fakePricingRepository.js';
+import { FakePricingCache } from '../fakePricingCache.js';
 import { createTestEvent } from '../helpers.js';
 import { MAX_LIST_LIMIT, DEFAULT_LIST_LIMIT } from '../../domain/models/usageEvent.js';
 import type { DailyUsageAggregate } from '../../domain/models/dailyAggregate.js';
@@ -77,6 +78,7 @@ describe('publicUsageRoutes', () => {
       usageEventRepository: eventRepo,
       usageAggregateRepository: aggregateRepo,
       pricingRepository: new FakePricingRepository(),
+      pricingCache: new FakePricingCache(),
       orchestratorSecret: 'test-secret',
     } satisfies ServiceContainer);
   });

--- a/apps/llm-usage-service/src/__tests__/routes/webhookUsageRoutes.test.ts
+++ b/apps/llm-usage-service/src/__tests__/routes/webhookUsageRoutes.test.ts
@@ -203,6 +203,50 @@ describe('webhookUsageRoutes', () => {
       expect(response.statusCode).toBe(400);
     });
 
+    it('rejects mismatched envelope — v1 schemaVersion with v2 events', async () => {
+      const v2Event = createTestEventInputV2({ eventId: 'evt_wh_mismatch_1' });
+      const payload = {
+        schemaVersion: 1,
+        events: [v2Event],
+      };
+      const { timestamp, signature } = signPayload(payload);
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/internal/webhooks/usage-events',
+        headers: {
+          'x-request-timestamp': timestamp,
+          'x-request-signature': signature,
+        },
+        payload,
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(eventRepo.getStoredEvents()).toHaveLength(0);
+    });
+
+    it('rejects mismatched envelope — v2 schemaVersion with v1 events', async () => {
+      const v1Event = createTestEventInput({ eventId: 'evt_wh_mismatch_2' });
+      const payload = {
+        schemaVersion: 2,
+        events: [v1Event],
+      };
+      const { timestamp, signature } = signPayload(payload);
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/internal/webhooks/usage-events',
+        headers: {
+          'x-request-timestamp': timestamp,
+          'x-request-signature': signature,
+        },
+        payload,
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(eventRepo.getStoredEvents()).toHaveLength(0);
+    });
+
     it('accepts v2 orchestrator events and stores enriched cost in Firestore', async () => {
       const pricingCache = new FakePricingCache();
       pricingCache.setPricing(LlmProviders.Anthropic, 'claude-sonnet-4-20250514', {

--- a/apps/llm-usage-service/src/__tests__/routes/webhookUsageRoutes.test.ts
+++ b/apps/llm-usage-service/src/__tests__/routes/webhookUsageRoutes.test.ts
@@ -6,7 +6,8 @@ import { setServices, resetServices, type ServiceContainer } from '../../service
 import { FakeUsageEventRepository } from '../fakeUsageEventRepository.js';
 import { FakeUsageAggregateRepository } from '../fakeUsageAggregateRepository.js';
 import { FakePricingRepository } from '../fakePricingRepository.js';
-import { createTestEventInput } from '../helpers.js';
+import { FakePricingCache } from '../fakePricingCache.js';
+import { createTestEventInput, createTestEventInputV2 } from '../helpers.js';
 
 const SECRET = 'test-webhook-secret';
 
@@ -35,6 +36,7 @@ describe('webhookUsageRoutes', () => {
       usageEventRepository: eventRepo,
       usageAggregateRepository: aggregateRepo,
       pricingRepository: new FakePricingRepository(),
+      pricingCache: new FakePricingCache(),
       orchestratorSecret: SECRET,
     } satisfies ServiceContainer);
   });
@@ -184,7 +186,7 @@ describe('webhookUsageRoutes', () => {
     });
 
     it('returns 400 for invalid schemaVersion', async () => {
-      const payload = { schemaVersion: 2, events: [] };
+      const payload = { schemaVersion: 3, events: [] };
       const { timestamp, signature } = signPayload(payload);
 
       const response = await app.inject({
@@ -198,6 +200,29 @@ describe('webhookUsageRoutes', () => {
       });
 
       expect(response.statusCode).toBe(400);
+    });
+
+    it('returns 200 for valid signed request with v2 orchestrator events', async () => {
+      const payload = {
+        schemaVersion: 2,
+        events: [createTestEventInputV2({ eventId: 'evt_wh_v2_1' })],
+      };
+      const { timestamp, signature } = signPayload(payload);
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/internal/webhooks/usage-events',
+        headers: {
+          'x-request-timestamp': timestamp,
+          'x-request-signature': signature,
+        },
+        payload,
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body) as { success: boolean; data: { accepted: number } };
+      expect(body.success).toBe(true);
+      expect(body.data.accepted).toBe(1);
     });
   });
 });

--- a/apps/llm-usage-service/src/__tests__/routes/webhookUsageRoutes.test.ts
+++ b/apps/llm-usage-service/src/__tests__/routes/webhookUsageRoutes.test.ts
@@ -1,6 +1,7 @@
 import crypto from 'node:crypto';
 import { describe, it, expect, beforeAll, beforeEach, afterAll, afterEach } from 'vitest';
 import type { FastifyInstance } from 'fastify';
+import { LlmProviders } from '@intexuraos/llm-contract';
 import { buildServer } from '../../server.js';
 import { setServices, resetServices, type ServiceContainer } from '../../services.js';
 import { FakeUsageEventRepository } from '../fakeUsageEventRepository.js';
@@ -202,7 +203,20 @@ describe('webhookUsageRoutes', () => {
       expect(response.statusCode).toBe(400);
     });
 
-    it('returns 200 for valid signed request with v2 orchestrator events', async () => {
+    it('accepts v2 orchestrator events and stores enriched cost in Firestore', async () => {
+      const pricingCache = new FakePricingCache();
+      pricingCache.setPricing(LlmProviders.Anthropic, 'claude-sonnet-4-20250514', {
+        inputPricePerMillion: 3.0,
+        outputPricePerMillion: 15.0,
+      });
+      setServices({
+        usageEventRepository: eventRepo,
+        usageAggregateRepository: aggregateRepo,
+        pricingRepository: new FakePricingRepository(),
+        pricingCache,
+        orchestratorSecret: SECRET,
+      } satisfies ServiceContainer);
+
       const payload = {
         schemaVersion: 2,
         events: [createTestEventInputV2({ eventId: 'evt_wh_v2_1' })],
@@ -223,6 +237,17 @@ describe('webhookUsageRoutes', () => {
       const body = JSON.parse(response.body) as { success: boolean; data: { accepted: number } };
       expect(body.success).toBe(true);
       expect(body.data.accepted).toBe(1);
+
+      // Verify Firestore round-trip: stored event has enriched cost shape
+      const stored = eventRepo.getStoredEvents();
+      expect(stored).toHaveLength(1);
+      const event = stored[0];
+      expect(event).toBeDefined();
+      expect(event?.schemaVersion).toBe(1);
+      expect(event?.cost.pricingSource).toBe('calculated');
+      expect(event?.cost.calculatedUsd).toBeGreaterThan(0);
+      expect(event?.cost.billedUsd).toBe(event?.cost.calculatedUsd);
+      expect(event?.cost.providerReportedUsd).toBeNull();
     });
   });
 });

--- a/apps/llm-usage-service/src/domain/models/usageEvent.ts
+++ b/apps/llm-usage-service/src/domain/models/usageEvent.ts
@@ -78,13 +78,28 @@ export interface UsageEvent {
   } | null;
 }
 
-/** UsageEventInput - what callers send (no receivedAt, no ingress) */
+/** UsageEventInput - what v1 callers send (no receivedAt, no ingress) */
 export type UsageEventInput = Omit<UsageEvent, 'receivedAt' | 'ingress'>;
+
+/** UsageEventInputV2 - what v2 callers send (cost has only providerReportedUsd + pending/provider_reported pricingSource) */
+export type UsageEventInputV2 = Omit<
+  UsageEvent,
+  'receivedAt' | 'ingress' | 'schemaVersion' | 'cost'
+> & {
+  schemaVersion: 2;
+  cost: {
+    providerReportedUsd: number | null;
+    pricingSource: 'pending' | 'provider_reported';
+  };
+};
+
+/** Discriminated union of all input event versions */
+export type UsageEventInputAny = UsageEventInput | UsageEventInputV2;
 
 /** Ingest request */
 export interface UsageIngestRequest {
-  schemaVersion: 1;
-  events: UsageEventInput[];
+  schemaVersion: 1 | 2;
+  events: UsageEventInputAny[];
 }
 
 /** Ingest response */

--- a/apps/llm-usage-service/src/domain/services/costCalculation.ts
+++ b/apps/llm-usage-service/src/domain/services/costCalculation.ts
@@ -27,6 +27,11 @@ export interface UsageTokens {
  * All prices in `pricing` are per-million tokens; the function uses
  * scaled integer math with `Math.round()` for precision.
  *
+ * Note: Image cost calculation (`calculateImageCost`) from `infra-gemini`
+ * and `infra-gpt` is NOT consolidated here — image generation events are
+ * not yet emitted with `schemaVersion: 2`. If image events are migrated
+ * in the future, add image cost handling to the relevant provider branches.
+ *
  * @param provider - The LLM provider identifier
  * @param usage - Token usage counts from the request
  * @param pricing - Model pricing configuration (per-million)
@@ -127,7 +132,11 @@ function calculateOpenAICost(usage: UsageTokens, pricing: ModelPricing): number 
 /**
  * Perplexity token-based cost calculation.
  *
- * - webSearchCalls defaults to 1 (Perplexity always charges at least one request)
+ * - webSearchCalls defaults to 1 when 0 (Perplexity always charges at least one
+ *   request fee per API call). This differs from the original infra-perplexity
+ *   calculator which used `?? 1` (nullish coalescing), but the original
+ *   `normalizeUsage()` always hardcoded `webSearchCalls: 1` before calling
+ *   `calculateTextCost`, so the effective behavior is the same.
  * - Request fee is charged per search call via webSearchCostPerCall
  */
 function calculatePerplexityCost(usage: UsageTokens, pricing: ModelPricing): number {

--- a/apps/llm-usage-service/src/domain/services/costCalculation.ts
+++ b/apps/llm-usage-service/src/domain/services/costCalculation.ts
@@ -1,0 +1,158 @@
+import type { LlmProvider, ModelPricing } from '@intexuraos/llm-contract';
+import { LlmProviders } from '@intexuraos/llm-contract';
+
+/**
+ * Token usage fields relevant to cost calculation.
+ *
+ * This is a subset of the usage event's `usage` field,
+ * containing only the fields needed for cost computation.
+ */
+export interface UsageTokens {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+  cachedTokens: number;
+  reasoningTokens: number;
+  thinkingTokens: number;
+  webSearchCalls: number;
+  groundingEnabled: boolean;
+  imageCount: number;
+}
+
+/**
+ * Consolidated cost calculation for all LLM providers.
+ *
+ * Dispatches to provider-specific logic based on the provider type.
+ * All prices in `pricing` are per-million tokens; the function uses
+ * scaled integer math with `Math.round()` for precision.
+ *
+ * @param provider - The LLM provider identifier
+ * @param usage - Token usage counts from the request
+ * @param pricing - Model pricing configuration (per-million)
+ * @returns Cost in USD
+ */
+export function calculateCost(
+  provider: LlmProvider,
+  usage: UsageTokens,
+  pricing: ModelPricing
+): number {
+  switch (provider) {
+    case LlmProviders.Anthropic:
+      return calculateAnthropicCost(usage, pricing);
+    case LlmProviders.Google:
+      return calculateGoogleCost(usage, pricing);
+    case LlmProviders.OpenAI:
+      return calculateOpenAICost(usage, pricing);
+    case LlmProviders.Perplexity:
+      return calculatePerplexityCost(usage, pricing);
+    case LlmProviders.OpenRouter:
+      return calculateOpenRouterCost(usage, pricing);
+    default: {
+      const exhaustive: never = provider;
+      throw new Error(`Unsupported provider: ${String(exhaustive)}`);
+    }
+  }
+}
+
+/**
+ * Anthropic cost calculation.
+ *
+ * - inputTokens are regular (non-cached) input tokens
+ * - cacheReadTokens charged at inputPrice * cacheReadMultiplier (default 0.1)
+ * - cacheWriteTokens charged at inputPrice * cacheWriteMultiplier (default 1.25)
+ * - Web search calls charged per call
+ */
+function calculateAnthropicCost(usage: UsageTokens, pricing: ModelPricing): number {
+  const inputPrice = pricing.inputPricePerMillion;
+  const outputPrice = pricing.outputPricePerMillion;
+  const searchPrice = pricing.webSearchCostPerCall ?? 0;
+
+  const cacheReadMultiplier = pricing.cacheReadMultiplier ?? 0.1;
+  const cacheWriteMultiplier = pricing.cacheWriteMultiplier ?? 1.25;
+
+  const regularCost = usage.inputTokens * inputPrice;
+  const readCost = usage.cacheReadTokens * inputPrice * cacheReadMultiplier;
+  const writeCost = usage.cacheWriteTokens * inputPrice * cacheWriteMultiplier;
+  const outputCost = usage.outputTokens * outputPrice;
+  const searchCostScaled = usage.webSearchCalls * searchPrice * 1_000_000;
+
+  return Math.round(regularCost + readCost + writeCost + outputCost + searchCostScaled) / 1_000_000;
+}
+
+/**
+ * Google cost calculation.
+ *
+ * - thinkingTokens charged at output price
+ * - Grounding adds a flat per-request cost when enabled
+ */
+function calculateGoogleCost(usage: UsageTokens, pricing: ModelPricing): number {
+  const inputPrice = pricing.inputPricePerMillion;
+  const outputPrice = pricing.outputPricePerMillion;
+  const groundingPrice = pricing.groundingCostPerRequest ?? 0;
+
+  const inputCost = usage.inputTokens * inputPrice;
+  const outputCost = usage.outputTokens * outputPrice;
+  const thinkingCost = usage.thinkingTokens * outputPrice;
+  const groundingCostScaled = (usage.groundingEnabled ? groundingPrice : 0) * 1_000_000;
+
+  return Math.round(inputCost + outputCost + thinkingCost + groundingCostScaled) / 1_000_000;
+}
+
+/**
+ * OpenAI cost calculation.
+ *
+ * - cachedTokens are subtracted from inputTokens to get regular input count
+ * - Cached tokens charged at inputPrice * cacheReadMultiplier (default 0.5)
+ * - Web search calls charged per call
+ */
+function calculateOpenAICost(usage: UsageTokens, pricing: ModelPricing): number {
+  const inputPrice = pricing.inputPricePerMillion;
+  const outputPrice = pricing.outputPricePerMillion;
+  const searchPrice = pricing.webSearchCostPerCall ?? 0;
+
+  const regularInputCount = Math.max(0, usage.inputTokens - usage.cachedTokens);
+  const cacheMultiplier = pricing.cacheReadMultiplier ?? 0.5;
+
+  const regularInputCost = regularInputCount * inputPrice;
+  const cachedInputCost = usage.cachedTokens * inputPrice * cacheMultiplier;
+  const outputCost = usage.outputTokens * outputPrice;
+  const searchCostScaled = usage.webSearchCalls * searchPrice * 1_000_000;
+
+  return (
+    Math.round(regularInputCost + cachedInputCost + outputCost + searchCostScaled) / 1_000_000
+  );
+}
+
+/**
+ * Perplexity token-based cost calculation.
+ *
+ * - webSearchCalls defaults to 1 (Perplexity always charges at least one request)
+ * - Request fee is charged per search call via webSearchCostPerCall
+ */
+function calculatePerplexityCost(usage: UsageTokens, pricing: ModelPricing): number {
+  const inputPrice = pricing.inputPricePerMillion;
+  const outputPrice = pricing.outputPricePerMillion;
+  const requestFee = pricing.webSearchCostPerCall ?? 0;
+
+  const inputCost = usage.inputTokens * inputPrice;
+  const outputCost = usage.outputTokens * outputPrice;
+
+  const requests = usage.webSearchCalls > 0 ? usage.webSearchCalls : 1;
+  const requestCostScaled = requests * requestFee * 1_000_000;
+
+  return Math.round(inputCost + outputCost + requestCostScaled) / 1_000_000;
+}
+
+/**
+ * OpenRouter token-based cost calculation.
+ *
+ * - Uses per-million prices divided down to per-token for calculation
+ * - Scales back up for rounding precision
+ */
+function calculateOpenRouterCost(usage: UsageTokens, pricing: ModelPricing): number {
+  const inputCost = usage.inputTokens * (pricing.inputPricePerMillion / 1_000_000);
+  const outputCost = usage.outputTokens * (pricing.outputPricePerMillion / 1_000_000);
+
+  return Math.round((inputCost + outputCost) * 1_000_000) / 1_000_000;
+}

--- a/apps/llm-usage-service/src/domain/services/costCalculation.ts
+++ b/apps/llm-usage-service/src/domain/services/costCalculation.ts
@@ -1,5 +1,8 @@
-import type { LlmProvider, ModelPricing } from '@intexuraos/llm-contract';
+import type { LlmProvider, ModelPricing, ImageSize } from '@intexuraos/llm-contract';
 import { LlmProviders } from '@intexuraos/llm-contract';
+
+/** Default image size used when only an image count is available (no per-request size). */
+const DEFAULT_IMAGE_SIZE: ImageSize = '1024x1024';
 
 /**
  * Token usage fields relevant to cost calculation.
@@ -27,10 +30,9 @@ export interface UsageTokens {
  * All prices in `pricing` are per-million tokens; the function uses
  * scaled integer math with `Math.round()` for precision.
  *
- * Note: Image cost calculation (`calculateImageCost`) from `infra-gemini`
- * and `infra-gpt` is NOT consolidated here — image generation events are
- * not yet emitted with `schemaVersion: 2`. If image events are migrated
- * in the future, add image cost handling to the relevant provider branches.
+ * Image generation costs are also handled: when `imageCount > 0` and the
+ * model has `imagePricing`, the per-image price for the default size
+ * (`1024x1024`) is multiplied by `imageCount` and added to the token cost.
  *
  * @param provider - The LLM provider identifier
  * @param usage - Token usage counts from the request
@@ -100,8 +102,9 @@ function calculateGoogleCost(usage: UsageTokens, pricing: ModelPricing): number 
   const outputCost = usage.outputTokens * outputPrice;
   const thinkingCost = usage.thinkingTokens * outputPrice;
   const groundingCostScaled = (usage.groundingEnabled ? groundingPrice : 0) * 1_000_000;
+  const imageCost = calculateImageCost(usage.imageCount, pricing);
 
-  return Math.round(inputCost + outputCost + thinkingCost + groundingCostScaled) / 1_000_000;
+  return Math.round(inputCost + outputCost + thinkingCost + groundingCostScaled) / 1_000_000 + imageCost;
 }
 
 /**
@@ -123,9 +126,10 @@ function calculateOpenAICost(usage: UsageTokens, pricing: ModelPricing): number 
   const cachedInputCost = usage.cachedTokens * inputPrice * cacheMultiplier;
   const outputCost = usage.outputTokens * outputPrice;
   const searchCostScaled = usage.webSearchCalls * searchPrice * 1_000_000;
+  const imageCost = calculateImageCost(usage.imageCount, pricing);
 
   return (
-    Math.round(regularInputCost + cachedInputCost + outputCost + searchCostScaled) / 1_000_000
+    Math.round(regularInputCost + cachedInputCost + outputCost + searchCostScaled) / 1_000_000 + imageCost
   );
 }
 
@@ -164,4 +168,20 @@ function calculateOpenRouterCost(usage: UsageTokens, pricing: ModelPricing): num
   const outputCost = usage.outputTokens * (pricing.outputPricePerMillion / 1_000_000);
 
   return Math.round((inputCost + outputCost) * 1_000_000) / 1_000_000;
+}
+
+/**
+ * Calculate image generation cost.
+ *
+ * Consolidated from `infra-gemini` and `infra-gpt` `calculateImageCost`.
+ * Uses the default image size (`1024x1024`) when only a count is available,
+ * since the usage event carries `imageCount` but not per-image dimensions.
+ *
+ * @returns Total image cost in USD (0 when no images or no imagePricing)
+ */
+function calculateImageCost(imageCount: number, pricing: ModelPricing): number {
+  if (imageCount <= 0) return 0;
+  if (pricing.imagePricing === undefined) return 0;
+  const perImagePrice = pricing.imagePricing[DEFAULT_IMAGE_SIZE] ?? 0;
+  return perImagePrice * imageCount;
 }

--- a/apps/llm-usage-service/src/domain/services/pricingCache.ts
+++ b/apps/llm-usage-service/src/domain/services/pricingCache.ts
@@ -1,0 +1,56 @@
+import type { LlmProvider, ProviderPricing, ModelPricing } from '@intexuraos/llm-contract';
+import type { PricingRepository } from '../repositories/pricingRepository.js';
+import type { Logger } from '@intexuraos/common-core';
+
+export interface PricingCache {
+  getModelPricing(provider: LlmProvider, model: string, logger: Logger): Promise<ModelPricing | null>;
+  invalidate(): void;
+}
+
+const DEFAULT_TTL_MS = 300_000; // 5 minutes
+
+export function createPricingCache(repo: PricingRepository, ttlMs?: number): PricingCache {
+  const effectiveTtl = ttlMs ?? DEFAULT_TTL_MS;
+  let cache: Record<LlmProvider, ProviderPricing> | null = null;
+  let loadedAt = 0;
+  let loadingPromise: Promise<Record<LlmProvider, ProviderPricing>> | null = null;
+
+  async function ensureLoaded(logger: Logger): Promise<Record<LlmProvider, ProviderPricing>> {
+    const now = Date.now();
+    if (cache !== null && now - loadedAt < effectiveTtl) {
+      return cache;
+    }
+
+    // Thread-safe: if a reload is already in progress, reuse it
+    if (loadingPromise !== null) {
+      return await loadingPromise;
+    }
+
+    loadingPromise = repo.getAll().then((data) => {
+      cache = data;
+      loadedAt = Date.now();
+      loadingPromise = null;
+      return data;
+    }).catch((error: unknown) => {
+      loadingPromise = null;
+      logger.error({ error }, 'Failed to load pricing data');
+      throw error;
+    });
+
+    return await loadingPromise;
+  }
+
+  return {
+    async getModelPricing(provider: LlmProvider, model: string, logger: Logger): Promise<ModelPricing | null> {
+      const allPricing = await ensureLoaded(logger);
+      const providerPricing = allPricing[provider];
+      const modelPricing = providerPricing.models[model];
+      return modelPricing ?? null;
+    },
+
+    invalidate(): void {
+      cache = null;
+      loadedAt = 0;
+    },
+  };
+}

--- a/apps/llm-usage-service/src/domain/usecases/ingestUsageEvents.ts
+++ b/apps/llm-usage-service/src/domain/usecases/ingestUsageEvents.ts
@@ -1,21 +1,24 @@
 import type { Logger } from '@intexuraos/common-core';
 import { isErr } from '@intexuraos/common-core';
-import type { UsageEventInput, UsageIngestResponse, RejectedEvent, UsageEvent } from '../models/usageEvent.js';
+import type { UsageEventInputAny, UsageEvent, UsageIngestResponse, RejectedEvent } from '../models/usageEvent.js';
 import type { UsageEventRepository } from '../repositories/usageEventRepository.js';
 import type { UsageAggregateRepository } from '../repositories/usageAggregateRepository.js';
+import type { PricingCache } from '../services/pricingCache.js';
+import { calculateCost } from '../services/costCalculation.js';
 
 export interface IngestUsageEventsDeps {
   logger: Logger;
   usageEventRepository: UsageEventRepository;
   usageAggregateRepository: UsageAggregateRepository;
+  pricingCache: PricingCache;
 }
 
 export async function ingestUsageEvents(
   deps: IngestUsageEventsDeps,
-  events: UsageEventInput[],
+  events: UsageEventInputAny[],
   ingress: 'internal' | 'orchestrator_webhook',
 ): Promise<UsageIngestResponse> {
-  const { logger, usageEventRepository, usageAggregateRepository } = deps;
+  const { logger, usageEventRepository, usageAggregateRepository, pricingCache } = deps;
 
   let accepted = 0;
   let duplicates = 0;
@@ -29,16 +32,9 @@ export async function ingestUsageEvents(
       continue;
     }
 
-    // Structural validation (schemaVersion, field presence/types/enums, additionalProperties)
-    // is performed by the Fastify route schema (UsageEventInput / OrchestratorUsageEventInput)
-    // before this use case runs. Malformed events never reach here; the only rejection path
-    // remaining is Firestore createEvent failures below.
-
-    const fullEvent: UsageEvent = {
-      ...input,
-      receivedAt,
-      ingress,
-    };
+    const fullEvent: UsageEvent = input.schemaVersion === 2
+      ? enrichV2Event(input, receivedAt, ingress, await resolveV2Cost(input, pricingCache, logger))
+      : { ...input, receivedAt, ingress };
 
     const createResult = await usageEventRepository.createEvent(fullEvent);
     if (!createResult.ok) {
@@ -77,4 +73,72 @@ export async function ingestUsageEvents(
   );
 
   return { accepted, duplicates, rejected };
+}
+
+interface ResolvedCost {
+  billedUsd: number;
+  providerReportedUsd: number | null;
+  calculatedUsd: number | null;
+  pricingSource: 'provider_reported' | 'calculated';
+}
+
+async function resolveV2Cost(
+  input: Extract<UsageEventInputAny, { schemaVersion: 2 }>,
+  pricingCache: PricingCache,
+  logger: Logger,
+): Promise<ResolvedCost> {
+  if (input.cost.pricingSource === 'provider_reported' && input.cost.providerReportedUsd !== null) {
+    return {
+      billedUsd: Math.max(0, input.cost.providerReportedUsd),
+      providerReportedUsd: input.cost.providerReportedUsd,
+      calculatedUsd: null,
+      pricingSource: 'provider_reported',
+    };
+  }
+
+  // pricingSource === 'pending' (or provider_reported with null USD)
+  const pricing = await pricingCache.getModelPricing(input.request.provider, input.request.model, logger);
+
+  if (pricing !== null) {
+    const calculatedUsd = calculateCost(input.request.provider, input.usage, pricing);
+    return {
+      billedUsd: calculatedUsd,
+      providerReportedUsd: null,
+      calculatedUsd,
+      pricingSource: 'calculated',
+    };
+  }
+
+  logger.warn(
+    { provider: input.request.provider, model: input.request.model },
+    'No pricing found for model; defaulting cost to 0',
+  );
+  return {
+    billedUsd: 0,
+    providerReportedUsd: null,
+    calculatedUsd: 0,
+    pricingSource: 'calculated',
+  };
+}
+
+function enrichV2Event(
+  input: Extract<UsageEventInputAny, { schemaVersion: 2 }>,
+  receivedAt: string,
+  ingress: 'internal' | 'orchestrator_webhook',
+  cost: ResolvedCost,
+): UsageEvent {
+  return {
+    schemaVersion: 1,
+    eventId: input.eventId,
+    occurredAt: input.occurredAt,
+    receivedAt,
+    ingress,
+    owner: input.owner,
+    source: input.source,
+    request: input.request,
+    usage: input.usage,
+    cost,
+    correlation: input.correlation,
+    error: input.error,
+  };
 }

--- a/apps/llm-usage-service/src/routes/internalUsageRoutes.ts
+++ b/apps/llm-usage-service/src/routes/internalUsageRoutes.ts
@@ -19,20 +19,32 @@ export const internalUsageRoutes: FastifyPluginCallback = (app, _opts, done) => 
         description: 'Internal endpoint for ingesting LLM usage events from other services.',
         tags: ['usage'],
         body: {
-          type: 'object',
-          required: ['schemaVersion', 'events'],
-          properties: {
-            schemaVersion: { type: 'integer', enum: [1, 2] },
-            events: {
-              type: 'array',
-              items: {
-                oneOf: [
-                  { $ref: 'UsageEventInput#' },
-                  { $ref: 'UsageEventInputV2#' },
-                ],
+          oneOf: [
+            {
+              type: 'object',
+              required: ['schemaVersion', 'events'],
+              additionalProperties: false,
+              properties: {
+                schemaVersion: { type: 'integer', enum: [1] },
+                events: {
+                  type: 'array',
+                  items: { $ref: 'UsageEventInput#' },
+                },
               },
             },
-          },
+            {
+              type: 'object',
+              required: ['schemaVersion', 'events'],
+              additionalProperties: false,
+              properties: {
+                schemaVersion: { type: 'integer', enum: [2] },
+                events: {
+                  type: 'array',
+                  items: { $ref: 'UsageEventInputV2#' },
+                },
+              },
+            },
+          ],
         },
         response: {
           200: {

--- a/apps/llm-usage-service/src/routes/internalUsageRoutes.ts
+++ b/apps/llm-usage-service/src/routes/internalUsageRoutes.ts
@@ -2,11 +2,11 @@ import type { FastifyPluginCallback, FastifyReply, FastifyRequest } from 'fastif
 import { validateInternalAuth, logIncomingRequest } from '@intexuraos/common-http';
 import { getServices } from '../services.js';
 import { ingestUsageEvents } from '../domain/usecases/ingestUsageEvents.js';
-import type { UsageEventInput } from '../domain/models/usageEvent.js';
+import type { UsageEventInputAny } from '../domain/models/usageEvent.js';
 
 interface IngestBody {
   schemaVersion: number;
-  events: UsageEventInput[];
+  events: UsageEventInputAny[];
 }
 
 export const internalUsageRoutes: FastifyPluginCallback = (app, _opts, done) => {
@@ -22,10 +22,15 @@ export const internalUsageRoutes: FastifyPluginCallback = (app, _opts, done) => 
           type: 'object',
           required: ['schemaVersion', 'events'],
           properties: {
-            schemaVersion: { type: 'integer', enum: [1] },
+            schemaVersion: { type: 'integer', enum: [1, 2] },
             events: {
               type: 'array',
-              items: { $ref: 'UsageEventInput#' },
+              items: {
+                oneOf: [
+                  { $ref: 'UsageEventInput#' },
+                  { $ref: 'UsageEventInputV2#' },
+                ],
+              },
             },
           },
         },
@@ -66,13 +71,12 @@ export const internalUsageRoutes: FastifyPluginCallback = (app, _opts, done) => 
         return await reply.fail('UNAUTHORIZED', 'Internal auth failed');
       }
 
-      // schemaVersion and events are validated by Fastify schema (enum: [1], type: array)
       const body = request.body as IngestBody;
 
-      const { usageEventRepository, usageAggregateRepository } = getServices();
+      const { usageEventRepository, usageAggregateRepository, pricingCache } = getServices();
 
       const result = await ingestUsageEvents(
-        { logger: request.log, usageEventRepository, usageAggregateRepository },
+        { logger: request.log, usageEventRepository, usageAggregateRepository, pricingCache },
         body.events,
         'internal',
       );

--- a/apps/llm-usage-service/src/routes/schemas/usageEventSchema.ts
+++ b/apps/llm-usage-service/src/routes/schemas/usageEventSchema.ts
@@ -162,6 +162,155 @@ export const usageEventInputSchema = {
 } as const;
 
 /**
+ * V2 usage event input JSON Schema. Mirrors the UsageEventInputV2 TypeScript
+ * type. The cost object only has providerReportedUsd and pricingSource;
+ * billedUsd and calculatedUsd are computed server-side.
+ */
+export const usageEventInputV2Schema = {
+  $id: 'UsageEventInputV2',
+  type: 'object',
+  additionalProperties: false,
+  required: [
+    'schemaVersion',
+    'eventId',
+    'occurredAt',
+    'owner',
+    'source',
+    'request',
+    'usage',
+    'cost',
+    'correlation',
+    'error',
+  ],
+  properties: {
+    schemaVersion: { type: 'integer', enum: [2] },
+    eventId: { type: 'string', minLength: 1 },
+    occurredAt: { type: 'string', format: 'date-time' },
+    owner: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['type', 'id'],
+      properties: {
+        type: { type: 'string', enum: ['user', 'system'] },
+        id: { type: 'string', minLength: 1 },
+      },
+    },
+    source: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['service', 'component', 'client', 'environment'],
+      properties: {
+        service: { type: 'string', minLength: 1 },
+        component: { type: 'string', minLength: 1 },
+        client: { type: 'string', minLength: 1 },
+        environment: {
+          type: 'string',
+          enum: ['dev', 'prod', 'test'],
+          description:
+            'The intexuraos environment of the caller that originated this usage. For events emitted by the orchestrator, this is the environment of the code-agent that dispatched the task, NOT the orchestrator\'s own environment (the orchestrator has no environment, only a location).',
+        },
+        workerLocation: {
+          type: 'string',
+          minLength: 1,
+          description:
+            "Physical location identifier of the orchestrator that produced this event (e.g. 'home-dev', 'mac-dev', 'office-pc'). Required at the webhook endpoint (via OrchestratorUsageEventInput); optional on the internal endpoint.",
+        },
+      },
+    },
+    request: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['provider', 'model', 'operation', 'success', 'durationMs'],
+      properties: {
+        provider: { type: 'string', enum: PROVIDER_VALUES },
+        model: { type: 'string', minLength: 1 },
+        operation: {
+          type: 'string',
+          enum: [
+            'research',
+            'generate',
+            'image_generation',
+            'tool_calling',
+            'other',
+          ],
+        },
+        success: { type: 'boolean' },
+        durationMs: { type: 'number', minimum: 0 },
+      },
+    },
+    usage: {
+      type: 'object',
+      additionalProperties: false,
+      required: [
+        'inputTokens',
+        'outputTokens',
+        'totalTokens',
+        'cacheReadTokens',
+        'cacheWriteTokens',
+        'cachedTokens',
+        'reasoningTokens',
+        'thinkingTokens',
+        'webSearchCalls',
+        'groundingEnabled',
+        'imageCount',
+      ],
+      properties: {
+        inputTokens: { type: 'number', minimum: 0 },
+        outputTokens: { type: 'number', minimum: 0 },
+        totalTokens: { type: 'number', minimum: 0 },
+        cacheReadTokens: { type: 'number', minimum: 0 },
+        cacheWriteTokens: { type: 'number', minimum: 0 },
+        cachedTokens: { type: 'number', minimum: 0 },
+        reasoningTokens: { type: 'number', minimum: 0 },
+        thinkingTokens: { type: 'number', minimum: 0 },
+        webSearchCalls: { type: 'number', minimum: 0 },
+        groundingEnabled: { type: 'boolean' },
+        imageCount: { type: 'number', minimum: 0 },
+      },
+    },
+    cost: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['providerReportedUsd', 'pricingSource'],
+      properties: {
+        providerReportedUsd: { type: ['number', 'null'] },
+        pricingSource: {
+          type: 'string',
+          enum: ['provider_reported', 'pending'],
+        },
+      },
+    },
+    correlation: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['requestId', 'traceId', 'taskId', 'researchId', 'attempt', 'sessionId'],
+      properties: {
+        requestId: { type: ['string', 'null'] },
+        traceId: { type: ['string', 'null'] },
+        taskId: { type: ['string', 'null'] },
+        researchId: { type: ['string', 'null'] },
+        attempt: { type: ['number', 'null'] },
+        sessionId: { type: ['string', 'null'] },
+      },
+    },
+    error: {
+      anyOf: [
+        { type: 'null' },
+        {
+          type: 'object',
+          additionalProperties: false,
+          required: ['code', 'message'],
+          properties: {
+            code: { type: ['string', 'null'] },
+            message: { type: ['string', 'null'] },
+          },
+        },
+      ],
+    },
+  },
+} as const;
+
+/**
  * Orchestrator-specific usage event input schema. Extends the base via `allOf`:
  *
  *   1. Pins `source.service` to the literal `'orchestrator'` (was previously
@@ -192,14 +341,42 @@ export const orchestratorUsageEventInputSchema = {
 } as const;
 
 /**
- * Registers both usage event schemas with the Fastify app's Ajv instance.
+ * Orchestrator-specific V2 usage event input schema. Extends the V2 base via `allOf`:
+ *
+ *   1. Pins `source.service` to the literal `'orchestrator'`.
+ *   2. Makes `source.workerLocation` a required field.
+ */
+export const orchestratorUsageEventInputV2Schema = {
+  $id: 'OrchestratorUsageEventInputV2',
+  allOf: [
+    { $ref: 'UsageEventInputV2#' },
+    {
+      type: 'object',
+      required: ['source'],
+      properties: {
+        source: {
+          type: 'object',
+          required: ['service', 'workerLocation'],
+          properties: {
+            service: { const: 'orchestrator' },
+          },
+        },
+      },
+    },
+  ],
+} as const;
+
+/**
+ * Registers all usage event schemas with the Fastify app's Ajv instance.
  *
  * Must be called AFTER `registerCoreSchemas(app)` and BEFORE any route is
  * registered that references these schemas via `$ref`. Order within this
- * function matters: the base schema must be added before the orchestrator
- * schema resolves its `$ref`.
+ * function matters: the base schemas must be added before the orchestrator
+ * schemas resolve their `$ref`.
  */
 export function registerUsageSchemas(app: FastifyInstance): void {
   app.addSchema(usageEventInputSchema);
+  app.addSchema(usageEventInputV2Schema);
   app.addSchema(orchestratorUsageEventInputSchema);
+  app.addSchema(orchestratorUsageEventInputV2Schema);
 }

--- a/apps/llm-usage-service/src/routes/webhookUsageRoutes.ts
+++ b/apps/llm-usage-service/src/routes/webhookUsageRoutes.ts
@@ -3,11 +3,11 @@ import { logIncomingRequest } from '@intexuraos/common-http';
 import { getServices } from '../services.js';
 import { ingestUsageEvents } from '../domain/usecases/ingestUsageEvents.js';
 import { validateOrchestratorSignature } from '../infra/webhookValidation.js';
-import type { UsageEventInput } from '../domain/models/usageEvent.js';
+import type { UsageEventInputAny } from '../domain/models/usageEvent.js';
 
 interface WebhookIngestBody {
   schemaVersion: number;
-  events: UsageEventInput[];
+  events: UsageEventInputAny[];
 }
 
 export const webhookUsageRoutes: FastifyPluginCallback = (app, _opts, done) => {
@@ -23,10 +23,15 @@ export const webhookUsageRoutes: FastifyPluginCallback = (app, _opts, done) => {
           type: 'object',
           required: ['schemaVersion', 'events'],
           properties: {
-            schemaVersion: { type: 'integer', enum: [1] },
+            schemaVersion: { type: 'integer', enum: [1, 2] },
             events: {
               type: 'array',
-              items: { $ref: 'OrchestratorUsageEventInput#' },
+              items: {
+                oneOf: [
+                  { $ref: 'OrchestratorUsageEventInput#' },
+                  { $ref: 'OrchestratorUsageEventInputV2#' },
+                ],
+              },
             },
           },
         },
@@ -61,7 +66,7 @@ export const webhookUsageRoutes: FastifyPluginCallback = (app, _opts, done) => {
     async (request: FastifyRequest, reply: FastifyReply) => {
       logIncomingRequest(request, { message: 'Orchestrator webhook usage event ingest' });
 
-      const { orchestratorSecret, usageEventRepository, usageAggregateRepository } = getServices();
+      const { orchestratorSecret, usageEventRepository, usageAggregateRepository, pricingCache } = getServices();
 
       const authResult = validateOrchestratorSignature(request, { orchestratorSecret });
       if (!authResult.ok) {
@@ -69,12 +74,10 @@ export const webhookUsageRoutes: FastifyPluginCallback = (app, _opts, done) => {
         return await reply.fail('UNAUTHORIZED', authResult.error.message);
       }
 
-      // schemaVersion, event shapes, and source.service === 'orchestrator' constraint
-      // are all validated by the Fastify route schema (OrchestratorUsageEventInput).
       const body = request.body as WebhookIngestBody;
 
       const result = await ingestUsageEvents(
-        { logger: request.log, usageEventRepository, usageAggregateRepository },
+        { logger: request.log, usageEventRepository, usageAggregateRepository, pricingCache },
         body.events,
         'orchestrator_webhook',
       );

--- a/apps/llm-usage-service/src/routes/webhookUsageRoutes.ts
+++ b/apps/llm-usage-service/src/routes/webhookUsageRoutes.ts
@@ -20,20 +20,32 @@ export const webhookUsageRoutes: FastifyPluginCallback = (app, _opts, done) => {
         description: 'Webhook endpoint for orchestrator to submit LLM usage events with HMAC signature validation.',
         tags: ['usage'],
         body: {
-          type: 'object',
-          required: ['schemaVersion', 'events'],
-          properties: {
-            schemaVersion: { type: 'integer', enum: [1, 2] },
-            events: {
-              type: 'array',
-              items: {
-                oneOf: [
-                  { $ref: 'OrchestratorUsageEventInput#' },
-                  { $ref: 'OrchestratorUsageEventInputV2#' },
-                ],
+          oneOf: [
+            {
+              type: 'object',
+              required: ['schemaVersion', 'events'],
+              additionalProperties: false,
+              properties: {
+                schemaVersion: { type: 'integer', enum: [1] },
+                events: {
+                  type: 'array',
+                  items: { $ref: 'OrchestratorUsageEventInput#' },
+                },
               },
             },
-          },
+            {
+              type: 'object',
+              required: ['schemaVersion', 'events'],
+              additionalProperties: false,
+              properties: {
+                schemaVersion: { type: 'integer', enum: [2] },
+                events: {
+                  type: 'array',
+                  items: { $ref: 'OrchestratorUsageEventInputV2#' },
+                },
+              },
+            },
+          ],
         },
         response: {
           200: {

--- a/apps/llm-usage-service/src/services.ts
+++ b/apps/llm-usage-service/src/services.ts
@@ -1,14 +1,17 @@
 import type { UsageEventRepository } from './domain/repositories/usageEventRepository.js';
 import type { UsageAggregateRepository } from './domain/repositories/usageAggregateRepository.js';
 import type { PricingRepository } from './domain/repositories/pricingRepository.js';
+import type { PricingCache } from './domain/services/pricingCache.js';
 import { FirestoreUsageEventRepository } from './infra/firestore/firestoreUsageEventRepository.js';
 import { FirestoreUsageAggregateRepository } from './infra/firestore/firestoreUsageAggregateRepository.js';
 import { FirestorePricingRepository } from './infra/firestore/firestorePricingRepository.js';
+import { createPricingCache } from './domain/services/pricingCache.js';
 
 export interface ServiceContainer {
   usageEventRepository: UsageEventRepository;
   usageAggregateRepository: UsageAggregateRepository;
   pricingRepository: PricingRepository;
+  pricingCache: PricingCache;
   orchestratorSecret: string;
 }
 
@@ -27,10 +30,12 @@ export function initializeServices(): void {
     throw new Error('INTEXURAOS_ORCHESTRATOR_SECRET is required');
   }
 
+  const pricingRepository = new FirestorePricingRepository();
   container = {
     usageEventRepository: new FirestoreUsageEventRepository(),
     usageAggregateRepository: new FirestoreUsageAggregateRepository(),
-    pricingRepository: new FirestorePricingRepository(),
+    pricingRepository,
+    pricingCache: createPricingCache(pricingRepository),
     orchestratorSecret,
   };
 }

--- a/apps/research-agent/src/__tests__/domain/research/services/contextLabels.test.ts
+++ b/apps/research-agent/src/__tests__/domain/research/services/contextLabels.test.ts
@@ -7,16 +7,10 @@
 import { describe, it, expect, vi } from 'vitest';
 import { generateContextLabels } from '../../../../domain/research/services/contextLabels.js';
 import { LlmModels } from '@intexuraos/llm-contract';
-import type { ModelPricing } from '@intexuraos/llm-contract';
 import type { Logger } from '@intexuraos/common-core';
 import { ok, err } from '@intexuraos/common-core';
 
 describe('generateContextLabels', () => {
-  const mockPricing: ModelPricing = {
-    inputPricePerMillion: 0.075,
-    outputPricePerMillion: 0.3,
-  };
-
   const mockLogger: Logger = {
     info: vi.fn(),
     warn: vi.fn(),
@@ -38,7 +32,6 @@ describe('generateContextLabels', () => {
       () => {
         throw new Error('Should not be called');
       },
-      mockPricing,
       mockLogger
     );
 
@@ -71,7 +64,6 @@ describe('generateContextLabels', () => {
       'user-123',
       undefined,
       () => mockGenerator,
-      mockPricing,
       mockLogger
     );
 
@@ -97,7 +89,6 @@ describe('generateContextLabels', () => {
       'user-123',
       undefined,
       () => mockGenerator,
-      mockPricing,
       mockLogger
     );
 
@@ -123,7 +114,6 @@ describe('generateContextLabels', () => {
       'user-123',
       undefined,
       () => mockGenerator,
-      mockPricing,
       mockLogger
     );
 
@@ -138,7 +128,6 @@ describe('generateContextLabels', () => {
     let capturedModel: unknown;
     let capturedApiKey: unknown;
     let capturedUserId: unknown;
-    let capturedPricing: unknown;
     let capturedLogger: unknown;
     let capturedResearchId: unknown;
 
@@ -152,23 +141,20 @@ describe('generateContextLabels', () => {
       'test-api-key',
       'test-user-id',
       'research-456',
-      (model, apiKey, userId, pricing, logger, researchId) => {
+      (model, apiKey, userId, logger, researchId) => {
         capturedModel = model;
         capturedApiKey = apiKey;
         capturedUserId = userId;
-        capturedPricing = pricing;
         capturedLogger = logger;
         capturedResearchId = researchId;
         return mockGenerator;
       },
-      mockPricing,
       mockLogger
     );
 
     expect(capturedModel).toBe(LlmModels.Gemini25Flash);
     expect(capturedApiKey).toBe('test-api-key');
     expect(capturedUserId).toBe('test-user-id');
-    expect(capturedPricing).toBe(mockPricing);
     expect(capturedLogger).toBe(mockLogger);
     expect(capturedResearchId).toBe('research-456');
   });
@@ -190,7 +176,7 @@ describe('generateContextLabels', () => {
       },
     };
 
-    await generateContextLabels(contexts, 'api-key', 'user', undefined, () => mockGenerator, mockPricing, mockLogger);
+    await generateContextLabels(contexts, 'api-key', 'user', undefined, () => mockGenerator, mockLogger);
 
     expect(callOrder).toEqual([1, 2, 3]);
   });

--- a/apps/research-agent/src/__tests__/infra/llm/ClaudeAdapter.test.ts
+++ b/apps/research-agent/src/__tests__/infra/llm/ClaudeAdapter.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { type ModelPricing, LlmModels } from '@intexuraos/llm-contract';
+import { LlmModels } from '@intexuraos/llm-contract';
 import type { Logger } from '@intexuraos/common-core';
 import { FakeUsageSink } from '@intexuraos/llm-pricing';
 
@@ -18,11 +18,6 @@ vi.mock('@intexuraos/infra-claude', () => ({
 }));
 
 const { ClaudeAdapter } = await import('../../../infra/llm/ClaudeAdapter.js');
-
-const testPricing: ModelPricing = {
-  inputPricePerMillion: 5.0,
-  outputPricePerMillion: 25.0,
-};
 
 const mockLogger: Logger = {
   info: vi.fn(),
@@ -42,7 +37,6 @@ describe('ClaudeAdapter', () => {
       'test-key',
       LlmModels.ClaudeOpus46,
       'test-user-id',
-      testPricing,
       mockLogger,
       fakeUsageSink
     );
@@ -55,7 +49,6 @@ describe('ClaudeAdapter', () => {
         'test-key',
         LlmModels.ClaudeOpus46,
         'test-user-id',
-        testPricing,
         mockLogger,
         fakeUsageSink,
         'research-123'
@@ -66,7 +59,6 @@ describe('ClaudeAdapter', () => {
         model: LlmModels.ClaudeOpus46,
         userId: 'test-user-id',
         researchId: 'research-123',
-        pricing: testPricing,
         logger: mockLogger,
         usageSink: fakeUsageSink,
       });

--- a/apps/research-agent/src/__tests__/infra/llm/ContextInferenceAdapter.test.ts
+++ b/apps/research-agent/src/__tests__/infra/llm/ContextInferenceAdapter.test.ts
@@ -5,7 +5,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Logger } from '@intexuraos/common-core';
 import type { ResearchContext, SynthesisContext } from '@intexuraos/llm-prompts';
-import { type ModelPricing, LlmModels } from '@intexuraos/llm-contract';
+import { LlmModels } from '@intexuraos/llm-contract';
 import { FakeUsageSink } from '@intexuraos/llm-pricing';
 
 const mockGenerate = vi.fn();
@@ -21,11 +21,6 @@ vi.mock('@intexuraos/infra-gemini', () => ({
 const { ContextInferenceAdapter } = await import('../../../infra/llm/ContextInferenceAdapter.js');
 
 const mockUsage = { inputTokens: 10, outputTokens: 20, totalTokens: 30, costUsd: 0.001 };
-
-const testPricing: ModelPricing = {
-  inputPricePerMillion: 0.1,
-  outputPricePerMillion: 0.4,
-};
 
 const validResearchContext: ResearchContext = {
   language: 'en',
@@ -98,7 +93,6 @@ describe('ContextInferenceAdapter', () => {
       'test-key',
       LlmModels.Gemini20Flash,
       'test-user',
-      testPricing,
       mockLogger,
       fakeUsageSink
     );
@@ -112,7 +106,6 @@ describe('ContextInferenceAdapter', () => {
         'test-key',
         LlmModels.Gemini20Flash,
         'test-user',
-        testPricing,
         testLogger,
         fakeUsageSink,
         'research-123'
@@ -123,7 +116,6 @@ describe('ContextInferenceAdapter', () => {
         model: LlmModels.Gemini20Flash,
         userId: 'test-user',
         researchId: 'research-123',
-        pricing: testPricing,
         logger: testLogger,
         usageSink: fakeUsageSink,
       });

--- a/apps/research-agent/src/__tests__/infra/llm/GeminiAdapter.test.ts
+++ b/apps/research-agent/src/__tests__/infra/llm/GeminiAdapter.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { type ModelPricing, LlmModels } from '@intexuraos/llm-contract';
+import { LlmModels } from '@intexuraos/llm-contract';
 import type { Logger } from '@intexuraos/common-core';
 import { FakeUsageSink } from '@intexuraos/llm-pricing';
 
@@ -23,11 +23,6 @@ const { GeminiAdapter } = await import('../../../infra/llm/GeminiAdapter.js');
 
 const mockUsage = { inputTokens: 10, outputTokens: 20, totalTokens: 30, costUsd: 0.001 };
 
-const testPricing: ModelPricing = {
-  inputPricePerMillion: 1.25,
-  outputPricePerMillion: 10.0,
-};
-
 const mockLogger: Logger = {
   info: vi.fn(),
   error: vi.fn(),
@@ -46,7 +41,6 @@ describe('GeminiAdapter', () => {
       'test-key',
       LlmModels.Gemini25Pro,
       'test-user-id',
-      testPricing,
       mockLogger,
       fakeUsageSink
     );
@@ -59,7 +53,6 @@ describe('GeminiAdapter', () => {
         'test-key',
         LlmModels.Gemini25Pro,
         'test-user-id',
-        testPricing,
         mockLogger,
         fakeUsageSink,
         'research-123'
@@ -70,7 +63,6 @@ describe('GeminiAdapter', () => {
         model: LlmModels.Gemini25Pro,
         userId: 'test-user-id',
         researchId: 'research-123',
-        pricing: testPricing,
         logger: mockLogger,
         usageSink: fakeUsageSink,
       });
@@ -81,7 +73,6 @@ describe('GeminiAdapter', () => {
         'test-key',
         LlmModels.Gemini25Pro,
         'test-user-id',
-        testPricing,
         mockLogger,
         fakeUsageSink
       );
@@ -218,7 +209,6 @@ describe('GeminiAdapter', () => {
         'test-key',
         LlmModels.Gemini25Pro,
         'test-user-id',
-        testPricing,
         mockLogger,
         fakeUsageSink
       );

--- a/apps/research-agent/src/__tests__/infra/llm/GptAdapter.test.ts
+++ b/apps/research-agent/src/__tests__/infra/llm/GptAdapter.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { type ModelPricing, LlmModels } from '@intexuraos/llm-contract';
+import { LlmModels } from '@intexuraos/llm-contract';
 import type { Logger } from '@intexuraos/common-core';
 import { FakeUsageSink } from '@intexuraos/llm-pricing';
 
@@ -20,11 +20,6 @@ vi.mock('@intexuraos/infra-gpt', () => ({
 }));
 
 const { GptAdapter } = await import('../../../infra/llm/GptAdapter.js');
-
-const testPricing: ModelPricing = {
-  inputPricePerMillion: 2.0,
-  outputPricePerMillion: 8.0,
-};
 
 const mockLogger: Logger = {
   info: vi.fn(),
@@ -44,7 +39,6 @@ describe('GptAdapter', () => {
       'test-key',
       LlmModels.O4MiniDeepResearch,
       'test-user-id',
-      testPricing,
       mockLogger,
       fakeUsageSink
     );
@@ -57,7 +51,6 @@ describe('GptAdapter', () => {
         'test-key',
         LlmModels.O4MiniDeepResearch,
         'test-user-id',
-        testPricing,
         mockLogger,
         fakeUsageSink,
         'research-123'
@@ -68,7 +61,6 @@ describe('GptAdapter', () => {
         model: LlmModels.O4MiniDeepResearch,
         userId: 'test-user-id',
         researchId: 'research-123',
-        pricing: testPricing,
         logger: mockLogger,
         usageSink: fakeUsageSink,
       });
@@ -210,7 +202,6 @@ describe('GptAdapter', () => {
         'test-key',
         LlmModels.O4MiniDeepResearch,
         'test-user-id',
-        testPricing,
         mockLogger,
         fakeUsageSink
       );

--- a/apps/research-agent/src/__tests__/infra/llm/InputValidationAdapter.test.ts
+++ b/apps/research-agent/src/__tests__/infra/llm/InputValidationAdapter.test.ts
@@ -29,7 +29,6 @@ describe('InputValidationAdapter', () => {
       'test-api-key',
       LlmModels.Gemini25Flash,
       'user-123',
-      { inputPricePerMillion: 0.1, outputPricePerMillion: 0.2 },
       mockLogger,
       new FakeUsageSink()
     );
@@ -202,7 +201,6 @@ describe('InputValidationAdapter', () => {
         'test-api-key',
         LlmModels.Gemini25Flash,
         'user-123',
-        { inputPricePerMillion: 0.1, outputPricePerMillion: 0.2 },
         mockLogger as unknown as import('@intexuraos/common-core').Logger,
         new FakeUsageSink()
       );

--- a/apps/research-agent/src/__tests__/infra/llm/LlmAdapterFactory.test.ts
+++ b/apps/research-agent/src/__tests__/infra/llm/LlmAdapterFactory.test.ts
@@ -3,11 +3,10 @@
  */
 
 import { describe, expect, it, vi } from 'vitest';
-import { TEST_PRICING, FakeUsageSink } from '@intexuraos/llm-pricing';
+import { FakeUsageSink } from '@intexuraos/llm-pricing';
 import type { Logger } from '@intexuraos/common-core';
 import { LlmModels, type ResearchModel } from '@intexuraos/llm-contract';
 
-const testPricing = TEST_PRICING;
 const mockLogger: Logger = {
   info: vi.fn(),
   error: vi.fn(),
@@ -27,7 +26,6 @@ vi.mock('../../../infra/llm/GeminiAdapter.js', () => ({
       apiKey: string,
       model: string,
       userId: string,
-      _pricing: unknown,
       _logger: Logger,
       _usageSink: unknown,
       researchId?: string
@@ -52,7 +50,6 @@ vi.mock('../../../infra/llm/ClaudeAdapter.js', () => ({
       apiKey: string,
       model: string,
       userId: string,
-      _pricing: unknown,
       _logger: Logger,
       _usageSink: unknown,
       researchId?: string
@@ -77,7 +74,6 @@ vi.mock('../../../infra/llm/GptAdapter.js', () => ({
       apiKey: string,
       model: string,
       userId: string,
-      _pricing: unknown,
       _logger: Logger,
       _usageSink: unknown,
       researchId?: string
@@ -102,7 +98,6 @@ vi.mock('../../../infra/llm/PerplexityAdapter.js', () => ({
       apiKey: string,
       model: string,
       userId: string,
-      _pricing: unknown,
       _logger: Logger,
       _usageSink: unknown,
       researchId?: string
@@ -127,7 +122,6 @@ vi.mock('../../../infra/llm/OpenRouterAdapter.js', () => ({
       apiKey: string,
       model: string,
       userId: string,
-      _pricing: unknown,
       _logger: Logger,
       _usageSink: unknown,
       researchId?: string
@@ -151,7 +145,7 @@ describe('LlmAdapterFactory', () => {
         LlmModels.Gemini25Pro,
         'google-key',
         'test-user-id',
-        testPricing,
+        
         mockLogger,
         fakeUsageSink,
         'research-123'
@@ -167,7 +161,7 @@ describe('LlmAdapterFactory', () => {
         LlmModels.ClaudeOpus46,
         'anthropic-key',
         'test-user-id',
-        testPricing,
+        
         mockLogger,
         fakeUsageSink,
         'research-123'
@@ -183,7 +177,7 @@ describe('LlmAdapterFactory', () => {
         LlmModels.O4MiniDeepResearch,
         'openai-key',
         'test-user-id',
-        testPricing,
+        
         mockLogger,
         fakeUsageSink,
         'research-123'
@@ -199,7 +193,7 @@ describe('LlmAdapterFactory', () => {
         LlmModels.SonarPro,
         'perplexity-key',
         'test-user-id',
-        testPricing,
+        
         mockLogger,
         fakeUsageSink,
         'research-123'
@@ -216,7 +210,6 @@ describe('LlmAdapterFactory', () => {
         openRouterModel as ResearchModel,
         'openrouter-key',
         'test-user-id',
-        testPricing,
         mockLogger,
         fakeUsageSink,
         'research-123'
@@ -234,7 +227,7 @@ describe('LlmAdapterFactory', () => {
         LlmModels.Gemini25Pro,
         'google-key',
         'test-user-id',
-        testPricing,
+        
         mockLogger,
         fakeUsageSink,
         'research-123'
@@ -250,7 +243,7 @@ describe('LlmAdapterFactory', () => {
           LlmModels.ClaudeOpus46,
           'anthropic-key',
           'test-user-id',
-          testPricing,
+          
           mockLogger,
           fakeUsageSink,
           'research-123'
@@ -263,7 +256,7 @@ describe('LlmAdapterFactory', () => {
         LlmModels.O4MiniDeepResearch,
         'openai-key',
         'test-user-id',
-        testPricing,
+        
         mockLogger,
         fakeUsageSink,
         'research-123'
@@ -281,7 +274,7 @@ describe('LlmAdapterFactory', () => {
           LlmModels.SonarPro,
           'perplexity-key',
           'test-user-id',
-          testPricing,
+          
           mockLogger,
           fakeUsageSink,
           'research-123'
@@ -295,7 +288,6 @@ describe('LlmAdapterFactory', () => {
         openRouterModel as ResearchModel,
         'openrouter-key',
         'test-user-id',
-        testPricing,
         mockLogger,
         fakeUsageSink,
         'research-123'
@@ -312,7 +304,7 @@ describe('LlmAdapterFactory', () => {
         LlmModels.Gemini20Flash,
         'google-key',
         'test-user-id',
-        testPricing,
+        
         mockLogger,
         fakeUsageSink,
         'research-123'

--- a/apps/research-agent/src/__tests__/infra/llm/LlmAdapterFactory.test.ts
+++ b/apps/research-agent/src/__tests__/infra/llm/LlmAdapterFactory.test.ts
@@ -145,7 +145,6 @@ describe('LlmAdapterFactory', () => {
         LlmModels.Gemini25Pro,
         'google-key',
         'test-user-id',
-        
         mockLogger,
         fakeUsageSink,
         'research-123'
@@ -161,7 +160,6 @@ describe('LlmAdapterFactory', () => {
         LlmModels.ClaudeOpus46,
         'anthropic-key',
         'test-user-id',
-        
         mockLogger,
         fakeUsageSink,
         'research-123'
@@ -177,7 +175,6 @@ describe('LlmAdapterFactory', () => {
         LlmModels.O4MiniDeepResearch,
         'openai-key',
         'test-user-id',
-        
         mockLogger,
         fakeUsageSink,
         'research-123'
@@ -193,7 +190,6 @@ describe('LlmAdapterFactory', () => {
         LlmModels.SonarPro,
         'perplexity-key',
         'test-user-id',
-        
         mockLogger,
         fakeUsageSink,
         'research-123'
@@ -227,7 +223,6 @@ describe('LlmAdapterFactory', () => {
         LlmModels.Gemini25Pro,
         'google-key',
         'test-user-id',
-        
         mockLogger,
         fakeUsageSink,
         'research-123'
@@ -243,7 +238,6 @@ describe('LlmAdapterFactory', () => {
           LlmModels.ClaudeOpus46,
           'anthropic-key',
           'test-user-id',
-          
           mockLogger,
           fakeUsageSink,
           'research-123'
@@ -256,7 +250,6 @@ describe('LlmAdapterFactory', () => {
         LlmModels.O4MiniDeepResearch,
         'openai-key',
         'test-user-id',
-        
         mockLogger,
         fakeUsageSink,
         'research-123'
@@ -274,7 +267,6 @@ describe('LlmAdapterFactory', () => {
           LlmModels.SonarPro,
           'perplexity-key',
           'test-user-id',
-          
           mockLogger,
           fakeUsageSink,
           'research-123'
@@ -304,7 +296,6 @@ describe('LlmAdapterFactory', () => {
         LlmModels.Gemini20Flash,
         'google-key',
         'test-user-id',
-        
         mockLogger,
         fakeUsageSink,
         'research-123'

--- a/apps/research-agent/src/__tests__/infra/llm/OpenRouterAdapter.test.ts
+++ b/apps/research-agent/src/__tests__/infra/llm/OpenRouterAdapter.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { type ModelPricing } from '@intexuraos/llm-contract';
+
 import type { Logger } from '@intexuraos/common-core';
 import { FakeUsageSink } from '@intexuraos/llm-pricing';
 
@@ -24,12 +24,6 @@ vi.mock('@intexuraos/infra-openrouter', () => ({
 
 const { OpenRouterAdapter } = await import('../../../infra/llm/OpenRouterAdapter.js');
 
-const testPricing: ModelPricing = {
-  inputPricePerMillion: 3.0,
-  outputPricePerMillion: 15.0,
-  useProviderCost: true,
-};
-
 const mockLogger: Logger = {
   info: vi.fn(),
   error: vi.fn(),
@@ -48,7 +42,6 @@ describe('OpenRouterAdapter', () => {
       'test-key',
       TEST_MODEL,
       'test-user-id',
-      testPricing,
       mockLogger,
       fakeUsageSink
     );
@@ -61,7 +54,6 @@ describe('OpenRouterAdapter', () => {
         'test-key',
         TEST_MODEL,
         'test-user-id',
-        testPricing,
         mockLogger,
         fakeUsageSink
       );
@@ -70,7 +62,6 @@ describe('OpenRouterAdapter', () => {
         apiKey: 'test-key',
         model: EXPECTED_RAW_MODEL,
         userId: 'test-user-id',
-        pricing: testPricing,
         logger: mockLogger,
         usageSink: fakeUsageSink,
       });
@@ -82,7 +73,6 @@ describe('OpenRouterAdapter', () => {
         'test-key',
         TEST_MODEL,
         'test-user-id',
-        testPricing,
         mockLogger,
         fakeUsageSink,
         'research-123'
@@ -93,7 +83,6 @@ describe('OpenRouterAdapter', () => {
         model: EXPECTED_RAW_MODEL,
         userId: 'test-user-id',
         researchId: 'research-123',
-        pricing: testPricing,
         logger: mockLogger,
         usageSink: fakeUsageSink,
       });
@@ -106,7 +95,6 @@ describe('OpenRouterAdapter', () => {
         'test-key',
         nonOpenRouterModel,
         'test-user-id',
-        testPricing,
         mockLogger,
         fakeUsageSink
       );
@@ -115,7 +103,6 @@ describe('OpenRouterAdapter', () => {
         apiKey: 'test-key',
         model: nonOpenRouterModel,
         userId: 'test-user-id',
-        pricing: testPricing,
         logger: mockLogger,
         usageSink: fakeUsageSink,
       });
@@ -425,7 +412,6 @@ describe('OpenRouterAdapter', () => {
         'test-key',
         TEST_MODEL,
         'test-user-id',
-        testPricing,
         mockLoggerLocal,
         fakeUsageSink
       );

--- a/apps/research-agent/src/__tests__/infra/llm/PerplexityAdapter.test.ts
+++ b/apps/research-agent/src/__tests__/infra/llm/PerplexityAdapter.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { type ModelPricing, LlmModels } from '@intexuraos/llm-contract';
+import { LlmModels } from '@intexuraos/llm-contract';
 import type { Logger } from '@intexuraos/common-core';
 import { FakeUsageSink } from '@intexuraos/llm-pricing';
 
@@ -14,12 +14,6 @@ vi.mock('@intexuraos/infra-perplexity', () => ({
 }));
 
 const { PerplexityAdapter } = await import('../../../infra/llm/PerplexityAdapter.js');
-
-const testPricing: ModelPricing = {
-  inputPricePerMillion: 3.0,
-  outputPricePerMillion: 15.0,
-  useProviderCost: true,
-};
 
 const mockLogger: Logger = {
   info: vi.fn(),
@@ -39,7 +33,6 @@ describe('PerplexityAdapter', () => {
       'test-key',
       LlmModels.SonarPro,
       'test-user-id',
-      testPricing,
       mockLogger,
       fakeUsageSink
     );
@@ -52,7 +45,6 @@ describe('PerplexityAdapter', () => {
         'test-key',
         LlmModels.SonarPro,
         'test-user-id',
-        testPricing,
         mockLogger,
         fakeUsageSink,
         'research-123'
@@ -63,7 +55,6 @@ describe('PerplexityAdapter', () => {
         model: LlmModels.SonarPro,
         userId: 'test-user-id',
         researchId: 'research-123',
-        pricing: testPricing,
         logger: mockLogger,
         usageSink: fakeUsageSink,
       });

--- a/apps/research-agent/src/__tests__/routes.test.ts
+++ b/apps/research-agent/src/__tests__/routes.test.ts
@@ -9,7 +9,6 @@ import Fastify from 'fastify';
 import * as jose from 'jose';
 import { clearJwksCache } from '@intexuraos/common-http';
 import { err, ok, type Result } from '@intexuraos/common-core';
-import { FakePricingContext } from '@intexuraos/llm-pricing';
 import { LlmModels, LlmProviders, type ResearchModel, type LlmProvider } from '@intexuraos/llm-contract';
 import { buildServer } from '../server.js';
 import { MIN_QUALITY_CHARS } from '../routes/internalRoutes.js';
@@ -43,7 +42,6 @@ import type {
   ValidationResult,
 } from '../infra/llm/InputValidationAdapter.js';
 
-const fakePricingContext = new FakePricingContext();
 
 const INTEXURAOS_AUTH0_DOMAIN = 'test-tenant.eu.auth0.com';
 const INTEXURAOS_AUTH_AUDIENCE = 'urn:intexuraos:api';
@@ -89,7 +87,6 @@ describe('Research Routes - Unauthenticated', () => {
     const services: ServiceContainer = {
       researchRepo: fakeRepo,
       researchExportSettings: new FakeResearchExportSettings(),
-      pricingContext: fakePricingContext,
       generateId: (): string => 'generated-id-123',
       researchEventPublisher: fakeResearchEventPublisher,
       llmCallPublisher: fakeLlmCallPublisher,
@@ -100,11 +97,11 @@ describe('Research Routes - Unauthenticated', () => {
       shareStorage: null,
       shareConfig: null,
       webAppUrl: 'https://app.example.com',
-      createResearchProvider: (_model, _apiKey, _userId, _pricing, _logger) => createFakeLlmResearchProvider(),
-      createSynthesizer: (_model, _apiKey, _userId, _pricing, _logger) => createFakeSynthesizer(),
-      createTitleGenerator: (_model, _apiKey, _userId, _pricing, _logger) => createFakeTitleGenerator(),
-      createContextInferrer: (_model, _apiKey, _userId, _pricing, _logger) => createFakeContextInferrer(),
-      createInputValidator: (_model, _apiKey, _userId, _pricing, _logger) => createFakeInputValidator(),
+      createResearchProvider: (_model, _apiKey, _userId, _logger) => createFakeLlmResearchProvider(),
+      createSynthesizer: (_model, _apiKey, _userId, _logger) => createFakeSynthesizer(),
+      createTitleGenerator: (_model, _apiKey, _userId, _logger) => createFakeTitleGenerator(),
+      createContextInferrer: (_model, _apiKey, _userId, _logger) => createFakeContextInferrer(),
+      createInputValidator: (_model, _apiKey, _userId, _logger) => createFakeInputValidator(),
       notionExporter: createFakeNotionExporter(),
     };
     setServices(services);
@@ -343,7 +340,6 @@ describe('Research Routes - Authenticated', () => {
     const services: ServiceContainer = {
       researchRepo: fakeRepo,
       researchExportSettings: new FakeResearchExportSettings(),
-      pricingContext: fakePricingContext,
       generateId: (): string => 'generated-id-123',
       researchEventPublisher: fakeResearchEventPublisher,
       llmCallPublisher: fakeLlmCallPublisher,
@@ -354,11 +350,11 @@ describe('Research Routes - Authenticated', () => {
       shareStorage: null,
       shareConfig: null,
       webAppUrl: 'https://app.example.com',
-      createResearchProvider: (_model, _apiKey, _userId, _pricing, _logger) => createFakeLlmResearchProvider(),
-      createSynthesizer: (_model, _apiKey, _userId, _pricing, _logger) => createFakeSynthesizer(),
-      createTitleGenerator: (_model, _apiKey, _userId, _pricing, _logger) => createFakeTitleGenerator(),
-      createContextInferrer: (_model, _apiKey, _userId, _pricing, _logger) => createFakeContextInferrer(),
-      createInputValidator: (_model, _apiKey, _userId, _pricing, _logger) => createFakeInputValidator(),
+      createResearchProvider: (_model, _apiKey, _userId, _logger) => createFakeLlmResearchProvider(),
+      createSynthesizer: (_model, _apiKey, _userId, _logger) => createFakeSynthesizer(),
+      createTitleGenerator: (_model, _apiKey, _userId, _logger) => createFakeTitleGenerator(),
+      createContextInferrer: (_model, _apiKey, _userId, _logger) => createFakeContextInferrer(),
+      createInputValidator: (_model, _apiKey, _userId, _logger) => createFakeInputValidator(),
       notionExporter: createFakeNotionExporter(),
     };
     setServices(services);
@@ -2184,7 +2180,6 @@ describe('Research Routes - Authenticated', () => {
       const services: ServiceContainer = {
         researchRepo: newFakeRepo,
       researchExportSettings: new FakeResearchExportSettings(),
-        pricingContext: fakePricingContext,
         generateId: (): string => 'generated-id-123',
         researchEventPublisher: newFakeResearchEventPublisher,
         llmCallPublisher: newFakeLlmCallPublisher,
@@ -2195,11 +2190,11 @@ describe('Research Routes - Authenticated', () => {
         shareStorage: null,
         shareConfig: null,
         webAppUrl: 'https://app.example.com',
-        createResearchProvider: (_model, _apiKey, _userId, _pricing, _logger) => createFakeLlmResearchProvider(),
-        createSynthesizer: (_model, _apiKey, _userId, _pricing, _logger) => createFailingSynthesizer('LLM API unavailable'),
-        createTitleGenerator: (_model, _apiKey, _userId, _pricing, _logger) => createFakeTitleGenerator(),
-        createContextInferrer: (_model, _apiKey, _userId, _pricing, _logger) => createFakeContextInferrer(),
-      createInputValidator: (_model, _apiKey, _userId, _pricing, _logger) => createFakeInputValidator(),
+        createResearchProvider: (_model, _apiKey, _userId, _logger) => createFakeLlmResearchProvider(),
+        createSynthesizer: (_model, _apiKey, _userId, _logger) => createFailingSynthesizer('LLM API unavailable'),
+        createTitleGenerator: (_model, _apiKey, _userId, _logger) => createFakeTitleGenerator(),
+        createContextInferrer: (_model, _apiKey, _userId, _logger) => createFakeContextInferrer(),
+      createInputValidator: (_model, _apiKey, _userId, _logger) => createFakeInputValidator(),
         notionExporter: createFakeNotionExporter(),
       };
       setServices(services);
@@ -2541,15 +2536,14 @@ describe('Research Routes - Authenticated', () => {
       notionServiceClient: new FakeNotionServiceClient(),
         notificationSender: new FakeNotificationSender(),
         llmCallPublisher: new FakeLlmCallPublisher(),
-        pricingContext: fakePricingContext,
         shareStorage: null,
         shareConfig: null,
         webAppUrl: 'https://app.example.com',
-        createResearchProvider: (_model, _apiKey, _userId, _pricing, _logger) => createFakeLlmResearchProvider(),
-        createSynthesizer: (_model, _apiKey, _userId, _pricing, _logger) => createFailingSynthesizer('LLM API unavailable'),
-        createTitleGenerator: (_model, _apiKey, _userId, _pricing, _logger) => createFakeTitleGenerator(),
-        createContextInferrer: (_model, _apiKey, _userId, _pricing, _logger) => createFakeContextInferrer(),
-      createInputValidator: (_model, _apiKey, _userId, _pricing, _logger) => createFakeInputValidator(),
+        createResearchProvider: (_model, _apiKey, _userId, _logger) => createFakeLlmResearchProvider(),
+        createSynthesizer: (_model, _apiKey, _userId, _logger) => createFailingSynthesizer('LLM API unavailable'),
+        createTitleGenerator: (_model, _apiKey, _userId, _logger) => createFakeTitleGenerator(),
+        createContextInferrer: (_model, _apiKey, _userId, _logger) => createFakeContextInferrer(),
+      createInputValidator: (_model, _apiKey, _userId, _logger) => createFakeInputValidator(),
         notionExporter: createFakeNotionExporter(),
       };
       setServices(services);
@@ -2668,7 +2662,6 @@ describe('Research Routes - Authenticated', () => {
       const newServices: ServiceContainer = {
         researchRepo: fakeRepo,
       researchExportSettings: new FakeResearchExportSettings(),
-        pricingContext: fakePricingContext,
         generateId: (): string => 'generated-id-123',
         researchEventPublisher: fakeResearchEventPublisher,
         llmCallPublisher: new FakeLlmCallPublisher(),
@@ -2679,11 +2672,11 @@ describe('Research Routes - Authenticated', () => {
         shareStorage: null,
         shareConfig: null,
         webAppUrl: 'https://app.example.com',
-        createResearchProvider: (_model, _apiKey, _userId, _pricing, _logger) => createFakeLlmResearchProvider(),
-        createSynthesizer: (_model, _apiKey, _userId, _pricing, _logger) => createFakeSynthesizer(),
-        createTitleGenerator: (_model, _apiKey, _userId, _pricing, _logger) => createFakeTitleGenerator(),
-        createContextInferrer: (_model, _apiKey, _userId, _pricing, _logger) => createFakeContextInferrer(),
-        createInputValidator: (_model, _apiKey, _userId, _pricing, _logger) => weakValidator,
+        createResearchProvider: (_model, _apiKey, _userId, _logger) => createFakeLlmResearchProvider(),
+        createSynthesizer: (_model, _apiKey, _userId, _logger) => createFakeSynthesizer(),
+        createTitleGenerator: (_model, _apiKey, _userId, _logger) => createFakeTitleGenerator(),
+        createContextInferrer: (_model, _apiKey, _userId, _logger) => createFakeContextInferrer(),
+        createInputValidator: (_model, _apiKey, _userId, _logger) => weakValidator,
         notionExporter: createFakeNotionExporter(),
       };
       setServices(newServices);
@@ -2714,7 +2707,6 @@ describe('Research Routes - Authenticated', () => {
         setServices({
           researchRepo: fakeRepo,
       researchExportSettings: new FakeResearchExportSettings(),
-          pricingContext: fakePricingContext,
           generateId: (): string => 'generated-id-123',
           researchEventPublisher: fakeResearchEventPublisher,
           llmCallPublisher: new FakeLlmCallPublisher(),
@@ -2725,11 +2717,11 @@ describe('Research Routes - Authenticated', () => {
           shareStorage: null,
           shareConfig: null,
           webAppUrl: 'https://app.example.com',
-          createResearchProvider: (_model, _apiKey, _userId, _pricing, _logger) => createFakeLlmResearchProvider(),
-          createSynthesizer: (_model, _apiKey, _userId, _pricing, _logger) => createFakeSynthesizer(),
-          createTitleGenerator: (_model, _apiKey, _userId, _pricing, _logger) => createFakeTitleGenerator(),
-          createContextInferrer: (_model, _apiKey, _userId, _pricing, _logger) => createFakeContextInferrer(),
-          createInputValidator: (_model, _apiKey, _userId, _pricing, _logger) => createFakeInputValidator(),
+          createResearchProvider: (_model, _apiKey, _userId, _logger) => createFakeLlmResearchProvider(),
+          createSynthesizer: (_model, _apiKey, _userId, _logger) => createFakeSynthesizer(),
+          createTitleGenerator: (_model, _apiKey, _userId, _logger) => createFakeTitleGenerator(),
+          createContextInferrer: (_model, _apiKey, _userId, _logger) => createFakeContextInferrer(),
+          createInputValidator: (_model, _apiKey, _userId, _logger) => createFakeInputValidator(),
           notionExporter: createFakeNotionExporter(),
         });
       }
@@ -2759,7 +2751,6 @@ describe('Research Routes - Authenticated', () => {
       const newServices: ServiceContainer = {
         researchRepo: fakeRepo,
       researchExportSettings: new FakeResearchExportSettings(),
-        pricingContext: fakePricingContext,
         generateId: (): string => 'generated-id-123',
         researchEventPublisher: fakeResearchEventPublisher,
         llmCallPublisher: new FakeLlmCallPublisher(),
@@ -2770,11 +2761,11 @@ describe('Research Routes - Authenticated', () => {
         shareStorage: null,
         shareConfig: null,
         webAppUrl: 'https://app.example.com',
-        createResearchProvider: (_model, _apiKey, _userId, _pricing, _logger) => createFakeLlmResearchProvider(),
-        createSynthesizer: (_model, _apiKey, _userId, _pricing, _logger) => createFakeSynthesizer(),
-        createTitleGenerator: (_model, _apiKey, _userId, _pricing, _logger) => createFakeTitleGenerator(),
-        createContextInferrer: (_model, _apiKey, _userId, _pricing, _logger) => createFakeContextInferrer(),
-        createInputValidator: (_model, _apiKey, _userId, _pricing, _logger) => weakValidator,
+        createResearchProvider: (_model, _apiKey, _userId, _logger) => createFakeLlmResearchProvider(),
+        createSynthesizer: (_model, _apiKey, _userId, _logger) => createFakeSynthesizer(),
+        createTitleGenerator: (_model, _apiKey, _userId, _logger) => createFakeTitleGenerator(),
+        createContextInferrer: (_model, _apiKey, _userId, _logger) => createFakeContextInferrer(),
+        createInputValidator: (_model, _apiKey, _userId, _logger) => weakValidator,
         notionExporter: createFakeNotionExporter(),
       };
       setServices(newServices);
@@ -2805,7 +2796,6 @@ describe('Research Routes - Authenticated', () => {
         setServices({
           researchRepo: fakeRepo,
       researchExportSettings: new FakeResearchExportSettings(),
-          pricingContext: fakePricingContext,
           generateId: (): string => 'generated-id-123',
           researchEventPublisher: fakeResearchEventPublisher,
           llmCallPublisher: new FakeLlmCallPublisher(),
@@ -2816,11 +2806,11 @@ describe('Research Routes - Authenticated', () => {
           shareStorage: null,
           shareConfig: null,
           webAppUrl: 'https://app.example.com',
-          createResearchProvider: (_model, _apiKey, _userId, _pricing, _logger) => createFakeLlmResearchProvider(),
-          createSynthesizer: (_model, _apiKey, _userId, _pricing, _logger) => createFakeSynthesizer(),
-          createTitleGenerator: (_model, _apiKey, _userId, _pricing, _logger) => createFakeTitleGenerator(),
-          createContextInferrer: (_model, _apiKey, _userId, _pricing, _logger) => createFakeContextInferrer(),
-          createInputValidator: (_model, _apiKey, _userId, _pricing, _logger) => createFakeInputValidator(),
+          createResearchProvider: (_model, _apiKey, _userId, _logger) => createFakeLlmResearchProvider(),
+          createSynthesizer: (_model, _apiKey, _userId, _logger) => createFakeSynthesizer(),
+          createTitleGenerator: (_model, _apiKey, _userId, _logger) => createFakeTitleGenerator(),
+          createContextInferrer: (_model, _apiKey, _userId, _logger) => createFakeContextInferrer(),
+          createInputValidator: (_model, _apiKey, _userId, _logger) => createFakeInputValidator(),
           notionExporter: createFakeNotionExporter(),
         });
       }
@@ -2851,7 +2841,6 @@ describe('Research Routes - Authenticated', () => {
       const newServices: ServiceContainer = {
         researchRepo: fakeRepo,
       researchExportSettings: new FakeResearchExportSettings(),
-        pricingContext: fakePricingContext,
         generateId: (): string => 'generated-id-123',
         researchEventPublisher: fakeResearchEventPublisher,
         llmCallPublisher: new FakeLlmCallPublisher(),
@@ -2862,11 +2851,11 @@ describe('Research Routes - Authenticated', () => {
         shareStorage: null,
         shareConfig: null,
         webAppUrl: 'https://app.example.com',
-        createResearchProvider: (_model, _apiKey, _userId, _pricing, _logger) => createFakeLlmResearchProvider(),
-        createSynthesizer: (_model, _apiKey, _userId, _pricing, _logger) => createFakeSynthesizer(),
-        createTitleGenerator: (_model, _apiKey, _userId, _pricing, _logger) => createFakeTitleGenerator(),
-        createContextInferrer: (_model, _apiKey, _userId, _pricing, _logger) => createFakeContextInferrer(),
-        createInputValidator: (_model, _apiKey, _userId, _pricing, _logger) => weakValidator,
+        createResearchProvider: (_model, _apiKey, _userId, _logger) => createFakeLlmResearchProvider(),
+        createSynthesizer: (_model, _apiKey, _userId, _logger) => createFakeSynthesizer(),
+        createTitleGenerator: (_model, _apiKey, _userId, _logger) => createFakeTitleGenerator(),
+        createContextInferrer: (_model, _apiKey, _userId, _logger) => createFakeContextInferrer(),
+        createInputValidator: (_model, _apiKey, _userId, _logger) => weakValidator,
         notionExporter: createFakeNotionExporter(),
       };
       setServices(newServices);
@@ -2897,7 +2886,6 @@ describe('Research Routes - Authenticated', () => {
         setServices({
           researchRepo: fakeRepo,
       researchExportSettings: new FakeResearchExportSettings(),
-          pricingContext: fakePricingContext,
           generateId: (): string => 'generated-id-123',
           researchEventPublisher: fakeResearchEventPublisher,
           llmCallPublisher: new FakeLlmCallPublisher(),
@@ -2908,11 +2896,11 @@ describe('Research Routes - Authenticated', () => {
           shareStorage: null,
           shareConfig: null,
           webAppUrl: 'https://app.example.com',
-          createResearchProvider: (_model, _apiKey, _userId, _pricing, _logger) => createFakeLlmResearchProvider(),
-          createSynthesizer: (_model, _apiKey, _userId, _pricing, _logger) => createFakeSynthesizer(),
-          createTitleGenerator: (_model, _apiKey, _userId, _pricing, _logger) => createFakeTitleGenerator(),
-          createContextInferrer: (_model, _apiKey, _userId, _pricing, _logger) => createFakeContextInferrer(),
-          createInputValidator: (_model, _apiKey, _userId, _pricing, _logger) => createFakeInputValidator(),
+          createResearchProvider: (_model, _apiKey, _userId, _logger) => createFakeLlmResearchProvider(),
+          createSynthesizer: (_model, _apiKey, _userId, _logger) => createFakeSynthesizer(),
+          createTitleGenerator: (_model, _apiKey, _userId, _logger) => createFakeTitleGenerator(),
+          createContextInferrer: (_model, _apiKey, _userId, _logger) => createFakeContextInferrer(),
+          createInputValidator: (_model, _apiKey, _userId, _logger) => createFakeInputValidator(),
           notionExporter: createFakeNotionExporter(),
         });
       }
@@ -2942,7 +2930,6 @@ describe('Research Routes - Authenticated', () => {
       const newServices: ServiceContainer = {
         researchRepo: fakeRepo,
       researchExportSettings: new FakeResearchExportSettings(),
-        pricingContext: fakePricingContext,
         generateId: (): string => 'generated-id-123',
         researchEventPublisher: fakeResearchEventPublisher,
         llmCallPublisher: new FakeLlmCallPublisher(),
@@ -2953,11 +2940,11 @@ describe('Research Routes - Authenticated', () => {
         shareStorage: null,
         shareConfig: null,
         webAppUrl: 'https://app.example.com',
-        createResearchProvider: (_model, _apiKey, _userId, _pricing, _logger) => createFakeLlmResearchProvider(),
-        createSynthesizer: (_model, _apiKey, _userId, _pricing, _logger) => createFakeSynthesizer(),
-        createTitleGenerator: (_model, _apiKey, _userId, _pricing, _logger) => createFakeTitleGenerator(),
-        createContextInferrer: (_model, _apiKey, _userId, _pricing, _logger) => createFakeContextInferrer(),
-        createInputValidator: (_model, _apiKey, _userId, _pricing, _logger) => failingValidator,
+        createResearchProvider: (_model, _apiKey, _userId, _logger) => createFakeLlmResearchProvider(),
+        createSynthesizer: (_model, _apiKey, _userId, _logger) => createFakeSynthesizer(),
+        createTitleGenerator: (_model, _apiKey, _userId, _logger) => createFakeTitleGenerator(),
+        createContextInferrer: (_model, _apiKey, _userId, _logger) => createFakeContextInferrer(),
+        createInputValidator: (_model, _apiKey, _userId, _logger) => failingValidator,
         notionExporter: createFakeNotionExporter(),
       };
       setServices(newServices);
@@ -2986,7 +2973,6 @@ describe('Research Routes - Authenticated', () => {
         setServices({
           researchRepo: fakeRepo,
       researchExportSettings: new FakeResearchExportSettings(),
-          pricingContext: fakePricingContext,
           generateId: (): string => 'generated-id-123',
           researchEventPublisher: fakeResearchEventPublisher,
           llmCallPublisher: new FakeLlmCallPublisher(),
@@ -2997,11 +2983,11 @@ describe('Research Routes - Authenticated', () => {
           shareStorage: null,
           shareConfig: null,
           webAppUrl: 'https://app.example.com',
-          createResearchProvider: (_model, _apiKey, _userId, _pricing, _logger) => createFakeLlmResearchProvider(),
-          createSynthesizer: (_model, _apiKey, _userId, _pricing, _logger) => createFakeSynthesizer(),
-          createTitleGenerator: (_model, _apiKey, _userId, _pricing, _logger) => createFakeTitleGenerator(),
-          createContextInferrer: (_model, _apiKey, _userId, _pricing, _logger) => createFakeContextInferrer(),
-          createInputValidator: (_model, _apiKey, _userId, _pricing, _logger) => createFakeInputValidator(),
+          createResearchProvider: (_model, _apiKey, _userId, _logger) => createFakeLlmResearchProvider(),
+          createSynthesizer: (_model, _apiKey, _userId, _logger) => createFakeSynthesizer(),
+          createTitleGenerator: (_model, _apiKey, _userId, _logger) => createFakeTitleGenerator(),
+          createContextInferrer: (_model, _apiKey, _userId, _logger) => createFakeContextInferrer(),
+          createInputValidator: (_model, _apiKey, _userId, _logger) => createFakeInputValidator(),
           notionExporter: createFakeNotionExporter(),
         });
       }
@@ -3108,7 +3094,6 @@ describe('Research Routes - Authenticated', () => {
       const newServices: ServiceContainer = {
         researchRepo: fakeRepo,
       researchExportSettings: new FakeResearchExportSettings(),
-        pricingContext: fakePricingContext,
         generateId: (): string => 'generated-id-123',
         researchEventPublisher: fakeResearchEventPublisher,
         llmCallPublisher: new FakeLlmCallPublisher(),
@@ -3119,11 +3104,11 @@ describe('Research Routes - Authenticated', () => {
         shareStorage: null,
         shareConfig: null,
         webAppUrl: 'https://app.example.com',
-        createResearchProvider: (_model, _apiKey, _userId, _pricing, _logger) => createFakeLlmResearchProvider(),
-        createSynthesizer: (_model, _apiKey, _userId, _pricing, _logger) => createFakeSynthesizer(),
-        createTitleGenerator: (_model, _apiKey, _userId, _pricing, _logger) => createFakeTitleGenerator(),
-        createContextInferrer: (_model, _apiKey, _userId, _pricing, _logger) => createFakeContextInferrer(),
-        createInputValidator: (_model, _apiKey, _userId, _pricing, _logger) => failingValidator,
+        createResearchProvider: (_model, _apiKey, _userId, _logger) => createFakeLlmResearchProvider(),
+        createSynthesizer: (_model, _apiKey, _userId, _logger) => createFakeSynthesizer(),
+        createTitleGenerator: (_model, _apiKey, _userId, _logger) => createFakeTitleGenerator(),
+        createContextInferrer: (_model, _apiKey, _userId, _logger) => createFakeContextInferrer(),
+        createInputValidator: (_model, _apiKey, _userId, _logger) => failingValidator,
         notionExporter: createFakeNotionExporter(),
       };
       setServices(newServices);
@@ -3151,7 +3136,6 @@ describe('Research Routes - Authenticated', () => {
         setServices({
           researchRepo: fakeRepo,
       researchExportSettings: new FakeResearchExportSettings(),
-          pricingContext: fakePricingContext,
           generateId: (): string => 'generated-id-123',
           researchEventPublisher: fakeResearchEventPublisher,
           llmCallPublisher: new FakeLlmCallPublisher(),
@@ -3162,11 +3146,11 @@ describe('Research Routes - Authenticated', () => {
           shareStorage: null,
           shareConfig: null,
           webAppUrl: 'https://app.example.com',
-          createResearchProvider: (_model, _apiKey, _userId, _pricing, _logger) => createFakeLlmResearchProvider(),
-          createSynthesizer: (_model, _apiKey, _userId, _pricing, _logger) => createFakeSynthesizer(),
-          createTitleGenerator: (_model, _apiKey, _userId, _pricing, _logger) => createFakeTitleGenerator(),
-          createContextInferrer: (_model, _apiKey, _userId, _pricing, _logger) => createFakeContextInferrer(),
-          createInputValidator: (_model, _apiKey, _userId, _pricing, _logger) => createFakeInputValidator(),
+          createResearchProvider: (_model, _apiKey, _userId, _logger) => createFakeLlmResearchProvider(),
+          createSynthesizer: (_model, _apiKey, _userId, _logger) => createFakeSynthesizer(),
+          createTitleGenerator: (_model, _apiKey, _userId, _logger) => createFakeTitleGenerator(),
+          createContextInferrer: (_model, _apiKey, _userId, _logger) => createFakeContextInferrer(),
+          createInputValidator: (_model, _apiKey, _userId, _logger) => createFakeInputValidator(),
           notionExporter: createFakeNotionExporter(),
         });
       }
@@ -3380,7 +3364,6 @@ describe('System Endpoints', () => {
     const services: ServiceContainer = {
       researchRepo: fakeRepo,
       researchExportSettings: new FakeResearchExportSettings(),
-      pricingContext: fakePricingContext,
       generateId: (): string => 'generated-id-123',
       researchEventPublisher: fakeResearchEventPublisher,
       llmCallPublisher: fakeLlmCallPublisher,
@@ -3391,11 +3374,11 @@ describe('System Endpoints', () => {
       shareStorage: null,
       shareConfig: null,
       webAppUrl: 'https://app.example.com',
-      createResearchProvider: (_model, _apiKey, _userId, _pricing, _logger) => createFakeLlmResearchProvider(),
-      createSynthesizer: (_model, _apiKey, _userId, _pricing, _logger) => createFakeSynthesizer(),
-      createTitleGenerator: (_model, _apiKey, _userId, _pricing, _logger) => createFakeTitleGenerator(),
-      createContextInferrer: (_model, _apiKey, _userId, _pricing, _logger) => createFakeContextInferrer(),
-      createInputValidator: (_model, _apiKey, _userId, _pricing, _logger) => createFakeInputValidator(),
+      createResearchProvider: (_model, _apiKey, _userId, _logger) => createFakeLlmResearchProvider(),
+      createSynthesizer: (_model, _apiKey, _userId, _logger) => createFakeSynthesizer(),
+      createTitleGenerator: (_model, _apiKey, _userId, _logger) => createFakeTitleGenerator(),
+      createContextInferrer: (_model, _apiKey, _userId, _logger) => createFakeContextInferrer(),
+      createInputValidator: (_model, _apiKey, _userId, _logger) => createFakeInputValidator(),
       notionExporter: createFakeNotionExporter(),
     };
     setServices(services);
@@ -3455,7 +3438,6 @@ describe('Internal Routes', () => {
     const services: ServiceContainer = {
       researchRepo: fakeRepo,
       researchExportSettings: new FakeResearchExportSettings(),
-      pricingContext: fakePricingContext,
       generateId: (): string => 'generated-id-123',
       researchEventPublisher: fakeResearchEventPublisher,
       llmCallPublisher: fakeLlmCallPublisher,
@@ -3466,11 +3448,11 @@ describe('Internal Routes', () => {
       shareStorage: null,
       shareConfig: null,
       webAppUrl: 'https://app.example.com',
-      createResearchProvider: (_model, _apiKey, _userId, _pricing, _logger) => createFakeLlmResearchProvider(),
-      createSynthesizer: (_model, _apiKey, _userId, _pricing, _logger) => createFakeSynthesizer(),
-      createTitleGenerator: (_model, _apiKey, _userId, _pricing, _logger) => createFakeTitleGenerator(),
-      createContextInferrer: (_model, _apiKey, _userId, _pricing, _logger) => createFakeContextInferrer(),
-      createInputValidator: (_model, _apiKey, _userId, _pricing, _logger) => createFakeInputValidator(),
+      createResearchProvider: (_model, _apiKey, _userId, _logger) => createFakeLlmResearchProvider(),
+      createSynthesizer: (_model, _apiKey, _userId, _logger) => createFakeSynthesizer(),
+      createTitleGenerator: (_model, _apiKey, _userId, _logger) => createFakeTitleGenerator(),
+      createContextInferrer: (_model, _apiKey, _userId, _logger) => createFakeContextInferrer(),
+      createInputValidator: (_model, _apiKey, _userId, _logger) => createFakeInputValidator(),
       notionExporter: createFakeNotionExporter(),
     };
     setServices(services);
@@ -3957,7 +3939,6 @@ describe('Internal Routes', () => {
       const services: ServiceContainer = {
         researchRepo: fakeRepo,
       researchExportSettings: new FakeResearchExportSettings(),
-        pricingContext: fakePricingContext,
         generateId: (): string => 'generated-id-123',
         researchEventPublisher: new FakeResearchEventPublisher(),
         llmCallPublisher: fakeLlmCallPublisher,
@@ -3968,11 +3949,11 @@ describe('Internal Routes', () => {
         shareStorage: null,
         shareConfig: null,
         webAppUrl: 'https://app.example.com',
-        createResearchProvider: (_model, _apiKey, _userId, _pricing, _logger) => createFakeLlmResearchProvider(),
-        createSynthesizer: (_model, _apiKey, _userId, _pricing, _logger) => createFakeSynthesizer(),
-        createTitleGenerator: (_model, _apiKey, _userId, _pricing, _logger) => createFakeTitleGenerator(),
-        createContextInferrer: (_model, _apiKey, _userId, _pricing, _logger) => createFakeContextInferrer(),
-      createInputValidator: (_model, _apiKey, _userId, _pricing, _logger) => createFakeInputValidator(),
+        createResearchProvider: (_model, _apiKey, _userId, _logger) => createFakeLlmResearchProvider(),
+        createSynthesizer: (_model, _apiKey, _userId, _logger) => createFakeSynthesizer(),
+        createTitleGenerator: (_model, _apiKey, _userId, _logger) => createFakeTitleGenerator(),
+        createContextInferrer: (_model, _apiKey, _userId, _logger) => createFakeContextInferrer(),
+      createInputValidator: (_model, _apiKey, _userId, _logger) => createFakeInputValidator(),
         notionExporter: createFakeNotionExporter(),
       };
       setServices(services);
@@ -4519,7 +4500,6 @@ describe('Internal Routes', () => {
       const services: ServiceContainer = {
         researchRepo: fakeRepo,
       researchExportSettings: new FakeResearchExportSettings(),
-        pricingContext: fakePricingContext,
         generateId: (): string => 'generated-id-123',
         researchEventPublisher: new FakeResearchEventPublisher(),
         llmCallPublisher: new FakeLlmCallPublisher(),
@@ -4530,11 +4510,11 @@ describe('Internal Routes', () => {
         shareStorage: null,
         shareConfig: null,
         webAppUrl: 'https://app.example.com',
-        createResearchProvider: (_model, _apiKey, _userId, _pricing, _logger) => createFailingLlmResearchProvider('LLM API error'),
-        createSynthesizer: (_model, _apiKey, _userId, _pricing, _logger) => createFakeSynthesizer(),
-        createTitleGenerator: (_model, _apiKey, _userId, _pricing, _logger) => createFakeTitleGenerator(),
-        createContextInferrer: (_model, _apiKey, _userId, _pricing, _logger) => createFakeContextInferrer(),
-      createInputValidator: (_model, _apiKey, _userId, _pricing, _logger) => createFakeInputValidator(),
+        createResearchProvider: (_model, _apiKey, _userId, _logger) => createFailingLlmResearchProvider('LLM API error'),
+        createSynthesizer: (_model, _apiKey, _userId, _logger) => createFakeSynthesizer(),
+        createTitleGenerator: (_model, _apiKey, _userId, _logger) => createFakeTitleGenerator(),
+        createContextInferrer: (_model, _apiKey, _userId, _logger) => createFakeContextInferrer(),
+      createInputValidator: (_model, _apiKey, _userId, _logger) => createFakeInputValidator(),
         notionExporter: createFakeNotionExporter(),
       };
       setServices(services);
@@ -4692,7 +4672,6 @@ describe('Internal Routes', () => {
       const services: ServiceContainer = {
         researchRepo: fakeRepo,
       researchExportSettings: new FakeResearchExportSettings(),
-        pricingContext: fakePricingContext,
         generateId: (): string => 'generated-id-123',
         researchEventPublisher: new FakeResearchEventPublisher(),
         llmCallPublisher: new FakeLlmCallPublisher(),
@@ -4703,11 +4682,11 @@ describe('Internal Routes', () => {
         shareStorage: null,
         shareConfig: null,
         webAppUrl: 'https://app.example.com',
-        createResearchProvider: (_model, _apiKey, _userId, _pricing, _logger) => createFakeLlmResearchProvider(),
-        createSynthesizer: (_model, _apiKey, _userId, _pricing, _logger) => createFakeSynthesizer(),
-        createTitleGenerator: (_model, _apiKey, _userId, _pricing, _logger) => createFakeTitleGenerator(),
-        createContextInferrer: (_model, _apiKey, _userId, _pricing, _logger) => createFakeContextInferrer(),
-        createInputValidator: (_model, _apiKey, _userId, _pricing, _logger) => createFakeInputValidator(),
+        createResearchProvider: (_model, _apiKey, _userId, _logger) => createFakeLlmResearchProvider(),
+        createSynthesizer: (_model, _apiKey, _userId, _logger) => createFakeSynthesizer(),
+        createTitleGenerator: (_model, _apiKey, _userId, _logger) => createFakeTitleGenerator(),
+        createContextInferrer: (_model, _apiKey, _userId, _logger) => createFakeContextInferrer(),
+        createInputValidator: (_model, _apiKey, _userId, _logger) => createFakeInputValidator(),
         notionExporter: createFakeNotionExporter(),
       };
       setServices(services);
@@ -4757,7 +4736,6 @@ describe('Internal Routes', () => {
       const services: ServiceContainer = {
         researchRepo: fakeRepo,
       researchExportSettings: new FakeResearchExportSettings(),
-        pricingContext: fakePricingContext,
         generateId: (): string => 'generated-id-123',
         researchEventPublisher: new FakeResearchEventPublisher(),
         llmCallPublisher: fakeLlmCallPublisher,
@@ -4768,11 +4746,11 @@ describe('Internal Routes', () => {
         shareStorage: null,
         shareConfig: null,
         webAppUrl: 'https://app.example.com',
-        createResearchProvider: (_model, _apiKey, _userId, _pricing, _logger) => createFakeLlmResearchProvider(),
-        createSynthesizer: (_model, _apiKey, _userId, _pricing, _logger) => createFakeSynthesizer(),
-        createTitleGenerator: (_model, _apiKey, _userId, _pricing, _logger) => createFakeTitleGenerator(),
-        createContextInferrer: (_model, _apiKey, _userId, _pricing, _logger) => createFakeContextInferrer(),
-        createInputValidator: (_model, _apiKey, _userId, _pricing, _logger) => createFakeInputValidator(),
+        createResearchProvider: (_model, _apiKey, _userId, _logger) => createFakeLlmResearchProvider(),
+        createSynthesizer: (_model, _apiKey, _userId, _logger) => createFakeSynthesizer(),
+        createTitleGenerator: (_model, _apiKey, _userId, _logger) => createFakeTitleGenerator(),
+        createContextInferrer: (_model, _apiKey, _userId, _logger) => createFakeContextInferrer(),
+        createInputValidator: (_model, _apiKey, _userId, _logger) => createFakeInputValidator(),
         notionExporter: createFakeNotionExporter(),
       };
       setServices(services);
@@ -5066,7 +5044,6 @@ describe('Internal Routes', () => {
       const services: ServiceContainer = {
         researchRepo: fakeRepo,
       researchExportSettings: new FakeResearchExportSettings(),
-        pricingContext: fakePricingContext,
         generateId: (): string => 'generated-id-123',
         researchEventPublisher: new FakeResearchEventPublisher(),
         llmCallPublisher: fakeLlmCallPublisher,
@@ -5077,15 +5054,15 @@ describe('Internal Routes', () => {
         shareStorage: null,
         shareConfig: null,
         webAppUrl: 'https://app.example.com',
-        createResearchProvider: (_model, _apiKey, _userId, _pricing, _logger) =>
+        createResearchProvider: (_model, _apiKey, _userId, _logger) =>
           createFakeLlmResearchProvider('Research content', {
             sources: ['https://example.com/source1', 'https://example.com/source2'],
             usage: { inputTokens: 100, outputTokens: 200, costUsd: 0.005 },
           }),
-        createSynthesizer: (_model, _apiKey, _userId, _pricing, _logger) => createFakeSynthesizer(),
-        createTitleGenerator: (_model, _apiKey, _userId, _pricing, _logger) => createFakeTitleGenerator(),
-        createContextInferrer: (_model, _apiKey, _userId, _pricing, _logger) => createFakeContextInferrer(),
-        createInputValidator: (_model, _apiKey, _userId, _pricing, _logger) => createFakeInputValidator(),
+        createSynthesizer: (_model, _apiKey, _userId, _logger) => createFakeSynthesizer(),
+        createTitleGenerator: (_model, _apiKey, _userId, _logger) => createFakeTitleGenerator(),
+        createContextInferrer: (_model, _apiKey, _userId, _logger) => createFakeContextInferrer(),
+        createInputValidator: (_model, _apiKey, _userId, _logger) => createFakeInputValidator(),
         notionExporter: createFakeNotionExporter(),
       };
       setServices(services);
@@ -5157,7 +5134,6 @@ describe('Internal Routes', () => {
       const services: ServiceContainer = {
         researchRepo: fakeRepo,
         researchExportSettings: new FakeResearchExportSettings(),
-        pricingContext: fakePricingContext,
         generateId: (): string => 'generated-id-123',
         researchEventPublisher: new FakeResearchEventPublisher(),
         llmCallPublisher: new FakeLlmCallPublisher(),
@@ -5168,12 +5144,12 @@ describe('Internal Routes', () => {
         shareStorage: null,
         shareConfig: null,
         webAppUrl: 'https://app.example.com',
-        createResearchProvider: (_model, _apiKey, _userId, _pricing, _logger) =>
+        createResearchProvider: (_model, _apiKey, _userId, _logger) =>
           createFakeLlmResearchProvider(shortContent),
-        createSynthesizer: (_model, _apiKey, _userId, _pricing, _logger) => createFakeSynthesizer(),
-        createTitleGenerator: (_model, _apiKey, _userId, _pricing, _logger) => createFakeTitleGenerator(),
-        createContextInferrer: (_model, _apiKey, _userId, _pricing, _logger) => createFakeContextInferrer(),
-        createInputValidator: (_model, _apiKey, _userId, _pricing, _logger) => createFakeInputValidator(),
+        createSynthesizer: (_model, _apiKey, _userId, _logger) => createFakeSynthesizer(),
+        createTitleGenerator: (_model, _apiKey, _userId, _logger) => createFakeTitleGenerator(),
+        createContextInferrer: (_model, _apiKey, _userId, _logger) => createFakeContextInferrer(),
+        createInputValidator: (_model, _apiKey, _userId, _logger) => createFakeInputValidator(),
         notionExporter: createFakeNotionExporter(),
       };
       setServices(services);
@@ -5217,7 +5193,6 @@ describe('Internal Routes', () => {
       const services: ServiceContainer = {
         researchRepo: fakeRepo,
         researchExportSettings: new FakeResearchExportSettings(),
-        pricingContext: fakePricingContext,
         generateId: (): string => 'generated-id-123',
         researchEventPublisher: new FakeResearchEventPublisher(),
         llmCallPublisher: new FakeLlmCallPublisher(),
@@ -5228,12 +5203,12 @@ describe('Internal Routes', () => {
         shareStorage: null,
         shareConfig: null,
         webAppUrl: 'https://app.example.com',
-        createResearchProvider: (_model, _apiKey, _userId, _pricing, _logger) =>
+        createResearchProvider: (_model, _apiKey, _userId, _logger) =>
           createFakeLlmResearchProvider(longContent),
-        createSynthesizer: (_model, _apiKey, _userId, _pricing, _logger) => createFakeSynthesizer(),
-        createTitleGenerator: (_model, _apiKey, _userId, _pricing, _logger) => createFakeTitleGenerator(),
-        createContextInferrer: (_model, _apiKey, _userId, _pricing, _logger) => createFakeContextInferrer(),
-        createInputValidator: (_model, _apiKey, _userId, _pricing, _logger) => createFakeInputValidator(),
+        createSynthesizer: (_model, _apiKey, _userId, _logger) => createFakeSynthesizer(),
+        createTitleGenerator: (_model, _apiKey, _userId, _logger) => createFakeTitleGenerator(),
+        createContextInferrer: (_model, _apiKey, _userId, _logger) => createFakeContextInferrer(),
+        createInputValidator: (_model, _apiKey, _userId, _logger) => createFakeInputValidator(),
         notionExporter: createFakeNotionExporter(),
       };
       setServices(services);
@@ -5308,7 +5283,6 @@ describe('Internal Routes', () => {
       const services: ServiceContainer = {
         researchRepo: fakeRepo,
       researchExportSettings: new FakeResearchExportSettings(),
-        pricingContext: fakePricingContext,
         generateId: (): string => 'generated-id-123',
         researchEventPublisher: new FakeResearchEventPublisher(),
         llmCallPublisher: fakeLlmCallPublisher,
@@ -5319,12 +5293,12 @@ describe('Internal Routes', () => {
         shareStorage: null,
         shareConfig: null,
         webAppUrl: 'https://app.example.com',
-        createResearchProvider: (_model, _apiKey, _userId, _pricing, _logger) =>
+        createResearchProvider: (_model, _apiKey, _userId, _logger) =>
           createFailingLlmResearchProvider('LLM failed'),
-        createSynthesizer: (_model, _apiKey, _userId, _pricing, _logger) => createFakeSynthesizer(),
-        createTitleGenerator: (_model, _apiKey, _userId, _pricing, _logger) => createFakeTitleGenerator(),
-        createContextInferrer: (_model, _apiKey, _userId, _pricing, _logger) => createFakeContextInferrer(),
-        createInputValidator: (_model, _apiKey, _userId, _pricing, _logger) => createFakeInputValidator(),
+        createSynthesizer: (_model, _apiKey, _userId, _logger) => createFakeSynthesizer(),
+        createTitleGenerator: (_model, _apiKey, _userId, _logger) => createFakeTitleGenerator(),
+        createContextInferrer: (_model, _apiKey, _userId, _logger) => createFakeContextInferrer(),
+        createInputValidator: (_model, _apiKey, _userId, _logger) => createFakeInputValidator(),
         notionExporter: createFakeNotionExporter(),
       };
       setServices(services);
@@ -5387,7 +5361,6 @@ describe('Internal Routes', () => {
       const services: ServiceContainer = {
         researchRepo: fakeRepo,
       researchExportSettings: new FakeResearchExportSettings(),
-        pricingContext: fakePricingContext,
         generateId: (): string => 'generated-id-123',
         researchEventPublisher: new FakeResearchEventPublisher(),
         llmCallPublisher: new FakeLlmCallPublisher(),
@@ -5402,10 +5375,10 @@ describe('Internal Routes', () => {
           model === LlmModels.Gemini25Pro
             ? createFakeLlmResearchProvider('Success')
             : createFailingLlmResearchProvider('Failed'),
-        createSynthesizer: (_model, _apiKey, _userId, _pricing, _logger) => createFakeSynthesizer(),
-        createTitleGenerator: (_model, _apiKey, _userId, _pricing, _logger) => createFakeTitleGenerator(),
-        createContextInferrer: (_model, _apiKey, _userId, _pricing, _logger) => createFakeContextInferrer(),
-        createInputValidator: (_model, _apiKey, _userId, _pricing, _logger) => createFakeInputValidator(),
+        createSynthesizer: (_model, _apiKey, _userId, _logger) => createFakeSynthesizer(),
+        createTitleGenerator: (_model, _apiKey, _userId, _logger) => createFakeTitleGenerator(),
+        createContextInferrer: (_model, _apiKey, _userId, _logger) => createFakeContextInferrer(),
+        createInputValidator: (_model, _apiKey, _userId, _logger) => createFakeInputValidator(),
         notionExporter: createFakeNotionExporter(),
       };
       setServices(services);
@@ -5464,7 +5437,6 @@ describe('Internal Routes', () => {
       const services: ServiceContainer = {
         researchRepo: fakeRepo,
         researchExportSettings: new FakeResearchExportSettings(),
-        pricingContext: fakePricingContext,
         generateId: (): string => 'generated-id-123',
         researchEventPublisher: new FakeResearchEventPublisher(),
         llmCallPublisher: new FakeLlmCallPublisher(),
@@ -5620,7 +5592,6 @@ describe('Research Routes - Coverage Tests for Uncovered Branches', () => {
     const services: ServiceContainer = {
       researchRepo: fakeRepo,
       researchExportSettings: new FakeResearchExportSettings(),
-      pricingContext: fakePricingContext,
       generateId: (): string => 'generated-id-123',
       researchEventPublisher: fakeResearchEventPublisher,
       llmCallPublisher: fakeLlmCallPublisher,
@@ -5631,12 +5602,12 @@ describe('Research Routes - Coverage Tests for Uncovered Branches', () => {
       shareStorage: null,
       shareConfig: null,
       webAppUrl: 'https://app.example.com',
-      createResearchProvider: (_model, _apiKey, _userId, _pricing, _logger) =>
+      createResearchProvider: (_model, _apiKey, _userId, _logger) =>
         createFakeLlmResearchProvider(),
-      createSynthesizer: (_model, _apiKey, _userId, _pricing, _logger) => createFakeSynthesizer(),
-      createTitleGenerator: (_model, _apiKey, _userId, _pricing, _logger) => createFakeTitleGenerator(),
-      createContextInferrer: (_model, _apiKey, _userId, _pricing, _logger) => createFakeContextInferrer(),
-      createInputValidator: (_model, _apiKey, _userId, _pricing, _logger) => createFakeInputValidator(),
+      createSynthesizer: (_model, _apiKey, _userId, _logger) => createFakeSynthesizer(),
+      createTitleGenerator: (_model, _apiKey, _userId, _logger) => createFakeTitleGenerator(),
+      createContextInferrer: (_model, _apiKey, _userId, _logger) => createFakeContextInferrer(),
+      createInputValidator: (_model, _apiKey, _userId, _logger) => createFakeInputValidator(),
       notionExporter: createFakeNotionExporter(),
     };
     setServices(services);
@@ -5745,7 +5716,6 @@ describe('Research Routes - Coverage Tests for Uncovered Branches', () => {
       const services: ServiceContainer = {
         researchRepo: fakeRepo,
       researchExportSettings: new FakeResearchExportSettings(),
-        pricingContext: fakePricingContext,
         generateId: (): string => 'generated-id-123',
         researchEventPublisher: fakeResearchEventPublisher,
         llmCallPublisher: fakeLlmCallPublisher,
@@ -5836,7 +5806,6 @@ describe('Research Routes - Coverage Tests for Uncovered Branches', () => {
       const services: ServiceContainer = {
         researchRepo: fakeRepo,
       researchExportSettings: new FakeResearchExportSettings(),
-        pricingContext: fakePricingContext,
         generateId: (): string => 'generated-id-123',
         researchEventPublisher: fakeResearchEventPublisher,
         llmCallPublisher: fakeLlmCallPublisher,
@@ -6183,7 +6152,6 @@ describe('Research Routes - Coverage Tests for Uncovered Branches', () => {
       const services: ServiceContainer = {
         researchRepo: fakeRepo,
       researchExportSettings: new FakeResearchExportSettings(),
-        pricingContext: fakePricingContext,
         generateId: (): string => 'generated-id-123',
         researchEventPublisher: fakeResearchEventPublisher,
         llmCallPublisher: fakeLlmCallPublisher,
@@ -6234,7 +6202,6 @@ describe('Research Routes - Coverage Tests for Uncovered Branches', () => {
       const services: ServiceContainer = {
         researchRepo: fakeRepo,
       researchExportSettings: new FakeResearchExportSettings(),
-        pricingContext: fakePricingContext,
         generateId: (): string => 'generated-id-123',
         researchEventPublisher: fakeResearchEventPublisher,
         llmCallPublisher: fakeLlmCallPublisher,
@@ -6341,7 +6308,6 @@ describe('Research Routes - Coverage Tests for Uncovered Branches', () => {
       const services: ServiceContainer = {
         researchRepo: fakeRepo,
       researchExportSettings: new FakeResearchExportSettings(),
-        pricingContext: fakePricingContext,
         generateId: (): string => 'generated-id-123',
         researchEventPublisher: fakeResearchEventPublisher,
         llmCallPublisher: fakeLlmCallPublisher,
@@ -7303,7 +7269,6 @@ describe('Research Routes - Coverage Tests for Uncovered Branches', () => {
       const services: ServiceContainer = {
         researchRepo: fakeRepo,
         researchExportSettings: new FakeResearchExportSettings(),
-        pricingContext: fakePricingContext,
         generateId: (): string => 'generated-id-123',
         researchEventPublisher: new FakeResearchEventPublisher(),
         llmCallPublisher: new (await import('./fakes.js')).FakeLlmCallPublisher(),
@@ -7315,10 +7280,10 @@ describe('Research Routes - Coverage Tests for Uncovered Branches', () => {
         shareConfig: null,
         webAppUrl: 'https://app.example.com',
         createResearchProvider: () => providerWithUsageNoCost,
-        createSynthesizer: (_model, _apiKey, _userId, _pricing, _logger) => createFakeSynthesizer(),
-        createTitleGenerator: (_model, _apiKey, _userId, _pricing, _logger) => createFakeTitleGenerator(),
-        createContextInferrer: (_model, _apiKey, _userId, _pricing, _logger) => createFakeContextInferrer(),
-        createInputValidator: (_model, _apiKey, _userId, _pricing, _logger) => createFakeInputValidator(),
+        createSynthesizer: (_model, _apiKey, _userId, _logger) => createFakeSynthesizer(),
+        createTitleGenerator: (_model, _apiKey, _userId, _logger) => createFakeTitleGenerator(),
+        createContextInferrer: (_model, _apiKey, _userId, _logger) => createFakeContextInferrer(),
+        createInputValidator: (_model, _apiKey, _userId, _logger) => createFakeInputValidator(),
         notionExporter: createFakeNotionExporter(),
       };
       setServices(services);

--- a/apps/research-agent/src/__tests__/routes/helpers/synthesisHelper.test.ts
+++ b/apps/research-agent/src/__tests__/routes/helpers/synthesisHelper.test.ts
@@ -8,7 +8,6 @@ import { beforeEach, describe, it, expect, vi } from 'vitest';
 import { createSynthesisProviders } from '../../../routes/helpers/synthesisHelper.js';
 import type { DecryptedApiKeys, ServiceContainer } from '../../../services.js';
 import { LlmModels, LlmProviders } from '@intexuraos/llm-contract';
-import * as openrouterModule from '@intexuraos/infra-openrouter';
 import type { ResearchModel } from '../../../domain/research/index.js';
 
 const mockLogger = {
@@ -35,9 +34,6 @@ describe('createSynthesisProviders', () => {
   const mockServices: ServiceContainer = {
     createSynthesizer: mockCreateSynthesizer,
     createContextInferrer: mockCreateContextInferrer,
-    pricingContext: {
-      getPricing: () => ({ inputCostPerMillionTokens: 0.1, outputCostPerMillionTokens: 0.2 }),
-    },
   } as unknown as ServiceContainer;
 
   beforeEach(() => {
@@ -63,7 +59,6 @@ describe('createSynthesisProviders', () => {
       'or:anthropic/claude-sonnet-4.6',
       'test-or-key',
       'user-123',
-      expect.any(Object),
       mockLogger,
       'research-123'
     );
@@ -71,7 +66,6 @@ describe('createSynthesisProviders', () => {
       LlmModels.Gemini25Flash,
       'test-google-key',
       'user-123',
-      expect.any(Object),
       mockLogger,
       'research-123'
     );
@@ -169,7 +163,7 @@ describe('createSynthesisProviders', () => {
     ).toThrow("OpenRouter model 'or:unknown-provider/not-in-allowlist' is not in the curated allowlist");
   });
 
-  it('uses allowlist pricing for valid OpenRouter models', () => {
+  it('succeeds for valid allowlisted OpenRouter models', () => {
     const apiKeys: DecryptedApiKeys = {
       openrouter: 'test-or-key',
     };
@@ -189,29 +183,4 @@ describe('createSynthesisProviders', () => {
     expect(result.synthesizer).toBeDefined();
   });
 
-  it('throws when getAllowlistPricing returns undefined for an allowed model', () => {
-    const apiKeys: DecryptedApiKeys = {
-      openrouter: 'test-or-key',
-    };
-
-    const validOrModel = 'or:anthropic/claude-sonnet-4.6' as ResearchModel;
-
-    // Temporarily make getAllowlistPricing return undefined while isAllowedModel still returns true
-    const spy = vi.spyOn(openrouterModule, 'getAllowlistPricing').mockReturnValue(undefined);
-
-    try {
-      expect(() =>
-        createSynthesisProviders(
-          validOrModel,
-          apiKeys,
-          'user-123',
-          undefined,
-          mockServices,
-          mockLogger as never
-        )
-      ).toThrow('No pricing for allowlisted model: or:anthropic/claude-sonnet-4.6');
-    } finally {
-      spy.mockRestore();
-    }
-  });
 });

--- a/apps/research-agent/src/__tests__/routes/openRouterRoutes.test.ts
+++ b/apps/research-agent/src/__tests__/routes/openRouterRoutes.test.ts
@@ -22,7 +22,6 @@ import {
   FakeNotionServiceClient,
   createFakeNotionExporter,
 } from '../fakes.js';
-import { FakePricingContext } from '@intexuraos/llm-pricing';
 import { OPENROUTER_ALLOWED_MODELS } from '@intexuraos/infra-openrouter';
 
 const INTEXURAOS_AUTH0_DOMAIN = 'test-tenant.eu.auth0.com';
@@ -87,7 +86,6 @@ describe('OpenRouter Routes - GET /research/openrouter/models', () => {
     const services: ServiceContainer = {
       researchRepo: new FakeResearchRepository(),
       researchExportSettings: new FakeResearchExportSettings(),
-      pricingContext: new FakePricingContext(),
       generateId: (): string => 'generated-id-123',
       researchEventPublisher: new FakeResearchEventPublisher(),
       llmCallPublisher: new FakeLlmCallPublisher(),

--- a/apps/research-agent/src/__tests__/routes/researchExportRoutes.test.ts
+++ b/apps/research-agent/src/__tests__/routes/researchExportRoutes.test.ts
@@ -22,7 +22,6 @@ import {
   createFakeNotionExporter,
   createFailingNotionExporter,
 } from '../fakes.js';
-import { FakePricingContext } from '@intexuraos/llm-pricing';
 import { LlmModels } from '@intexuraos/llm-contract';
 import type { ResearchModel } from '@intexuraos/llm-contract';
 import type { ResearchExportSettingsError } from '../../infra/firestore/researchExportSettingsRepository.js';
@@ -43,7 +42,6 @@ describe('Research Export Routes - Unauthenticated', () => {
     const services: ServiceContainer = {
       researchRepo: new FakeResearchRepository(),
       researchExportSettings: new FakeResearchExportSettings(),
-      pricingContext: new FakePricingContext(),
       generateId: (): string => 'generated-id-123',
       researchEventPublisher: new FakeResearchEventPublisher(),
       llmCallPublisher: new FakeLlmCallPublisher(),
@@ -181,7 +179,6 @@ describe('Research Export Routes - Authenticated', () => {
       const services: ServiceContainer = {
         researchRepo: new FakeResearchRepository(),
         researchExportSettings: fakeResearchExportSettings,
-        pricingContext: new FakePricingContext(),
         generateId: (): string => 'generated-id-123',
         researchEventPublisher: new FakeResearchEventPublisher(),
         llmCallPublisher: new FakeLlmCallPublisher(),
@@ -276,7 +273,6 @@ describe('Research Export Routes - Authenticated', () => {
       const services: ServiceContainer = {
         researchRepo: new FakeResearchRepository(),
         researchExportSettings: new FailingFakeResearchExportSettings(),
-        pricingContext: new FakePricingContext(),
         generateId: (): string => 'generated-id-123',
         researchEventPublisher: new FakeResearchEventPublisher(),
         llmCallPublisher: new FakeLlmCallPublisher(),
@@ -335,7 +331,6 @@ describe('Research Export Routes - Authenticated', () => {
       const services: ServiceContainer = {
         researchRepo: new FakeResearchRepository(),
         researchExportSettings: new FakeResearchExportSettings(),
-        pricingContext: new FakePricingContext(),
         generateId: (): string => 'generated-id-123',
         researchEventPublisher: new FakeResearchEventPublisher(),
         llmCallPublisher: new FakeLlmCallPublisher(),
@@ -503,7 +498,6 @@ describe('Research Export Routes - Authenticated', () => {
       const services: ServiceContainer = {
         researchRepo: new FakeResearchRepository(),
         researchExportSettings: fakeResearchExportSettings,
-        pricingContext: new FakePricingContext(),
         generateId: (): string => 'generated-id-123',
         researchEventPublisher: new FakeResearchEventPublisher(),
         llmCallPublisher: new FakeLlmCallPublisher(),
@@ -666,7 +660,6 @@ describe('Research Export Routes - Authenticated', () => {
       const services: ServiceContainer = {
         researchRepo: new FakeResearchRepository(),
         researchExportSettings: new FailingFakeResearchExportSettings(),
-        pricingContext: new FakePricingContext(),
         generateId: (): string => 'generated-id-123',
         researchEventPublisher: new FakeResearchEventPublisher(),
         llmCallPublisher: new FakeLlmCallPublisher(),
@@ -735,7 +728,6 @@ describe('Research Export Routes - Authenticated', () => {
       const services: ServiceContainer = {
         researchRepo: fakeResearchRepo,
         researchExportSettings: fakeResearchExportSettings,
-        pricingContext: new FakePricingContext(),
         generateId: (): string => 'generated-id-123',
         researchEventPublisher: new FakeResearchEventPublisher(),
         llmCallPublisher: new FakeLlmCallPublisher(),
@@ -1091,7 +1083,6 @@ describe('Research Export Routes - Authenticated', () => {
       const services: ServiceContainer = {
         researchRepo: fakeResearchRepo,
         researchExportSettings: fakeResearchExportSettings,
-        pricingContext: new FakePricingContext(),
         generateId: (): string => 'generated-id-123',
         researchEventPublisher: new FakeResearchEventPublisher(),
         llmCallPublisher: new FakeLlmCallPublisher(),
@@ -1158,7 +1149,6 @@ describe('Research Export Routes - Authenticated', () => {
       const services: ServiceContainer = {
         researchRepo: fakeResearchRepo,
         researchExportSettings: fakeResearchExportSettings,
-        pricingContext: new FakePricingContext(),
         generateId: (): string => 'generated-id-123',
         researchEventPublisher: new FakeResearchEventPublisher(),
         llmCallPublisher: new FakeLlmCallPublisher(),
@@ -1225,7 +1215,6 @@ describe('Research Export Routes - Authenticated', () => {
       const services: ServiceContainer = {
         researchRepo: fakeResearchRepo,
         researchExportSettings: fakeResearchExportSettings,
-        pricingContext: new FakePricingContext(),
         generateId: (): string => 'generated-id-123',
         researchEventPublisher: new FakeResearchEventPublisher(),
         llmCallPublisher: new FakeLlmCallPublisher(),
@@ -1292,7 +1281,6 @@ describe('Research Export Routes - Authenticated', () => {
       const services: ServiceContainer = {
         researchRepo: fakeResearchRepo,
         researchExportSettings: fakeResearchExportSettings,
-        pricingContext: new FakePricingContext(),
         generateId: (): string => 'generated-id-123',
         researchEventPublisher: new FakeResearchEventPublisher(),
         llmCallPublisher: new FakeLlmCallPublisher(),

--- a/apps/research-agent/src/domain/research/services/contextLabels.ts
+++ b/apps/research-agent/src/domain/research/services/contextLabels.ts
@@ -5,7 +5,7 @@
 
 import { LlmModels } from '@intexuraos/llm-contract';
 import type { Logger } from '@intexuraos/common-core';
-import type { ModelPricing, Gemini25Flash } from '@intexuraos/llm-contract';
+import type { Gemini25Flash } from '@intexuraos/llm-contract';
 import type { TitleGenerator } from '../ports/llmProvider.js';
 
 export interface ContextWithLabel {
@@ -22,11 +22,9 @@ export async function generateContextLabels(
     model: Gemini25Flash,
     apiKey: string,
     userId: string,
-    pricing: ModelPricing,
     logger: Logger,
     researchId: string | undefined
   ) => TitleGenerator,
-  pricing: ModelPricing,
   logger: Logger
 ): Promise<ContextWithLabel[]> {
   if (googleApiKey === undefined) {
@@ -37,7 +35,6 @@ export async function generateContextLabels(
     LlmModels.Gemini25Flash,
     googleApiKey,
     userId,
-    pricing,
     logger,
     researchId
   );

--- a/apps/research-agent/src/index.ts
+++ b/apps/research-agent/src/index.ts
@@ -1,11 +1,5 @@
 import { validateRequiredEnv } from '@intexuraos/http-server';
 import { getErrorMessage } from '@intexuraos/common-core';
-import {
-  fetchAllPricingWithRetry,
-  createPricingContext,
-  type IPricingContext,
-} from '@intexuraos/llm-pricing';
-import { type LLMModel, LlmModels } from '@intexuraos/llm-contract';
 import { buildServer } from './server.js';
 import { initializeServices } from './services.js';
 import { initSentry } from '@intexuraos/infra-sentry';
@@ -44,43 +38,9 @@ initSentry(sentryConfig);
 const PORT = Number(process.env['PORT'] ?? 8080);
 const HOST = process.env['HOST'] ?? '0.0.0.0';
 
-/** All models used by research-agent for research and synthesis */
-const REQUIRED_MODELS: LLMModel[] = [
-  // Research models
-  LlmModels.Gemini25Pro,
-  LlmModels.Gemini25Flash,
-  LlmModels.ClaudeOpus46,
-  LlmModels.ClaudeSonnet46,
-  LlmModels.O4MiniDeepResearch,
-  LlmModels.GPT54,
-  LlmModels.Sonar,
-  LlmModels.SonarPro,
-  LlmModels.SonarDeepResearch,
-  // Fast models for title generation
-  LlmModels.Gemini20Flash,
-];
-
-async function loadPricing(): Promise<IPricingContext> {
-  const usageServiceUrl = process.env['INTEXURAOS_LLM_USAGE_SERVICE_URL'] ?? '';
-  const internalAuthToken = process.env['INTEXURAOS_INTERNAL_AUTH_TOKEN'] ?? '';
-
-  process.stdout.write(`Fetching pricing from ${usageServiceUrl}\n`);
-  const pricingResult = await fetchAllPricingWithRetry(usageServiceUrl, internalAuthToken);
-  if (!pricingResult.ok) {
-    throw new Error(`Failed to fetch pricing: ${pricingResult.error.message}`);
-  }
-
-  const context = createPricingContext(pricingResult.value, REQUIRED_MODELS);
-  process.stdout.write(`Loaded pricing for ${String(REQUIRED_MODELS.length)} models: ${REQUIRED_MODELS.join(', ')}\n`);
-  return context;
-}
-
 async function main(): Promise<void> {
-  // Load pricing from llm-usage-service
-  const pricingContext = await loadPricing();
-
   // Initialize dependency injection container
-  initializeServices(pricingContext);
+  initializeServices();
 
   const app = await buildServer();
 

--- a/apps/research-agent/src/infra/llm/ClaudeAdapter.ts
+++ b/apps/research-agent/src/infra/llm/ClaudeAdapter.ts
@@ -5,7 +5,6 @@
 
 import { type ClaudeClient, createClaudeClient } from '@intexuraos/infra-claude';
 import type { Logger, Result } from '@intexuraos/common-core';
-import type { ModelPricing } from '@intexuraos/llm-contract';
 import type { UsageSink } from '@intexuraos/llm-pricing';
 import { buildResearchPrompt, type ResearchContext } from '@intexuraos/llm-prompts';
 import type {
@@ -23,7 +22,6 @@ export class ClaudeAdapter implements LlmResearchProvider {
     apiKey: string,
     model: string,
     userId: string,
-    pricing: ModelPricing,
     logger: Logger,
     usageSink: UsageSink,
     researchId?: string
@@ -33,7 +31,6 @@ export class ClaudeAdapter implements LlmResearchProvider {
       model,
       userId,
       ...(researchId !== undefined && { researchId }),
-      pricing,
       logger,
       usageSink,
     });

--- a/apps/research-agent/src/infra/llm/ContextInferenceAdapter.ts
+++ b/apps/research-agent/src/infra/llm/ContextInferenceAdapter.ts
@@ -4,7 +4,6 @@
  */
 
 import { createGeminiClient, type GeminiClient } from '@intexuraos/infra-gemini';
-import type { ModelPricing } from '@intexuraos/llm-contract';
 import type { UsageSink } from '@intexuraos/llm-pricing';
 import {
   buildInferResearchContextPrompt,
@@ -74,7 +73,6 @@ export class ContextInferenceAdapter implements ContextInferenceProvider {
     apiKey: string,
     model: string,
     userId: string,
-    pricing: ModelPricing,
     logger: Logger,
     usageSink: UsageSink,
     researchId?: string
@@ -84,7 +82,6 @@ export class ContextInferenceAdapter implements ContextInferenceProvider {
       model,
       userId,
       ...(researchId !== undefined && { researchId }),
-      pricing,
       logger,
       usageSink,
     });

--- a/apps/research-agent/src/infra/llm/GeminiAdapter.ts
+++ b/apps/research-agent/src/infra/llm/GeminiAdapter.ts
@@ -5,7 +5,6 @@
 
 import { createGeminiClient, type GeminiClient } from '@intexuraos/infra-gemini';
 import type { Logger, Result } from '@intexuraos/common-core';
-import type { ModelPricing } from '@intexuraos/llm-contract';
 import type { UsageSink } from '@intexuraos/llm-pricing';
 import {
   buildResearchPrompt,
@@ -34,7 +33,6 @@ export class GeminiAdapter implements LlmResearchProvider, LlmSynthesisProvider 
     apiKey: string,
     model: string,
     userId: string,
-    pricing: ModelPricing,
     logger: Logger,
     usageSink: UsageSink,
     researchId?: string
@@ -44,7 +42,6 @@ export class GeminiAdapter implements LlmResearchProvider, LlmSynthesisProvider 
       model,
       userId,
       ...(researchId !== undefined && { researchId }),
-      pricing,
       logger,
       usageSink,
     });

--- a/apps/research-agent/src/infra/llm/GptAdapter.ts
+++ b/apps/research-agent/src/infra/llm/GptAdapter.ts
@@ -5,7 +5,6 @@
 
 import { createGptClient, type GptClient } from '@intexuraos/infra-gpt';
 import type { Logger, Result } from '@intexuraos/common-core';
-import type { ModelPricing } from '@intexuraos/llm-contract';
 import type { UsageSink } from '@intexuraos/llm-pricing';
 import { buildResearchPrompt, buildSynthesisPrompt, titlePrompt, type ResearchContext, type SynthesisContext } from '@intexuraos/llm-prompts';
 import type {
@@ -26,7 +25,6 @@ export class  GptAdapter implements LlmResearchProvider, LlmSynthesisProvider {
     apiKey: string,
     model: string,
     userId: string,
-    pricing: ModelPricing,
     logger: Logger,
     usageSink: UsageSink,
     researchId?: string
@@ -36,7 +34,6 @@ export class  GptAdapter implements LlmResearchProvider, LlmSynthesisProvider {
       model,
       userId,
       ...(researchId !== undefined && { researchId }),
-      pricing,
       logger,
       usageSink,
     });

--- a/apps/research-agent/src/infra/llm/InputValidationAdapter.ts
+++ b/apps/research-agent/src/infra/llm/InputValidationAdapter.ts
@@ -4,7 +4,6 @@
  */
 
 import { createGeminiClient, type GeminiClient } from '@intexuraos/infra-gemini';
-import type { ModelPricing } from '@intexuraos/llm-contract';
 import type { UsageSink } from '@intexuraos/llm-pricing';
 import {
   buildImprovementRepairPrompt,
@@ -51,11 +50,10 @@ export class InputValidationAdapter implements InputValidationProvider {
     apiKey: string,
     model: string,
     userId: string,
-    pricing: ModelPricing,
     logger: Logger,
     usageSink: UsageSink
   ) {
-    this.client = createGeminiClient({ apiKey, model, userId, pricing, logger, usageSink });
+    this.client = createGeminiClient({ apiKey, model, userId, logger, usageSink });
     this.model = model;
     this.logger = logger;
   }

--- a/apps/research-agent/src/infra/llm/LlmAdapterFactory.ts
+++ b/apps/research-agent/src/infra/llm/LlmAdapterFactory.ts
@@ -6,7 +6,6 @@
 import type { Logger } from '@intexuraos/common-core';
 import {
   getProviderForModel,
-  type ModelPricing,
   type ResearchModel,
   type FastModel,
 } from '@intexuraos/llm-contract';
@@ -32,7 +31,6 @@ export function createResearchProvider(
   model: ResearchModel,
   apiKey: string,
   userId: string,
-  pricing: ModelPricing,
   logger: Logger,
   usageSink: UsageSink,
   researchId: string | undefined // @allow-undefined-type -- positional arg kept for call-site compat
@@ -41,15 +39,15 @@ export function createResearchProvider(
 
   switch (provider) {
     case 'google':
-      return new GeminiAdapter(apiKey, model, userId, pricing, logger, usageSink, researchId);
+      return new GeminiAdapter(apiKey, model, userId, logger, usageSink, researchId);
     case 'anthropic':
-      return new ClaudeAdapter(apiKey, model, userId, pricing, logger, usageSink, researchId);
+      return new ClaudeAdapter(apiKey, model, userId, logger, usageSink, researchId);
     case 'openai':
-      return new GptAdapter(apiKey, model, userId, pricing, logger, usageSink, researchId);
+      return new GptAdapter(apiKey, model, userId, logger, usageSink, researchId);
     case 'perplexity':
-      return new PerplexityAdapter(apiKey, model, userId, pricing, logger, usageSink, researchId);
+      return new PerplexityAdapter(apiKey, model, userId, logger, usageSink, researchId);
     case 'openrouter':
-      return new OpenRouterAdapter(apiKey, model, userId, pricing, logger, usageSink, researchId);
+      return new OpenRouterAdapter(apiKey, model, userId, logger, usageSink, researchId);
   }
 }
 
@@ -57,7 +55,6 @@ export function createSynthesizer(
   model: ResearchModel,
   apiKey: string,
   userId: string,
-  pricing: ModelPricing,
   logger: Logger,
   usageSink: UsageSink,
   researchId: string | undefined // @allow-undefined-type -- positional arg kept for call-site compat
@@ -66,15 +63,15 @@ export function createSynthesizer(
 
   switch (provider) {
     case 'google':
-      return new GeminiAdapter(apiKey, model, userId, pricing, logger, usageSink, researchId);
+      return new GeminiAdapter(apiKey, model, userId, logger, usageSink, researchId);
     case 'anthropic':
       throw new Error('Anthropic does not support synthesis');
     case 'openai':
-      return new GptAdapter(apiKey, model, userId, pricing, logger, usageSink, researchId);
+      return new GptAdapter(apiKey, model, userId, logger, usageSink, researchId);
     case 'perplexity':
       throw new Error('Perplexity does not support synthesis');
     case 'openrouter':
-      return new OpenRouterAdapter(apiKey, model, userId, pricing, logger, usageSink, researchId);
+      return new OpenRouterAdapter(apiKey, model, userId, logger, usageSink, researchId);
   }
 }
 
@@ -82,35 +79,32 @@ export function createTitleGenerator(
   model: FastModel,
   apiKey: string,
   userId: string,
-  pricing: ModelPricing,
   logger: Logger,
   usageSink: UsageSink,
   researchId: string | undefined // @allow-undefined-type -- positional arg kept for call-site compat
 ): TitleGenerator {
-  return new GeminiAdapter(apiKey, model, userId, pricing, logger, usageSink, researchId);
+  return new GeminiAdapter(apiKey, model, userId, logger, usageSink, researchId);
 }
 
 export function createContextInferrer(
   model: FastModel,
   apiKey: string,
   userId: string,
-  pricing: ModelPricing,
   logger: Logger,
   usageSink: UsageSink,
   researchId: string | undefined // @allow-undefined-type -- positional arg kept for call-site compat
 ): ContextInferenceProvider {
-  return new ContextInferenceAdapter(apiKey, model, userId, pricing, logger, usageSink, researchId);
+  return new ContextInferenceAdapter(apiKey, model, userId, logger, usageSink, researchId);
 }
 
 export function createInputValidator(
   model: FastModel,
   apiKey: string,
   userId: string,
-  pricing: ModelPricing,
   logger: Logger,
   usageSink: UsageSink
 ): InputValidationProvider {
-  return new InputValidationAdapter(apiKey, model, userId, pricing, logger, usageSink);
+  return new InputValidationAdapter(apiKey, model, userId, logger, usageSink);
 }
 
 export type { InputValidationProvider };

--- a/apps/research-agent/src/infra/llm/OpenRouterAdapter.ts
+++ b/apps/research-agent/src/infra/llm/OpenRouterAdapter.ts
@@ -9,7 +9,7 @@
 
 import { createOpenRouterClient, type OpenRouterClient } from '@intexuraos/infra-openrouter';
 import type { Logger, Result } from '@intexuraos/common-core';
-import { type ModelPricing, isOpenRouterModel, getOpenRouterRawId } from '@intexuraos/llm-contract';
+import { isOpenRouterModel, getOpenRouterRawId } from '@intexuraos/llm-contract';
 import type { UsageSink } from '@intexuraos/llm-pricing';
 import { buildResearchPrompt, buildSynthesisPrompt, titlePrompt, type ResearchContext, type SynthesisContext } from '@intexuraos/llm-prompts';
 import type {
@@ -30,7 +30,6 @@ export class OpenRouterAdapter implements LlmResearchProvider, LlmSynthesisProvi
     apiKey: string,
     model: string,
     userId: string,
-    pricing: ModelPricing,
     logger: Logger,
     usageSink: UsageSink,
     researchId?: string
@@ -42,7 +41,6 @@ export class OpenRouterAdapter implements LlmResearchProvider, LlmSynthesisProvi
       model: rawModel,
       userId,
       ...(researchId !== undefined && { researchId }),
-      pricing,
       logger,
       usageSink,
     });

--- a/apps/research-agent/src/infra/llm/PerplexityAdapter.ts
+++ b/apps/research-agent/src/infra/llm/PerplexityAdapter.ts
@@ -6,7 +6,6 @@
 
 import { createPerplexityClient, type PerplexityClient } from '@intexuraos/infra-perplexity';
 import type { Logger, Result } from '@intexuraos/common-core';
-import type { ModelPricing } from '@intexuraos/llm-contract';
 import type { UsageSink } from '@intexuraos/llm-pricing';
 import { buildResearchPrompt, type ResearchContext } from '@intexuraos/llm-prompts';
 import type {
@@ -24,7 +23,6 @@ export class PerplexityAdapter implements LlmResearchProvider {
     apiKey: string,
     model: string,
     userId: string,
-    pricing: ModelPricing,
     logger: Logger,
     usageSink: UsageSink,
     researchId?: string
@@ -34,7 +32,6 @@ export class PerplexityAdapter implements LlmResearchProvider {
       model,
       userId,
       ...(researchId !== undefined && { researchId }),
-      pricing,
       logger,
       usageSink,
     });

--- a/apps/research-agent/src/routes/helpers/__tests__/completionHandlers.test.ts
+++ b/apps/research-agent/src/routes/helpers/__tests__/completionHandlers.test.ts
@@ -118,9 +118,6 @@ describe('handleAllCompleted', () => {
             })
           ),
         }),
-        pricingContext: {
-          getPricing: () => ({ inputPricePerMillion: 0.1, outputPricePerMillion: 0.2 }),
-        },
       } as unknown as AllCompletedHandlerParams['services'],
       userServiceClient: {
         reportLlmSuccess: vi.fn().mockResolvedValue(ok(undefined)),
@@ -265,9 +262,6 @@ describe('handleAllCompleted', () => {
           })
         ),
       }),
-      pricingContext: {
-        getPricing: () => ({ inputPricePerMillion: 0.1, outputPricePerMillion: 0.2 }),
-      },
     } as unknown as AllCompletedHandlerParams['services'];
 
     await handleAllCompleted(mockParams);
@@ -353,9 +347,6 @@ describe('handleAllCompleted', () => {
           })
         ),
       }),
-      pricingContext: {
-        getPricing: () => ({ inputPricePerMillion: 0.1, outputPricePerMillion: 0.2 }),
-      },
     } as unknown as AllCompletedHandlerParams['services'];
 
     await handleAllCompleted(mockParams);

--- a/apps/research-agent/src/routes/helpers/synthesisHelper.ts
+++ b/apps/research-agent/src/routes/helpers/synthesisHelper.ts
@@ -2,8 +2,8 @@
  * Synthesis helper functions for creating synthesis providers.
  */
 
-import { getProviderForModel, isOpenRouterModel, getOpenRouterRawId, LlmModels, type LLMModel, type ModelPricing } from '@intexuraos/llm-contract';
-import { getAllowlistPricing, isAllowedModel } from '@intexuraos/infra-openrouter';
+import { getProviderForModel, isOpenRouterModel, getOpenRouterRawId, LlmModels } from '@intexuraos/llm-contract';
+import { isAllowedModel } from '@intexuraos/infra-openrouter';
 import type { ResearchModel } from '../../domain/research/index.js';
 import type { ServiceContainer, DecryptedApiKeys } from '../../services.js';
 import type { Logger } from '@intexuraos/common-core';
@@ -23,7 +23,7 @@ export function createSynthesisProviders(
   services: ServiceContainer,
   logger: Logger
 ): SynthesisProviders {
-  const { createSynthesizer, createContextInferrer, pricingContext } = services;
+  const { createSynthesizer, createContextInferrer } = services;
 
   const synthesisProvider = getProviderForModel(synthesisModel);
   const synthesisKey = apiKeys[synthesisProvider];
@@ -35,17 +35,6 @@ export function createSynthesisProviders(
     );
   }
 
-  let synthesisPricing: ModelPricing;
-  if (isOpenRouterModel(synthesisModel)) {
-    const pricing = getAllowlistPricing(getOpenRouterRawId(synthesisModel));
-    if (pricing === undefined) {
-      throw new Error(`No pricing for allowlisted model: ${String(synthesisModel)}`);
-    }
-    synthesisPricing = pricing;
-  } else {
-    synthesisPricing = pricingContext.getPricing(synthesisModel as LLMModel);
-  }
-
   if (synthesisKey === undefined || synthesisKey === '') {
     throw new Error(`No API key configured for provider '${synthesisProvider}'`);
   }
@@ -54,7 +43,6 @@ export function createSynthesisProviders(
     synthesisModel,
     synthesisKey,
     userId,
-    synthesisPricing,
     logger,
     researchId
   );
@@ -66,7 +54,6 @@ export function createSynthesisProviders(
       LlmModels.Gemini25Flash,
       apiKeys.google,
       userId,
-      pricingContext.getPricing(LlmModels.Gemini25Flash),
       logger,
       researchId
     );

--- a/apps/research-agent/src/routes/internalRoutes.ts
+++ b/apps/research-agent/src/routes/internalRoutes.ts
@@ -22,8 +22,8 @@ import {
   type TextGenerationClient,
 } from '../domain/research/index.js';
 import { formatLlmError } from '../domain/research/formatLlmError.js';
-import { getProviderForModel, isOpenRouterModel, getOpenRouterRawId, LlmModels, type LLMModel, type ModelPricing } from '@intexuraos/llm-contract';
-import { getAllowlistPricing, isAllowedModel } from '@intexuraos/infra-openrouter';
+import { getProviderForModel, isOpenRouterModel, getOpenRouterRawId, LlmModels } from '@intexuraos/llm-contract';
+import { isAllowedModel } from '@intexuraos/infra-openrouter';
 import { getServices, type DecryptedApiKeys } from '../services.js';
 import { createSynthesisProviders } from './helpers/synthesisHelper.js';
 import { handleAllCompleted } from './helpers/completionHandlers.js';
@@ -451,7 +451,6 @@ export const internalRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
             LlmModels.Gemini25Flash,
             apiKeys.google,
             research.userId,
-            services.pricingContext.getPricing(LlmModels.Gemini25Flash),
             request.log,
             event.researchId
           );
@@ -875,24 +874,10 @@ export const internalRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
           return await reply.fail('INVALID_REQUEST', 'Model not in curated allowlist');
         }
 
-        let researchPricing: ModelPricing;
-        if (isOpenRouterModel(event.model)) {
-          const pricing = getAllowlistPricing(getOpenRouterRawId(event.model));
-          /* v8 ignore start -- upstream: prior isAllowedModel guard validated the model; this defensive null check is guaranteed unreachable @preserve */
-          if (pricing === undefined) {
-            throw new Error(`No pricing for allowlisted model: ${String(event.model)}`);
-          }
-          /* v8 ignore stop @preserve */
-          researchPricing = pricing;
-        } else {
-          researchPricing = services.pricingContext.getPricing(event.model as LLMModel);
-        }
-
         const llmProvider = services.createResearchProvider(
           event.model,
           apiKey,
           event.userId,
-          researchPricing,
           request.log,
           event.researchId
         );

--- a/apps/research-agent/src/routes/researchRoutes.ts
+++ b/apps/research-agent/src/routes/researchRoutes.ts
@@ -227,7 +227,6 @@ export const researchRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
           user.userId,
           researchId,
           createTitleGenerator,
-          
           request.log
         );
         submitParams.inputContexts = contextsWithLabels;
@@ -303,7 +302,6 @@ export const researchRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
           LlmModels.Gemini25Flash,
           apiKeys.google,
           user.userId,
-          
           request.log,
           draftId
         );
@@ -331,7 +329,6 @@ export const researchRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
           user.userId,
           draftId,
           createTitleGenerator,
-          
           request.log
         );
         const now = new Date().toISOString();
@@ -434,7 +431,6 @@ export const researchRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
             LlmModels.Gemini25Flash,
             apiKeys.google,
             user.userId,
-            
             request.log,
             existing.id
           );
@@ -462,7 +458,6 @@ export const researchRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
           user.userId,
           existing.id,
           createTitleGenerator,
-          
           request.log
         );
         const now = new Date().toISOString();
@@ -542,7 +537,6 @@ export const researchRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
         LlmModels.Gemini25Flash,
         googleKey,
         user.userId,
-        
         request.log
       );
 
@@ -628,7 +622,6 @@ export const researchRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
         LlmModels.Gemini25Flash,
         googleKey,
         user.userId,
-        
         request.log
       );
 
@@ -1292,7 +1285,6 @@ export const researchRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
           user.userId,
           id,
           createTitleGenerator,
-          
           request.log
         );
         enhanceInput.additionalContexts = contextsWithLabels;

--- a/apps/research-agent/src/routes/researchRoutes.ts
+++ b/apps/research-agent/src/routes/researchRoutes.ts
@@ -177,7 +177,6 @@ export const researchRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
         researchEventPublisher,
         userServiceClient,
         createTitleGenerator,
-        pricingContext,
       } = getServices();
 
       const apiKeysResult = await userServiceClient.getApiKeys(user.userId);
@@ -228,7 +227,7 @@ export const researchRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
           user.userId,
           researchId,
           createTitleGenerator,
-          pricingContext.getPricing(LlmModels.Gemini25Flash),
+          
           request.log
         );
         submitParams.inputContexts = contextsWithLabels;
@@ -289,7 +288,7 @@ export const researchRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
       }
 
       const body = request.body as SaveDraftBody;
-      const { researchRepo, generateId, userServiceClient, createTitleGenerator, pricingContext } =
+      const { researchRepo, generateId, userServiceClient, createTitleGenerator } =
         getServices();
       const draftId = generateId();
 
@@ -304,7 +303,7 @@ export const researchRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
           LlmModels.Gemini25Flash,
           apiKeys.google,
           user.userId,
-          pricingContext.getPricing(LlmModels.Gemini25Flash),
+          
           request.log,
           draftId
         );
@@ -332,7 +331,7 @@ export const researchRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
           user.userId,
           draftId,
           createTitleGenerator,
-          pricingContext.getPricing(LlmModels.Gemini25Flash),
+          
           request.log
         );
         const now = new Date().toISOString();
@@ -399,7 +398,7 @@ export const researchRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
 
       const { id } = request.params as { id: string };
       const body = request.body as SaveDraftBody;
-      const { researchRepo, generateId, userServiceClient, createTitleGenerator, pricingContext } =
+      const { researchRepo, generateId, userServiceClient, createTitleGenerator } =
         getServices();
 
       // Get existing research
@@ -435,7 +434,7 @@ export const researchRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
             LlmModels.Gemini25Flash,
             apiKeys.google,
             user.userId,
-            pricingContext.getPricing(LlmModels.Gemini25Flash),
+            
             request.log,
             existing.id
           );
@@ -463,7 +462,7 @@ export const researchRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
           user.userId,
           existing.id,
           createTitleGenerator,
-          pricingContext.getPricing(LlmModels.Gemini25Flash),
+          
           request.log
         );
         const now = new Date().toISOString();
@@ -522,7 +521,7 @@ export const researchRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
       }
 
       const body = request.body as { prompt: string; includeImprovement?: boolean };
-      const { userServiceClient, createInputValidator, pricingContext, generateId } = getServices();
+      const { userServiceClient, createInputValidator, generateId } = getServices();
       const requestId = generateId();
       const startTime = Date.now();
 
@@ -543,7 +542,7 @@ export const researchRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
         LlmModels.Gemini25Flash,
         googleKey,
         user.userId,
-        pricingContext.getPricing(LlmModels.Gemini25Flash),
+        
         request.log
       );
 
@@ -609,7 +608,7 @@ export const researchRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
       }
 
       const body = request.body as { prompt: string };
-      const { userServiceClient, createInputValidator, pricingContext, generateId } = getServices();
+      const { userServiceClient, createInputValidator, generateId } = getServices();
       const requestId = generateId();
       const startTime = Date.now();
 
@@ -629,7 +628,7 @@ export const researchRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
         LlmModels.Gemini25Flash,
         googleKey,
         user.userId,
-        pricingContext.getPricing(LlmModels.Gemini25Flash),
+        
         request.log
       );
 
@@ -1235,7 +1234,6 @@ export const researchRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
         researchEventPublisher,
         userServiceClient,
         createTitleGenerator,
-        pricingContext,
       } = getServices();
 
       const apiKeysResult = await userServiceClient.getApiKeys(user.userId);
@@ -1294,7 +1292,7 @@ export const researchRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
           user.userId,
           id,
           createTitleGenerator,
-          pricingContext.getPricing(LlmModels.Gemini25Flash),
+          
           request.log
         );
         enhanceInput.additionalContexts = contextsWithLabels;

--- a/apps/research-agent/src/services.ts
+++ b/apps/research-agent/src/services.ts
@@ -39,8 +39,7 @@ import {
 export type { DecryptedApiKeys } from '@intexuraos/internal-clients';
 export type { ImageServiceClient, GeneratedImageData, PromptModel, ImageModel } from './infra/image/index.js';
 import type { Logger, Result } from '@intexuraos/common-core';
-import type { ModelPricing, ResearchModel, FastModel } from '@intexuraos/llm-contract';
-import type { IPricingContext } from '@intexuraos/llm-pricing';
+import type { ResearchModel, FastModel } from '@intexuraos/llm-contract';
 import {
   type LlmResearchProvider,
   type LlmSynthesisProvider,
@@ -81,7 +80,6 @@ export interface ResearchExportSettingsPort {
 export interface ServiceContainer {
   researchRepo: ResearchRepository;
   researchExportSettings: ResearchExportSettingsPort;
-  pricingContext: IPricingContext;
   generateId: () => string;
   researchEventPublisher: ResearchEventPublisher;
   llmCallPublisher: LlmCallPublisher;
@@ -96,7 +94,6 @@ export interface ServiceContainer {
     model: ResearchModel,
     apiKey: string,
     userId: string,
-    pricing: ModelPricing,
     logger: Logger,
     researchId: string | undefined // @allow-undefined-type -- positional arg preserved for call-site compat
   ) => LlmResearchProvider;
@@ -104,7 +101,6 @@ export interface ServiceContainer {
     model: ResearchModel,
     apiKey: string,
     userId: string,
-    pricing: ModelPricing,
     logger: Logger,
     researchId: string | undefined // @allow-undefined-type -- positional arg preserved for call-site compat
   ) => LlmSynthesisProvider;
@@ -112,7 +108,6 @@ export interface ServiceContainer {
     model: FastModel,
     apiKey: string,
     userId: string,
-    pricing: ModelPricing,
     logger: Logger,
     researchId: string | undefined // @allow-undefined-type -- positional arg preserved for call-site compat
   ) => TitleGenerator;
@@ -120,7 +115,6 @@ export interface ServiceContainer {
     model: FastModel,
     apiKey: string,
     userId: string,
-    pricing: ModelPricing,
     logger: Logger,
     researchId: string | undefined // @allow-undefined-type -- positional arg preserved for call-site compat
   ) => ContextInferenceProvider;
@@ -128,7 +122,6 @@ export interface ServiceContainer {
     model: FastModel,
     apiKey: string,
     userId: string,
-    pricing: ModelPricing,
     logger: Logger
   ) => InputValidationProvider;
   notionExporter: typeof exportResearchToNotion;
@@ -217,7 +210,7 @@ function createShareStorageAndConfig(): {
 /**
  * Initialize the service container with all dependencies.
  */
-export function initializeServices(pricingContext: IPricingContext): void {
+export function initializeServices(): void {
   const researchRepo = new FirestoreResearchRepository();
 
   const llmUsageServiceUrl = process.env['INTEXURAOS_LLM_USAGE_SERVICE_URL'] ?? '';
@@ -235,7 +228,6 @@ export function initializeServices(pricingContext: IPricingContext): void {
   const userServiceClient = createUserServiceClient({
     baseUrl: process.env['INTEXURAOS_USER_SERVICE_URL'] ?? 'http://localhost:8081',
     internalAuthToken,
-    pricingContext,
     logger: createAppLogger({ name: 'user-service-client' }),
     usageSink: buildUsageSink('user-service-client'),
     platformGeminiApiKey: process.env['INTEXURAOS_GEMINI_APP_API_KEY'],
@@ -279,7 +271,6 @@ export function initializeServices(pricingContext: IPricingContext): void {
       getResearchSettings,
       saveResearchSettings,
     },
-    pricingContext,
     generateId: (): string => crypto.randomUUID(),
     researchEventPublisher,
     llmCallPublisher,
@@ -294,7 +285,6 @@ export function initializeServices(pricingContext: IPricingContext): void {
       model: ResearchModel,
       apiKey: string,
       userId: string,
-      pricing: ModelPricing,
       logger: Logger,
       researchId: string | undefined // @allow-undefined-type -- positional arg matches container type
     ): LlmResearchProvider =>
@@ -302,7 +292,6 @@ export function initializeServices(pricingContext: IPricingContext): void {
         model,
         apiKey,
         userId,
-        pricing,
         logger,
         buildUsageSink(`research:${model}`),
         researchId
@@ -311,7 +300,6 @@ export function initializeServices(pricingContext: IPricingContext): void {
       model: ResearchModel,
       apiKey: string,
       userId: string,
-      pricing: ModelPricing,
       logger: Logger,
       researchId: string | undefined // @allow-undefined-type -- positional arg matches container type
     ): LlmSynthesisProvider =>
@@ -319,7 +307,6 @@ export function initializeServices(pricingContext: IPricingContext): void {
         model,
         apiKey,
         userId,
-        pricing,
         logger,
         buildUsageSink(`synthesis:${model}`),
         researchId
@@ -328,7 +315,6 @@ export function initializeServices(pricingContext: IPricingContext): void {
       model: FastModel,
       apiKey: string,
       userId: string,
-      pricing: ModelPricing,
       logger: Logger,
       researchId: string | undefined // @allow-undefined-type -- positional arg matches container type
     ): TitleGenerator =>
@@ -336,7 +322,6 @@ export function initializeServices(pricingContext: IPricingContext): void {
         model,
         apiKey,
         userId,
-        pricing,
         logger,
         buildUsageSink('title-generator'),
         researchId
@@ -345,7 +330,6 @@ export function initializeServices(pricingContext: IPricingContext): void {
       model: FastModel,
       apiKey: string,
       userId: string,
-      pricing: ModelPricing,
       logger: Logger,
       researchId: string | undefined // @allow-undefined-type -- positional arg matches container type
     ): ContextInferenceProvider =>
@@ -353,7 +337,6 @@ export function initializeServices(pricingContext: IPricingContext): void {
         model,
         apiKey,
         userId,
-        pricing,
         logger,
         buildUsageSink('context-inferrer'),
         researchId
@@ -362,14 +345,12 @@ export function initializeServices(pricingContext: IPricingContext): void {
       model: FastModel,
       apiKey: string,
       userId: string,
-      pricing: ModelPricing,
       logger: Logger
     ): InputValidationProvider =>
       createInputValidator(
         model,
         apiKey,
         userId,
-        pricing,
         logger,
         buildUsageSink('input-validator')
       ),

--- a/apps/research-agent/src/services.ts
+++ b/apps/research-agent/src/services.ts
@@ -235,7 +235,6 @@ export function initializeServices(pricingContext: IPricingContext): void {
   const userServiceClient = createUserServiceClient({
     baseUrl: process.env['INTEXURAOS_USER_SERVICE_URL'] ?? 'http://localhost:8081',
     internalAuthToken,
-    pricingContext,
     logger: createAppLogger({ name: 'user-service-client' }),
     usageSink: buildUsageSink('user-service-client'),
     platformGeminiApiKey: process.env['INTEXURAOS_GEMINI_APP_API_KEY'],

--- a/apps/todos-agent/src/services.ts
+++ b/apps/todos-agent/src/services.ts
@@ -9,10 +9,8 @@ import { createUserServiceClient, type UserServiceClient } from '@intexuraos/int
 import { createTodoItemExtractionService, type TodoItemExtractionService } from './infra/gemini/todoItemExtractionService.js';
 import {
   fetchAllPricingWithRetry,
-  createPricingContext,
   HttpInternalAuthUsageSink,
 } from '@intexuraos/llm-pricing';
-import { LlmModels } from '@intexuraos/llm-contract';
 
 export interface ServiceContainer {
   todoRepository: TodoRepository;
@@ -41,15 +39,10 @@ export async function initServices(config: ServiceConfig): Promise<void> {
     throw new Error(`Failed to fetch pricing: ${pricingResult.error.message}`);
   }
 
-  const pricingContext = createPricingContext(pricingResult.value, [
-    LlmModels.Gemini25Flash,
-  ]);
-
   const userServiceClientLogger = createAppLogger({ name: 'userServiceClient' });
   const userServiceClient = createUserServiceClient({
     baseUrl: config.userServiceUrl,
     internalAuthToken: config.internalAuthKey,
-    pricingContext,
     logger: userServiceClientLogger,
     usageSink: new HttpInternalAuthUsageSink({
       usageServiceUrl: config.llmUsageServiceUrl,

--- a/apps/web-agent/src/services.ts
+++ b/apps/web-agent/src/services.ts
@@ -47,7 +47,6 @@ export function initServices(dependencies: ServiceDependencies): void {
     userServiceClient: createUserServiceClient({
       baseUrl: dependencies.userServiceUrl,
       internalAuthToken: dependencies.internalAuthToken,
-      pricingContext: dependencies.pricingContext,
       logger: createAppLogger({ name: 'userServiceClient' }),
       usageSink: new HttpInternalAuthUsageSink({
         usageServiceUrl: dependencies.llmUsageServiceUrl,

--- a/packages/infra-claude/src/__tests__/client.test.ts
+++ b/packages/infra-claude/src/__tests__/client.test.ts
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { ModelPricing } from '@intexuraos/llm-contract';
 import type { Logger } from '@intexuraos/common-core';
 import type { UsageSink } from '@intexuraos/llm-pricing';
 
@@ -44,33 +43,22 @@ const { createClaudeClient } = await import('../client.js');
 
 const TEST_MODEL = 'claude-sonnet-4-20250514';
 
-const createTestPricing = (overrides: Partial<ModelPricing> = {}): ModelPricing => ({
-  inputPricePerMillion: 3.0,
-  outputPricePerMillion: 15.0,
-  cacheReadMultiplier: 0.1,
-  cacheWriteMultiplier: 1.25,
-  webSearchCostPerCall: 0.01,
-  ...overrides,
-});
-
 describe('createClaudeClient', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   describe('research', () => {
-    it('returns research result with content and usage from pricing', async () => {
+    it('returns research result with content and usage', async () => {
       mockMessagesCreate.mockResolvedValue({
         content: [{ type: 'text', text: 'Research findings about AI.' }],
         usage: { input_tokens: 100, output_tokens: 50 },
       });
 
-      const pricing = createTestPricing();
       const client = createClaudeClient({
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing,
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -78,11 +66,11 @@ describe('createClaudeClient', () => {
 
       expect(result.ok).toBe(true);
       if (result.ok) {
-        expect(result.value.usage.costUsd).toBeCloseTo(0.00105, 6);
+        expect(result.value.usage.costUsd).toBe(0);
       }
     });
 
-    it('counts web search calls and adds cost', async () => {
+    it('counts web search calls', async () => {
       mockMessagesCreate.mockResolvedValue({
         content: [
           { type: 'tool_use', name: 'web_search', id: 'call1' },
@@ -92,12 +80,10 @@ describe('createClaudeClient', () => {
         usage: { input_tokens: 100, output_tokens: 50 },
       });
 
-      const pricing = createTestPricing({ webSearchCostPerCall: 0.01 });
       const client = createClaudeClient({
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing,
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -106,11 +92,11 @@ describe('createClaudeClient', () => {
       expect(result.ok).toBe(true);
       if (result.ok) {
         expect(result.value.usage.webSearchCalls).toBe(2);
-        expect(result.value.usage.costUsd).toBeCloseTo(0.02105, 5);
+        expect(result.value.usage.costUsd).toBe(0);
       }
     });
 
-    it('handles cache read tokens with multiplier', async () => {
+    it('handles cache read tokens', async () => {
       mockMessagesCreate.mockResolvedValue({
         content: [{ type: 'text', text: 'Content' }],
         usage: {
@@ -120,12 +106,10 @@ describe('createClaudeClient', () => {
         },
       });
 
-      const pricing = createTestPricing({ cacheReadMultiplier: 0.1 });
       const client = createClaudeClient({
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing,
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -135,15 +119,10 @@ describe('createClaudeClient', () => {
       if (result.ok) {
         // Contract Compliance: expect aggregated 'cacheTokens'
         expect(result.value.usage.cacheTokens).toBe(30);
-
-        // Cost verification (Read price):
-        // Cost: ((70+3)/1M * 3.0) + (50/1M * 15.0) = 0.000969
-        // Note: Regular input calculation logic inside calculator handles the logic:
-        // regularInput (100) is passed. We assume standard usage struct from client maps correctly.
       }
     });
 
-    it('handles cache creation tokens with multiplier', async () => {
+    it('handles cache creation tokens', async () => {
       mockMessagesCreate.mockResolvedValue({
         content: [{ type: 'text', text: 'Content' }],
         usage: {
@@ -153,12 +132,10 @@ describe('createClaudeClient', () => {
         },
       });
 
-      const pricing = createTestPricing({ cacheWriteMultiplier: 1.25 });
       const client = createClaudeClient({
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing,
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -183,12 +160,10 @@ describe('createClaudeClient', () => {
         usage: { input_tokens: 100, output_tokens: 50 },
       });
 
-      const pricing = createTestPricing();
       const client = createClaudeClient({
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing,
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -214,12 +189,10 @@ describe('createClaudeClient', () => {
         usage: { input_tokens: 100, output_tokens: 50 },
       });
 
-      const pricing = createTestPricing();
       const client = createClaudeClient({
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing,
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -234,12 +207,10 @@ describe('createClaudeClient', () => {
     it('returns error on API failure', async () => {
       mockMessagesCreate.mockRejectedValue(new MockAPIError(401, 'Invalid key'));
 
-      const pricing = createTestPricing();
       const client = createClaudeClient({
         apiKey: 'bad-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing,
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -254,12 +225,10 @@ describe('createClaudeClient', () => {
     it('handles rate limit error', async () => {
       mockMessagesCreate.mockRejectedValue(new MockAPIError(429, 'Rate limited'));
 
-      const pricing = createTestPricing();
       const client = createClaudeClient({
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing,
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -274,12 +243,10 @@ describe('createClaudeClient', () => {
     it('handles overloaded error', async () => {
       mockMessagesCreate.mockRejectedValue(new MockAPIError(529, 'Overloaded'));
 
-      const pricing = createTestPricing();
       const client = createClaudeClient({
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing,
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -294,12 +261,10 @@ describe('createClaudeClient', () => {
     it('handles timeout error', async () => {
       mockMessagesCreate.mockRejectedValue(new MockAPIError(500, 'Request timeout'));
 
-      const pricing = createTestPricing();
       const client = createClaudeClient({
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing,
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -314,12 +279,10 @@ describe('createClaudeClient', () => {
     it('handles generic API error', async () => {
       mockMessagesCreate.mockRejectedValue(new MockAPIError(500, 'Internal error'));
 
-      const pricing = createTestPricing();
       const client = createClaudeClient({
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing,
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -334,12 +297,10 @@ describe('createClaudeClient', () => {
     it('handles non-APIError exceptions', async () => {
       mockMessagesCreate.mockRejectedValue(new Error('Network failure'));
 
-      const pricing = createTestPricing();
       const client = createClaudeClient({
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing,
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -360,12 +321,10 @@ describe('createClaudeClient', () => {
         usage: { input_tokens: 200, output_tokens: 100 },
       });
 
-      const pricing = createTestPricing();
       const client = createClaudeClient({
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing,
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -374,9 +333,7 @@ describe('createClaudeClient', () => {
       expect(result.ok).toBe(true);
       if (result.ok) {
         expect(result.value.content).toBe('Generated text output.');
-        // Input: 200 * 3.0 = 600, Output: 100 * 15.0 = 1500
-        // Total: 2100 / 1M = 0.0021
-        expect(result.value.usage.costUsd).toBeCloseTo(0.0021, 6);
+        expect(result.value.usage.costUsd).toBe(0);
       }
     });
 
@@ -391,12 +348,10 @@ describe('createClaudeClient', () => {
         },
       });
 
-      const pricing = createTestPricing();
       const client = createClaudeClient({
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing,
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -411,12 +366,10 @@ describe('createClaudeClient', () => {
     it('returns error on API failure in generate', async () => {
       mockMessagesCreate.mockRejectedValue(new MockAPIError(401, 'Invalid key'));
 
-      const pricing = createTestPricing();
       const client = createClaudeClient({
         apiKey: 'bad-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing,
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -439,7 +392,6 @@ describe('createClaudeClient', () => {
       apiKey: 'test-key',
       model: TEST_MODEL,
       userId: 'test-user',
-      pricing: createTestPricing(),
       logger: mockLogger,
       usageSink: mockUsageSink,
       ownerType: 'user',

--- a/packages/infra-claude/src/__tests__/costCalculator.test.ts
+++ b/packages/infra-claude/src/__tests__/costCalculator.test.ts
@@ -1,80 +1,31 @@
 import { describe, expect, it } from 'vitest';
-import { calculateTextCost, normalizeUsage } from '../costCalculator.js';
-import type { ModelPricing } from '@intexuraos/llm-contract';
+import { normalizeUsage } from '../costCalculator.js';
 
 describe('infra-claude costCalculator', () => {
-  const basePricing: ModelPricing = {
-    inputPricePerMillion: 3.0,
-    outputPricePerMillion: 15.0,
-    cacheReadMultiplier: 0.1,
-    cacheWriteMultiplier: 1.25,
-    webSearchCostPerCall: 0.03,
-  };
-
-  describe('calculateTextCost', () => {
-    it('calculates write and read cache correctly', () => {
-      const usage = {
-        inputTokens: 1000,
-        outputTokens: 100,
-        cachedTokens: 2000, // Read
-        cacheCreationTokens: 500, // Write
-      };
-      // Regular: 1000 * 3 = 3000
-      // Read: 2000 * 3 * 0.1 = 600
-      // Write: 500 * 3 * 1.25 = 1875
-      // Output: 100 * 15 = 1500
-      // Total: 6975 / 1M = 0.006975
-      expect(calculateTextCost(usage, basePricing)).toBeCloseTo(0.006975, 6);
-    });
-
-    it('uses default multipliers when not provided', () => {
-      const minimalPricing: ModelPricing = {
-        inputPricePerMillion: 3.0,
-        outputPricePerMillion: 15.0,
-      };
-      const usage = {
-        inputTokens: 1000,
-        outputTokens: 100,
-        cachedTokens: 2000,
-        cacheCreationTokens: 500,
-      };
-      // Default: cacheReadMultiplier=0.1, cacheWriteMultiplier=1.25
-      // Same calculation as above: 0.006975
-      expect(calculateTextCost(usage, minimalPricing)).toBeCloseTo(0.006975, 6);
-    });
-
-    it('handles undefined cache tokens', () => {
-      const usage = { inputTokens: 1000, outputTokens: 100 };
-      // Regular: 1000 * 3 = 3000
-      // Output: 100 * 15 = 1500
-      // Total: 4500 / 1M = 0.0045
-      expect(calculateTextCost(usage, basePricing)).toBeCloseTo(0.0045, 6);
-    });
-
-    it('handles web search cost when undefined in pricing', () => {
-      const pricingWithoutSearch: ModelPricing = {
-        inputPricePerMillion: 3.0,
-        outputPricePerMillion: 15.0,
-      };
-      const usage = { inputTokens: 1000, outputTokens: 100, webSearchCalls: 5 };
-      // Search cost defaults to 0
-      expect(calculateTextCost(usage, pricingWithoutSearch)).toBeCloseTo(0.0045, 6);
-    });
-  });
-
   describe('normalizeUsage', () => {
     it('aggregates cache tokens into single contract field', () => {
       // 2000 Read + 500 Write
-      const result = normalizeUsage(1000, 100, 2000, 500, 1, basePricing);
+      const result = normalizeUsage(1000, 100, 2000, 500, 1);
 
       // Contract compliance:
       expect(result.cacheTokens).toBe(2500); // 2000 + 500
+      expect(result.costUsd).toBe(0);
+      expect(result.webSearchCalls).toBe(1);
+    });
 
-      // Cost calculation remains precise:
-      // Token Cost (from cache test): 0.006975
-      // Search Cost (1 call * 0.03): 0.03
-      // Total: 0.036975
-      expect(result.costUsd).toBeCloseTo(0.036975, 6);
+    it('omits cacheTokens when zero', () => {
+      const result = normalizeUsage(1000, 100, 0, 0, 0);
+      expect(result.cacheTokens).toBeUndefined();
+    });
+
+    it('omits webSearchCalls when zero', () => {
+      const result = normalizeUsage(1000, 100, 0, 0, 0);
+      expect(result.webSearchCalls).toBeUndefined();
+    });
+
+    it('returns correct totalTokens including cache', () => {
+      const result = normalizeUsage(1000, 100, 200, 300, 0);
+      expect(result.totalTokens).toBe(1000 + 100 + 500); // input + output + cache
     });
   });
 });

--- a/packages/infra-claude/src/client.ts
+++ b/packages/infra-claude/src/client.ts
@@ -17,13 +17,8 @@
  *   apiKey: process.env.ANTHROPIC_API_KEY,
  *   model: 'claude-sonnet-4-5',
  *   userId: 'user-123',
- *   pricing: {
- *     inputPricePerMillion: 3.00,
- *     outputPricePerMillion: 15.00,
- *     cacheReadMultiplier: 0.1,
- *     cacheWriteMultiplier: 1.25,
- *     webSearchCostPerCall: 0.0035,
- *   }
+ *   logger: pinoLogger,
+ *   usageSink: myUsageSink,
  * });
  *
  * // Research with web search
@@ -31,7 +26,6 @@
  * if (research.ok) {
  *   console.log(research.data.content);
  *   console.log('Sources:', research.data.sources);
- *   console.log('Cost:', research.data.usage.costUsd);
  * }
  *
  * // Simple generation
@@ -76,19 +70,14 @@ const MAX_TOKENS = 8192;
  *   apiKey: process.env.ANTHROPIC_API_KEY,
  *   model: 'claude-sonnet-4-5',
  *   userId: 'user-123',
- *   pricing: {
- *     inputPricePerMillion: 3.00,
- *     outputPricePerMillion: 15.00,
- *     cacheReadMultiplier: 0.1,
- *     cacheWriteMultiplier: 1.25,
- *     webSearchCostPerCall: 0.0035,
- *   }
+ *   logger: pinoLogger,
+ *   usageSink: myUsageSink,
  * });
  * ```
  */
 export function createClaudeClient(config: ClaudeConfig): ClaudeClient {
   const client = new Anthropic({ apiKey: config.apiKey });
-  const { model, userId, pricing, logger, usageSink, ownerType } = config;
+  const { model, userId, logger, usageSink, ownerType } = config;
   const usageLogger = createUsageLogger({ logger, sink: usageSink });
 
   function trackUsage(
@@ -147,8 +136,7 @@ export function createClaudeClient(config: ClaudeConfig): ClaudeClient {
           usageDetails.outputTokens,
           usageDetails.cacheReadTokens,
           usageDetails.cacheCreationTokens,
-          webSearchCalls,
-          pricing
+          webSearchCalls
         );
 
         trackUsage('research', usage, true);
@@ -185,8 +173,7 @@ export function createClaudeClient(config: ClaudeConfig): ClaudeClient {
           usageDetails.outputTokens,
           usageDetails.cacheReadTokens,
           usageDetails.cacheCreationTokens,
-          0,
-          pricing
+          0
         );
 
         trackUsage('generate', usage, true);

--- a/packages/infra-claude/src/client.ts
+++ b/packages/infra-claude/src/client.ts
@@ -49,6 +49,7 @@ import { err, getErrorMessage, ok, type Result } from '@intexuraos/common-core';
 import {
   LlmProviders,
   type LLMClient,
+  type ModelPricing,
   type NormalizedUsage,
   type GenerateResult,
 } from '@intexuraos/llm-contract';
@@ -57,6 +58,8 @@ import type { ClaudeConfig, ClaudeError, ResearchResult } from './types.js';
 import { normalizeUsage } from './costCalculator.js';
 
 export type ClaudeClient = LLMClient;
+
+const ZERO_PRICING: ModelPricing = { inputPricePerMillion: 0, outputPricePerMillion: 0 };
 
 const MAX_TOKENS = 8192;
 
@@ -88,7 +91,7 @@ const MAX_TOKENS = 8192;
  */
 export function createClaudeClient(config: ClaudeConfig): ClaudeClient {
   const client = new Anthropic({ apiKey: config.apiKey });
-  const { model, userId, pricing, logger, usageSink, ownerType } = config;
+  const { model, userId, pricing = ZERO_PRICING, logger, usageSink, ownerType } = config;
   const usageLogger = createUsageLogger({ logger, sink: usageSink });
 
   function trackUsage(

--- a/packages/infra-claude/src/client.ts
+++ b/packages/infra-claude/src/client.ts
@@ -57,11 +57,10 @@ const MAX_TOKENS = 8192;
 /**
  * Creates a configured Anthropic Claude client.
  *
- * The client implements {@link LLMClient} with automatic cost calculation,
- * usage logging, and audit tracking. All costs are calculated from the
- * provided `pricing` configuration.
+ * The client implements {@link LLMClient} with usage logging and audit
+ * tracking. Cost calculation is handled server-side by llm-usage-service.
  *
- * @param config - Client configuration including API key, model, user ID, and pricing
+ * @param config - Client configuration including API key, model, user ID
  * @returns A configured {@link ClaudeClient} instance
  *
  * @example

--- a/packages/infra-claude/src/costCalculator.ts
+++ b/packages/infra-claude/src/costCalculator.ts
@@ -1,46 +1,12 @@
-import type { TokenUsage, NormalizedUsage, ModelPricing } from '@intexuraos/llm-contract';
-
-export function calculateTextCost(usage: TokenUsage, pricing: ModelPricing): number {
-  const inputPrice = pricing.inputPricePerMillion;
-  const outputPrice = pricing.outputPricePerMillion;
-  const searchPrice = pricing.webSearchCostPerCall ?? 0;
-
-  const cacheReadMultiplier = pricing.cacheReadMultiplier ?? 0.1;
-  const cacheWriteMultiplier = pricing.cacheWriteMultiplier ?? 1.25;
-
-  const regularInput = usage.inputTokens;
-  // Fallback to 0 if undefined
-  const cacheRead = usage.cachedTokens ?? 0;
-  const cacheWrite = usage.cacheCreationTokens ?? 0;
-
-  // Scaled Math for Precision
-  const regularCost = regularInput * inputPrice;
-  const readCost = cacheRead * inputPrice * cacheReadMultiplier;
-  const writeCost = cacheWrite * inputPrice * cacheWriteMultiplier;
-  const outputCost = usage.outputTokens * outputPrice;
-
-  // Web Search Cost
-  const searchCostScaled = (usage.webSearchCalls ?? 0) * searchPrice * 1_000_000;
-
-  return Math.round(regularCost + readCost + writeCost + outputCost + searchCostScaled) / 1_000_000;
-}
+import type { NormalizedUsage } from '@intexuraos/llm-contract';
 
 export function normalizeUsage(
   inputTokens: number,
   outputTokens: number,
   cacheReadTokens: number,
   cacheWriteTokens: number,
-  webSearchCalls: number,
-  pricing: ModelPricing
+  webSearchCalls: number
 ): NormalizedUsage {
-  const usage: TokenUsage = {
-    inputTokens,
-    outputTokens,
-    cachedTokens: cacheReadTokens,
-    cacheCreationTokens: cacheWriteTokens,
-    webSearchCalls,
-  };
-
   // Aggregate cache tokens to satisfy the shared contract
   const totalCacheTokens = cacheReadTokens + cacheWriteTokens;
 
@@ -48,7 +14,7 @@ export function normalizeUsage(
     inputTokens,
     outputTokens,
     totalTokens: inputTokens + outputTokens + totalCacheTokens,
-    costUsd: calculateTextCost(usage, pricing),
+    costUsd: 0,
     // Map both Read and Write into the single standard field
     ...(totalCacheTokens > 0 && { cacheTokens: totalCacheTokens }),
     ...(webSearchCalls > 0 && { webSearchCalls }),

--- a/packages/infra-claude/src/index.ts
+++ b/packages/infra-claude/src/index.ts
@@ -1,5 +1,5 @@
 export { createClaudeClient, type ClaudeClient } from './client.js';
-export { calculateTextCost, normalizeUsage } from './costCalculator.js';
+export { normalizeUsage } from './costCalculator.js';
 export type {
   ClaudeConfig,
   ClaudeError,

--- a/packages/infra-claude/src/types.ts
+++ b/packages/infra-claude/src/types.ts
@@ -50,8 +50,8 @@ export interface ClaudeConfig {
   userId: string;
   /** Optional research ID for correlating audit logs to a research run */
   researchId?: string;
-  /** Cost configuration per million tokens */
-  pricing: import('@intexuraos/llm-contract').ModelPricing;
+  /** Cost configuration per million tokens. Optional — defaults to zero cost when omitted. */
+  pricing?: import('@intexuraos/llm-contract').ModelPricing;
   /** Pino logger for structured LLM usage logging */
   logger: Logger;
   /** Usage sink. Required — pass NoopUsageSink to explicitly opt out. */

--- a/packages/infra-claude/src/types.ts
+++ b/packages/infra-claude/src/types.ts
@@ -42,7 +42,7 @@ export interface ClaudeConfig {
   /** Optional research ID for correlating audit logs to a research run */
   researchId?: string;
   /**
-   * @deprecated No longer used. Costs are computed by llm-usage-service on ingestion.
+   * No longer used. Costs are computed by llm-usage-service on ingestion.
    * Kept as optional for backward compatibility with apps that still pass it.
    */
   pricing?: import('@intexuraos/llm-contract').ModelPricing;

--- a/packages/infra-claude/src/types.ts
+++ b/packages/infra-claude/src/types.ts
@@ -14,13 +14,10 @@ export type {
   ResearchResult,
   GenerateResult,
   SynthesisInput,
-  ModelPricing,
 } from '@intexuraos/llm-contract';
 
 /**
  * Configuration for creating a Claude client.
- *
- * Extends {@link LLMConfig} with Anthropic-specific pricing configuration.
  *
  * @example
  * ```ts
@@ -30,14 +27,8 @@ export type {
  *   apiKey: process.env.ANTHROPIC_API_KEY,
  *   model: 'claude-sonnet-4-5',
  *   userId: 'user-123',
- *   pricing: {
- *     inputPricePerMillion: 3.00,
- *     outputPricePerMillion: 15.00,
- *     cacheReadMultiplier: 0.1,
- *     cacheWriteMultiplier: 1.25,
- *     webSearchCostPerCall: 0.0035,
- *   },
- *   logger: pinoLogger, // Optional pino logger for structured logging
+ *   logger: pinoLogger,
+ *   usageSink: myUsageSink,
  * });
  * ```
  */
@@ -50,8 +41,11 @@ export interface ClaudeConfig {
   userId: string;
   /** Optional research ID for correlating audit logs to a research run */
   researchId?: string;
-  /** Cost configuration per million tokens */
-  pricing: import('@intexuraos/llm-contract').ModelPricing;
+  /**
+   * @deprecated No longer used. Costs are computed by llm-usage-service on ingestion.
+   * Kept as optional for backward compatibility with apps that still pass it.
+   */
+  pricing?: import('@intexuraos/llm-contract').ModelPricing;
   /** Pino logger for structured LLM usage logging */
   logger: Logger;
   /** Usage sink. Required — pass NoopUsageSink to explicitly opt out. */

--- a/packages/infra-gemini/src/__tests__/client.test.ts
+++ b/packages/infra-gemini/src/__tests__/client.test.ts
@@ -35,7 +35,6 @@ const { createUsageLogger } = await import('@intexuraos/llm-pricing');
 
 const TEST_MODEL = LlmModels.Gemini25Flash;
 
-
 describe('createGeminiClient', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/packages/infra-gemini/src/__tests__/client.test.ts
+++ b/packages/infra-gemini/src/__tests__/client.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { type ModelPricing, LlmModels, LlmProviders } from '@intexuraos/llm-contract';
+import { LlmModels, LlmProviders } from '@intexuraos/llm-contract';
 import type { Logger } from '@intexuraos/common-core';
 import type { UsageSink } from '@intexuraos/llm-pricing';
 
@@ -35,17 +35,6 @@ const { createUsageLogger } = await import('@intexuraos/llm-pricing');
 
 const TEST_MODEL = LlmModels.Gemini25Flash;
 
-const createTestPricing = (overrides: Partial<ModelPricing> = {}): ModelPricing => ({
-  inputPricePerMillion: 0.15,
-  outputPricePerMillion: 0.6,
-  groundingCostPerRequest: 0.035,
-  imagePricing: {
-    '1024x1024': 0.02,
-    '1536x1024': 0.04,
-    '1024x1536': 0.04,
-  },
-  ...overrides,
-});
 
 describe('createGeminiClient', () => {
   beforeEach(() => {
@@ -64,7 +53,6 @@ describe('createGeminiClient', () => {
       apiKey: 'test-key',
       model: TEST_MODEL,
       userId: 'test-user',
-      pricing: createTestPricing(),
       logger: mockLogger,
       usageSink,
     });
@@ -80,19 +68,17 @@ describe('createGeminiClient', () => {
   });
 
   describe('research', () => {
-    it('returns research result with content and usage from pricing', async () => {
+    it('returns research result with content and usage', async () => {
       mockGenerateContent.mockResolvedValue({
         text: 'Research findings about AI.',
         usageMetadata: { promptTokenCount: 100, candidatesTokenCount: 50 },
         candidates: [{ groundingMetadata: {} }],
       });
 
-      const pricing = createTestPricing();
       const client = createGeminiClient({
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing,
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -106,8 +92,7 @@ describe('createGeminiClient', () => {
           outputTokens: 50,
           totalTokens: 150,
         });
-        // Cost with grounding: (100/1M * 0.15) + (50/1M * 0.6) + 0.035 = 0.000015 + 0.00003 + 0.035 = 0.035045
-        expect(result.value.usage.costUsd).toBeCloseTo(0.035045, 6);
+        expect(result.value.usage.costUsd).toBe(0);
       }
     });
 
@@ -131,7 +116,6 @@ describe('createGeminiClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -164,7 +148,6 @@ describe('createGeminiClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -183,12 +166,10 @@ describe('createGeminiClient', () => {
         candidates: [{ groundingMetadata: {} }],
       });
 
-      const pricing = createTestPricing({ groundingCostPerRequest: 0.035 });
       const client = createGeminiClient({
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing,
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -197,8 +178,7 @@ describe('createGeminiClient', () => {
       expect(result.ok).toBe(true);
       if (result.ok) {
         expect(result.value.usage.groundingEnabled).toBe(true);
-        // Cost includes grounding: tokens + 0.035
-        expect(result.value.usage.costUsd).toBeGreaterThan(0.035);
+        expect(result.value.usage.costUsd).toBe(0);
       }
     });
 
@@ -209,12 +189,10 @@ describe('createGeminiClient', () => {
         candidates: [{}],
       });
 
-      const pricing = createTestPricing({ groundingCostPerRequest: 0.035 });
       const client = createGeminiClient({
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing,
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -222,8 +200,7 @@ describe('createGeminiClient', () => {
 
       expect(result.ok).toBe(true);
       if (result.ok) {
-        // Cost without grounding: only token costs
-        expect(result.value.usage.costUsd).toBeLessThan(0.001);
+        expect(result.value.usage.costUsd).toBe(0);
       }
     });
 
@@ -238,7 +215,6 @@ describe('createGeminiClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -262,7 +238,6 @@ describe('createGeminiClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -281,7 +256,6 @@ describe('createGeminiClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -300,7 +274,6 @@ describe('createGeminiClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -319,7 +292,6 @@ describe('createGeminiClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -344,12 +316,10 @@ describe('createGeminiClient', () => {
         candidates: [{ groundingMetadata: {} }],
       });
 
-      const pricing = createTestPricing();
       const client = createGeminiClient({
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing,
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -358,30 +328,22 @@ describe('createGeminiClient', () => {
       expect(result.ok).toBe(true);
       if (result.ok) {
         expect(result.value.usage.thinkingTokens).toBe(200);
-        // Cost with thinking + grounding:
-        // input: 100 * 0.15 / 1M = 0.000015
-        // output: 50 * 0.6 / 1M = 0.00003
-        // thinking: 200 * 0.6 / 1M = 0.00012
-        // grounding: 0.035
-        // total: 0.035165
-        expect(result.value.usage.costUsd).toBeCloseTo(0.035165, 6);
+        expect(result.value.usage.costUsd).toBe(0);
       }
     });
   });
 
   describe('generate', () => {
-    it('returns generate result with content and usage from pricing', async () => {
+    it('returns generate result with content and usage', async () => {
       mockGenerateContent.mockResolvedValue({
         text: 'Generated text.',
         usageMetadata: { promptTokenCount: 50, candidatesTokenCount: 100 },
       });
 
-      const pricing = createTestPricing();
       const client = createGeminiClient({
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing,
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -395,8 +357,7 @@ describe('createGeminiClient', () => {
           outputTokens: 100,
           totalTokens: 150,
         });
-        // Cost without grounding: (50/1M * 0.15) + (100/1M * 0.6) = 0.0000075 + 0.00006 = 0.0000675
-        expect(result.value.usage.costUsd).toBeCloseTo(0.0000675, 6);
+        expect(result.value.usage.costUsd).toBe(0);
       }
     });
 
@@ -410,7 +371,6 @@ describe('createGeminiClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -434,7 +394,6 @@ describe('createGeminiClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -453,7 +412,6 @@ describe('createGeminiClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -475,12 +433,10 @@ describe('createGeminiClient', () => {
         },
       });
 
-      const pricing = createTestPricing();
       const client = createGeminiClient({
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing,
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -489,13 +445,7 @@ describe('createGeminiClient', () => {
       expect(result.ok).toBe(true);
       if (result.ok) {
         expect(result.value.usage.thinkingTokens).toBe(500);
-        // Cost without grounding (scaled integers, then / 1M):
-        // input: 50 * 0.15 = 7.5
-        // output: 100 * 0.6 = 60
-        // thinking: 500 * 0.6 = 300
-        // total scaled: 367.5 → Math.round → 368
-        // costUsd: 368 / 1M = 0.000368
-        expect(result.value.usage.costUsd).toBeCloseTo(0.000368, 6);
+        expect(result.value.usage.costUsd).toBe(0);
       }
     });
 
@@ -513,7 +463,6 @@ describe('createGeminiClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -538,7 +487,6 @@ describe('createGeminiClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -552,7 +500,7 @@ describe('createGeminiClient', () => {
   });
 
   describe('generateImage', () => {
-    it('returns image result with cost from pricing', async () => {
+    it('returns image result with zero cost', async () => {
       const imageB64 = Buffer.from('fake-image-data').toString('base64');
       mockGenerateContent.mockResolvedValue({
         candidates: [
@@ -564,14 +512,10 @@ describe('createGeminiClient', () => {
         ],
       });
 
-      const pricing = createTestPricing({
-        imagePricing: { '1024x1024': 0.02, '1536x1024': 0.04, '1024x1536': 0.04 },
-      });
       const client = createGeminiClient({
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing,
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -582,11 +526,11 @@ describe('createGeminiClient', () => {
       if (result.ok) {
         expect(result.value.model).toBe(LlmModels.Gemini25FlashImage);
         expect(result.value.imageData).toBeInstanceOf(Buffer);
-        expect(result.value.usage.costUsd).toBe(0.02);
+        expect(result.value.usage.costUsd).toBe(0);
       }
     });
 
-    it('uses specified image size for cost calculation', async () => {
+    it('uses specified image size', async () => {
       const imageB64 = Buffer.from('fake-image-data').toString('base64');
       mockGenerateContent.mockResolvedValue({
         candidates: [
@@ -598,14 +542,10 @@ describe('createGeminiClient', () => {
         ],
       });
 
-      const pricing = createTestPricing({
-        imagePricing: { '1024x1024': 0.02, '1536x1024': 0.04, '1024x1536': 0.04 },
-      });
       const client = createGeminiClient({
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing,
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -614,11 +554,11 @@ describe('createGeminiClient', () => {
 
       expect(result.ok).toBe(true);
       if (result.ok) {
-        expect(result.value.usage.costUsd).toBe(0.04);
+        expect(result.value.usage.costUsd).toBe(0);
       }
     });
 
-    it('uses separate imagePricing when provided', async () => {
+    it('returns image with zero cost when no imagePricing', async () => {
       const imageB64 = Buffer.from('fake-image-data').toString('base64');
       mockGenerateContent.mockResolvedValue({
         candidates: [
@@ -630,18 +570,10 @@ describe('createGeminiClient', () => {
         ],
       });
 
-      const pricing = createTestPricing();
-      const imagePricing: ModelPricing = {
-        inputPricePerMillion: 0,
-        outputPricePerMillion: 0,
-        imagePricing: { '1024x1024': 0.01, '1536x1024': 0.02, '1024x1536': 0.02 },
-      };
       const client = createGeminiClient({
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing,
-        imagePricing,
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -650,7 +582,7 @@ describe('createGeminiClient', () => {
 
       expect(result.ok).toBe(true);
       if (result.ok) {
-        expect(result.value.usage.costUsd).toBe(0.01);
+        expect(result.value.usage.costUsd).toBe(0);
       }
     });
 
@@ -669,7 +601,6 @@ describe('createGeminiClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -699,7 +630,6 @@ describe('createGeminiClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -721,7 +651,6 @@ describe('createGeminiClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -743,7 +672,6 @@ describe('createGeminiClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -762,7 +690,6 @@ describe('createGeminiClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -781,7 +708,6 @@ describe('createGeminiClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -800,7 +726,6 @@ describe('createGeminiClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -819,7 +744,6 @@ describe('createGeminiClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -838,7 +762,6 @@ describe('createGeminiClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -857,7 +780,6 @@ describe('createGeminiClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -876,7 +798,6 @@ describe('createGeminiClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -895,7 +816,6 @@ describe('createGeminiClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -914,7 +834,6 @@ describe('createGeminiClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -934,7 +853,6 @@ describe('createGeminiClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -954,7 +872,6 @@ describe('createGeminiClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -974,7 +891,6 @@ describe('createGeminiClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -994,7 +910,6 @@ describe('createGeminiClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -1013,7 +928,6 @@ describe('createGeminiClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -1032,7 +946,6 @@ describe('createGeminiClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -1057,7 +970,6 @@ describe('createGeminiClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -1093,7 +1005,6 @@ describe('createGeminiClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -1116,7 +1027,6 @@ describe('createGeminiClient', () => {
       apiKey: 'test-key',
       model: TEST_MODEL,
       userId: 'test-user',
-      pricing: createTestPricing(),
       logger: mockLogger,
       usageSink: mockUsageSink,
       ownerType: 'user',

--- a/packages/infra-gemini/src/__tests__/costCalculator.test.ts
+++ b/packages/infra-gemini/src/__tests__/costCalculator.test.ts
@@ -1,118 +1,49 @@
 import { describe, expect, it } from 'vitest';
-import { calculateTextCost, calculateImageCost, normalizeUsage } from '../costCalculator.js';
-import type { ModelPricing } from '@intexuraos/llm-contract';
+import { normalizeUsage } from '../costCalculator.js';
 
 describe('infra-gemini costCalculator', () => {
-  const basePricing: ModelPricing = {
-    inputPricePerMillion: 0.1,
-    outputPricePerMillion: 0.4,
-    groundingCostPerRequest: 0.035,
-  };
-
-  describe('calculateTextCost', () => {
-    it('calculates basic cost without grounding', () => {
-      const usage = { inputTokens: 1000, outputTokens: 500 };
-      expect(calculateTextCost(usage, basePricing)).toBeCloseTo(0.0003, 6);
-    });
-
-    it('adds grounding cost when enabled', () => {
-      const usage = { inputTokens: 1000, outputTokens: 500, groundingEnabled: true };
-      expect(calculateTextCost(usage, basePricing)).toBeCloseTo(0.0353, 6);
-    });
-
-    it('uses zero grounding cost when not provided in pricing', () => {
-      const minimalPricing: ModelPricing = {
-        inputPricePerMillion: 0.1,
-        outputPricePerMillion: 0.4,
-      };
-      const usage = { inputTokens: 1000, outputTokens: 500, groundingEnabled: true };
-      // No grounding cost added: just input + output
-      expect(calculateTextCost(usage, minimalPricing)).toBeCloseTo(0.0003, 6);
-    });
-
-    it('includes thinking tokens at output rate', () => {
-      const usage = { inputTokens: 1000, outputTokens: 500, thinkingTokens: 300 };
-      // input: 1000 * 0.1 = 100, output: 500 * 0.4 = 200, thinking: 300 * 0.4 = 120
-      // total scaled = 420, / 1_000_000 = 0.00042
-      expect(calculateTextCost(usage, basePricing)).toBeCloseTo(0.00042, 6);
-    });
-
-    it('treats undefined thinkingTokens as zero', () => {
-      const usage = { inputTokens: 1000, outputTokens: 500 };
-      expect(calculateTextCost(usage, basePricing)).toBeCloseTo(0.0003, 6);
-    });
-  });
-
-  describe('calculateImageCost', () => {
-    it('returns price for existing size', () => {
-      const pricingWithImage: ModelPricing = {
-        inputPricePerMillion: 0.1,
-        outputPricePerMillion: 0.4,
-        imagePricing: { '1024x1024': 0.04, '1536x1024': 0.06 },
-      };
-      expect(calculateImageCost('1024x1024', pricingWithImage)).toBe(0.04);
-    });
-
-    it('returns 0 when imagePricing is undefined', () => {
-      const pricingNoImage: ModelPricing = {
-        inputPricePerMillion: 0.1,
-        outputPricePerMillion: 0.4,
-      };
-      expect(calculateImageCost('1024x1024', pricingNoImage)).toBe(0);
-    });
-
-    it('returns 0 for missing size in imagePricing', () => {
-      const pricingWithImage: ModelPricing = {
-        inputPricePerMillion: 0.1,
-        outputPricePerMillion: 0.4,
-        imagePricing: { '1536x1024': 0.06 },
-      };
-      expect(calculateImageCost('1024x1024', pricingWithImage)).toBe(0);
-    });
-  });
-
   describe('normalizeUsage', () => {
-    it('returns normalized usage with cost', () => {
-      const result = normalizeUsage(1000, 500, true, basePricing);
+    it('returns normalized usage with costUsd always 0', () => {
+      const result = normalizeUsage(1000, 500, true);
       expect(result).toEqual({
         inputTokens: 1000,
         outputTokens: 500,
         totalTokens: 1500,
-        costUsd: expect.closeTo(0.0353, 6),
+        costUsd: 0,
         groundingEnabled: true,
       });
     });
 
     it('omits groundingEnabled when false', () => {
-      const result = normalizeUsage(1000, 500, false, basePricing);
+      const result = normalizeUsage(1000, 500, false);
       expect(result).toEqual({
         inputTokens: 1000,
         outputTokens: 500,
         totalTokens: 1500,
-        costUsd: expect.closeTo(0.0003, 6),
+        costUsd: 0,
       });
       expect(result.groundingEnabled).toBeUndefined();
     });
 
-    it('includes thinkingTokens in cost and exposes on result', () => {
-      const result = normalizeUsage(1000, 500, false, basePricing, 300);
+    it('includes thinkingTokens when provided and non-zero', () => {
+      const result = normalizeUsage(1000, 500, false, 300);
       expect(result).toEqual({
         inputTokens: 1000,
         outputTokens: 500,
         totalTokens: 1500,
-        costUsd: expect.closeTo(0.00042, 6),
+        costUsd: 0,
         thinkingTokens: 300,
       });
     });
 
     it('omits thinkingTokens from result when zero', () => {
-      const result = normalizeUsage(1000, 500, false, basePricing, 0);
+      const result = normalizeUsage(1000, 500, false, 0);
       expect(result.thinkingTokens).toBeUndefined();
-      expect(result.costUsd).toBeCloseTo(0.0003, 6);
+      expect(result.costUsd).toBe(0);
     });
 
     it('omits thinkingTokens from result when undefined', () => {
-      const result = normalizeUsage(1000, 500, false, basePricing);
+      const result = normalizeUsage(1000, 500, false);
       expect(result.thinkingTokens).toBeUndefined();
     });
   });

--- a/packages/infra-gemini/src/__tests__/toolCallingClient.test.ts
+++ b/packages/infra-gemini/src/__tests__/toolCallingClient.test.ts
@@ -36,11 +36,9 @@ vi.mock('@intexuraos/llm-pricing', () => ({
 }));
 
 const { createUsageLogger } = await import('@intexuraos/llm-pricing');
-const { createGeminiToolCallingClient, TOOL_CALLING_PRICING } =
-  await import('../toolCallingClient.js');
+const { createGeminiToolCallingClient } = await import('../toolCallingClient.js');
 
 const TEST_MODEL = LlmModels.Gemini25Flash;
-
 
 const mockUsageSink: UsageSink = { log: vi.fn().mockResolvedValue(undefined) };
 
@@ -466,14 +464,6 @@ describe('createGeminiToolCallingClient', () => {
         success: true,
       })
     );
-  });
-
-  it('exports TOOL_CALLING_PRICING with gemini-2.5-flash', () => {
-    expect(TOOL_CALLING_PRICING[LlmModels.Gemini25Flash]).toEqual({
-      inputPricePerMillion: 0.3,
-      outputPricePerMillion: 2.5,
-      groundingCostPerRequest: 0,
-    });
   });
 
   it('includes thinking tokens in aggregated usage', async () => {

--- a/packages/infra-gemini/src/__tests__/toolCallingClient.test.ts
+++ b/packages/infra-gemini/src/__tests__/toolCallingClient.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { LlmModels } from '@intexuraos/llm-contract';
-import type { ModelPricing, ToolCallingClient } from '@intexuraos/llm-contract';
+import type { ToolCallingClient } from '@intexuraos/llm-contract';
 import type { UsageSink } from '@intexuraos/llm-pricing';
 import type { Logger } from '@intexuraos/common-core';
 
@@ -41,11 +41,6 @@ const { createGeminiToolCallingClient, TOOL_CALLING_PRICING } =
 
 const TEST_MODEL = LlmModels.Gemini25Flash;
 
-const TEST_PRICING: ModelPricing = {
-  inputPricePerMillion: 0.5,
-  outputPricePerMillion: 2.0,
-  groundingCostPerRequest: 0,
-};
 
 const mockUsageSink: UsageSink = { log: vi.fn().mockResolvedValue(undefined) };
 
@@ -54,7 +49,6 @@ function createClient(): ToolCallingClient {
     apiKey: 'test-key',
     model: TEST_MODEL,
     userId: 'test-user',
-    pricing: TEST_PRICING,
     logger: mockLogger,
     usageSink: mockUsageSink,
   });
@@ -521,16 +515,10 @@ describe('createGeminiToolCallingClient', () => {
       },
     });
 
-    const pricing: ModelPricing = {
-      inputPricePerMillion: 0.3,
-      outputPricePerMillion: 2.5,
-      groundingCostPerRequest: 0,
-    };
     const client = createGeminiToolCallingClient({
       apiKey: 'test-key',
       model: LlmModels.Gemini25Flash,
       userId: 'test-user',
-      pricing,
       logger: mockLogger,
       usageSink: mockUsageSink,
     });
@@ -554,8 +542,7 @@ describe('createGeminiToolCallingClient', () => {
       expect(result.value.usage.inputTokens).toBe(300);
       expect(result.value.usage.outputTokens).toBe(50);
       expect(result.value.usage.thinkingTokens).toBe(130);
-      // Cost: (300*0.3 + 50*2.5 + 130*2.5) / 1_000_000 = (90 + 125 + 325) / 1_000_000 = 0.00054
-      expect(result.value.usage.costUsd).toBeCloseTo(0.00054, 6);
+      expect(result.value.usage.costUsd).toBe(0);
     }
   });
 
@@ -569,7 +556,6 @@ describe('createGeminiToolCallingClient', () => {
       apiKey: 'test-key',
       model: TEST_MODEL,
       userId: 'test-user',
-      pricing: TEST_PRICING,
       logger: mockLogger,
       usageSink: fakeSink,
     });

--- a/packages/infra-gemini/src/client.ts
+++ b/packages/infra-gemini/src/client.ts
@@ -17,17 +17,13 @@
  *   apiKey: process.env.GOOGLE_API_KEY,
  *   model: 'gemini-2.5-flash',
  *   userId: 'user-123',
- *   pricing: {
- *     inputPricePerMillion: 0.075,
- *     outputPricePerMillion: 0.30,
- *     groundingCostPerRequest: 0.002,
- *   }
+ *   logger: pinoLogger,
+ *   usageSink: myUsageSink,
  * });
  *
  * const result = await client.generate('Explain quantum computing');
  * if (result.ok) {
  *   console.log(result.data.content);
- *   console.log('Cost:', result.data.usage.costUsd);
  * }
  * ```
  */
@@ -42,21 +38,19 @@ import {
   type ImageGenerateOptions,
   type ImageGenerationResult,
   type GenerateResult,
-  type ImageSize,
 } from '@intexuraos/llm-contract';
 import { createUsageLogger, type CallType } from '@intexuraos/llm-pricing';
 import type { GeminiConfig, GeminiError, ResearchResult } from './types.js';
-import { normalizeUsage, calculateImageCost } from './costCalculator.js';
+import { normalizeUsage } from './costCalculator.js';
 import { resolveVertexRedirectUrls } from './vertexUrlResolver.js';
 
 export type GeminiClient = LLMClient;
 
 const IMAGE_MODEL = LlmModels.Gemini25FlashImage;
-const DEFAULT_IMAGE_SIZE: ImageSize = '1024x1024';
 
 export function createGeminiClient(config: GeminiConfig): GeminiClient {
   const ai = new GoogleGenAI({ apiKey: config.apiKey });
-  const { model, userId, pricing, imagePricing, logger, usageSink, ownerType } = config;
+  const { model, userId, logger, usageSink, ownerType } = config;
   const usageLogger = createUsageLogger({ logger, sink: usageSink });
 
   function trackUsage(
@@ -97,7 +91,6 @@ export function createGeminiClient(config: GeminiConfig): GeminiClient {
           inputTokens,
           outputTokens,
           groundingEnabled,
-          pricing,
           thinkingTokens
         );
 
@@ -124,7 +117,7 @@ export function createGeminiClient(config: GeminiConfig): GeminiClient {
         const inputTokens = response.usageMetadata?.promptTokenCount ?? 0;
         const outputTokens = response.usageMetadata?.candidatesTokenCount ?? 0;
         const thinkingTokens = response.usageMetadata?.thoughtsTokenCount ?? 0;
-        const usage = normalizeUsage(inputTokens, outputTokens, false, pricing, thinkingTokens);
+        const usage = normalizeUsage(inputTokens, outputTokens, false, thinkingTokens);
 
         trackUsage('generate', usage, true);
 
@@ -144,7 +137,7 @@ export function createGeminiClient(config: GeminiConfig): GeminiClient {
 
     async generateImage(
       prompt: string,
-      options?: ImageGenerateOptions
+      _options?: ImageGenerateOptions
     ): Promise<Result<ImageGenerationResult, GeminiError>> {
       try {
         const response = await ai.models.generateContent({
@@ -161,15 +154,12 @@ export function createGeminiClient(config: GeminiConfig): GeminiClient {
         }
 
         const imageBuffer = Buffer.from(imagePart.inlineData.data, 'base64');
-        const size: ImageSize = options?.size ?? DEFAULT_IMAGE_SIZE;
-        const pricingConfig = imagePricing ?? pricing;
-        const imageCost = calculateImageCost(size, pricingConfig);
 
         const usage: NormalizedUsage = {
           inputTokens: 0,
           outputTokens: 0,
           totalTokens: 0,
-          costUsd: imageCost,
+          costUsd: 0,
         };
 
         trackUsage('image_generation', usage, true);

--- a/packages/infra-gemini/src/client.ts
+++ b/packages/infra-gemini/src/client.ts
@@ -38,6 +38,7 @@ import {
   LlmModels,
   LlmProviders,
   type LLMClient,
+  type ModelPricing,
   type NormalizedUsage,
   type ImageGenerateOptions,
   type ImageGenerationResult,
@@ -51,12 +52,14 @@ import { resolveVertexRedirectUrls } from './vertexUrlResolver.js';
 
 export type GeminiClient = LLMClient;
 
+const ZERO_PRICING: ModelPricing = { inputPricePerMillion: 0, outputPricePerMillion: 0 };
+
 const IMAGE_MODEL = LlmModels.Gemini25FlashImage;
 const DEFAULT_IMAGE_SIZE: ImageSize = '1024x1024';
 
 export function createGeminiClient(config: GeminiConfig): GeminiClient {
   const ai = new GoogleGenAI({ apiKey: config.apiKey });
-  const { model, userId, pricing, imagePricing, logger, usageSink, ownerType } = config;
+  const { model, userId, pricing = ZERO_PRICING, imagePricing, logger, usageSink, ownerType } = config;
   const usageLogger = createUsageLogger({ logger, sink: usageSink });
 
   function trackUsage(

--- a/packages/infra-gemini/src/client.ts
+++ b/packages/infra-gemini/src/client.ts
@@ -87,12 +87,7 @@ export function createGeminiClient(config: GeminiConfig): GeminiClient {
         const inputTokens = response.usageMetadata?.promptTokenCount ?? 0;
         const outputTokens = response.usageMetadata?.candidatesTokenCount ?? 0;
         const thinkingTokens = response.usageMetadata?.thoughtsTokenCount ?? 0;
-        const usage = normalizeUsage(
-          inputTokens,
-          outputTokens,
-          groundingEnabled,
-          thinkingTokens
-        );
+        const usage = normalizeUsage(inputTokens, outputTokens, groundingEnabled, thinkingTokens);
 
         trackUsage('research', usage, true);
 

--- a/packages/infra-gemini/src/client.ts
+++ b/packages/infra-gemini/src/client.ts
@@ -59,7 +59,15 @@ const DEFAULT_IMAGE_SIZE: ImageSize = '1024x1024';
 
 export function createGeminiClient(config: GeminiConfig): GeminiClient {
   const ai = new GoogleGenAI({ apiKey: config.apiKey });
-  const { model, userId, pricing = ZERO_PRICING, imagePricing, logger, usageSink, ownerType } = config;
+  const {
+    model,
+    userId,
+    pricing = ZERO_PRICING,
+    imagePricing,
+    logger,
+    usageSink,
+    ownerType,
+  } = config;
   const usageLogger = createUsageLogger({ logger, sink: usageSink });
 
   function trackUsage(

--- a/packages/infra-gemini/src/costCalculator.ts
+++ b/packages/infra-gemini/src/costCalculator.ts
@@ -1,50 +1,16 @@
-import type {
-  TokenUsage,
-  NormalizedUsage,
-  ModelPricing,
-  ImageSize,
-} from '@intexuraos/llm-contract';
-
-export function calculateTextCost(usage: TokenUsage, pricing: ModelPricing): number {
-  const inputPrice = pricing.inputPricePerMillion;
-  const outputPrice = pricing.outputPricePerMillion;
-  const groundingPrice = pricing.groundingCostPerRequest ?? 0;
-
-  const inputCost = usage.inputTokens * inputPrice;
-  const outputCost = usage.outputTokens * outputPrice;
-  const thinkingCost = (usage.thinkingTokens ?? 0) * outputPrice;
-
-  // Safe Math: Calculate Grounding Scaled
-  const groundingCostScaled = (usage.groundingEnabled === true ? groundingPrice : 0) * 1_000_000;
-
-  const totalScaledCost = inputCost + outputCost + thinkingCost + groundingCostScaled;
-
-  return Math.round(totalScaledCost) / 1_000_000;
-}
-
-export function calculateImageCost(size: ImageSize, pricing: ModelPricing): number {
-  if (!pricing.imagePricing) return 0;
-  return pricing.imagePricing[size] ?? 0;
-}
+import type { NormalizedUsage } from '@intexuraos/llm-contract';
 
 export function normalizeUsage(
   inputTokens: number,
   outputTokens: number,
   groundingEnabled: boolean,
-  pricing: ModelPricing,
   thinkingTokens?: number
 ): NormalizedUsage {
-  const usage: TokenUsage = {
-    inputTokens,
-    outputTokens,
-    groundingEnabled,
-    ...(thinkingTokens !== undefined && { thinkingTokens }),
-  };
   return {
     inputTokens,
     outputTokens,
     totalTokens: inputTokens + outputTokens,
-    costUsd: calculateTextCost(usage, pricing),
+    costUsd: 0,
     ...(groundingEnabled && { groundingEnabled: true }),
     ...(thinkingTokens !== undefined && thinkingTokens > 0 && { thinkingTokens }),
   };

--- a/packages/infra-gemini/src/index.ts
+++ b/packages/infra-gemini/src/index.ts
@@ -12,6 +12,5 @@ export type {
 } from './types.js';
 export {
   createGeminiToolCallingClient,
-  TOOL_CALLING_PRICING,
   type ToolCallingClientConfig,
 } from './toolCallingClient.js';

--- a/packages/infra-gemini/src/index.ts
+++ b/packages/infra-gemini/src/index.ts
@@ -1,6 +1,6 @@
 export { createGeminiClient, type GeminiClient } from './client.js';
 export { resolveVertexRedirectUrls } from './vertexUrlResolver.js';
-export { calculateTextCost, calculateImageCost, normalizeUsage } from './costCalculator.js';
+export { normalizeUsage } from './costCalculator.js';
 export type {
   GeminiConfig,
   GeminiError,

--- a/packages/infra-gemini/src/toolCallingClient.ts
+++ b/packages/infra-gemini/src/toolCallingClient.ts
@@ -29,6 +29,8 @@ import { normalizeUsage } from './costCalculator.js';
 
 const DEFAULT_MAX_ITERATIONS = 5;
 
+const ZERO_PRICING: ModelPricing = { inputPricePerMillion: 0, outputPricePerMillion: 0 };
+
 /**
  * Self-contained pricing for tool calling models.
  * Same pattern as VERIFIER_PRICING in completion-verifier.ts.
@@ -50,7 +52,7 @@ export interface ToolCallingClientConfig {
   apiKey: string;
   model: ToolCallingModel;
   userId: string;
-  pricing: ModelPricing;
+  pricing?: ModelPricing;
   logger: Logger;
   /** Usage sink. Required — pass NoopUsageSink to explicitly opt out. */
   usageSink: UsageSink;
@@ -61,7 +63,7 @@ export interface ToolCallingClientConfig {
  */
 export function createGeminiToolCallingClient(config: ToolCallingClientConfig): ToolCallingClient {
   const ai = new GoogleGenAI({ apiKey: config.apiKey });
-  const { model, userId, pricing, logger, usageSink } = config;
+  const { model, userId, pricing = ZERO_PRICING, logger, usageSink } = config;
 
   const usageLogger = createUsageLogger({ logger, sink: usageSink });
 

--- a/packages/infra-gemini/src/toolCallingClient.ts
+++ b/packages/infra-gemini/src/toolCallingClient.ts
@@ -15,33 +15,18 @@ import type { Content, FunctionDeclaration, Part } from '@google/genai';
 import { err, getErrorMessage, ok, type Result } from '@intexuraos/common-core';
 import type {
   LLMError,
-  ModelPricing,
   NormalizedUsage,
   ToolCallingClient,
   ToolCallingResult,
   ToolDefinition,
   ToolCallingModel,
 } from '@intexuraos/llm-contract';
-import { LlmModels, LlmProviders } from '@intexuraos/llm-contract';
+import { LlmProviders } from '@intexuraos/llm-contract';
 import { createUsageLogger, type UsageSink } from '@intexuraos/llm-pricing';
 import type { Logger } from '@intexuraos/common-core';
 import { normalizeUsage } from './costCalculator.js';
 
 const DEFAULT_MAX_ITERATIONS = 5;
-
-/**
- * Self-contained pricing for tool calling models.
- *
- * Kept for backward compatibility with apps that still reference it.
- * Will be removed once all apps stop passing pricing to tool calling clients.
- */
-export const TOOL_CALLING_PRICING: Record<ToolCallingModel, ModelPricing> = {
-  [LlmModels.Gemini25Flash]: {
-    inputPricePerMillion: 0.3,
-    outputPricePerMillion: 2.5,
-    groundingCostPerRequest: 0,
-  },
-};
 
 /**
  * Configuration for creating a Gemini tool calling client.
@@ -51,11 +36,6 @@ export interface ToolCallingClientConfig {
   apiKey: string;
   model: ToolCallingModel;
   userId: string;
-  /**
-   * No longer used. Costs are computed by llm-usage-service on ingestion.
-   * Kept as optional for backward compatibility with apps that still pass it.
-   */
-  pricing?: ModelPricing;
   logger: Logger;
   /** Usage sink. Required — pass NoopUsageSink to explicitly opt out. */
   usageSink: UsageSink;

--- a/packages/infra-gemini/src/toolCallingClient.ts
+++ b/packages/infra-gemini/src/toolCallingClient.ts
@@ -32,7 +32,7 @@ const DEFAULT_MAX_ITERATIONS = 5;
 /**
  * Self-contained pricing for tool calling models.
  *
- * @deprecated Kept for backward compatibility with apps that still reference it.
+ * Kept for backward compatibility with apps that still reference it.
  * Will be removed once all apps stop passing pricing to tool calling clients.
  */
 export const TOOL_CALLING_PRICING: Record<ToolCallingModel, ModelPricing> = {
@@ -52,7 +52,7 @@ export interface ToolCallingClientConfig {
   model: ToolCallingModel;
   userId: string;
   /**
-   * @deprecated No longer used. Costs are computed by llm-usage-service on ingestion.
+   * No longer used. Costs are computed by llm-usage-service on ingestion.
    * Kept as optional for backward compatibility with apps that still pass it.
    */
   pricing?: ModelPricing;
@@ -157,12 +157,7 @@ export function createGeminiToolCallingClient(config: ToolCallingClientConfig): 
             const inputTokens = response.usageMetadata?.promptTokenCount ?? 0;
             const outputTokens = response.usageMetadata?.candidatesTokenCount ?? 0;
             const thinkingTokens = response.usageMetadata?.thoughtsTokenCount ?? 0;
-            const iterationUsage = normalizeUsage(
-              inputTokens,
-              outputTokens,
-              false,
-              thinkingTokens
-            );
+            const iterationUsage = normalizeUsage(inputTokens, outputTokens, false, thinkingTokens);
             aggregatedUsage = addUsage(aggregatedUsage, iterationUsage);
 
             // Extract parts from response

--- a/packages/infra-gemini/src/toolCallingClient.ts
+++ b/packages/infra-gemini/src/toolCallingClient.ts
@@ -31,8 +31,9 @@ const DEFAULT_MAX_ITERATIONS = 5;
 
 /**
  * Self-contained pricing for tool calling models.
- * Same pattern as VERIFIER_PRICING in completion-verifier.ts.
- * Bypasses code-agent's pricingContext (which throws on pricing operations).
+ *
+ * @deprecated Kept for backward compatibility with apps that still reference it.
+ * Will be removed once all apps stop passing pricing to tool calling clients.
  */
 export const TOOL_CALLING_PRICING: Record<ToolCallingModel, ModelPricing> = {
   [LlmModels.Gemini25Flash]: {
@@ -50,7 +51,11 @@ export interface ToolCallingClientConfig {
   apiKey: string;
   model: ToolCallingModel;
   userId: string;
-  pricing: ModelPricing;
+  /**
+   * @deprecated No longer used. Costs are computed by llm-usage-service on ingestion.
+   * Kept as optional for backward compatibility with apps that still pass it.
+   */
+  pricing?: ModelPricing;
   logger: Logger;
   /** Usage sink. Required — pass NoopUsageSink to explicitly opt out. */
   usageSink: UsageSink;
@@ -61,7 +66,7 @@ export interface ToolCallingClientConfig {
  */
 export function createGeminiToolCallingClient(config: ToolCallingClientConfig): ToolCallingClient {
   const ai = new GoogleGenAI({ apiKey: config.apiKey });
-  const { model, userId, pricing, logger, usageSink } = config;
+  const { model, userId, logger, usageSink } = config;
 
   const usageLogger = createUsageLogger({ logger, sink: usageSink });
 
@@ -156,7 +161,6 @@ export function createGeminiToolCallingClient(config: ToolCallingClientConfig): 
               inputTokens,
               outputTokens,
               false,
-              pricing,
               thinkingTokens
             );
             aggregatedUsage = addUsage(aggregatedUsage, iterationUsage);

--- a/packages/infra-gemini/src/types.ts
+++ b/packages/infra-gemini/src/types.ts
@@ -51,8 +51,8 @@ export interface GeminiConfig {
   userId: string;
   /** Optional research ID for correlating audit logs to a research run */
   researchId?: string;
-  /** Cost configuration per million tokens for text operations */
-  pricing: import('@intexuraos/llm-contract').ModelPricing;
+  /** Cost configuration per million tokens for text operations. Optional — defaults to zero cost when omitted. */
+  pricing?: import('@intexuraos/llm-contract').ModelPricing;
   /** Optional separate pricing for image generation (Gemini 2.5 Flash) */
   imagePricing?: import('@intexuraos/llm-contract').ModelPricing;
   /** Pino logger for structured LLM usage logging */

--- a/packages/infra-gemini/src/types.ts
+++ b/packages/infra-gemini/src/types.ts
@@ -44,12 +44,12 @@ export interface GeminiConfig {
   /** Optional research ID for correlating audit logs to a research run */
   researchId?: string;
   /**
-   * @deprecated No longer used. Costs are computed by llm-usage-service on ingestion.
+   * No longer used. Costs are computed by llm-usage-service on ingestion.
    * Kept as optional for backward compatibility with apps that still pass it.
    */
   pricing?: import('@intexuraos/llm-contract').ModelPricing;
   /**
-   * @deprecated No longer used. Costs are computed by llm-usage-service on ingestion.
+   * No longer used. Costs are computed by llm-usage-service on ingestion.
    * Kept as optional for backward compatibility with apps that still pass it.
    */
   imagePricing?: import('@intexuraos/llm-contract').ModelPricing;

--- a/packages/infra-gemini/src/types.ts
+++ b/packages/infra-gemini/src/types.ts
@@ -16,14 +16,10 @@ export type {
   ImageGenerationResult,
   ImageGenerateOptions,
   SynthesisInput,
-  ModelPricing,
 } from '@intexuraos/llm-contract';
 
 /**
  * Configuration for creating a Gemini client.
- *
- * Extends {@link LLMConfig} with Google-specific pricing configuration.
- * Supports both text generation and image generation with separate pricing.
  *
  * @example
  * ```ts
@@ -33,12 +29,8 @@ export type {
  *   apiKey: process.env.GOOGLE_API_KEY,
  *   model: 'gemini-2.5-flash',
  *   userId: 'user-123',
- *   pricing: {
- *     inputPricePerMillion: 0.075,
- *     outputPricePerMillion: 0.30,
- *     groundingCostPerRequest: 0.002,
- *   },
- *   logger: pinoLogger, // Optional pino logger for structured logging
+ *   logger: pinoLogger,
+ *   usageSink: myUsageSink,
  * });
  * ```
  */
@@ -51,9 +43,15 @@ export interface GeminiConfig {
   userId: string;
   /** Optional research ID for correlating audit logs to a research run */
   researchId?: string;
-  /** Cost configuration per million tokens for text operations */
-  pricing: import('@intexuraos/llm-contract').ModelPricing;
-  /** Optional separate pricing for image generation (Gemini 2.5 Flash) */
+  /**
+   * @deprecated No longer used. Costs are computed by llm-usage-service on ingestion.
+   * Kept as optional for backward compatibility with apps that still pass it.
+   */
+  pricing?: import('@intexuraos/llm-contract').ModelPricing;
+  /**
+   * @deprecated No longer used. Costs are computed by llm-usage-service on ingestion.
+   * Kept as optional for backward compatibility with apps that still pass it.
+   */
   imagePricing?: import('@intexuraos/llm-contract').ModelPricing;
   /** Pino logger for structured LLM usage logging */
   logger: Logger;

--- a/packages/infra-gpt/src/__tests__/client.test.ts
+++ b/packages/infra-gpt/src/__tests__/client.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { type ModelPricing, LlmModels, LlmProviders } from '@intexuraos/llm-contract';
+import { LlmModels, LlmProviders } from '@intexuraos/llm-contract';
 import type { Logger } from '@intexuraos/common-core';
 import type { UsageSink } from '@intexuraos/llm-pricing';
 
@@ -50,18 +50,6 @@ const { createGptClient } = await import('../client.js');
 
 const TEST_MODEL = 'gpt-4o';
 
-const createTestPricing = (overrides: Partial<ModelPricing> = {}): ModelPricing => ({
-  inputPricePerMillion: 2.5,
-  outputPricePerMillion: 10.0,
-  cacheReadMultiplier: 0.5,
-  webSearchCostPerCall: 0.03,
-  imagePricing: {
-    '1024x1024': 0.04,
-    '1536x1024': 0.08,
-    '1024x1536': 0.08,
-  },
-  ...overrides,
-});
 
 describe('createGptClient', () => {
   beforeEach(() => {
@@ -69,19 +57,17 @@ describe('createGptClient', () => {
   });
 
   describe('research', () => {
-    it('returns research result with content and usage from pricing', async () => {
+    it('returns research result with content and usage', async () => {
       mockResponsesCreate.mockResolvedValue({
         output_text: 'Research findings about AI.',
         output: [],
         usage: { input_tokens: 100, output_tokens: 50 },
       });
 
-      const pricing = createTestPricing();
       const client = createGptClient({
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing,
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -95,8 +81,7 @@ describe('createGptClient', () => {
           outputTokens: 50,
           totalTokens: 150,
         });
-        // Cost calculated from pricing: (100/1M * 2.5) + (50/1M * 10)
-        expect(result.value.usage.costUsd).toBeCloseTo(0.00075, 6);
+        expect(result.value.usage.costUsd).toBe(0);
       }
     });
 
@@ -116,7 +101,6 @@ describe('createGptClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -145,7 +129,6 @@ describe('createGptClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -157,19 +140,17 @@ describe('createGptClient', () => {
       }
     });
 
-    it('counts web search calls and adds cost', async () => {
+    it('counts web search calls', async () => {
       mockResponsesCreate.mockResolvedValue({
         output_text: 'Content',
         output: [{ type: 'web_search_call' }, { type: 'web_search_call' }],
         usage: { input_tokens: 100, output_tokens: 50 },
       });
 
-      const pricing = createTestPricing({ webSearchCostPerCall: 0.03 });
       const client = createGptClient({
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing,
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -178,12 +159,11 @@ describe('createGptClient', () => {
       expect(result.ok).toBe(true);
       if (result.ok) {
         expect(result.value.usage.webSearchCalls).toBe(2);
-        // Cost: tokens + 2 web search calls = 0.00075 + 0.06 = 0.06075
-        expect(result.value.usage.costUsd).toBeCloseTo(0.06075, 5);
+        expect(result.value.usage.costUsd).toBe(0);
       }
     });
 
-    it('handles cached tokens with multiplier', async () => {
+    it('handles cached tokens', async () => {
       mockResponsesCreate.mockResolvedValue({
         output_text: 'Content',
         output: [],
@@ -194,12 +174,10 @@ describe('createGptClient', () => {
         },
       });
 
-      const pricing = createTestPricing({ cacheReadMultiplier: 0.5 });
       const client = createGptClient({
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing,
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -208,9 +186,7 @@ describe('createGptClient', () => {
       expect(result.ok).toBe(true);
       if (result.ok) {
         expect(result.value.usage.cacheTokens).toBe(50);
-        // Effective input: 100 - 50*(1-0.5) = 75 tokens charged at full price
-        // Cost: (75/1M * 2.5) + (50/1M * 10) = 0.0001875 + 0.0005 = 0.0006875
-        expect(result.value.usage.costUsd).toBeCloseTo(0.000688, 5);
+        expect(result.value.usage.costUsd).toBe(0);
       }
     });
 
@@ -225,7 +201,6 @@ describe('createGptClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -249,7 +224,6 @@ describe('createGptClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -268,7 +242,6 @@ describe('createGptClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -289,7 +262,6 @@ describe('createGptClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -308,7 +280,6 @@ describe('createGptClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -324,18 +295,16 @@ describe('createGptClient', () => {
   });
 
   describe('generate', () => {
-    it('returns generate result with content and usage from pricing', async () => {
+    it('returns generate result with content and usage', async () => {
       mockChatCompletionsCreate.mockResolvedValue({
         choices: [{ message: { content: 'Generated text.' } }],
         usage: { prompt_tokens: 50, completion_tokens: 100 },
       });
 
-      const pricing = createTestPricing();
       const client = createGptClient({
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing,
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -349,8 +318,7 @@ describe('createGptClient', () => {
           outputTokens: 100,
           totalTokens: 150,
         });
-        // Cost: (50/1M * 2.5) + (100/1M * 10) = 0.000125 + 0.001 = 0.001125
-        expect(result.value.usage.costUsd).toBeCloseTo(0.001125, 6);
+        expect(result.value.usage.costUsd).toBe(0);
       }
     });
 
@@ -364,7 +332,6 @@ describe('createGptClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -388,7 +355,6 @@ describe('createGptClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -407,7 +373,6 @@ describe('createGptClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -421,20 +386,16 @@ describe('createGptClient', () => {
   });
 
   describe('generateImage', () => {
-    it('returns image result with cost from pricing', async () => {
+    it('returns image result with zero cost', async () => {
       const imageB64 = Buffer.from('fake-image-data').toString('base64');
       mockImagesGenerate.mockResolvedValue({
         data: [{ b64_json: imageB64 }],
       });
 
-      const pricing = createTestPricing({
-        imagePricing: { '1024x1024': 0.04, '1536x1024': 0.08, '1024x1536': 0.08 },
-      });
       const client = createGptClient({
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing,
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -445,24 +406,20 @@ describe('createGptClient', () => {
       if (result.ok) {
         expect(result.value.model).toBe(LlmModels.GPTImage1);
         expect(result.value.imageData).toBeInstanceOf(Buffer);
-        expect(result.value.usage.costUsd).toBe(0.04);
+        expect(result.value.usage.costUsd).toBe(0);
       }
     });
 
-    it('uses specified image size for cost calculation', async () => {
+    it('uses specified image size', async () => {
       const imageB64 = Buffer.from('fake-image-data').toString('base64');
       mockImagesGenerate.mockResolvedValue({
         data: [{ b64_json: imageB64 }],
       });
 
-      const pricing = createTestPricing({
-        imagePricing: { '1024x1024': 0.04, '1536x1024': 0.08, '1024x1536': 0.08 },
-      });
       const client = createGptClient({
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing,
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -471,28 +428,20 @@ describe('createGptClient', () => {
 
       expect(result.ok).toBe(true);
       if (result.ok) {
-        expect(result.value.usage.costUsd).toBe(0.08);
+        expect(result.value.usage.costUsd).toBe(0);
       }
     });
 
-    it('uses separate imagePricing when provided', async () => {
+    it('returns image with zero cost when no imagePricing', async () => {
       const imageB64 = Buffer.from('fake-image-data').toString('base64');
       mockImagesGenerate.mockResolvedValue({
         data: [{ b64_json: imageB64 }],
       });
 
-      const pricing = createTestPricing();
-      const imagePricing: ModelPricing = {
-        inputPricePerMillion: 0,
-        outputPricePerMillion: 0,
-        imagePricing: { '1024x1024': 0.02, '1536x1024': 0.04, '1024x1536': 0.04 },
-      };
       const client = createGptClient({
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing,
-        imagePricing,
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -501,7 +450,7 @@ describe('createGptClient', () => {
 
       expect(result.ok).toBe(true);
       if (result.ok) {
-        expect(result.value.usage.costUsd).toBe(0.02);
+        expect(result.value.usage.costUsd).toBe(0);
       }
     });
 
@@ -514,7 +463,6 @@ describe('createGptClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -538,7 +486,6 @@ describe('createGptClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -568,7 +515,6 @@ describe('createGptClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -591,7 +537,6 @@ describe('createGptClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -616,7 +561,6 @@ describe('createGptClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -644,7 +588,6 @@ describe('createGptClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -671,7 +614,6 @@ describe('createGptClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -701,7 +643,6 @@ describe('createGptClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -729,7 +670,6 @@ describe('createGptClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -756,7 +696,6 @@ describe('createGptClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -777,7 +716,6 @@ describe('createGptClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -797,7 +735,6 @@ describe('createGptClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -817,7 +754,6 @@ describe('createGptClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -840,7 +776,6 @@ describe('createGptClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -863,7 +798,6 @@ describe('createGptClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -888,7 +822,6 @@ describe('createGptClient', () => {
       apiKey: 'test-key',
       model: TEST_MODEL,
       userId: 'test-user',
-      pricing: createTestPricing(),
       logger: mockLogger,
       usageSink: mockUsageSink,
       ownerType: 'user',

--- a/packages/infra-gpt/src/__tests__/client.test.ts
+++ b/packages/infra-gpt/src/__tests__/client.test.ts
@@ -50,7 +50,6 @@ const { createGptClient } = await import('../client.js');
 
 const TEST_MODEL = 'gpt-4o';
 
-
 describe('createGptClient', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/packages/infra-gpt/src/__tests__/costCalculator.test.ts
+++ b/packages/infra-gpt/src/__tests__/costCalculator.test.ts
@@ -1,99 +1,27 @@
 import { describe, expect, it } from 'vitest';
-import { calculateTextCost, calculateImageCost, normalizeUsage } from '../costCalculator.js';
-import type { ModelPricing } from '@intexuraos/llm-contract';
+import { normalizeUsage } from '../costCalculator.js';
 
 describe('infra-gpt costCalculator', () => {
-  const basePricing: ModelPricing = {
-    inputPricePerMillion: 2.5,
-    outputPricePerMillion: 10.0,
-    webSearchCostPerCall: 0.01,
-    cacheReadMultiplier: 0.5,
-  };
-
-  describe('calculateTextCost', () => {
-    it('calculates cost with cache split', () => {
-      const usage = { inputTokens: 1000, outputTokens: 500, cachedTokens: 200 };
-      expect(calculateTextCost(usage, basePricing)).toBeCloseTo(0.00725, 6);
-    });
-
-    it('includes deep research search cost', () => {
-      const usage = { inputTokens: 0, outputTokens: 0, webSearchCalls: 5 };
-      expect(calculateTextCost(usage, basePricing)).toBeCloseTo(0.05, 6);
-    });
-
-    it('uses zero search cost when not provided in pricing', () => {
-      const pricingNoSearch: ModelPricing = {
-        inputPricePerMillion: 2.5,
-        outputPricePerMillion: 10.0,
-      };
-      const usage = { inputTokens: 1000, outputTokens: 500, webSearchCalls: 5 };
-      // No search cost added: (1000 * 2.5 + 500 * 10) / 1M = 0.0075
-      expect(calculateTextCost(usage, pricingNoSearch)).toBeCloseTo(0.0075, 6);
-    });
-
-    it('uses default cache multiplier when not provided', () => {
-      const pricingNoMultiplier: ModelPricing = {
-        inputPricePerMillion: 2.5,
-        outputPricePerMillion: 10.0,
-      };
-      const usage = { inputTokens: 1000, outputTokens: 500, cachedTokens: 200 };
-      // Default cacheReadMultiplier = 0.5
-      // Regular: (1000 - 200) * 2.5 = 2000
-      // Cached: 200 * 2.5 * 0.5 = 250
-      // Output: 500 * 10 = 5000
-      // Total: 7250 / 1M = 0.00725
-      expect(calculateTextCost(usage, pricingNoMultiplier)).toBeCloseTo(0.00725, 6);
-    });
-  });
-
-  describe('calculateImageCost', () => {
-    it('returns price for existing size', () => {
-      const pricingWithImage: ModelPricing = {
-        inputPricePerMillion: 2.5,
-        outputPricePerMillion: 10.0,
-        imagePricing: { '1024x1024': 0.04, '1536x1024': 0.06 },
-      };
-      expect(calculateImageCost('1024x1024', pricingWithImage)).toBe(0.04);
-    });
-
-    it('returns 0 when imagePricing is undefined', () => {
-      const pricingNoImage: ModelPricing = {
-        inputPricePerMillion: 2.5,
-        outputPricePerMillion: 10.0,
-      };
-      expect(calculateImageCost('1024x1024', pricingNoImage)).toBe(0);
-    });
-
-    it('returns 0 for missing size in imagePricing', () => {
-      const pricingWithImage: ModelPricing = {
-        inputPricePerMillion: 2.5,
-        outputPricePerMillion: 10.0,
-        imagePricing: { '1536x1024': 0.06 },
-      };
-      expect(calculateImageCost('1024x1024', pricingWithImage)).toBe(0);
-    });
-  });
-
   describe('normalizeUsage', () => {
-    it('returns normalized structure', () => {
-      const result = normalizeUsage(1000, 500, 200, 1, undefined, basePricing);
-      expect(result.costUsd).toBeCloseTo(0.00725 + 0.01, 6);
+    it('returns normalized structure with costUsd always 0', () => {
+      const result = normalizeUsage(1000, 500, 200, 1, undefined);
+      expect(result.costUsd).toBe(0);
       expect(result.cacheTokens).toBe(200);
       expect(result.webSearchCalls).toBe(1);
     });
 
     it('includes reasoningTokens when provided', () => {
-      const result = normalizeUsage(1000, 500, 0, 0, 150, basePricing);
+      const result = normalizeUsage(1000, 500, 0, 0, 150);
       expect(result.reasoningTokens).toBe(150);
     });
 
     it('omits reasoningTokens when zero', () => {
-      const result = normalizeUsage(1000, 500, 0, 0, 0, basePricing);
+      const result = normalizeUsage(1000, 500, 0, 0, 0);
       expect(result.reasoningTokens).toBeUndefined();
     });
 
     it('omits optional fields when zero', () => {
-      const result = normalizeUsage(1000, 500, 0, 0, undefined, basePricing);
+      const result = normalizeUsage(1000, 500, 0, 0, undefined);
       expect(result.cacheTokens).toBeUndefined();
       expect(result.webSearchCalls).toBeUndefined();
       expect(result.reasoningTokens).toBeUndefined();

--- a/packages/infra-gpt/src/client.ts
+++ b/packages/infra-gpt/src/client.ts
@@ -94,7 +94,15 @@ const DEFAULT_IMAGE_SIZE: ImageSize = '1024x1024';
  */
 export function createGptClient(config: GptConfig): GptClient {
   const client = new OpenAI({ apiKey: config.apiKey });
-  const { model, userId, pricing = ZERO_PRICING, imagePricing, logger, usageSink, ownerType } = config;
+  const {
+    model,
+    userId,
+    pricing = ZERO_PRICING,
+    imagePricing,
+    logger,
+    usageSink,
+    ownerType,
+  } = config;
   const usageLogger = createUsageLogger({ logger, sink: usageSink });
 
   function trackUsage(

--- a/packages/infra-gpt/src/client.ts
+++ b/packages/infra-gpt/src/client.ts
@@ -45,6 +45,7 @@ import {
   LlmModels,
   LlmProviders,
   type LLMClient,
+  type ModelPricing,
   type NormalizedUsage,
   type ImageGenerateOptions,
   type ImageGenerationResult,
@@ -56,6 +57,8 @@ import type { GptConfig, GptError, ResearchResult } from './types.js';
 import { normalizeUsage, calculateImageCost } from './costCalculator.js';
 
 export type GptClient = LLMClient;
+
+const ZERO_PRICING: ModelPricing = { inputPricePerMillion: 0, outputPricePerMillion: 0 };
 
 const MAX_TOKENS = 8192;
 const IMAGE_MODEL = LlmModels.GPTImage1;
@@ -91,7 +94,7 @@ const DEFAULT_IMAGE_SIZE: ImageSize = '1024x1024';
  */
 export function createGptClient(config: GptConfig): GptClient {
   const client = new OpenAI({ apiKey: config.apiKey });
-  const { model, userId, pricing, imagePricing, logger, usageSink, ownerType } = config;
+  const { model, userId, pricing = ZERO_PRICING, imagePricing, logger, usageSink, ownerType } = config;
   const usageLogger = createUsageLogger({ logger, sink: usageSink });
 
   function trackUsage(

--- a/packages/infra-gpt/src/client.ts
+++ b/packages/infra-gpt/src/client.ts
@@ -61,11 +61,11 @@ const DEFAULT_IMAGE_SIZE: ImageSize = '1024x1024';
 /**
  * Creates a configured OpenAI GPT client.
  *
- * The client implements {@link LLMClient} with automatic cost calculation,
- * usage logging, and audit tracking. Supports text generation, research,
- * and image generation.
+ * The client implements {@link LLMClient} with usage logging and audit
+ * tracking. Supports text generation, research, and image generation.
+ * Cost calculation is handled server-side by llm-usage-service.
  *
- * @param config - Client configuration including API key, model, user ID, and pricing
+ * @param config - Client configuration including API key, model, user ID
  * @returns A configured {@link GptClient} instance
  *
  * @example

--- a/packages/infra-gpt/src/client.ts
+++ b/packages/infra-gpt/src/client.ts
@@ -18,17 +18,14 @@
  *   apiKey: process.env.OPENAI_API_KEY,
  *   model: 'gpt-4.1',
  *   userId: 'user-123',
- *   pricing: {
- *     inputPricePerMillion: 2.50,
- *     outputPricePerMillion: 10.00,
- *   }
+ *   logger: pinoLogger,
+ *   usageSink: myUsageSink,
  * });
  *
  * // Research with web search
  * const research = await client.research('Latest TypeScript features');
  * if (research.ok) {
  *   console.log(research.data.content);
- *   console.log('Cost:', research.data.usage.costUsd);
  * }
  *
  * // Image generation
@@ -53,7 +50,7 @@ import {
 } from '@intexuraos/llm-contract';
 import { createUsageLogger, type CallType } from '@intexuraos/llm-pricing';
 import type { GptConfig, GptError, ResearchResult } from './types.js';
-import { normalizeUsage, calculateImageCost } from './costCalculator.js';
+import { normalizeUsage } from './costCalculator.js';
 
 export type GptClient = LLMClient;
 
@@ -77,21 +74,14 @@ const DEFAULT_IMAGE_SIZE: ImageSize = '1024x1024';
  *   apiKey: process.env.OPENAI_API_KEY,
  *   model: 'gpt-4.1',
  *   userId: 'user-123',
- *   pricing: {
- *     inputPricePerMillion: 2.50,
- *     outputPricePerMillion: 10.00,
- *   },
- *   imagePricing: {
- *     inputPricePerMillion: 0,
- *     outputPricePerMillion: 0,
- *     imagePricing: { '1024x1024': 0.040 }
- *   }
+ *   logger: pinoLogger,
+ *   usageSink: myUsageSink,
  * });
  * ```
  */
 export function createGptClient(config: GptConfig): GptClient {
   const client = new OpenAI({ apiKey: config.apiKey });
-  const { model, userId, pricing, imagePricing, logger, usageSink, ownerType } = config;
+  const { model, userId, logger, usageSink, ownerType } = config;
   const usageLogger = createUsageLogger({ logger, sink: usageSink });
 
   function trackUsage(
@@ -162,8 +152,7 @@ export function createGptClient(config: GptConfig): GptClient {
           usageDetails.outputTokens,
           usageDetails.cachedTokens,
           webSearchCalls,
-          usageDetails.reasoningTokens,
-          pricing
+          usageDetails.reasoningTokens
         );
 
         trackUsage('research', usage, true);
@@ -197,8 +186,7 @@ export function createGptClient(config: GptConfig): GptClient {
           usageDetails.outputTokens,
           usageDetails.cachedTokens,
           0,
-          usageDetails.reasoningTokens,
-          pricing
+          usageDetails.reasoningTokens
         );
 
         trackUsage('generate', usage, true);
@@ -252,14 +240,11 @@ export function createGptClient(config: GptConfig): GptClient {
           imageBuffer = Buffer.from(arrayBuffer);
         }
 
-        const pricingConfig = imagePricing ?? pricing;
-        const imageCost = calculateImageCost(size, pricingConfig);
-
         const usage: NormalizedUsage = {
           inputTokens: 0,
           outputTokens: 0,
           totalTokens: 0,
-          costUsd: imageCost,
+          costUsd: 0,
         };
 
         trackUsage('image_generation', usage, true);

--- a/packages/infra-gpt/src/costCalculator.ts
+++ b/packages/infra-gpt/src/costCalculator.ts
@@ -1,56 +1,17 @@
-import type {
-  TokenUsage,
-  NormalizedUsage,
-  ModelPricing,
-  ImageSize,
-} from '@intexuraos/llm-contract';
-
-export function calculateTextCost(usage: TokenUsage, pricing: ModelPricing): number {
-  const inputPrice = pricing.inputPricePerMillion;
-  const outputPrice = pricing.outputPricePerMillion;
-  const searchPrice = pricing.webSearchCostPerCall ?? 0;
-
-  // Split Input into Regular and Cached
-  const totalInput = usage.inputTokens;
-  const cachedCount = usage.cachedTokens ?? 0;
-  const regularInputCount = Math.max(0, totalInput - cachedCount);
-
-  const cacheMultiplier = pricing.cacheReadMultiplier ?? 0.5;
-
-  // Scaled Math
-  const regularInputCost = regularInputCount * inputPrice;
-  const cachedInputCost = cachedCount * inputPrice * cacheMultiplier;
-  const outputCost = usage.outputTokens * outputPrice;
-  const searchCostScaled = (usage.webSearchCalls ?? 0) * searchPrice * 1_000_000;
-
-  return Math.round(regularInputCost + cachedInputCost + outputCost + searchCostScaled) / 1_000_000;
-}
-
-export function calculateImageCost(size: ImageSize, pricing: ModelPricing): number {
-  if (!pricing.imagePricing) return 0;
-  return pricing.imagePricing[size] ?? 0;
-}
+import type { NormalizedUsage } from '@intexuraos/llm-contract';
 
 export function normalizeUsage(
   inputTokens: number,
   outputTokens: number,
   cachedTokens: number,
   webSearchCalls: number,
-  reasoningTokens: number | undefined,
-  pricing: ModelPricing
+  reasoningTokens: number | undefined
 ): NormalizedUsage {
-  const usage: TokenUsage = {
-    inputTokens,
-    outputTokens,
-    cachedTokens,
-    webSearchCalls,
-  };
-
   return {
     inputTokens,
     outputTokens,
     totalTokens: inputTokens + outputTokens,
-    costUsd: calculateTextCost(usage, pricing),
+    costUsd: 0,
     ...(cachedTokens > 0 && { cacheTokens: cachedTokens }),
     ...(reasoningTokens !== undefined && reasoningTokens > 0 && { reasoningTokens }),
     ...(webSearchCalls > 0 && { webSearchCalls }),

--- a/packages/infra-gpt/src/index.ts
+++ b/packages/infra-gpt/src/index.ts
@@ -1,5 +1,5 @@
 export { createGptClient, type GptClient } from './client.js';
-export { calculateTextCost, calculateImageCost, normalizeUsage } from './costCalculator.js';
+export { normalizeUsage } from './costCalculator.js';
 export {
   EmbeddingClient,
   type EmbeddingClientDeps,

--- a/packages/infra-gpt/src/types.ts
+++ b/packages/infra-gpt/src/types.ts
@@ -16,14 +16,10 @@ export type {
   ImageGenerationResult,
   ImageGenerateOptions,
   SynthesisInput,
-  ModelPricing,
 } from '@intexuraos/llm-contract';
 
 /**
  * Configuration for creating a GPT client.
- *
- * Extends {@link LLMConfig} with OpenAI-specific pricing configuration.
- * Supports both text generation and image generation with separate pricing.
  *
  * @example
  * ```ts
@@ -33,20 +29,8 @@ export type {
  *   apiKey: process.env.OPENAI_API_KEY,
  *   model: 'gpt-4.1',
  *   userId: 'user-123',
- *   pricing: {
- *     inputPricePerMillion: 2.50,
- *     outputPricePerMillion: 10.00,
- *   },
- *   imagePricing: {
- *     inputPricePerMillion: 0,
- *     outputPricePerMillion: 0,
- *     imagePricing: {
- *       '1024x1024': 0.040,
- *       '1536x1024': 0.050,
- *       '1024x1536': 0.050,
- *     }
- *   },
- *   logger: pinoLogger, // Optional pino logger for structured logging
+ *   logger: pinoLogger,
+ *   usageSink: myUsageSink,
  * });
  * ```
  */
@@ -59,9 +43,15 @@ export interface GptConfig {
   userId: string;
   /** Optional research ID for correlating audit logs to a research run */
   researchId?: string;
-  /** Cost configuration per million tokens for text operations */
-  pricing: import('@intexuraos/llm-contract').ModelPricing;
-  /** Optional separate pricing for image generation */
+  /**
+   * @deprecated No longer used. Costs are computed by llm-usage-service on ingestion.
+   * Kept as optional for backward compatibility with apps that still pass it.
+   */
+  pricing?: import('@intexuraos/llm-contract').ModelPricing;
+  /**
+   * @deprecated No longer used. Costs are computed by llm-usage-service on ingestion.
+   * Kept as optional for backward compatibility with apps that still pass it.
+   */
   imagePricing?: import('@intexuraos/llm-contract').ModelPricing;
   /** Pino logger for structured LLM usage logging */
   logger: Logger;

--- a/packages/infra-gpt/src/types.ts
+++ b/packages/infra-gpt/src/types.ts
@@ -44,12 +44,12 @@ export interface GptConfig {
   /** Optional research ID for correlating audit logs to a research run */
   researchId?: string;
   /**
-   * @deprecated No longer used. Costs are computed by llm-usage-service on ingestion.
+   * No longer used. Costs are computed by llm-usage-service on ingestion.
    * Kept as optional for backward compatibility with apps that still pass it.
    */
   pricing?: import('@intexuraos/llm-contract').ModelPricing;
   /**
-   * @deprecated No longer used. Costs are computed by llm-usage-service on ingestion.
+   * No longer used. Costs are computed by llm-usage-service on ingestion.
    * Kept as optional for backward compatibility with apps that still pass it.
    */
   imagePricing?: import('@intexuraos/llm-contract').ModelPricing;

--- a/packages/infra-gpt/src/types.ts
+++ b/packages/infra-gpt/src/types.ts
@@ -59,8 +59,8 @@ export interface GptConfig {
   userId: string;
   /** Optional research ID for correlating audit logs to a research run */
   researchId?: string;
-  /** Cost configuration per million tokens for text operations */
-  pricing: import('@intexuraos/llm-contract').ModelPricing;
+  /** Cost configuration per million tokens for text operations. Optional — defaults to zero cost when omitted. */
+  pricing?: import('@intexuraos/llm-contract').ModelPricing;
   /** Optional separate pricing for image generation */
   imagePricing?: import('@intexuraos/llm-contract').ModelPricing;
   /** Pino logger for structured LLM usage logging */

--- a/packages/infra-openrouter/src/__tests__/client.test.ts
+++ b/packages/infra-openrouter/src/__tests__/client.test.ts
@@ -27,7 +27,6 @@ const { createOpenRouterClient } = await import('../client.js');
 const API_BASE_URL = 'https://openrouter.ai/api/v1';
 const TEST_MODEL = 'anthropic/claude-sonnet-4.6';
 
-
 describe('createOpenRouterClient', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/packages/infra-openrouter/src/__tests__/client.test.ts
+++ b/packages/infra-openrouter/src/__tests__/client.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import nock from 'nock';
-import { type ModelPricing, LlmProviders } from '@intexuraos/llm-contract';
+import { LlmProviders } from '@intexuraos/llm-contract';
 import type { Logger } from '@intexuraos/common-core';
 import type { UsageSink } from '@intexuraos/llm-pricing';
 
@@ -27,12 +27,6 @@ const { createOpenRouterClient } = await import('../client.js');
 const API_BASE_URL = 'https://openrouter.ai/api/v1';
 const TEST_MODEL = 'anthropic/claude-sonnet-4.6';
 
-const createTestPricing = (overrides: Partial<ModelPricing> = {}): ModelPricing => ({
-  inputPricePerMillion: 3.0,
-  outputPricePerMillion: 15.0,
-  useProviderCost: true,
-  ...overrides,
-});
 
 describe('createOpenRouterClient', () => {
   beforeEach(() => {
@@ -72,7 +66,6 @@ describe('createOpenRouterClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -110,7 +103,6 @@ describe('createOpenRouterClient', () => {
         apiKey: 'test-key',
         model: `${TEST_MODEL}:online`, // Model already has :online suffix
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -143,7 +135,6 @@ describe('createOpenRouterClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -158,8 +149,7 @@ describe('createOpenRouterClient', () => {
           outputTokens: 50,
           totalTokens: 150,
         });
-        // Cost: 100 * (3.0/1M) + 50 * (15.0/1M) = 0.0003 + 0.00075 = 0.00105
-        expect(result.value.usage.costUsd).toBeCloseTo(0.00105, 5);
+        expect(result.value.usage.costUsd).toBe(0);
       }
     });
 
@@ -179,7 +169,6 @@ describe('createOpenRouterClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -219,7 +208,6 @@ describe('createOpenRouterClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -256,7 +244,6 @@ describe('createOpenRouterClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -292,7 +279,6 @@ describe('createOpenRouterClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -317,7 +303,6 @@ describe('createOpenRouterClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -337,7 +322,6 @@ describe('createOpenRouterClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -357,7 +341,6 @@ describe('createOpenRouterClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -377,7 +360,6 @@ describe('createOpenRouterClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -399,7 +381,6 @@ describe('createOpenRouterClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -419,7 +400,6 @@ describe('createOpenRouterClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -461,7 +441,6 @@ describe('createOpenRouterClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -494,7 +473,6 @@ describe('createOpenRouterClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -509,8 +487,7 @@ describe('createOpenRouterClient', () => {
           outputTokens: 100,
           totalTokens: 150,
         });
-        // Cost: 50 * (3.0/1M) + 100 * (15.0/1M) = 0.00015 + 0.0015 = 0.00165
-        expect(result.value.usage.costUsd).toBeCloseTo(0.00165, 5);
+        expect(result.value.usage.costUsd).toBe(0);
       }
     });
 
@@ -536,7 +513,6 @@ describe('createOpenRouterClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -558,7 +534,6 @@ describe('createOpenRouterClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -578,7 +553,6 @@ describe('createOpenRouterClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -598,7 +572,6 @@ describe('createOpenRouterClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -618,7 +591,6 @@ describe('createOpenRouterClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -638,7 +610,6 @@ describe('createOpenRouterClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -658,7 +629,6 @@ describe('createOpenRouterClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -693,7 +663,6 @@ describe('createOpenRouterClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -733,7 +702,6 @@ describe('createOpenRouterClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -770,7 +738,6 @@ describe('createOpenRouterClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -796,7 +763,6 @@ describe('createOpenRouterClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -834,7 +800,6 @@ describe('createOpenRouterClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing({ useProviderCost: true }),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -869,7 +834,6 @@ describe('createOpenRouterClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing({ inputPricePerMillion: 1, outputPricePerMillion: 2 }),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -878,7 +842,7 @@ describe('createOpenRouterClient', () => {
 
       const callArg = mockUsageLoggerLog.mock.calls[0]?.[0] as Record<string, unknown>;
       expect(callArg['providerReportedUsd']).toBeUndefined();
-      expect((callArg['usage'] as { costUsd: number }).costUsd).toBeGreaterThan(0); // token-fallback still produces non-zero cost
+      expect((callArg['usage'] as { costUsd: number }).costUsd).toBe(0);
     });
 
     it('forwards providerReportedUsd on the research callType too', async () => {
@@ -903,7 +867,6 @@ describe('createOpenRouterClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing({ useProviderCost: true }),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -942,7 +905,6 @@ describe('createOpenRouterClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: fakeSink,
       });
@@ -966,7 +928,6 @@ describe('createOpenRouterClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -987,7 +948,6 @@ describe('createOpenRouterClient', () => {
         apiKey: 'bad-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -1007,7 +967,6 @@ describe('createOpenRouterClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -1027,7 +986,6 @@ describe('createOpenRouterClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -1047,7 +1005,6 @@ describe('createOpenRouterClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -1083,7 +1040,6 @@ describe('createOpenRouterClient', () => {
       apiKey: 'test-key',
       model: TEST_MODEL,
       userId: 'test-user',
-      pricing: createTestPricing(),
       logger: mockLogger,
       usageSink: mockUsageSink,
       ownerType: 'user',

--- a/packages/infra-openrouter/src/__tests__/costCalculator.test.ts
+++ b/packages/infra-openrouter/src/__tests__/costCalculator.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { toModelPricing, calculateTextCost, normalizeUsage } from '../costCalculator.js';
-import type { ModelPricing } from '@intexuraos/llm-contract';
+import { toModelPricing, normalizeUsage } from '../costCalculator.js';
 
 describe('costCalculator', () => {
   describe('toModelPricing', () => {
@@ -19,67 +18,26 @@ describe('costCalculator', () => {
     });
   });
 
-  describe('calculateTextCost', () => {
-    const basePricing: ModelPricing = {
-      inputPricePerMillion: 3.0,
-      outputPricePerMillion: 15.0,
-      useProviderCost: true,
-    };
-
-    it('uses provider cost when useProviderCost is true and cost is provided', () => {
-      const usage = { inputTokens: 100, outputTokens: 50 };
-      const cost = calculateTextCost(usage, basePricing, 0.005);
-      expect(cost).toBe(0.005);
+  describe('normalizeUsage', () => {
+    it('normalizes usage with provider cost — costUsd is always 0', () => {
+      const result = normalizeUsage(100, 50, 0.005);
+      expect(result.inputTokens).toBe(100);
+      expect(result.outputTokens).toBe(50);
+      expect(result.totalTokens).toBe(150);
+      expect(result.costUsd).toBe(0);
     });
 
-    it('falls back to token calculation when useProviderCost is false', () => {
-      const pricing = { ...basePricing, useProviderCost: false };
-      const usage = { inputTokens: 100, outputTokens: 50 };
-      const cost = calculateTextCost(usage, pricing, undefined);
-      // 100 * (3.0/1M) + 50 * (15.0/1M) = 0.0003 + 0.00075 = 0.00105
-      expect(cost).toBeCloseTo(0.00105, 5);
-    });
-
-    it('falls back to token calculation when useProviderCost is true but no cost provided', () => {
-      const usage = { inputTokens: 100, outputTokens: 50 };
-      const cost = calculateTextCost(usage, basePricing, undefined);
-      expect(cost).toBeCloseTo(0.00105, 5);
+    it('normalizes usage without provider cost — costUsd is always 0', () => {
+      const result = normalizeUsage(100, 50, undefined);
+      expect(result.inputTokens).toBe(100);
+      expect(result.outputTokens).toBe(50);
+      expect(result.totalTokens).toBe(150);
+      expect(result.costUsd).toBe(0);
     });
 
     it('handles zero tokens', () => {
-      const usage = { inputTokens: 0, outputTokens: 0 };
-      const cost = calculateTextCost(usage, basePricing, undefined);
-      expect(cost).toBe(0);
-    });
-  });
-
-  describe('normalizeUsage', () => {
-    const basePricing: ModelPricing = {
-      inputPricePerMillion: 3.0,
-      outputPricePerMillion: 15.0,
-      useProviderCost: true,
-    };
-
-    it('normalizes usage with provider cost', () => {
-      const result = normalizeUsage(100, 50, 0.005, basePricing);
-      expect(result.inputTokens).toBe(100);
-      expect(result.outputTokens).toBe(50);
-      expect(result.totalTokens).toBe(150);
-      expect(result.costUsd).toBe(0.005);
-    });
-
-    it('normalizes usage without provider cost using pricing', () => {
-      const result = normalizeUsage(100, 50, undefined, basePricing);
-      expect(result.inputTokens).toBe(100);
-      expect(result.outputTokens).toBe(50);
-      expect(result.totalTokens).toBe(150);
-      expect(result.costUsd).toBeCloseTo(0.00105, 5);
-    });
-
-    it('handles undefined provider cost correctly', () => {
-      const result = normalizeUsage(1000, 500, undefined, basePricing);
-      // 1000 * (3.0/1M) + 500 * (15.0/1M) = 0.003 + 0.0075 = 0.0105
-      expect(result.costUsd).toBeCloseTo(0.0105, 4);
+      const result = normalizeUsage(0, 0, undefined);
+      expect(result.costUsd).toBe(0);
     });
   });
 });

--- a/packages/infra-openrouter/src/client.ts
+++ b/packages/infra-openrouter/src/client.ts
@@ -15,13 +15,9 @@
  *   apiKey: process.env.OPENROUTER_API_KEY,
  *   model: 'anthropic/claude-sonnet-4.6',
  *   userId: 'user-123',
- *   pricing: {
- *     inputPricePerMillion: 3.0,
- *     outputPricePerMillion: 15.0,
- *     useProviderCost: true,
- *   },
  *   timeoutMs: 840000,
  *   logger: pinoLogger,
+ *   usageSink: myUsageSink,
  * });
  *
  * // Research with web search (append :online to model ID)
@@ -122,7 +118,6 @@ export function createOpenRouterClient(config: OpenRouterConfig): OpenRouterClie
     apiKey,
     model,
     userId,
-    pricing,
     timeoutMs = DEFAULT_TIMEOUT_MS,
     logger,
     usageSink,
@@ -168,8 +163,7 @@ export function createOpenRouterClient(config: OpenRouterConfig): OpenRouterClie
     const normalized = normalizeUsage(
       usage.prompt_tokens,
       usage.completion_tokens,
-      providerReportedUsd ?? undefined,
-      pricing
+      providerReportedUsd ?? undefined
     );
     return { normalized, providerReportedUsd };
   }

--- a/packages/infra-openrouter/src/client.ts
+++ b/packages/infra-openrouter/src/client.ts
@@ -40,6 +40,7 @@ import { err, getErrorMessage, ok, type Result } from '@intexuraos/common-core';
 import {
   LlmProviders,
   type LLMClient,
+  type ModelPricing,
   type NormalizedUsage,
   type GenerateResult,
 } from '@intexuraos/llm-contract';
@@ -71,6 +72,8 @@ export type OpenRouterClient = Pick<LLMClient, 'research'> & {
    */
   validateKey: (apiKey: string) => Promise<Result<OpenRouterKeyInfo, OpenRouterError>>;
 };
+
+const ZERO_PRICING: ModelPricing = { inputPricePerMillion: 0, outputPricePerMillion: 0 };
 
 /** OpenRouter API base URL */
 const API_BASE_URL = 'https://openrouter.ai/api/v1';
@@ -122,7 +125,7 @@ export function createOpenRouterClient(config: OpenRouterConfig): OpenRouterClie
     apiKey,
     model,
     userId,
-    pricing,
+    pricing = ZERO_PRICING,
     timeoutMs = DEFAULT_TIMEOUT_MS,
     logger,
     usageSink,

--- a/packages/infra-openrouter/src/costCalculator.ts
+++ b/packages/infra-openrouter/src/costCalculator.ts
@@ -5,7 +5,7 @@
  * and handles usage normalization.
  */
 
-import type { TokenUsage, NormalizedUsage, ModelPricing } from '@intexuraos/llm-contract';
+import type { NormalizedUsage, ModelPricing } from '@intexuraos/llm-contract';
 
 /**
  * Convert OpenRouter per-token pricing strings to per-million ModelPricing.
@@ -30,51 +30,17 @@ export function toModelPricing(promptPerToken: string, completionPerToken: strin
 }
 
 /**
- * Calculate text generation cost based on token usage and pricing.
- * Prioritizes direct provider cost. Falls back to calculation from token prices.
- */
-export function calculateTextCost(
-  usage: TokenUsage,
-  pricing: ModelPricing,
-  providerCost: number | undefined
-): number {
-  // 1. Direct Provider Cost (Priority)
-  if (pricing.useProviderCost === true && providerCost !== undefined) {
-    return providerCost;
-  }
-  /* v8 ignore start -- upstream: usage.providerCost fallback when provider doesn't supply direct cost @preserve */
-  if (usage.providerCost !== undefined) {
-    return usage.providerCost;
-  }
-  /* v8 ignore stop @preserve */
-
-  // 2. Fallback Calculation using per-million prices
-  // Formula: tokens * (pricePerMillion / 1_000_000) = tokens * pricePerToken
-  const inputCost = usage.inputTokens * (pricing.inputPricePerMillion / 1_000_000);
-  const outputCost = usage.outputTokens * (pricing.outputPricePerMillion / 1_000_000);
-
-  return Math.round((inputCost + outputCost) * 1_000_000) / 1_000_000;
-}
-
-/**
  * Normalize OpenRouter usage into our standard format.
  */
 export function normalizeUsage(
   inputTokens: number,
   outputTokens: number,
-  providerCost: number | undefined,
-  pricing: ModelPricing
+  _providerCost: number | null | undefined
 ): NormalizedUsage {
-  const usage: TokenUsage = {
-    inputTokens,
-    outputTokens,
-    ...(providerCost !== undefined && { providerCost }),
-  };
-
   return {
     inputTokens,
     outputTokens,
     totalTokens: inputTokens + outputTokens,
-    costUsd: calculateTextCost(usage, pricing, providerCost),
+    costUsd: 0,
   };
 }

--- a/packages/infra-openrouter/src/index.ts
+++ b/packages/infra-openrouter/src/index.ts
@@ -22,7 +22,7 @@ export {
   getDefaultAllowlistPricing,
   type DefaultAllowedOpenRouterModel,
 } from './defaultAllowlist.js';
-export { calculateTextCost, normalizeUsage, toModelPricing } from './costCalculator.js';
+export { normalizeUsage, toModelPricing } from './costCalculator.js';
 export type {
   GenerateOptions,
   OpenRouterConfig,

--- a/packages/infra-openrouter/src/types.ts
+++ b/packages/infra-openrouter/src/types.ts
@@ -12,7 +12,6 @@ export type {
   LLMError as OpenRouterError,
   ResearchResult,
   GenerateResult,
-  ModelPricing,
 } from '@intexuraos/llm-contract';
 
 /**
@@ -37,12 +36,8 @@ export interface GenerateOptions {
  *   apiKey: process.env.OPENROUTER_API_KEY,
  *   model: 'anthropic/claude-sonnet-4.6',
  *   userId: 'user-123',
- *   pricing: {
- *     inputPricePerMillion: 3.0,
- *     outputPricePerMillion: 15.0,
- *     useProviderCost: true,
- *   },
  *   logger: pinoLogger,
+ *   usageSink: myUsageSink,
  * });
  * ```
  */
@@ -55,8 +50,11 @@ export interface OpenRouterConfig {
   userId: string;
   /** Optional research ID for correlating audit logs to a research run */
   researchId?: string;
-  /** Cost configuration per million tokens */
-  pricing: import('@intexuraos/llm-contract').ModelPricing;
+  /**
+   * @deprecated No longer used. Costs are computed by llm-usage-service on ingestion.
+   * Kept as optional for backward compatibility with apps that still pass it.
+   */
+  pricing?: import('@intexuraos/llm-contract').ModelPricing;
   /** Request timeout in milliseconds. Default: 840000 (14 minutes) */
   timeoutMs?: number;
   /** Pino logger for structured LLM usage logging */

--- a/packages/infra-openrouter/src/types.ts
+++ b/packages/infra-openrouter/src/types.ts
@@ -55,8 +55,8 @@ export interface OpenRouterConfig {
   userId: string;
   /** Optional research ID for correlating audit logs to a research run */
   researchId?: string;
-  /** Cost configuration per million tokens */
-  pricing: import('@intexuraos/llm-contract').ModelPricing;
+  /** Cost configuration per million tokens. Optional — defaults to zero cost when omitted. */
+  pricing?: import('@intexuraos/llm-contract').ModelPricing;
   /** Request timeout in milliseconds. Default: 840000 (14 minutes) */
   timeoutMs?: number;
   /** Pino logger for structured LLM usage logging */

--- a/packages/infra-openrouter/src/types.ts
+++ b/packages/infra-openrouter/src/types.ts
@@ -51,7 +51,7 @@ export interface OpenRouterConfig {
   /** Optional research ID for correlating audit logs to a research run */
   researchId?: string;
   /**
-   * @deprecated No longer used. Costs are computed by llm-usage-service on ingestion.
+   * No longer used. Costs are computed by llm-usage-service on ingestion.
    * Kept as optional for backward compatibility with apps that still pass it.
    */
   pricing?: import('@intexuraos/llm-contract').ModelPricing;

--- a/packages/infra-perplexity/src/__tests__/client.test.ts
+++ b/packages/infra-perplexity/src/__tests__/client.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import nock from 'nock';
-import { type ModelPricing, LlmModels, LlmProviders } from '@intexuraos/llm-contract';
+import { LlmModels, LlmProviders } from '@intexuraos/llm-contract';
 import type { Logger } from '@intexuraos/common-core';
 import type { UsageSink } from '@intexuraos/llm-pricing';
 
@@ -27,12 +27,6 @@ const { createPerplexityClient } = await import('../client.js');
 const API_BASE_URL = 'https://api.perplexity.ai';
 const TEST_MODEL = LlmModels.SonarPro;
 
-const createTestPricing = (overrides: Partial<ModelPricing> = {}): ModelPricing => ({
-  inputPricePerMillion: 3.0,
-  outputPricePerMillion: 15.0,
-  useProviderCost: true,
-  ...overrides,
-});
 
 /**
  * Helper to create SSE stream response body for research() tests.
@@ -89,7 +83,7 @@ describe('createPerplexityClient', () => {
   });
 
   describe('research', () => {
-    it('returns research result with content and usage from pricing (streaming)', async () => {
+    it('returns research result with content and usage (streaming)', async () => {
       nock(API_BASE_URL)
         .post('/chat/completions', (body) => body.stream === true)
         .reply(
@@ -106,12 +100,10 @@ describe('createPerplexityClient', () => {
           { 'Content-Type': 'text/event-stream' }
         );
 
-      const pricing = createTestPricing({ useProviderCost: false });
       const client = createPerplexityClient({
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing,
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -125,12 +117,11 @@ describe('createPerplexityClient', () => {
           outputTokens: 50,
           totalTokens: 150,
         });
-        // Cost from tokens: (100/1M * 3.0) + (50/1M * 15.0) = 0.0003 + 0.00075 = 0.00105
-        expect(result.value.usage.costUsd).toBeCloseTo(0.00105, 6);
+        expect(result.value.usage.costUsd).toBe(0);
       }
     });
 
-    it('uses provider cost when useProviderCost is true (streaming)', async () => {
+    it('returns costUsd 0 regardless of provider cost in response (streaming)', async () => {
       nock(API_BASE_URL)
         .post('/chat/completions', (body) => body.stream === true)
         .reply(
@@ -148,12 +139,10 @@ describe('createPerplexityClient', () => {
           { 'Content-Type': 'text/event-stream' }
         );
 
-      const pricing = createTestPricing({ useProviderCost: true });
       const client = createPerplexityClient({
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing,
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -161,7 +150,7 @@ describe('createPerplexityClient', () => {
 
       expect(result.ok).toBe(true);
       if (result.ok) {
-        expect(result.value.usage.costUsd).toBe(0.005);
+        expect(result.value.usage.costUsd).toBe(0);
       }
     });
 
@@ -183,7 +172,6 @@ describe('createPerplexityClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -214,7 +202,6 @@ describe('createPerplexityClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -243,7 +230,6 @@ describe('createPerplexityClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -272,7 +258,6 @@ describe('createPerplexityClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -296,7 +281,6 @@ describe('createPerplexityClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -315,7 +299,6 @@ describe('createPerplexityClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -334,7 +317,6 @@ describe('createPerplexityClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -353,7 +335,6 @@ describe('createPerplexityClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -374,7 +355,6 @@ describe('createPerplexityClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -403,7 +383,6 @@ describe('createPerplexityClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -417,7 +396,7 @@ describe('createPerplexityClient', () => {
   });
 
   describe('generate', () => {
-    it('returns generate result with content and usage from pricing', async () => {
+    it('returns generate result with content and usage', async () => {
       nock(API_BASE_URL)
         .post('/chat/completions')
         .reply(200, {
@@ -425,12 +404,10 @@ describe('createPerplexityClient', () => {
           usage: { prompt_tokens: 50, completion_tokens: 100, total_tokens: 150 },
         });
 
-      const pricing = createTestPricing({ useProviderCost: false });
       const client = createPerplexityClient({
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing,
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -444,12 +421,11 @@ describe('createPerplexityClient', () => {
           outputTokens: 100,
           totalTokens: 150,
         });
-        // Cost: (50/1M * 3.0) + (100/1M * 15.0) = 0.00015 + 0.0015 = 0.00165
-        expect(result.value.usage.costUsd).toBeCloseTo(0.00165, 6);
+        expect(result.value.usage.costUsd).toBe(0);
       }
     });
 
-    it('uses provider cost for generate when useProviderCost is true', async () => {
+    it('returns costUsd 0 for generate regardless of provider cost', async () => {
       nock(API_BASE_URL)
         .post('/chat/completions')
         .reply(200, {
@@ -462,12 +438,10 @@ describe('createPerplexityClient', () => {
           },
         });
 
-      const pricing = createTestPricing({ useProviderCost: true });
       const client = createPerplexityClient({
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing,
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -475,7 +449,7 @@ describe('createPerplexityClient', () => {
 
       expect(result.ok).toBe(true);
       if (result.ok) {
-        expect(result.value.usage.costUsd).toBe(0.003);
+        expect(result.value.usage.costUsd).toBe(0);
       }
     });
 
@@ -491,7 +465,6 @@ describe('createPerplexityClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -517,7 +490,6 @@ describe('createPerplexityClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -541,7 +513,6 @@ describe('createPerplexityClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -560,7 +531,6 @@ describe('createPerplexityClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -579,7 +549,6 @@ describe('createPerplexityClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -592,8 +561,8 @@ describe('createPerplexityClient', () => {
     });
   });
 
-  describe('fallback pricing behavior', () => {
-    it('uses token-based calculation when useProviderCost is false and no provider cost', async () => {
+  describe('costUsd always zero', () => {
+    it('returns costUsd 0 regardless of provider cost settings', async () => {
       nock(API_BASE_URL)
         .post('/chat/completions', (body) => body.stream === true)
         .reply(
@@ -606,12 +575,10 @@ describe('createPerplexityClient', () => {
           { 'Content-Type': 'text/event-stream' }
         );
 
-      const pricing = createTestPricing({ useProviderCost: false });
       const client = createPerplexityClient({
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing,
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -619,12 +586,11 @@ describe('createPerplexityClient', () => {
 
       expect(result.ok).toBe(true);
       if (result.ok) {
-        // (1000/1M * 3.0) + (500/1M * 15.0) = 0.003 + 0.0075 = 0.0105
-        expect(result.value.usage.costUsd).toBeCloseTo(0.0105, 6);
+        expect(result.value.usage.costUsd).toBe(0);
       }
     });
 
-    it('falls back to token calculation when useProviderCost is true but no cost in response', async () => {
+    it('returns costUsd 0 even when no provider cost in response', async () => {
       nock(API_BASE_URL)
         .post('/chat/completions', (body) => body.stream === true)
         .reply(
@@ -637,12 +603,10 @@ describe('createPerplexityClient', () => {
           { 'Content-Type': 'text/event-stream' }
         );
 
-      const pricing = createTestPricing({ useProviderCost: true });
       const client = createPerplexityClient({
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing,
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -650,8 +614,7 @@ describe('createPerplexityClient', () => {
 
       expect(result.ok).toBe(true);
       if (result.ok) {
-        // Falls back to token calculation: (100/1M * 3.0) + (50/1M * 15.0) = 0.00105
-        expect(result.value.usage.costUsd).toBeCloseTo(0.00105, 6);
+        expect(result.value.usage.costUsd).toBe(0);
       }
     });
 
@@ -672,7 +635,6 @@ describe('createPerplexityClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -700,7 +662,6 @@ describe('createPerplexityClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -734,7 +695,6 @@ describe('createPerplexityClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -768,7 +728,6 @@ describe('createPerplexityClient', () => {
         apiKey: 'test-key',
         model: 'unknown-model' as (typeof LlmModels)[keyof typeof LlmModels],
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -784,7 +743,6 @@ describe('createPerplexityClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -805,7 +763,6 @@ describe('createPerplexityClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -826,7 +783,6 @@ describe('createPerplexityClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -845,7 +801,6 @@ describe('createPerplexityClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -878,7 +833,6 @@ describe('createPerplexityClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -903,7 +857,6 @@ describe('createPerplexityClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -921,7 +874,6 @@ describe('createPerplexityClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -943,7 +895,6 @@ describe('createPerplexityClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -966,7 +917,6 @@ describe('createPerplexityClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
         timeoutMs: 1000, // 1 second timeout
@@ -996,7 +946,6 @@ describe('createPerplexityClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
         // timeoutMs not specified, should use DEFAULT_TIMEOUT_MS
@@ -1023,7 +972,6 @@ describe('createPerplexityClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
         timeoutMs: 100,
@@ -1046,7 +994,6 @@ describe('createPerplexityClient', () => {
         apiKey: 'test-key',
         model: TEST_MODEL,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
         timeoutMs: 50, // Shorter than delay
@@ -1072,7 +1019,6 @@ describe('createPerplexityClient', () => {
       apiKey: 'test-key',
       model: TEST_MODEL,
       userId: 'test-user',
-      pricing: createTestPricing({ useProviderCost: false }),
       logger: mockLogger,
       usageSink: mockUsageSink,
       ownerType: 'user',

--- a/packages/infra-perplexity/src/__tests__/client.test.ts
+++ b/packages/infra-perplexity/src/__tests__/client.test.ts
@@ -27,7 +27,6 @@ const { createPerplexityClient } = await import('../client.js');
 const API_BASE_URL = 'https://api.perplexity.ai';
 const TEST_MODEL = LlmModels.SonarPro;
 
-
 /**
  * Helper to create SSE stream response body for research() tests.
  * Returns a string in SSE format that nock can use.

--- a/packages/infra-perplexity/src/__tests__/costCalculator.test.ts
+++ b/packages/infra-perplexity/src/__tests__/costCalculator.test.ts
@@ -1,42 +1,17 @@
 import { describe, expect, it } from 'vitest';
-import { calculateTextCost, normalizeUsage } from '../costCalculator.js';
-import type { ModelPricing } from '@intexuraos/llm-contract';
+import { normalizeUsage } from '../costCalculator.js';
 
 describe('infra-perplexity costCalculator', () => {
-  const basePricing: ModelPricing = {
-    inputPricePerMillion: 3.0,
-    outputPricePerMillion: 15.0,
-    webSearchCostPerCall: 0.005, // Request Fee
-    useProviderCost: true,
-  };
-
-  describe('calculateTextCost', () => {
-    it('uses provider cost if available', () => {
-      const usage = { inputTokens: 100, outputTokens: 100 };
-      expect(calculateTextCost(usage, basePricing, 0.12)).toBe(0.12);
-    });
-
-    it('uses usage.providerCost when pricing flag is false', () => {
-      const pricingNoFlag: ModelPricing = {
-        inputPricePerMillion: 3.0,
-        outputPricePerMillion: 15.0,
-        useProviderCost: false,
-      };
-      const usage = { inputTokens: 100, outputTokens: 100, providerCost: 0.08 };
-      expect(calculateTextCost(usage, pricingNoFlag, undefined)).toBe(0.08);
-    });
-
-    it('falls back to calculation with request fee if provider cost missing', () => {
-      const usage = { inputTokens: 1000, outputTokens: 500 };
-      expect(calculateTextCost(usage, basePricing, undefined)).toBeCloseTo(0.0155, 6);
-    });
-  });
-
   describe('normalizeUsage', () => {
-    it('normalizes usage using provider cost priority', () => {
-      const result = normalizeUsage(1000, 500, 0.05, basePricing);
-      expect(result.costUsd).toBe(0.05);
+    it('normalizes usage with costUsd always 0', () => {
+      const result = normalizeUsage(1000, 500, 0.05);
+      expect(result.costUsd).toBe(0);
       expect(result.totalTokens).toBe(1500);
+    });
+
+    it('always returns webSearchCalls: 1', () => {
+      const result = normalizeUsage(1000, 500, undefined);
+      expect(result.webSearchCalls).toBe(1);
     });
   });
 });

--- a/packages/infra-perplexity/src/client.ts
+++ b/packages/infra-perplexity/src/client.ts
@@ -22,11 +22,9 @@
  *   apiKey: process.env.PERPLEXITY_API_KEY,
  *   model: 'sonar-pro',
  *   userId: 'user-123',
- *   pricing: {
- *     inputPricePerMillion: 1.00,
- *     outputPricePerMillion: 1.00,
- *   },
  *   timeoutMs: 840000, // 14 minutes for deep research
+ *   logger: pinoLogger,
+ *   usageSink: myUsageSink,
  * });
  *
  * const result = await client.research('Latest AI developments');
@@ -191,7 +189,6 @@ export function createPerplexityClient(config: PerplexityConfig): PerplexityClie
     apiKey,
     model,
     userId,
-    pricing,
     timeoutMs = DEFAULT_TIMEOUT_MS,
     logger,
     usageSink,
@@ -224,8 +221,7 @@ export function createPerplexityClient(config: PerplexityConfig): PerplexityClie
     return normalizeUsage(
       usage.prompt_tokens,
       usage.completion_tokens,
-      usage.cost?.total_cost,
-      pricing
+      usage.cost?.total_cost
     );
   }
 

--- a/packages/infra-perplexity/src/client.ts
+++ b/packages/infra-perplexity/src/client.ts
@@ -31,7 +31,7 @@
  * if (result.ok) {
  *   console.log(result.data.content);
  *   console.log('Sources:', result.data.sources);
- *   console.log('Cost:', result.data.usage.costUsd);
+ *   console.log('Tokens:', result.data.usage.totalTokens);
  * }
  * ```
  */
@@ -218,11 +218,7 @@ export function createPerplexityClient(config: PerplexityConfig): PerplexityClie
     if (usage === undefined) {
       return { inputTokens: 0, outputTokens: 0, totalTokens: 0, costUsd: 0 };
     }
-    return normalizeUsage(
-      usage.prompt_tokens,
-      usage.completion_tokens,
-      usage.cost?.total_cost
-    );
+    return normalizeUsage(usage.prompt_tokens, usage.completion_tokens, usage.cost?.total_cost);
   }
 
   return {

--- a/packages/infra-perplexity/src/client.ts
+++ b/packages/infra-perplexity/src/client.ts
@@ -43,6 +43,7 @@ import {
   LlmModels,
   LlmProviders,
   type LLMClient,
+  type ModelPricing,
   type NormalizedUsage,
   type GenerateResult,
 } from '@intexuraos/llm-contract';
@@ -59,6 +60,8 @@ import type {
 import { normalizeUsage } from './costCalculator.js';
 
 export type PerplexityClient = Pick<LLMClient, 'research' | 'generate'>;
+
+const ZERO_PRICING: ModelPricing = { inputPricePerMillion: 0, outputPricePerMillion: 0 };
 
 const API_BASE_URL = 'https://api.perplexity.ai';
 
@@ -191,7 +194,7 @@ export function createPerplexityClient(config: PerplexityConfig): PerplexityClie
     apiKey,
     model,
     userId,
-    pricing,
+    pricing = ZERO_PRICING,
     timeoutMs = DEFAULT_TIMEOUT_MS,
     logger,
     usageSink,

--- a/packages/infra-perplexity/src/costCalculator.ts
+++ b/packages/infra-perplexity/src/costCalculator.ts
@@ -1,56 +1,15 @@
-import type { TokenUsage, NormalizedUsage, ModelPricing } from '@intexuraos/llm-contract';
-
-/**
- * Calculate text generation cost based on token usage and pricing.
- * Prioritizes direct provider cost. Falls back to calculation with request fees.
- */
-export function calculateTextCost(
-  usage: TokenUsage,
-  pricing: ModelPricing,
-  providerCost: number | undefined
-): number {
-  // 1. Direct Provider Cost (Priority)
-  if (pricing.useProviderCost === true && providerCost !== undefined) {
-    return providerCost;
-  }
-  if (usage.providerCost !== undefined) {
-    return usage.providerCost;
-  }
-
-  // 2. Fallback Calculation
-  const inputPrice = pricing.inputPricePerMillion;
-  const outputPrice = pricing.outputPricePerMillion;
-
-  // Perplexity Request Fee
-  const requestFee = pricing.webSearchCostPerCall ?? 0;
-
-  const inputCost = usage.inputTokens * inputPrice;
-  const outputCost = usage.outputTokens * outputPrice;
-
-  const requests = usage.webSearchCalls ?? 1;
-  const requestCostScaled = requests * requestFee * 1_000_000;
-
-  return Math.round(inputCost + outputCost + requestCostScaled) / 1_000_000;
-}
+import type { NormalizedUsage } from '@intexuraos/llm-contract';
 
 export function normalizeUsage(
   inputTokens: number,
   outputTokens: number,
-  providerCost: number | undefined,
-  pricing: ModelPricing
+  _providerCost: number | null | undefined
 ): NormalizedUsage {
-  const usage: TokenUsage = {
-    inputTokens,
-    outputTokens,
-    ...(providerCost !== undefined && { providerCost }),
-    webSearchCalls: 1, // Default to 1 call for Perplexity normalization
-  };
-
   return {
     inputTokens,
     outputTokens,
     totalTokens: inputTokens + outputTokens,
-    costUsd: calculateTextCost(usage, pricing, providerCost),
+    costUsd: 0,
     webSearchCalls: 1,
   };
 }

--- a/packages/infra-perplexity/src/index.ts
+++ b/packages/infra-perplexity/src/index.ts
@@ -1,3 +1,3 @@
 export { createPerplexityClient, type PerplexityClient } from './client.js';
-export { calculateTextCost, normalizeUsage } from './costCalculator.js';
+export { normalizeUsage } from './costCalculator.js';
 export type { PerplexityConfig, PerplexityError, ResearchResult, GenerateResult } from './types.js';

--- a/packages/infra-perplexity/src/types.ts
+++ b/packages/infra-perplexity/src/types.ts
@@ -12,7 +12,6 @@ export type {
   LLMError as PerplexityError,
   ResearchResult,
   GenerateResult,
-  ModelPricing,
 } from '@intexuraos/llm-contract';
 
 /**
@@ -28,12 +27,9 @@ export type {
  *   apiKey: process.env.PERPLEXITY_API_KEY,
  *   model: 'sonar-pro',
  *   userId: 'user-123',
- *   pricing: {
- *     inputPricePerMillion: 1.00,
- *     outputPricePerMillion: 1.00,
- *   },
  *   timeoutMs: 840000, // 14 minutes
- *   logger: pinoLogger, // Optional pino logger for structured logging
+ *   logger: pinoLogger,
+ *   usageSink: myUsageSink,
  * });
  * ```
  */
@@ -46,8 +42,11 @@ export interface PerplexityConfig {
   userId: string;
   /** Optional research ID for correlating audit logs to a research run */
   researchId?: string;
-  /** Cost configuration per million tokens */
-  pricing: import('@intexuraos/llm-contract').ModelPricing;
+  /**
+   * @deprecated No longer used. Costs are computed by llm-usage-service on ingestion.
+   * Kept as optional for backward compatibility with apps that still pass it.
+   */
+  pricing?: import('@intexuraos/llm-contract').ModelPricing;
   /** Request timeout in milliseconds. Default: 840000 (14 minutes) */
   timeoutMs?: number;
   /** Pino logger for structured LLM usage logging */

--- a/packages/infra-perplexity/src/types.ts
+++ b/packages/infra-perplexity/src/types.ts
@@ -46,8 +46,8 @@ export interface PerplexityConfig {
   userId: string;
   /** Optional research ID for correlating audit logs to a research run */
   researchId?: string;
-  /** Cost configuration per million tokens */
-  pricing: import('@intexuraos/llm-contract').ModelPricing;
+  /** Cost configuration per million tokens. Optional — defaults to zero cost when omitted. */
+  pricing?: import('@intexuraos/llm-contract').ModelPricing;
   /** Request timeout in milliseconds. Default: 840000 (14 minutes) */
   timeoutMs?: number;
   /** Pino logger for structured LLM usage logging */

--- a/packages/infra-perplexity/src/types.ts
+++ b/packages/infra-perplexity/src/types.ts
@@ -43,7 +43,7 @@ export interface PerplexityConfig {
   /** Optional research ID for correlating audit logs to a research run */
   researchId?: string;
   /**
-   * @deprecated No longer used. Costs are computed by llm-usage-service on ingestion.
+   * No longer used. Costs are computed by llm-usage-service on ingestion.
    * Kept as optional for backward compatibility with apps that still pass it.
    */
   pricing?: import('@intexuraos/llm-contract').ModelPricing;

--- a/packages/internal-clients/src/user-service/__tests__/client-fallback.test.ts
+++ b/packages/internal-clients/src/user-service/__tests__/client-fallback.test.ts
@@ -7,7 +7,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import nock from 'nock';
 import { LlmModels } from '@intexuraos/llm-contract';
-import { createFakePricingContext, createFakeUsageSink } from '@intexuraos/llm-pricing';
+import { createFakeUsageSink } from '@intexuraos/llm-pricing';
 import type { LlmClientConfig } from '@intexuraos/llm-factory';
 import type { LlmGenerateClient, GenerateResult } from '@intexuraos/llm-factory';
 import type { Result } from '@intexuraos/common-core';
@@ -37,7 +37,6 @@ const mockLogger = {
 const config = {
   baseUrl: 'http://localhost:3000',
   internalAuthToken: 'test-token',
-  pricingContext: createFakePricingContext(),
   logger: mockLogger,
   usageSink: createFakeUsageSink(),
 };

--- a/packages/internal-clients/src/user-service/__tests__/client.test.ts
+++ b/packages/internal-clients/src/user-service/__tests__/client.test.ts
@@ -717,6 +717,44 @@ describe('createUserServiceClient', () => {
         expect.fail('Expected error result');
       }
     });
+
+    it('returns client with zero pricing when pricingContext is omitted', async () => {
+      const mockSettings = {
+        llmPreferences: {
+          defaultModel: LlmModels.Gemini25Flash,
+        },
+      };
+
+      const mockKeys = {
+        google: 'google-key',
+      };
+
+      nock('http://localhost:3000')
+        .get('/internal/users/user123/settings')
+        .matchHeader('X-Internal-Auth', 'test-token')
+        .reply(200, { success: true, data: mockSettings });
+
+      nock('http://localhost:3000')
+        .get('/internal/users/user123/llm-keys')
+        .matchHeader('X-Internal-Auth', 'test-token')
+        .reply(200, { success: true, data: mockKeys });
+
+      const noPricingConfig = {
+        baseUrl: 'http://localhost:3000',
+        internalAuthToken: 'test-token',
+        logger: mockLogger,
+        usageSink: createFakeUsageSink(),
+      };
+
+      const client = createUserServiceClient(noPricingConfig);
+      const result = await client.getLlmClient('user123');
+
+      if (result.ok) {
+        expect(result.value).toBeDefined();
+      } else {
+        expect.fail('Expected successful result');
+      }
+    });
   });
 
   describe('reportLlmSuccess', () => {

--- a/packages/internal-clients/src/user-service/__tests__/client.test.ts
+++ b/packages/internal-clients/src/user-service/__tests__/client.test.ts
@@ -749,11 +749,12 @@ describe('createUserServiceClient', () => {
       const client = createUserServiceClient(noPricingConfig);
       const result = await client.getLlmClient('user123');
 
-      if (result.ok) {
-        expect(result.value).toBeDefined();
-      } else {
-        expect.fail('Expected successful result');
-      }
+      // Zero pricing is the expected intermediate state during the INT-1377
+      // migration: consumers drop pricingContext now, server-side pricing lands later.
+      expect(result.ok).toBe(true);
+      if (!result.ok) throw new Error('unreachable');
+      expect(result.value).toBeDefined();
+      expect(typeof result.value.generate).toBe('function');
     });
   });
 

--- a/packages/internal-clients/src/user-service/__tests__/client.test.ts
+++ b/packages/internal-clients/src/user-service/__tests__/client.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import nock from 'nock';
 import { createUserServiceClient, providerToKeyField } from '../client.js';
 import { LlmModels, LlmProviders } from '@intexuraos/llm-contract';
-import { createFakePricingContext, createFakeUsageSink } from '@intexuraos/llm-pricing';
+import { createFakeUsageSink } from '@intexuraos/llm-pricing';
 
 describe('providerToKeyField', () => {
   it('returns google for Google provider', () => {
@@ -34,12 +34,9 @@ describe('createUserServiceClient', () => {
     debug: vi.fn(),
   };
 
-  const mockPricingContext = createFakePricingContext();
-
   const config = {
     baseUrl: 'http://localhost:3000',
     internalAuthToken: 'test-token',
-    pricingContext: mockPricingContext,
     logger: mockLogger,
     usageSink: createFakeUsageSink(),
   };

--- a/packages/internal-clients/src/user-service/client.ts
+++ b/packages/internal-clients/src/user-service/client.ts
@@ -244,7 +244,12 @@ export function createUserServiceClient(config: UserServiceConfig): UserServiceC
             return { inputPricePerMillion: 0, outputPricePerMillion: 0, useProviderCost: true };
             /* v8 ignore stop @preserve */
           }
-          return config.pricingContext?.getPricing(model as LLMModel) ?? { inputPricePerMillion: 0, outputPricePerMillion: 0 };
+          return (
+            config.pricingContext?.getPricing(model as LLMModel) ?? {
+              inputPricePerMillion: 0,
+              outputPricePerMillion: 0,
+            }
+          );
         }
 
         // Helper: build a client for a given model using the fetched API keys

--- a/packages/internal-clients/src/user-service/client.ts
+++ b/packages/internal-clients/src/user-service/client.ts
@@ -8,8 +8,6 @@ import { err, getErrorMessage, ok } from '@intexuraos/common-core';
 import {
   getProviderForModel,
   isDefaultEligibleModel,
-  isOpenRouterModel,
-  getOpenRouterRawId,
   LlmModels,
   LlmProviders,
   type LlmProvider,
@@ -20,7 +18,6 @@ import {
   type LlmClientConfig,
   type LlmGenerateClient,
 } from '@intexuraos/llm-factory';
-import { getDefaultAllowlistPricing } from '@intexuraos/infra-openrouter';
 
 import type {
   UserServiceConfig,
@@ -204,12 +201,10 @@ export function createUserServiceClient(config: UserServiceConfig): UserServiceC
               'No API key for provider, falling back to platform Gemini25Flash'
             );
             const fallbackModel = LlmModels.Gemini25Flash;
-            const fallbackPricing = config.pricingContext.getPricing(fallbackModel);
             const fallbackClient = createLlmClient({
               apiKey: config.platformGeminiApiKey,
               model: fallbackModel,
               userId,
-              pricing: fallbackPricing,
               logger: config.logger,
               usageSink: config.usageSink,
               ownerType: 'user',
@@ -230,23 +225,6 @@ export function createUserServiceClient(config: UserServiceConfig): UserServiceC
           });
         }
 
-        // Helper: resolve pricing for a model (static or OpenRouter)
-        function resolvePricing(model: string): {
-          inputPricePerMillion: number;
-          outputPricePerMillion: number;
-          useProviderCost?: boolean;
-        } {
-          if (isOpenRouterModel(model)) {
-            const rawId = getOpenRouterRawId(model);
-            const allowlistPricing = getDefaultAllowlistPricing(rawId);
-            /* v8 ignore start -- upstream: isDefaultEligibleModel rejects non-allowlist models before resolvePricing runs; getDefaultAllowlistPricing always returns defined for allowlisted models @preserve */
-            if (allowlistPricing !== undefined) return allowlistPricing;
-            return { inputPricePerMillion: 0, outputPricePerMillion: 0, useProviderCost: true };
-            /* v8 ignore stop @preserve */
-          }
-          return config.pricingContext.getPricing(model as LLMModel);
-        }
-
         // Helper: build a client for a given model using the fetched API keys
         function buildClientForModel(
           model: string,
@@ -261,22 +239,17 @@ export function createUserServiceClient(config: UserServiceConfig): UserServiceC
             apiKey: modelApiKey,
             model: model as LLMModel,
             userId,
-            pricing: resolvePricing(model),
             logger: config.logger,
             usageSink: config.usageSink,
             ownerType: 'user',
           });
         }
 
-        // Step 4: Get pricing for the model
-        const pricing = resolvePricing(defaultModel);
-
-        // Step 5: Create and return the LLM client
+        // Step 4: Create and return the LLM client
         const clientConfig: LlmClientConfig = {
           apiKey,
           model: defaultModel as LLMModel,
           userId,
-          pricing,
           logger: config.logger,
           usageSink: config.usageSink,
           ownerType: 'user',

--- a/packages/internal-clients/src/user-service/client.ts
+++ b/packages/internal-clients/src/user-service/client.ts
@@ -204,12 +204,12 @@ export function createUserServiceClient(config: UserServiceConfig): UserServiceC
               'No API key for provider, falling back to platform Gemini25Flash'
             );
             const fallbackModel = LlmModels.Gemini25Flash;
-            const fallbackPricing = config.pricingContext.getPricing(fallbackModel);
+            const fallbackPricing = config.pricingContext?.getPricing(fallbackModel);
             const fallbackClient = createLlmClient({
               apiKey: config.platformGeminiApiKey,
               model: fallbackModel,
               userId,
-              pricing: fallbackPricing,
+              ...(fallbackPricing !== undefined && { pricing: fallbackPricing }),
               logger: config.logger,
               usageSink: config.usageSink,
               ownerType: 'user',
@@ -244,7 +244,7 @@ export function createUserServiceClient(config: UserServiceConfig): UserServiceC
             return { inputPricePerMillion: 0, outputPricePerMillion: 0, useProviderCost: true };
             /* v8 ignore stop @preserve */
           }
-          return config.pricingContext.getPricing(model as LLMModel);
+          return config.pricingContext?.getPricing(model as LLMModel) ?? { inputPricePerMillion: 0, outputPricePerMillion: 0 };
         }
 
         // Helper: build a client for a given model using the fetched API keys

--- a/packages/internal-clients/src/user-service/types.ts
+++ b/packages/internal-clients/src/user-service/types.ts
@@ -10,7 +10,7 @@ export interface UserServiceConfig {
   baseUrl: string;
   internalAuthToken: string;
   /**
-   * @deprecated No longer used. Costs are computed by llm-usage-service on ingestion.
+   * No longer used. Costs are computed by llm-usage-service on ingestion.
    * Kept as optional for backward compatibility with apps that still pass it.
    */
   pricingContext?: IPricingContext;

--- a/packages/internal-clients/src/user-service/types.ts
+++ b/packages/internal-clients/src/user-service/types.ts
@@ -1,5 +1,5 @@
 import type { Logger, Result } from '@intexuraos/common-core';
-import type { IPricingContext, UsageSink } from '@intexuraos/llm-pricing';
+import type { UsageSink } from '@intexuraos/llm-pricing';
 import type { LlmGenerateClient } from '@intexuraos/llm-factory';
 import type { LlmProvider } from '@intexuraos/llm-contract';
 
@@ -9,11 +9,6 @@ import type { LlmProvider } from '@intexuraos/llm-contract';
 export interface UserServiceConfig {
   baseUrl: string;
   internalAuthToken: string;
-  /**
-   * No longer used. Costs are computed by llm-usage-service on ingestion.
-   * Kept as optional for backward compatibility with apps that still pass it.
-   */
-  pricingContext?: IPricingContext;
   logger: Logger;
   /**
    * Usage sink used when materializing per-user LLM clients via

--- a/packages/internal-clients/src/user-service/types.ts
+++ b/packages/internal-clients/src/user-service/types.ts
@@ -9,7 +9,11 @@ import type { LlmProvider } from '@intexuraos/llm-contract';
 export interface UserServiceConfig {
   baseUrl: string;
   internalAuthToken: string;
-  pricingContext: IPricingContext;
+  /**
+   * @deprecated No longer used. Costs are computed by llm-usage-service on ingestion.
+   * Kept as optional for backward compatibility with apps that still pass it.
+   */
+  pricingContext?: IPricingContext;
   logger: Logger;
   /**
    * Usage sink used when materializing per-user LLM clients via

--- a/packages/internal-clients/src/user-service/types.ts
+++ b/packages/internal-clients/src/user-service/types.ts
@@ -9,7 +9,7 @@ import type { LlmProvider } from '@intexuraos/llm-contract';
 export interface UserServiceConfig {
   baseUrl: string;
   internalAuthToken: string;
-  pricingContext: IPricingContext;
+  pricingContext?: IPricingContext;
   logger: Logger;
   /**
    * Usage sink used when materializing per-user LLM clients via

--- a/packages/llm-contract/src/index.ts
+++ b/packages/llm-contract/src/index.ts
@@ -71,7 +71,7 @@ export type {
   OpenRouter,
 } from './supportedModels.js';
 
-export type { ImageSize, ModelPricing, ProviderPricing, CostCalculator } from './pricing.js';
+export type { ImageSize, ModelPricing, ProviderPricing } from './pricing.js';
 
 export type {
   ToolCallingMessage,

--- a/packages/llm-contract/src/pricing.ts
+++ b/packages/llm-contract/src/pricing.ts
@@ -1,13 +1,12 @@
 /**
  * Pricing types for LLM cost calculation.
  *
- * Used by llm-usage-service (for fetching/storing prices) and infra-*
- * packages (for calculating request costs).
+ * Used by llm-usage-service for fetching/storing prices and computing
+ * costs on ingestion. Client packages no longer calculate costs locally.
  *
  * @packageDocumentation
  */
 
-import type { TokenUsage } from './types.js';
 import type { LlmProvider } from './supportedModels.js';
 
 /** Supported image generation dimensions */
@@ -89,30 +88,4 @@ export interface ProviderPricing {
    * Metadata marker for providers whose pricing table entries are informational only.
    */
   costSource?: string;
-}
-
-/**
- * Interface for calculating LLM operation costs.
- *
- * Implemented by individual provider packages (infra-claude, infra-gpt, etc.)
- * to handle provider-specific cost calculations.
- */
-export interface CostCalculator {
-  /**
-   * Calculate text generation cost from token usage.
-   *
-   * @param usage - Raw token usage from provider response
-   * @param pricing - Model pricing configuration
-   * @returns Cost in USD
-   */
-  calculateTextCost(usage: TokenUsage, pricing: ModelPricing): number;
-
-  /**
-   * Calculate image generation cost.
-   *
-   * @param size - Image dimensions
-   * @param pricing - Model pricing configuration (must include imagePricing)
-   * @returns Cost in USD
-   */
-  calculateImageCost(size: ImageSize, pricing: ModelPricing): number;
 }

--- a/packages/llm-contract/src/pricing.ts
+++ b/packages/llm-contract/src/pricing.ts
@@ -28,8 +28,7 @@ export type ImageSize = '1024x1024' | '1536x1024' | '1024x1536';
  *   webSearchCostPerCall: 0.0035, // $0.0035 per web search call
  * };
  *
- * // Calculate cost for a request:
- * const cost = calculateTextCost(usage, claudePricing);
+ * // Used by llm-usage-service for server-side cost calculation
  * ```
  */
 export interface ModelPricing {

--- a/packages/llm-factory/src/__tests__/llmClientFactory.test.ts
+++ b/packages/llm-factory/src/__tests__/llmClientFactory.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { LlmProviders, LlmModels, type ModelPricing } from '@intexuraos/llm-contract';
+import { LlmProviders, LlmModels } from '@intexuraos/llm-contract';
 import type { Logger } from '@intexuraos/common-core';
 import type { UsageSink } from '@intexuraos/llm-pricing';
 
@@ -36,12 +36,6 @@ vi.mock('../openRouterGenerateClient.js', () => ({
 const { createLlmClient, createToolCallingClient, isSupportedProvider } =
   await import('../llmClientFactory.js');
 
-const createTestPricing = (overrides: Partial<ModelPricing> = {}): ModelPricing => ({
-  inputPricePerMillion: 0.6,
-  outputPricePerMillion: 2.2,
-  webSearchCostPerCall: 0.005,
-  ...overrides,
-});
 
 describe('llmClientFactory', () => {
   beforeEach(() => {
@@ -54,7 +48,6 @@ describe('llmClientFactory', () => {
         apiKey: 'test-key',
         model: LlmModels.Gemini25Flash,
         userId: 'user-123',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -68,7 +61,6 @@ describe('llmClientFactory', () => {
         apiKey: 'test-key',
         model: LlmModels.Gemini25Pro,
         userId: 'user-123',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -82,7 +74,6 @@ describe('llmClientFactory', () => {
         apiKey: 'test-key',
         model: LlmModels.Gemini25Flash,
         userId: 'user-123',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -96,7 +87,6 @@ describe('llmClientFactory', () => {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           model: 'gemini-2.5-flash-exp-unsupported' as any,
           userId: 'user-123',
-          pricing: createTestPricing(),
           logger: mockLogger,
           usageSink: mockUsageSink,
         })
@@ -112,7 +102,6 @@ describe('llmClientFactory', () => {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           model: 'claude-opus' as any,
           userId: 'user-123',
-          pricing: createTestPricing(),
           logger: mockLogger,
           usageSink: mockUsageSink,
         })
@@ -125,7 +114,6 @@ describe('llmClientFactory', () => {
           apiKey: 'test-key',
           model: LlmModels.ClaudeHaiku35,
           userId: 'user-123',
-          pricing: createTestPricing(),
           logger: mockLogger,
           usageSink: mockUsageSink,
         })
@@ -138,7 +126,6 @@ describe('llmClientFactory', () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         model: 'or:google/gemma-4-31b-it:free' as any,
         userId: 'user-123',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -154,7 +141,6 @@ describe('llmClientFactory', () => {
         apiKey: 'test-key',
         model: LlmModels.Gemini25Flash,
         userId: 'test-user',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });
@@ -169,7 +155,6 @@ describe('llmClientFactory', () => {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           model: 'nonexistent-model' as any,
           userId: 'test-user',
-          pricing: createTestPricing(),
           logger: mockLogger,
           usageSink: mockUsageSink,
         })
@@ -183,7 +168,6 @@ describe('llmClientFactory', () => {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           model: LlmModels.ClaudeOpus46 as any,
           userId: 'test-user',
-          pricing: createTestPricing(),
           logger: mockLogger,
           usageSink: mockUsageSink,
         })
@@ -200,7 +184,6 @@ describe('llmClientFactory', () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         model: 'or:google/gemma-4-31b-it:free' as any,
         userId: 'user-123',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
         ownerType: 'user',
@@ -218,7 +201,6 @@ describe('llmClientFactory', () => {
         apiKey: 'test-key',
         model: LlmModels.Gemini25Flash,
         userId: 'user-123',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
         ownerType: 'user',
@@ -236,7 +218,6 @@ describe('llmClientFactory', () => {
         apiKey: 'test-key',
         model: LlmModels.Gemini25Flash,
         userId: 'user-123',
-        pricing: createTestPricing(),
         logger: mockLogger,
         usageSink: mockUsageSink,
       });

--- a/packages/llm-factory/src/__tests__/llmClientFactory.test.ts
+++ b/packages/llm-factory/src/__tests__/llmClientFactory.test.ts
@@ -132,46 +132,6 @@ describe('llmClientFactory', () => {
       ).toThrow('Unsupported LLM provider: anthropic');
     });
 
-    it('defaults to zero-cost pricing when pricing is omitted (Gemini)', async () => {
-      const { createGeminiClient } = await import('@intexuraos/infra-gemini');
-
-      createLlmClient({
-        apiKey: 'test-key',
-        model: LlmModels.Gemini25Flash,
-        userId: 'user-123',
-        logger: mockLogger,
-        usageSink: mockUsageSink,
-      });
-
-      const callArg = vi.mocked(createGeminiClient).mock.calls[0]?.[0] as unknown as Record<
-        string,
-        unknown
-      >;
-      expect(callArg?.['pricing']).toEqual({
-        inputPricePerMillion: 0,
-        outputPricePerMillion: 0,
-      });
-    });
-
-    it('defaults to zero-cost pricing when pricing is omitted (OpenRouter)', async () => {
-      const { createOpenRouterGenerateClient } = await import('../openRouterGenerateClient.js');
-
-      createLlmClient({
-        apiKey: 'test-key',
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        model: 'or:google/gemma-4-31b-it:free' as any,
-        userId: 'user-123',
-        logger: mockLogger,
-        usageSink: mockUsageSink,
-      });
-
-      expect(vi.mocked(createOpenRouterGenerateClient)).toHaveBeenCalledWith(
-        expect.objectContaining({
-          pricing: { inputPricePerMillion: 0, outputPricePerMillion: 0 },
-        })
-      );
-    });
-
     it('creates OpenRouter client for or: prefixed models', () => {
       const client = createLlmClient({
         apiKey: 'test-key',

--- a/packages/llm-factory/src/__tests__/llmClientFactory.test.ts
+++ b/packages/llm-factory/src/__tests__/llmClientFactory.test.ts
@@ -132,6 +132,46 @@ describe('llmClientFactory', () => {
       ).toThrow('Unsupported LLM provider: anthropic');
     });
 
+    it('defaults to zero-cost pricing when pricing is omitted (Gemini)', async () => {
+      const { createGeminiClient } = await import('@intexuraos/infra-gemini');
+
+      createLlmClient({
+        apiKey: 'test-key',
+        model: LlmModels.Gemini25Flash,
+        userId: 'user-123',
+        logger: mockLogger,
+        usageSink: mockUsageSink,
+      });
+
+      const callArg = vi.mocked(createGeminiClient).mock.calls[0]?.[0] as unknown as Record<
+        string,
+        unknown
+      >;
+      expect(callArg?.['pricing']).toEqual({
+        inputPricePerMillion: 0,
+        outputPricePerMillion: 0,
+      });
+    });
+
+    it('defaults to zero-cost pricing when pricing is omitted (OpenRouter)', async () => {
+      const { createOpenRouterGenerateClient } = await import('../openRouterGenerateClient.js');
+
+      createLlmClient({
+        apiKey: 'test-key',
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        model: 'or:google/gemma-4-31b-it:free' as any,
+        userId: 'user-123',
+        logger: mockLogger,
+        usageSink: mockUsageSink,
+      });
+
+      expect(vi.mocked(createOpenRouterGenerateClient)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          pricing: { inputPricePerMillion: 0, outputPricePerMillion: 0 },
+        })
+      );
+    });
+
     it('creates OpenRouter client for or: prefixed models', () => {
       const client = createLlmClient({
         apiKey: 'test-key',

--- a/packages/llm-factory/src/__tests__/llmClientFactory.test.ts
+++ b/packages/llm-factory/src/__tests__/llmClientFactory.test.ts
@@ -36,7 +36,6 @@ vi.mock('../openRouterGenerateClient.js', () => ({
 const { createLlmClient, createToolCallingClient, isSupportedProvider } =
   await import('../llmClientFactory.js');
 
-
 describe('llmClientFactory', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/packages/llm-factory/src/__tests__/openRouterGenerateClient.test.ts
+++ b/packages/llm-factory/src/__tests__/openRouterGenerateClient.test.ts
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { type ModelPricing } from '@intexuraos/llm-contract';
 import type { Logger } from '@intexuraos/common-core';
 import { ok, err } from '@intexuraos/common-core';
 import type { UsageSink } from '@intexuraos/llm-pricing';
@@ -23,18 +22,10 @@ vi.mock('@intexuraos/infra-openrouter', () => ({
 
 const { createOpenRouterGenerateClient } = await import('../openRouterGenerateClient.js');
 
-const createTestPricing = (overrides: Partial<ModelPricing> = {}): ModelPricing => ({
-  inputPricePerMillion: 0.6,
-  outputPricePerMillion: 2.2,
-  webSearchCostPerCall: 0.005,
-  ...overrides,
-});
-
 const baseConfig = {
   apiKey: 'test-key',
   model: 'or:google/gemma-4-31b-it:free' as unknown as import('@intexuraos/llm-contract').LLMModel,
   userId: 'user-123',
-  pricing: createTestPricing(),
   logger: mockLogger,
   usageSink: mockUsageSink,
 };

--- a/packages/llm-factory/src/llmClientFactory.ts
+++ b/packages/llm-factory/src/llmClientFactory.ts
@@ -59,7 +59,7 @@ export interface LlmClientConfig {
   model: LLMModel;
   /** User ID for usage tracking */
   userId: string;
-  /** Optional. When omitted, local cost calculation is skipped (costs computed server-side). */
+  /** When omitted, defaults to zero-cost pricing (costs computed server-side by llm-usage-service). */
   pricing?: ModelPricing;
   /** Logger for structured LLM usage logging */
   logger: Logger;

--- a/packages/llm-factory/src/llmClientFactory.ts
+++ b/packages/llm-factory/src/llmClientFactory.ts
@@ -18,7 +18,8 @@
  *   apiKey: 'sk-...',
  *   model: 'gemini-2.5-flash',
  *   userId: 'user-123',
- *   pricing: { inputPricePerMillion: 0.3, outputPricePerMillion: 2.5 },
+ *   logger: pinoLogger,
+ *   usageSink: myUsageSink,
  * });
  *
  * const result = await client.generate('Write a poem');
@@ -41,7 +42,6 @@ import {
   LlmProviders,
   type LLMError,
   type LLMModel,
-  type ModelPricing,
   type ToolCallingClient,
   type OwnerType,
 } from '@intexuraos/llm-contract';
@@ -58,8 +58,11 @@ export interface LlmClientConfig {
   model: LLMModel;
   /** User ID for usage tracking */
   userId: string;
-  /** Pricing information for the model */
-  pricing: ModelPricing;
+  /**
+   * @deprecated No longer used. Costs are computed by llm-usage-service on ingestion.
+   * Kept as optional for backward compatibility with apps that still pass it.
+   */
+  pricing?: import('@intexuraos/llm-contract').ModelPricing;
   /** Logger for structured LLM usage logging */
   logger: Logger;
   /** Usage sink. Required — pass NoopUsageSink to explicitly opt out. */
@@ -120,7 +123,8 @@ type SupportedProvider = typeof LlmProviders.Google | typeof LlmProviders.OpenRo
  *   apiKey: 'sk-...',
  *   model: 'gemini-2.5-flash',
  *   userId: 'user-123',
- *   pricing: getPricing('gemini-2.5-flash'),
+ *   logger: pinoLogger,
+ *   usageSink: myUsageSink,
  * });
  * ```
  */

--- a/packages/llm-factory/src/llmClientFactory.ts
+++ b/packages/llm-factory/src/llmClientFactory.ts
@@ -59,7 +59,7 @@ export interface LlmClientConfig {
   /** User ID for usage tracking */
   userId: string;
   /**
-   * @deprecated No longer used. Costs are computed by llm-usage-service on ingestion.
+   * No longer used. Costs are computed by llm-usage-service on ingestion.
    * Kept as optional for backward compatibility with apps that still pass it.
    */
   pricing?: import('@intexuraos/llm-contract').ModelPricing;

--- a/packages/llm-factory/src/llmClientFactory.ts
+++ b/packages/llm-factory/src/llmClientFactory.ts
@@ -18,7 +18,6 @@
  *   apiKey: 'sk-...',
  *   model: 'gemini-2.5-flash',
  *   userId: 'user-123',
- *   pricing: { inputPricePerMillion: 0.3, outputPricePerMillion: 2.5 },
  * });
  *
  * const result = await client.generate('Write a poem');
@@ -48,6 +47,8 @@ import {
 import { createOpenRouterGenerateClient } from './openRouterGenerateClient.js';
 import type { Logger, Result } from '@intexuraos/common-core';
 
+const ZERO_PRICING: ModelPricing = { inputPricePerMillion: 0, outputPricePerMillion: 0 };
+
 /**
  * Configuration for creating an LLM client.
  */
@@ -58,8 +59,8 @@ export interface LlmClientConfig {
   model: LLMModel;
   /** User ID for usage tracking */
   userId: string;
-  /** Pricing information for the model */
-  pricing: ModelPricing;
+  /** Optional. When omitted, local cost calculation is skipped (costs computed server-side). */
+  pricing?: ModelPricing;
   /** Logger for structured LLM usage logging */
   logger: Logger;
   /** Usage sink. Required — pass NoopUsageSink to explicitly opt out. */
@@ -120,7 +121,6 @@ type SupportedProvider = typeof LlmProviders.Google | typeof LlmProviders.OpenRo
  *   apiKey: 'sk-...',
  *   model: 'gemini-2.5-flash',
  *   userId: 'user-123',
- *   pricing: getPricing('gemini-2.5-flash'),
  * });
  * ```
  */
@@ -129,7 +129,7 @@ export function createLlmClient(config: LlmClientConfig): LlmGenerateClient {
 
   // OpenRouter models (or: prefix) are routed to the OpenRouter client
   if (isOpenRouterModel(model)) {
-    return createOpenRouterGenerateClient(config);
+    return createOpenRouterGenerateClient({ ...config, pricing: config.pricing ?? ZERO_PRICING });
   }
 
   // Validate model is a known static model
@@ -145,7 +145,7 @@ export function createLlmClient(config: LlmClientConfig): LlmGenerateClient {
     );
   }
 
-  return createGeminiClient(config);
+  return createGeminiClient({ ...config, pricing: config.pricing ?? ZERO_PRICING });
 }
 
 /**

--- a/packages/llm-factory/src/llmClientFactory.ts
+++ b/packages/llm-factory/src/llmClientFactory.ts
@@ -58,11 +58,6 @@ export interface LlmClientConfig {
   model: LLMModel;
   /** User ID for usage tracking */
   userId: string;
-  /**
-   * No longer used. Costs are computed by llm-usage-service on ingestion.
-   * Kept as optional for backward compatibility with apps that still pass it.
-   */
-  pricing?: import('@intexuraos/llm-contract').ModelPricing;
   /** Logger for structured LLM usage logging */
   logger: Logger;
   /** Usage sink. Required — pass NoopUsageSink to explicitly opt out. */

--- a/packages/llm-factory/src/llmClientFactory.ts
+++ b/packages/llm-factory/src/llmClientFactory.ts
@@ -18,6 +18,7 @@
  *   apiKey: 'sk-...',
  *   model: 'gemini-2.5-flash',
  *   userId: 'user-123',
+ *   pricing: { inputPricePerMillion: 0.3, outputPricePerMillion: 2.5 },
  * });
  *
  * const result = await client.generate('Write a poem');
@@ -47,8 +48,6 @@ import {
 import { createOpenRouterGenerateClient } from './openRouterGenerateClient.js';
 import type { Logger, Result } from '@intexuraos/common-core';
 
-const ZERO_PRICING: ModelPricing = { inputPricePerMillion: 0, outputPricePerMillion: 0 };
-
 /**
  * Configuration for creating an LLM client.
  */
@@ -59,8 +58,8 @@ export interface LlmClientConfig {
   model: LLMModel;
   /** User ID for usage tracking */
   userId: string;
-  /** When omitted, defaults to zero-cost pricing (costs computed server-side by llm-usage-service). */
-  pricing?: ModelPricing;
+  /** Pricing information for the model */
+  pricing: ModelPricing;
   /** Logger for structured LLM usage logging */
   logger: Logger;
   /** Usage sink. Required — pass NoopUsageSink to explicitly opt out. */
@@ -121,6 +120,7 @@ type SupportedProvider = typeof LlmProviders.Google | typeof LlmProviders.OpenRo
  *   apiKey: 'sk-...',
  *   model: 'gemini-2.5-flash',
  *   userId: 'user-123',
+ *   pricing: getPricing('gemini-2.5-flash'),
  * });
  * ```
  */
@@ -129,7 +129,7 @@ export function createLlmClient(config: LlmClientConfig): LlmGenerateClient {
 
   // OpenRouter models (or: prefix) are routed to the OpenRouter client
   if (isOpenRouterModel(model)) {
-    return createOpenRouterGenerateClient({ ...config, pricing: config.pricing ?? ZERO_PRICING });
+    return createOpenRouterGenerateClient(config);
   }
 
   // Validate model is a known static model
@@ -145,7 +145,7 @@ export function createLlmClient(config: LlmClientConfig): LlmGenerateClient {
     );
   }
 
-  return createGeminiClient({ ...config, pricing: config.pricing ?? ZERO_PRICING });
+  return createGeminiClient(config);
 }
 
 /**

--- a/packages/llm-factory/src/llmClientFactory.ts
+++ b/packages/llm-factory/src/llmClientFactory.ts
@@ -58,8 +58,8 @@ export interface LlmClientConfig {
   model: LLMModel;
   /** User ID for usage tracking */
   userId: string;
-  /** Pricing information for the model */
-  pricing: ModelPricing;
+  /** Pricing information for the model. Optional — defaults to zero cost when omitted. */
+  pricing?: ModelPricing;
   /** Logger for structured LLM usage logging */
   logger: Logger;
   /** Usage sink. Required — pass NoopUsageSink to explicitly opt out. */

--- a/packages/llm-factory/src/openRouterGenerateClient.ts
+++ b/packages/llm-factory/src/openRouterGenerateClient.ts
@@ -1,10 +1,16 @@
 import { createOpenRouterClient } from '@intexuraos/infra-openrouter';
-import { getOpenRouterRawId, isOpenRouterModel } from '@intexuraos/llm-contract';
+import { getOpenRouterRawId, isOpenRouterModel, type ModelPricing } from '@intexuraos/llm-contract';
 import type { LlmClientConfig, LlmGenerateClient, GenerateResult } from './llmClientFactory.js';
 import type { LLMError } from '@intexuraos/llm-contract';
 import type { Result } from '@intexuraos/common-core';
 
-export function createOpenRouterGenerateClient(config: LlmClientConfig): LlmGenerateClient {
+/**
+ * Create an OpenRouter generate client.
+ * Requires pricing to be resolved (provided by {@link createLlmClient} which defaults to zero pricing).
+ */
+export function createOpenRouterGenerateClient(
+  config: LlmClientConfig & { pricing: ModelPricing }
+): LlmGenerateClient {
   const rawModel = isOpenRouterModel(config.model as string)
     ? getOpenRouterRawId(config.model as string)
     : (config.model as string);
@@ -13,7 +19,7 @@ export function createOpenRouterGenerateClient(config: LlmClientConfig): LlmGene
     apiKey: config.apiKey,
     model: rawModel,
     userId: config.userId,
-    pricing: config.pricing ?? { inputPricePerMillion: 0, outputPricePerMillion: 0 },
+    pricing: config.pricing,
     logger: config.logger,
     usageSink: config.usageSink,
     ...(config.ownerType !== undefined && { ownerType: config.ownerType }),

--- a/packages/llm-factory/src/openRouterGenerateClient.ts
+++ b/packages/llm-factory/src/openRouterGenerateClient.ts
@@ -1,16 +1,10 @@
 import { createOpenRouterClient } from '@intexuraos/infra-openrouter';
-import { getOpenRouterRawId, isOpenRouterModel, type ModelPricing } from '@intexuraos/llm-contract';
+import { getOpenRouterRawId, isOpenRouterModel } from '@intexuraos/llm-contract';
 import type { LlmClientConfig, LlmGenerateClient, GenerateResult } from './llmClientFactory.js';
 import type { LLMError } from '@intexuraos/llm-contract';
 import type { Result } from '@intexuraos/common-core';
 
-/**
- * Create an OpenRouter generate client.
- * Requires pricing to be resolved (provided by {@link createLlmClient} which defaults to zero pricing).
- */
-export function createOpenRouterGenerateClient(
-  config: LlmClientConfig & { pricing: ModelPricing }
-): LlmGenerateClient {
+export function createOpenRouterGenerateClient(config: LlmClientConfig): LlmGenerateClient {
   const rawModel = isOpenRouterModel(config.model as string)
     ? getOpenRouterRawId(config.model as string)
     : (config.model as string);

--- a/packages/llm-factory/src/openRouterGenerateClient.ts
+++ b/packages/llm-factory/src/openRouterGenerateClient.ts
@@ -13,7 +13,7 @@ export function createOpenRouterGenerateClient(config: LlmClientConfig): LlmGene
     apiKey: config.apiKey,
     model: rawModel,
     userId: config.userId,
-    pricing: config.pricing,
+    pricing: config.pricing ?? { inputPricePerMillion: 0, outputPricePerMillion: 0 },
     logger: config.logger,
     usageSink: config.usageSink,
     ...(config.ownerType !== undefined && { ownerType: config.ownerType }),

--- a/packages/llm-factory/src/openRouterGenerateClient.ts
+++ b/packages/llm-factory/src/openRouterGenerateClient.ts
@@ -13,7 +13,7 @@ export function createOpenRouterGenerateClient(config: LlmClientConfig): LlmGene
     apiKey: config.apiKey,
     model: rawModel,
     userId: config.userId,
-    pricing: config.pricing,
+    ...(config.pricing !== undefined && { pricing: config.pricing }),
     logger: config.logger,
     usageSink: config.usageSink,
     ...(config.ownerType !== undefined && { ownerType: config.ownerType }),

--- a/packages/llm-factory/src/openRouterGenerateClient.ts
+++ b/packages/llm-factory/src/openRouterGenerateClient.ts
@@ -13,7 +13,6 @@ export function createOpenRouterGenerateClient(config: LlmClientConfig): LlmGene
     apiKey: config.apiKey,
     model: rawModel,
     userId: config.userId,
-    pricing: config.pricing,
     logger: config.logger,
     usageSink: config.usageSink,
     ...(config.ownerType !== undefined && { ownerType: config.ownerType }),

--- a/packages/llm-pricing/src/__tests__/buildUsageEvent.test.ts
+++ b/packages/llm-pricing/src/__tests__/buildUsageEvent.test.ts
@@ -4,12 +4,11 @@ import { buildUsageEvent } from '../buildUsageEvent.js';
 import type { UsageLogParams } from '../usageLogger.js';
 
 interface EventForTests {
+  schemaVersion: number;
   owner: { type: string; id: string };
   source: { service: string; component: string; client: string; environment: string };
   cost: {
-    billedUsd: number;
     providerReportedUsd: number | null;
-    calculatedUsd: number;
     pricingSource: string;
   };
   [k: string]: unknown;
@@ -20,13 +19,18 @@ const baseParams: UsageLogParams = {
   provider: LlmProviders.OpenRouter,
   model: 'or:nvidia/nemotron-3-super-120b-a12b:free',
   callType: 'generate',
-  usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30, costUsd: 0.001 },
+  usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30, costUsd: 0 },
   success: true,
 };
 
 const baseSource = { service: 'linear-agent', component: 'title-gen' };
 
 describe('buildUsageEvent', () => {
+  it('emits schemaVersion 2', () => {
+    const event = buildUsageEvent(baseParams, baseSource) as EventForTests;
+    expect(event.schemaVersion).toBe(2);
+  });
+
   it('defaults owner.type to "system" when ownerType not provided', () => {
     const event = buildUsageEvent(baseParams, baseSource) as EventForTests;
     expect(event.owner).toEqual({ type: 'system', id: 'user-123' });
@@ -58,22 +62,18 @@ describe('buildUsageEvent', () => {
     expect(event.source.client).not.toMatch(/\//);
   });
 
-  it('cost.providerReportedUsd is null and pricingSource is "calculated" by default', () => {
+  it('cost.providerReportedUsd is null and pricingSource is "pending" by default', () => {
     const event = buildUsageEvent(baseParams, baseSource) as EventForTests;
     expect(event.cost.providerReportedUsd).toBeNull();
-    expect(event.cost.pricingSource).toBe('calculated');
-    expect(event.cost.billedUsd).toBe(0.001);
-    expect(event.cost.calculatedUsd).toBe(0.001);
+    expect(event.cost.pricingSource).toBe('pending');
   });
 
-  it('cost uses providerReportedUsd as billedUsd when provided; pricingSource = "provider_reported"', () => {
+  it('cost uses providerReportedUsd when provided; pricingSource = "provider_reported"', () => {
     const event = buildUsageEvent(
       { ...baseParams, providerReportedUsd: 0.0042 },
       baseSource
     ) as EventForTests;
     expect(event.cost.providerReportedUsd).toBe(0.0042);
-    expect(event.cost.billedUsd).toBe(0.0042);
-    expect(event.cost.calculatedUsd).toBe(0.001);
     expect(event.cost.pricingSource).toBe('provider_reported');
   });
 
@@ -83,15 +83,6 @@ describe('buildUsageEvent', () => {
       baseSource
     ) as EventForTests;
     expect(event.cost.providerReportedUsd).toBeNull();
-    expect(event.cost.pricingSource).toBe('calculated');
-    expect(event.cost.billedUsd).toBe(0.001);
-  });
-
-  it('clamps a negative providerReportedUsd to 0 (schema requires billedUsd >= 0)', () => {
-    const event = buildUsageEvent(
-      { ...baseParams, providerReportedUsd: -0.001 },
-      baseSource
-    ) as EventForTests;
-    expect(event.cost.billedUsd).toBeGreaterThanOrEqual(0);
+    expect(event.cost.pricingSource).toBe('pending');
   });
 });

--- a/packages/llm-pricing/src/__tests__/httpInternalAuthUsageSink.test.ts
+++ b/packages/llm-pricing/src/__tests__/httpInternalAuthUsageSink.test.ts
@@ -56,9 +56,7 @@ interface CapturedEvent {
     imageCount: number;
   };
   cost: {
-    billedUsd: number;
     providerReportedUsd: number | null;
-    calculatedUsd: number | null;
     pricingSource: string;
   };
   correlation: {
@@ -147,7 +145,7 @@ describe('HttpInternalAuthUsageSink', () => {
 
       const event = parsedBody.events[0];
       expect(event).toBeDefined();
-      expect(event?.schemaVersion).toBe(1);
+      expect(event?.schemaVersion).toBe(2);
       expect(event?.eventId).toMatch(
         /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
       );
@@ -180,10 +178,8 @@ describe('HttpInternalAuthUsageSink', () => {
         imageCount: 0,
       });
       expect(event?.cost).toEqual({
-        billedUsd: 0.0105,
         providerReportedUsd: null,
-        calculatedUsd: 0.0105,
-        pricingSource: 'calculated',
+        pricingSource: 'pending',
       });
       expect(event?.correlation).toEqual({
         requestId: null,

--- a/packages/llm-pricing/src/__tests__/httpWebhookUsageSink.test.ts
+++ b/packages/llm-pricing/src/__tests__/httpWebhookUsageSink.test.ts
@@ -57,9 +57,7 @@ interface CapturedEvent {
     imageCount: number;
   };
   cost: {
-    billedUsd: number;
     providerReportedUsd: number | null;
-    calculatedUsd: number | null;
     pricingSource: string;
   };
   correlation: {
@@ -141,7 +139,7 @@ describe('HttpWebhookUsageSink', () => {
 
       const event = parsedBody.events[0];
       expect(event).toBeDefined();
-      expect(event?.schemaVersion).toBe(1);
+      expect(event?.schemaVersion).toBe(2);
       expect(event?.eventId).toMatch(
         /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
       );
@@ -174,10 +172,8 @@ describe('HttpWebhookUsageSink', () => {
         imageCount: 0,
       });
       expect(event?.cost).toEqual({
-        billedUsd: 0.0105,
         providerReportedUsd: null,
-        calculatedUsd: 0.0105,
-        pricingSource: 'calculated',
+        pricingSource: 'pending',
       });
       expect(event?.correlation).toEqual({
         requestId: null,

--- a/packages/llm-pricing/src/buildUsageEvent.ts
+++ b/packages/llm-pricing/src/buildUsageEvent.ts
@@ -26,6 +26,8 @@ export type UsageEventPayload = Record<string, unknown>;
  * Shared helper that maps UsageLogParams to a usage event payload.
  * Used by both HttpWebhookUsageSink and HttpInternalAuthUsageSink to avoid duplication.
  *
+ * Schema v2: clients emit raw token counts; llm-usage-service computes costs on ingestion.
+ *
  * @internal
  */
 export function buildUsageEvent(
@@ -39,12 +41,9 @@ export function buildUsageEvent(
   const clientName = params.clientName ?? source.component;
   const providerReportedUsd = params.providerReportedUsd ?? null;
   const useProviderCost = providerReportedUsd !== null;
-  // Schema requires billedUsd >= 0; clamp defensively so a misbehaving provider can't 400 the receiver.
-  const billedUsd = useProviderCost ? Math.max(0, providerReportedUsd) : params.usage.costUsd;
-  const pricingSource = useProviderCost ? 'provider_reported' : 'calculated';
 
   return {
-    schemaVersion: 1,
+    schemaVersion: 2,
     eventId: crypto.randomUUID(),
     occurredAt: new Date().toISOString(),
     owner: { type: ownerType, id: params.userId },
@@ -75,10 +74,8 @@ export function buildUsageEvent(
       imageCount: 0,
     },
     cost: {
-      billedUsd,
       providerReportedUsd,
-      calculatedUsd: params.usage.costUsd,
-      pricingSource,
+      pricingSource: useProviderCost ? 'provider_reported' : 'pending',
     },
     correlation: {
       requestId: correlationOverrides?.requestId ?? null,

--- a/packages/llm-pricing/src/pricingClient.ts
+++ b/packages/llm-pricing/src/pricingClient.ts
@@ -10,22 +10,10 @@
  * Pricing data is fetched from `/internal/pricing` endpoint
  * and cached in a `PricingContext` for efficient runtime access.
  *
- * @example
- * ```ts
- * import { fetchAllPricing, createPricingContext } from '@intexuraos/llm-pricing';
- *
- * // Fetch pricing from llm-usage-service
- * const result = await fetchAllPricing(
- *   'http://llm-usage-service/internal',
- *   'internal-auth-token'
- * );
- *
- * if (result.ok) {
- *   const pricingContext = createPricingContext(result.data);
- *   const pricing = pricingContext.getPricing('claude-sonnet-4-5');
- *   console.log(pricing.inputPricePerMillion); // 3.00
- * }
- * ```
+ * @deprecated The fetch/retry/context functions in this module are slated for
+ * removal once all apps have migrated away from client-side pricing. New code
+ * should NOT depend on fetchAllPricing, fetchAllPricingWithRetry,
+ * PricingContext, or createPricingContext.
  */
 
 import {
@@ -43,24 +31,6 @@ import { err, getErrorMessage, ok, type Result } from '@intexuraos/common-core';
  * @remarks
  * Contains pricing data for all LLM providers. Each provider's pricing
  * includes models with their per-million-token input/output prices.
- *
- * @example
- * ```ts
- * const response: AllPricingResponse = {
- *   anthropic: {
- *     models: {
- *       'claude-sonnet-4-5': {
- *         inputPricePerMillion: 3.00,
- *         outputPricePerMillion: 15.00,
- *         cacheReadMultiplier: 0.1,
- *         cacheWriteMultiplier: 1.25,
- *       },
- *     },
- *     updatedAt: '2026-01-13T00:00:00Z',
- *   },
- *   // ... other providers
- * };
- * ```
  */
 export interface AllPricingResponse {
   /** Google Gemini pricing */
@@ -77,20 +47,6 @@ export interface AllPricingResponse {
 
 /**
  * Error returned from pricing client operations.
- *
- * @example
- * ```ts
- * if (!result.ok) {
- *   switch (result.error.code) {
- *     case 'NETWORK_ERROR':
- *       console.error('Network error:', result.error.message);
- *       break;
- *     case 'API_ERROR':
- *       console.error('API error:', result.error.message);
- *       break;
- *   }
- * }
- * ```
  */
 export interface PricingClientError {
   /** Network connectivity error */
@@ -104,27 +60,7 @@ export interface PricingClientError {
 /**
  * Fetch all LLM pricing from llm-usage-service.
  *
- * @remarks
- * Calls `/internal/pricing` with `X-Internal-Auth` header.
- * Returns a {@link Result} type - use pattern matching to handle errors.
- *
- * @param baseUrl - Base URL of llm-usage-service (e.g., `'http://llm-usage-service'`)
- * @param authToken - Internal auth token for `X-Internal-Auth` header
- * @returns Result with all provider pricing or error
- *
- * @example
- * ```ts
- * const result = await fetchAllPricing(
- *   'http://llm-usage-service',
- *   process.env.INTERNAL_AUTH_TOKEN
- * );
- *
- * if (result.ok) {
- *   console.log('Pricing loaded:', Object.keys(result.data.anthropic.models));
- * } else {
- *   console.error('Failed to fetch pricing:', result.error.message);
- * }
- * ```
+ * @deprecated Will be removed once apps stop using client-side pricing.
  */
 export async function fetchAllPricing(
   baseUrl: string,
@@ -175,6 +111,8 @@ export async function fetchAllPricing(
 
 /**
  * Configuration for retry behavior in {@link fetchAllPricingWithRetry}.
+ *
+ * @deprecated Will be removed once apps stop using client-side pricing.
  */
 export interface PricingRetryOptions {
   /** Maximum number of retry attempts (default: 5) */
@@ -195,23 +133,10 @@ const DEFAULT_MAX_DELAY_MS = 15000;
 
 /**
  * Whether a pricing client error is transient and worth retrying.
- *
- * Retries on:
- * - NETWORK_ERROR: connection refused, DNS failure, timeout
- * - API_ERROR with HTTP 404, 5xx: service not yet deployed or temporarily down
- *
- * Does NOT retry:
- * - API_ERROR with HTTP 401/403: auth misconfiguration won't self-heal
- * - VALIDATION_ERROR: response format issues won't self-heal
  */
 function isTransientError(error: PricingClientError): boolean {
-  // Network errors (connection refused, DNS failure, timeout) are always transient
   if (error.code === 'NETWORK_ERROR') return true;
-
-  // API_ERROR — check if the HTTP status is transient
   if (error.statusCode === undefined) return false;
-
-  // 404 = route not deployed yet; 5xx = server error
   return error.statusCode === 404 || error.statusCode >= 500;
 }
 
@@ -227,32 +152,7 @@ function defaultDelay(ms: number): Promise<void> {
 /**
  * Fetch all LLM pricing with exponential backoff retries.
  *
- * @remarks
- * Wraps {@link fetchAllPricing} with retry logic to handle transient failures
- * during deployment (e.g., llm-usage-service not yet ready). Uses exponential
- * backoff: 1s → 2s → 4s → 8s → 15s (capped). Total max wait ≈ 30s with
- * default settings.
- *
- * Only retries on transient errors (network failures, HTTP 404/5xx).
- * Non-transient errors (401, 403, validation) fail immediately.
- *
- * @param baseUrl - Base URL of llm-usage-service
- * @param authToken - Internal auth token for `X-Internal-Auth` header
- * @param options - Optional retry configuration
- * @returns Result with all provider pricing or error after exhausting retries
- *
- * @example
- * ```ts
- * // At service startup — resilient to deployment ordering
- * const result = await fetchAllPricingWithRetry(
- *   process.env.INTEXURAOS_LLM_USAGE_SERVICE_URL,
- *   process.env.INTEXURAOS_INTERNAL_AUTH_TOKEN
- * );
- *
- * if (!result.ok) {
- *   throw new Error(`Failed to fetch pricing: ${result.error.message}`);
- * }
- * ```
+ * @deprecated Will be removed once apps stop using client-side pricing.
  */
 export async function fetchAllPricingWithRetry(
   baseUrl: string,
@@ -300,9 +200,7 @@ export async function fetchAllPricingWithRetry(
 /**
  * Interface for pricing context.
  *
- * @remarks
- * Allows test fakes by defining the pricing lookup contract.
- * Implemented by {@link PricingContext}.
+ * @deprecated Will be removed once apps stop using client-side pricing.
  */
 export interface IPricingContext {
   /** Get pricing for a model; returns zero pricing for unknown models with a warn for ops audit */
@@ -320,28 +218,7 @@ export interface IPricingContext {
 /**
  * Runtime pricing lookup context.
  *
- * @remarks
- * Created at application startup with fetched pricing from llm-usage-service.
- * Caches all pricing in a Map for O(1) lookups during LLM operations.
- *
- * @example
- * ```ts
- * import { createPricingContext } from '@intexuraos/llm-pricing';
- *
- * const context = createPricingContext(allPricingResponse);
- *
- * // Get pricing for a specific model
- * const pricing = context.getPricing('claude-sonnet-4-5');
- * console.log(pricing.inputPricePerMillion);
- *
- * // Check if pricing exists
- * if (context.hasPricing('claude-opus-4-5')) {
- *   // Model is available
- * }
- *
- * // Validate before using
- * context.validateModels(['claude-sonnet-4-5', 'gpt-4.1']);
- * ```
+ * @deprecated Will be removed once apps stop using client-side pricing.
  */
 export class PricingContext implements IPricingContext {
   /** Map of model to pricing for O(1) lookups */
@@ -367,17 +244,9 @@ export class PricingContext implements IPricingContext {
     }
   }
 
-  /**
-   * Get pricing for a model.
-   *
-   * Returns zero pricing for unknown models so producers can still emit a
-   * usage event with cost=$0 instead of crashing. Use validateModels() at
-   * startup if you need fail-fast for known-static dependencies.
-   */
   getPricing(model: LLMModel): ModelPricing {
     const pricing = this.pricing.get(model);
     if (pricing === undefined) {
-      // process.stderr.write (no Logger dep in PricingContext) — Cloud Logging picks it up as severity=WARNING.
       process.stderr.write(
         `[llm-pricing] No pricing for model ${model} — falling back to $0; emit-don't-skip policy\n`
       );
@@ -386,17 +255,10 @@ export class PricingContext implements IPricingContext {
     return pricing;
   }
 
-  /**
-   * Check if pricing exists for a model.
-   */
   hasPricing(model: LLMModel): boolean {
     return this.pricing.has(model);
   }
 
-  /**
-   * Validate that all specified models have pricing.
-   * @throws Error listing missing models
-   */
   validateModels(models: LLMModel[]): void {
     const missing = models.filter((m) => !this.pricing.has(m));
     if (missing.length > 0) {
@@ -404,18 +266,10 @@ export class PricingContext implements IPricingContext {
     }
   }
 
-  /**
-   * Validate that ALL LLM models have pricing defined.
-   * Used by llm-usage-service at startup.
-   * @throws Error listing missing models
-   */
   validateAllModels(): void {
     this.validateModels(ALL_LLM_MODELS);
   }
 
-  /**
-   * Get all models that have pricing defined.
-   */
   getModelsWithPricing(): LLMModel[] {
     return Array.from(this.pricing.keys());
   }
@@ -431,29 +285,7 @@ function isValidLLMModel(model: string): model is LLMModel {
 /**
  * Create a PricingContext from fetched pricing.
  *
- * @remarks
- * Validates that all required models have pricing defined before returning.
- * Throws an error listing missing models if validation fails.
- *
- * @param allPricing - Pricing response from llm-usage-service
- * @param requiredModels - Models that must have pricing (default: all models)
- * @returns Validated pricing context
- * @throws Error if any required model is missing pricing
- *
- * @example
- * ```ts
- * import { createPricingContext } from '@intexuraos/llm-pricing';
- *
- * // Validate all models have pricing (for llm-usage-service)
- * const context = createPricingContext(allPricing);
- *
- * // Validate only specific models (for client services)
- * const clientContext = createPricingContext(allPricing, [
- *   'claude-sonnet-4-5',
- *   'claude-opus-4-5',
- *   'gpt-4.1',
- * ]);
- * ```
+ * @deprecated Will be removed once apps stop using client-side pricing.
  */
 export function createPricingContext(
   allPricing: AllPricingResponse,

--- a/packages/llm-pricing/src/pricingClient.ts
+++ b/packages/llm-pricing/src/pricingClient.ts
@@ -10,8 +10,8 @@
  * Pricing data is fetched from `/internal/pricing` endpoint
  * and cached in a `PricingContext` for efficient runtime access.
  *
- * @deprecated The fetch/retry/context functions in this module are slated for
- * removal once all apps have migrated away from client-side pricing. New code
+ * Note: The fetch/retry/context functions in this module will be removed
+ * once all apps have migrated away from client-side pricing. New code
  * should NOT depend on fetchAllPricing, fetchAllPricingWithRetry,
  * PricingContext, or createPricingContext.
  */
@@ -60,7 +60,7 @@ export interface PricingClientError {
 /**
  * Fetch all LLM pricing from llm-usage-service.
  *
- * @deprecated Will be removed once apps stop using client-side pricing.
+ * Will be removed once apps stop using client-side pricing.
  */
 export async function fetchAllPricing(
   baseUrl: string,
@@ -112,7 +112,7 @@ export async function fetchAllPricing(
 /**
  * Configuration for retry behavior in {@link fetchAllPricingWithRetry}.
  *
- * @deprecated Will be removed once apps stop using client-side pricing.
+ * Will be removed once apps stop using client-side pricing.
  */
 export interface PricingRetryOptions {
   /** Maximum number of retry attempts (default: 5) */
@@ -152,7 +152,7 @@ function defaultDelay(ms: number): Promise<void> {
 /**
  * Fetch all LLM pricing with exponential backoff retries.
  *
- * @deprecated Will be removed once apps stop using client-side pricing.
+ * Will be removed once apps stop using client-side pricing.
  */
 export async function fetchAllPricingWithRetry(
   baseUrl: string,
@@ -200,7 +200,7 @@ export async function fetchAllPricingWithRetry(
 /**
  * Interface for pricing context.
  *
- * @deprecated Will be removed once apps stop using client-side pricing.
+ * Will be removed once apps stop using client-side pricing.
  */
 export interface IPricingContext {
   /** Get pricing for a model; returns zero pricing for unknown models with a warn for ops audit */
@@ -218,7 +218,7 @@ export interface IPricingContext {
 /**
  * Runtime pricing lookup context.
  *
- * @deprecated Will be removed once apps stop using client-side pricing.
+ * Will be removed once apps stop using client-side pricing.
  */
 export class PricingContext implements IPricingContext {
   /** Map of model to pricing for O(1) lookups */
@@ -285,7 +285,7 @@ function isValidLLMModel(model: string): model is LLMModel {
 /**
  * Create a PricingContext from fetched pricing.
  *
- * @deprecated Will be removed once apps stop using client-side pricing.
+ * Will be removed once apps stop using client-side pricing.
  */
 export function createPricingContext(
   allPricing: AllPricingResponse,

--- a/packages/llm-pricing/src/testFixtures.ts
+++ b/packages/llm-pricing/src/testFixtures.ts
@@ -1,5 +1,5 @@
 /**
- * Test fixtures for pricing.
+ * Test fixtures for pricing and usage logging.
  * Provides mock pricing, PricingContext, and UsageSink for tests.
  */
 
@@ -9,6 +9,8 @@ import type { UsageLogParams, UsageSink } from './usageLogger.js';
 
 /**
  * Default test pricing for all models.
+ *
+ * @deprecated Will be removed once apps stop using client-side pricing.
  */
 export const TEST_PRICING: ModelPricing = {
   inputPricePerMillion: 1.0,
@@ -17,6 +19,8 @@ export const TEST_PRICING: ModelPricing = {
 
 /**
  * Test image pricing.
+ *
+ * @deprecated Will be removed once apps stop using client-side pricing.
  */
 export const TEST_IMAGE_PRICING: ModelPricing = {
   inputPricePerMillion: 0,
@@ -30,6 +34,8 @@ export const TEST_IMAGE_PRICING: ModelPricing = {
 
 /**
  * Fake PricingContext for tests.
+ *
+ * @deprecated Will be removed once apps stop using client-side pricing.
  */
 export class FakePricingContext implements IPricingContext {
   readonly testPricing: ModelPricing;
@@ -85,6 +91,8 @@ export class FakePricingContext implements IPricingContext {
 
 /**
  * Create a fake PricingContext for tests.
+ *
+ * @deprecated Will be removed once apps stop using client-side pricing.
  */
 export function createFakePricingContext(
   pricing: ModelPricing = TEST_PRICING,

--- a/packages/llm-pricing/src/testFixtures.ts
+++ b/packages/llm-pricing/src/testFixtures.ts
@@ -10,7 +10,7 @@ import type { UsageLogParams, UsageSink } from './usageLogger.js';
 /**
  * Default test pricing for all models.
  *
- * @deprecated Will be removed once apps stop using client-side pricing.
+ * Will be removed once apps stop using client-side pricing.
  */
 export const TEST_PRICING: ModelPricing = {
   inputPricePerMillion: 1.0,
@@ -20,7 +20,7 @@ export const TEST_PRICING: ModelPricing = {
 /**
  * Test image pricing.
  *
- * @deprecated Will be removed once apps stop using client-side pricing.
+ * Will be removed once apps stop using client-side pricing.
  */
 export const TEST_IMAGE_PRICING: ModelPricing = {
   inputPricePerMillion: 0,
@@ -35,7 +35,7 @@ export const TEST_IMAGE_PRICING: ModelPricing = {
 /**
  * Fake PricingContext for tests.
  *
- * @deprecated Will be removed once apps stop using client-side pricing.
+ * Will be removed once apps stop using client-side pricing.
  */
 export class FakePricingContext implements IPricingContext {
   readonly testPricing: ModelPricing;
@@ -92,7 +92,7 @@ export class FakePricingContext implements IPricingContext {
 /**
  * Create a fake PricingContext for tests.
  *
- * @deprecated Will be removed once apps stop using client-side pricing.
+ * Will be removed once apps stop using client-side pricing.
  */
 export function createFakePricingContext(
   pricing: ModelPricing = TEST_PRICING,

--- a/workers/orchestrator/src/services/__tests__/validation-model-clients.test.ts
+++ b/workers/orchestrator/src/services/__tests__/validation-model-clients.test.ts
@@ -115,15 +115,19 @@ describe('buildValidationClients', () => {
     expect(clients[1]?.modelName).toBe('gemini-2.5-flash');
     expect(createLlmClientMock).toHaveBeenCalledTimes(2);
 
+    const zeroPricing = { inputPricePerMillion: 0, outputPricePerMillion: 0 };
+
     // First call: OpenRouter model
     const firstCallConfig = createLlmClientMock.mock.calls[0]?.[0] as Record<string, unknown>;
     expect(firstCallConfig['apiKey']).toBe('or-key');
     expect(firstCallConfig['model']).toBe('or:google/gemma-4-31b-it:free');
+    expect(firstCallConfig['pricing']).toEqual(zeroPricing);
 
     // Second call: Gemini model
     const secondCallConfig = createLlmClientMock.mock.calls[1]?.[0] as Record<string, unknown>;
     expect(secondCallConfig['apiKey']).toBe('gem-key');
     expect(secondCallConfig['model']).toBe('gemini-2.5-flash');
+    expect(secondCallConfig['pricing']).toEqual(zeroPricing);
   });
 
   it('throws when openRouterApiKey is empty and an or: model is present', () => {

--- a/workers/orchestrator/src/services/__tests__/validation-model-clients.test.ts
+++ b/workers/orchestrator/src/services/__tests__/validation-model-clients.test.ts
@@ -8,14 +8,6 @@ vi.mock('@intexuraos/llm-factory', () => ({
   createLlmClient: createLlmClientMock,
 }));
 
-const { getDefaultAllowlistPricingMock } = vi.hoisted(() => ({
-  getDefaultAllowlistPricingMock: vi.fn(),
-}));
-
-vi.mock('@intexuraos/infra-openrouter', () => ({
-  getDefaultAllowlistPricing: getDefaultAllowlistPricingMock,
-}));
-
 const { HttpWebhookUsageSinkMock } = vi.hoisted(() => {
   const constructorSpy = vi.fn();
   function HttpWebhookUsageSinkMock(this: Record<string, unknown>, config: unknown): void {
@@ -30,7 +22,7 @@ vi.mock('@intexuraos/llm-pricing', () => ({
   HttpWebhookUsageSink: HttpWebhookUsageSinkMock,
 }));
 
-const { parseValidationModels, buildValidationClients, GEMINI_VALIDATION_PRICING } =
+const { parseValidationModels, buildValidationClients } =
   await import('../validation-model-clients.js');
 
 const fakeLogger = {
@@ -103,10 +95,6 @@ describe('buildValidationClients', () => {
     const fakeClient1 = { generate: vi.fn() };
     const fakeClient2 = { generate: vi.fn() };
     createLlmClientMock.mockReturnValueOnce(fakeClient1).mockReturnValueOnce(fakeClient2);
-    getDefaultAllowlistPricingMock.mockReturnValue({
-      inputPricePerMillion: 0,
-      outputPricePerMillion: 0,
-    });
 
     const models = parseValidationModels('or:google/gemma-4-31b-it:free,gemini-2.5-flash');
     const clients = buildValidationClients({
@@ -136,70 +124,6 @@ describe('buildValidationClients', () => {
     const secondCallConfig = createLlmClientMock.mock.calls[1]?.[0] as Record<string, unknown>;
     expect(secondCallConfig['apiKey']).toBe('gem-key');
     expect(secondCallConfig['model']).toBe('gemini-2.5-flash');
-  });
-
-  it('uses getDefaultAllowlistPricing for OpenRouter models', () => {
-    const expectedPricing = { inputPricePerMillion: 0.3, outputPricePerMillion: 1.0 };
-    getDefaultAllowlistPricingMock.mockReturnValue(expectedPricing);
-    createLlmClientMock.mockReturnValue({ generate: vi.fn() });
-
-    const models = parseValidationModels('or:google/gemma-4-31b-it:free');
-    buildValidationClients({
-      models,
-      openRouterApiKey: 'or-key',
-      geminiApiKey: 'gem-key',
-      usageWebhookUrl: 'http://usage',
-      orchestratorSecret: 'secret',
-      internalAuthToken: 'token',
-      logger: fakeLogger,
-      getCorrelationTaskId: () => null,
-    });
-
-    expect(getDefaultAllowlistPricingMock).toHaveBeenCalledWith('google/gemma-4-31b-it:free');
-    const callConfig = createLlmClientMock.mock.calls[0]?.[0] as Record<string, unknown>;
-    expect(callConfig['pricing']).toBe(expectedPricing);
-  });
-
-  it('falls back to zero pricing when OpenRouter model is not in default allowlist', () => {
-    getDefaultAllowlistPricingMock.mockReturnValue(undefined);
-    createLlmClientMock.mockReturnValue({ generate: vi.fn() });
-
-    const models = parseValidationModels('or:unknown/model');
-    buildValidationClients({
-      models,
-      openRouterApiKey: 'or-key',
-      geminiApiKey: 'gem-key',
-      usageWebhookUrl: 'http://usage',
-      orchestratorSecret: 'secret',
-      internalAuthToken: 'token',
-      logger: fakeLogger,
-      getCorrelationTaskId: () => null,
-    });
-
-    const callConfig = createLlmClientMock.mock.calls[0]?.[0] as Record<string, unknown>;
-    expect(callConfig['pricing']).toEqual({
-      inputPricePerMillion: 0,
-      outputPricePerMillion: 0,
-    });
-  });
-
-  it('uses GEMINI_VALIDATION_PRICING for Gemini models', () => {
-    createLlmClientMock.mockReturnValue({ generate: vi.fn() });
-
-    const models = parseValidationModels('gemini-2.5-flash');
-    buildValidationClients({
-      models,
-      openRouterApiKey: 'or-key',
-      geminiApiKey: 'gem-key',
-      usageWebhookUrl: 'http://usage',
-      orchestratorSecret: 'secret',
-      internalAuthToken: 'token',
-      logger: fakeLogger,
-      getCorrelationTaskId: () => null,
-    });
-
-    const callConfig = createLlmClientMock.mock.calls[0]?.[0] as Record<string, unknown>;
-    expect(callConfig['pricing']).toBe(GEMINI_VALIDATION_PRICING);
   });
 
   it('throws when openRouterApiKey is empty and an or: model is present', () => {
@@ -236,10 +160,6 @@ describe('buildValidationClients', () => {
 
   it('threads getCorrelationTaskId into the HttpWebhookUsageSink for each client', () => {
     createLlmClientMock.mockReturnValue({ generate: vi.fn() });
-    getDefaultAllowlistPricingMock.mockReturnValue({
-      inputPricePerMillion: 0,
-      outputPricePerMillion: 0,
-    });
 
     const getCorrelationTaskId = vi.fn().mockReturnValue('task-123');
     const models = parseValidationModels('or:google/gemma-4-31b-it:free,gemini-2.5-flash');

--- a/workers/orchestrator/src/services/validation-model-clients.ts
+++ b/workers/orchestrator/src/services/validation-model-clients.ts
@@ -1,7 +1,14 @@
 import type { Logger } from '@intexuraos/common-core';
-import type { LLMModel } from '@intexuraos/llm-contract';
+import type { LLMModel, ModelPricing } from '@intexuraos/llm-contract';
 import { createLlmClient, type LlmGenerateClient } from '@intexuraos/llm-factory';
 import { HttpWebhookUsageSink } from '@intexuraos/llm-pricing';
+
+/**
+ * Temporary zero-cost pricing placeholder.
+ * Once llm-usage-service computes costs server-side (INT-1377, Child Issue 2),
+ * `pricing` will become optional in `LlmClientConfig` and this constant can be removed.
+ */
+const ZERO_PRICING: ModelPricing = { inputPricePerMillion: 0, outputPricePerMillion: 0 };
 
 export interface ParsedValidationModel {
   provider: 'openrouter' | 'gemini';
@@ -93,6 +100,7 @@ export function buildValidationClients(
           apiKey: config.openRouterApiKey,
           model: model.modelId as LLMModel,
           userId: 'orchestrator-validation',
+          pricing: ZERO_PRICING,
           logger: config.logger,
           usageSink: new HttpWebhookUsageSink({
             webhookUrl: config.usageWebhookUrl,
@@ -120,6 +128,7 @@ export function buildValidationClients(
         apiKey: config.geminiApiKey,
         model: model.modelId as LLMModel,
         userId: 'orchestrator-validation',
+        pricing: ZERO_PRICING,
         logger: config.logger,
         usageSink: new HttpWebhookUsageSink({
           webhookUrl: config.usageWebhookUrl,

--- a/workers/orchestrator/src/services/validation-model-clients.ts
+++ b/workers/orchestrator/src/services/validation-model-clients.ts
@@ -1,7 +1,6 @@
 import type { Logger } from '@intexuraos/common-core';
-import type { LLMModel, ModelPricing } from '@intexuraos/llm-contract';
+import type { LLMModel } from '@intexuraos/llm-contract';
 import { createLlmClient, type LlmGenerateClient } from '@intexuraos/llm-factory';
-import { getDefaultAllowlistPricing } from '@intexuraos/infra-openrouter';
 import { HttpWebhookUsageSink } from '@intexuraos/llm-pricing';
 
 export interface ParsedValidationModel {
@@ -11,21 +10,6 @@ export interface ParsedValidationModel {
   /** Raw model ID without or: prefix */
   rawId: string;
 }
-
-/**
- * Static pricing for Gemini models used in validation.
- * Matches the previously-hardcoded VERIFIER_PRICING for Gemini 2.5 Flash.
- */
-export const GEMINI_VALIDATION_PRICING: ModelPricing = {
-  inputPricePerMillion: 0.3,
-  outputPricePerMillion: 2.5,
-  groundingCostPerRequest: 0,
-};
-
-const ZERO_PRICING: ModelPricing = {
-  inputPricePerMillion: 0,
-  outputPricePerMillion: 0,
-};
 
 /**
  * Parse the comma-separated INTEXURAOS_ORCHESTRATOR_VALIDATION_MODELS env var
@@ -103,15 +87,12 @@ export function buildValidationClients(
         );
       }
 
-      const pricing = getDefaultAllowlistPricing(model.rawId) ?? ZERO_PRICING;
-
       return {
         modelName: model.modelId,
         client: createLlmClient({
           apiKey: config.openRouterApiKey,
           model: model.modelId as LLMModel,
           userId: 'orchestrator-validation',
-          pricing,
           logger: config.logger,
           usageSink: new HttpWebhookUsageSink({
             webhookUrl: config.usageWebhookUrl,
@@ -139,7 +120,6 @@ export function buildValidationClients(
         apiKey: config.geminiApiKey,
         model: model.modelId as LLMModel,
         userId: 'orchestrator-validation',
-        pricing: GEMINI_VALIDATION_PRICING,
         logger: config.logger,
         usageSink: new HttpWebhookUsageSink({
           webhookUrl: config.usageWebhookUrl,


### PR DESCRIPTION
## Summary

Consolidated merge of all 4 child PRs under [INT-1377](https://linear.app/pbuchman/issue/INT-1377) (centralize LLM pricing in `llm-usage-service` as single source of truth). Merged as one branch to avoid repeated cross-package conflicts and fragmented CI runs.

Fixes INT-1386

## Consolidated PRs (all closed, branches preserved)

| Closed PR | Issue | Scope |
| -- | -- | -- |
| #1820 | [INT-1378](https://linear.app/pbuchman/issue/INT-1378) | `llm-usage-service`: server-side cost calculation, v2 event schema, pricing cache |
| #1822 | [INT-1379](https://linear.app/pbuchman/issue/INT-1379) | `packages/*`: remove pricing from LLM client APIs, emit v2 events with `pricingSource: 'pending'` |
| #1821 | [INT-1381](https://linear.app/pbuchman/issue/INT-1381) | `workers/orchestrator`: remove pricing from validation-model-clients |
| #1823 | [INT-1380](https://linear.app/pbuchman/issue/INT-1380) | `apps/chat-agent`, `code-agent`, `research-agent`: remove pricing from consumers |

## Merge order (dependency-driven)

1. INT-1378 first — `llm-usage-service` accepts v2 events and computes cost server-side
2. INT-1379 next — client APIs start emitting v2 events
3. INT-1381, INT-1380 after — orchestrator and consumer callers drop pricing

## Conflict resolution

16 files conflicted between #1822 (packages) and #1823 (consumers) because both made `pricing` optional on shared config types. Resolved by:

- **packages/\***: preferred #1822's cleaner removal — `pricing` field kept as optional for backward compat but no longer destructured or defaulted to `ZERO_PRICING` (dead code elimination).
- **apps/chat-agent/src/services.ts**: preferred #1823's version — removes boot-time `fetchAllPricingWithRetry` call and associated import (#1822 did not touch this file).

Net effect matches the design doc (`docs/designs/2026-04-14-centralize-llm-pricing.md`): clients emit raw tokens, `llm-usage-service` computes cost.

## Verification

- [x] `pnpm run ci:tracked` — all 4 phases green, 14,722 tests pass
- [x] 100% branch coverage maintained
- [x] No v8 ignore regressions
- [x] Pushed to origin

## Deployment order

Per the parent design doc:

1. Deploy `llm-usage-service` first (has dual-schema v1+v2 support)
2. Deploy the other services in any order after step 1

## Endpoint Changes

- **Modified**: `POST /internal/usage`, `POST /webhook/usage` in `llm-usage-service` now accept both v1 and v2 event schemas via `oneOf`
- **Created**: none
- **Removed**: none
- **Unchanged**: all public routes

## Draft rationale

Opened as **draft** per request — ready for review but not auto-merged. Do not mark ready until:
- Staging smoke of v2 event ingestion is verified
- Deployment plan for rollout order is confirmed

---

Consolidation coordinated by Claude Code. Original child PRs: #1820, #1821, #1822, #1823 (all closed, branches retained).