### PR TITLE
[INT-1380] fix(code-agent): suppress merge step for closed/merged PRs

### DIFF
--- a/apps/code-agent/src/__tests__/domain/issueGrouping/groupByLinearIssue.test.ts
+++ b/apps/code-agent/src/__tests__/domain/issueGrouping/groupByLinearIssue.test.ts
@@ -563,6 +563,35 @@ describe('derivePipeline', () => {
     expect(mergeStep?.state).toBe('actionable');
   });
 
+  it('does NOT create merge step (execution path) when PR has prClosedAt, even with ready-to-merge label', () => {
+    const tasks = [
+      makeTask({
+        id: 'task-1',
+        status: 'implemented',
+        agentType: 'execution',
+        prClosedAt: '2026-03-01T12:00:00.000Z',
+        result: { prUrl: 'https://github.com/owner/repo/pull/42' },
+        linearIssue: {
+          identifier: 'INT-100',
+          title: 'Test',
+          state: { name: 'In Progress', type: 'started' },
+          priority: 1,
+          assignee: null,
+          labels: [{ name: 'ready-to-merge' }],
+          url: 'https://linear.app/INT-100',
+          commentCount: 0,
+          lastCommentAt: null,
+        },
+      }),
+    ];
+
+    const pipeline = derivePipeline(tasks);
+
+    expect(pipeline.steps.find((s) => s.agentType === 'merge')).toBeUndefined();
+    expect(pipeline.pr?.status).toBe('closed');
+    expect(deriveAggregateStatus(tasks, pipeline)).toBe('done');
+  });
+
   it('creates merge step via review fallback when review completed with prNumber, needs_remediation=0, and ready-to-merge label', () => {
     const tasks = [
       makeTask({
@@ -591,6 +620,36 @@ describe('derivePipeline', () => {
     const mergeStep = pipeline.steps.find((s) => s.agentType === 'merge');
     expect(mergeStep).toBeDefined();
     expect(mergeStep?.state).toBe('actionable');
+  });
+
+  it('does NOT create merge step (review fallback) when PR has prMergedAt, even with ready-to-merge label', () => {
+    const tasks = [
+      makeTask({
+        id: 'task-1',
+        status: 'reviewed',
+        agentType: 'review',
+        prNumber: 42,
+        prMergedAt: '2026-03-01T12:00:00.000Z',
+        result: { needs_remediation: '0', prUrl: 'https://github.com/owner/repo/pull/42' },
+        linearIssue: {
+          identifier: 'INT-100',
+          parentIdentifier: null,
+          title: 'Test',
+          state: { name: 'Done', type: 'completed' },
+          priority: 2,
+          assignee: null,
+          labels: [{ name: 'ready-to-merge' }],
+          url: 'https://linear.app/test',
+          commentCount: 0,
+          lastCommentAt: null,
+        },
+      }),
+    ];
+
+    const pipeline = derivePipeline(tasks);
+
+    expect(pipeline.steps.find((s) => s.agentType === 'merge')).toBeUndefined();
+    expect(pipeline.pr?.status).toBe('merged');
   });
 
   it('does NOT create merge step via review fallback when ready-to-merge label is absent', () => {

--- a/apps/code-agent/src/domain/issueGrouping/groupByLinearIssue.ts
+++ b/apps/code-agent/src/domain/issueGrouping/groupByLinearIssue.ts
@@ -88,9 +88,16 @@ export function derivePipeline(tasks: SerializedTask[]): PipelineState {
   // Guard: do not show merge button while any task is actively processing
   const hasActiveTask = tasks.some((t) => ACTIVE_STATUSES.has(t.status));
 
+  // Authoritative PR terminal state — the Linear ready-to-merge label may lag
+  // after handlePrClose, so prMergedAt/prClosedAt take precedence.
+  const isMerged = tasks.some((t) => t.prMergedAt !== undefined);
+  const isClosed = tasks.some((t) => t.prClosedAt !== undefined);
+  const isPrClosedOrMerged = isMerged || isClosed;
+
   // Merge-ready logic: if execution step is completed, PR exists, and ready-to-merge label present
   if (
     !hasActiveTask &&
+    !isPrClosedOrMerged &&
     executionEntry?.step.state === 'completed' &&
     executionEntry.task.result?.prUrl !== undefined &&
     hasMergeReadyLabel(executionEntry.task.linearIssue?.labels)
@@ -111,6 +118,7 @@ export function derivePipeline(tasks: SerializedTask[]): PipelineState {
   const reviewEntry = stepMap.get('review');
   if (
     !hasActiveTask &&
+    !isPrClosedOrMerged &&
     reviewEntry?.step.state === 'completed' &&
     reviewEntry.task.prNumber !== undefined &&
     reviewEntry.task.result?.needs_remediation === REMEDIATION_NOT_NEEDED &&
@@ -133,10 +141,7 @@ export function derivePipeline(tasks: SerializedTask[]): PipelineState {
     if (prUrl !== undefined) {
       const match = PR_URL_REGEX.exec(prUrl);
       if (match?.[1] !== undefined) {
-        // Derive PR status from task data
         const hasMergeStep = steps.some((s) => s.agentType === 'merge' && s.state === 'actionable');
-        const isMerged = tasks.some((t) => t.prMergedAt !== undefined);
-        const isClosed = tasks.some((t) => t.prClosedAt !== undefined);
 
         let status: 'open' | 'merged' | 'closed' | 'mergeable';
         if (isMerged) {
@@ -155,11 +160,12 @@ export function derivePipeline(tasks: SerializedTask[]): PipelineState {
     }
   }
 
-  // failedAttempts: count of tasks with status === 'failed'
-  const failedAttempts = tasks.filter((t) => t.status === 'failed').length;
-
-  // archivedCount: count of tasks with status === 'archived'
-  const archivedCount = tasks.filter((t) => t.status === 'archived').length;
+  let failedAttempts = 0;
+  let archivedCount = 0;
+  for (const t of tasks) {
+    if (t.status === 'failed') failedAttempts++;
+    else if (t.status === 'archived') archivedCount++;
+  }
 
   return { steps, pr, failedAttempts, archivedCount };
 }


### PR DESCRIPTION
## Summary

Closed PRs that kept the Linear `ready-to-merge` label (e.g. PR #1823 for INT-1380) rendered a stale purple Merge button and a `needs-action` aggregate status instead of the expected red `#1823` closed badge and `done`. The merge-step branches in `derivePipeline` (`apps/code-agent/src/domain/issueGrouping/groupByLinearIssue.ts`) consulted only the Linear label, which lags when `handlePrClose`'s best-effort `removeLabel` fails or races with a re-add.

- Guard both merge-step branches with `!isPrClosedOrMerged`, derived from task-level `prClosedAt` / `prMergedAt` (authoritative — these are the webhook-confirmed PR terminal timestamps)
- Hoist `isMerged` / `isClosed` to the top of `derivePipeline`, reuse for both the guard and the PR-status derivation — 3 task scans -> 2, single source of truth
- Collapse the `failedAttempts` / `archivedCount` computations into a single loop

Firestore evidence confirmed 3 stuck groups at investigation time — INT-1380/PR1823, INT-1379/PR1822, INT-1381/PR1821 — all with `prClosedAt` set on tasks but `ready-to-merge` still present on the Linear issue. No backfill is needed: the live derivation short-circuits on the PR timestamp as soon as this ships.

The Linear label-drift root cause (why `removeLabel` didn't take effect) is out of scope; tracking separately.

## Test plan

- [x] `pnpm vitest run apps/code-agent/src/__tests__/domain/issueGrouping/groupByLinearIssue.test.ts` — 64 tests pass (62 existing + 2 new covering execution-path `prClosedAt` and review-fallback `prMergedAt`)
- [x] `pnpm run verify:workspace:tracked code-agent` — all 4 phases pass
- [x] `pnpm run ci:tracked` — 14562 tests pass, lint/types/coverage/format green
- [ ] Post-merge manual check on dev: load `/#/code-tasks`, confirm INT-1380/1379/1381 rows show red `#<pr>` closed badge and aggregate `done`, matching INT-1378's current (correct) rendering

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>