### PR TITLE
[INT-1392] fix(orchestrator): preserve worker container on TASK_EXIT_CODE_OVERRIDE and TASK_FATAL_EXIT_CODE

### DIFF
--- a/docs/plans/2026-04-14-self-healing-failure-triage.md
+++ b/docs/plans/2026-04-14-self-healing-failure-triage.md
@@ -25,15 +25,15 @@ The original issue design had several assumptions that don't match the current c
 
 ### New Files
 
-| File                                           | Responsibility                                                 |
-| ---------------------------------------------- | -------------------------------------------------------------- |
-| `src/domain/utils/classifyFailure.ts`          | Pure failure classifier function (~40 lines)                   |
-| `src/domain/utils/classifyFailure.test.ts`     | Tests for classifier (all 11 error codes + edge cases)         |
-| `src/domain/usecases/autoRetryTask.ts`         | System-initiated auto-retry use case                           |
-| `src/domain/usecases/autoRetryTask.test.ts`    | Tests for auto-retry creation, budget check, chain walking     |
-| `src/domain/usecases/triageFailedTask.ts`      | Orchestrates triage: classify -> budget check -> retry or fail |
+| File                                           | Responsibility                                                  |
+| ---------------------------------------------- | --------------------------------------------------------------- |
+| `src/domain/utils/classifyFailure.ts`          | Pure failure classifier function (~40 lines)                    |
+| `src/domain/utils/classifyFailure.test.ts`     | Tests for classifier (all 11 error codes + edge cases)          |
+| `src/domain/usecases/autoRetryTask.ts`         | System-initiated auto-retry use case                            |
+| `src/domain/usecases/autoRetryTask.test.ts`    | Tests for auto-retry creation, budget check, chain walking      |
+| `src/domain/usecases/triageFailedTask.ts`      | Orchestrates triage: classify -> budget check -> retry or fail  |
 | `src/domain/usecases/triageFailedTask.test.ts` | Tests for triage orchestration including user-selected LLM path |
-| `src/domain/prompts/failureTriagePrompt.ts`    | Prompt for `*_ENFORCEMENT_FAILED` triage via user-selected LLM |
+| `src/domain/prompts/failureTriagePrompt.ts`    | Prompt for `*_ENFORCEMENT_FAILED` triage via user-selected LLM  |
 
 ### Modified Files
 

--- a/docs/plans/INT-1369-evidence.md
+++ b/docs/plans/INT-1369-evidence.md
@@ -31,16 +31,16 @@
 
 ## File Structure
 
-| Area | Files | Responsibility |
-| --- | --- | --- |
-| Orchestrator env + boot | `workers/orchestrator/src/start.ts`, `terraform/environments/dev/main.tf`, `ecosystem.config.cjs`, `workers/orchestrator/README.md` | Parse one ordered validation-model env var, wire required secrets, document the new configuration |
-| Orchestrator client selection | `workers/orchestrator/src/services/completion-verifier.ts`, `workers/orchestrator/src/services/agent-compliance-validator.ts`, new helper in `workers/orchestrator/src/services/` | Build provider-agnostic validation clients from prioritized models and retry/fallback on failure |
-| Orchestrator tests | `workers/orchestrator/src/services/__tests__/completion-verifier.test.ts`, `workers/orchestrator/src/services/__tests__/agent-compliance-validator.test.ts`, possibly `workers/orchestrator/src/__tests__/task-dispatcher.test.ts` | Cover ordered-model parsing, missing-key handling, primary failure -> secondary fallback, and logging |
-| Hellscript migration | `apps/hellscript-agent/src/index.ts`, `apps/hellscript-agent/src/services.ts`, `apps/hellscript-agent/src/infra/llm/geminiIntentInterpreter.ts`, `apps/hellscript-agent/src/infra/llm/geminiDraftGenerator.ts`, related tests | Remove direct Gemini bootstrapping and use a generic user-backed generate client |
-| Image-service migration | `apps/image-service/src/serviceFactory.ts`, `apps/image-service/src/infra/llm/GeminiPromptAdapter.ts`, `apps/image-service/src/application/generatePrompt.ts`, related tests | Resolve prompt-generation model and pricing dynamically from user defaults instead of Gemini constants |
-| Linear-agent migration | `apps/linear-agent/src/index.ts`, `apps/linear-agent/src/services.ts`, prune route tests | Stop creating a fixed `Gemini25Flash` pruning client at startup; resolve a user-backed client at classification time |
-| Chat-agent migration | `apps/chat-agent/src/services.ts`, `apps/chat-agent/src/routes/chatRoutes.ts`, related tests | Keep guest Gemini fixed, but route authenticated user generation through the default user client with fallback |
-| Audit appendix | `docs/plans/INT-1369-evidence.md` | Preserve the migration list plus classify omitted hardcoded Gemini/OpenRouter sites so the document is complete |
+| Area                          | Files                                                                                                                                                                                                                              | Responsibility                                                                                                       |
+| ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| Orchestrator env + boot       | `workers/orchestrator/src/start.ts`, `terraform/environments/dev/main.tf`, `ecosystem.config.cjs`, `workers/orchestrator/README.md`                                                                                                | Parse one ordered validation-model env var, wire required secrets, document the new configuration                    |
+| Orchestrator client selection | `workers/orchestrator/src/services/completion-verifier.ts`, `workers/orchestrator/src/services/agent-compliance-validator.ts`, new helper in `workers/orchestrator/src/services/`                                                  | Build provider-agnostic validation clients from prioritized models and retry/fallback on failure                     |
+| Orchestrator tests            | `workers/orchestrator/src/services/__tests__/completion-verifier.test.ts`, `workers/orchestrator/src/services/__tests__/agent-compliance-validator.test.ts`, possibly `workers/orchestrator/src/__tests__/task-dispatcher.test.ts` | Cover ordered-model parsing, missing-key handling, primary failure -> secondary fallback, and logging                |
+| Hellscript migration          | `apps/hellscript-agent/src/index.ts`, `apps/hellscript-agent/src/services.ts`, `apps/hellscript-agent/src/infra/llm/geminiIntentInterpreter.ts`, `apps/hellscript-agent/src/infra/llm/geminiDraftGenerator.ts`, related tests      | Remove direct Gemini bootstrapping and use a generic user-backed generate client                                     |
+| Image-service migration       | `apps/image-service/src/serviceFactory.ts`, `apps/image-service/src/infra/llm/GeminiPromptAdapter.ts`, `apps/image-service/src/application/generatePrompt.ts`, related tests                                                       | Resolve prompt-generation model and pricing dynamically from user defaults instead of Gemini constants               |
+| Linear-agent migration        | `apps/linear-agent/src/index.ts`, `apps/linear-agent/src/services.ts`, prune route tests                                                                                                                                           | Stop creating a fixed `Gemini25Flash` pruning client at startup; resolve a user-backed client at classification time |
+| Chat-agent migration          | `apps/chat-agent/src/services.ts`, `apps/chat-agent/src/routes/chatRoutes.ts`, related tests                                                                                                                                       | Keep guest Gemini fixed, but route authenticated user generation through the default user client with fallback       |
+| Audit appendix                | `docs/plans/INT-1369-evidence.md`                                                                                                                                                                                                  | Preserve the migration list plus classify omitted hardcoded Gemini/OpenRouter sites so the document is complete      |
 
 ## Endpoint Changes
 
@@ -202,16 +202,16 @@ None.
 
 These are the eight user-facing points the owner explicitly approved for migration:
 
-| # | Service | File | Migration intent |
-| --- | --- | --- | --- |
-| 1 | hellscript-agent | `src/index.ts` | remove startup Gemini singleton |
-| 2 | hellscript-agent | `src/services.ts` | remove Gemini-specific container typing |
-| 3 | hellscript-agent | `src/infra/llm/geminiDraftGenerator.ts` | accept generic generate client |
-| 4 | hellscript-agent | `src/infra/llm/geminiIntentInterpreter.ts` | accept generic generate client |
-| 5 | image-service | `src/infra/llm/GeminiPromptAdapter.ts` | resolve model dynamically from user defaults |
-| 6 | image-service | `src/serviceFactory.ts` | remove Gemini-only pricing assumption |
-| 7 | linear-agent | `src/services.ts` | replace fixed pruning client with user-backed client |
-| 8 | chat-agent | `src/services.ts` | keep guest Gemini, migrate authenticated path |
+| #   | Service          | File                                       | Migration intent                                     |
+| --- | ---------------- | ------------------------------------------ | ---------------------------------------------------- |
+| 1   | hellscript-agent | `src/index.ts`                             | remove startup Gemini singleton                      |
+| 2   | hellscript-agent | `src/services.ts`                          | remove Gemini-specific container typing              |
+| 3   | hellscript-agent | `src/infra/llm/geminiDraftGenerator.ts`    | accept generic generate client                       |
+| 4   | hellscript-agent | `src/infra/llm/geminiIntentInterpreter.ts` | accept generic generate client                       |
+| 5   | image-service    | `src/infra/llm/GeminiPromptAdapter.ts`     | resolve model dynamically from user defaults         |
+| 6   | image-service    | `src/serviceFactory.ts`                    | remove Gemini-only pricing assumption                |
+| 7   | linear-agent     | `src/services.ts`                          | replace fixed pruning client with user-backed client |
+| 8   | chat-agent       | `src/services.ts`                          | keep guest Gemini, migrate authenticated path        |
 
 ---
 
@@ -219,16 +219,16 @@ These are the eight user-facing points the owner explicitly approved for migrati
 
 These sites were missing from the original audit. They are not part of the approved migration scope, but they are now classified so this document is complete.
 
-| File | Current hardcoding | Classification | Reason |
-| --- | --- | --- | --- |
-| `workers/orchestrator/src/start.ts`, `workers/orchestrator/src/services/completion-verifier.ts`, `workers/orchestrator/src/services/agent-compliance-validator.ts` | validation models | **Change in this task** | owner explicitly asked for prioritized primary/secondary validation clients |
-| `apps/cron-agent/src/index.ts` | `Gemini25Flash` tool-calling + generate clients | **No change in this task** | platform-owned scheduler, no user context |
-| `apps/code-agent/src/services.ts` | Gemini tool-calling + execution-memory models | **No change in this task** | system-owned orchestration/classification path, not one of the approved eight migration points |
-| `apps/research-agent/src/routes/researchRoutes.ts`, `apps/research-agent/src/routes/internalRoutes.ts`, `apps/research-agent/src/routes/helpers/synthesisHelper.ts` | `Gemini25Flash` for title/context helpers | **No change in this task** | research helper flows are product-defined Google helpers, not user default-model replacement scope here |
-| `packages/llm-prompts/src/research/modelExtractionPrompt.ts`, `apps/research-agent/src/domain/research/usecases/extractModelPreferences.ts`, `apps/research-agent/src/infra/llm/GeminiAdapter.ts` | research Gemini selection infrastructure | **No change in this task** | explicit research-model selection must stay provider/model aware |
-| `apps/user-service/src/infra/llm/LlmValidatorImpl.ts` | `Gemini20Flash` validation probe | **No change in this task** | cheapest-provider validation probe |
-| `apps/image-service/src/infra/image/GoogleImageGenerator.ts`, `packages/infra-gemini/src/client.ts` | `Gemini25FlashImage` | **No change in this task** | capability-specific image generation |
-| `packages/infra-gemini/src/toolCallingClient.ts` | `TOOL_CALLING_PRICING[Gemini25Flash]` | **No change in this task** | tool-calling support is currently Gemini-specific |
+| File                                                                                                                                                                                              | Current hardcoding                              | Classification             | Reason                                                                                                  |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `workers/orchestrator/src/start.ts`, `workers/orchestrator/src/services/completion-verifier.ts`, `workers/orchestrator/src/services/agent-compliance-validator.ts`                                | validation models                               | **Change in this task**    | owner explicitly asked for prioritized primary/secondary validation clients                             |
+| `apps/cron-agent/src/index.ts`                                                                                                                                                                    | `Gemini25Flash` tool-calling + generate clients | **No change in this task** | platform-owned scheduler, no user context                                                               |
+| `apps/code-agent/src/services.ts`                                                                                                                                                                 | Gemini tool-calling + execution-memory models   | **No change in this task** | system-owned orchestration/classification path, not one of the approved eight migration points          |
+| `apps/research-agent/src/routes/researchRoutes.ts`, `apps/research-agent/src/routes/internalRoutes.ts`, `apps/research-agent/src/routes/helpers/synthesisHelper.ts`                               | `Gemini25Flash` for title/context helpers       | **No change in this task** | research helper flows are product-defined Google helpers, not user default-model replacement scope here |
+| `packages/llm-prompts/src/research/modelExtractionPrompt.ts`, `apps/research-agent/src/domain/research/usecases/extractModelPreferences.ts`, `apps/research-agent/src/infra/llm/GeminiAdapter.ts` | research Gemini selection infrastructure        | **No change in this task** | explicit research-model selection must stay provider/model aware                                        |
+| `apps/user-service/src/infra/llm/LlmValidatorImpl.ts`                                                                                                                                             | `Gemini20Flash` validation probe                | **No change in this task** | cheapest-provider validation probe                                                                      |
+| `apps/image-service/src/infra/image/GoogleImageGenerator.ts`, `packages/infra-gemini/src/client.ts`                                                                                               | `Gemini25FlashImage`                            | **No change in this task** | capability-specific image generation                                                                    |
+| `packages/infra-gemini/src/toolCallingClient.ts`                                                                                                                                                  | `TOOL_CALLING_PRICING[Gemini25Flash]`           | **No change in this task** | tool-calling support is currently Gemini-specific                                                       |
 
 ---
 

--- a/workers/orchestrator/src/__tests__/task-dispatcher.test.ts
+++ b/workers/orchestrator/src/__tests__/task-dispatcher.test.ts
@@ -3267,7 +3267,7 @@ describe('TaskDispatcher', () => {
       vi.useFakeTimers();
       const preserveState = createStatePersistence();
       const localDestroyWorker = vi.fn(async () => undefined);
-      const localPreserveWorker = vi.fn(async () => undefined);
+      const localPreserveWorker = vi.fn(async () => true);
       const localIsolationProvider: IsolationProvider = {
         ...mockIsolationProvider,
         destroyWorker: localDestroyWorker,
@@ -3326,15 +3326,271 @@ describe('TaskDispatcher', () => {
       expect(localPreserveWorker).toHaveBeenCalledWith('preserve-failed-container-task');
       expect(mockLogForwarder.appendChunk).toHaveBeenCalledWith(
         'preserve-failed-container-task',
-        expect.stringContaining('Preserving worker container for debugging')
+        expect.stringContaining('Preserved worker container for debugging')
       );
       vi.useRealTimers();
+    });
+
+    it('preserves worker container on TASK_EXIT_CODE_OVERRIDE when preserveWorkerContainers is enabled', async () => {
+      vi.useFakeTimers();
+      try {
+        const preserveState = createStatePersistence();
+        const localDestroyWorker = vi.fn(async () => undefined);
+        const localPreserveWorker = vi.fn(async () => true);
+        const localCleanupSession = vi.fn(async () => undefined);
+        const localIsolationProvider: IsolationProvider = {
+          ...mockIsolationProvider,
+          destroyWorker: localDestroyWorker,
+          preserveWorker: localPreserveWorker,
+          cleanupTaskSession: localCleanupSession,
+          isWorkerRunning: vi.fn(async () => false),
+        };
+        const localIsolation: IsolationConfig = {
+          ...mockIsolationConfig,
+          provider: localIsolationProvider,
+        };
+        const verify = vi.fn().mockResolvedValue({
+          passed: true,
+          missingFields: [],
+          verifierFailure: false,
+          trace: dummyTrace,
+          agentData: {
+            agentType: 'execution' as const,
+            outcome: 'implemented',
+            superpowers_subagent_driven_dev: 'not used',
+            superpowers_requesting_code_review: 'used',
+            gh_pr_url: '',
+            memory_ids_used: '',
+            memory_ids_rejected: '',
+            memory_usage_summary: '',
+            summary: 'Execution completed',
+          },
+        });
+
+        const preserveDispatcher = new TaskDispatcher(
+          mockConfig,
+          preserveState,
+          mockWorktreeManager,
+          mockLogForwarder,
+          mockWebhookClient,
+          mockGitHubTokenService,
+          mockLogger,
+          localIsolation,
+          {
+            maxAttempts: 1,
+            activityTimeout: disabledActivityTimeout,
+            preserveWorkerContainers: true,
+            verifier: {
+              verify,
+              describe: (): { enabled: boolean } => ({ enabled: true }),
+              extractResumeSummary: vi.fn().mockResolvedValue(undefined),
+            },
+          }
+        );
+
+        const request: CreateTaskRequest = {
+          taskId: 'preserve-exit-override',
+          workerType: 'auto',
+          prompt: 'Pass verifier but exit nonzero',
+          webhookUrl: 'https://example.com/webhook',
+          webhookSecret: 'secret',
+          linearIssueLabels: [],
+          hasChildren: false,
+          agentType: 'execution',
+        };
+
+        await preserveDispatcher.submitTask(request);
+        await vi.advanceTimersByTimeAsync(0);
+
+        const internalExitCodes = preserveDispatcher as unknown as {
+          taskExitCodes: Map<string, number>;
+        };
+        internalExitCodes.taskExitCodes.set('preserve-exit-override', 1);
+
+        await vi.advanceTimersByTimeAsync(30 * 1000);
+
+        const task = await preserveDispatcher.getTask('preserve-exit-override');
+        expect(task?.status).toBe('failed');
+        expect(localPreserveWorker).toHaveBeenCalledWith('preserve-exit-override');
+        expect(localDestroyWorker).not.toHaveBeenCalled();
+        expect(localCleanupSession).not.toHaveBeenCalled();
+        expect(mockWebhookClient.send).toHaveBeenCalledWith(
+          expect.objectContaining({
+            payload: expect.objectContaining({
+              status: 'failed',
+              error: expect.objectContaining({ code: 'TASK_EXIT_CODE_OVERRIDE' }),
+            }),
+          })
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('preserves worker container on TASK_FATAL_EXIT_CODE when preserveWorkerContainers is enabled', async () => {
+      vi.useFakeTimers();
+      try {
+        const preserveState = createStatePersistence();
+        const localDestroyWorker = vi.fn(async () => undefined);
+        const localPreserveWorker = vi.fn(async () => true);
+        const localCleanupSession = vi.fn(async () => undefined);
+        const localIsolationProvider: IsolationProvider = {
+          ...mockIsolationProvider,
+          destroyWorker: localDestroyWorker,
+          preserveWorker: localPreserveWorker,
+          cleanupTaskSession: localCleanupSession,
+          isWorkerRunning: vi.fn(async () => false),
+        };
+        const localIsolation: IsolationConfig = {
+          ...mockIsolationConfig,
+          provider: localIsolationProvider,
+        };
+        const verify = vi.fn().mockResolvedValue({
+          passed: false,
+          missingFields: ['fatal_exit_code_137'],
+          verifierFailure: false,
+          trace: dummyTrace,
+        });
+
+        const preserveDispatcher = new TaskDispatcher(
+          mockConfig,
+          preserveState,
+          mockWorktreeManager,
+          mockLogForwarder,
+          mockWebhookClient,
+          mockGitHubTokenService,
+          mockLogger,
+          localIsolation,
+          {
+            maxAttempts: 3,
+            activityTimeout: disabledActivityTimeout,
+            preserveWorkerContainers: true,
+            verifier: {
+              verify,
+              describe: (): { enabled: boolean } => ({ enabled: true }),
+              extractResumeSummary: vi.fn().mockResolvedValue(undefined),
+            },
+          }
+        );
+
+        const request: CreateTaskRequest = {
+          taskId: 'preserve-fatal-exit',
+          workerType: 'auto',
+          prompt: 'Crash with SIGKILL',
+          webhookUrl: 'https://example.com/webhook',
+          webhookSecret: 'secret',
+          linearIssueLabels: [],
+          hasChildren: false,
+          agentType: 'execution',
+        };
+
+        await preserveDispatcher.submitTask(request);
+        await vi.advanceTimersByTimeAsync(0);
+
+        await vi.advanceTimersByTimeAsync(30 * 1000);
+
+        const task = await preserveDispatcher.getTask('preserve-fatal-exit');
+        expect(task?.status).toBe('failed');
+        expect(localPreserveWorker).toHaveBeenCalledWith('preserve-fatal-exit');
+        expect(localDestroyWorker).not.toHaveBeenCalled();
+        expect(localCleanupSession).not.toHaveBeenCalled();
+        expect(mockWebhookClient.send).toHaveBeenCalledWith(
+          expect.objectContaining({
+            payload: expect.objectContaining({
+              status: 'failed',
+              error: expect.objectContaining({
+                code: 'TASK_FATAL_EXIT_CODE',
+                message: expect.stringContaining('fatal_exit_code_137'),
+              }),
+            }),
+          })
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('falls back to teardownAttempt and logs failure when preserveWorker returns false', async () => {
+      const preserveState = createStatePersistence();
+      const localDestroyWorker = vi.fn(async () => undefined);
+      const localPreserveWorker = vi.fn(async () => false);
+      const localCleanupSession = vi.fn(async () => undefined);
+      const localIsolationProvider: IsolationProvider = {
+        ...mockIsolationProvider,
+        destroyWorker: localDestroyWorker,
+        preserveWorker: localPreserveWorker,
+        cleanupTaskSession: localCleanupSession,
+      };
+      const localIsolation: IsolationConfig = {
+        ...mockIsolationConfig,
+        provider: localIsolationProvider,
+      };
+
+      const preserveDispatcher = new TaskDispatcher(
+        mockConfig,
+        preserveState,
+        mockWorktreeManager,
+        mockLogForwarder,
+        mockWebhookClient,
+        mockGitHubTokenService,
+        mockLogger,
+        localIsolation,
+        {
+          maxAttempts: 1,
+          activityTimeout: disabledActivityTimeout,
+          preserveWorkerContainers: true,
+          verifier: {
+            verify: vi.fn().mockResolvedValue({
+              passed: true,
+              missingFields: [],
+              verifierFailure: false,
+              trace: dummyTrace,
+            }),
+            describe: (): { enabled: boolean } => ({ enabled: true }),
+            extractResumeSummary: vi.fn().mockResolvedValue(undefined),
+          },
+        }
+      );
+
+      const taskId = 'preserve-fallback-teardown';
+      await preserveDispatcher.submitTask({
+        taskId,
+        workerType: 'auto',
+        prompt: 'Preservation will be reported as failed',
+        webhookUrl: 'https://example.com/webhook',
+        webhookSecret: 'secret',
+        linearIssueLabels: [],
+        hasChildren: false,
+      });
+      await flushAsync();
+
+      const task = await preserveDispatcher.getTask(taskId);
+      if (task === null) {
+        throw new Error('Task not found');
+      }
+
+      const preserveInternal = preserveDispatcher as unknown as {
+        finalizeTask: (
+          taskArg: Record<string, unknown>,
+          finalStatus: 'failed',
+          payload: { result?: unknown; error?: unknown }
+        ) => Promise<void>;
+      };
+      await preserveInternal.finalizeTask(task as unknown as Record<string, unknown>, 'failed', {});
+
+      expect(localPreserveWorker).toHaveBeenCalledWith(taskId);
+      expect(localDestroyWorker).toHaveBeenCalledWith(taskId);
+      expect(localCleanupSession).toHaveBeenCalledWith(taskId);
+      expect(mockLogForwarder.appendChunk).toHaveBeenCalledWith(
+        taskId,
+        expect.stringContaining('Failed to preserve worker container (no tracked worker)')
+      );
     });
 
     it('preserves container when interrupted finalization is invoked with preserve flag', async () => {
       const preserveState = createStatePersistence();
       const localDestroyWorker = vi.fn(async () => undefined);
-      const localPreserveWorker = vi.fn(async () => undefined);
+      const localPreserveWorker = vi.fn(async () => true);
       const localIsolationProvider: IsolationProvider = {
         ...mockIsolationProvider,
         destroyWorker: localDestroyWorker,
@@ -3405,7 +3661,7 @@ describe('TaskDispatcher', () => {
       expect(localPreserveWorker).toHaveBeenCalledWith(taskId);
       expect(mockLogForwarder.appendChunk).toHaveBeenCalledWith(
         taskId,
-        expect.stringContaining('Preserving worker container for debugging')
+        expect.stringContaining('Preserved worker container for debugging')
       );
     });
 
@@ -3416,7 +3672,7 @@ describe('TaskDispatcher', () => {
     } {
       const state = createStatePersistence();
       const destroyWorker = vi.fn(async () => undefined);
-      const preserveWorker = vi.fn(async () => undefined);
+      const preserveWorker = vi.fn(async () => true);
       const cleanupTaskSession = vi.fn(async () => undefined);
       const isolationProvider: IsolationProvider = {
         ...mockIsolationProvider,
@@ -3575,7 +3831,7 @@ describe('TaskDispatcher', () => {
     it('destroys existing preserved pull_request container for same PR before preserving new one', async () => {
       const state = createStatePersistence();
       const destroyWorker = vi.fn(async () => undefined);
-      const preserveWorker = vi.fn(async () => undefined);
+      const preserveWorker = vi.fn(async () => true);
       const oldTaskId = 'pr-old-task';
       const newTaskId = 'pr-new-task';
       const prNumber = 100;
@@ -3684,7 +3940,7 @@ describe('TaskDispatcher', () => {
     it('does not destroy preserved pull_request container for different PR', async () => {
       const state = createStatePersistence();
       const destroyWorker = vi.fn(async () => undefined);
-      const preserveWorker = vi.fn(async () => undefined);
+      const preserveWorker = vi.fn(async () => true);
       const oldTaskId = 'pr-different-old-task';
       const newTaskId = 'pr-different-new-task';
 
@@ -3793,7 +4049,7 @@ describe('TaskDispatcher', () => {
     it('skips destroyWorker loop when listPreservedWorkers returns empty array', async () => {
       const state = createStatePersistence();
       const destroyWorker = vi.fn(async () => undefined);
-      const preserveWorker = vi.fn(async () => undefined);
+      const preserveWorker = vi.fn(async () => true);
       const listPreservedWorkers = vi.fn(async () => []);
 
       const isolationProvider: IsolationProvider = {
@@ -3876,7 +4132,7 @@ describe('TaskDispatcher', () => {
     it('skips listPreservedWorkers check when provider does not implement it', async () => {
       const state = createStatePersistence();
       const destroyWorker = vi.fn(async () => undefined);
-      const preserveWorker = vi.fn(async () => undefined);
+      const preserveWorker = vi.fn(async () => true);
 
       // Intentionally omit listPreservedWorkers to exercise optional chaining
       const isolationProvider: IsolationProvider = {

--- a/workers/orchestrator/src/services/isolation/__tests__/docker-provider.test.ts
+++ b/workers/orchestrator/src/services/isolation/__tests__/docker-provider.test.ts
@@ -839,16 +839,17 @@ describe('DockerProvider', () => {
     it('moves worker from active to preserved map', async () => {
       await provider.createWorker(createTestConfig({ taskId: 'task-1' }));
 
-      await provider.preserveWorker('task-1');
+      const preserved = await provider.preserveWorker('task-1');
 
+      expect(preserved).toBe(true);
       const workers = await provider.listWorkers();
       expect(workers).toHaveLength(0);
 
-      const preserved = await provider.listPreservedWorkers();
-      expect(preserved).toHaveLength(1);
-      expect(preserved[0]?.taskId).toBe('task-1');
-      expect(preserved[0]?.containerId).toBe('test-container-id');
-      expect(preserved[0]?.preservedAt).toBeDefined();
+      const preservedList = await provider.listPreservedWorkers();
+      expect(preservedList).toHaveLength(1);
+      expect(preservedList[0]?.taskId).toBe('task-1');
+      expect(preservedList[0]?.containerId).toBe('test-container-id');
+      expect(preservedList[0]?.preservedAt).toBeDefined();
     });
 
     it('frees concurrency slot so new workers can be created', async () => {
@@ -894,11 +895,16 @@ describe('DockerProvider', () => {
       expect(mocks.mockContainer.remove).not.toHaveBeenCalled();
     });
 
-    it('returns early for non-existent worker', async () => {
-      await provider.preserveWorker('non-existent');
+    it('returns false and warns for non-existent worker', async () => {
+      const preserved = await provider.preserveWorker('non-existent');
 
-      const preserved = await provider.listPreservedWorkers();
-      expect(preserved).toHaveLength(0);
+      expect(preserved).toBe(false);
+      const preservedList = await provider.listPreservedWorkers();
+      expect(preservedList).toHaveLength(0);
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ taskId: 'non-existent' }),
+        expect.stringContaining('preserveWorker called for unknown worker')
+      );
     });
 
     it('logs secrets cleanup failure without throwing', async () => {

--- a/workers/orchestrator/src/services/isolation/docker-provider.ts
+++ b/workers/orchestrator/src/services/isolation/docker-provider.ts
@@ -1074,10 +1074,14 @@ export class DockerProvider implements IsolationProvider {
     }
   }
 
-  async preserveWorker(taskId: string): Promise<void> {
+  async preserveWorker(taskId: string): Promise<boolean> {
     const worker = this.workers.get(taskId);
     if (worker === undefined) {
-      return;
+      this.logger.warn(
+        { taskId },
+        'preserveWorker called for unknown worker — container may already be destroyed'
+      );
+      return false;
     }
 
     this.preservedWorkers.set(taskId, {
@@ -1105,6 +1109,7 @@ export class DockerProvider implements IsolationProvider {
     }
 
     this.logger.info({ taskId, containerId: worker.containerId }, 'Worker preserved for debugging');
+    return true;
   }
 
   async listPreservedWorkers(): Promise<

--- a/workers/orchestrator/src/services/isolation/types.ts
+++ b/workers/orchestrator/src/services/isolation/types.ts
@@ -208,7 +208,12 @@ export interface IsolationProvider {
    */
   cleanupTaskSession?(taskId: string): Promise<void>;
 
-  preserveWorker?(taskId: string): Promise<void>;
+  /**
+   * Preserve a worker's container for post-mortem debugging instead of
+   * destroying it. Returns true when the container was moved into the
+   * preserved set, false when no matching worker is tracked.
+   */
+  preserveWorker?(taskId: string): Promise<boolean>;
 
   listPreservedWorkers?(): Promise<{ containerId: string; taskId: string; preservedAt: string }[]>;
 

--- a/workers/orchestrator/src/services/task-dispatcher.ts
+++ b/workers/orchestrator/src/services/task-dispatcher.ts
@@ -1466,7 +1466,6 @@ export class TaskDispatcher {
     // Verification passed
     if (verification.passed && verification.agentData !== undefined) {
       // Non-zero exit code overrides verifier passed decision
-      /* v8 ignore start -- upstream: exit code override path requires non-zero taskExitCodes entry set by runtime; fake isolation provider cannot simulate non-zero container exit codes @preserve */
       if (exitCode !== undefined && exitCode !== 0) {
         this.appendOrchestratorTaskLog(
           task.taskId,
@@ -1474,19 +1473,19 @@ export class TaskDispatcher {
         );
         await this.flushTaskLogs(task.taskId);
         await this.collectTurnMetrics(task, attempt);
-        await this.teardownAttempt(task.taskId, false);
         const error: TaskError = {
           code: 'TASK_EXIT_CODE_OVERRIDE',
           message: `Non-zero exit code (${String(exitCode)}) overrides verifier passed decision`,
           remediation: { action: 'retry' },
         };
+        /* v8 ignore start -- ts-type: conditional spread for exact optional property types; FakeIsolationProvider cannot deliver a result alongside a non-zero exit code in the same fake-driven completion tick @preserve */
         await this.finalizeTask(task, 'failed', {
           ...(result !== undefined && { result }),
           error,
         });
+        /* v8 ignore stop @preserve */
         return;
       }
-      /* v8 ignore stop @preserve */
 
       /* v8 ignore start -- upstream: pending messages delivery path requires sendMessage called on a completing task; timing-dependent race cannot be reproduced with fake timer sequential execution @preserve */
       const pendingQueue = this.pendingMessages.get(task.taskId);
@@ -1552,7 +1551,6 @@ export class TaskDispatcher {
     }
 
     // Fatal exit code (SIGKILL=137, SIGSEGV=139): do not retry — session state is corrupted
-    /* v8 ignore start -- upstream: fatal exit code path requires SIGKILL/SIGSEGV in missingFields; fake verifier always returns empty missingFields and cannot simulate signal-based termination @preserve */
     const fatalField = hasFatalExitCodeField(verification.missingFields);
     if (fatalField !== undefined) {
       this.appendOrchestratorTaskLog(
@@ -1561,7 +1559,6 @@ export class TaskDispatcher {
       );
       await this.flushTaskLogs(task.taskId);
       await this.collectTurnMetrics(task, attempt);
-      await this.teardownAttempt(task.taskId, false);
       const error: TaskError = {
         code: 'TASK_FATAL_EXIT_CODE',
         message: `Worker process killed by signal: ${fatalField}`,
@@ -1574,6 +1571,7 @@ export class TaskDispatcher {
       return;
     }
 
+    /* v8 ignore start -- upstream: FakeIsolationProvider cannot drive the missing-fields retry or terminal-failure paths in the remainder of this method — the fake always returns exitCode 0 and unable to reproduce multi-attempt verifier sequences or runtime resume signals @preserve */
     // Missing fields: re-launch the selected runtime with an adjusted prompt if attempts remain
     if (verification.missingFields.length > 0 && attempt < maxAttempts) {
       this.logForwarder.appendChunk(task.taskId, '\n\n');
@@ -2346,12 +2344,6 @@ export class TaskDispatcher {
       this.preserveWorkerContainers &&
       !isNonPreservableAgentType &&
       (finalStatus === 'failed' || finalStatus === 'interrupted' || finalStatus === 'completed');
-    if (shouldPreserve) {
-      this.appendOrchestratorTaskLog(
-        task.taskId,
-        `Preserving worker container for debugging: taskId=${task.taskId} status=${finalStatus}`
-      );
-    }
     this.appendOrchestratorTaskLog(
       task.taskId,
       `Finalizing task: status=${finalStatus} hasResult=${String(payload.result !== undefined)} hasError=${String(payload.error !== undefined)}`
@@ -2394,7 +2386,21 @@ export class TaskDispatcher {
       }
     }
     if (shouldPreserve) {
-      await this.isolation.provider.preserveWorker?.(task.taskId);
+      /* v8 ignore start -- ts-type: optional chaining + nullish coalescing on preserveWorker; IsolationProvider.preserveWorker is structurally optional but always defined by both DockerProvider and the FakeIsolationProvider, so the undefined branch is unreachable from any test entry point @preserve */
+      const preserved = (await this.isolation.provider.preserveWorker?.(task.taskId)) ?? false;
+      /* v8 ignore stop @preserve */
+      if (preserved) {
+        this.appendOrchestratorTaskLog(
+          task.taskId,
+          `Preserved worker container for debugging: taskId=${task.taskId} status=${finalStatus}`
+        );
+      } else {
+        this.appendOrchestratorTaskLog(
+          task.taskId,
+          `Failed to preserve worker container (no tracked worker): taskId=${task.taskId} status=${finalStatus}`
+        );
+        await this.teardownAttempt(task.taskId, false);
+      }
     } else {
       await this.teardownAttempt(task.taskId, false);
     }


### PR DESCRIPTION
## Summary

- Failure branches `TASK_EXIT_CODE_OVERRIDE` and `TASK_FATAL_EXIT_CODE` were calling `teardownAttempt(taskId, false)` before `finalizeTask`, destroying the worker container before finalize could preserve it. The `Preserving worker container for debugging` log line was written, then `preserveWorker` silently no-op'd because the worker was already removed from `docker-provider`'s map. Containers for failed tasks were unrecoverable.
- Concrete incident: task `task_181fd5dd-60c4-474b-b926-4523f3ade254` (INT-1392 execution) hit an OpenAI Codex quota mid-second-review, exited 1, verifier still passed; orchestrator overrode the verdict, claimed to preserve, container was already gone, branch `feature/int-1392-required-prompt-type` was never pushed → work lost.
- Fix removes the pre-finalize teardown from both branches and lets `finalizeTask` own the single preserve-vs-teardown decision. `preserveWorker` now returns `Promise<boolean>` and warns when called for an unknown worker. Log line moves to fire only after preservation succeeds; on failure, logs the failure and falls back to `teardownAttempt`.
- Stale v8-ignore at the exit-code-override branch removed (now covered by new test); fatal-exit v8-ignore narrowed to the still-untestable missing-fields/terminal-failure paths.

## Test plan

- [x] pnpm --filter @intexuraos/orchestrator test — 1575 passed, 2 skipped
- [x] pnpm run ci:tracked — green
- [x] New regression tests:
  - preserves worker container on TASK_EXIT_CODE_OVERRIDE when preserveWorkerContainers is enabled
  - preserves worker container on TASK_FATAL_EXIT_CODE when preserveWorkerContainers is enabled
  - falls back to teardownAttempt and logs failure when preserveWorker returns false
  - docker-provider: returns false and warns for non-existent worker
- [ ] Manual: restart intexuraos-orchestrator@pbuchman with this build, submit a task that exits non-zero with verifier-pass, confirm container appears as Exited in docker ps -a --filter name=code-worker-task_* after finalize and that listPreservedWorkers() reports it.

## Notes

- No INT-XXX reference per maintainer waiver for this fix.
- Includes unrelated whitespace updates to docs/plans/2026-04-14-self-healing-failure-triage.md and docs/plans/INT-1369-evidence.md that were present in the working tree (per maintainer instruction to bundle).

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>