### PR TITLE
[INT-1397] Fix orchestrator verifier race on inactivity kill + de-anchor prompts

### DIFF
--- a/workers/orchestrator/src/__tests__/task-dispatcher.test.ts
+++ b/workers/orchestrator/src/__tests__/task-dispatcher.test.ts
@@ -3029,7 +3029,7 @@ describe('TaskDispatcher', () => {
       vi.useRealTimers();
     });
 
-    it('fails immediately when verifier reports Gemini failure', async () => {
+    it('fails immediately when verifier reports all-models failure', async () => {
       vi.useFakeTimers();
       const verifierFailureState = createStatePersistence();
       const verify = vi.fn().mockResolvedValue({
@@ -3089,12 +3089,12 @@ describe('TaskDispatcher', () => {
 
       const task = await verifierFailureDispatcher.getTask('verifier-failure-task');
       expect(task?.status).toBe('failed');
-      // attemptCount is 2 because verifier retries Gemini once (attempt + 1)
+      // attemptCount is 2 because verifier retries once (attempt + 1)
       expect(task?.attemptCount).toBe(2);
       expect(task?.verificationHistory?.[0]?.verifierFailure).toBe(true);
-      // Gemini retry also recorded
+      // Verifier retry also recorded
       expect(task?.verificationHistory?.[1]?.verifierFailure).toBe(true);
-      // createWorker called once (only task worker, not the Gemini retry)
+      // createWorker called once (only task worker, not the verifier retry)
       expect(mockIsolationProvider.createWorker).toHaveBeenCalledTimes(1);
       expect(mockWebhookClient.send).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -3105,7 +3105,7 @@ describe('TaskDispatcher', () => {
             }),
             error: expect.objectContaining({
               code: 'TASK_COMPLETION_VERIFIER_FAILED',
-              message: expect.stringContaining('Gemini verifier unavailable'),
+              message: expect.stringContaining('Completion verifier unavailable'),
             }),
           }),
         })
@@ -9938,6 +9938,155 @@ describe('TaskDispatcher', () => {
           }),
         })
       );
+
+      vi.useRealTimers();
+      vi.mocked(mockIsolationProvider.isWorkerRunning).mockResolvedValue(false);
+    });
+
+    it('completion monitor does not verify while inactivity restart is in progress', async () => {
+      vi.useFakeTimers();
+      vi.mocked(mockIsolationProvider.isWorkerRunning).mockResolvedValue(true);
+      const raceState = createStatePersistence();
+      const raceVerify = vi.fn(async () => ({
+        passed: true,
+        missingFields: [] as string[],
+        verifierFailure: false,
+        trace: dummyTrace,
+        agentData: {
+          agentType: 'planning' as const,
+          outcome: 'planned' as const,
+          superpowers_writing_plans: 'used' as const,
+          linear_url: '',
+          is_complex: '0' as const,
+          has_plan_doc: '0' as const,
+          subtask_urls: '',
+          pr_url: '',
+          memory_ids_used: '',
+          memory_ids_rejected: '',
+          memory_usage_summary: '',
+          summary: 'Task completed',
+          unclear_clarification: '',
+        },
+      }));
+      const raceDispatcher = new TaskDispatcher(
+        mockConfig,
+        raceState,
+        mockWorktreeManager,
+        mockLogForwarder,
+        mockWebhookClient,
+        mockGitHubTokenService,
+        mockLogger,
+        mockIsolationConfig,
+        {
+          maxAttempts: 1,
+          activityTimeout: { timeoutMs: 10 * 60 * 1000, maxRestarts: 3 },
+          verifier: {
+            verify: raceVerify,
+            describe: (): { enabled: boolean; provider: string; model: string } => ({
+              enabled: true,
+              provider: 'gemini',
+              model: 'gemini-2.5-flash',
+            }),
+            extractResumeSummary: vi.fn().mockResolvedValue(undefined),
+          },
+        }
+      );
+
+      const request: CreateTaskRequest = {
+        taskId: 'race-restart-verify',
+        workerType: 'auto',
+        prompt: 'Test race guard',
+        webhookUrl: 'https://example.com/webhook',
+        webhookSecret: 'secret',
+        linearIssueLabels: [],
+        hasChildren: false,
+      };
+
+      await raceDispatcher.submitTask(request);
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Simulate "inactivity restart in progress" by seeding the flag directly.
+      // Production sets it synchronously at the top of handleInactivityRestart,
+      // before any await — guaranteeing the monitor tick sees it during the
+      // destroyWorker/startWorkerAttempt window.
+      const internal = raceDispatcher as unknown as {
+        inactivityRestartInProgress: Set<string>;
+      };
+      internal.inactivityRestartInProgress.add('race-restart-verify');
+
+      // Container is gone during the restart window
+      vi.mocked(mockIsolationProvider.isWorkerRunning).mockResolvedValue(false);
+
+      // Advance multiple monitor intervals — the monitor must not call verify
+      await vi.advanceTimersByTimeAsync(30 * 1000);
+      await vi.advanceTimersByTimeAsync(30 * 1000);
+      await vi.advanceTimersByTimeAsync(30 * 1000);
+
+      expect(raceVerify).not.toHaveBeenCalled();
+
+      internal.inactivityRestartInProgress.delete('race-restart-verify');
+      vi.useRealTimers();
+      vi.mocked(mockIsolationProvider.isWorkerRunning).mockResolvedValue(false);
+    });
+
+    it('passes the worker exitCode to the completion verifier as lastExitCode', async () => {
+      vi.useFakeTimers();
+      vi.mocked(mockIsolationProvider.isWorkerRunning).mockResolvedValue(true);
+      const exitCodeVerify = vi.fn(async () => ({
+        passed: false,
+        missingFields: ['fatal_exit_code_137'],
+        verifierFailure: false,
+        trace: dummyTrace,
+      }));
+      const exitCodeState = createStatePersistence();
+      const exitCodeDispatcher = new TaskDispatcher(
+        mockConfig,
+        exitCodeState,
+        mockWorktreeManager,
+        mockLogForwarder,
+        mockWebhookClient,
+        mockGitHubTokenService,
+        mockLogger,
+        mockIsolationConfig,
+        {
+          maxAttempts: 1,
+          activityTimeout: disabledActivityTimeout,
+          verifier: {
+            verify: exitCodeVerify,
+            describe: (): { enabled: boolean; provider: string; model: string } => ({
+              enabled: true,
+              provider: 'gemini',
+              model: 'gemini-2.5-flash',
+            }),
+            extractResumeSummary: vi.fn().mockResolvedValue(undefined),
+          },
+        }
+      );
+
+      const request: CreateTaskRequest = {
+        taskId: 'exitcode-137-passthrough',
+        workerType: 'auto',
+        prompt: 'Test exit code propagation',
+        webhookUrl: 'https://example.com/webhook',
+        webhookSecret: 'secret',
+        linearIssueLabels: [],
+        hasChildren: false,
+      };
+
+      await exitCodeDispatcher.submitTask(request);
+      await vi.advanceTimersByTimeAsync(0);
+
+      const createWorkerCall = vi.mocked(mockIsolationProvider.createWorker).mock.calls.at(-1);
+      const onComplete = createWorkerCall?.[0]?.onComplete;
+      expect(onComplete).toBeDefined();
+
+      onComplete?.(137);
+
+      vi.mocked(mockIsolationProvider.isWorkerRunning).mockResolvedValue(false);
+      await vi.advanceTimersByTimeAsync(30 * 1000);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(exitCodeVerify).toHaveBeenCalledWith(expect.objectContaining({ lastExitCode: 137 }));
 
       vi.useRealTimers();
       vi.mocked(mockIsolationProvider.isWorkerRunning).mockResolvedValue(false);

--- a/workers/orchestrator/src/services/__tests__/completion-verifier.test.ts
+++ b/workers/orchestrator/src/services/__tests__/completion-verifier.test.ts
@@ -14,6 +14,7 @@ const {
   buildExecutionPrompt,
   buildPullRequestPrompt,
   buildReviewPrompt,
+  buildRemediationPrompt,
   buildResumeSummaryPrompt,
   getLast50Lines,
   getLast50ClaudeLines,
@@ -608,8 +609,8 @@ describe('buildPlanningPrompt', () => {
     expect(prompt).toContain(
       'LLM agent delivers its summary in one of the last assistant messages'
     );
-    expect(prompt).toContain('Sample Linear URL format');
-    expect(prompt).toContain('Sample PR URL format');
+    expect(prompt).toContain('Linear URL format example');
+    expect(prompt).toContain('GitHub PR URL format example');
   });
 });
 
@@ -2166,6 +2167,245 @@ describe('verify — fatal exit code pre-check', () => {
     expect(result.passed).toBe(true);
     expect(generateMock).toHaveBeenCalledOnce();
   });
+});
+
+// ---------------------------------------------------------------------------
+// verify — fatal exit code pre-check via lastExitCode input
+// ---------------------------------------------------------------------------
+
+describe('verify — fatal exit code via lastExitCode input', () => {
+  it.each([
+    { exitCode: 137, signal: 'SIGKILL' },
+    { exitCode: 139, signal: 'SIGSEGV' },
+  ])(
+    'short-circuits for lastExitCode=$exitCode ($signal) without calling any model',
+    async ({ exitCode }) => {
+      const verifier = createVerifier();
+      const result = await verifier.verify({
+        taskId: `task-lastexit-${String(exitCode)}`,
+        attempt: 1,
+        maxAttempts: 5,
+        agentType: 'execution',
+        rawLogs: 'worker made no terminal entrypoint log before being killed externally',
+        lastExitCode: exitCode,
+      });
+      expect(result.passed).toBe(false);
+      expect(result.missingFields).toEqual([`fatal_exit_code_${String(exitCode)}`]);
+      expect(result.verifierFailure).toBe(false);
+      expect(result.agentData).toBeUndefined();
+      expect(generateMock).not.toHaveBeenCalled();
+    }
+  );
+
+  it('proceeds to verification for lastExitCode=0', async () => {
+    generateMock.mockResolvedValueOnce({
+      ok: true,
+      value: {
+        content: JSON.stringify({
+          outcome: 'planned',
+          superpowers_writing_plans: 'used',
+          linear_url: 'https://linear.app/pbuchman/issue/INT-100',
+          is_complex: '0',
+          has_plan_doc: '0',
+          subtask_urls: '',
+          pr_url: 'https://github.com/pbuchman/intexuraos/pull/100',
+          summary: 'Planned.',
+          unclear_clarification: '',
+        }),
+        usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30, costUsd: 0.001 },
+      },
+    });
+    const verifier = createVerifier();
+    const result = await verifier.verify({
+      taskId: 'task-exit-zero',
+      attempt: 1,
+      maxAttempts: 5,
+      agentType: 'planning',
+      rawLogs: 'output',
+      lastExitCode: 0,
+    });
+    expect(result.passed).toBe(true);
+    expect(generateMock).toHaveBeenCalledOnce();
+  });
+
+  it('proceeds to verification when lastExitCode is undefined', async () => {
+    generateMock.mockResolvedValueOnce({
+      ok: true,
+      value: {
+        content: JSON.stringify({
+          outcome: 'planned',
+          superpowers_writing_plans: 'used',
+          linear_url: 'https://linear.app/pbuchman/issue/INT-100',
+          is_complex: '0',
+          has_plan_doc: '0',
+          subtask_urls: '',
+          pr_url: 'https://github.com/pbuchman/intexuraos/pull/100',
+          summary: 'Planned.',
+          unclear_clarification: '',
+        }),
+        usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30, costUsd: 0.001 },
+      },
+    });
+    const verifier = createVerifier();
+    const result = await verifier.verify({
+      taskId: 'task-exit-undefined',
+      attempt: 1,
+      maxAttempts: 5,
+      agentType: 'planning',
+      rawLogs: 'output',
+    });
+    expect(result.passed).toBe(true);
+    expect(generateMock).toHaveBeenCalledOnce();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// verify — succeededModelName threading
+// ---------------------------------------------------------------------------
+
+describe('verify — succeededModelName', () => {
+  const validPlanningContent = JSON.stringify({
+    outcome: 'planned',
+    superpowers_writing_plans: 'used',
+    linear_url: 'https://linear.app/pbuchman/issue/INT-100',
+    is_complex: '0',
+    has_plan_doc: '0',
+    subtask_urls: '',
+    pr_url: 'https://github.com/pbuchman/intexuraos/pull/100',
+    summary: 'Planned.',
+    unclear_clarification: '',
+  });
+
+  it('reports the primary model name when primary succeeds', async () => {
+    generateMock.mockResolvedValueOnce({
+      ok: true,
+      value: {
+        content: validPlanningContent,
+        usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30, costUsd: 0.001 },
+      },
+    });
+    const verifier = createVerifier({ primaryModelName: 'or:google/gemma-4-31b-it:free' });
+    const result = await verifier.verify({
+      taskId: 'task-primary',
+      attempt: 1,
+      maxAttempts: 5,
+      agentType: 'planning',
+      rawLogs: 'logs',
+    });
+    expect(result.passed).toBe(true);
+    expect(result.succeededModelName).toBe('or:google/gemma-4-31b-it:free');
+  });
+
+  it('reports the fallback model name when primary fails and fallback succeeds', async () => {
+    const fallbackGenerate = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      value: {
+        content: validPlanningContent,
+        usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30, costUsd: 0.001 },
+      },
+    });
+    generateMock.mockResolvedValueOnce({
+      ok: false,
+      error: { code: 'API_ERROR', message: 'primary down' },
+    });
+    const verifier = createVerifier({
+      primaryModelName: 'or:google/gemma-4-31b-it:free',
+      fallbackClients: [{ generate: fallbackGenerate }],
+      fallbackModelNames: ['gemini-2.5-flash'],
+    });
+    const result = await verifier.verify({
+      taskId: 'task-fallback-name',
+      attempt: 1,
+      maxAttempts: 5,
+      agentType: 'planning',
+      rawLogs: 'logs',
+    });
+    expect(result.passed).toBe(true);
+    expect(result.succeededModelName).toBe('gemini-2.5-flash');
+  });
+
+  it('reports the model name even on schema validation failure', async () => {
+    generateMock.mockResolvedValueOnce({
+      ok: true,
+      value: {
+        content: JSON.stringify({ outcome: 'planned' }), // missing required fields
+        usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30, costUsd: 0.001 },
+      },
+    });
+    const verifier = createVerifier({ primaryModelName: 'or:google/gemma-4-31b-it:free' });
+    const result = await verifier.verify({
+      taskId: 'task-schema-fail',
+      attempt: 1,
+      maxAttempts: 5,
+      agentType: 'planning',
+      rawLogs: 'logs',
+    });
+    expect(result.passed).toBe(false);
+    expect(result.succeededModelName).toBe('or:google/gemma-4-31b-it:free');
+  });
+
+  it('leaves succeededModelName undefined when all models fail to generate', async () => {
+    generateMock.mockResolvedValueOnce({
+      ok: false,
+      error: { code: 'API_ERROR', message: 'primary down' },
+    });
+    const verifier = createVerifier({ primaryModelName: 'or:google/gemma-4-31b-it:free' });
+    const result = await verifier.verify({
+      taskId: 'task-all-fail',
+      attempt: 1,
+      maxAttempts: 5,
+      agentType: 'planning',
+      rawLogs: 'logs',
+    });
+    expect(result.passed).toBe(false);
+    expect(result.verifierFailure).toBe(true);
+    expect(result.succeededModelName).toBeUndefined();
+  });
+
+  it('leaves succeededModelName undefined on fatal exit code short-circuit', async () => {
+    const verifier = createVerifier();
+    const result = await verifier.verify({
+      taskId: 'task-fatal',
+      attempt: 1,
+      maxAttempts: 5,
+      agentType: 'execution',
+      rawLogs: 'output\n[entrypoint] Claude attempt finished with exit code: 137\n',
+    });
+    expect(result.passed).toBe(false);
+    expect(result.succeededModelName).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// prompt examples — no anchoring URLs
+// ---------------------------------------------------------------------------
+
+describe('prompt examples contain no real repo/issue URLs', () => {
+  const forbiddenFragments = [
+    'pbuchman/intexuraos/pull/944',
+    'pbuchman/intexuraos/pull/901',
+    'pbuchman/intexuraos/pull/950',
+    'INT-631',
+    'INT-632',
+    'INT-633',
+  ];
+
+  const builders = [
+    { name: 'buildPlanningPrompt', build: buildPlanningPrompt },
+    { name: 'buildExecutionPrompt', build: buildExecutionPrompt },
+    { name: 'buildPullRequestPrompt', build: buildPullRequestPrompt },
+    { name: 'buildReviewPrompt', build: buildReviewPrompt },
+    { name: 'buildRemediationPrompt', build: buildRemediationPrompt },
+  ] as const;
+
+  for (const { name, build } of builders) {
+    for (const fragment of forbiddenFragments) {
+      it(`${name} prompt does not contain "${fragment}"`, () => {
+        const prompt = build('sample transcript');
+        expect(prompt).not.toContain(fragment);
+      });
+    }
+  }
 });
 
 // ---------------------------------------------------------------------------

--- a/workers/orchestrator/src/services/completion-verifier.ts
+++ b/workers/orchestrator/src/services/completion-verifier.ts
@@ -26,6 +26,11 @@ export interface CompletionVerifierInput {
   maxAttempts: number;
   agentType: CompletionAgentType;
   rawLogs: string;
+  /** Exit code of the worker process if known (Docker exit code). When set to
+   *  137 (SIGKILL) or 139 (SIGSEGV), verification short-circuits without
+   *  calling any LLM — used to catch cases where the entrypoint was killed
+   *  externally and never wrote its own exit-code line. */
+  lastExitCode?: number;
   executionMemoryContext?: ExecutionMemoryPromptContext;
 }
 
@@ -46,6 +51,10 @@ export interface CompletionVerifierVerdict {
     | PullRequestAgentData
     | ReviewAgentData
     | RemediationAgentData;
+  /** Model name that produced the response. Undefined when no model produced
+   *  content (all generate() calls failed) or when the short-circuit on
+   *  fatal exit codes fires before any model is called. */
+  succeededModelName?: string;
   trace: CompletionVerifierTrace;
 }
 
@@ -257,8 +266,8 @@ function sharedPreamble(): string[] {
     '- Analyze the transcript from the END toward the beginning. The most recent output takes priority — e.g. pnpm run ci:tracked may have failed and then succeeded; the expected result is the final outcome.',
     '- The LLM agent delivers its summary in one of the last assistant messages.',
     '- superpowers_writing_plans: "used" only if the agent explicitly claims it invoked the writing-plans superpowers skill.',
-    '- Sample Linear URL format: https://linear.app/pbuchman/issue/INT-631/feature-introduce-github-webhook-agent-ownership-orchestration',
-    '- Sample PR URL format: https://github.com/pbuchman/intexuraos/pull/944',
+    '- Linear URL format example (DO NOT copy this URL; extract the real one from the transcript): https://linear.app/example-org/issue/EXAMPLE-1/example-issue-slug',
+    '- GitHub PR URL format example (DO NOT copy this URL; extract the real one from the transcript): https://github.com/example-org/example-repo/pull/999',
     '',
   ];
 }
@@ -284,8 +293,8 @@ export function buildPlanningPrompt(transcript: string): string {
     '- summary: concise bullet-point summary (markdown *, max 5-6 points) of what happened — the LLM agent typically states this clearly as a summary block in its final output',
     '- unclear_clarification: required when outcome is "unclear" — the message explaining why; empty string if outcome is "planned"',
     '',
-    'Example valid response:',
-    '{"outcome":"planned","superpowers_writing_plans":"used","linear_url":"https://linear.app/pbuchman/issue/INT-631/feature-introduce-github-webhook-agent-ownership-orchestration","is_complex":"1","has_plan_doc":"1","subtask_urls":"https://linear.app/pbuchman/issue/INT-632/subtask-one,https://linear.app/pbuchman/issue/INT-633/subtask-two","pr_url":"https://github.com/pbuchman/intexuraos/pull/944","memory_ids_used":"mem_142","memory_ids_rejected":"mem_188","memory_usage_summary":"Used the planning memory to keep the implementation split aligned with prior architecture.","summary":"* Analyzed task requirements for the GitHub webhook agent ownership feature\\n* Decided on a complex implementation requiring parallel subtasks\\n* Created 5 child issues covering API endpoints, database schema, and test strategy\\n* Produced a plan PR with the full implementation design","unclear_clarification":""}',
+    'Example valid response (placeholder URLs — do NOT copy these; extract real ones from the transcript):',
+    '{"outcome":"planned","superpowers_writing_plans":"used","linear_url":"https://linear.app/example-org/issue/EXAMPLE-1/example-issue-slug","is_complex":"1","has_plan_doc":"1","subtask_urls":"https://linear.app/example-org/issue/EXAMPLE-2/example-subtask-a,https://linear.app/example-org/issue/EXAMPLE-3/example-subtask-b","pr_url":"https://github.com/example-org/example-repo/pull/999","memory_ids_used":"mem_142","memory_ids_rejected":"mem_188","memory_usage_summary":"Used the planning memory to keep the implementation split aligned with prior architecture.","summary":"* Analyzed task requirements\\n* Decided on a complex implementation requiring parallel subtasks\\n* Created 5 child issues covering API endpoints, database schema, and test strategy\\n* Produced a plan PR with the full implementation design","unclear_clarification":""}',
     '',
     'Transcript (last 50 lines):',
     transcript,
@@ -309,9 +318,9 @@ export function buildExecutionPrompt(transcript: string): string {
     '- memory_usage_summary: one-sentence summary of how the memories helped or why they were rejected (string, empty string if not found)',
     '- summary: concise bullet-point summary (markdown *, max 5-6 points) of what was implemented — the LLM agent typically states this clearly as a summary block in its final output',
     '',
-    'Example valid responses:',
-    '{"outcome":"implemented","superpowers_subagent_driven_dev":"used","superpowers_requesting_code_review":"used","gh_pr_url":"https://github.com/pbuchman/intexuraos/pull/901","memory_ids_used":"mem_142,mem_155","memory_ids_rejected":"mem_188","memory_usage_summary":"Used the route logging and coverage memories to keep the callback fix aligned with existing verification patterns.","summary":"* Implemented the feature with 3 new API endpoints and updated database schema\\n* CI passed on the first attempt\\n* Created PR targeting the development branch"}',
-    '{"outcome":"already_completed","superpowers_subagent_driven_dev":"used","superpowers_requesting_code_review":"not used","gh_pr_url":"https://github.com/pbuchman/intexuraos/pull/950","memory_ids_used":"","memory_ids_rejected":"mem_188","memory_usage_summary":"Rejected the supplied memory because the codebase already matched the current repo state.","summary":"* Discovered the requested work was already implemented and merged into development\\n* Verified all tests pass and the feature is present in the codebase\\n* Created evidence PR documenting completion"}',
+    'Example valid responses (placeholder URLs — do NOT copy these; extract real ones from the transcript):',
+    '{"outcome":"implemented","superpowers_subagent_driven_dev":"used","superpowers_requesting_code_review":"used","gh_pr_url":"https://github.com/example-org/example-repo/pull/999","memory_ids_used":"mem_142,mem_155","memory_ids_rejected":"mem_188","memory_usage_summary":"Used the route logging and coverage memories to keep the callback fix aligned with existing verification patterns.","summary":"* Implemented the feature with 3 new API endpoints and updated database schema\\n* CI passed on the first attempt\\n* Created PR targeting the development branch"}',
+    '{"outcome":"already_completed","superpowers_subagent_driven_dev":"used","superpowers_requesting_code_review":"not used","gh_pr_url":"https://github.com/example-org/example-repo/pull/998","memory_ids_used":"","memory_ids_rejected":"mem_188","memory_usage_summary":"Rejected the supplied memory because the codebase already matched the current repo state.","summary":"* Discovered the requested work was already implemented and merged into development\\n* Verified all tests pass and the feature is present in the codebase\\n* Created evidence PR documenting completion"}',
     '',
     'Transcript (last 50 lines):',
     transcript,
@@ -334,8 +343,8 @@ export function buildPullRequestPrompt(transcript: string): string {
     '- memory_usage_summary: one-sentence summary of how injected memories influenced the PR work, or empty string if none were injected',
     '- summary: concise bullet-point summary (markdown *, max 5-6 points) of what was done — the LLM agent typically states this clearly as a summary block in its final output',
     '',
-    'Example valid response:',
-    '{"gh_pr_url":"https://github.com/pbuchman/intexuraos/pull/901","comments_replied":"yes","tracking_comment_id":"2345678","memory_ids_used":"mem_142","memory_ids_rejected":"","memory_usage_summary":"Used the injected PR memory to keep the replies aligned with existing workflow expectations.","summary":"* Addressed 3 review comments on PR #901\\n* Pushed code changes and CI passed\\n* All reviewer feedback resolved"}',
+    'Example valid response (placeholder URL — do NOT copy this; extract the real one from the transcript):',
+    '{"gh_pr_url":"https://github.com/example-org/example-repo/pull/999","comments_replied":"yes","tracking_comment_id":"2345678","memory_ids_used":"mem_142","memory_ids_rejected":"","memory_usage_summary":"Used the injected PR memory to keep the replies aligned with existing workflow expectations.","summary":"* Addressed 3 review comments on the PR\\n* Pushed code changes and CI passed\\n* All reviewer feedback resolved"}',
     '',
     'Transcript (last 50 lines):',
     transcript,
@@ -362,8 +371,8 @@ export function buildReviewPrompt(transcript: string): string {
     '- needs_remediation: "0" if the PR is clean or all findings are informational only, "1" if any finding requires code changes. Operational/manual verification steps (deploying migrations, running commands in environments, manual testing in dev/prod) are post-merge activities and do NOT count as code remediation',
     '- summary: concise bullet-point summary (markdown *, max 5-6 points) of the review findings — the LLM agent typically states this clearly as a summary block in its final output',
     '',
-    'Example valid response:',
-    '{"gh_pr_url":"https://github.com/pbuchman/intexuraos/pull/901","review_id":"321654987","review_comments_posted":"3","review_types":"code_quality,security","memory_ids_used":"mem_142","memory_ids_rejected":"mem_188","memory_usage_summary":"Used the injected review memory to validate the architecture findings against prior incidents.","requirements_tracker_updated":"yes","gh_actions_status":"all passed","needs_remediation":"1","summary":"* Reviewed PR #901 for code quality and security issues\\n* Found 3 issues: missing null check, unused import, and potential XSS vulnerability\\n* All findings posted as inline review comments"}',
+    'Example valid response (placeholder URL — do NOT copy this; extract the real one from the transcript):',
+    '{"gh_pr_url":"https://github.com/example-org/example-repo/pull/999","review_id":"321654987","review_comments_posted":"3","review_types":"code_quality,security","memory_ids_used":"mem_142","memory_ids_rejected":"mem_188","memory_usage_summary":"Used the injected review memory to validate the architecture findings against prior incidents.","requirements_tracker_updated":"yes","gh_actions_status":"all passed","needs_remediation":"1","summary":"* Reviewed the PR for code quality and security issues\\n* Found 3 issues: missing null check, unused import, and potential XSS vulnerability\\n* All findings posted as inline review comments"}',
     '',
     'The review_id must be the numeric GitHub review ID created by the single POST /reviews call, not a comment ID. If the transcript does not contain it, omit review_id instead of inventing or blanking it.',
     '',
@@ -388,9 +397,9 @@ export function buildRemediationPrompt(transcript: string): string {
     '- requires_re_review: "1" if the agent decided the PR must be re-reviewed after the changes, "0" otherwise',
     '- summary: concise bullet-point summary (markdown *, max 5-6 points) of the remediation work — the LLM agent typically states this clearly as a summary block in its final output',
     '',
-    'Example valid responses:',
-    '{"outcome":"implemented","gh_pr_url":"https://github.com/pbuchman/intexuraos/pull/901","memory_ids_used":"mem_142","memory_ids_rejected":"mem_188","memory_usage_summary":"Used the remediation memory to keep the fix scoped to the reviewed invariant.","requires_re_review":"1","summary":"* Addressed review findings on the existing PR branch and updated affected tests\\n* Pushed fixes to the PR\\n* Marked for re-review due to changes in reviewed areas"}',
-    '{"outcome":"already_completed","gh_pr_url":"https://github.com/pbuchman/intexuraos/pull/901","memory_ids_used":"","memory_ids_rejected":"mem_188","memory_usage_summary":"Rejected the supplied remediation memory because the fix was already present on the branch.","requires_re_review":"0","summary":"* Verified reported findings were already resolved on the PR branch\\n* No new code changes or push required"}',
+    'Example valid responses (placeholder URLs — do NOT copy these; extract real ones from the transcript):',
+    '{"outcome":"implemented","gh_pr_url":"https://github.com/example-org/example-repo/pull/999","memory_ids_used":"mem_142","memory_ids_rejected":"mem_188","memory_usage_summary":"Used the remediation memory to keep the fix scoped to the reviewed invariant.","requires_re_review":"1","summary":"* Addressed review findings on the existing PR branch and updated affected tests\\n* Pushed fixes to the PR\\n* Marked for re-review due to changes in reviewed areas"}',
+    '{"outcome":"already_completed","gh_pr_url":"https://github.com/example-org/example-repo/pull/999","memory_ids_used":"","memory_ids_rejected":"mem_188","memory_usage_summary":"Rejected the supplied remediation memory because the fix was already present on the branch.","requires_re_review":"0","summary":"* Verified reported findings were already resolved on the PR branch\\n* No new code changes or push required"}',
     '',
     'Transcript (last 50 lines):',
     transcript,
@@ -593,7 +602,9 @@ export class OrchestratorCompletionVerifier implements CompletionVerifier {
   private async doVerify(input: CompletionVerifierInput): Promise<CompletionVerifierVerdict> {
     const transcript = getLast50Lines(input.rawLogs);
 
-    const fatalExitCode = detectFatalExitCode(input.rawLogs);
+    const directExitCode =
+      input.lastExitCode === 137 || input.lastExitCode === 139 ? input.lastExitCode : undefined;
+    const fatalExitCode = directExitCode ?? detectFatalExitCode(input.rawLogs);
     if (fatalExitCode !== undefined) {
       this.logger.warn(
         {
@@ -601,6 +612,7 @@ export class OrchestratorCompletionVerifier implements CompletionVerifier {
           attempt: input.attempt,
           agentType: input.agentType,
           exitCode: fatalExitCode,
+          source: directExitCode !== undefined ? 'lastExitCode' : 'rawLogs',
         },
         'Fatal exit code detected — skipping completion verification'
       );
@@ -730,6 +742,7 @@ export class OrchestratorCompletionVerifier implements CompletionVerifier {
           passed: false,
           missingFields,
           verifierFailure: false,
+          succeededModelName,
           trace: { transcript, prompt, response: lastGeneratedContent },
         };
       }
@@ -781,6 +794,7 @@ export class OrchestratorCompletionVerifier implements CompletionVerifier {
           passed: false,
           missingFields: emptyMemoryFields,
           verifierFailure: false,
+          succeededModelName,
           trace: { transcript, prompt, response: lastGeneratedContent },
         };
       }
@@ -805,6 +819,7 @@ export class OrchestratorCompletionVerifier implements CompletionVerifier {
         passed: false,
         missingFields: memoryValidationFailures,
         verifierFailure: false,
+        succeededModelName,
         trace: { transcript, prompt, response: lastGeneratedContent },
       };
     }
@@ -824,6 +839,7 @@ export class OrchestratorCompletionVerifier implements CompletionVerifier {
       missingFields: [],
       verifierFailure: false,
       agentData,
+      succeededModelName,
       trace: { transcript, prompt, response: lastGeneratedContent },
     };
   }

--- a/workers/orchestrator/src/services/task-dispatcher.ts
+++ b/workers/orchestrator/src/services/task-dispatcher.ts
@@ -177,6 +177,11 @@ export class TaskDispatcher {
   private readonly taskExitCodes = new Map<string, number>();
   private readonly attemptCompletionSignals = new Set<string>();
   private readonly completionInProgress = new Set<string>();
+  /** Task IDs whose handleInactivityRestart is currently mid-flight (after the
+   *  old worker was killed, before the restart worker is up). The completion
+   *  monitor skips these to avoid running verification on the stale transcript
+   *  of the killed session. */
+  private readonly inactivityRestartInProgress = new Set<string>();
   private readonly pendingMessages = new Map<string, string[]>();
   private readonly lastOutputAt = new Map<string, number>();
   private readonly completionMaxAttempts: number;
@@ -1059,6 +1064,18 @@ export class TaskDispatcher {
   }
 
   private async handleInactivityRestart(taskId: string): Promise<void> {
+    // Mark the restart as in-flight synchronously before any await so the
+    // completion monitor cannot race and run verification on the stale
+    // transcript while destroyWorker/startWorkerAttempt are pending.
+    this.inactivityRestartInProgress.add(taskId);
+    try {
+      await this.doHandleInactivityRestart(taskId);
+    } finally {
+      this.inactivityRestartInProgress.delete(taskId);
+    }
+  }
+
+  private async doHandleInactivityRestart(taskId: string): Promise<void> {
     // Guard: skip if completion is already in progress
     if (this.completionInProgress.has(taskId)) {
       this.logger.debug({ taskId }, 'Inactivity restart skipped: completion already in progress');
@@ -1205,6 +1222,16 @@ export class TaskDispatcher {
             if (this.completionInProgress.has(taskId)) {
               return;
             }
+            // Skip: an inactivity restart is mid-flight (old worker destroyed,
+            // new one not yet up). Running completion now would verify on the
+            // stale transcript of the killed session.
+            if (this.inactivityRestartInProgress.has(taskId)) {
+              this.logger.debug(
+                { taskId },
+                'Completion monitor tick skipped: inactivity restart in progress'
+              );
+              return;
+            }
             this.completionInProgress.add(taskId);
             try {
               await this.handleTaskCompletion(task);
@@ -1348,6 +1375,7 @@ export class TaskDispatcher {
       maxAttempts,
       agentType: completionAgentType,
       rawLogs,
+      ...(exitCode !== undefined && { lastExitCode: exitCode }),
       ...(task.executionMemoryContext !== undefined && {
         executionMemoryContext: task.executionMemoryContext,
       }),
@@ -1380,7 +1408,7 @@ export class TaskDispatcher {
     /* v8 ignore start -- ts-type: optional chaining on agentData creates narrowing branch; agentData guaranteed to have summary when present @preserve */
     this.appendOrchestratorTaskLog(
       task.taskId,
-      `🤖 Gemini summary: ${verification.agentData?.summary ?? '(no summary extracted)'}`
+      `🤖 Verifier summary (${verification.succeededModelName ?? 'unknown'}): ${verification.agentData?.summary ?? '(no summary extracted)'}`
     );
     /* v8 ignore stop @preserve */
 
@@ -1400,13 +1428,13 @@ export class TaskDispatcher {
       },
     ];
 
-    // Verifier failure (Gemini down/parse error): retry Gemini immediately if attempts remain
-    /* v8 ignore start -- upstream: verifierFailure path requires Gemini to return parse errors; FakeCompletionVerifier always returns valid responses and cannot simulate upstream failures @preserve */
+    // Verifier failure (all validation models down or unparseable output): retry immediately if attempts remain
+    /* v8 ignore start -- upstream: verifierFailure path requires all validation models to return parse errors; FakeCompletionVerifier always returns valid responses and cannot simulate upstream failures @preserve */
     if (verification.verifierFailure) {
       if (attempt < maxAttempts) {
         this.appendOrchestratorTaskLog(
           task.taskId,
-          `Verifier failure; retrying Gemini (${String(attempt + 1)}/${String(maxAttempts)})`
+          `Verifier failure; retrying verifier (${String(attempt + 1)}/${String(maxAttempts)})`
         );
         // Re-call verifier with same logs — counts as an attempt
         const retryVerification = await this.completionVerifier.verify({
@@ -1443,12 +1471,12 @@ export class TaskDispatcher {
 
       const error: TaskError = {
         code: 'TASK_COMPLETION_VERIFIER_FAILED',
-        message: 'Gemini verifier unavailable',
+        message: 'Completion verifier unavailable (all validation models failed)',
         remediation: {
           action: 'contact_support',
           manualSteps: [
-            'Ensure INTEXURAOS_GEMINI_APP_API_KEY is configured for orchestrator.',
-            'Check Gemini provider connectivity and retry task after verifier is healthy.',
+            'Ensure INTEXURAOS_GEMINI_APP_API_KEY and INTEXURAOS_OPENROUTER_APP_API_KEY are configured for orchestrator.',
+            'Check connectivity to all configured validation models and retry task after verifier is healthy.',
           ],
         },
       };


### PR DESCRIPTION
## Summary

After a 600s inactivity SIGKILL on a code-task worker, the completion monitor can race the restart flow and run completion verification on the stale transcript of the killed worker. One prod task (`task_c4612397-247d-4d85-a0f1-76d1b5fb1b1a`, INT-1397) was finalized `status: implemented` from a Gemma-4-31B summary describing a wholly unrelated repo (Go + SvelteKit `webhook_agent_owner`), and stored `prUrl: pull/944` — a real older PR whose URL was copy-pasted out of the verifier's own prompt examples.

Three interlocking fixes shipped together:

- **Race guard**: `handleInactivityRestart` now marks the task in a synchronous `inactivityRestartInProgress` set before any `await`. The completion monitor tick skips the task whenever that flag is set, so the stale transcript can't reach `verify()` during the destroy/restart window.
- **Belt-and-suspenders**: worker exit code is threaded to `CompletionVerifier.verify` as `lastExitCode`. When it is 137 or 139, verification short-circuits without calling any LLM. The previous `detectFatalExitCode` regex only fired when the entrypoint wrote its own exit line — which never happens on external SIGKILL.
- **De-anchor prompts**: all prompt examples that contained real URLs (`pbuchman/intexuraos/pull/944`, `pull/901`, `pull/950`, `INT-631/feature-introduce-github-webhook-agent-ownership-orchestration`) are replaced with `example-org/example-repo/pull/999` and `EXAMPLE-1` placeholders, annotated `DO NOT copy these URLs`. Removes the anchoring vector that made the smaller validation models hallucinate a real-looking answer when fed a degenerate transcript.

Also de-Geminified naming: verifier is a multi-model chain (`gemma-4-31b-it:free → gemma-4-31b-it → gemini-2.5-flash`). `🤖 Gemini summary:` becomes `🤖 Verifier summary (<modelName>)` via a new `succeededModelName` field on `CompletionVerifierVerdict`; failure-path strings and comments updated accordingly.

## Test plan

- [x] `pnpm run verify:workspace:tracked orchestrator` — 14,767 tests pass
- [x] `pnpm run ci:tracked` at repo root — all phases green
- [x] New unit tests for `lastExitCode` short-circuit (137/139 → no LLM call)
- [x] New unit tests asserting `succeededModelName` threading on success, schema-failure, and all-models-failed paths
- [x] Regression tests: every `build*Prompt` output asserted not to contain the real pre-change URLs
- [x] Race test: with `inactivityRestartInProgress` seeded, three 30-second monitor ticks do not call `verify`
- [x] `lastExitCode` propagation test: `onComplete(137)` surfaces in the verifier's input

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>