### PR TITLE
[INT-1388] fix(web): send correct important value on toggle

### DIFF
--- a/apps/web/src/hooks/__tests__/useIssueGroups.test.ts
+++ b/apps/web/src/hooks/__tests__/useIssueGroups.test.ts
@@ -21,9 +21,11 @@ vi.mock('../../context/index.js', () => ({
 }));
 
 const mockListIssueGroups = vi.fn();
+const mockSetGroupImportant = vi.fn();
 
 vi.mock('../../services/issueGroupsApi.js', () => ({
   listIssueGroups: (...args: unknown[]): unknown => mockListIssueGroups(...args),
+  setGroupImportant: (...args: unknown[]): unknown => mockSetGroupImportant(...args),
 }));
 
 /* ── helpers ───────────────────────────────────────────────────────── */
@@ -460,6 +462,105 @@ describe('useIssueGroups', () => {
     expect(result.current.refreshing).toBe(false);
 
     unmount();
+  });
+
+  describe('toggleImportant', () => {
+    beforeEach(() => {
+      mockSetGroupImportant.mockResolvedValue({ important: true });
+    });
+
+    it('sends important=true when toggling a non-important group', async () => {
+      mockListIssueGroups.mockResolvedValue(
+        makeResponse({ groups: [makeGroup({ linearIssueId: 'INT-750', isImportant: undefined })] }),
+      );
+
+      const { result } = renderHook(() => useIssueGroups({}));
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      // Deferred token for the click path only — this creates the exact
+      // window in which the ref-vs-state race occurs: React commits the
+      // optimistic setGroups while the IIFE is suspended on `await
+      // getAccessToken()`.
+      let resolveToken!: (value: string) => void;
+      mockGetAccessToken.mockImplementationOnce(
+        () => new Promise<string>((r) => { resolveToken = r; }),
+      );
+
+      await act(async () => {
+        result.current.toggleImportant('INT-750');
+      });
+
+      // Optimistic update must be committed — UI shows important=true.
+      expect(result.current.groups[0]?.isImportant).toBe(true);
+
+      // Unblock the token; the IIFE resumes and fires the PATCH.
+      await act(async () => {
+        resolveToken('test-token');
+      });
+
+      expect(mockSetGroupImportant).toHaveBeenCalledTimes(1);
+      expect(mockSetGroupImportant).toHaveBeenCalledWith('test-token', 'INT-750', true);
+    });
+
+    it('sends important=false when toggling an already-important group', async () => {
+      mockListIssueGroups.mockResolvedValue(
+        makeResponse({ groups: [makeGroup({ linearIssueId: 'INT-750', isImportant: true })] }),
+      );
+
+      const { result } = renderHook(() => useIssueGroups({}));
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      let resolveToken!: (value: string) => void;
+      mockGetAccessToken.mockImplementationOnce(
+        () => new Promise<string>((r) => { resolveToken = r; }),
+      );
+
+      await act(async () => {
+        result.current.toggleImportant('INT-750');
+      });
+
+      expect(result.current.groups[0]?.isImportant).toBeUndefined();
+
+      await act(async () => {
+        resolveToken('test-token');
+      });
+
+      expect(mockSetGroupImportant).toHaveBeenCalledWith('test-token', 'INT-750', false);
+    });
+
+    it('reverts optimistic update when API call fails', async () => {
+      mockListIssueGroups.mockResolvedValue(
+        makeResponse({ groups: [makeGroup({ linearIssueId: 'INT-750', isImportant: undefined })] }),
+      );
+      mockSetGroupImportant.mockRejectedValue(new Error('network down'));
+
+      const { result } = renderHook(() => useIssueGroups({}));
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      // Next list call (revert via refresh) returns the server truth.
+      mockListIssueGroups.mockResolvedValue(
+        makeResponse({ groups: [makeGroup({ linearIssueId: 'INT-750', isImportant: undefined })] }),
+      );
+
+      await act(async () => {
+        result.current.toggleImportant('INT-750');
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      await waitFor(() => {
+        expect(result.current.groups[0]?.isImportant).toBeUndefined();
+      });
+    });
   });
 
   it('re-fetches when filter options change', async () => {

--- a/apps/web/src/hooks/useIssueGroups.ts
+++ b/apps/web/src/hooks/useIssueGroups.ts
@@ -272,16 +272,22 @@ export function useIssueGroups(options: {
 
   const toggleImportant = useCallback(
     (groupKey: string): void => {
-      // Optimistic update: toggle in local state immediately
+      // Capture the target value BEFORE the optimistic setGroups runs.
+      // Reading groupsRef.current after an await would see the post-commit
+      // state and flip newImportant to the wrong value.
+      const currentGroup = groupsRef.current.find(
+        (g) => (g.linearIssueId ?? `standalone_${g.latestTask.id}`) === groupKey,
+      );
+      const newImportant = currentGroup?.isImportant !== true;
+
+      // Optimistic update: apply target value immediately.
       setGroups((prev) =>
         prev.map((g): IssueGroup => {
           const key = g.linearIssueId ?? `standalone_${g.latestTask.id}`;
           if (key !== groupKey) return g;
-          if (g.isImportant === true) {
-            const { isImportant: _, ...rest } = g;
-            return rest;
-          }
-          return { ...g, isImportant: true };
+          if (newImportant) return { ...g, isImportant: true };
+          const { isImportant: _, ...rest } = g;
+          return rest;
         }),
       );
 
@@ -289,8 +295,6 @@ export function useIssueGroups(options: {
       void (async (): Promise<void> => {
         try {
           const token = await getAccessToken();
-          const currentGroup = groupsRef.current.find((g) => (g.linearIssueId ?? `standalone_${g.latestTask.id}`) === groupKey);
-          const newImportant = currentGroup?.isImportant !== true;
           await setGroupImportant(token, groupKey, newImportant);
         } catch (_err) {
           // Revert on error by refreshing


### PR DESCRIPTION
## Summary

- `toggleImportant` in `useIssueGroups` read `groupsRef.current` *after* `await getAccessToken()`. React committed the optimistic `setGroups` during that await, so the ref reflected the post-flip value and `newImportant` resolved to the opposite of what the user intended. Result: clicking the "Mark as important" button on a non-important issue fired `PATCH {"important": false}`, and vice versa.
- Fix: capture `newImportant` synchronously (before `setGroups`) and use that single value to drive both the optimistic state update and the PATCH body.
- Regression tests use a deferred `getAccessToken` promise so React commits the optimistic update before the IIFE resumes — which is the exact window where the ref-vs-state race happens in the browser.

Regression introduced by 9977a4d (`fix(web): stabilize toggleImportant callback with groupsRef`): stabilizing the callback identity was right, but replacing the stale-closure read with `groupsRef.current` conflated "stable identity" with "latest value".

## Test plan

- [x] `pnpm --filter @intexuraos/web test -- --run src/hooks/__tests__/useIssueGroups.test.ts`
- [x] `pnpm run ci:tracked`
- [ ] Manual: toggle an important/non-important issue in dev, verify request body matches the desired state and the UI sticks after the next poll.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>