### PR TITLE
[INT-1409] fix(mobile-notifications): digest filters by groupTitlePrefix, not slug

### DIFF
--- a/apps/mobile-notifications-service/src/__tests__/domain/usecases/runDigestForGroup.test.ts
+++ b/apps/mobile-notifications-service/src/__tests__/domain/usecases/runDigestForGroup.test.ts
@@ -49,7 +49,7 @@ describe('runDigestForGroup', () => {
     });
     const result = await runDigestForGroup(
       { llmClient: llm, logger: noopLogger, modelId: 'or:google/gemini-3-flash-preview' },
-      { userId: 'u', groupKey: 'g', date: '2026-04-15', holder: 'manual' },
+      { userId: 'u', groupKey: 'g', groupTitlePrefix: 'G', date: '2026-04-15', holder: 'manual' },
     );
     expect(result.ok).toBe(false);
     if (result.ok) return;
@@ -82,7 +82,7 @@ describe('runDigestForGroup', () => {
     });
     const result = await runDigestForGroup(
       { llmClient: llm, logger: noopLogger, modelId: 'or:google/gemini-3-flash-preview' },
-      { userId: 'u', groupKey: 'g', date: '2026-04-15', holder: 'manual' },
+      { userId: 'u', groupKey: 'g', groupTitlePrefix: 'G', date: '2026-04-15', holder: 'manual' },
     );
     expect(result.ok).toBe(true);
     if (!result.ok) return;
@@ -114,7 +114,7 @@ describe('runDigestForGroup', () => {
     });
     await runDigestForGroup(
       { llmClient: llm, logger: noopLogger, modelId: 'm' },
-      { userId: 'u', groupKey: 'g', date: '2026-04-15', holder: 'manual' },
+      { userId: 'u', groupKey: 'g', groupTitlePrefix: 'G', date: '2026-04-15', holder: 'manual' },
     );
     expect(capturedPromptDate).toBe('2026-04-15');
   });
@@ -132,7 +132,7 @@ describe('runDigestForGroup', () => {
     });
     const result = await runDigestForGroup(
       { llmClient: llm, logger: noopLogger, modelId: 'm' },
-      { userId: 'u', groupKey: 'g', date: '2026-04-15', holder: 'cron' },
+      { userId: 'u', groupKey: 'g', groupTitlePrefix: 'G', date: '2026-04-15', holder: 'cron' },
     );
     expect(result.ok).toBe(false);
     if (result.ok) return;
@@ -152,7 +152,7 @@ describe('runDigestForGroup', () => {
     });
     const result = await runDigestForGroup(
       { llmClient: llm, logger: noopLogger, modelId: 'm' },
-      { userId: 'u', groupKey: 'g', date: '2026-04-15', holder: 'cron' },
+      { userId: 'u', groupKey: 'g', groupTitlePrefix: 'G', date: '2026-04-15', holder: 'cron' },
     );
     expect(result.ok).toBe(false);
     if (result.ok) return;
@@ -173,7 +173,7 @@ describe('runDigestForGroup', () => {
     });
     const result = await runDigestForGroup(
       { llmClient: llm, logger: noopLogger, modelId: 'm' },
-      { userId: 'u', groupKey: 'g', date: '2026-04-15', holder: 'cron' },
+      { userId: 'u', groupKey: 'g', groupTitlePrefix: 'G', date: '2026-04-15', holder: 'cron' },
     );
     expect(result.ok).toBe(false);
     if (result.ok) return;
@@ -195,7 +195,7 @@ describe('runDigestForGroup', () => {
     });
     const result = await runDigestForGroup(
       { llmClient: llm, logger: noopLogger, modelId: 'm' },
-      { userId: 'u', groupKey: 'g', date: '2026-04-15', holder: 'cron' },
+      { userId: 'u', groupKey: 'g', groupTitlePrefix: 'G', date: '2026-04-15', holder: 'cron' },
     );
     expect(result.ok).toBe(false);
     if (result.ok) return;
@@ -215,7 +215,7 @@ describe('runDigestForGroup', () => {
     });
     const result = await runDigestForGroup(
       { llmClient: llm, logger: noopLogger, modelId: 'm' },
-      { userId: 'u', groupKey: 'g', date: '2026-04-15', holder: 'cron' },
+      { userId: 'u', groupKey: 'g', groupTitlePrefix: 'G', date: '2026-04-15', holder: 'cron' },
     );
     expect(result.ok).toBe(false);
     if (result.ok) return;
@@ -232,7 +232,7 @@ describe('runDigestForGroup', () => {
     });
     const result = await runDigestForGroup(
       { llmClient: llm, logger: noopLogger, modelId: 'm' },
-      { userId: 'u', groupKey: 'g', date: '2026-04-15', holder: 'cron' },
+      { userId: 'u', groupKey: 'g', groupTitlePrefix: 'G', date: '2026-04-15', holder: 'cron' },
     );
     expect(result.ok).toBe(false);
     if (result.ok) return;
@@ -254,7 +254,7 @@ describe('runDigestForGroup', () => {
     });
     const result = await runDigestForGroup(
       { llmClient: llm, logger: noopLogger, modelId: 'm' },
-      { userId: 'u', groupKey: 'g', date: '2026-04-15', holder: 'cron' },
+      { userId: 'u', groupKey: 'g', groupTitlePrefix: 'G', date: '2026-04-15', holder: 'cron' },
     );
     expect(result.ok).toBe(false);
     if (result.ok) return;
@@ -280,11 +280,37 @@ describe('runDigestForGroup', () => {
     });
     const result = await runDigestForGroup(
       { llmClient: llm, logger: noopLogger, modelId: 'm' },
-      { userId: 'u', groupKey: 'g', date: '2026-04-15', holder: 'cron' },
+      { userId: 'u', groupKey: 'g', groupTitlePrefix: 'G', date: '2026-04-15', holder: 'cron' },
     );
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.error.code).toBe('persistence-failed');
+  });
+
+  it('filters notifications by groupTitlePrefix, not groupKey slug', async () => {
+    // Stored WhatsApp notifications have human-readable titles like
+    // "Grupa Wędkarska Skool (5 messages): ~ Zuza". The groupKey is the slug
+    // (dashes, stripped diacritics) and does not appear in stored titles.
+    // The digest must filter by the subscription's groupTitlePrefix.
+    const llm = new FakeLlmClient([{ type: 'content', value: JSON.stringify(COLD_START_EXAMPLE) }]);
+    let capturedTitleFilter: string | undefined;
+    setMockServices({
+      digestLockRepository: { acquire: async () => ({ ok: true, value: { acquired: true } }), release: async () => ({ ok: true, value: undefined }) },
+      notificationRepository: {
+        ...fakeNotificationRepo([]),
+        findByUserIdPaginated: async (_userId, opts) => {
+          capturedTitleFilter = opts?.filter?.title;
+          return { ok: true as const, value: { notifications: [] } };
+        },
+      },
+      digestRepository: { save: async () => ({ ok: true, value: { summary: EXAMPLE_SUMMARY, generation: 1, generatedAt: '', modelId: '' } }), findByDate: async () => ({ ok: true, value: null }), findRecentByGroup: async () => ({ ok: true, value: [] }), findInRange: async () => ({ ok: true, value: { items: [] } }) },
+      groupStateRepository: { getByDate: async () => ({ ok: true, value: null }), getLatest: async () => ({ ok: true, value: null }), save: async () => ({ ok: true, value: undefined }) },
+    });
+    await runDigestForGroup(
+      { llmClient: llm, logger: noopLogger, modelId: 'm' },
+      { userId: 'u', groupKey: 'grupa-wedkarska-skool', groupTitlePrefix: 'Grupa Wędkarska Skool', date: '2026-04-15', holder: 'manual' },
+    );
+    expect(capturedTitleFilter).toBe('Grupa Wędkarska Skool');
   });
 
   it('regenerated is true when digest already exists for the date', async () => {
@@ -302,7 +328,7 @@ describe('runDigestForGroup', () => {
     });
     const result = await runDigestForGroup(
       { llmClient: llm, logger: noopLogger, modelId: 'm' },
-      { userId: 'u', groupKey: 'g', date: '2026-04-15', holder: 'cron' },
+      { userId: 'u', groupKey: 'g', groupTitlePrefix: 'G', date: '2026-04-15', holder: 'cron' },
     );
     expect(result.ok).toBe(true);
     if (!result.ok) return;

--- a/apps/mobile-notifications-service/src/__tests__/helpers/mockServices.ts
+++ b/apps/mobile-notifications-service/src/__tests__/helpers/mockServices.ts
@@ -17,6 +17,9 @@ export function setMockServices(overrides: Partial<ServiceContainer>): ServiceCo
     groupStateRepository: overrides.groupStateRepository ?? stub('groupStateRepository'),
     digestLockRepository: overrides.digestLockRepository ?? stub('digestLockRepository'),
     backfillRunRepository: overrides.backfillRunRepository ?? stub('backfillRunRepository'),
+    digestSubscriptions: overrides.digestSubscriptions ?? [
+      { userId: 'u', groupKey: 'g', groupTitlePrefix: 'G' },
+    ],
   };
   setServices(container);
   return container;

--- a/apps/mobile-notifications-service/src/__tests__/routes/digestRoutes.test.ts
+++ b/apps/mobile-notifications-service/src/__tests__/routes/digestRoutes.test.ts
@@ -918,3 +918,46 @@ describe('POST /internal/notifications/digest/run (error paths)', () => {
     await app.close();
   });
 });
+
+describe('unknown subscription returns 400', () => {
+  it('POST /internal/notifications/digest/run rejects unknown (userId, groupKey)', async () => {
+    setMockServices({ digestSubscriptions: [] });
+    const app = await buildServer();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/internal/notifications/digest/run',
+      headers: { 'x-internal-auth': INTERNAL_AUTH_TOKEN },
+      payload: { userId: 'u', groupKey: 'g', date: '2026-04-15' },
+    });
+    expect(res.statusCode).toBe(400);
+    await app.close();
+  });
+
+  it('POST /notifications/digests/run rejects unknown groupKey', async () => {
+    setMockServices({ digestSubscriptions: [] });
+    const app = await buildServer();
+    const token = await createToken({ sub: 'google-oauth2|test-user' });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/notifications/digests/run',
+      headers: { authorization: `Bearer ${token}` },
+      payload: { groupKey: 'unknown', date: '2026-04-15' },
+    });
+    expect(res.statusCode).toBe(400);
+    await app.close();
+  });
+
+  it('POST /notifications/digests/backfill rejects unknown groupKey', async () => {
+    setMockServices({ digestSubscriptions: [] });
+    const app = await buildServer();
+    const token = await createToken({ sub: 'google-oauth2|test-user' });
+    const res = await app.inject({
+      method: 'POST',
+      url: '/notifications/digests/backfill',
+      headers: { authorization: `Bearer ${token}` },
+      payload: { groupKey: 'unknown', fromDate: '2026-04-01', toDate: '2026-04-03' },
+    });
+    expect(res.statusCode).toBe(400);
+    await app.close();
+  });
+});

--- a/apps/mobile-notifications-service/src/domain/digestSubscriptions.ts
+++ b/apps/mobile-notifications-service/src/domain/digestSubscriptions.ts
@@ -17,3 +17,11 @@ export const DIGEST_SUBSCRIPTIONS: readonly DigestSubscription[] = [
     groupTitlePrefix: 'Grupa Wędkarska Skool',
   },
 ] as const;
+
+export function findSubscription(
+  list: readonly DigestSubscription[],
+  userId: string,
+  groupKey: string,
+): DigestSubscription | undefined {
+  return list.find((s) => s.userId === userId && s.groupKey === groupKey);
+}

--- a/apps/mobile-notifications-service/src/domain/usecases/runDigestForGroup.ts
+++ b/apps/mobile-notifications-service/src/domain/usecases/runDigestForGroup.ts
@@ -21,6 +21,7 @@ export interface RunDigestForGroupDeps {
 export interface RunDigestForGroupInput {
   readonly userId: string;
   readonly groupKey: string;
+  readonly groupTitlePrefix: string;
   readonly date: string; // YYYY-MM-DD (CET interpretation)
   readonly holder: DigestLockHolder;
 }
@@ -60,7 +61,7 @@ export async function runDigestForGroup(
       }),
       services.notificationRepository.findByUserIdPaginated(input.userId, {
         limit: 1000,
-        filter: { title: input.groupKey, app: ['com.whatsapp'] },
+        filter: { title: input.groupTitlePrefix, app: ['com.whatsapp'] },
       }),
     ]);
     if (!previousState.ok) return err(persistenceFailed(previousState.error.message));

--- a/apps/mobile-notifications-service/src/routes/digestRoutes.ts
+++ b/apps/mobile-notifications-service/src/routes/digestRoutes.ts
@@ -8,7 +8,7 @@ import type { BackfillRunRepository } from '../domain/repositories/digestReposit
 import { runDigestForGroup, type RunDigestForGroupResult } from '../domain/usecases/runDigestForGroup.js';
 import type { DigestError } from '../domain/usecases/digestErrors.js';
 import { yesterdayCet } from '../domain/usecases/yesterdayCet.js';
-import { DIGEST_SUBSCRIPTIONS } from '../domain/digestSubscriptions.js';
+import { findSubscription } from '../domain/digestSubscriptions.js';
 import { startDigestBackfill } from '../domain/usecases/runDigestBackfill.js';
 import { runRequestSchema, runResponseSchema } from './digestSchemas.js';
 
@@ -189,12 +189,16 @@ export const digestRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
         return await reply.fail('UNAUTHORIZED', 'missing or invalid internal auth');
       }
       const { userId, groupKey, date, chainNext } = req.body;
+      const subscription = findSubscription(getServices().digestSubscriptions, userId, groupKey);
+      if (subscription === undefined) {
+        return await reply.fail('INVALID_REQUEST', `no digest subscription for userId=${userId} groupKey=${groupKey}`);
+      }
       const llmClient = buildLlmClient(userId);
       const modelId = getDigestModel();
       const holder = chainNext !== undefined ? 'backfill' : 'manual';
       const result = await runDigestForGroup(
         { llmClient, logger, modelId },
-        { userId, groupKey, date, holder },
+        { userId, groupKey, groupTitlePrefix: subscription.groupTitlePrefix, date, holder },
       );
 
       if (chainNext !== undefined) {
@@ -258,11 +262,11 @@ export const digestRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
       }
       const date = yesterdayCet();
       const results = await Promise.all(
-        DIGEST_SUBSCRIPTIONS.map(async (sub) => {
+        getServices().digestSubscriptions.map(async (sub) => {
           const llm = buildLlmClient(sub.userId);
           const r = await runDigestForGroup(
             { llmClient: llm, logger, modelId: getDigestModel() },
-            { userId: sub.userId, groupKey: sub.groupKey, date, holder: 'cron' },
+            { userId: sub.userId, groupKey: sub.groupKey, groupTitlePrefix: sub.groupTitlePrefix, date, holder: 'cron' },
           );
           return r.ok ? 1 as const : 0 as const;
         }),
@@ -422,11 +426,15 @@ export const digestRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
       const user = await requireAuth(req, reply);
       if (user === null) return;
       const { groupKey, date } = req.body;
+      const subscription = findSubscription(getServices().digestSubscriptions, user.userId, groupKey);
+      if (subscription === undefined) {
+        return await reply.fail('INVALID_REQUEST', `no digest subscription for groupKey=${groupKey}`);
+      }
       const llmClient = buildLlmClient(user.userId);
       const modelId = getDigestModel();
       const result = await runDigestForGroup(
         { llmClient, logger, modelId },
-        { userId: user.userId, groupKey, date, holder: 'manual' },
+        { userId: user.userId, groupKey, groupTitlePrefix: subscription.groupTitlePrefix, date, holder: 'manual' },
       );
       if (!result.ok) {
         if (result.error.code === 'lock-held') {
@@ -476,6 +484,9 @@ export const digestRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
       const { groupKey, fromDate, toDate } = req.body;
       if (fromDate > toDate) {
         return await reply.fail('INVALID_REQUEST', 'fromDate must be on or before toDate');
+      }
+      if (findSubscription(getServices().digestSubscriptions, user.userId, groupKey) === undefined) {
+        return await reply.fail('INVALID_REQUEST', `no digest subscription for groupKey=${groupKey}`);
       }
 
       const base = getSelfBaseUrl();

--- a/apps/mobile-notifications-service/src/services.ts
+++ b/apps/mobile-notifications-service/src/services.ts
@@ -9,6 +9,8 @@ import type {
   GroupStateRepository,
   DigestLockRepository,
 } from './domain/repositories/digestRepositories.js';
+import type { DigestSubscription } from './domain/digestSubscriptions.js';
+import { DIGEST_SUBSCRIPTIONS } from './domain/digestSubscriptions.js';
 import { FirestoreSignatureConnectionRepository } from './infra/firestore/firestoreSignatureConnectionRepository.js';
 import { FirestoreNotificationRepository } from './infra/firestore/firestoreNotificationRepository.js';
 import { FirestoreNotificationFiltersRepository } from './infra/firestore/notificationFiltersRepository.js';
@@ -25,6 +27,7 @@ export interface ServiceContainer {
   groupStateRepository: GroupStateRepository;
   digestLockRepository: DigestLockRepository;
   backfillRunRepository: BackfillRunRepository;
+  digestSubscriptions: readonly DigestSubscription[];
 }
 
 let container: ServiceContainer | null = null;
@@ -38,6 +41,7 @@ export function getServices(): ServiceContainer {
     groupStateRepository: new FirestoreGroupStateRepository(),
     digestLockRepository: new FirestoreDigestLockRepository(),
     backfillRunRepository: new FirestoreBackfillRunRepository(),
+    digestSubscriptions: DIGEST_SUBSCRIPTIONS,
   };
   return container;
 }


### PR DESCRIPTION
## Summary

- `runDigestForGroup` was filtering WhatsApp notifications by the slugified `groupKey` (`grupa-wedkarska-skool`) while stored titles are raw human strings (`Grupa Wędkarska Skool (5 messages): ~ Zuza`). Case-insensitive substring never matched → every digest was `messageCount: 0` with a "no activity" narrative.
- `DIGEST_SUBSCRIPTIONS` already carried `groupTitlePrefix` but no code read it.
- Route handlers now resolve the subscription (list injected through the `ServiceContainer` so tests can override) and pass `groupTitlePrefix` as a required field on `RunDigestForGroupInput`. Unknown `(userId, groupKey)` returns 400 instead of silently producing empty digests.
- Existing empty digests and their group-state/backfill-run docs were deleted from dev Firestore so the user can re-run the backfill manually.

## Endpoint Changes

- Modified: `POST /internal/notifications/digest/run`, `POST /internal/notifications/digest/run-yesterday`, `POST /notifications/digests/run`, `POST /notifications/digests/backfill` — all three now reject unknown `(userId, groupKey)` with 400.
- Created: none
- Removed: none
- Unchanged: all GET endpoints, `/internal/mobile-notifications/*`.

## Test plan

- [x] `pnpm run ci:tracked` — 15005 tests pass, static validation pass, build+format pass
- [x] New TDD test: `filters notifications by groupTitlePrefix, not groupKey slug` (runDigestForGroup)
- [x] New route tests: unknown subscription returns 400 for all three POST endpoints
- [ ] Manual: rerun `/notifications/digests/backfill` from the web UI once merged + deployed — expect non-zero `messageCount` on days with real messages