### PR TITLE
[INT-1412] fix(mobile-notifications): treat digest timestamp filter as seconds

### DIFF
--- a/apps/mobile-notifications-service/src/__tests__/infra/firestoreNotificationRepository.test.ts
+++ b/apps/mobile-notifications-service/src/__tests__/infra/firestoreNotificationRepository.test.ts
@@ -363,20 +363,20 @@ describe('FirestoreNotificationRepository', () => {
     });
 
     it('filters by postTimeSec range when postTimeSecFrom/postTimeSecTo are set', async () => {
-      const mk = (text: string, timestampMs: number, notifId: string): CreateNotificationInput => ({
+      const mk = (text: string, timestampSec: number, notifId: string): CreateNotificationInput => ({
         userId: 'user-range',
         source: 'android',
         device: 'dev',
         app: 'com.whatsapp',
         title: 'Grupa',
         text,
-        timestamp: timestampMs,
-        postTime: String(Math.floor(timestampMs / 1000)),
+        timestamp: timestampSec,
+        postTime: String(timestampSec),
         notificationId: notifId,
       });
-      await repository.save(mk('t1', 100_000, 'r1'));
-      await repository.save(mk('t2', 200_000, 'r2'));
-      await repository.save(mk('t3', 300_000, 'r3'));
+      await repository.save(mk('t1', 100, 'r1'));
+      await repository.save(mk('t2', 200, 'r2'));
+      await repository.save(mk('t3', 300, 'r3'));
 
       const result = await repository.findByUserIdPaginated('user-range', {
         limit: 10,
@@ -398,7 +398,7 @@ describe('FirestoreNotificationRepository', () => {
         app: string,
         title: string,
         text: string,
-        timestampMs: number,
+        timestampSec: number,
         notifId: string
       ): CreateNotificationInput => ({
         userId: 'user-combo',
@@ -407,14 +407,14 @@ describe('FirestoreNotificationRepository', () => {
         app,
         title,
         text,
-        timestamp: timestampMs,
-        postTime: String(Math.floor(timestampMs / 1000)),
+        timestamp: timestampSec,
+        postTime: String(timestampSec),
         notificationId: notifId,
       });
-      await repository.save(mk('com.whatsapp', 'Grupa Wedkarska', 'A', 200_000, 'c1'));
-      await repository.save(mk('com.whatsapp', 'Other Group', 'B', 200_000, 'c2'));
-      await repository.save(mk('com.telegram', 'Grupa Wedkarska', 'C', 200_000, 'c3'));
-      await repository.save(mk('com.whatsapp', 'Grupa Wedkarska', 'D', 500_000, 'c4'));
+      await repository.save(mk('com.whatsapp', 'Grupa Wedkarska', 'A', 200, 'c1'));
+      await repository.save(mk('com.whatsapp', 'Other Group', 'B', 200, 'c2'));
+      await repository.save(mk('com.telegram', 'Grupa Wedkarska', 'C', 200, 'c3'));
+      await repository.save(mk('com.whatsapp', 'Grupa Wedkarska', 'D', 500, 'c4'));
 
       const result = await repository.findByUserIdPaginated('user-combo', {
         limit: 10,

--- a/apps/mobile-notifications-service/src/domain/notifications/models/notification.ts
+++ b/apps/mobile-notifications-service/src/domain/notifications/models/notification.ts
@@ -16,7 +16,7 @@ export interface Notification {
   title: string;
   /** Notification content/body */
   text: string;
-  /** Timestamp from the device (Unix milliseconds) */
+  /** Timestamp from the device (Unix seconds; Tasker webhook sends %TIMES). */
   timestamp: number;
   /** Post time string from device */
   postTime: string;

--- a/apps/mobile-notifications-service/src/infra/firestore/firestoreNotificationRepository.ts
+++ b/apps/mobile-notifications-service/src/infra/firestore/firestoreNotificationRepository.ts
@@ -151,11 +151,12 @@ export class FirestoreNotificationRepository implements NotificationRepository {
         if (options.filter?.app !== undefined && options.filter.app.length > 0) {
           query = query.where('app', 'in', options.filter.app);
         }
+        // Stored `timestamp` is Unix seconds (Tasker %TIMES), so compare directly.
         if (options.filter?.postTimeSecFrom !== undefined) {
-          query = query.where('timestamp', '>=', options.filter.postTimeSecFrom * 1000);
+          query = query.where('timestamp', '>=', options.filter.postTimeSecFrom);
         }
         if (options.filter?.postTimeSecTo !== undefined) {
-          query = query.where('timestamp', '<', options.filter.postTimeSecTo * 1000);
+          query = query.where('timestamp', '<', options.filter.postTimeSecTo);
         }
 
         query = query.orderBy('receivedAt', 'desc');


### PR DESCRIPTION
## Summary

- `FirestoreNotificationRepository.findByUserIdPaginated` compared the `timestamp` column against `postTimeSecFrom/To * 1000`, assuming ms. The device writes **Unix seconds** (Tasker `%TIMES`), so the query matched zero docs and every digest backfill reported "no activity".
- Remove the `*1000`, compare in seconds. Fix the misleading `Notification.timestamp` doc-comment (was "Unix milliseconds"). Rewrite the two range-filter tests that had encoded the wrong unit in their fixtures.

## Evidence

Live dev doc (`mobile_notifications`) for the affected user/group:

```
timestamp:  1776447658              // = 2026-04-17T17:40:58Z (seconds)
postTime:   "1776447658"
receivedAt: "2026-04-17T17:40:59.120Z"
```

Cloud Run logs after the INT-1412 index fix:

```
msg="runDigestForGroup: input prepared"  raw=0  filtered=0
```

Audit: rg 'timestamp\s*\*\s*1000|timestamp\s*/\s*1000' found no other sites. rg 'new Date\(.*timestamp' in the web app found no consumers of notification.timestamp as a JS Date.

## Test plan

- [x] pnpm vitest run on the repo test file: both range-filter tests RED on HEAD~1, GREEN with the fix.
- [x] pnpm run verify:workspace:tracked mobile-notifications-service (typecheck + lint + full suite).
- [x] pnpm run ci:tracked — green.
- [ ] Smoke: re-run backfill for grupa-wedkarska-skool from the UI after deploy; expect non-zero messageCount and real headline/bullets.

## Notes

- Wrong summaries (8 digests + 8 group states) for grupa-wedkarska-skool were cleared from Firestore before this PR so regeneration starts clean post-deploy.
- No schema, migration, or API contract change. The mobile_notifications.timestamp field name stays as-is (renaming would break the web response schema; out of scope for this hotfix).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>