### PR TITLE
test(orchestrator): give verifier tests enough transcript lines

### DIFF
--- a/workers/orchestrator/src/services/__tests__/completion-verifier.test.ts
+++ b/workers/orchestrator/src/services/__tests__/completion-verifier.test.ts
@@ -2323,7 +2323,7 @@ describe('verify — fatal exit code via lastExitCode input', () => {
       attempt: 1,
       maxAttempts: 5,
       agentType: 'planning',
-      rawLogs: 'output',
+      rawLogs: transcriptWithMeaningfulLines('exit-zero'),
       lastExitCode: 0,
     });
     expect(result.passed).toBe(true);
@@ -2354,7 +2354,7 @@ describe('verify — fatal exit code via lastExitCode input', () => {
       attempt: 1,
       maxAttempts: 5,
       agentType: 'planning',
-      rawLogs: 'output',
+      rawLogs: transcriptWithMeaningfulLines('exit-undefined'),
     });
     expect(result.passed).toBe(true);
     expect(generateMock).toHaveBeenCalledOnce();
@@ -2392,7 +2392,7 @@ describe('verify — succeededModelName', () => {
       attempt: 1,
       maxAttempts: 5,
       agentType: 'planning',
-      rawLogs: 'logs',
+      rawLogs: transcriptWithMeaningfulLines('primary'),
     });
     expect(result.passed).toBe(true);
     expect(result.succeededModelName).toBe('or:google/gemma-4-31b-it:free');
@@ -2420,7 +2420,7 @@ describe('verify — succeededModelName', () => {
       attempt: 1,
       maxAttempts: 5,
       agentType: 'planning',
-      rawLogs: 'logs',
+      rawLogs: transcriptWithMeaningfulLines('fallback'),
     });
     expect(result.passed).toBe(true);
     expect(result.succeededModelName).toBe('gemini-2.5-flash');
@@ -2440,7 +2440,7 @@ describe('verify — succeededModelName', () => {
       attempt: 1,
       maxAttempts: 5,
       agentType: 'planning',
-      rawLogs: 'logs',
+      rawLogs: transcriptWithMeaningfulLines('schema-fail'),
     });
     expect(result.passed).toBe(false);
     expect(result.succeededModelName).toBe('or:google/gemma-4-31b-it:free');
@@ -2457,7 +2457,7 @@ describe('verify — succeededModelName', () => {
       attempt: 1,
       maxAttempts: 5,
       agentType: 'planning',
-      rawLogs: 'logs',
+      rawLogs: transcriptWithMeaningfulLines('all-fail'),
     });
     expect(result.passed).toBe(false);
     expect(result.verifierFailure).toBe(true);


### PR DESCRIPTION
## Summary
- Six tests in `completion-verifier.test.ts` failed on `development` CI (Tests shard 1/3) because they passed `rawLogs: 'output'` or `'logs'` (1 line), tripping the `MIN_MEANINGFUL_TRANSCRIPT_LINES=5` short-circuit before the behavior they meant to test (lastExitCode handling, `succeededModelName` threading) could run.
- Root cause: tests added in `f01819cb7` pre-dated the guard added in `f355192b7`.
- Fix: use the existing `transcriptWithMeaningfulLines()` helper so those tests exercise their intended code path.

## Test plan
- [x] `pnpm vitest run workers/orchestrator/src/services/__tests__/completion-verifier.test.ts` — 159 pass, 0 fail
- [x] `pnpm run ci:tracked` — passes end-to-end
- [ ] CI on this PR is green

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>