### PR TITLE
[INT-1399] Auto-retry tasks that fail with TASK_EXIT_CODE_OVERRIDE

### DIFF
--- a/apps/code-agent/src/__tests__/domain/utils/classifyFailure.test.ts
+++ b/apps/code-agent/src/__tests__/domain/utils/classifyFailure.test.ts
@@ -11,7 +11,7 @@ describe('classifyFailure', () => {
     ['worker_unavailable', 'All worker health probes failed'],
     ['network_error', 'Connection refused'],
   ])('returns "retry" for infrastructure error code "%s"', (code, message) => {
-    expect(classifyFailure(code, message)).toBe('retry' satisfies FailureVerdict);
+    expect(classifyFailure({ code, message })).toBe('retry' satisfies FailureVerdict);
   });
 
   // Container crash with OOM/SIGKILL (exit 137)
@@ -20,7 +20,7 @@ describe('classifyFailure', () => {
     ['TASK_FATAL_EXIT_CODE', 'Worker process terminated with signal 137'],
     ['TASK_COMPLETION_VERIFICATION_FAILED', 'fatal_exit_code_137: container killed'],
   ])('returns "retry" for exit-137 pattern in code "%s"', (code, message) => {
-    expect(classifyFailure(code, message)).toBe('retry' satisfies FailureVerdict);
+    expect(classifyFailure({ code, message })).toBe('retry' satisfies FailureVerdict);
   });
 
   // Container stopped / Docker issues
@@ -28,12 +28,12 @@ describe('classifyFailure', () => {
     ['RESUME_ATTEMPT_FAILED', 'Container returned 409 Conflict'],
     ['RESUME_ATTEMPT_FAILED', 'Docker request timed out after 30s'],
   ])('returns "retry" for Docker transient in code "%s"', (code, message) => {
-    expect(classifyFailure(code, message)).toBe('retry' satisfies FailureVerdict);
+    expect(classifyFailure({ code, message })).toBe('retry' satisfies FailureVerdict);
   });
 
   // Rate limit — retry after cooloff
   it('returns "retry_after_cooloff" for 429 rate limit', () => {
-    expect(classifyFailure('TASK_RESUMED_HARD_ERROR', 'API returned 429 Too Many Requests'))
+    expect(classifyFailure({ code: 'TASK_RESUMED_HARD_ERROR', message: 'API returned 429 Too Many Requests' }))
       .toBe('retry_after_cooloff' satisfies FailureVerdict);
   });
 
@@ -44,7 +44,41 @@ describe('classifyFailure', () => {
     ['PULL_REQUEST_AGENT_ENFORCEMENT_FAILED', 'PR URL missing from output'],
     ['REVIEW_AGENT_ENFORCEMENT_FAILED', 'Review summary missing'],
   ])('returns "ask_llm" for enforcement code "%s"', (code, message) => {
-    expect(classifyFailure(code, message)).toBe('ask_llm' satisfies FailureVerdict);
+    expect(classifyFailure({ code, message })).toBe('ask_llm' satisfies FailureVerdict);
+  });
+
+  // Exit-code-override: orchestrator ran verifier-pass but worker exited non-zero.
+  // Underlying cause is usually transient (git lock, stale container). Always retry.
+  it('returns "retry" for TASK_EXIT_CODE_OVERRIDE (regression guard — see fix/auto-retry-exit-code-override)', () => {
+    expect(classifyFailure({ code: 'TASK_EXIT_CODE_OVERRIDE', message: 'Non-zero exit code (255) overrides verifier passed decision' }))
+      .toBe('retry' satisfies FailureVerdict);
+  });
+
+  // Orchestrator remediation hint — honor the orchestrator's retry signal as fallback.
+  // Guards against classifier/orchestrator drift when new orchestrator error codes are added.
+  it('returns "retry" when remediation.action is "retry" on an otherwise-unknown error code', () => {
+    expect(classifyFailure({
+      code: 'some_future_orchestrator_error',
+      message: 'Transient infra glitch',
+      remediation: { action: 'retry' },
+    })).toBe('retry' satisfies FailureVerdict);
+  });
+
+  // Remediation.action=retry must not override more-specific nuanced verdicts (e.g. cooloff, ask_llm).
+  it('prefers specific verdict over remediation.action for rate limit', () => {
+    expect(classifyFailure({
+      code: 'TASK_RESUMED_HARD_ERROR',
+      message: 'API returned 429 Too Many Requests',
+      remediation: { action: 'retry' },
+    })).toBe('retry_after_cooloff' satisfies FailureVerdict);
+  });
+
+  it('prefers specific verdict over remediation.action for enforcement failures', () => {
+    expect(classifyFailure({
+      code: 'EXECUTION_AGENT_ENFORCEMENT_FAILED',
+      message: 'Missing fields',
+      remediation: { action: 'retry' },
+    })).toBe('ask_llm' satisfies FailureVerdict);
   });
 
   // Permanent failures
@@ -54,18 +88,18 @@ describe('classifyFailure', () => {
     ['UNKNOWN_FAILURE', 'Task failed without error details'],
     ['some_new_error', 'Unexpected error'],
   ])('returns "fail" for permanent error code "%s"', (code, message) => {
-    expect(classifyFailure(code, message)).toBe('fail' satisfies FailureVerdict);
+    expect(classifyFailure({ code, message })).toBe('fail' satisfies FailureVerdict);
   });
 
   // Edge: TASK_RESUMED_HARD_ERROR with exit 1 AND 429 should be rate limit, not permanent
   it('prioritizes 429 over exit code 1 in TASK_RESUMED_HARD_ERROR', () => {
-    expect(classifyFailure('TASK_RESUMED_HARD_ERROR', 'exit code: 1 after 429 rate limit'))
+    expect(classifyFailure({ code: 'TASK_RESUMED_HARD_ERROR', message: 'exit code: 1 after 429 rate limit' }))
       .toBe('retry_after_cooloff' satisfies FailureVerdict);
   });
 
   // Edge: TASK_RESUMED_HARD_ERROR with both exit 137 and 429 should be retry (137 checked first)
   it('prioritizes exit 137 over 429 in TASK_RESUMED_HARD_ERROR', () => {
-    expect(classifyFailure('TASK_RESUMED_HARD_ERROR', 'exit code: 137 after 429'))
+    expect(classifyFailure({ code: 'TASK_RESUMED_HARD_ERROR', message: 'exit code: 137 after 429' }))
       .toBe('retry' satisfies FailureVerdict);
   });
 });

--- a/apps/code-agent/src/__tests__/routes/webhooks.test.ts
+++ b/apps/code-agent/src/__tests__/routes/webhooks.test.ts
@@ -4082,6 +4082,56 @@ describe('POST /internal/webhooks/task-complete', () => {
       expect(getResult.value.callbackReceived).toBe(true);
     });
 
+    it('persists error.remediation when orchestrator includes it on failed webhook', async () => {
+      const createResult = await codeTaskRepo.create({
+        userId: 'user-123',
+        prompt: 'Task that fails with remediation hint',
+        sanitizedPrompt: 'Task that fails with remediation hint',
+        systemPromptHash: 'default',
+        workerType: 'auto',
+        workerLocation: 'mac',
+        repository: 'pbuchman/intexuraos',
+        baseBranch: 'development',
+        traceId: 'trace_remediation_persist',
+        webhookSecret: 'test-webhook-secret',
+        agentType: 'execution',
+      });
+      expect(createResult.ok).toBe(true);
+      if (!createResult.ok) throw new Error('Failed to create task');
+      const task = createResult.value;
+
+      const payload = {
+        taskId: task.id,
+        status: 'failed' as const,
+        error: {
+          code: 'TASK_EXIT_CODE_OVERRIDE',
+          message: 'Non-zero exit code (255) overrides verifier passed decision',
+          remediation: { action: 'retry' as const },
+        },
+      };
+
+      const { timestamp, signature } = generateWebhookSignature(payload, 'test-webhook-secret');
+      const response = await app.inject({
+        method: 'POST',
+        url: '/internal/webhooks/task-complete',
+        headers: {
+          'x-internal-auth': 'test-internal-token',
+          'x-request-timestamp': timestamp,
+          'x-request-signature': signature,
+        },
+        payload,
+      });
+
+      expect(response.statusCode).toBe(200);
+
+      const getResult = await codeTaskRepo.findById(task.id);
+      expect(getResult.ok).toBe(true);
+      if (!getResult.ok) throw new Error('Failed to get task');
+      expect(getResult.value.status).toBe('failed');
+      expect(getResult.value.error?.code).toBe('TASK_EXIT_CODE_OVERRIDE');
+      expect(getResult.value.error?.remediation?.action).toBe('retry');
+    });
+
     it('populates prNumber and prBranch from result.prUrl on completion (INT-465)', async () => {
       const createResult = await codeTaskRepo.create({
         userId: 'user-123',

--- a/apps/code-agent/src/domain/models/codeTask.ts
+++ b/apps/code-agent/src/domain/models/codeTask.ts
@@ -138,6 +138,7 @@ export interface TaskError {
   code: string;             // Error code (see design lines 1774-1812)
   message: string;          // Human-readable message
   remediation?: {           // Design reference: Lines 1818-1848
+    action?: 'retry' | 'wait' | 'fix_code' | 'contact_support' | 'retry_smaller';  // Orchestrator hint; honored by classifyFailure as fallback
     retryAfter?: number;    // Seconds to wait before retry
     manualSteps?: string;   // Instructions for user
     supportLink?: string;   // Link to docs/support

--- a/apps/code-agent/src/domain/usecases/triageFailedTask.ts
+++ b/apps/code-agent/src/domain/usecases/triageFailedTask.ts
@@ -43,7 +43,7 @@ export async function triageFailedTask(
   const { task, taskError } = request;
 
   // Step 1: Classify the failure
-  const verdict = classifyFailure(taskError.code, taskError.message);
+  const verdict = classifyFailure(taskError);
   logger.info({ taskId: task.id, errorCode: taskError.code, verdict }, 'Failure classified');
 
   // Step 2: Handle permanent failures immediately

--- a/apps/code-agent/src/domain/utils/classifyFailure.ts
+++ b/apps/code-agent/src/domain/utils/classifyFailure.ts
@@ -10,6 +10,8 @@
  * INT-1375: Self-healing failure triage.
  */
 
+import type { TaskError } from '../models/codeTask.js';
+
 export type FailureVerdict = 'retry' | 'retry_after_cooloff' | 'ask_llm' | 'fail';
 
 /** Infrastructure error codes that always indicate transient failures. */
@@ -20,9 +22,15 @@ const INFRA_RETRY_CODES = new Set([
   'queue_full',
   'worker_unavailable',
   'network_error',
+  // Verifier ran and passed but worker exited non-zero. Root causes observed so
+  // far (git lock file, stale container state) are transient. The orchestrator
+  // attaches remediation.action=retry; we also match by code for belt-and-suspenders.
+  'TASK_EXIT_CODE_OVERRIDE',
 ]);
 
-export function classifyFailure(errorCode: string, errorMessage: string): FailureVerdict {
+export function classifyFailure(error: TaskError): FailureVerdict {
+  const { code: errorCode, message: errorMessage, remediation } = error;
+
   // Infrastructure — always retry
   if (INFRA_RETRY_CODES.has(errorCode)) {
     return 'retry';
@@ -53,6 +61,14 @@ export function classifyFailure(errorCode: string, errorMessage: string): Failur
   // AI quality failures — ask the user's configured LLM
   if (errorCode.endsWith('_ENFORCEMENT_FAILED')) {
     return 'ask_llm';
+  }
+
+  // Orchestrator remediation hint — honor it as a fallback before defaulting to fail.
+  // The orchestrator has direct context (exit code, verifier result) this classifier
+  // only sees via stringified code/message. Guards against drift when new orchestrator
+  // error codes are added without a matching classifier branch.
+  if (remediation?.action === 'retry') {
+    return 'retry';
   }
 
   // Everything else — permanent failure

--- a/apps/code-agent/src/routes/webhookRoutes.ts
+++ b/apps/code-agent/src/routes/webhookRoutes.ts
@@ -176,6 +176,12 @@ export const webhookRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
     error?: {
       code: string;
       message: string;
+      remediation?: {
+        action?: 'retry' | 'wait' | 'fix_code' | 'contact_support' | 'retry_smaller';
+        retryAfter?: number;
+        manualSteps?: string;
+        supportLink?: string;
+      };
     };
     duration?: number;
     resumedCompletion?: boolean;
@@ -235,6 +241,16 @@ export const webhookRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
               properties: {
                 code: { type: 'string' },
                 message: { type: 'string' },
+                remediation: {
+                  type: 'object',
+                  properties: {
+                    action: { type: 'string', enum: ['retry', 'wait', 'fix_code', 'contact_support', 'retry_smaller'] },
+                    retryAfter: { type: 'number' },
+                    manualSteps: { type: 'string' },
+                    supportLink: { type: 'string' },
+                  },
+                  required: [],
+                },
               },
               required: ['code', 'message'],
             },
@@ -1763,6 +1779,7 @@ export const webhookRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
           error: {
             code: taskError.code,
             message: taskError.message,
+            ...(taskError.remediation !== undefined && { remediation: taskError.remediation }),
           },
           ...(shouldQueueExecutionMemoryPostRun({
             agentType: task.agentType,


### PR DESCRIPTION
## Summary

- **Root cause**: prod task `task_bd0a0dd6-6a2b-499b-8ae5-4b950081538e` failed with a transient git-lock exit-255 error. The orchestrator flagged it as retryable (`remediation.action='retry'`), but the code-agent classifier had no branch for `TASK_EXIT_CODE_OVERRIDE` and defaulted to permanent-failure, so no auto-retry fired.
- **Fix 1 (narrow)**: add `TASK_EXIT_CODE_OVERRIDE` to `INFRA_RETRY_CODES` — exact symptom retried regardless of remediation plumbing.
- **Fix 2 (broad)**: honor `taskError.remediation.action === 'retry'` as a fallback before the final `'fail'` verdict — guards against classifier/orchestrator drift when new error codes ship.
- **Plumbing**: `TaskError.remediation` gains an optional `action` field, the task-complete webhook schema accepts the `remediation` object, and the Firestore persistence preserves it instead of stripping to `{code, message}`.
- Specific verdicts (`retry_after_cooloff` for 429, `ask_llm` for `*_ENFORCEMENT_FAILED`) still take precedence over the remediation hint — tests pin this.

## Endpoint Changes

- **Modified**: `POST /internal/webhooks/task-complete` — request schema now accepts `error.remediation.{action,retryAfter,manualSteps,supportLink}` (was silently accepting+stripping before).
- **Created**: none.
- **Removed**: none.
- **Unchanged**: all other endpoints.

## Test plan

- [x] `classifyFailure` unit tests: `TASK_EXIT_CODE_OVERRIDE` → `retry`, arbitrary error + `remediation.action='retry'` → `retry`, specific verdicts still preferred over remediation hint (26 tests total, all passing).
- [x] Webhook integration test: orchestrator-sent `remediation.action` persists to Firestore (was being dropped before).
- [x] `pnpm run ci:tracked` passes clean.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>