### PR TITLE
[INT-1401] Allow Gemini 3 Flash Preview as a user default LLM model

### DIFF
--- a/packages/llm-contract/src/__tests__/supportedModels.test.ts
+++ b/packages/llm-contract/src/__tests__/supportedModels.test.ts
@@ -299,14 +299,15 @@ describe('supportedModels', () => {
 
 describe('DefaultEligibleModel', () => {
   describe('DEFAULT_OPENROUTER_MODELS', () => {
-    it('contains exactly 5 models', () => {
-      expect(DEFAULT_OPENROUTER_MODELS).toHaveLength(5);
+    it('contains exactly 6 models', () => {
+      expect(DEFAULT_OPENROUTER_MODELS).toHaveLength(6);
     });
 
     it('contains expected model IDs', () => {
       const ids = DEFAULT_OPENROUTER_MODELS.map((m) => m.id);
       expect(ids).toContain('google/gemma-4-31b-it:free');
       expect(ids).toContain('google/gemma-4-31b-it');
+      expect(ids).toContain('google/gemini-3-flash-preview');
       expect(ids).toContain('minimax/minimax-m2.7');
       expect(ids).toContain('qwen/qwen3.6-plus');
       expect(ids).toContain('nvidia/nemotron-3-super-120b-a12b:free');
@@ -333,6 +334,7 @@ describe('DefaultEligibleModel', () => {
     it('accepts OpenRouter default models with or: prefix', () => {
       expect(isDefaultEligibleModel('or:google/gemma-4-31b-it:free')).toBe(true);
       expect(isDefaultEligibleModel('or:google/gemma-4-31b-it')).toBe(true);
+      expect(isDefaultEligibleModel('or:google/gemini-3-flash-preview')).toBe(true);
       expect(isDefaultEligibleModel('or:minimax/minimax-m2.7')).toBe(true);
       expect(isDefaultEligibleModel('or:qwen/qwen3.6-plus')).toBe(true);
       expect(isDefaultEligibleModel('or:nvidia/nemotron-3-super-120b-a12b:free')).toBe(true);
@@ -388,6 +390,9 @@ describe('DefaultEligibleModel', () => {
         'Gemma 4 31B IT (Free)'
       );
       expect(DEFAULT_MODEL_DISPLAY_NAMES['or:google/gemma-4-31b-it']).toBe('Gemma 4 31B IT');
+      expect(DEFAULT_MODEL_DISPLAY_NAMES['or:google/gemini-3-flash-preview']).toBe(
+        'Gemini 3 Flash Preview'
+      );
       expect(DEFAULT_MODEL_DISPLAY_NAMES['or:minimax/minimax-m2.7']).toBe('MiniMax M2.7');
       expect(DEFAULT_MODEL_DISPLAY_NAMES['or:qwen/qwen3.6-plus']).toBe('Qwen 3.6 Plus');
       expect(DEFAULT_MODEL_DISPLAY_NAMES['or:nvidia/nemotron-3-super-120b-a12b:free']).toBe(
@@ -395,8 +400,8 @@ describe('DefaultEligibleModel', () => {
       );
     });
 
-    it('has exactly 9 entries (4 fast + 5 OpenRouter)', () => {
-      expect(Object.keys(DEFAULT_MODEL_DISPLAY_NAMES)).toHaveLength(9);
+    it('has exactly 10 entries (4 fast + 6 OpenRouter)', () => {
+      expect(Object.keys(DEFAULT_MODEL_DISPLAY_NAMES)).toHaveLength(10);
     });
   });
 });

--- a/packages/llm-contract/src/supportedModels.ts
+++ b/packages/llm-contract/src/supportedModels.ts
@@ -260,6 +260,7 @@ export interface DefaultOpenRouterModel {
 export const DEFAULT_OPENROUTER_MODELS: readonly DefaultOpenRouterModel[] = [
   { id: 'google/gemma-4-31b-it:free', name: 'Gemma 4 31B IT (Free)', provider: 'Google' },
   { id: 'google/gemma-4-31b-it', name: 'Gemma 4 31B IT', provider: 'Google' },
+  { id: 'google/gemini-3-flash-preview', name: 'Gemini 3 Flash Preview', provider: 'Google' },
   { id: 'minimax/minimax-m2.7', name: 'MiniMax M2.7', provider: 'MiniMax' },
   { id: 'qwen/qwen3.6-plus', name: 'Qwen 3.6 Plus', provider: 'Qwen' },
   {


### PR DESCRIPTION
## Summary
- Add `google/gemini-3-flash-preview` to `DEFAULT_OPENROUTER_MODELS` in `packages/llm-contract/src/supportedModels.ts`
- Update corresponding tests to reflect the new model count (5 → 6) and add assertions for the new entry

## Test plan
- [x] `pnpm vitest run packages/llm-contract/src/__tests__/supportedModels.test.ts` — 53 tests pass
- [x] `pnpm run verify:workspace:tracked llm-contract` — all checks pass

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>