### PR TITLE
[INT-1361] Fix inactivity-restart wrong-PR bug and add kill-time forensics

### DIFF
--- a/apps/code-agent/src/__tests__/routes/webhooks.test.ts
+++ b/apps/code-agent/src/__tests__/routes/webhooks.test.ts
@@ -31,7 +31,7 @@ import { buildServer } from '../../server.js';
 
 import { getServices, resetServices, setServices } from '../../services.js';
 import { createFakeFirestore, resetFirestore, setFirestore } from '@intexuraos/infra-firestore';
-import type { Firestore } from '@google-cloud/firestore';
+import { Timestamp, type Firestore } from '@google-cloud/firestore';
 import pino from 'pino';
 import type { Logger } from 'pino';
 import { err, ok } from '@intexuraos/common-core';
@@ -10292,7 +10292,66 @@ describe('POST /internal/webhooks/task-complete - Additional branch coverage', (
     return { gitHubPRClient };
   }
 
-  it('flags task with prUrlValidationFailed when PR title does not match Linear issue ID', async () => {
+  it('fails task with EXECUTION_AGENT_PR_URL_VALIDATION_FAILED when PR title is wrong AND PR predates dispatch', async () => {
+    const dispatchedAt = new Date('2026-04-15T00:00:00Z');
+    const createResult = await codeTaskRepo.create({
+      userId: 'user-123', prompt: 'a', sanitizedPrompt: 'a', systemPromptHash: 'default', workerType: 'auto', workerLocation: 'mac',
+      repository: 'pbuchman/intexuraos', baseBranch: 'development', traceId: 't-prval-gate', linearIssueId: 'INT-123', webhookSecret: 'test-webhook-secret', agentType: 'execution',
+    });
+    expect(createResult.ok).toBe(true);
+    if (!createResult.ok) throw new Error('Failed');
+    const task = createResult.value;
+    // Inject dispatchedAt directly into the FakeFirestore store. The Fake's
+    // DocumentReference.update treats objects with `isEqual` (including Timestamp) as
+    // FieldValue.delete sentinels, so we cannot use codeTaskRepo.update for Timestamps.
+    const docRef = fakeFirestore.collection('code_tasks').doc(task.id) as unknown as { _store: Map<string, Map<string, Record<string, unknown>>>; _collectionName: string; id: string };
+    const existingDoc = docRef._store.get(docRef._collectionName)?.get(docRef.id);
+    if (existingDoc !== undefined) {
+      existingDoc['dispatchedAt'] = Timestamp.fromDate(dispatchedAt);
+    }
+
+    const lac = getServices().linearAgentClient;
+    vi.mocked(lac.validateIssue).mockReset();
+    vi.mocked(lac.validateIssue).mockResolvedValue(ok({ id: 'uuid', identifier: 'INT-123', title: 'T', url: 'u', labels: [], childCount: 0, parentId: null }));
+    vi.mocked(lac.addComment).mockReset();
+    vi.mocked(lac.addComment).mockResolvedValue(ok({ commentId: 'c1' }));
+    vi.mocked(lac.updateIssueState).mockReset();
+    vi.mocked(lac.updateIssueState).mockResolvedValue(ok(undefined));
+    vi.mocked(lac.updateIssueMetadata).mockReset();
+    vi.mocked(lac.updateIssueMetadata).mockResolvedValue(ok({ droppedLabels: [] }));
+
+    const { gitHubPRClient } = installPRValidationServices();
+    vi.mocked(gitHubPRClient.getPullRequestDetails).mockResolvedValue(ok({
+      number: 970,
+      title: 'Some unrelated PR',
+      body: null,
+      state: 'open',
+      authorLogin: 'test-user',
+      baseBranch: 'development',
+      headBranch: 'feature/unrelated',
+      mergeable: null,
+      mergeableState: null,
+      headSha: 'abc123',
+      createdAt: '2026-03-01T00:00:00Z',
+    }));
+
+    const payload = { taskId: task.id, status: 'completed' as const, result: { prUrl: 'https://github.com/pbuchman/intexuraos/pull/970', execution_outcome_label: 'implemented' as const, execution_linear_issue_url: 'https://linear.app/pbuchman/issue/INT-123' } };
+    const { timestamp, signature } = generateWebhookSignature(payload, 'test-webhook-secret');
+    const response = await app.inject({ method: 'POST', url: '/internal/webhooks/task-complete', headers: { 'x-internal-auth': 'test-internal-token', 'x-request-timestamp': timestamp, 'x-request-signature': signature }, payload });
+    expect(response.statusCode).toBe(200);
+    const g = await codeTaskRepo.findById(task.id);
+    expect(g.ok).toBe(true);
+    if (!g.ok) throw new Error('Failed');
+    expect(g.value.status).toBe('failed');
+    expect(g.value.error?.code).toBe('EXECUTION_AGENT_PR_URL_VALIDATION_FAILED');
+    expect(g.value.error?.message).toContain('does not contain expected Linear issue ID');
+    expect(g.value.error?.message).toContain('before task was dispatched');
+    expect(g.value.prUrlValidationFailed).toBe(true);
+    expect(g.value.prUrlValidationErrors).toBeDefined();
+    expect(g.value.prUrlValidationErrors?.length).toBe(2);
+  });
+
+  it('fails task with EXECUTION_AGENT_PR_URL_VALIDATION_FAILED when PR title does not match Linear issue ID', async () => {
     const createResult = await codeTaskRepo.create({
       userId: 'user-123', prompt: 'a', sanitizedPrompt: 'a', systemPromptHash: 'default', workerType: 'auto', workerLocation: 'mac',
       repository: 'pbuchman/intexuraos', baseBranch: 'development', traceId: 't-prval-1', linearIssueId: 'INT-123', webhookSecret: 'test-webhook-secret', agentType: 'execution',
@@ -10333,13 +10392,14 @@ describe('POST /internal/webhooks/task-complete - Additional branch coverage', (
     const g = await codeTaskRepo.findById(task.id);
     expect(g.ok).toBe(true);
     if (!g.ok) throw new Error('Failed');
-    expect(g.value.status).toBe('implemented');
+    expect(g.value.status).toBe('failed');
+    expect(g.value.error?.code).toBe('EXECUTION_AGENT_PR_URL_VALIDATION_FAILED');
     expect(g.value.prUrlValidationFailed).toBe(true);
     expect(g.value.prUrlValidationErrors).toBeDefined();
     expect(g.value.prUrlValidationErrors?.[0]).toContain('does not contain expected Linear issue ID');
   });
 
-  it('flags task with prUrlValidationFailed when PR does not exist (NOT_FOUND)', async () => {
+  it('fails task with EXECUTION_AGENT_PR_URL_VALIDATION_FAILED when PR does not exist (NOT_FOUND)', async () => {
     const createResult = await codeTaskRepo.create({
       userId: 'user-123', prompt: 'a', sanitizedPrompt: 'a', systemPromptHash: 'default', workerType: 'auto', workerLocation: 'mac',
       repository: 'pbuchman/intexuraos', baseBranch: 'development', traceId: 't-prval-2', linearIssueId: 'INT-123', webhookSecret: 'test-webhook-secret', agentType: 'execution',
@@ -10369,7 +10429,8 @@ describe('POST /internal/webhooks/task-complete - Additional branch coverage', (
     const g = await codeTaskRepo.findById(task.id);
     expect(g.ok).toBe(true);
     if (!g.ok) throw new Error('Failed');
-    expect(g.value.status).toBe('implemented');
+    expect(g.value.status).toBe('failed');
+    expect(g.value.error?.code).toBe('EXECUTION_AGENT_PR_URL_VALIDATION_FAILED');
     expect(g.value.prUrlValidationFailed).toBe(true);
     expect(g.value.prUrlValidationErrors?.[0]).toContain('does not exist');
   });

--- a/apps/code-agent/src/routes/webhookRoutes.ts
+++ b/apps/code-agent/src/routes/webhookRoutes.ts
@@ -742,7 +742,7 @@ export const webhookRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
 
       const enforceExecutionOutcome = async (
         executionResult: NonNullable<typeof result>
-      ): Promise<{ ok: true; prUrlValidationFailed?: boolean; prUrlValidationErrors?: string[] } | { ok: false; message: string; code: string }> => {
+      ): Promise<{ ok: true } | { ok: false; message: string; code: string; prUrlValidationErrors?: string[] }> => {
         if (task.linearIssueId === undefined) {
           return {
             ok: false,
@@ -876,8 +876,6 @@ export const webhookRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
         }
 
         // PR URL validation (INT-1361): verify PR exists, title matches, and recency
-        let prUrlValidationFailed: boolean | undefined; // @allow-undefined-type -- local variable, not interface property
-        let prUrlValidationErrors: string[] | undefined; // @allow-undefined-type -- local variable, not interface property
         const prNumberFromUrl = /\/pull\/(\d+)/.exec(executionResult.prUrl);
         /* v8 ignore start -- ts-type: prUrl always returns a match for /pull/N after enforcement check at line 658; parseOwnerRepo cannot return null for valid task.repository @preserve */
         if (prNumberFromUrl?.[1] !== undefined) {
@@ -900,8 +898,12 @@ export const webhookRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
                 logger,
               });
               if (validationResult.failed) {
-                prUrlValidationFailed = true;
-                prUrlValidationErrors = validationResult.errors;
+                return {
+                  ok: false,
+                  code: 'EXECUTION_AGENT_PR_URL_VALIDATION_FAILED',
+                  message: validationResult.errors.join('; '),
+                  prUrlValidationErrors: validationResult.errors,
+                };
               }
             } else {
               logger.warn({ taskId, userId: task.userId }, 'PR URL validation skipped: no GitHub token available');
@@ -950,11 +952,7 @@ export const webhookRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
           };
         }
 
-        return {
-          ok: true,
-          ...(prUrlValidationFailed === true && { prUrlValidationFailed }),
-          ...(prUrlValidationErrors !== undefined && { prUrlValidationErrors }),
-        };
+        return { ok: true };
       };
 
       const enforcePullRequestOutcome = async (
@@ -1099,10 +1097,6 @@ export const webhookRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
       };
 
       // Step 3: Update task based on status
-      // PR URL validation fields (INT-1361) — hoisted so they survive across agent-type blocks
-      let executionPrUrlValidationFailed: boolean | undefined; // @allow-undefined-type -- hoisted mutable variable
-      let executionPrUrlValidationErrors: string[] | undefined; // @allow-undefined-type -- hoisted mutable variable
-
       if (status === 'completed') {
         // Trace which agent type is being handled for debugging
         request.log.info({ taskId, agentType: task.agentType }, 'Processing completed task');
@@ -1157,6 +1151,10 @@ export const webhookRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
                 code: executionEnforcement.code,
                 message: executionEnforcement.message,
               },
+              ...(executionEnforcement.prUrlValidationErrors !== undefined && {
+                prUrlValidationFailed: true,
+                prUrlValidationErrors: executionEnforcement.prUrlValidationErrors,
+              }),
               callbackReceived: true,
             });
             if (!failResult.ok) {
@@ -1173,10 +1171,6 @@ export const webhookRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
             // @allow-raw-send: external webhook callback - orchestrator expects { received: true }
             return await reply.send({ received: true });
           }
-
-          // Capture PR URL validation fields for the shared task update (INT-1361)
-          executionPrUrlValidationFailed = executionEnforcement.prUrlValidationFailed;
-          executionPrUrlValidationErrors = executionEnforcement.prUrlValidationErrors;
         }
 
         if (task.agentType === 'pull_request') {
@@ -1469,10 +1463,6 @@ export const webhookRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
           ...(executionMemoryPostRun !== undefined && { executionMemoryPostRun }),
           ...(remediationRequiresReReview !== undefined && {
               requiresReReview: remediationRequiresReReview,
-            }),
-          ...(executionPrUrlValidationFailed === true && executionPrUrlValidationErrors !== undefined && {
-              prUrlValidationFailed: true,
-              prUrlValidationErrors: executionPrUrlValidationErrors,
             }),
           callbackReceived: true,
         });

--- a/docs/plans/2026-04-17-evidence/agent1-A1-completion-verifier.patch
+++ b/docs/plans/2026-04-17-evidence/agent1-A1-completion-verifier.patch
@@ -1,0 +1,388 @@
+diff --git a/workers/orchestrator/src/services/__tests__/completion-verifier.test.ts b/workers/orchestrator/src/services/__tests__/completion-verifier.test.ts
+index 43ec133f0..77759c335 100644
+--- a/workers/orchestrator/src/services/__tests__/completion-verifier.test.ts
++++ b/workers/orchestrator/src/services/__tests__/completion-verifier.test.ts
+@@ -55,8 +55,20 @@ function createVerifier(
+ 
+ const generateMock = vi.fn();
+ 
++function transcriptWithMeaningfulLines(label: string): string {
++  return [
++    '[orchestrator] starting',
++    `[claude] ${label} line 1`,
++    `[claude] ${label} line 2`,
++    `[claude] ${label} line 3`,
++    `[claude] ${label} line 4`,
++    `[claude] ${label} line 5`,
++  ].join('\n');
++}
++
+ beforeEach(() => {
+   vi.clearAllMocks();
++  generateMock.mockReset();
+   createLlmClientMock.mockReturnValue({ generate: generateMock });
+ });
+ 
+@@ -780,7 +792,7 @@ describe('OrchestratorCompletionVerifier', () => {
+         attempt: 1,
+         maxAttempts: 5,
+         agentType: 'planning',
+-        rawLogs: 'some logs',
++        rawLogs: transcriptWithMeaningfulLines('planning-1'),
+       });
+       expect(result.passed).toBe(true);
+       expect(result.verifierFailure).toBe(false);
+@@ -828,7 +840,7 @@ describe('OrchestratorCompletionVerifier', () => {
+         attempt: 1,
+         maxAttempts: 5,
+         agentType: 'planning',
+-        rawLogs: 'logs',
++        rawLogs: transcriptWithMeaningfulLines('planning-2'),
+       });
+       expect(result.passed).toBe(true);
+       expect(result.agentData?.agentType).toBe('planning');
+@@ -870,7 +882,7 @@ describe('OrchestratorCompletionVerifier', () => {
+         attempt: 1,
+         maxAttempts: 5,
+         agentType: 'execution',
+-        rawLogs: 'exec logs',
++        rawLogs: transcriptWithMeaningfulLines('exec'),
+       });
+       expect(result.passed).toBe(true);
+       expect(result.agentData).toEqual({
+@@ -918,7 +930,7 @@ describe('OrchestratorCompletionVerifier', () => {
+         attempt: 1,
+         maxAttempts: 5,
+         agentType: 'pull_request',
+-        rawLogs: 'pr logs',
++        rawLogs: transcriptWithMeaningfulLines('pr'),
+       });
+       expect(result.passed).toBe(true);
+       expect(result.agentData).toEqual({
+@@ -959,7 +971,7 @@ describe('OrchestratorCompletionVerifier', () => {
+         attempt: 1,
+         maxAttempts: 5,
+         agentType: 'review',
+-        rawLogs: 'review logs',
++        rawLogs: transcriptWithMeaningfulLines('review'),
+       });
+       expect(result.passed).toBe(true);
+       expect(result.agentData).toEqual({
+@@ -996,7 +1008,7 @@ describe('OrchestratorCompletionVerifier', () => {
+         attempt: 1,
+         maxAttempts: 5,
+         agentType: 'review',
+-        rawLogs: 'review logs',
++        rawLogs: transcriptWithMeaningfulLines('review'),
+       });
+       expect(result.passed).toBe(true);
+       expect(result.agentData).toEqual({
+@@ -1036,7 +1048,7 @@ describe('OrchestratorCompletionVerifier', () => {
+         attempt: 1,
+         maxAttempts: 5,
+         agentType: 'remediation',
+-        rawLogs: 'remediation logs',
++        rawLogs: transcriptWithMeaningfulLines('remediation'),
+       });
+       expect(result.passed).toBe(true);
+       expect(result.agentData).toEqual({
+@@ -1070,7 +1082,7 @@ describe('OrchestratorCompletionVerifier', () => {
+         attempt: 1,
+         maxAttempts: 5,
+         agentType: 'planning',
+-        rawLogs: 'logs',
++        rawLogs: transcriptWithMeaningfulLines('fail'),
+       });
+       expect(result.passed).toBe(false);
+       expect(result.verifierFailure).toBe(true);
+@@ -1099,7 +1111,7 @@ describe('OrchestratorCompletionVerifier', () => {
+         attempt: 1,
+         maxAttempts: 5,
+         agentType: 'execution',
+-        rawLogs: 'logs',
++        rawLogs: transcriptWithMeaningfulLines('parse'),
+       });
+       expect(result.passed).toBe(false);
+       expect(result.verifierFailure).toBe(true);
+@@ -1127,7 +1139,7 @@ describe('OrchestratorCompletionVerifier', () => {
+         attempt: 1,
+         maxAttempts: 5,
+         agentType: 'pull_request',
+-        rawLogs: 'logs',
++        rawLogs: transcriptWithMeaningfulLines('zod'),
+       });
+       expect(result.passed).toBe(false);
+       expect(result.verifierFailure).toBe(false);
+@@ -1186,52 +1198,38 @@ describe('OrchestratorCompletionVerifier', () => {
+       expect(logged).not.toContain('second line');
+     });
+ 
+-    it('logs full transcript when <=2 non-empty lines', async () => {
+-      generateMock.mockResolvedValueOnce({
+-        ok: true,
+-        value: {
+-          content: validPlanningResponse,
+-          usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30, costUsd: 0.001 },
+-        },
+-      });
++    it('short-circuits via the transcript guard for single-line rawLogs', async () => {
+       const verifier = createVerifier();
+-      await verifier.verify({
++      const result = await verifier.verify({
+         taskId: 'task-short',
+         attempt: 1,
+         maxAttempts: 5,
+         agentType: 'planning',
+         rawLogs: 'only one line',
+       });
++      expect(result.missingFields).toEqual(['transcript_too_short']);
+       const infoCall = loggerInfo.mock.calls.find(
+         (c: unknown[]) => typeof c[1] === 'string' && c[1] === 'Gemini completion verifier request'
+-      ) as [Record<string, unknown>, string] | undefined;
+-      expect(infoCall).toBeDefined();
+-      const logged = infoCall?.[0]?.['transcript'] as string;
+-      expect(logged).toBe('only one line');
++      );
++      expect(infoCall).toBeUndefined();
++      expect(generateMock).not.toHaveBeenCalled();
+     });
+ 
+-    it('handles whitespace-only rawLogs with empty fallback', async () => {
+-      generateMock.mockResolvedValueOnce({
+-        ok: true,
+-        value: {
+-          content: validPlanningResponse,
+-          usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30, costUsd: 0.001 },
+-        },
+-      });
++    it('short-circuits via the transcript guard for whitespace-only rawLogs', async () => {
+       const verifier = createVerifier();
+-      await verifier.verify({
++      const result = await verifier.verify({
+         taskId: 'task-empty',
+         attempt: 1,
+         maxAttempts: 5,
+         agentType: 'planning',
+         rawLogs: '   \n  \n   ',
+       });
++      expect(result.missingFields).toEqual(['transcript_too_short']);
+       const infoCall = loggerInfo.mock.calls.find(
+         (c: unknown[]) => typeof c[1] === 'string' && c[1] === 'Gemini completion verifier request'
+-      ) as [Record<string, unknown>, string] | undefined;
+-      expect(infoCall).toBeDefined();
+-      const logged = infoCall?.[0]?.['transcript'] as string;
+-      expect(logged).toBe('');
++      );
++      expect(infoCall).toBeUndefined();
++      expect(generateMock).not.toHaveBeenCalled();
+     });
+   });
+ 
+@@ -1261,7 +1259,7 @@ describe('OrchestratorCompletionVerifier', () => {
+         attempt: 1,
+         maxAttempts: 5,
+         agentType: 'planning',
+-        rawLogs: 'logs',
++        rawLogs: transcriptWithMeaningfulLines('wrapped'),
+       });
+       expect(result.passed).toBe(true);
+       expect(result.agentData?.agentType).toBe('planning');
+@@ -1379,7 +1377,7 @@ describe('verify — fatal exit code pre-check', () => {
+       attempt: 1,
+       maxAttempts: 5,
+       agentType: 'planning',
+-      rawLogs: 'output\n[entrypoint] Claude attempt finished with exit code: 0\n',
++      rawLogs: `${transcriptWithMeaningfulLines('exit-0')}\n[entrypoint] Claude attempt finished with exit code: 0\n`,
+     });
+     expect(result.passed).toBe(true);
+     expect(generateMock).toHaveBeenCalledOnce();
+@@ -1408,7 +1406,117 @@ describe('verify — fatal exit code pre-check', () => {
+       attempt: 1,
+       maxAttempts: 5,
+       agentType: 'execution',
+-      rawLogs: 'output\n[entrypoint] Claude attempt finished with exit code: 1\n',
++      rawLogs: `${transcriptWithMeaningfulLines('exit-1')}\n[entrypoint] Claude attempt finished with exit code: 1\n`,
++    });
++    expect(result.passed).toBe(true);
++    expect(generateMock).toHaveBeenCalledOnce();
++  });
++});
++
++// ---------------------------------------------------------------------------
++// verify — short transcript guard
++// ---------------------------------------------------------------------------
++
++describe('verify — short transcript guard', () => {
++  const validPlanningResponse = JSON.stringify({
++    outcome: 'planned',
++    superpowers_writing_plans: 'used',
++    linear_url: 'https://linear.app/pbuchman/issue/INT-100',
++    is_complex: '0',
++    has_plan_doc: '0',
++    subtask_urls: '',
++    pr_url: 'https://github.com/pbuchman/intexuraos/pull/100',
++    summary: 'Planned.',
++    unclear_clarification: '',
++  });
++
++  it('returns transcript_too_short and skips Gemini when only infrastructure lines are present', async () => {
++    const verifier = createVerifier();
++    const result = await verifier.verify({
++      taskId: 'task-empty-transcript',
++      attempt: 1,
++      maxAttempts: 5,
++      agentType: 'execution',
++      rawLogs: [
++        '[orchestrator] doing things',
++        '[hook] hook ran',
++        '[entrypoint] starting',
++        '[system] task_started',
++      ].join('\n'),
++    });
++    expect(result.passed).toBe(false);
++    expect(result.missingFields).toEqual(['transcript_too_short']);
++    expect(result.verifierFailure).toBe(false);
++    expect(result.agentData).toBeUndefined();
++    expect(result.trace).toEqual({ transcript: expect.any(String), prompt: '', response: '' });
++    expect(generateMock).not.toHaveBeenCalled();
++    expect(loggerWarn).toHaveBeenCalledWith(
++      expect.objectContaining({
++        taskId: 'task-empty-transcript',
++        attempt: 1,
++        agentType: 'execution',
++        meaningfulLines: 0,
++      }),
++      'Completion verifier: transcript too short, refusing to call LLM'
++    );
++  });
++
++  it('rejects when meaningful line count is one below the threshold (4 lines)', async () => {
++    const verifier = createVerifier();
++    const result = await verifier.verify({
++      taskId: 'task-boundary-low',
++      attempt: 2,
++      maxAttempts: 5,
++      agentType: 'execution',
++      rawLogs: [
++        '[orchestrator] starting',
++        '[claude] line 1',
++        '[hook] hook ran',
++        '[claude] line 2',
++        '[entrypoint] starting',
++        '[claude] line 3',
++        '[system] noise',
++        '[claude] line 4',
++      ].join('\n'),
++    });
++    expect(result.passed).toBe(false);
++    expect(result.missingFields).toEqual(['transcript_too_short']);
++    expect(result.verifierFailure).toBe(false);
++    expect(generateMock).not.toHaveBeenCalled();
++    expect(loggerWarn).toHaveBeenCalledWith(
++      expect.objectContaining({
++        taskId: 'task-boundary-low',
++        meaningfulLines: 4,
++      }),
++      'Completion verifier: transcript too short, refusing to call LLM'
++    );
++  });
++
++  it('passes the guard and calls Gemini when meaningful line count equals the threshold (5 lines)', async () => {
++    generateMock.mockResolvedValueOnce({
++      ok: true,
++      value: {
++        content: validPlanningResponse,
++        usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30, costUsd: 0.001 },
++      },
++    });
++    const verifier = createVerifier();
++    const result = await verifier.verify({
++      taskId: 'task-boundary-ok',
++      attempt: 1,
++      maxAttempts: 5,
++      agentType: 'planning',
++      rawLogs: [
++        '[orchestrator] starting',
++        '[claude] line 1',
++        '[hook] hook ran',
++        '[claude] line 2',
++        '[entrypoint] starting',
++        '[claude] line 3',
++        '[system] noise',
++        '[claude] line 4',
++        '[claude] line 5',
++      ].join('\n'),
+     });
+     expect(result.passed).toBe(true);
+     expect(generateMock).toHaveBeenCalledOnce();
+diff --git a/workers/orchestrator/src/services/completion-verifier.ts b/workers/orchestrator/src/services/completion-verifier.ts
+index 433f123ea..ad10d2018 100644
+--- a/workers/orchestrator/src/services/completion-verifier.ts
++++ b/workers/orchestrator/src/services/completion-verifier.ts
+@@ -198,6 +198,25 @@ const VERIFIER_PRICING: Partial<Record<LLMModel, ModelPricing>> = {
+ const FATAL_EXIT_CODE_PATTERN =
+   /\[entrypoint\] (?:Claude|Codex) attempt finished with exit code: (137|139)/;
+ 
++const MIN_MEANINGFUL_TRANSCRIPT_LINES = 5;
++
++const INFRASTRUCTURE_LINE_PREFIXES = ['[orchestrator]', '[hook]', '[entrypoint]', '[system]'];
++
++function countMeaningfulTranscriptLines(transcript: string): number {
++  let count = 0;
++  for (const line of transcript.split('\n')) {
++    const trimmed = line.trim();
++    if (trimmed === '') {
++      continue;
++    }
++    if (INFRASTRUCTURE_LINE_PREFIXES.some((prefix) => trimmed.startsWith(prefix))) {
++      continue;
++    }
++    count += 1;
++  }
++  return count;
++}
++
+ export function detectFatalExitCode(rawLogs: string): number | undefined {
+   // Only search the last 5 lines to avoid false positives from Claude's
+   // stream-json output containing test fixtures or code snippets with the pattern.
+@@ -495,6 +514,25 @@ export class OrchestratorCompletionVerifier implements CompletionVerifier {
+       };
+     }
+ 
++    const meaningfulLines = countMeaningfulTranscriptLines(transcript);
++    if (meaningfulLines < MIN_MEANINGFUL_TRANSCRIPT_LINES) {
++      this.logger.warn(
++        {
++          taskId: input.taskId,
++          attempt: input.attempt,
++          agentType: input.agentType,
++          meaningfulLines,
++        },
++        'Completion verifier: transcript too short, refusing to call LLM'
++      );
++      return {
++        passed: false,
++        missingFields: ['transcript_too_short'],
++        verifierFailure: false,
++        trace: { transcript, prompt: '', response: '' },
++      };
++    }
++
+     const { schema, prompt } = selectSchemaAndPrompt(input.agentType, transcript);
+ 
+     this.logger.info(
+@@ -507,11 +545,11 @@ export class OrchestratorCompletionVerifier implements CompletionVerifier {
+         promptChars: prompt.length,
+         transcript: ((): string => {
+           const tLines = transcript.split('\n').filter((l) => l.trim() !== '');
++          /* v8 ignore start -- auth-guard: transcript guard guarantees tLines.length >= MIN_MEANINGFUL_TRANSCRIPT_LINES, so noUncheckedIndexedAccess fallbacks are unreachable @preserve */
+           const first = tLines[0] ?? '';
+           const last = tLines[tLines.length - 1] ?? '';
+-          return tLines.length <= 2
+-            ? tLines.join('\n')
+-            : `${first}\n  ... (${String(tLines.length - 2)} lines omitted) ...\n${last}`;
++          /* v8 ignore stop @preserve */
++          return `${first}\n  ... (${String(tLines.length - 2)} lines omitted) ...\n${last}`;
+         })(),
+       },
+       'Gemini completion verifier request'

--- a/docs/plans/2026-04-17-evidence/agent2-A2-webhook-pr-validation.patch
+++ b/docs/plans/2026-04-17-evidence/agent2-A2-webhook-pr-validation.patch
@@ -1,0 +1,202 @@
+diff --git a/apps/code-agent/src/__tests__/routes/webhooks.test.ts b/apps/code-agent/src/__tests__/routes/webhooks.test.ts
+index 22be11430..a467c49c5 100644
+--- a/apps/code-agent/src/__tests__/routes/webhooks.test.ts
++++ b/apps/code-agent/src/__tests__/routes/webhooks.test.ts
+@@ -31,7 +31,7 @@ import { buildServer } from '../../server.js';
+ 
+ import { getServices, resetServices, setServices } from '../../services.js';
+ import { createFakeFirestore, resetFirestore, setFirestore } from '@intexuraos/infra-firestore';
+-import type { Firestore } from '@google-cloud/firestore';
++import { Timestamp, type Firestore } from '@google-cloud/firestore';
+ import pino from 'pino';
+ import type { Logger } from 'pino';
+ import { err, ok } from '@intexuraos/common-core';
+@@ -10292,7 +10292,66 @@ describe('POST /internal/webhooks/task-complete - Additional branch coverage', (
+     return { gitHubPRClient };
+   }
+ 
+-  it('flags task with prUrlValidationFailed when PR title does not match Linear issue ID', async () => {
++  it('fails task with EXECUTION_AGENT_PR_URL_VALIDATION_FAILED when PR title is wrong AND PR predates dispatch', async () => {
++    const dispatchedAt = new Date('2026-04-15T00:00:00Z');
++    const createResult = await codeTaskRepo.create({
++      userId: 'user-123', prompt: 'a', sanitizedPrompt: 'a', systemPromptHash: 'default', workerType: 'auto', workerLocation: 'mac',
++      repository: 'pbuchman/intexuraos', baseBranch: 'development', traceId: 't-prval-gate', linearIssueId: 'INT-123', webhookSecret: 'test-webhook-secret', agentType: 'execution',
++    });
++    expect(createResult.ok).toBe(true);
++    if (!createResult.ok) throw new Error('Failed');
++    const task = createResult.value;
++    // Inject dispatchedAt directly into the FakeFirestore store. The Fake's
++    // DocumentReference.update treats objects with `isEqual` (including Timestamp) as
++    // FieldValue.delete sentinels, so we cannot use codeTaskRepo.update for Timestamps.
++    const docRef = fakeFirestore.collection('code_tasks').doc(task.id) as unknown as { _store: Map<string, Map<string, Record<string, unknown>>>; _collectionName: string; id: string };
++    const existingDoc = docRef._store.get(docRef._collectionName)?.get(docRef.id);
++    if (existingDoc !== undefined) {
++      existingDoc['dispatchedAt'] = Timestamp.fromDate(dispatchedAt);
++    }
++
++    const lac = getServices().linearAgentClient;
++    vi.mocked(lac.validateIssue).mockReset();
++    vi.mocked(lac.validateIssue).mockResolvedValue(ok({ id: 'uuid', identifier: 'INT-123', title: 'T', url: 'u', labels: [], childCount: 0, parentId: null }));
++    vi.mocked(lac.addComment).mockReset();
++    vi.mocked(lac.addComment).mockResolvedValue(ok({ commentId: 'c1' }));
++    vi.mocked(lac.updateIssueState).mockReset();
++    vi.mocked(lac.updateIssueState).mockResolvedValue(ok(undefined));
++    vi.mocked(lac.updateIssueMetadata).mockReset();
++    vi.mocked(lac.updateIssueMetadata).mockResolvedValue(ok({ droppedLabels: [] }));
++
++    const { gitHubPRClient } = installPRValidationServices();
++    vi.mocked(gitHubPRClient.getPullRequestDetails).mockResolvedValue(ok({
++      number: 970,
++      title: 'Some unrelated PR',
++      body: null,
++      state: 'open',
++      authorLogin: 'test-user',
++      baseBranch: 'development',
++      headBranch: 'feature/unrelated',
++      mergeable: null,
++      mergeableState: null,
++      headSha: 'abc123',
++      createdAt: '2026-03-01T00:00:00Z',
++    }));
++
++    const payload = { taskId: task.id, status: 'completed' as const, result: { prUrl: 'https://github.com/pbuchman/intexuraos/pull/970', execution_outcome_label: 'implemented' as const, execution_linear_issue_url: 'https://linear.app/pbuchman/issue/INT-123' } };
++    const { timestamp, signature } = generateWebhookSignature(payload, 'test-webhook-secret');
++    const response = await app.inject({ method: 'POST', url: '/internal/webhooks/task-complete', headers: { 'x-internal-auth': 'test-internal-token', 'x-request-timestamp': timestamp, 'x-request-signature': signature }, payload });
++    expect(response.statusCode).toBe(200);
++    const g = await codeTaskRepo.findById(task.id);
++    expect(g.ok).toBe(true);
++    if (!g.ok) throw new Error('Failed');
++    expect(g.value.status).toBe('failed');
++    expect(g.value.error?.code).toBe('EXECUTION_AGENT_PR_URL_VALIDATION_FAILED');
++    expect(g.value.error?.message).toContain('does not contain expected Linear issue ID');
++    expect(g.value.error?.message).toContain('before task was dispatched');
++    expect(g.value.prUrlValidationFailed).toBe(true);
++    expect(g.value.prUrlValidationErrors).toBeDefined();
++    expect(g.value.prUrlValidationErrors?.length).toBe(2);
++  });
++
++  it('fails task with EXECUTION_AGENT_PR_URL_VALIDATION_FAILED when PR title does not match Linear issue ID', async () => {
+     const createResult = await codeTaskRepo.create({
+       userId: 'user-123', prompt: 'a', sanitizedPrompt: 'a', systemPromptHash: 'default', workerType: 'auto', workerLocation: 'mac',
+       repository: 'pbuchman/intexuraos', baseBranch: 'development', traceId: 't-prval-1', linearIssueId: 'INT-123', webhookSecret: 'test-webhook-secret', agentType: 'execution',
+@@ -10333,13 +10392,14 @@ describe('POST /internal/webhooks/task-complete - Additional branch coverage', (
+     const g = await codeTaskRepo.findById(task.id);
+     expect(g.ok).toBe(true);
+     if (!g.ok) throw new Error('Failed');
+-    expect(g.value.status).toBe('implemented');
++    expect(g.value.status).toBe('failed');
++    expect(g.value.error?.code).toBe('EXECUTION_AGENT_PR_URL_VALIDATION_FAILED');
+     expect(g.value.prUrlValidationFailed).toBe(true);
+     expect(g.value.prUrlValidationErrors).toBeDefined();
+     expect(g.value.prUrlValidationErrors?.[0]).toContain('does not contain expected Linear issue ID');
+   });
+ 
+-  it('flags task with prUrlValidationFailed when PR does not exist (NOT_FOUND)', async () => {
++  it('fails task with EXECUTION_AGENT_PR_URL_VALIDATION_FAILED when PR does not exist (NOT_FOUND)', async () => {
+     const createResult = await codeTaskRepo.create({
+       userId: 'user-123', prompt: 'a', sanitizedPrompt: 'a', systemPromptHash: 'default', workerType: 'auto', workerLocation: 'mac',
+       repository: 'pbuchman/intexuraos', baseBranch: 'development', traceId: 't-prval-2', linearIssueId: 'INT-123', webhookSecret: 'test-webhook-secret', agentType: 'execution',
+@@ -10369,7 +10429,8 @@ describe('POST /internal/webhooks/task-complete - Additional branch coverage', (
+     const g = await codeTaskRepo.findById(task.id);
+     expect(g.ok).toBe(true);
+     if (!g.ok) throw new Error('Failed');
+-    expect(g.value.status).toBe('implemented');
++    expect(g.value.status).toBe('failed');
++    expect(g.value.error?.code).toBe('EXECUTION_AGENT_PR_URL_VALIDATION_FAILED');
+     expect(g.value.prUrlValidationFailed).toBe(true);
+     expect(g.value.prUrlValidationErrors?.[0]).toContain('does not exist');
+   });
+diff --git a/apps/code-agent/src/routes/webhookRoutes.ts b/apps/code-agent/src/routes/webhookRoutes.ts
+index 19ad9bcad..3354bfcf0 100644
+--- a/apps/code-agent/src/routes/webhookRoutes.ts
++++ b/apps/code-agent/src/routes/webhookRoutes.ts
+@@ -742,7 +742,7 @@ export const webhookRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
+ 
+       const enforceExecutionOutcome = async (
+         executionResult: NonNullable<typeof result>
+-      ): Promise<{ ok: true; prUrlValidationFailed?: boolean; prUrlValidationErrors?: string[] } | { ok: false; message: string; code: string }> => {
++      ): Promise<{ ok: true } | { ok: false; message: string; code: string; prUrlValidationErrors?: string[] }> => {
+         if (task.linearIssueId === undefined) {
+           return {
+             ok: false,
+@@ -876,8 +876,6 @@ export const webhookRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
+         }
+ 
+         // PR URL validation (INT-1361): verify PR exists, title matches, and recency
+-        let prUrlValidationFailed: boolean | undefined; // @allow-undefined-type -- local variable, not interface property
+-        let prUrlValidationErrors: string[] | undefined; // @allow-undefined-type -- local variable, not interface property
+         const prNumberFromUrl = /\/pull\/(\d+)/.exec(executionResult.prUrl);
+         /* v8 ignore start -- ts-type: prUrl always returns a match for /pull/N after enforcement check at line 658; parseOwnerRepo cannot return null for valid task.repository @preserve */
+         if (prNumberFromUrl?.[1] !== undefined) {
+@@ -900,8 +898,12 @@ export const webhookRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
+                 logger,
+               });
+               if (validationResult.failed) {
+-                prUrlValidationFailed = true;
+-                prUrlValidationErrors = validationResult.errors;
++                return {
++                  ok: false,
++                  code: 'EXECUTION_AGENT_PR_URL_VALIDATION_FAILED',
++                  message: validationResult.errors.join('; '),
++                  prUrlValidationErrors: validationResult.errors,
++                };
+               }
+             } else {
+               logger.warn({ taskId, userId: task.userId }, 'PR URL validation skipped: no GitHub token available');
+@@ -950,11 +952,7 @@ export const webhookRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
+           };
+         }
+ 
+-        return {
+-          ok: true,
+-          ...(prUrlValidationFailed === true && { prUrlValidationFailed }),
+-          ...(prUrlValidationErrors !== undefined && { prUrlValidationErrors }),
+-        };
++        return { ok: true };
+       };
+ 
+       const enforcePullRequestOutcome = async (
+@@ -1099,10 +1097,6 @@ export const webhookRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
+       };
+ 
+       // Step 3: Update task based on status
+-      // PR URL validation fields (INT-1361) — hoisted so they survive across agent-type blocks
+-      let executionPrUrlValidationFailed: boolean | undefined; // @allow-undefined-type -- hoisted mutable variable
+-      let executionPrUrlValidationErrors: string[] | undefined; // @allow-undefined-type -- hoisted mutable variable
+-
+       if (status === 'completed') {
+         // Trace which agent type is being handled for debugging
+         request.log.info({ taskId, agentType: task.agentType }, 'Processing completed task');
+@@ -1157,6 +1151,10 @@ export const webhookRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
+                 code: executionEnforcement.code,
+                 message: executionEnforcement.message,
+               },
++              ...(executionEnforcement.prUrlValidationErrors !== undefined && {
++                prUrlValidationFailed: true,
++                prUrlValidationErrors: executionEnforcement.prUrlValidationErrors,
++              }),
+               callbackReceived: true,
+             });
+             if (!failResult.ok) {
+@@ -1173,10 +1171,6 @@ export const webhookRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
+             // @allow-raw-send: external webhook callback - orchestrator expects { received: true }
+             return await reply.send({ received: true });
+           }
+-
+-          // Capture PR URL validation fields for the shared task update (INT-1361)
+-          executionPrUrlValidationFailed = executionEnforcement.prUrlValidationFailed;
+-          executionPrUrlValidationErrors = executionEnforcement.prUrlValidationErrors;
+         }
+ 
+         if (task.agentType === 'pull_request') {
+@@ -1470,10 +1464,6 @@ export const webhookRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
+           ...(remediationRequiresReReview !== undefined && {
+               requiresReReview: remediationRequiresReReview,
+             }),
+-          ...(executionPrUrlValidationFailed === true && executionPrUrlValidationErrors !== undefined && {
+-              prUrlValidationFailed: true,
+-              prUrlValidationErrors: executionPrUrlValidationErrors,
+-            }),
+           callbackReceived: true,
+         });
+ 

--- a/docs/plans/2026-04-17-inactivity-restart-wrong-pr-and-evidence.md
+++ b/docs/plans/2026-04-17-inactivity-restart-wrong-pr-and-evidence.md
@@ -1,0 +1,352 @@
+# Inactivity-Restart Wrong-PR Bug + 600s-Stall Evidence Capture
+
+**Status:** in progress (plan complete, implementation pending in main tree)
+**Branch:** `fix/inactivity-restart-wrong-pr-and-evidence` (off `development`)
+**Linear issue:** TBD — user has not provided one yet, ASK before opening PR
+**Date:** 2026-04-17
+
+---
+
+## 1. Background — the incident
+
+Production task `task_64dddd18-1a9c-4cec-b10f-649a35564a81` (INT-1392, LLM client refactor) on home-dev:
+
+- 22:08 UTC dispatch. Agent worked on the right thing for ~1.7h (49 modified files in worktree).
+- 23:49 UTC ran `pnpm run ci:tracked 2>&1 | tee /tmp/ci-full.txt; echo "EXIT:$?"`.
+- 23:49 → 23:59 (600s): zero log lines reached the orchestrator.
+- 23:59:02 orchestrator fired inactivity timeout, SIGKILLed worker (`exitCode=137`).
+- 23:59:13 restart attempt 2 with `--resume` and `continueSession=true` started in fresh container.
+- 23:59:25 attempt 2 "finished" after 12s.
+- 23:59:33 completion verifier called Gemini with **`transcript:""`** (empty/near-empty payload — only post-restart infrastructure markers).
+- Gemini hallucinated PR `#970` (a 1.5-month-old, unrelated PR titled "Fix planning branch merge logs missing from task output", about Slack `sendMessage.ts`).
+- `validatePrUrl` (INT-1361) detected the mismatch, set `prUrlValidationFailed: true` + 2 errors in `prUrlValidationErrors`. **Did not block.** Task finalized as `status: implemented`.
+- Compliance validation comment posted to wrong PR `#970`.
+
+49 modified files for INT-1392 were never committed. They sat in `home-dev:/home/pbuchman/code-workers/worktrees/task_64dddd18-...` until cleanup.
+
+## 2. Root causes (with code evidence)
+
+### 2.1 Empty-transcript verifier (primary)
+
+`workers/orchestrator/src/services/completion-verifier.ts` `OrchestratorCompletionVerifier.doVerify()`:
+
+- Calls `getLast50Lines(input.rawLogs)`.
+- After inactivity restart, `rawLogs` comes from the new container only (`docker-provider.ts:950 getWorkerLogs` reads from current container, not pre-restart).
+- The 12-second restart attempt produces only `[orchestrator]`, `[hook]`, `[entrypoint]`, `[system]` lines — no `[claude]`/`[tool]` agent content.
+- `detectFatalExitCode` only fires on `[entrypoint] Claude/Codex attempt finished with exit code: 137|139` in the LAST 5 LINES of rawLogs — the inactivity-killed attempt 1's exit-code line is in attempt 1's container, NOT in attempt 2's logs. So the fatal-exit-code guard does not catch this case.
+- Verifier sends prompt to Gemini regardless of transcript size. Gemini hallucinates plausible JSON.
+
+### 2.2 Advisory-only PR-URL validation (secondary)
+
+`apps/code-agent/src/routes/webhookRoutes.ts` `enforceExecutionOutcome()` (lines 743-958, specifically 902-910):
+
+```ts
+if (validationResult.failed) {
+  prUrlValidationFailed = true;
+  prUrlValidationErrors = validationResult.errors;
+}
+```
+
+Sets fields. Continues execution. Task ends `implemented`. Persistence at lines 1473-1476 writes the flag/errors to Firestore but does not change status.
+
+### 2.3 Dead `EXECUTION_AGENT_WRONG_ISSUE_MISMATCH` gate (out of scope)
+
+`apps/code-agent/src/routes/webhookRoutes.ts` lines 827-876 compare `reportedIssueUrl` against `task.linearIssueId`. But `reportedIssueUrl` is **synthesized server-side** by the orchestrator at `workers/orchestrator/src/services/task-dispatcher.ts:1711` and `:1755`:
+
+```ts
+base.execution_linear_issue_url = `https://linear.app/pbuchman/issue/${task.linearIssueId}`;
+```
+
+So the gate compares `task.linearIssueId` against itself. Cannot fire. **Deferred** — fixing requires either adding the field to `EXECUTION_SCHEMA` (and Gemini extracting it from the agent transcript, hallucination-prone) or deleting the gate + ~30 fixture-using tests in `apps/code-agent/src/__tests__/routes/webhooks.test.ts`. Track as follow-up tech debt.
+
+### 2.4 600s stall — UNKNOWN root cause
+
+We have NO direct evidence of what the container was doing during the 600s of silence. Pre-existing worktree CI history at `home-dev:/home/pbuchman/code-workers/worktrees/task_64dddd18.../.claude/ci-failures/repo-task_64dddd18-...jsonl` shows late-task CI runs taking 797s/994s/1099s — so this worktree's CI is genuinely slow (49 modified files cascading). But slow ≠ silent. The completed runs all emitted output. The killed run emitted nothing for 600s straight. Could be:
+- CI hung
+- Output buffered somewhere (tee, vitest, container stdio)
+- Container CPU-bound but not flushing
+- Something else
+
+Container is gone. `/tmp/ci-full.txt` died with it. **Not investigable without future evidence.** Hence Part B (instrument before guessing).
+
+## 3. Plan — three changes, one PR
+
+### A1 — Empty-transcript guard in completion-verifier
+
+**File:** `workers/orchestrator/src/services/completion-verifier.ts`
+
+Add module-level constants near the existing `FATAL_EXIT_CODE_PATTERN` (around line 225, but actual current line on `fix/inactivity-restart-wrong-pr-and-evidence` branch may differ — verify with Read first):
+
+```ts
+const MIN_MEANINGFUL_TRANSCRIPT_LINES = 5;
+
+const INFRASTRUCTURE_LINE_PREFIXES = ['[orchestrator]', '[hook]', '[entrypoint]', '[system]'];
+
+function countMeaningfulTranscriptLines(transcript: string): number {
+  let count = 0;
+  for (const line of transcript.split('\n')) {
+    const trimmed = line.trim();
+    if (trimmed === '') {
+      continue;
+    }
+    if (INFRASTRUCTURE_LINE_PREFIXES.some((prefix) => trimmed.startsWith(prefix))) {
+      continue;
+    }
+    count += 1;
+  }
+  return count;
+}
+```
+
+In `OrchestratorCompletionVerifier.doVerify()` (the existing function around current line 593), AFTER the `detectFatalExitCode` early-return (current line 596-613) and BEFORE `selectSchemaAndPrompt(...)` (current line 615), insert:
+
+```ts
+const meaningfulLines = countMeaningfulTranscriptLines(transcript);
+if (meaningfulLines < MIN_MEANINGFUL_TRANSCRIPT_LINES) {
+  this.logger.warn(
+    {
+      taskId: input.taskId,
+      attempt: input.attempt,
+      agentType: input.agentType,
+      meaningfulLines,
+    },
+    'Completion verifier: transcript too short, refusing to call LLM'
+  );
+  return {
+    passed: false,
+    missingFields: ['transcript_too_short'],
+    verifierFailure: false,
+    trace: { transcript, prompt: '', response: '' },
+  };
+}
+```
+
+**Side-effect:** the existing transcript-summary IIFE at current line 625-632 had a `tLines.length <= 2` branch that becomes unreachable after the guard (5 meaningful lines implies ≥5 non-empty lines). Either remove the branch or wrap fallbacks in `/* v8 ignore start -- auth-guard: transcript guard guarantees tLines.length >= MIN_MEANINGFUL_TRANSCRIPT_LINES @preserve */`.
+
+**Tests:** `workers/orchestrator/src/services/__tests__/completion-verifier.test.ts`
+
+Add helper at top of file:
+```ts
+function transcriptWithMeaningfulLines(label: string): string {
+  return [
+    '[orchestrator] starting',
+    `[claude] ${label} line 1`,
+    `[claude] ${label} line 2`,
+    `[claude] ${label} line 3`,
+    `[claude] ${label} line 4`,
+    `[claude] ${label} line 5`,
+  ].join('\n');
+}
+```
+
+In `beforeEach`, ADD `generateMock.mockReset();` after `vi.clearAllMocks();` — `vi.clearAllMocks()` does NOT clear queued `mockResolvedValueOnce` responses; without `mockReset` they leak across tests after the new guard short-circuits.
+
+Add a new `describe('verify — short transcript guard', ...)` block with:
+- Test A: pure infrastructure transcript → `passed: false`, `missingFields: ['transcript_too_short']`, `generateMock` not called, warn log fired with `meaningfulLines: 0`.
+- Test B: 4 `[claude]` lines mixed with infra → rejected, `meaningfulLines: 4`.
+- Test C: exactly 5 `[claude]` lines mixed with infra → guard passes, generateMock called once.
+
+Update existing tests using `rawLogs: 'logs'` / `'some logs'` / `'exec logs'` etc. to use `transcriptWithMeaningfulLines('<label>')`.
+
+Replace the two existing tests `'logs full transcript when <=2 non-empty lines'` and `'handles whitespace-only rawLogs with empty fallback'` with versions that assert the guard short-circuits (because the `<=2 lines` branch is now unreachable).
+
+**Reference patch:** `docs/plans/2026-04-17-evidence/agent1-A1-completion-verifier.patch` (388 lines, against base `6c1340fe8` from 2026-04-08). 17 commits touched these files between that base and current `fix/inactivity-restart-wrong-pr-and-evidence` tip — patch DOES NOT apply cleanly. Use it as REFERENCE only; rewrite against current tip.
+
+**One known string drift:** Agent 1's patch references log message string `'Gemini completion verifier request'`. Current branch uses `'Completion verifier request'` (no "Gemini" prefix). Adapt accordingly.
+
+**Verification:** `pnpm run verify:workspace:tracked orchestrator` from repo root. 100% branch coverage.
+
+### A2 — PR-URL validation gate in webhookRoutes
+
+**File:** `apps/code-agent/src/routes/webhookRoutes.ts`
+
+Change `enforceExecutionOutcome` return type:
+```ts
+- ): Promise<{ ok: true; prUrlValidationFailed?: boolean; prUrlValidationErrors?: string[] } | { ok: false; message: string; code: string }> => {
++ ): Promise<{ ok: true } | { ok: false; message: string; code: string; prUrlValidationErrors?: string[] }> => {
+```
+
+Replace lines 902-910 (the advisory `if (validationResult.failed)` block):
+```ts
+- if (validationResult.failed) {
+-   prUrlValidationFailed = true;
+-   prUrlValidationErrors = validationResult.errors;
+- }
++ if (validationResult.failed) {
++   return {
++     ok: false,
++     code: 'EXECUTION_AGENT_PR_URL_VALIDATION_FAILED',
++     message: validationResult.errors.join('; '),
++     prUrlValidationErrors: validationResult.errors,
++   };
++ }
+```
+
+Delete the now-dead `let prUrlValidationFailed`/`let prUrlValidationErrors` declarations at lines 879-880, and the conditional spread at the end of the function (lines 953-957).
+
+In the call site (around line 1141-1175 where `enforceExecutionOutcome` returns `{ok: false}`), persist evidence to the failed task document:
+```ts
+{
+  status: 'failed',
+  error: {
+    code: executionEnforcement.code,
+    message: executionEnforcement.message,
+  },
+  ...(executionEnforcement.prUrlValidationErrors !== undefined && {
+    prUrlValidationFailed: true,
+    prUrlValidationErrors: executionEnforcement.prUrlValidationErrors,
+  }),
+  callbackReceived: true,
+}
+```
+
+Delete the hoisted `let executionPrUrlValidationFailed`/`let executionPrUrlValidationErrors` (around lines 1099-1100) and the conditional persistence block in `resolvedStatus` update (around lines 1473-1476).
+
+**Tests:** `apps/code-agent/src/__tests__/routes/webhooks.test.ts`
+
+Add new test asserting:
+- `status: 'failed'`
+- `error.code: 'EXECUTION_AGENT_PR_URL_VALIDATION_FAILED'`
+- `error.message` contains both validation errors when title-mismatch + dispatch-recency both fail
+- `prUrlValidationFailed: true` and `prUrlValidationErrors` (length 2) preserved on task
+
+To set `dispatchedAt` for the dispatch-recency test, **DO NOT use `codeTaskRepo.update({ dispatchedAt })`**. The FakeFirestore has a bug where `Timestamp` values are misclassified as `FieldValue.delete()` sentinels (because `Timestamp` has an `isEqual` method, which the Fake's `isFieldValueDelete` heuristic checks). Workaround — write directly to the underlying `_store` Map:
+```ts
+const docRef = fakeFirestore.collection('code_tasks').doc(task.id) as unknown as { _store: Map<string, Map<string, Record<string, unknown>>>; _collectionName: string; id: string };
+const existingDoc = docRef._store.get(docRef._collectionName)?.get(docRef.id);
+if (existingDoc !== undefined) {
+  existingDoc['dispatchedAt'] = Timestamp.fromDate(dispatchedAt);
+}
+```
+File a separate tech-debt issue for the Fake bug at `packages/infra-firestore/src/testing/firestoreFake.ts:29-32, 104-107, 742-748`.
+
+Update existing tests `'flags task with prUrlValidationFailed when PR title does not match Linear issue ID'` and `'flags task with prUrlValidationFailed when PR does not exist (NOT_FOUND)'`:
+- Rename to `'fails task with EXECUTION_AGENT_PR_URL_VALIDATION_FAILED ...'`
+- Change assertion `expect(g.value.status).toBe('implemented')` → `expect(g.value.status).toBe('failed')` + `expect(g.value.error?.code).toBe('EXECUTION_AGENT_PR_URL_VALIDATION_FAILED')`
+
+**Reference patch:** `docs/plans/2026-04-17-evidence/agent2-A2-webhook-pr-validation.patch` (202 lines, against base `6368b6572` from 2026-04-16 — same as current branch tip). Per Agent 2's report, `pnpm run verify:workspace:tracked code-agent` passed with 14727 tests + 1 skipped. Patch SHOULD apply cleanly to current branch — try `/usr/bin/git apply --check docs/plans/2026-04-17-evidence/agent2-A2-webhook-pr-validation.patch` first.
+
+**Verification:** `pnpm run verify:workspace:tracked code-agent` from repo root. 100% branch coverage.
+
+### B1 + B2 — Inactivity-kill instrumentation (greenfield)
+
+**Why:** No fix for the 600s stall — collect evidence first. Capture `/tmp` and a docker stats snapshot BEFORE killing the container. Best-effort only; must not block the restart.
+
+**Files:**
+- `workers/orchestrator/src/services/isolation/types.ts` (find `IsolationProvider` interface — `Grep "interface IsolationProvider"` to locate)
+- `workers/orchestrator/src/services/isolation/docker-provider.ts`
+- `workers/orchestrator/src/services/task-dispatcher.ts` — `handleInactivityRestart()` method, currently around line 1100 (search for `'Inactivity restart triggered'` log message)
+- The fake `IsolationProvider` used in `task-dispatcher.test.ts` (search for `getWorkerLogs(` in `__tests__/`)
+
+**Interface additions:**
+```ts
+interface ContainerStatsSnapshot {
+  cpuTotalUsage: number;
+  memoryUsage: number;
+  pidsCurrent: number;
+}
+
+// In IsolationProvider:
+copyOut(taskId: string, srcPath: string, destPath: string): Promise<void>;
+statsSnapshot(taskId: string): Promise<ContainerStatsSnapshot | null>;
+```
+
+**Docker provider implementation:**
+- `copyOut`: `container.getArchive({ path: srcPath })` returns a tar stream. `mkdir -p destPath` then extract via `tar` package. **Check first:** is `tar` already a dep? `Grep "from 'tar'"` and `Grep "\"tar\"" workers/orchestrator/package.json`. If not present, prefer node-tar (`pnpm add tar -w workers/orchestrator`); document why in commit message.
+- `statsSnapshot`: `container.stats({ stream: false })` returns one snapshot. Map `cpu_stats.cpu_usage.total_usage`, `memory_stats.usage`, `pids_stats.current`. If container missing, return `null` (match pattern of `isWorkerRunning`).
+
+**Fake provider:** add no-op or recording stub implementations. New tests need recording.
+
+**Dispatcher hook (`handleInactivityRestart`)** — BEFORE the existing `await this.isolation.provider.destroyWorker(taskId);` call:
+
+```ts
+const evidenceDir = `/var/log/orchestrator/inactivity-evidence/${taskId}/`;
+try {
+  await this.isolation.provider.copyOut(taskId, '/tmp', evidenceDir);
+} catch (e) {
+  this.logger.warn(
+    { taskId, error: getErrorMessage(e) },
+    'Failed to copy /tmp evidence before inactivity kill'
+  );
+}
+try {
+  const stats = await this.isolation.provider.statsSnapshot(taskId);
+  this.logger.warn({ taskId, stats }, 'Container stats at inactivity kill');
+} catch (e) {
+  this.logger.warn(
+    { taskId, error: getErrorMessage(e) },
+    'Failed to capture container stats before inactivity kill'
+  );
+}
+```
+
+Use `getErrorMessage` from `@intexuraos/common-core` (already imported in this file).
+
+**Tests:** in `workers/orchestrator/src/__tests__/task-dispatcher.test.ts` near existing `inactivityRestartCount` tests (search):
+- Test 1: trigger inactivity restart → `copyOut` called once with `(taskId, '/tmp', stringContaining(taskId))`, `statsSnapshot` called once with `(taskId)`, BOTH BEFORE `destroyWorker`. Track call order in fake.
+- Test 2: `copyOut` rejects → restart still proceeds (`destroyWorker` called, `inactivityRestartCount` increments, no exception escapes).
+- Test 3: `statsSnapshot` rejects → restart still proceeds.
+- Test 4: `statsSnapshot` returns `null` → warn log fires with `stats: null`, restart proceeds.
+
+**Verification:** `pnpm run verify:workspace:tracked orchestrator` from repo root. 100% branch coverage.
+
+## 4. Implementation order (in main tree)
+
+CLAUDE.md prohibits git worktrees. Run sequentially in main workspace `/Users/p.buchman/personal/intexuraos-5/`:
+
+1. **A2 first** — Agent 2's patch may apply cleanly. Try:
+   ```
+   /usr/bin/git apply --check docs/plans/2026-04-17-evidence/agent2-A2-webhook-pr-validation.patch
+   ```
+   If clean: `git apply ...`, then `pnpm run verify:workspace:tracked code-agent`. If not clean: rewrite from scratch using the structural guidance in §3 A2.
+
+2. **A1 next** — Agent 1's patch will NOT apply (17 commits drift). Implement from §3 A1 above by hand. Use the patch as reference for test structure. Read current `completion-verifier.ts` first to find correct line numbers for insertion. Watch for the `'Gemini completion verifier request'` vs `'Completion verifier request'` log string drift — current branch uses the latter. After: `pnpm run verify:workspace:tracked orchestrator`.
+
+3. **B1+B2 last** — greenfield. Implement per §3 B1+B2. After: `pnpm run verify:workspace:tracked orchestrator`.
+
+4. Final: `pnpm run ci:tracked` from repo root. Capture with `tee /tmp/ci-output-final.txt` per CLAUDE.md.
+
+5. Commit per Commit Gate. Push. **Ask user for INT-XXX before opening PR.** PR title must contain `INT-XXX`. PR body: `Fixes INT-XXX`.
+
+## 5. Cleanup before starting
+
+Two leftover worktrees from the rule-violating dispatch:
+```
+~/personal/intexuraos-5/.claude/worktrees/agent-a61ac9eb [worktree-agent-a61ac9eb] (Agent 1, has unresolved stash conflicts after rebase)
+~/personal/intexuraos-5/.claude/worktrees/agent-af624dda [worktree-agent-af624dda] (Agent 2, clean)
+```
+
+Both worktree branches were created off random older commits (Agent 1: `6c1340fe8` from 2026-04-08; Agent 2: `6368b6572` matched current tip). Patches are preserved at `docs/plans/2026-04-17-evidence/`. Safe to delete worktrees:
+```
+/usr/bin/git worktree remove --force .claude/worktrees/agent-a61ac9eb
+/usr/bin/git worktree remove --force .claude/worktrees/agent-af624dda
+/usr/bin/git branch -D worktree-agent-a61ac9eb worktree-agent-af624dda
+```
+
+## 6. Out-of-scope follow-ups (separate Linear issues)
+
+- **Dead `EXECUTION_AGENT_WRONG_ISSUE_MISMATCH` gate** (§2.3) — synthesized URL compared to itself. Two options: add field to `EXECUTION_SCHEMA` + remove orchestrator synthesis (re-enables real check, but Gemini-extracted field is hallucination-prone — A1's transcript guard helps), OR delete gate + ~30 fixture-using tests. Pick one.
+- **FakeFirestore Timestamp bug** at `packages/infra-firestore/src/testing/firestoreFake.ts:29-32, 104-107, 742-748` — `isFieldValueDelete` heuristic flags any object with `isEqual` method as a delete sentinel; `Timestamp` has `isEqual`. Affects any test trying to set Timestamp via `update()`.
+- **Cleanup orphaned PR-#970 compliance comment** posted by the buggy task — user explicitly said "ignore" but worth noting.
+
+## 7. Files modified summary
+
+- `workers/orchestrator/src/services/completion-verifier.ts` (A1)
+- `workers/orchestrator/src/services/__tests__/completion-verifier.test.ts` (A1)
+- `apps/code-agent/src/routes/webhookRoutes.ts` (A2)
+- `apps/code-agent/src/__tests__/routes/webhooks.test.ts` (A2)
+- `workers/orchestrator/src/services/isolation/types.ts` (B1+B2 — interface)
+- `workers/orchestrator/src/services/isolation/docker-provider.ts` (B1+B2 — implementation)
+- `workers/orchestrator/src/services/task-dispatcher.ts` (B1+B2 — `handleInactivityRestart` site)
+- `workers/orchestrator/src/__tests__/task-dispatcher.test.ts` (B1+B2 — tests)
+- Possibly `workers/orchestrator/package.json` if `tar` not already a dep (B1)
+
+No HTTP endpoint changes — Endpoint Changes section omitted per CLAUDE.md plan-doc convention.
+
+## 8. Reference artifacts (preserved across compaction)
+
+- `/tmp/task-logs.txt` — full Firestore log dump from the failed task (1914 lines, 5491 source lines from agent transcript). May be cleared on tmpfs eviction.
+- `docs/plans/2026-04-17-evidence/agent1-A1-completion-verifier.patch` — Agent 1's full diff (reference only, won't apply).
+- `docs/plans/2026-04-17-evidence/agent2-A2-webhook-pr-validation.patch` — Agent 2's full diff (try apply first).
+- Original task ID: `task_64dddd18-1a9c-4cec-b10f-649a35564a81`. Re-fetch with `node .claude/skills/debug-code-task/scripts/fetch-task.cjs task_64dddd18-1a9c-4cec-b10f-649a35564a81 --logs-only` (after `unset FIRESTORE_EMULATOR_HOST GOOGLE_CLOUD_PROJECT`).
+- Original orchestrator journal: `ssh home-dev journalctl -u intexuraos-orchestrator@pbuchman --since "2026-04-16 21:48:00 UTC" --until "2026-04-16 22:00:30 UTC"`.

--- a/workers/orchestrator/src/__tests__/task-dispatcher.test.ts
+++ b/workers/orchestrator/src/__tests__/task-dispatcher.test.ts
@@ -208,6 +208,8 @@ describe('TaskDispatcher', () => {
     streamLogs: vi.fn(async () => undefined),
     waitForCompletion: vi.fn(async () => 0),
     getResourceUsage: vi.fn(async () => ({ cpuPercent: 0, memoryUsedMB: 0, memoryLimitMB: 0 })),
+    copyOut: vi.fn(async () => undefined),
+    statsSnapshot: vi.fn(async () => ({ cpuTotalUsage: 0, memoryUsage: 0, pidsCurrent: 0 })),
     listWorkers: vi.fn(async () => []),
     cleanupTaskSession: vi.fn(async () => undefined),
     isResumeAvailable: vi.fn(async () => true),
@@ -9419,6 +9421,238 @@ describe('TaskDispatcher', () => {
       expect(task?.status).toBe('running');
       expect(task?.inactivityRestartCount).toBe(1);
 
+      vi.useRealTimers();
+      vi.mocked(mockIsolationProvider.isWorkerRunning).mockResolvedValue(false);
+    });
+
+    it('captures /tmp evidence and stats snapshot before destroying worker on inactivity', async () => {
+      vi.useFakeTimers();
+      vi.mocked(mockIsolationProvider.isWorkerRunning).mockResolvedValue(true);
+      vi.mocked(mockIsolationProvider.copyOut).mockClear();
+      vi.mocked(mockIsolationProvider.statsSnapshot).mockClear();
+      vi.mocked(mockIsolationProvider.destroyWorker).mockClear();
+
+      const evidenceState = createStatePersistence();
+      const evidenceDispatcher = new TaskDispatcher(
+        mockConfig,
+        evidenceState,
+        mockWorktreeManager,
+        mockLogForwarder,
+        mockWebhookClient,
+        mockGitHubTokenService,
+        mockLogger,
+        mockIsolationConfig,
+        {
+          maxAttempts: 1,
+          activityTimeout: { timeoutMs: 10 * 60 * 1000, maxRestarts: 3 },
+          verifier: singleAttemptCompletionControl.verifier,
+        }
+      );
+
+      await evidenceDispatcher.submitTask({
+        taskId: 'evidence-capture-test',
+        workerType: 'auto',
+        prompt: 'p',
+        webhookUrl: 'https://example.com/webhook',
+        webhookSecret: 'secret',
+        linearIssueLabels: [],
+        hasChildren: false,
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      {
+        const state = await evidenceState.load();
+        const task = state.tasks['evidence-capture-test'];
+        if (!task) throw new Error('Task not found');
+        task.runtimeSessionId = 'aaaaaaaa-0000-4000-a000-000000000000';
+        await evidenceState.save(state);
+      }
+
+      await vi.advanceTimersByTimeAsync(10 * 60 * 1000);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(mockIsolationProvider.copyOut).toHaveBeenCalledWith(
+        'evidence-capture-test',
+        '/tmp',
+        expect.stringContaining('evidence-capture-test')
+      );
+      expect(mockIsolationProvider.statsSnapshot).toHaveBeenCalledWith('evidence-capture-test');
+
+      const copyOutOrder = vi.mocked(mockIsolationProvider.copyOut).mock.invocationCallOrder[0];
+      const statsOrder = vi.mocked(mockIsolationProvider.statsSnapshot).mock.invocationCallOrder[0];
+      const destroyCalls = vi.mocked(mockIsolationProvider.destroyWorker).mock.calls;
+      const destroyOrders = vi.mocked(mockIsolationProvider.destroyWorker).mock.invocationCallOrder;
+      const destroyIdx = destroyCalls.findIndex((c) => c[0] === 'evidence-capture-test');
+      expect(destroyIdx).toBeGreaterThanOrEqual(0);
+      const destroyOrder = destroyOrders[destroyIdx];
+      expect(copyOutOrder).toBeDefined();
+      expect(statsOrder).toBeDefined();
+      expect(destroyOrder).toBeDefined();
+      if (copyOutOrder !== undefined && destroyOrder !== undefined) {
+        expect(copyOutOrder).toBeLessThan(destroyOrder);
+      }
+      if (statsOrder !== undefined && destroyOrder !== undefined) {
+        expect(statsOrder).toBeLessThan(destroyOrder);
+      }
+
+      vi.useRealTimers();
+      vi.mocked(mockIsolationProvider.isWorkerRunning).mockResolvedValue(false);
+    });
+
+    it('proceeds with inactivity restart even when copyOut rejects', async () => {
+      vi.useFakeTimers();
+      vi.mocked(mockIsolationProvider.isWorkerRunning).mockResolvedValue(true);
+      vi.mocked(mockIsolationProvider.copyOut).mockRejectedValueOnce(new Error('docker busy'));
+
+      const copyFailState = createStatePersistence();
+      const copyFailDispatcher = new TaskDispatcher(
+        mockConfig,
+        copyFailState,
+        mockWorktreeManager,
+        mockLogForwarder,
+        mockWebhookClient,
+        mockGitHubTokenService,
+        mockLogger,
+        mockIsolationConfig,
+        {
+          maxAttempts: 1,
+          activityTimeout: { timeoutMs: 10 * 60 * 1000, maxRestarts: 3 },
+          verifier: singleAttemptCompletionControl.verifier,
+        }
+      );
+
+      await copyFailDispatcher.submitTask({
+        taskId: 'copyout-fail-test',
+        workerType: 'auto',
+        prompt: 'p',
+        webhookUrl: 'https://example.com/webhook',
+        webhookSecret: 'secret',
+        linearIssueLabels: [],
+        hasChildren: false,
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      {
+        const state = await copyFailState.load();
+        const task = state.tasks['copyout-fail-test'];
+        if (!task) throw new Error('Task not found');
+        task.runtimeSessionId = 'aaaaaaaa-0000-4000-a000-000000000000';
+        await copyFailState.save(state);
+      }
+
+      await vi.advanceTimersByTimeAsync(10 * 60 * 1000);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(mockIsolationProvider.destroyWorker).toHaveBeenCalledWith('copyout-fail-test');
+      const task = await copyFailDispatcher.getTask('copyout-fail-test');
+      expect(task?.inactivityRestartCount).toBe(1);
+
+      vi.useRealTimers();
+      vi.mocked(mockIsolationProvider.isWorkerRunning).mockResolvedValue(false);
+    });
+
+    it('proceeds with inactivity restart even when statsSnapshot rejects', async () => {
+      vi.useFakeTimers();
+      vi.mocked(mockIsolationProvider.isWorkerRunning).mockResolvedValue(true);
+      vi.mocked(mockIsolationProvider.statsSnapshot).mockRejectedValueOnce(
+        new Error('stats unavailable')
+      );
+
+      const statsFailState = createStatePersistence();
+      const statsFailDispatcher = new TaskDispatcher(
+        mockConfig,
+        statsFailState,
+        mockWorktreeManager,
+        mockLogForwarder,
+        mockWebhookClient,
+        mockGitHubTokenService,
+        mockLogger,
+        mockIsolationConfig,
+        {
+          maxAttempts: 1,
+          activityTimeout: { timeoutMs: 10 * 60 * 1000, maxRestarts: 3 },
+          verifier: singleAttemptCompletionControl.verifier,
+        }
+      );
+
+      await statsFailDispatcher.submitTask({
+        taskId: 'stats-fail-test',
+        workerType: 'auto',
+        prompt: 'p',
+        webhookUrl: 'https://example.com/webhook',
+        webhookSecret: 'secret',
+        linearIssueLabels: [],
+        hasChildren: false,
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      {
+        const state = await statsFailState.load();
+        const task = state.tasks['stats-fail-test'];
+        if (!task) throw new Error('Task not found');
+        task.runtimeSessionId = 'aaaaaaaa-0000-4000-a000-000000000000';
+        await statsFailState.save(state);
+      }
+
+      await vi.advanceTimersByTimeAsync(10 * 60 * 1000);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(mockIsolationProvider.destroyWorker).toHaveBeenCalledWith('stats-fail-test');
+      const task = await statsFailDispatcher.getTask('stats-fail-test');
+      expect(task?.inactivityRestartCount).toBe(1);
+
+      vi.useRealTimers();
+      vi.mocked(mockIsolationProvider.isWorkerRunning).mockResolvedValue(false);
+    });
+
+    it('logs stats: null warn and proceeds when statsSnapshot returns null', async () => {
+      vi.useFakeTimers();
+      vi.mocked(mockIsolationProvider.isWorkerRunning).mockResolvedValue(true);
+      vi.mocked(mockIsolationProvider.statsSnapshot).mockResolvedValueOnce(null);
+      const warnSpy = vi.spyOn(mockLogger, 'warn');
+
+      const statsNullState = createStatePersistence();
+      const statsNullDispatcher = new TaskDispatcher(
+        mockConfig,
+        statsNullState,
+        mockWorktreeManager,
+        mockLogForwarder,
+        mockWebhookClient,
+        mockGitHubTokenService,
+        mockLogger,
+        mockIsolationConfig,
+        {
+          maxAttempts: 1,
+          activityTimeout: { timeoutMs: 10 * 60 * 1000, maxRestarts: 3 },
+          verifier: singleAttemptCompletionControl.verifier,
+        }
+      );
+
+      await statsNullDispatcher.submitTask({
+        taskId: 'stats-null-test',
+        workerType: 'auto',
+        prompt: 'p',
+        webhookUrl: 'https://example.com/webhook',
+        webhookSecret: 'secret',
+        linearIssueLabels: [],
+        hasChildren: false,
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      {
+        const state = await statsNullState.load();
+        const task = state.tasks['stats-null-test'];
+        if (!task) throw new Error('Task not found');
+        task.runtimeSessionId = 'aaaaaaaa-0000-4000-a000-000000000000';
+        await statsNullState.save(state);
+      }
+
+      await vi.advanceTimersByTimeAsync(10 * 60 * 1000);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ taskId: 'stats-null-test', stats: null }),
+        'Container stats at inactivity kill'
+      );
+      expect(mockIsolationProvider.destroyWorker).toHaveBeenCalledWith('stats-null-test');
+
+      warnSpy.mockRestore();
       vi.useRealTimers();
       vi.mocked(mockIsolationProvider.isWorkerRunning).mockResolvedValue(false);
     });

--- a/workers/orchestrator/src/__tests__/task-dispatcher.test.ts
+++ b/workers/orchestrator/src/__tests__/task-dispatcher.test.ts
@@ -9425,17 +9425,11 @@ describe('TaskDispatcher', () => {
       vi.mocked(mockIsolationProvider.isWorkerRunning).mockResolvedValue(false);
     });
 
-    it('captures /tmp evidence and stats snapshot before destroying worker on inactivity', async () => {
-      vi.useFakeTimers();
-      vi.mocked(mockIsolationProvider.isWorkerRunning).mockResolvedValue(true);
-      vi.mocked(mockIsolationProvider.copyOut).mockClear();
-      vi.mocked(mockIsolationProvider.statsSnapshot).mockClear();
-      vi.mocked(mockIsolationProvider.destroyWorker).mockClear();
-
-      const evidenceState = createStatePersistence();
-      const evidenceDispatcher = new TaskDispatcher(
+    async function triggerInactivityRestart(taskId: string): Promise<TaskDispatcher> {
+      const state = createStatePersistence();
+      const dispatcher = new TaskDispatcher(
         mockConfig,
-        evidenceState,
+        state,
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
@@ -9448,9 +9442,8 @@ describe('TaskDispatcher', () => {
           verifier: singleAttemptCompletionControl.verifier,
         }
       );
-
-      await evidenceDispatcher.submitTask({
-        taskId: 'evidence-capture-test',
+      await dispatcher.submitTask({
+        taskId,
         workerType: 'auto',
         prompt: 'p',
         webhookUrl: 'https://example.com/webhook',
@@ -9459,16 +9452,24 @@ describe('TaskDispatcher', () => {
         hasChildren: false,
       });
       await vi.advanceTimersByTimeAsync(0);
-      {
-        const state = await evidenceState.load();
-        const task = state.tasks['evidence-capture-test'];
-        if (!task) throw new Error('Task not found');
-        task.runtimeSessionId = 'aaaaaaaa-0000-4000-a000-000000000000';
-        await evidenceState.save(state);
-      }
-
+      const loaded = await state.load();
+      const task = loaded.tasks[taskId];
+      if (!task) throw new Error('Task not found');
+      task.runtimeSessionId = 'aaaaaaaa-0000-4000-a000-000000000000';
+      await state.save(loaded);
       await vi.advanceTimersByTimeAsync(10 * 60 * 1000);
       await vi.advanceTimersByTimeAsync(0);
+      return dispatcher;
+    }
+
+    it('captures /tmp evidence and stats snapshot before destroying worker on inactivity', async () => {
+      vi.useFakeTimers();
+      vi.mocked(mockIsolationProvider.isWorkerRunning).mockResolvedValue(true);
+      vi.mocked(mockIsolationProvider.copyOut).mockClear();
+      vi.mocked(mockIsolationProvider.statsSnapshot).mockClear();
+      vi.mocked(mockIsolationProvider.destroyWorker).mockClear();
+
+      await triggerInactivityRestart('evidence-capture-test');
 
       expect(mockIsolationProvider.copyOut).toHaveBeenCalledWith(
         'evidence-capture-test',
@@ -9503,46 +9504,10 @@ describe('TaskDispatcher', () => {
       vi.mocked(mockIsolationProvider.isWorkerRunning).mockResolvedValue(true);
       vi.mocked(mockIsolationProvider.copyOut).mockRejectedValueOnce(new Error('docker busy'));
 
-      const copyFailState = createStatePersistence();
-      const copyFailDispatcher = new TaskDispatcher(
-        mockConfig,
-        copyFailState,
-        mockWorktreeManager,
-        mockLogForwarder,
-        mockWebhookClient,
-        mockGitHubTokenService,
-        mockLogger,
-        mockIsolationConfig,
-        {
-          maxAttempts: 1,
-          activityTimeout: { timeoutMs: 10 * 60 * 1000, maxRestarts: 3 },
-          verifier: singleAttemptCompletionControl.verifier,
-        }
-      );
-
-      await copyFailDispatcher.submitTask({
-        taskId: 'copyout-fail-test',
-        workerType: 'auto',
-        prompt: 'p',
-        webhookUrl: 'https://example.com/webhook',
-        webhookSecret: 'secret',
-        linearIssueLabels: [],
-        hasChildren: false,
-      });
-      await vi.advanceTimersByTimeAsync(0);
-      {
-        const state = await copyFailState.load();
-        const task = state.tasks['copyout-fail-test'];
-        if (!task) throw new Error('Task not found');
-        task.runtimeSessionId = 'aaaaaaaa-0000-4000-a000-000000000000';
-        await copyFailState.save(state);
-      }
-
-      await vi.advanceTimersByTimeAsync(10 * 60 * 1000);
-      await vi.advanceTimersByTimeAsync(0);
+      const dispatcher = await triggerInactivityRestart('copyout-fail-test');
 
       expect(mockIsolationProvider.destroyWorker).toHaveBeenCalledWith('copyout-fail-test');
-      const task = await copyFailDispatcher.getTask('copyout-fail-test');
+      const task = await dispatcher.getTask('copyout-fail-test');
       expect(task?.inactivityRestartCount).toBe(1);
 
       vi.useRealTimers();
@@ -9556,46 +9521,10 @@ describe('TaskDispatcher', () => {
         new Error('stats unavailable')
       );
 
-      const statsFailState = createStatePersistence();
-      const statsFailDispatcher = new TaskDispatcher(
-        mockConfig,
-        statsFailState,
-        mockWorktreeManager,
-        mockLogForwarder,
-        mockWebhookClient,
-        mockGitHubTokenService,
-        mockLogger,
-        mockIsolationConfig,
-        {
-          maxAttempts: 1,
-          activityTimeout: { timeoutMs: 10 * 60 * 1000, maxRestarts: 3 },
-          verifier: singleAttemptCompletionControl.verifier,
-        }
-      );
-
-      await statsFailDispatcher.submitTask({
-        taskId: 'stats-fail-test',
-        workerType: 'auto',
-        prompt: 'p',
-        webhookUrl: 'https://example.com/webhook',
-        webhookSecret: 'secret',
-        linearIssueLabels: [],
-        hasChildren: false,
-      });
-      await vi.advanceTimersByTimeAsync(0);
-      {
-        const state = await statsFailState.load();
-        const task = state.tasks['stats-fail-test'];
-        if (!task) throw new Error('Task not found');
-        task.runtimeSessionId = 'aaaaaaaa-0000-4000-a000-000000000000';
-        await statsFailState.save(state);
-      }
-
-      await vi.advanceTimersByTimeAsync(10 * 60 * 1000);
-      await vi.advanceTimersByTimeAsync(0);
+      const dispatcher = await triggerInactivityRestart('stats-fail-test');
 
       expect(mockIsolationProvider.destroyWorker).toHaveBeenCalledWith('stats-fail-test');
-      const task = await statsFailDispatcher.getTask('stats-fail-test');
+      const task = await dispatcher.getTask('stats-fail-test');
       expect(task?.inactivityRestartCount).toBe(1);
 
       vi.useRealTimers();
@@ -9608,43 +9537,7 @@ describe('TaskDispatcher', () => {
       vi.mocked(mockIsolationProvider.statsSnapshot).mockResolvedValueOnce(null);
       const warnSpy = vi.spyOn(mockLogger, 'warn');
 
-      const statsNullState = createStatePersistence();
-      const statsNullDispatcher = new TaskDispatcher(
-        mockConfig,
-        statsNullState,
-        mockWorktreeManager,
-        mockLogForwarder,
-        mockWebhookClient,
-        mockGitHubTokenService,
-        mockLogger,
-        mockIsolationConfig,
-        {
-          maxAttempts: 1,
-          activityTimeout: { timeoutMs: 10 * 60 * 1000, maxRestarts: 3 },
-          verifier: singleAttemptCompletionControl.verifier,
-        }
-      );
-
-      await statsNullDispatcher.submitTask({
-        taskId: 'stats-null-test',
-        workerType: 'auto',
-        prompt: 'p',
-        webhookUrl: 'https://example.com/webhook',
-        webhookSecret: 'secret',
-        linearIssueLabels: [],
-        hasChildren: false,
-      });
-      await vi.advanceTimersByTimeAsync(0);
-      {
-        const state = await statsNullState.load();
-        const task = state.tasks['stats-null-test'];
-        if (!task) throw new Error('Task not found');
-        task.runtimeSessionId = 'aaaaaaaa-0000-4000-a000-000000000000';
-        await statsNullState.save(state);
-      }
-
-      await vi.advanceTimersByTimeAsync(10 * 60 * 1000);
-      await vi.advanceTimersByTimeAsync(0);
+      await triggerInactivityRestart('stats-null-test');
 
       expect(warnSpy).toHaveBeenCalledWith(
         expect.objectContaining({ taskId: 'stats-null-test', stats: null }),

--- a/workers/orchestrator/src/services/__tests__/completion-verifier.test.ts
+++ b/workers/orchestrator/src/services/__tests__/completion-verifier.test.ts
@@ -36,6 +36,17 @@ const logger: Logger = {
 
 const generateMock = vi.fn();
 
+function transcriptWithMeaningfulLines(label: string): string {
+  return [
+    '[orchestrator] starting',
+    `[claude] ${label} line 1`,
+    `[claude] ${label} line 2`,
+    `[claude] ${label} line 3`,
+    `[claude] ${label} line 4`,
+    `[claude] ${label} line 5`,
+  ].join('\n');
+}
+
 function createVerifier(
   overrides: Partial<{
     primaryModelName: string;
@@ -58,6 +69,7 @@ function createVerifier(
 
 beforeEach(() => {
   vi.clearAllMocks();
+  generateMock.mockReset();
 });
 
 // ---------------------------------------------------------------------------
@@ -816,7 +828,7 @@ describe('OrchestratorCompletionVerifier', () => {
         attempt: 1,
         maxAttempts: 1,
         agentType: 'planning',
-        rawLogs: 'test logs',
+        rawLogs: transcriptWithMeaningfulLines('test'),
       });
 
       expect(result.passed).toBe(true);
@@ -851,7 +863,7 @@ describe('OrchestratorCompletionVerifier', () => {
         attempt: 1,
         maxAttempts: 1,
         agentType: 'planning',
-        rawLogs: 'test logs',
+        rawLogs: transcriptWithMeaningfulLines('test'),
       });
 
       expect(result.passed).toBe(false);
@@ -894,7 +906,7 @@ describe('OrchestratorCompletionVerifier', () => {
         attempt: 1,
         maxAttempts: 1,
         agentType: 'planning',
-        rawLogs: 'test logs',
+        rawLogs: transcriptWithMeaningfulLines('test'),
       });
 
       expect(result.passed).toBe(true);
@@ -943,7 +955,7 @@ describe('OrchestratorCompletionVerifier', () => {
         attempt: 1,
         maxAttempts: 1,
         agentType: 'planning',
-        rawLogs: 'test logs',
+        rawLogs: transcriptWithMeaningfulLines('test'),
       });
 
       expect(result.passed).toBe(true);
@@ -986,7 +998,7 @@ describe('OrchestratorCompletionVerifier', () => {
         attempt: 1,
         maxAttempts: 5,
         agentType: 'planning',
-        rawLogs: 'some logs',
+        rawLogs: transcriptWithMeaningfulLines('plan'),
       });
       expect(result.passed).toBe(true);
       expect(result.verifierFailure).toBe(false);
@@ -1037,7 +1049,7 @@ describe('OrchestratorCompletionVerifier', () => {
         attempt: 1,
         maxAttempts: 5,
         agentType: 'planning',
-        rawLogs: 'logs',
+        rawLogs: transcriptWithMeaningfulLines('generic'),
       });
       expect(result.passed).toBe(true);
       expect(result.agentData?.agentType).toBe('planning');
@@ -1079,7 +1091,7 @@ describe('OrchestratorCompletionVerifier', () => {
         attempt: 1,
         maxAttempts: 5,
         agentType: 'execution',
-        rawLogs: 'exec logs',
+        rawLogs: transcriptWithMeaningfulLines('exec'),
       });
       expect(result.passed).toBe(true);
       expect(result.agentData).toEqual({
@@ -1123,7 +1135,8 @@ describe('OrchestratorCompletionVerifier', () => {
         attempt: 1,
         maxAttempts: 5,
         agentType: 'execution',
-        rawLogs: '[claude] Work started\n[claude] Finished without memory block\n',
+        rawLogs:
+          '[claude] Work started\n[claude] step 2\n[claude] step 3\n[claude] step 4\n[claude] Finished without memory block\n',
         executionMemoryContext: {
           applicationId: 'app-123',
           retrievalVersion: 'execution-memory-retrieval@1.0.0',
@@ -1189,6 +1202,8 @@ describe('OrchestratorCompletionVerifier', () => {
           '[claude] 📋 **Execution Memories Received:**',
           '[claude] - [mem_142] Route logging',
           '[claude] - [mem_155] Route coverage',
+          '[claude] started work',
+          '[claude] finished work',
         ].join('\n'),
         executionMemoryContext: {
           applicationId: 'app-123',
@@ -1242,7 +1257,8 @@ describe('OrchestratorCompletionVerifier', () => {
         attempt: 1,
         maxAttempts: 5,
         agentType: 'execution',
-        rawLogs: '[claude] Finished without memory block\n',
+        rawLogs:
+          '[claude] step 1\n[claude] step 2\n[claude] step 3\n[claude] step 4\n[claude] Finished without memory block\n',
         executionMemoryContext: {
           applicationId: 'app-123',
           retrievalVersion: 'execution-memory-retrieval@1.0.0',
@@ -1280,7 +1296,7 @@ describe('OrchestratorCompletionVerifier', () => {
         attempt: 1,
         maxAttempts: 5,
         agentType: 'pull_request',
-        rawLogs: 'pr logs',
+        rawLogs: transcriptWithMeaningfulLines('pr'),
       });
       expect(result.passed).toBe(true);
       expect(result.agentData).toEqual({
@@ -1324,7 +1340,7 @@ describe('OrchestratorCompletionVerifier', () => {
         maxAttempts: 5,
         agentType: 'pull_request',
         rawLogs:
-          '[claude] 📋 **Execution Memories Received:**\n[claude] - [mem_142] PR reply pattern\n',
+          '[claude] 📋 **Execution Memories Received:**\n[claude] - [mem_142] PR reply pattern\n[claude] step 1\n[claude] step 2\n[claude] done\n',
         executionMemoryContext: {
           applicationId: 'app-123',
           retrievalVersion: 'execution-memory-retrieval@1.0.0',
@@ -1380,7 +1396,7 @@ describe('OrchestratorCompletionVerifier', () => {
         attempt: 1,
         maxAttempts: 5,
         agentType: 'review',
-        rawLogs: 'review logs',
+        rawLogs: transcriptWithMeaningfulLines('review'),
       });
       expect(result.passed).toBe(true);
       expect(result.agentData).toEqual({
@@ -1420,7 +1436,7 @@ describe('OrchestratorCompletionVerifier', () => {
         attempt: 1,
         maxAttempts: 5,
         agentType: 'review',
-        rawLogs: 'review logs',
+        rawLogs: transcriptWithMeaningfulLines('review'),
       });
       expect(result.passed).toBe(true);
       expect(result.agentData).toEqual({
@@ -1463,7 +1479,7 @@ describe('OrchestratorCompletionVerifier', () => {
         attempt: 1,
         maxAttempts: 5,
         agentType: 'remediation',
-        rawLogs: 'remediation logs',
+        rawLogs: transcriptWithMeaningfulLines('remediation'),
       });
       expect(result.passed).toBe(true);
       expect(result.agentData).toEqual({
@@ -1532,7 +1548,8 @@ describe('OrchestratorCompletionVerifier', () => {
         attempt: 1,
         maxAttempts: 5,
         agentType: 'planning',
-        rawLogs: '[claude] Planning completed',
+        rawLogs:
+          '[claude] step 1\n[claude] step 2\n[claude] step 3\n[claude] step 4\n[claude] Planning completed',
         executionMemoryContext: makeMemoryContext(['mem_142']),
       });
       expect(result.passed).toBe(false);
@@ -1571,7 +1588,7 @@ describe('OrchestratorCompletionVerifier', () => {
         maxAttempts: 5,
         agentType: 'planning',
         rawLogs:
-          '[claude] 📋 **Execution Memories Received:**\n[claude] - [mem_142] Memory for planning\n',
+          '[claude] 📋 **Execution Memories Received:**\n[claude] - [mem_142] Memory for planning\n[claude] step 1\n[claude] step 2\n[claude] done\n',
         executionMemoryContext: makeMemoryContext(['mem_142']),
       });
       expect(result.passed).toBe(true);
@@ -1605,7 +1622,7 @@ describe('OrchestratorCompletionVerifier', () => {
         maxAttempts: 5,
         agentType: 'planning',
         rawLogs:
-          '[claude] 📋 **Execution Memories Received:**\n[claude] - [mem_142] Memory for planning\n',
+          '[claude] 📋 **Execution Memories Received:**\n[claude] - [mem_142] Memory for planning\n[claude] step 1\n[claude] step 2\n[claude] done\n',
         executionMemoryContext: makeMemoryContext(['mem_142']),
       });
       expect(result.passed).toBe(true);
@@ -1633,7 +1650,8 @@ describe('OrchestratorCompletionVerifier', () => {
         attempt: 1,
         maxAttempts: 5,
         agentType: 'pull_request',
-        rawLogs: '[claude] PR work done',
+        rawLogs:
+          '[claude] step 1\n[claude] step 2\n[claude] step 3\n[claude] step 4\n[claude] PR work done',
         executionMemoryContext: makeMemoryContext(['mem_200']),
       });
       expect(result.passed).toBe(false);
@@ -1664,7 +1682,8 @@ describe('OrchestratorCompletionVerifier', () => {
         attempt: 1,
         maxAttempts: 5,
         agentType: 'review',
-        rawLogs: '[claude] Review done',
+        rawLogs:
+          '[claude] step 1\n[claude] step 2\n[claude] step 3\n[claude] step 4\n[claude] Review done',
         executionMemoryContext: makeMemoryContext(['mem_300']),
       });
       expect(result.passed).toBe(false);
@@ -1694,7 +1713,8 @@ describe('OrchestratorCompletionVerifier', () => {
         attempt: 1,
         maxAttempts: 5,
         agentType: 'remediation',
-        rawLogs: '[claude] Remediation done',
+        rawLogs:
+          '[claude] step 1\n[claude] step 2\n[claude] step 3\n[claude] step 4\n[claude] Remediation done',
         executionMemoryContext: makeMemoryContext(['mem_400']),
       });
       expect(result.passed).toBe(false);
@@ -1725,7 +1745,8 @@ describe('OrchestratorCompletionVerifier', () => {
         attempt: 1,
         maxAttempts: 5,
         agentType: 'review',
-        rawLogs: '[claude] Review done',
+        rawLogs:
+          '[claude] step 1\n[claude] step 2\n[claude] step 3\n[claude] step 4\n[claude] Review done',
         executionMemoryContext: {
           applicationId: 'app-123',
           retrievalVersion: 'execution-memory-retrieval@1.0.0',
@@ -1759,7 +1780,8 @@ describe('OrchestratorCompletionVerifier', () => {
         attempt: 1,
         maxAttempts: 5,
         agentType: 'review',
-        rawLogs: '[claude] Review done',
+        rawLogs:
+          '[claude] step 1\n[claude] step 2\n[claude] step 3\n[claude] step 4\n[claude] Review done',
       });
       expect(result.passed).toBe(true);
     });
@@ -1790,7 +1812,8 @@ describe('OrchestratorCompletionVerifier', () => {
         attempt: 1,
         maxAttempts: 5,
         agentType: 'execution',
-        rawLogs: '[claude] Execution done',
+        rawLogs:
+          '[claude] step 1\n[claude] step 2\n[claude] step 3\n[claude] step 4\n[claude] Execution done',
         executionMemoryContext: makeMemoryContext(['mem_500']),
       });
       // Fails via validateMemoryReporting (memory_acknowledgment, memory_ids_unaccounted, memory_usage_summary),
@@ -1823,7 +1846,7 @@ describe('OrchestratorCompletionVerifier', () => {
         attempt: 1,
         maxAttempts: 5,
         agentType: 'planning',
-        rawLogs: 'logs',
+        rawLogs: transcriptWithMeaningfulLines('generic'),
       });
       expect(result.passed).toBe(false);
       expect(result.verifierFailure).toBe(true);
@@ -1852,7 +1875,7 @@ describe('OrchestratorCompletionVerifier', () => {
         attempt: 1,
         maxAttempts: 5,
         agentType: 'execution',
-        rawLogs: 'logs',
+        rawLogs: transcriptWithMeaningfulLines('generic'),
       });
       expect(result.passed).toBe(false);
       expect(result.verifierFailure).toBe(true);
@@ -1880,7 +1903,7 @@ describe('OrchestratorCompletionVerifier', () => {
         attempt: 1,
         maxAttempts: 5,
         agentType: 'pull_request',
-        rawLogs: 'logs',
+        rawLogs: transcriptWithMeaningfulLines('generic'),
       });
       expect(result.passed).toBe(false);
       expect(result.verifierFailure).toBe(false);
@@ -1939,52 +1962,129 @@ describe('OrchestratorCompletionVerifier', () => {
       expect(logged).not.toContain('second line');
     });
 
-    it('logs full transcript when <=2 non-empty lines', async () => {
-      generateMock.mockResolvedValueOnce({
-        ok: true,
-        value: {
-          content: validPlanningResponse,
-          usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30, costUsd: 0.001 },
-        },
-      });
+    it('short transcript short-circuits before logger.info (<=2 non-empty lines)', async () => {
       const verifier = createVerifier();
-      await verifier.verify({
+      const result = await verifier.verify({
         taskId: 'task-short',
         attempt: 1,
         maxAttempts: 5,
         agentType: 'planning',
         rawLogs: 'only one line',
       });
+      expect(result.passed).toBe(false);
+      expect(result.missingFields).toEqual(['transcript_too_short']);
       const infoCall = loggerInfo.mock.calls.find(
         (c: unknown[]) => typeof c[1] === 'string' && c[1] === 'Completion verifier request'
-      ) as [Record<string, unknown>, string] | undefined;
-      expect(infoCall).toBeDefined();
-      const logged = infoCall?.[0]?.['transcript'] as string;
-      expect(logged).toBe('only one line');
+      );
+      expect(infoCall).toBeUndefined();
     });
 
-    it('handles whitespace-only rawLogs with empty fallback', async () => {
-      generateMock.mockResolvedValueOnce({
-        ok: true,
-        value: {
-          content: validPlanningResponse,
-          usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30, costUsd: 0.001 },
-        },
-      });
+    it('whitespace-only rawLogs short-circuits before logger.info', async () => {
       const verifier = createVerifier();
-      await verifier.verify({
+      const result = await verifier.verify({
         taskId: 'task-empty',
         attempt: 1,
         maxAttempts: 5,
         agentType: 'planning',
         rawLogs: '   \n  \n   ',
       });
+      expect(result.passed).toBe(false);
+      expect(result.missingFields).toEqual(['transcript_too_short']);
       const infoCall = loggerInfo.mock.calls.find(
         (c: unknown[]) => typeof c[1] === 'string' && c[1] === 'Completion verifier request'
-      ) as [Record<string, unknown>, string] | undefined;
-      expect(infoCall).toBeDefined();
-      const logged = infoCall?.[0]?.['transcript'] as string;
-      expect(logged).toBe('');
+      );
+      expect(infoCall).toBeUndefined();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // verify — short transcript guard
+  // ---------------------------------------------------------------------------
+
+  describe('verify — short transcript guard', () => {
+    it('rejects pure infrastructure transcript without calling LLM', async () => {
+      const verifier = createVerifier();
+      const result = await verifier.verify({
+        taskId: 'task-guard-pure-infra',
+        attempt: 2,
+        maxAttempts: 5,
+        agentType: 'execution',
+        rawLogs: [
+          '[orchestrator] attempt 2 starting',
+          '[hook] pre-hook fired',
+          '[entrypoint] container ready',
+          '[system] Inactivity restart completed',
+          '[entrypoint] Claude attempt finished with exit code: 0',
+        ].join('\n'),
+      });
+      expect(result.passed).toBe(false);
+      expect(result.missingFields).toEqual(['transcript_too_short']);
+      expect(result.verifierFailure).toBe(false);
+      expect(generateMock).not.toHaveBeenCalled();
+      expect(loggerWarn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          taskId: 'task-guard-pure-infra',
+          attempt: 2,
+          agentType: 'execution',
+          meaningfulLines: 0,
+        }),
+        'Completion verifier: transcript too short, refusing to call LLM'
+      );
+    });
+
+    it('rejects transcript with 4 meaningful lines mixed with infra', async () => {
+      const verifier = createVerifier();
+      const result = await verifier.verify({
+        taskId: 'task-guard-four',
+        attempt: 1,
+        maxAttempts: 5,
+        agentType: 'planning',
+        rawLogs: [
+          '[orchestrator] starting',
+          '[claude] line 1',
+          '[claude] line 2',
+          '[system] heartbeat',
+          '[claude] line 3',
+          '[claude] line 4',
+        ].join('\n'),
+      });
+      expect(result.passed).toBe(false);
+      expect(result.missingFields).toEqual(['transcript_too_short']);
+      expect(generateMock).not.toHaveBeenCalled();
+      expect(loggerWarn).toHaveBeenCalledWith(
+        expect.objectContaining({ meaningfulLines: 4 }),
+        'Completion verifier: transcript too short, refusing to call LLM'
+      );
+    });
+
+    it('allows transcript with exactly 5 meaningful lines', async () => {
+      generateMock.mockResolvedValueOnce({
+        ok: true,
+        value: {
+          content: JSON.stringify({
+            outcome: 'planned',
+            superpowers_writing_plans: 'used',
+            linear_url: 'https://linear.app/pbuchman/issue/INT-100',
+            is_complex: '0',
+            has_plan_doc: '0',
+            subtask_urls: '',
+            pr_url: 'https://github.com/pbuchman/intexuraos/pull/100',
+            summary: 'Planned.',
+            unclear_clarification: '',
+          }),
+          usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30, costUsd: 0.001 },
+        },
+      });
+      const verifier = createVerifier();
+      const result = await verifier.verify({
+        taskId: 'task-guard-five',
+        attempt: 1,
+        maxAttempts: 5,
+        agentType: 'planning',
+        rawLogs: transcriptWithMeaningfulLines('guard-five'),
+      });
+      expect(result.passed).toBe(true);
+      expect(generateMock).toHaveBeenCalledOnce();
     });
   });
 
@@ -2014,7 +2114,7 @@ describe('OrchestratorCompletionVerifier', () => {
         attempt: 1,
         maxAttempts: 5,
         agentType: 'planning',
-        rawLogs: 'logs',
+        rawLogs: transcriptWithMeaningfulLines('generic'),
       });
       expect(result.passed).toBe(true);
       expect(result.agentData?.agentType).toBe('planning');
@@ -2132,7 +2232,8 @@ describe('verify — fatal exit code pre-check', () => {
       attempt: 1,
       maxAttempts: 5,
       agentType: 'planning',
-      rawLogs: 'output\n[entrypoint] Claude attempt finished with exit code: 0\n',
+      rawLogs:
+        '[claude] step 1\n[claude] step 2\n[claude] step 3\n[claude] step 4\noutput\n[entrypoint] Claude attempt finished with exit code: 0\n',
     });
     expect(result.passed).toBe(true);
     expect(generateMock).toHaveBeenCalledOnce();
@@ -2161,7 +2262,8 @@ describe('verify — fatal exit code pre-check', () => {
       attempt: 1,
       maxAttempts: 5,
       agentType: 'execution',
-      rawLogs: 'output\n[entrypoint] Claude attempt finished with exit code: 1\n',
+      rawLogs:
+        '[claude] step 1\n[claude] step 2\n[claude] step 3\n[claude] step 4\noutput\n[entrypoint] Claude attempt finished with exit code: 1\n',
     });
     expect(result.passed).toBe(true);
     expect(generateMock).toHaveBeenCalledOnce();

--- a/workers/orchestrator/src/services/completion-verifier.ts
+++ b/workers/orchestrator/src/services/completion-verifier.ts
@@ -229,13 +229,10 @@ const MIN_MEANINGFUL_TRANSCRIPT_LINES = 5;
 
 const INFRASTRUCTURE_LINE_PREFIXES = ['[orchestrator]', '[hook]', '[entrypoint]', '[system]'];
 
-export function countMeaningfulTranscriptLines(transcript: string): number {
+export function countMeaningfulTranscriptLines(nonEmptyLines: readonly string[]): number {
   let count = 0;
-  for (const line of transcript.split('\n')) {
+  for (const line of nonEmptyLines) {
     const trimmed = line.trim();
-    if (trimmed === '') {
-      continue;
-    }
     if (INFRASTRUCTURE_LINE_PREFIXES.some((prefix) => trimmed.startsWith(prefix))) {
       continue;
     }
@@ -631,7 +628,8 @@ export class OrchestratorCompletionVerifier implements CompletionVerifier {
       };
     }
 
-    const meaningfulLines = countMeaningfulTranscriptLines(transcript);
+    const tLines = transcript.split('\n').filter((l) => l.trim() !== '');
+    const meaningfulLines = countMeaningfulTranscriptLines(tLines);
     if (meaningfulLines < MIN_MEANINGFUL_TRANSCRIPT_LINES) {
       this.logger.warn(
         {
@@ -661,7 +659,6 @@ export class OrchestratorCompletionVerifier implements CompletionVerifier {
         model: this.primaryModelName,
         promptChars: prompt.length,
         transcript: ((): string => {
-          const tLines = transcript.split('\n').filter((l) => l.trim() !== '');
           /* v8 ignore start -- ts-type: nullish coalescing on array access required by noUncheckedIndexedAccess; transcript guard guarantees tLines.length >= MIN_MEANINGFUL_TRANSCRIPT_LINES @preserve */
           const first = tLines[0] ?? '';
           const last = tLines[tLines.length - 1] ?? '';

--- a/workers/orchestrator/src/services/completion-verifier.ts
+++ b/workers/orchestrator/src/services/completion-verifier.ts
@@ -225,6 +225,25 @@ export const RESUME_SUMMARY_SCHEMA = z.object({
 const FATAL_EXIT_CODE_PATTERN =
   /\[entrypoint\] (?:Claude|Codex) attempt finished with exit code: (137|139)/;
 
+const MIN_MEANINGFUL_TRANSCRIPT_LINES = 5;
+
+const INFRASTRUCTURE_LINE_PREFIXES = ['[orchestrator]', '[hook]', '[entrypoint]', '[system]'];
+
+export function countMeaningfulTranscriptLines(transcript: string): number {
+  let count = 0;
+  for (const line of transcript.split('\n')) {
+    const trimmed = line.trim();
+    if (trimmed === '') {
+      continue;
+    }
+    if (INFRASTRUCTURE_LINE_PREFIXES.some((prefix) => trimmed.startsWith(prefix))) {
+      continue;
+    }
+    count += 1;
+  }
+  return count;
+}
+
 export function detectFatalExitCode(rawLogs: string): number | undefined {
   // Only search the last 5 lines to avoid false positives from Claude's
   // stream-json output containing test fixtures or code snippets with the pattern.
@@ -612,6 +631,25 @@ export class OrchestratorCompletionVerifier implements CompletionVerifier {
       };
     }
 
+    const meaningfulLines = countMeaningfulTranscriptLines(transcript);
+    if (meaningfulLines < MIN_MEANINGFUL_TRANSCRIPT_LINES) {
+      this.logger.warn(
+        {
+          taskId: input.taskId,
+          attempt: input.attempt,
+          agentType: input.agentType,
+          meaningfulLines,
+        },
+        'Completion verifier: transcript too short, refusing to call LLM'
+      );
+      return {
+        passed: false,
+        missingFields: ['transcript_too_short'],
+        verifierFailure: false,
+        trace: { transcript, prompt: '', response: '' },
+      };
+    }
+
     const { schema, prompt } = selectSchemaAndPrompt(input.agentType, transcript);
 
     this.logger.info(
@@ -624,11 +662,11 @@ export class OrchestratorCompletionVerifier implements CompletionVerifier {
         promptChars: prompt.length,
         transcript: ((): string => {
           const tLines = transcript.split('\n').filter((l) => l.trim() !== '');
+          /* v8 ignore start -- ts-type: nullish coalescing on array access required by noUncheckedIndexedAccess; transcript guard guarantees tLines.length >= MIN_MEANINGFUL_TRANSCRIPT_LINES @preserve */
           const first = tLines[0] ?? '';
           const last = tLines[tLines.length - 1] ?? '';
-          return tLines.length <= 2
-            ? tLines.join('\n')
-            : `${first}\n  ... (${String(tLines.length - 2)} lines omitted) ...\n${last}`;
+          /* v8 ignore stop @preserve */
+          return `${first}\n  ... (${String(tLines.length - 2)} lines omitted) ...\n${last}`;
         })(),
       },
       'Completion verifier request'

--- a/workers/orchestrator/src/services/isolation/docker-provider.ts
+++ b/workers/orchestrator/src/services/isolation/docker-provider.ts
@@ -6,7 +6,9 @@ import { fileURLToPath } from 'node:url';
 import type { Logger } from '@intexuraos/common-core';
 import type { WorkerRuntime } from '../runtime/types.js';
 import { withTimeout } from '../../with-timeout.js';
+import { pipeline } from 'node:stream/promises';
 import type {
+  ContainerStatsSnapshot,
   DiscoveredContainer,
   IsolationProvider,
   WorkerConfig,
@@ -1049,6 +1051,40 @@ export class DockerProvider implements IsolationProvider {
       cpuPercent: Math.round(cpuPercent * 100) / 100,
       memoryUsedMB: Math.round(stats.memory_stats.usage / 1024 / 1024),
       memoryLimitMB: Math.round(stats.memory_stats.limit / 1024 / 1024),
+    };
+  }
+
+  async copyOut(taskId: string, srcPath: string, destPath: string): Promise<void> {
+    const worker = this.workers.get(taskId);
+    /* v8 ignore start -- ts-type: Map.get() returns T | undefined; unit test cannot reach this branch because copyOut is only invoked from handleInactivityRestart where the worker !== undefined invariant always holds @preserve */
+    if (worker === undefined) {
+      throw new Error(`Worker ${taskId} not found`);
+    }
+    /* v8 ignore stop @preserve */
+    const container = this.docker.getContainer(worker.containerId);
+    const tarStream = await container.getArchive({ path: srcPath });
+    await fs.promises.mkdir(destPath, { recursive: true });
+    // Save the raw tar archive (no extraction) to keep `tar` package out of deps.
+    // Evidence is recoverable via `tar -xf <file>` when a human investigates.
+    const tarPath = path.join(destPath, `${path.basename(srcPath)}.tar`);
+    await pipeline(tarStream, fs.createWriteStream(tarPath));
+  }
+
+  async statsSnapshot(taskId: string): Promise<ContainerStatsSnapshot | null> {
+    const worker = this.workers.get(taskId);
+    /* v8 ignore start -- ts-type: Map.get() returns T | undefined; unit test cannot reach this branch because statsSnapshot is only invoked from handleInactivityRestart where the worker !== undefined invariant always holds @preserve */
+    if (worker === undefined) {
+      return null;
+    }
+    /* v8 ignore stop @preserve */
+    const container = this.docker.getContainer(worker.containerId);
+    const stats = await container.stats({ stream: false });
+    return {
+      cpuTotalUsage: stats.cpu_stats.cpu_usage.total_usage,
+      memoryUsage: stats.memory_stats.usage,
+      /* v8 ignore start -- ts-type: nullish coalescing on optional dockerode field required by strict TS @preserve */
+      pidsCurrent: stats.pids_stats?.current ?? 0,
+      /* v8 ignore stop @preserve */
     };
   }
 

--- a/workers/orchestrator/src/services/isolation/docker-provider.ts
+++ b/workers/orchestrator/src/services/isolation/docker-provider.ts
@@ -1062,10 +1062,11 @@ export class DockerProvider implements IsolationProvider {
     }
     /* v8 ignore stop @preserve */
     const container = this.docker.getContainer(worker.containerId);
-    const tarStream = await container.getArchive({ path: srcPath });
-    await fs.promises.mkdir(destPath, { recursive: true });
-    // Save the raw tar archive (no extraction) to keep `tar` package out of deps.
-    // Evidence is recoverable via `tar -xf <file>` when a human investigates.
+    const [tarStream] = await Promise.all([
+      container.getArchive({ path: srcPath }),
+      fs.promises.mkdir(destPath, { recursive: true }),
+    ]);
+    // Raw tar archive (no extraction) — keeps `tar` package out of production deps.
     const tarPath = path.join(destPath, `${path.basename(srcPath)}.tar`);
     await pipeline(tarStream, fs.createWriteStream(tarPath));
   }

--- a/workers/orchestrator/src/services/isolation/types.ts
+++ b/workers/orchestrator/src/services/isolation/types.ts
@@ -148,6 +148,12 @@ export interface ResourceUsage {
   memoryLimitMB: number;
 }
 
+export interface ContainerStatsSnapshot {
+  cpuTotalUsage: number;
+  memoryUsage: number;
+  pidsCurrent: number;
+}
+
 export interface DiscoveredContainer {
   containerId: string;
   taskId: string;
@@ -197,6 +203,19 @@ export interface IsolationProvider {
    * Get current resource usage of worker container.
    */
   getResourceUsage(taskId: string): Promise<ResourceUsage>;
+
+  /**
+   * Copy a file or directory from the container filesystem to the host.
+   * Used to capture forensic evidence before destructive operations (e.g.
+   * inactivity-kill). Writes a tar archive to destPath.
+   */
+  copyOut(taskId: string, srcPath: string, destPath: string): Promise<void>;
+
+  /**
+   * Capture a one-shot docker stats snapshot of the container.
+   * Returns null when the container no longer exists.
+   */
+  statsSnapshot(taskId: string): Promise<ContainerStatsSnapshot | null>;
 
   /**
    * List all running worker containers.

--- a/workers/orchestrator/src/services/task-dispatcher.ts
+++ b/workers/orchestrator/src/services/task-dispatcher.ts
@@ -1118,6 +1118,25 @@ export class TaskDispatcher {
       'Inactivity restart triggered'
     );
 
+    const evidenceDir = `/var/log/orchestrator/inactivity-evidence/${taskId}/`;
+    try {
+      await this.isolation.provider.copyOut(taskId, '/tmp', evidenceDir);
+    } catch (evidenceError) {
+      this.logger.warn(
+        { taskId, error: getErrorMessage(evidenceError) },
+        'Failed to copy /tmp evidence before inactivity kill'
+      );
+    }
+    try {
+      const stats = await this.isolation.provider.statsSnapshot(taskId);
+      this.logger.warn({ taskId, stats }, 'Container stats at inactivity kill');
+    } catch (statsError) {
+      this.logger.warn(
+        { taskId, error: getErrorMessage(statsError) },
+        'Failed to capture container stats before inactivity kill'
+      );
+    }
+
     try {
       await this.isolation.provider.destroyWorker(taskId);
     } catch (destroyError) {

--- a/workers/orchestrator/src/services/task-dispatcher.ts
+++ b/workers/orchestrator/src/services/task-dispatcher.ts
@@ -1119,20 +1119,21 @@ export class TaskDispatcher {
     );
 
     const evidenceDir = `/var/log/orchestrator/inactivity-evidence/${taskId}/`;
-    try {
-      await this.isolation.provider.copyOut(taskId, '/tmp', evidenceDir);
-    } catch (evidenceError) {
+    const [copyResult, statsResult] = await Promise.allSettled([
+      this.isolation.provider.copyOut(taskId, '/tmp', evidenceDir),
+      this.isolation.provider.statsSnapshot(taskId),
+    ]);
+    if (copyResult.status === 'rejected') {
       this.logger.warn(
-        { taskId, error: getErrorMessage(evidenceError) },
+        { taskId, error: getErrorMessage(copyResult.reason) },
         'Failed to copy /tmp evidence before inactivity kill'
       );
     }
-    try {
-      const stats = await this.isolation.provider.statsSnapshot(taskId);
-      this.logger.warn({ taskId, stats }, 'Container stats at inactivity kill');
-    } catch (statsError) {
+    if (statsResult.status === 'fulfilled') {
+      this.logger.warn({ taskId, stats: statsResult.value }, 'Container stats at inactivity kill');
+    } else {
       this.logger.warn(
-        { taskId, error: getErrorMessage(statsError) },
+        { taskId, error: getErrorMessage(statsResult.reason) },
         'Failed to capture container stats before inactivity kill'
       );
     }


### PR DESCRIPTION
## Summary

Production task was finalized as `implemented` against an unrelated 6-week-old PR after an inactivity restart. Three coordinated fixes:

- **A1 — Empty-transcript guard** (`workers/orchestrator/src/services/completion-verifier.ts`): add `MIN_MEANINGFUL_TRANSCRIPT_LINES=5` guard that short-circuits before the LLM call when the post-restart transcript contains fewer than 5 non-infrastructure lines. Prevents Gemini from hallucinating a plausible PR URL from an empty/near-empty transcript.
- **A2 — PR-URL validation hard-fail** (`apps/code-agent/src/routes/webhookRoutes.ts`): promote INT-1361's `prUrlValidationFailed` from advisory flag to hard-fail. Task now ends as `failed` with error code `EXECUTION_AGENT_PR_URL_VALIDATION_FAILED` when title-match or dispatch-recency checks reject the reported PR.
- **B1 + B2 — Inactivity-kill forensics** (`workers/orchestrator/src/services/isolation/*`, `task-dispatcher.ts`): add `copyOut` and `statsSnapshot` to `IsolationProvider`. `handleInactivityRestart` now captures a `/tmp` tar archive and docker stats snapshot before destroying the worker. Evidence is best-effort; failures don't block the restart.

Full plan: `docs/plans/2026-04-17-inactivity-restart-wrong-pr-and-evidence.md`.

## Test plan

- [x] `pnpm run verify:workspace:tracked code-agent` (14727 passed)
- [x] `pnpm run verify:workspace:tracked orchestrator` (14734 passed — +7 new tests)
- [x] `pnpm run ci:tracked` (all checks green)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>