### PR TITLE
[INT-1403] refactor: simplify execution memory pipeline fix

### DIFF
--- a/workers/orchestrator/src/__tests__/create-task-request-schema.test.ts
+++ b/workers/orchestrator/src/__tests__/create-task-request-schema.test.ts
@@ -77,3 +77,22 @@ describe('CreateTaskRequestSchema', () => {
     expect(result.success).toBe(true);
   });
 });
+
+describe('CreateTaskRequestSchema — retriedFrom', () => {
+  it('accepts retriedFrom and preserves it through parse', () => {
+    const result = CreateTaskRequestSchema.safeParse({
+      taskId: 't1',
+      workerType: 'auto',
+      prompt: 'p',
+      webhookUrl: 'https://example.com/hook',
+      webhookSecret: 'sec',
+      linearIssueLabels: [],
+      hasChildren: false,
+      retriedFrom: 'task_original_abc',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.retriedFrom).toBe('task_original_abc');
+    }
+  });
+});

--- a/workers/orchestrator/src/__tests__/routes.test.ts
+++ b/workers/orchestrator/src/__tests__/routes.test.ts
@@ -464,6 +464,102 @@ describe('Routes', () => {
     });
   });
 
+  describe('POST /tasks — field propagation to dispatcher', () => {
+    it('forwards executionMemoryContext to dispatcher.submitTask', async () => {
+      const payload = {
+        taskId: 'emc-1',
+        workerType: 'auto',
+        prompt: 'p',
+        webhookUrl: 'https://example.com/hook',
+        webhookSecret: 'sec',
+        linearIssueLabels: [],
+        hasChildren: false,
+        executionMemoryContext: {
+          applicationId: 'app_1',
+          retrievalVersion: 'v1',
+          querySummary: 'q',
+          matchedMemories: [
+            {
+              memoryId: 'mem_1',
+              title: 't',
+              memoryType: 'implementation_pattern',
+              score: 0.5,
+              appliesWhen: 'a',
+              action: 'x',
+              avoid: 'y',
+              verification: 'z',
+            },
+          ],
+        },
+      };
+      const { headers, body } = createSignedRequest(payload);
+      const response = await app.inject({ method: 'POST', url: '/tasks', headers, body });
+      expect(response.statusCode).toBe(202);
+      expect(dispatcher.submitTask).toHaveBeenCalledWith(
+        expect.objectContaining({
+          executionMemoryContext: payload.executionMemoryContext,
+        })
+      );
+    });
+
+    it('forwards trackingCommentId to dispatcher.submitTask', async () => {
+      const payload = {
+        taskId: 'tc-1',
+        workerType: 'auto',
+        prompt: 'p',
+        webhookUrl: 'https://example.com/hook',
+        webhookSecret: 'sec',
+        linearIssueLabels: [],
+        hasChildren: false,
+        trackingCommentId: '1234567',
+      };
+      const { headers, body } = createSignedRequest(payload);
+      const response = await app.inject({ method: 'POST', url: '/tasks', headers, body });
+      expect(response.statusCode).toBe(202);
+      expect(dispatcher.submitTask).toHaveBeenCalledWith(
+        expect.objectContaining({ trackingCommentId: '1234567' })
+      );
+    });
+
+    it('forwards reviewTypes to dispatcher.submitTask', async () => {
+      const payload = {
+        taskId: 'rt-1',
+        workerType: 'auto',
+        prompt: 'p',
+        webhookUrl: 'https://example.com/hook',
+        webhookSecret: 'sec',
+        linearIssueLabels: [],
+        hasChildren: false,
+        reviewTypes: ['code_quality', 'security'],
+      };
+      const { headers, body } = createSignedRequest(payload);
+      const response = await app.inject({ method: 'POST', url: '/tasks', headers, body });
+      expect(response.statusCode).toBe(202);
+      expect(dispatcher.submitTask).toHaveBeenCalledWith(
+        expect.objectContaining({ reviewTypes: ['code_quality', 'security'] })
+      );
+    });
+
+    it('forwards retriedFrom to dispatcher.submitTask', async () => {
+      const payload = {
+        taskId: 'rf-1',
+        workerType: 'auto',
+        prompt: 'p',
+        webhookUrl: 'https://example.com/hook',
+        webhookSecret: 'sec',
+        linearIssueLabels: [],
+        hasChildren: false,
+        retriedFrom: 'task_original_abc',
+      };
+      const { headers, body } = createSignedRequest(payload);
+      const response = await app.inject({ method: 'POST', url: '/tasks', headers, body });
+      expect(response.statusCode).toBe(202);
+      expect(dispatcher.submitTask).toHaveBeenCalledWith(
+        expect.objectContaining({ retriedFrom: 'task_original_abc' })
+      );
+    });
+  });
+
   describe('GET /tasks/:id', () => {
     it('should return task status', async () => {
       vi.mocked(dispatcher.getTask).mockResolvedValueOnce({

--- a/workers/orchestrator/src/__tests__/routes.test.ts
+++ b/workers/orchestrator/src/__tests__/routes.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import Fastify, { type FastifyInstance } from 'fastify';
 import { createHmac } from 'node:crypto';
 import { registerRoutes, cleanUpExpiredNonces } from '../routes.js';
+import { buildSystemPrompt } from '../services/system-prompt.js';
 import type { TaskDispatcher } from '../services/task-dispatcher.js';
 import type { GitHubTokenService } from '../github/token-service.js';
 import type { IsolationProvider } from '../services/isolation/types.js';
@@ -557,6 +558,57 @@ describe('Routes', () => {
       expect(dispatcher.submitTask).toHaveBeenCalledWith(
         expect.objectContaining({ retriedFrom: 'task_original_abc' })
       );
+    });
+
+    it('executionMemoryContext flows from POST body into the rendered system prompt', async () => {
+      const memoryContext = {
+        applicationId: 'app_e2e',
+        retrievalVersion: 'v1',
+        querySummary: 'q',
+        matchedMemories: [
+          {
+            memoryId: 'mem_e2e_abc',
+            title: 'Check composite index before query',
+            memoryType: 'verification_pattern' as const,
+            score: 0.7,
+            appliesWhen: 'multi-field firestore queries',
+            action: 'add index to firestore-collections.json',
+            avoid: 'running query without index',
+            verification: 'query returns results without error',
+          },
+        ],
+      };
+      const payload = {
+        taskId: 'e2e-1',
+        workerType: 'auto',
+        prompt: 'p',
+        webhookUrl: 'https://example.com/hook',
+        webhookSecret: 'sec',
+        linearIssueLabels: [],
+        hasChildren: false,
+        agentType: 'review',
+        executionMemoryContext: memoryContext,
+      };
+      const { headers, body } = createSignedRequest(payload);
+      const response = await app.inject({ method: 'POST', url: '/tasks', headers, body });
+      expect(response.statusCode).toBe(202);
+
+      const submitCalls = (dispatcher.submitTask as ReturnType<typeof vi.fn>).mock.calls;
+      expect(submitCalls.length).toBeGreaterThanOrEqual(1);
+      const firstCall = submitCalls[0];
+      expect(firstCall).toBeDefined();
+      const submitted = (firstCall as unknown as [Record<string, unknown>])[0];
+      expect(submitted['executionMemoryContext']).toEqual(memoryContext);
+
+      const rendered = buildSystemPrompt({
+        taskId: submitted['taskId'] as string,
+        linearIssueLabels: submitted['linearIssueLabels'] as string[],
+        agentType: 'review',
+        executionMemoryContext: submitted['executionMemoryContext'] as typeof memoryContext,
+      });
+      expect(rendered).toContain('### Execution Memory Context');
+      expect(rendered).toContain('mem_e2e_abc');
+      expect(rendered).toContain('Execution Memories Received');
     });
   });
 

--- a/workers/orchestrator/src/__tests__/system-prompt.test.ts
+++ b/workers/orchestrator/src/__tests__/system-prompt.test.ts
@@ -255,7 +255,6 @@ describe('buildExecutionMemorySection acknowledgment and reporting', () => {
       linearIssueLabels: [],
     });
 
-    // The memory acknowledgment / reporting instructions only appear when memories are injected.
     expect(prompt).not.toContain('MANDATORY: Acknowledge Execution Memories NOW');
     expect(prompt).not.toContain('MANDATORY: Report Memory Usage in Final Output');
     // The final-block template still lists memory_ids_used with a "none" fallback so workers

--- a/workers/orchestrator/src/__tests__/system-prompt.test.ts
+++ b/workers/orchestrator/src/__tests__/system-prompt.test.ts
@@ -364,8 +364,8 @@ describe('askAgentPrompt', () => {
 });
 
 describe('prompt versions', () => {
-  it('reviewPrompt version is 9.2.1', () => {
-    expect(reviewPrompt.version).toBe('9.2.1');
+  it('reviewPrompt version is 10.0.0', () => {
+    expect(reviewPrompt.version).toBe('10.0.0');
   });
 
   it('pullRequestPrompt version is 5.0.0', () => {

--- a/workers/orchestrator/src/__tests__/system-prompt.test.ts
+++ b/workers/orchestrator/src/__tests__/system-prompt.test.ts
@@ -249,15 +249,18 @@ describe('buildExecutionMemorySection acknowledgment and reporting', () => {
     expect(prompt).toContain('memory_usage_summary');
   });
 
-  it('does not include acknowledgment or reporting when no memories matched', () => {
+  it('does not include acknowledgment or reporting instructions when no memories matched', () => {
     const prompt = planningPrompt.build({
       taskId: 'task-no-mem',
       linearIssueLabels: [],
     });
 
+    // The memory acknowledgment / reporting instructions only appear when memories are injected.
     expect(prompt).not.toContain('MANDATORY: Acknowledge Execution Memories NOW');
     expect(prompt).not.toContain('MANDATORY: Report Memory Usage in Final Output');
-    expect(prompt).not.toContain('memory_ids_used');
+    // The final-block template still lists memory_ids_used with a "none" fallback so workers
+    // always report these fields — even when no memories are injected.
+    expect(prompt).toContain('memory_ids_used: <comma-separated injected IDs you applied, or "none">');
   });
 });
 

--- a/workers/orchestrator/src/__tests__/system-prompt.test.ts
+++ b/workers/orchestrator/src/__tests__/system-prompt.test.ts
@@ -368,8 +368,8 @@ describe('prompt versions', () => {
     expect(reviewPrompt.version).toBe('9.2.1');
   });
 
-  it('pullRequestPrompt version is 4.3.0', () => {
-    expect(pullRequestPrompt.version).toBe('4.3.0');
+  it('pullRequestPrompt version is 5.0.0', () => {
+    expect(pullRequestPrompt.version).toBe('5.0.0');
   });
 });
 

--- a/workers/orchestrator/src/__tests__/system-prompt.test.ts
+++ b/workers/orchestrator/src/__tests__/system-prompt.test.ts
@@ -260,7 +260,9 @@ describe('buildExecutionMemorySection acknowledgment and reporting', () => {
     expect(prompt).not.toContain('MANDATORY: Report Memory Usage in Final Output');
     // The final-block template still lists memory_ids_used with a "none" fallback so workers
     // always report these fields — even when no memories are injected.
-    expect(prompt).toContain('memory_ids_used: <comma-separated injected IDs you applied, or "none">');
+    expect(prompt).toContain(
+      'memory_ids_used: <comma-separated injected IDs you applied, or "none">'
+    );
   });
 });
 

--- a/workers/orchestrator/src/routes.ts
+++ b/workers/orchestrator/src/routes.ts
@@ -164,6 +164,14 @@ export function registerRoutes(
         continuationPrBranch: parsed.continuationPrBranch,
       }),
       ...(parsed.prNumber !== undefined && { prNumber: parsed.prNumber }),
+      ...(parsed.executionMemoryContext !== undefined && {
+        executionMemoryContext: parsed.executionMemoryContext,
+      }),
+      ...(parsed.trackingCommentId !== undefined && {
+        trackingCommentId: parsed.trackingCommentId,
+      }),
+      ...(parsed.reviewTypes !== undefined && { reviewTypes: parsed.reviewTypes }),
+      ...(parsed.retriedFrom !== undefined && { retriedFrom: parsed.retriedFrom }),
     };
 
     logger.info(

--- a/workers/orchestrator/src/services/__tests__/system-prompt.test.ts
+++ b/workers/orchestrator/src/services/__tests__/system-prompt.test.ts
@@ -1264,8 +1264,8 @@ describe('system-prompt', () => {
     }
   });
 
-  it('planning prompt version is 6.1.0', () => {
-    expect(planningPrompt.version).toBe('6.1.0');
+  it('planning prompt version is 7.0.0', () => {
+    expect(planningPrompt.version).toBe('7.0.0');
   });
 
   it('execution prompt version is 9.1.0', () => {
@@ -1318,6 +1318,93 @@ describe('system-prompt', () => {
     expect(executionResult).toContain('memory_ids_rejected');
     expect(executionResult).toContain('memory_usage_summary');
     expect(planningResult).not.toContain('### Execution Memory');
+  });
+
+  describe('memory fields in agent final blocks', () => {
+    const memoryContext = {
+      applicationId: 'app_1',
+      retrievalVersion: 'v1',
+      querySummary: 'q',
+      matchedMemories: [
+        {
+          memoryId: 'mem_abc',
+          title: 't',
+          memoryType: 'implementation_pattern' as const,
+          score: 0.5,
+          appliesWhen: 'a',
+          action: 'x',
+          avoid: 'y',
+          verification: 'z',
+        },
+      ],
+    };
+
+    const extractFinalBlock = (prompt: string, marker: string): string => {
+      // Find the fenced code block that begins with the marker (not the textual references).
+      const fenceMarker = '```\n' + marker;
+      const fenceStart = prompt.indexOf(fenceMarker);
+      expect(fenceStart).toBeGreaterThanOrEqual(0);
+      const blockStart = fenceStart + '```\n'.length;
+      const blockEnd = prompt.indexOf('```', blockStart);
+      expect(blockEnd).toBeGreaterThan(blockStart);
+      return prompt.slice(blockStart, blockEnd);
+    };
+
+    it('lists memory_ids_used/rejected/usage_summary in PLANNING_AGENT_FINAL', () => {
+      const prompt = planningPrompt.build({
+        taskId: 't1',
+        linearIssueLabels: [],
+        workerType: 'auto',
+        executionMemoryContext: memoryContext,
+      });
+      const block = extractFinalBlock(prompt, 'PLANNING_AGENT_FINAL:');
+      expect(block).toContain('memory_ids_used:');
+      expect(block).toContain('memory_ids_rejected:');
+      expect(block).toContain('memory_usage_summary:');
+    });
+
+    it('lists memory fields in REMEDIATION_AGENT_FINAL', () => {
+      const prompt = remediationPrompt.build({
+        taskId: 't1',
+        linearIssueLabels: [],
+        workerType: 'auto',
+        executionMemoryContext: memoryContext,
+      });
+      const block = extractFinalBlock(prompt, 'REMEDIATION_AGENT_FINAL:');
+      expect(block).toContain('memory_ids_used:');
+      expect(block).toContain('memory_ids_rejected:');
+      expect(block).toContain('memory_usage_summary:');
+    });
+
+    it('lists memory fields in every PULL_REQUEST_AGENT_FINAL occurrence in the source file', async () => {
+      const { readFile } = await import('node:fs/promises');
+      const { fileURLToPath } = await import('node:url');
+      const currentUrl = import.meta.url;
+      const currentDir = fileURLToPath(new URL('.', currentUrl));
+      const src = await readFile(`${currentDir}../system-prompt.ts`, 'utf8');
+      const occurrences = src.split('PULL_REQUEST_AGENT_FINAL:').length - 1;
+      expect(occurrences).toBeGreaterThanOrEqual(2);
+      const blocks = src.split('PULL_REQUEST_AGENT_FINAL:').slice(1);
+      for (const tail of blocks) {
+        const block = tail.slice(0, tail.indexOf('```'));
+        expect(block).toContain('memory_ids_used:');
+        expect(block).toContain('memory_ids_rejected:');
+        expect(block).toContain('memory_usage_summary:');
+      }
+    });
+
+    it('lists memory fields in REVIEW_AGENT_FINAL', () => {
+      const prompt = reviewPrompt.build({
+        taskId: 't1',
+        linearIssueLabels: [],
+        workerType: 'auto',
+        executionMemoryContext: memoryContext,
+      });
+      const block = extractFinalBlock(prompt, 'REVIEW_AGENT_FINAL:');
+      expect(block).toContain('memory_ids_used:');
+      expect(block).toContain('memory_ids_rejected:');
+      expect(block).toContain('memory_usage_summary:');
+    });
   });
 
   it('review agent prompt includes Linear section when linearIssueId is provided', () => {

--- a/workers/orchestrator/src/services/__tests__/system-prompt.test.ts
+++ b/workers/orchestrator/src/services/__tests__/system-prompt.test.ts
@@ -1376,21 +1376,32 @@ describe('system-prompt', () => {
       expect(block).toContain('memory_usage_summary:');
     });
 
-    it('lists memory fields in every PULL_REQUEST_AGENT_FINAL occurrence in the source file', async () => {
-      const { readFile } = await import('node:fs/promises');
-      const { fileURLToPath } = await import('node:url');
-      const currentUrl = import.meta.url;
-      const currentDir = fileURLToPath(new URL('.', currentUrl));
-      const src = await readFile(`${currentDir}../system-prompt.ts`, 'utf8');
-      const occurrences = src.split('PULL_REQUEST_AGENT_FINAL:').length - 1;
-      expect(occurrences).toBeGreaterThanOrEqual(2);
-      const blocks = src.split('PULL_REQUEST_AGENT_FINAL:').slice(1);
-      for (const tail of blocks) {
-        const block = tail.slice(0, tail.indexOf('```'));
-        expect(block).toContain('memory_ids_used:');
-        expect(block).toContain('memory_ids_rejected:');
-        expect(block).toContain('memory_usage_summary:');
-      }
+    it('lists memory fields in PULL_REQUEST_AGENT_FINAL (default block)', () => {
+      const prompt = pullRequestPrompt.build({
+        taskId: 't1',
+        linearIssueLabels: [],
+        workerType: 'auto',
+        executionMemoryContext: memoryContext,
+      });
+      const block = extractFinalBlock(prompt, 'PULL_REQUEST_AGENT_FINAL:');
+      expect(block).toContain('memory_ids_used:');
+      expect(block).toContain('memory_ids_rejected:');
+      expect(block).toContain('memory_usage_summary:');
+    });
+
+    it('lists memory fields in PULL_REQUEST_AGENT_FINAL (PR review overlay override)', () => {
+      // prReviewOverlayPrompt appends a second completion-block override used when
+      // PR Review Mode activates — it must also list the memory fields.
+      const overlay = prReviewOverlayPrompt.build({
+        taskId: 't1',
+        linearIssueLabels: [],
+        workerType: 'auto',
+        executionMemoryContext: memoryContext,
+      });
+      const block = extractFinalBlock(overlay, 'PULL_REQUEST_AGENT_FINAL:');
+      expect(block).toContain('memory_ids_used:');
+      expect(block).toContain('memory_ids_rejected:');
+      expect(block).toContain('memory_usage_summary:');
     });
 
     it('lists memory fields in REVIEW_AGENT_FINAL', () => {

--- a/workers/orchestrator/src/services/__tests__/system-prompt.test.ts
+++ b/workers/orchestrator/src/services/__tests__/system-prompt.test.ts
@@ -1272,8 +1272,8 @@ describe('system-prompt', () => {
     expect(executionPrompt.version).toBe('9.1.0');
   });
 
-  it('remediation prompt version is 3.3.0', () => {
-    expect(remediationPrompt.version).toBe('3.3.0');
+  it('remediation prompt version is 4.0.0', () => {
+    expect(remediationPrompt.version).toBe('4.0.0');
   });
 
   it('injects execution memory section only for execution tasks', () => {

--- a/workers/orchestrator/src/services/system-prompt.ts
+++ b/workers/orchestrator/src/services/system-prompt.ts
@@ -144,7 +144,7 @@ The union of memory_ids_used and memory_ids_rejected MUST equal the full set of 
 export const planningPrompt: PromptBuilder<SystemPromptParams> = {
   name: 'orchestrator-planning',
   description: 'Planning agent system prompt for autonomous code task planning',
-  version: '6.1.0',
+  version: '7.0.0',
   build(params: SystemPromptParams): string {
     const { taskId, linearIssueId, linearIssueTitle, taskUrl, workerType, modelName } = params;
     return `[SYSTEM CONTEXT]
@@ -308,6 +308,9 @@ PLANNING_AGENT_FINAL:
 - Plan PR: <full GitHub PR URL — MANDATORY for ALL planned outcomes, including SIMPLE tasks>
 - Parallel breakdown proof: <required when Complex task=1; must show service boundaries and contracts between subissues — empty otherwise>
 - Clarification message: <REQUIRED for unclear outcomes; MUST be empty for successfully planned outcomes>
+- memory_ids_used: <comma-separated injected IDs you applied, or "none">
+- memory_ids_rejected: <comma-separated injected IDs you rejected as not applicable, or "none">
+- memory_usage_summary: <one-sentence description of how memories influenced the plan, or "none" if no memories were injected>
 - Summary: <concise bullet-point list (markdown *, max 5-6 points) answering: what was the task, what was decided (simple/plan-doc/complex), what artifacts were produced (plan doc, subtasks, PR), why unclear (if applicable). The fewer points the better. No separation by question — each bullet is a self-contained fact.>
 \`\`\`
 

--- a/workers/orchestrator/src/services/system-prompt.ts
+++ b/workers/orchestrator/src/services/system-prompt.ts
@@ -878,7 +878,7 @@ Rules:
 export const reviewPrompt: PromptBuilder<SystemPromptParams> = {
   name: 'orchestrator-review',
   description: 'Review agent system prompt for automated read-only PR review',
-  version: '9.2.1',
+  version: '10.0.0',
   build(params: SystemPromptParams): string {
     const { taskId, linearIssueId, linearIssueTitle, taskUrl, workerType, modelName, reviewTypes } =
       params;
@@ -1170,6 +1170,9 @@ REVIEW_AGENT_FINAL:
 - requirements_tracker_updated: <yes|no — whether the requirements tracker comment was created/updated>
 - gh_actions_status: <all passed|N failed|pending|not yet triggered — GitHub Actions check result>
 - needs_remediation: <0|1 — 1 if any finding requires code changes that bring value to the codebase, 0 if clean or all findings are informational/cosmetic only. Operational/manual verification steps (deploying migrations, running commands in environments, manual testing in dev/prod, applying infrastructure changes) are post-merge activities — they do NOT count as code remediation and must NOT set this to 1 on their own>
+- memory_ids_used: <comma-separated injected IDs you applied, or "none">
+- memory_ids_rejected: <comma-separated injected IDs you rejected as not applicable, or "none">
+- memory_usage_summary: <one-sentence description of how memories influenced the review, or "none" if no memories were injected>
 - Summary: <concise bullet-point list (markdown *, max 5-6 points) answering: what was reviewed, key findings, overall quality assessment, remediation needed. The fewer points the better. No separation by question — each bullet is a self-contained fact.>
 \`\`\`
 

--- a/workers/orchestrator/src/services/system-prompt.ts
+++ b/workers/orchestrator/src/services/system-prompt.ts
@@ -480,7 +480,7 @@ After this block, stop. Do not append any other checklist or schema payload.`;
 export const remediationPrompt: PromptBuilder<SystemPromptParams> = {
   name: 'orchestrator-remediation',
   description: 'Remediation agent system prompt for addressing review findings on an existing PR',
-  version: '3.3.0',
+  version: '4.0.0',
   build(params: SystemPromptParams): string {
     const { taskId, linearIssueId, linearIssueTitle, taskUrl, workerType, modelName } = params;
     const continuationPrNumber = params.continuationPrNumber;
@@ -568,6 +568,9 @@ REMEDIATION_AGENT_FINAL:
 - Outcome: <implemented|already_completed>
 - PR: <full GitHub PR URL>
 - requires_re_review: <0|1>
+- memory_ids_used: <comma-separated injected IDs you applied, or "none">
+- memory_ids_rejected: <comma-separated injected IDs you rejected as not applicable, or "none">
+- memory_usage_summary: <one-sentence description of how memories influenced remediation, or "none" if no memories were injected>
 - Summary: <concise bullet-point list (markdown *, max 5-6 points) answering: what review findings were addressed, what was skipped and why, what was pushed. The fewer points the better. No separation by question — each bullet is a self-contained fact.>
 \`\`\`
 

--- a/workers/orchestrator/src/services/system-prompt.ts
+++ b/workers/orchestrator/src/services/system-prompt.ts
@@ -581,7 +581,7 @@ After this block, stop. Do not append any other checklist or schema payload.`;
 export const pullRequestPrompt: PromptBuilder<SystemPromptParams> = {
   name: 'orchestrator-pull-request',
   description: 'Pull request agent system prompt for addressing PR review feedback',
-  version: '4.3.0',
+  version: '5.0.0',
   build(params: SystemPromptParams): string {
     const {
       taskId,
@@ -705,6 +705,9 @@ PULL_REQUEST_AGENT_FINAL:
 - Tracking comment ID: <numeric ID from initial POST response>
 - Tracking comment: updated
 - Total PR comments posted: 1
+- memory_ids_used: <comma-separated injected IDs you applied, or "none">
+- memory_ids_rejected: <comma-separated injected IDs you rejected as not applicable, or "none">
+- memory_usage_summary: <one-sentence description of how memories influenced the PR work, or "none" if no memories were injected>
 - Summary: <concise bullet-point list (markdown *, max 5-6 points) answering: what PR feedback was addressed, what changes were made, what is the outcome. The fewer points the better. No separation by question — each bullet is a self-contained fact.>
 \`\`\`
 
@@ -799,6 +802,9 @@ PULL_REQUEST_AGENT_FINAL:
 - Tracking comment ID: <numeric ID from initial POST response>
 - Tracking comment: updated
 - Total PR comments posted: 1
+- memory_ids_used: <comma-separated injected IDs you applied, or "none">
+- memory_ids_rejected: <comma-separated injected IDs you rejected as not applicable, or "none">
+- memory_usage_summary: <one-sentence description of how memories influenced the PR work, or "none" if no memories were injected>
 - Summary: <concise bullet-point list (markdown *, max 5-6 points) answering: what PR feedback was addressed, what changes were made, what is the outcome. The fewer points the better. No separation by question — each bullet is a self-contained fact.>
 \`\`\`
 

--- a/workers/orchestrator/src/types/schemas.ts
+++ b/workers/orchestrator/src/types/schemas.ts
@@ -63,6 +63,7 @@ export const CreateTaskRequestSchema = z.object({
   webhookUrl: z.string().url(),
   webhookSecret: z.string().min(1),
   actionId: z.string().optional(),
+  retriedFrom: z.string().min(1).optional(),
   agentType: z
     .enum(['planning', 'execution', 'pull_request', 'review', 'remediation', 'ask_agent'])
     .optional(),


### PR DESCRIPTION
## Summary

This PR restores the execution-memory feedback pipeline end-to-end. Prior state: every completed code task had empty `execution_memory_ids_used` / `_rejected` / `_usage_summary` in its Firestore `result`, no `📋 Execution Memories Received` acknowledgment in worker logs, and the verifier's memory checks never fired — despite the retrieval pipeline correctly populating `executionMemoryContext.matchedMemories` upstream.

### Root cause

`workers/orchestrator/src/routes.ts:145-167` validated the POST `/tasks` body against `CreateTaskRequestSchema`, then constructed a narrower `CreateTaskRequest` body that silently dropped `executionMemoryContext`, `trackingCommentId`, `reviewTypes`, and `retriedFrom` before calling `dispatcher.submitTask()`. TypeScript didn't catch it because all four fields are optional. As a result `task.executionMemoryContext` was always `undefined` on the orchestrator, so `buildExecutionMemorySection()` in `system-prompt.ts:80` returned `''` (workers never saw memories), and the verifier's `hasInjectedMemories` gate at `completion-verifier.ts:757` evaluated false, short-circuiting both the both-empty check and `validateMemoryReporting`.

`retriedFrom` was additionally missing from `CreateTaskRequestSchema`, so Zod's default `strip` mode discarded it even before the route handler saw it.

### Secondary defect

Four of five `*_AGENT_FINAL` templates in `system-prompt.ts` (planning, remediation, pull_request [both occurrences], review) did not list the three mandated memory fields in their structured output schema. Only `EXECUTION_AGENT_FINAL` did. Since every template ends with *"After this block, stop. Do not append any other checklist or schema payload."*, workers faithfully omitted memory fields from their output even when the memory section was rendered. Addressed by adding the three fields to each affected template with a `"none"` fallback when no memories are injected.

## Changes

### Core fix (`routes.ts` + schema)
- `workers/orchestrator/src/types/schemas.ts` — declare `retriedFrom: z.string().min(1).optional()` in `CreateTaskRequestSchema` so Zod `strip` mode does not discard it.
- `workers/orchestrator/src/routes.ts:145-167` — propagate `executionMemoryContext`, `trackingCommentId`, `reviewTypes`, and `retriedFrom` from the parsed request into the downstream `CreateTaskRequest` body.

### Prompt templates (`system-prompt.ts`) — MAJOR version bumps, behavior change
- `planningPrompt` 6.1.0 → 7.0.0 — added memory fields to `PLANNING_AGENT_FINAL`.
- `remediationPrompt` 3.3.0 → 4.0.0 — added memory fields to `REMEDIATION_AGENT_FINAL`.
- `pullRequestPrompt` 4.3.0 → 5.0.0 — added memory fields to both `PULL_REQUEST_AGENT_FINAL` occurrences (default + PR-review-overlay override).
- `reviewPrompt` 9.2.1 → 10.0.0 — added memory fields to `REVIEW_AGENT_FINAL`.

### Tests
- Field-propagation regression tests for each of the four dropped fields on POST `/tasks`.
- Schema test for `retriedFrom` round-trip.
- System-prompt tests asserting the three memory fields are listed in each of the four final-block templates when `executionMemoryContext` is provided.
- End-to-end regression test: POST `/tasks` with `executionMemoryContext` → captured `dispatcher.submitTask` call → rendered `buildSystemPrompt` output contains the memory section and the memory ID.

### Simplify pass cleanups (this final commit)
- `workers/orchestrator/src/__tests__/system-prompt.test.ts:258` — removed a narrative comment that restated the test's purpose.
- `workers/orchestrator/src/services/__tests__/system-prompt.test.ts:1379` — replaced a source-file-reading test (imported `readFile` + `fileURLToPath`, split source text on marker) with two behavioral tests: one on `pullRequestPrompt.build()` for the default block, one on `prReviewOverlayPrompt.build()` for the overlay override block. Same coverage, no disk I/O, no leaky test abstraction.

## Test plan

- [x] `pnpm run ci:tracked` green (14813 tests pass across the monorepo)
- [x] Typecheck, lint, build, format, all static validations green
- [x] Prompt-version validator green (all 4 bumps recorded correctly)
- [ ] Post-merge dev-env verification: dispatch a review task on a PR that retrieves matched memories. Confirm:
  - `code_tasks/<id>.result.execution_memory_ids_used` is non-empty
  - Worker logs contain `📋 **Execution Memories Received:**` and `APPLICABLE` / `NOT APPLICABLE` per memory
  - Orchestrator systemd journal no longer logs `"Completion verifier parsed verdict"` with empty memory fields
  - Verifier fails tasks that omit the memory acknowledgment (negative test)