### PR TITLE
[INT-1414] fix: make task finalization robust via dedicated status endpoint

### DIFF
--- a/apps/code-agent/package.json
+++ b/apps/code-agent/package.json
@@ -34,6 +34,8 @@
     "@intexuraos/llm-factory": "workspace:*",
     "@intexuraos/llm-pricing": "workspace:*",
     "@intexuraos/llm-prompts": "workspace:*",
+    "ajv": "^8.17.1",
+    "ajv-formats": "^3.0.1",
     "fastify": "^5.1.0",
     "jose": "^6.1.3",
     "openai": "^6.15.0",

--- a/apps/code-agent/src/__tests__/domain/usecases/drainTaskQueue.test.ts
+++ b/apps/code-agent/src/__tests__/domain/usecases/drainTaskQueue.test.ts
@@ -958,10 +958,12 @@ describe('drainTaskQueue', () => {
       expect(result.value).toEqual({ action: 'dispatched', taskId: 'task-123' });
     }
 
-    // Verify task updated with dispatched status, cancel nonce, and worker location
+    // Verify task updated with dispatched status, cancel nonce, worker location,
+    // and initial lastHeartbeat (so findZombieTasks can catch tasks that fail before the first real heartbeat).
     expect(mockCodeTaskRepo.update).toHaveBeenCalledWith('task-123', {
       status: 'dispatched',
       dispatchedAt: expect.any(Date),
+      lastHeartbeat: expect.any(Date),
       workerLocation: 'home-mac',
       cancelNonce: 'abcd1234',
       cancelNonceExpiresAt: expect.any(String),

--- a/apps/code-agent/src/__tests__/infra/repositories/firestoreCodeTaskRepository.test.ts
+++ b/apps/code-agent/src/__tests__/infra/repositories/firestoreCodeTaskRepository.test.ts
@@ -1355,7 +1355,34 @@ describe('firestoreCodeTaskRepository', () => {
   });
 
   describe('findZombieTasks', () => {
-    it('finds stale tasks', async () => {
+    it('finds tasks whose lastHeartbeat is older than threshold even when updatedAt is recent', async () => {
+      const repo = createFirestoreCodeTaskRepository({
+        firestore: fakeFirestore as unknown as Firestore,
+        logger,
+      });
+
+      const created = await repo.create(createTaskInput());
+      expect(created.ok).toBe(true);
+      if (!created.ok) return;
+
+      // Simulate a running task with stale heartbeat but recently-touched updatedAt
+      // (e.g. PR merge webhook wrote prMergedAt, bumping updatedAt).
+      await repo.update(created.value.id, {
+        status: 'running',
+        dispatchedAt: new Date(Date.now() - 45 * 60 * 1000), // dispatched 45 min ago
+        lastHeartbeat: new Date(Date.now() - 40 * 60 * 1000), // 40 min ago
+        updatedAt: new Date(), // just now — unrelated write simulation
+      });
+
+      const staleThreshold = new Date(Date.now() - 30 * 60 * 1000);
+      const result = await repo.findZombieTasks(staleThreshold);
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.map((t) => t.id)).toContain(created.value.id);
+    });
+
+    it('does NOT find tasks whose lastHeartbeat is recent', async () => {
       const repo = createFirestoreCodeTaskRepository({
         firestore: fakeFirestore as unknown as Firestore,
         logger,
@@ -1367,14 +1394,15 @@ describe('firestoreCodeTaskRepository', () => {
 
       await repo.update(created.value.id, {
         status: 'running',
-        dispatchedAt: new Date(Date.now() - 10 * 60 * 1000), // 10 minutes ago
+        lastHeartbeat: new Date(), // fresh heartbeat
       });
 
-      // Just test the query works - actual filtering depends on Firestore
-      const staleThreshold = new Date(Date.now() - 5 * 60 * 1000); // 5 minutes ago
+      const staleThreshold = new Date(Date.now() - 30 * 60 * 1000);
       const result = await repo.findZombieTasks(staleThreshold);
 
       expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.map((t) => t.id)).not.toContain(created.value.id);
     });
 
     it('returns empty array when no zombie tasks', async () => {
@@ -1390,6 +1418,33 @@ describe('firestoreCodeTaskRepository', () => {
       if (!result.ok) return;
 
       expect(result.value).toEqual([]);
+    });
+
+    it('finds dispatched tasks that never heartbeat once dispatchedAt exceeds threshold (via initial lastHeartbeat)', async () => {
+      const repo = createFirestoreCodeTaskRepository({
+        firestore: fakeFirestore as unknown as Firestore,
+        logger,
+      });
+
+      const created = await repo.create(createTaskInput());
+      expect(created.ok).toBe(true);
+      if (!created.ok) return;
+
+      // Simulate a task dispatched 40 minutes ago with the initial heartbeat set at dispatch time
+      // (as drainTaskQueue does) but no subsequent real heartbeat from the worker.
+      const dispatchedMoment = new Date(Date.now() - 40 * 60 * 1000);
+      await repo.update(created.value.id, {
+        status: 'dispatched',
+        dispatchedAt: dispatchedMoment,
+        lastHeartbeat: dispatchedMoment, // initial heartbeat at dispatch; worker never sent real one
+      });
+
+      const staleThreshold = new Date(Date.now() - 30 * 60 * 1000);
+      const result = await repo.findZombieTasks(staleThreshold);
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.map((t) => t.id)).toContain(created.value.id);
     });
   });
 

--- a/apps/code-agent/src/__tests__/infra/webhookValidation.test.ts
+++ b/apps/code-agent/src/__tests__/infra/webhookValidation.test.ts
@@ -187,6 +187,58 @@ describe('validateWebhookSignature', () => {
       // 15 minutes = 900 seconds, which should pass (timestampAge > fifteenMinutes fails)
       expect(result.ok).toBe(true);
     });
+
+    it('uses request.rawBody for HMAC when rawBody is attached, ignoring re-serialized body', () => {
+      const secret = 'shared-orch-secret';
+      // Simulate the bytes that the sender HMAC'd: a JSON string with key order and
+      // whitespace that JSON.stringify(request.body) would NOT reproduce.
+      const rawBody = '{"taskIds":["task_1","task_2"]}';
+      const timestamp = Math.floor(Date.now() / 1000);
+      const expected = crypto
+        .createHmac('sha256', secret)
+        .update(`${String(timestamp)}.${rawBody}`)
+        .digest('hex');
+
+      // Inject a body whose re-serialization would DIFFER (extra field injected).
+      const mutatedBody = { taskIds: ['task_1', 'task_2'], extraInjectedByAjv: true };
+
+      const request = {
+        headers: {
+          'x-request-timestamp': String(timestamp),
+          'x-request-signature': expected,
+        },
+        body: mutatedBody,
+        rawBody,
+      } as unknown as FastifyRequest;
+
+      const result = validateOrchestratorSignature(request, { orchestratorSecret: secret });
+
+      expect(result.ok).toBe(true);
+    });
+
+    it('falls back to JSON.stringify(body) when rawBody is absent', () => {
+      const secret = 'shared-orch-secret';
+      const body = { taskIds: ['a'] };
+      const rawBody = JSON.stringify(body);
+      const timestamp = Math.floor(Date.now() / 1000);
+      const expected = crypto
+        .createHmac('sha256', secret)
+        .update(`${String(timestamp)}.${rawBody}`)
+        .digest('hex');
+
+      const request = {
+        headers: {
+          'x-request-timestamp': String(timestamp),
+          'x-request-signature': expected,
+        },
+        body,
+        // no rawBody
+      } as unknown as FastifyRequest;
+
+      const result = validateOrchestratorSignature(request, { orchestratorSecret: secret });
+
+      expect(result.ok).toBe(true);
+    });
   });
 
   describe('validateWebhookSignature', () => {

--- a/apps/code-agent/src/__tests__/integration/status-update-e2e.test.ts
+++ b/apps/code-agent/src/__tests__/integration/status-update-e2e.test.ts
@@ -1,0 +1,289 @@
+/**
+ * End-to-end regression test for the orchestrator → code-agent status update
+ * round-trip.
+ *
+ * Regression guard for the "schema coerces body, HMAC mismatches, task stays
+ * running" bug class that motivated the INT-1412/INT-1413 finalize-task
+ * robustness PR: the orchestrator signed the raw body with HMAC, Fastify's
+ * default Ajv (with `coerceTypes: true` and `removeAdditional: true`) silently
+ * mutated the body before the handler recomputed the signature, and the
+ * signature check rejected the request as forged. Task stayed stuck in
+ * `running` forever.
+ *
+ * This test wires up:
+ *   - the REAL orchestrator `StatusUpdateClient` (signs with orchestrator
+ *     secret + real HMAC-SHA256 + real JSON serialization)
+ *   - a REAL Fastify server (not `app.inject`) listening on a local port so
+ *     requests traverse the socket layer — that's where any silent
+ *     serialization/mutation drift would hide
+ *   - the REAL `updateTaskStatusRoute` handler with its strict Ajv
+ *     (`additionalProperties: false`, `coerceTypes: false`) + HMAC
+ *     verification over `request.rawBody`
+ *   - a mocked `codeTaskRepo` seeded with a `running` task
+ *
+ * If any future change to schema, signing, or body parsing re-introduces the
+ * class of bugs this PR fixes, the first test fails: the 200 + persistence
+ * assertion flips to 401 / signature mismatch.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as jose from 'jose';
+
+vi.mock('jose', () => ({
+  createRemoteJWKSet: vi.fn(() => vi.fn()),
+  jwtVerify: vi.fn(),
+}));
+
+import pino from 'pino';
+import { ok } from '@intexuraos/common-core';
+import { createFakeFirestore, setFirestore, resetFirestore } from '@intexuraos/infra-firestore';
+import type { Firestore } from '@google-cloud/firestore';
+
+import { buildServer } from '../../server.js';
+import { setServices, resetServices, type ServiceContainer } from '../../services.js';
+// Cross-workspace import via relative path. StatusUpdateClient has zero external
+// deps (only `node:crypto` built-in and `pino` type-only), so pulling it into
+// the code-agent test workspace does not break dependency resolution.
+// We intentionally depend on the REAL client — its signing correctness is the
+// thing under test.
+import { StatusUpdateClient } from '../../../../../workers/orchestrator/src/services/status-update-client.js';
+
+const ORCHESTRATOR_SECRET = 'shared-test-orchestrator-secret';
+const INTERNAL_AUTH_TOKEN = 'shared-test-internal-auth-token';
+const TASK_ID = 'task_int_e2e';
+
+describe('StatusUpdateClient <-> updateTaskStatusRoute end-to-end', () => {
+  let app: Awaited<ReturnType<typeof buildServer>>;
+  let serverUrl: string;
+  let mockCodeTaskRepo: {
+    findById: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
+    findByIdForUser: ReturnType<typeof vi.fn>;
+    list: ReturnType<typeof vi.fn>;
+    hasActiveBlockingTaskForIssue: ReturnType<typeof vi.fn>;
+    findActiveTasksForRepository: ReturnType<typeof vi.fn>;
+    findByLinearIssueId: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(async () => {
+    vi.mocked(jose.jwtVerify).mockResolvedValue({
+      payload: { sub: 'test-user-id', email: 'test@example.com' },
+      protectedHeader: new Uint8Array(),
+    } as never);
+
+    process.env['INTEXURAOS_INTERNAL_AUTH_TOKEN'] = INTERNAL_AUTH_TOKEN;
+    process.env['INTEXURAOS_ORCHESTRATOR_SECRET'] = ORCHESTRATOR_SECRET;
+    process.env['INTEXURAOS_AUTH_AUDIENCE'] = 'https://api.intexuraos.cloud';
+    process.env['INTEXURAOS_AUTH_ISSUER'] = 'https://intexuraos.eu.auth0.com/';
+    process.env['INTEXURAOS_AUTH_JWKS_URL'] = 'https://intexuraos.eu.auth0.com/.well-known/jwks.json';
+
+    const fakeFirestore = createFakeFirestore() as unknown as Firestore;
+    setFirestore(fakeFirestore);
+
+    // In-memory fake codeTaskRepo seeded with a task in `running` state, as
+    // `findById` is called to check the current status before the handler
+    // decides to mutate vs. no-op. `update` captures the persisted fields so
+    // we can assert end-to-end Firestore persistence.
+    mockCodeTaskRepo = {
+      findById: vi.fn().mockResolvedValue(
+        ok({
+          id: TASK_ID,
+          repository: 'pbuchman/intexuraos',
+          userId: 'user-e2e',
+          status: 'running',
+          agentType: 'execution',
+        })
+      ),
+      update: vi.fn().mockResolvedValue(
+        ok({
+          id: TASK_ID,
+          repository: 'pbuchman/intexuraos',
+          userId: 'user-e2e',
+          status: 'failed',
+        })
+      ),
+      create: vi.fn(),
+      findByIdForUser: vi.fn(),
+      list: vi.fn(),
+      hasActiveBlockingTaskForIssue: vi.fn(),
+      findActiveTasksForRepository: vi.fn(),
+      findByLinearIssueId: vi.fn(),
+    };
+
+    const logger = pino({ level: 'silent' });
+
+    setServices({
+      firestore: fakeFirestore,
+      logger,
+      codeTaskRepo: mockCodeTaskRepo as never,
+      automationLog: {} as never,
+      logChunkRepo: {} as never,
+      logLineRepo: {} as never,
+      taskDispatcher: {} as never,
+      whatsappNotifier: {} as never,
+      actionsAgentClient: {} as never,
+      linearAgentClient: {} as never,
+      linearIssueService: {} as never,
+      statusMirrorService: {} as never,
+      processHeartbeat: {} as never,
+      detectZombieTasks: {} as never,
+      cleanupTaskLogs: {} as never,
+      archiveStaleGroups: {} as never,
+      autoArchiveMergedTasks: {} as never,
+      metricsClient: {} as never,
+      workerSettingsRepo: {} as never,
+      workerHealthProbe: {} as never,
+      gitHubPREventRepo: {} as never,
+      gitHubPRSummaryRepo: {} as never,
+      turnMetricsRepo: {} as never,
+      userServiceClient: {} as never,
+      gitHubPRClient: {} as never,
+      webhookRules: {} as never,
+      dispatchService: {} as never,
+      resolveToolCallingClient: (() => {
+        throw new Error('unused');
+      }) as never,
+      eventDecisionRepo: {} as never,
+      dispatchRetryRepo: {} as never,
+      unifiedEvaluator: {} as never,
+      taskEnqueueService: {} as never,
+      mergeConflictDetector: {
+        detectOnPush: vi.fn().mockResolvedValue(undefined),
+        reconcile: vi.fn().mockResolvedValue({ processed: 0 }),
+      },
+      mergeQueueWatchRepo: {
+        create: vi.fn(),
+        findById: vi.fn(),
+        findActiveByUserAndBranch: vi.fn(),
+        findAllActive: vi.fn(),
+        findByUserAndRepo: vi.fn(),
+        update: vi.fn(),
+        appendMergedPr: vi.fn(),
+      },
+      prTriagePublisher: {} as never,
+    } as ServiceContainer);
+
+    app = await buildServer();
+    // Listen on an ephemeral port so the request traverses the real socket
+    // layer — `app.inject` would bypass the HTTP parser and hide any raw-body
+    // drift that HMAC verification depends on.
+    await app.listen({ port: 0, host: '127.0.0.1' });
+    const address = app.server.address();
+    if (address === null || typeof address === 'string') {
+      throw new Error('unexpected fastify server address (pipe or null)');
+    }
+    serverUrl = `http://127.0.0.1:${String(address.port)}`;
+  });
+
+  afterEach(async () => {
+    await app.close();
+    resetServices();
+    resetFirestore();
+    vi.clearAllMocks();
+    delete process.env['INTEXURAOS_INTERNAL_AUTH_TOKEN'];
+    delete process.env['INTEXURAOS_ORCHESTRATOR_SECRET'];
+    delete process.env['INTEXURAOS_AUTH_AUDIENCE'];
+    delete process.env['INTEXURAOS_AUTH_ISSUER'];
+    delete process.env['INTEXURAOS_AUTH_JWKS_URL'];
+  });
+
+  it('orchestrator client commits status=failed and code-agent persists it', async () => {
+    const client = new StatusUpdateClient({
+      codeAgentUrl: serverUrl,
+      orchestratorSecret: ORCHESTRATOR_SECRET,
+      internalAuthToken: INTERNAL_AUTH_TOKEN,
+      logger: pino({ level: 'silent' }),
+      // No retries: a single attempt is enough for the happy path, and keeps
+      // the test fast. `maxAttempts = retryDelaysMs.length + 1 = 1`. See
+      // StatusUpdateClient constructor.
+      retryDelaysMs: [],
+    });
+
+    const completedAt = new Date('2026-04-17T18:10:27.316Z');
+    const result = await client.commit({
+      taskId: TASK_ID,
+      status: 'failed',
+      completedAt,
+      error: {
+        code: 'TASK_COMPLETION_VERIFICATION_FAILED',
+        message: 'Missing fields: memory_acknowledgment',
+      },
+      result: {
+        prUrl: 'https://github.com/x/y/pull/1',
+        branch: 'fix/x',
+        summary: '[INT-X] example',
+      },
+    });
+
+    expect(result.ok).toBe(true);
+
+    // End-to-end persistence: the handler must have reached `codeTaskRepo.update`
+    // with the decoded body. If schema/HMAC drift ever re-emerges, the request
+    // would be rejected with 401 before reaching this line.
+    expect(mockCodeTaskRepo.update).toHaveBeenCalledOnce();
+    const [persistedTaskId, persistedFields] = mockCodeTaskRepo.update.mock.calls[0] as [
+      string,
+      Record<string, unknown>,
+    ];
+    expect(persistedTaskId).toBe(TASK_ID);
+    expect(persistedFields['status']).toBe('failed');
+    expect(persistedFields['completedAt']).toBeInstanceOf(Date);
+    expect((persistedFields['completedAt'] as Date).toISOString()).toBe(
+      '2026-04-17T18:10:27.316Z'
+    );
+    expect(persistedFields['error']).toEqual({
+      code: 'TASK_COMPLETION_VERIFICATION_FAILED',
+      message: 'Missing fields: memory_acknowledgment',
+    });
+    expect(persistedFields['result']).toEqual({
+      prUrl: 'https://github.com/x/y/pull/1',
+      branch: 'fix/x',
+      summary: '[INT-X] example',
+    });
+  });
+
+  it("maps status='completed' to 'implemented' for agentType='execution' end-to-end", async () => {
+    // Same seeded task (agentType='execution', status='running'). The handler
+    // must map the orchestrator-vocabulary 'completed' to code-agent's
+    // execution-agent terminal status 'implemented' per updateTaskStatusRoute
+    // mapping — mirroring /internal/webhooks/task-complete.
+    const client = new StatusUpdateClient({
+      codeAgentUrl: serverUrl,
+      orchestratorSecret: ORCHESTRATOR_SECRET,
+      internalAuthToken: INTERNAL_AUTH_TOKEN,
+      logger: pino({ level: 'silent' }),
+      retryDelaysMs: [],
+    });
+
+    const result = await client.commit({
+      taskId: TASK_ID,
+      status: 'completed',
+      completedAt: new Date('2026-04-17T19:00:00.000Z'),
+      result: {
+        prUrl: 'https://github.com/x/y/pull/2',
+        branch: 'feat/e2e',
+        summary: '[INT-E2E] example',
+      },
+    });
+
+    expect(result.ok).toBe(true);
+
+    expect(mockCodeTaskRepo.update).toHaveBeenCalledOnce();
+    const [, persistedFields] = mockCodeTaskRepo.update.mock.calls[0] as [
+      string,
+      Record<string, unknown>,
+    ];
+    // `completed` → `implemented` for execution agents. Non-negotiable: the
+    // Firestore TaskStatus type does not include 'completed'.
+    expect(persistedFields['status']).toBe('implemented');
+    // `error: null` is written to clear any stale error from the running phase,
+    // mirroring webhookRoutes.ts behavior.
+    expect(persistedFields['error']).toBeNull();
+    expect(persistedFields['result']).toEqual({
+      prUrl: 'https://github.com/x/y/pull/2',
+      branch: 'feat/e2e',
+      summary: '[INT-E2E] example',
+    });
+  });
+});

--- a/apps/code-agent/src/__tests__/routes/code/updateTaskStatusRoute.test.ts
+++ b/apps/code-agent/src/__tests__/routes/code/updateTaskStatusRoute.test.ts
@@ -1,0 +1,604 @@
+/**
+ * Tests for PATCH /internal/code-tasks/:id/status
+ *
+ * Dedicated, minimal endpoint for the orchestrator to commit terminal task
+ * status to Firestore. Authed via X-Internal-Auth + orchestratorSecret HMAC.
+ * Idempotent: no-ops when task already terminal.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as jose from 'jose';
+
+vi.mock('jose', () => ({
+  createRemoteJWKSet: vi.fn(() => vi.fn()),
+  jwtVerify: vi.fn(),
+}));
+
+import crypto from 'node:crypto';
+import { buildServer } from '../../../server.js';
+import { setServices, resetServices, type ServiceContainer } from '../../../services.js';
+import { createFakeFirestore, setFirestore, resetFirestore } from '@intexuraos/infra-firestore';
+import type { Firestore } from '@google-cloud/firestore';
+import pino from 'pino';
+import { ok, err } from '@intexuraos/common-core';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function sign(
+  body: unknown,
+  secret: string
+): { rawBody: string; timestamp: string; signature: string } {
+  const rawBody = JSON.stringify(body);
+  const timestamp = String(Math.floor(Date.now() / 1000));
+  const signature = crypto
+    .createHmac('sha256', secret)
+    .update(`${timestamp}.${rawBody}`)
+    .digest('hex');
+  return { rawBody, timestamp, signature };
+}
+
+const ORCHESTRATOR_SECRET = 'test-orchestrator-secret';
+const INTERNAL_AUTH_TOKEN = 'test-internal-token';
+const TASK_ID = 'task-abc';
+
+describe('PATCH /internal/code-tasks/:id/status', () => {
+  let app: Awaited<ReturnType<typeof buildServer>>;
+  let mockCodeTaskRepo: {
+    findById: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
+    findByIdForUser: ReturnType<typeof vi.fn>;
+    list: ReturnType<typeof vi.fn>;
+    hasActiveBlockingTaskForIssue: ReturnType<typeof vi.fn>;
+    findActiveTasksForRepository: ReturnType<typeof vi.fn>;
+    findByLinearIssueId: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(async () => {
+    vi.mocked(jose.jwtVerify).mockResolvedValue({
+      payload: { sub: 'test-user-id', email: 'test@example.com' },
+      protectedHeader: new Uint8Array(),
+    } as never);
+
+    process.env['INTEXURAOS_INTERNAL_AUTH_TOKEN'] = INTERNAL_AUTH_TOKEN;
+    process.env['INTEXURAOS_ORCHESTRATOR_SECRET'] = ORCHESTRATOR_SECRET;
+    process.env['INTEXURAOS_AUTH_AUDIENCE'] = 'https://api.intexuraos.cloud';
+    process.env['INTEXURAOS_AUTH_ISSUER'] = 'https://intexuraos.eu.auth0.com/';
+    process.env['INTEXURAOS_AUTH_JWKS_URL'] = 'https://intexuraos.eu.auth0.com/.well-known/jwks.json';
+
+    const fakeFirestore = createFakeFirestore() as unknown as Firestore;
+    setFirestore(fakeFirestore);
+
+    mockCodeTaskRepo = {
+      findById: vi.fn().mockResolvedValue(
+        ok({
+          id: TASK_ID,
+          repository: 'pbuchman/intexuraos',
+          userId: 'user-123',
+          status: 'running',
+        })
+      ),
+      update: vi.fn().mockResolvedValue(
+        ok({
+          id: TASK_ID,
+          repository: 'pbuchman/intexuraos',
+          userId: 'user-123',
+          status: 'failed',
+        })
+      ),
+      create: vi.fn(),
+      findByIdForUser: vi.fn(),
+      list: vi.fn(),
+      hasActiveBlockingTaskForIssue: vi.fn(),
+      findActiveTasksForRepository: vi.fn(),
+      findByLinearIssueId: vi.fn(),
+    };
+
+    const logger = pino({ level: 'silent' });
+
+    setServices({
+      firestore: fakeFirestore,
+      logger,
+      codeTaskRepo: mockCodeTaskRepo as never,
+      automationLog: {} as never,
+      logChunkRepo: {} as never,
+      logLineRepo: {} as never,
+      taskDispatcher: {} as never,
+      whatsappNotifier: {} as never,
+      actionsAgentClient: {} as never,
+      linearAgentClient: {} as never,
+      linearIssueService: {} as never,
+      statusMirrorService: {} as never,
+      processHeartbeat: {} as never,
+      detectZombieTasks: {} as never,
+      cleanupTaskLogs: {} as never,
+      archiveStaleGroups: {} as never,
+      autoArchiveMergedTasks: {} as never,
+      metricsClient: {} as never,
+      workerSettingsRepo: {} as never,
+      workerHealthProbe: {} as never,
+      gitHubPREventRepo: {} as never,
+      gitHubPRSummaryRepo: {} as never,
+      turnMetricsRepo: {} as never,
+      userServiceClient: {} as never,
+      gitHubPRClient: {} as never,
+      webhookRules: {} as never,
+      dispatchService: {} as never,
+      resolveToolCallingClient: (() => {
+        throw new Error('unused');
+      }) as never,
+      eventDecisionRepo: {} as never,
+      dispatchRetryRepo: {} as never,
+      unifiedEvaluator: {} as never,
+      taskEnqueueService: {} as never,
+      mergeConflictDetector: {
+        detectOnPush: vi.fn().mockResolvedValue(undefined),
+        reconcile: vi.fn().mockResolvedValue({ processed: 0 }),
+      },
+      mergeQueueWatchRepo: {
+        create: vi.fn(),
+        findById: vi.fn(),
+        findActiveByUserAndBranch: vi.fn(),
+        findAllActive: vi.fn(),
+        findByUserAndRepo: vi.fn(),
+        update: vi.fn(),
+        appendMergedPr: vi.fn(),
+      },
+      prTriagePublisher: {} as never,
+    } as ServiceContainer);
+
+    app = await buildServer();
+  });
+
+  afterEach(async () => {
+    await app.close();
+    resetServices();
+    resetFirestore();
+    vi.clearAllMocks();
+    delete process.env['INTEXURAOS_INTERNAL_AUTH_TOKEN'];
+    delete process.env['INTEXURAOS_ORCHESTRATOR_SECRET'];
+    delete process.env['INTEXURAOS_AUTH_AUDIENCE'];
+    delete process.env['INTEXURAOS_AUTH_ISSUER'];
+    delete process.env['INTEXURAOS_AUTH_JWKS_URL'];
+  });
+
+  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+  function sendUpdate(
+    id: string,
+    body: unknown,
+    overrides?: { token?: string; skipSignature?: boolean; badSignature?: boolean }
+  ) {
+    const { rawBody, timestamp, signature } = sign(body, ORCHESTRATOR_SECRET);
+
+    const headers: Record<string, string> = {
+      'content-type': 'application/json',
+    };
+    if (overrides?.token !== undefined) {
+      headers['x-internal-auth'] = overrides.token;
+    } else if (overrides?.token !== null) {
+      headers['x-internal-auth'] = INTERNAL_AUTH_TOKEN;
+    }
+
+    if (overrides?.skipSignature !== true) {
+      headers['x-request-timestamp'] = timestamp;
+      headers['x-request-signature'] = overrides?.badSignature === true
+        ? 'a'.repeat(signature.length)
+        : signature;
+    }
+
+    return app.inject({
+      method: 'PATCH',
+      url: `/internal/code-tasks/${id}/status`,
+      headers,
+      payload: rawBody,
+    });
+  }
+
+  // -----------------------------------------------------------------------
+  // Happy path
+  // -----------------------------------------------------------------------
+
+  it('updates task from running→failed and persists error + result', async () => {
+    const body = {
+      taskId: TASK_ID,
+      status: 'failed',
+      completedAt: '2026-04-17T12:00:00.000Z',
+      error: { code: 'TIMEOUT', message: 'Worker timed out' },
+      result: { prUrl: 'https://github.com/x/y/pull/1', branch: 'feat/abc', summary: 'x' },
+    };
+
+    const response = await sendUpdate(TASK_ID, body);
+
+    expect(response.statusCode).toBe(200);
+    const json = response.json() as { success: boolean; data: { received: boolean } };
+    expect(json.success).toBe(true);
+    expect(json.data.received).toBe(true);
+
+    expect(mockCodeTaskRepo.update).toHaveBeenCalledOnce();
+    const [calledTaskId, updateFields] = mockCodeTaskRepo.update.mock.calls[0] as [
+      string,
+      Record<string, unknown>,
+    ];
+    expect(calledTaskId).toBe(TASK_ID);
+    expect(updateFields['status']).toBe('failed');
+    expect(updateFields['completedAt']).toBeInstanceOf(Date);
+    expect((updateFields['completedAt'] as Date).toISOString()).toBe('2026-04-17T12:00:00.000Z');
+    expect(updateFields['error']).toEqual({ code: 'TIMEOUT', message: 'Worker timed out' });
+    expect(updateFields['result']).toEqual({
+      prUrl: 'https://github.com/x/y/pull/1',
+      branch: 'feat/abc',
+      summary: 'x',
+    });
+  });
+
+  it('updates task with only required fields (no error → error:null, no result)', async () => {
+    const body = {
+      taskId: TASK_ID,
+      status: 'failed',
+      completedAt: '2026-04-17T12:00:00.000Z',
+    };
+
+    const response = await sendUpdate(TASK_ID, body);
+
+    expect(response.statusCode).toBe(200);
+    const [, updateFields] = mockCodeTaskRepo.update.mock.calls[0] as [
+      string,
+      Record<string, unknown>,
+    ];
+    expect(updateFields['status']).toBe('failed');
+    // `error` is always written: either the provided value or explicit null to
+    // clear any stale error captured during the `running` phase. Mirrors the
+    // existing /internal/webhooks/task-complete behavior this endpoint replaces.
+    expect(updateFields['error']).toBeNull();
+    expect(updateFields).not.toHaveProperty('result');
+  });
+
+  // -----------------------------------------------------------------------
+  // Error-field clearing on success
+  //
+  // The existing /internal/webhooks/task-complete handler writes `error: null`
+  // on success to clear any stale error captured during `running`. This
+  // endpoint replaces that handler as the primary status writer, so it must
+  // mirror the behavior to avoid leaving stale errors on tasks that went
+  // running→implemented via this path.
+  // -----------------------------------------------------------------------
+
+  it('clears stale error field when status is completed and no error is provided', async () => {
+    mockCodeTaskRepo.findById.mockResolvedValue(
+      ok({
+        id: TASK_ID,
+        repository: 'pbuchman/intexuraos',
+        userId: 'user-123',
+        status: 'running',
+        agentType: 'execution',
+        error: { code: 'TRANSIENT', message: 'prev' },
+      })
+    );
+
+    const body = {
+      taskId: TASK_ID,
+      status: 'completed',
+      completedAt: '2026-04-17T12:00:00.000Z',
+    };
+
+    const response = await sendUpdate(TASK_ID, body);
+
+    expect(response.statusCode).toBe(200);
+    expect(mockCodeTaskRepo.update).toHaveBeenCalledOnce();
+    const [, updateFields] = mockCodeTaskRepo.update.mock.calls[0] as [
+      string,
+      Record<string, unknown>,
+    ];
+    expect(updateFields['status']).toBe('implemented');
+    expect(updateFields['error']).toBeNull();
+  });
+
+  it('persists explicit error (does not null it out) when status is failed', async () => {
+    const body = {
+      taskId: TASK_ID,
+      status: 'failed',
+      completedAt: '2026-04-17T12:00:00.000Z',
+      error: { code: 'X', message: 'y' },
+    };
+
+    const response = await sendUpdate(TASK_ID, body);
+
+    expect(response.statusCode).toBe(200);
+    expect(mockCodeTaskRepo.update).toHaveBeenCalledOnce();
+    const [, updateFields] = mockCodeTaskRepo.update.mock.calls[0] as [
+      string,
+      Record<string, unknown>,
+    ];
+    expect(updateFields['error']).toEqual({ code: 'X', message: 'y' });
+  });
+
+  // -----------------------------------------------------------------------
+  // 'completed' → agent-type-specific mapping
+  //
+  // The Firestore TaskStatus type does not include 'completed'; it uses
+  // 'planned' | 'implemented' | 'reviewed' based on task.agentType. This
+  // mirrors the existing /internal/webhooks/task-complete webhook mapping
+  // (webhookRoutes.ts around line 1451) so the stored Firestore status is
+  // consistent across both paths.
+  // -----------------------------------------------------------------------
+
+  it.each([
+    ['execution', 'implemented'],
+    ['review', 'reviewed'],
+    ['planning', 'planned'],
+    ['remediation', 'implemented'],
+  ] as const)(
+    "maps status: 'completed' to stored status '%s' when agentType is '%s'",
+    async (agentType, expectedStoredStatus) => {
+      mockCodeTaskRepo.findById.mockResolvedValue(
+        ok({
+          id: TASK_ID,
+          repository: 'pbuchman/intexuraos',
+          userId: 'user-123',
+          status: 'running',
+          agentType,
+        })
+      );
+
+      const body = {
+        taskId: TASK_ID,
+        status: 'completed',
+        completedAt: '2026-04-17T12:00:00.000Z',
+      };
+
+      const response = await sendUpdate(TASK_ID, body);
+
+      expect(response.statusCode).toBe(200);
+      expect(mockCodeTaskRepo.update).toHaveBeenCalledOnce();
+      const [, updateFields] = mockCodeTaskRepo.update.mock.calls[0] as [
+        string,
+        Record<string, unknown>,
+      ];
+      expect(updateFields['status']).toBe(expectedStoredStatus);
+    }
+  );
+
+  it("passes non-'completed' status through unchanged regardless of agentType", async () => {
+    mockCodeTaskRepo.findById.mockResolvedValue(
+      ok({
+        id: TASK_ID,
+        repository: 'pbuchman/intexuraos',
+        userId: 'user-123',
+        status: 'running',
+        agentType: 'planning',
+      })
+    );
+
+    const body = {
+      taskId: TASK_ID,
+      status: 'failed',
+      completedAt: '2026-04-17T12:00:00.000Z',
+    };
+
+    const response = await sendUpdate(TASK_ID, body);
+
+    expect(response.statusCode).toBe(200);
+    const [, updateFields] = mockCodeTaskRepo.update.mock.calls[0] as [
+      string,
+      Record<string, unknown>,
+    ];
+    expect(updateFields['status']).toBe('failed');
+  });
+
+  // -----------------------------------------------------------------------
+  // Idempotency
+  // -----------------------------------------------------------------------
+
+  it('returns 200 no-op when task is already in terminal state', async () => {
+    mockCodeTaskRepo.findById.mockResolvedValue(
+      ok({
+        id: TASK_ID,
+        repository: 'pbuchman/intexuraos',
+        userId: 'user-123',
+        status: 'completed',
+      })
+    );
+
+    const body = {
+      taskId: TASK_ID,
+      status: 'failed',
+      completedAt: '2026-04-17T12:00:00.000Z',
+    };
+
+    const response = await sendUpdate(TASK_ID, body);
+
+    expect(response.statusCode).toBe(200);
+    const json = response.json() as { success: boolean; data: { received: boolean } };
+    expect(json.data.received).toBe(true);
+    expect(mockCodeTaskRepo.update).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    'completed',
+    'failed',
+    'interrupted',
+    'cancelled',
+    'implemented',
+    'planned',
+    'reviewed',
+    'archived',
+  ] as const)(
+    'returns 200 no-op when task status is already %s',
+    async (terminalStatus) => {
+      mockCodeTaskRepo.findById.mockResolvedValue(
+        ok({
+          id: TASK_ID,
+          repository: 'pbuchman/intexuraos',
+          userId: 'user-123',
+          status: terminalStatus,
+        })
+      );
+
+      const body = {
+        taskId: TASK_ID,
+        status: 'failed',
+        completedAt: '2026-04-17T12:00:00.000Z',
+      };
+
+      const response = await sendUpdate(TASK_ID, body);
+
+      expect(response.statusCode).toBe(200);
+      expect(mockCodeTaskRepo.update).not.toHaveBeenCalled();
+    }
+  );
+
+  // -----------------------------------------------------------------------
+  // Auth
+  // -----------------------------------------------------------------------
+
+  it('returns 401 when X-Internal-Auth is missing', async () => {
+    const body = {
+      taskId: TASK_ID,
+      status: 'failed',
+      completedAt: '2026-04-17T12:00:00.000Z',
+    };
+    const { rawBody, timestamp, signature } = sign(body, ORCHESTRATOR_SECRET);
+
+    const response = await app.inject({
+      method: 'PATCH',
+      url: `/internal/code-tasks/${TASK_ID}/status`,
+      headers: {
+        'content-type': 'application/json',
+        'x-request-timestamp': timestamp,
+        'x-request-signature': signature,
+      },
+      payload: rawBody,
+    });
+
+    expect(response.statusCode).toBe(401);
+    expect(mockCodeTaskRepo.update).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when HMAC signature is invalid', async () => {
+    const body = {
+      taskId: TASK_ID,
+      status: 'failed',
+      completedAt: '2026-04-17T12:00:00.000Z',
+    };
+
+    const response = await sendUpdate(TASK_ID, body, { badSignature: true });
+
+    expect(response.statusCode).toBe(401);
+    expect(mockCodeTaskRepo.update).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when signature headers are missing', async () => {
+    const body = {
+      taskId: TASK_ID,
+      status: 'failed',
+      completedAt: '2026-04-17T12:00:00.000Z',
+    };
+
+    const response = await sendUpdate(TASK_ID, body, { skipSignature: true });
+
+    expect(response.statusCode).toBe(401);
+    expect(mockCodeTaskRepo.update).not.toHaveBeenCalled();
+  });
+
+  // -----------------------------------------------------------------------
+  // Lookup
+  // -----------------------------------------------------------------------
+
+  it('returns 404 when task does not exist', async () => {
+    mockCodeTaskRepo.findById.mockResolvedValue(
+      err({ code: 'NOT_FOUND', message: 'Task not found' })
+    );
+
+    const body = {
+      taskId: TASK_ID,
+      status: 'failed',
+      completedAt: '2026-04-17T12:00:00.000Z',
+    };
+
+    const response = await sendUpdate(TASK_ID, body);
+
+    expect(response.statusCode).toBe(404);
+    expect(mockCodeTaskRepo.update).not.toHaveBeenCalled();
+  });
+
+  // -----------------------------------------------------------------------
+  // Validation (schema)
+  // -----------------------------------------------------------------------
+
+  it('returns 400 when status is not one of the terminal enum values', async () => {
+    const body = {
+      taskId: TASK_ID,
+      status: 'running',
+      completedAt: '2026-04-17T12:00:00.000Z',
+    };
+
+    const response = await sendUpdate(TASK_ID, body);
+
+    expect(response.statusCode).toBe(400);
+    expect(mockCodeTaskRepo.update).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when taskId in body does not match :id path param', async () => {
+    const body = {
+      taskId: 'task-different',
+      status: 'failed',
+      completedAt: '2026-04-17T12:00:00.000Z',
+    };
+
+    const response = await sendUpdate(TASK_ID, body);
+
+    expect(response.statusCode).toBe(400);
+    expect(mockCodeTaskRepo.update).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when request contains an unexpected field with an array value (additionalProperties:false guard)', async () => {
+    // Regression guard: original bug was a schema coercing `manualSteps: string[]` →
+    // `string`, which mutated the body and broke HMAC. With additionalProperties:false,
+    // this shape must be rejected with 400 *before* any body mutation happens.
+    const body = {
+      taskId: TASK_ID,
+      status: 'failed',
+      completedAt: '2026-04-17T12:00:00.000Z',
+      manualSteps: ['step 1', 'step 2'],
+    };
+
+    const response = await sendUpdate(TASK_ID, body);
+
+    expect(response.statusCode).toBe(400);
+    expect(mockCodeTaskRepo.update).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when completedAt is missing', async () => {
+    const body = {
+      taskId: TASK_ID,
+      status: 'failed',
+    };
+
+    const response = await sendUpdate(TASK_ID, body);
+
+    expect(response.statusCode).toBe(400);
+    expect(mockCodeTaskRepo.update).not.toHaveBeenCalled();
+  });
+
+  // -----------------------------------------------------------------------
+  // Repo failure
+  // -----------------------------------------------------------------------
+
+  it('returns 500 when repository update fails', async () => {
+    mockCodeTaskRepo.update.mockResolvedValue(
+      err({ code: 'FIRESTORE_ERROR', message: 'boom' })
+    );
+
+    const body = {
+      taskId: TASK_ID,
+      status: 'failed',
+      completedAt: '2026-04-17T12:00:00.000Z',
+    };
+
+    const response = await sendUpdate(TASK_ID, body);
+
+    expect(response.statusCode).toBe(500);
+  });
+});

--- a/apps/code-agent/src/__tests__/routes/codeRoutes.branches.test.ts
+++ b/apps/code-agent/src/__tests__/routes/codeRoutes.branches.test.ts
@@ -450,11 +450,9 @@ describe('codeRoutes branch coverage', () => {
       expect(body.data.dispatchedAt).toBe(now.toISOString());
     });
 
-    it('falls back to empty string when timestampToIso returns undefined for createdAt', async () => {
-      const { Timestamp } = await import('@google-cloud/firestore');
-      const now = new Date();
-      // Mock findByIdForUser to return a task where createdAt is an object without toDate()
-      // This exercises the ?? '' fallback path at line 317
+    it('falls back to empty string when timestampToIso returns undefined for createdAt and updatedAt', async () => {
+      // Mock findByIdForUser to return a task where createdAt and updatedAt are objects without toDate()
+      // This exercises the ?? '' fallback path for both timestamp fields
       const mockRepo = {
         ...getServices().codeTaskRepo,
         findByIdForUser: vi.fn().mockResolvedValue(ok({
@@ -473,7 +471,7 @@ describe('codeRoutes branch coverage', () => {
           callbackReceived: false,
           // Pass objects without toDate() to trigger timestampToIso returning undefined
           createdAt: { seconds: 123 } as never,
-          updatedAt: Timestamp.fromDate(now),
+          updatedAt: { seconds: 456 } as never,
         })),
       } as unknown as CodeTaskRepository;
 
@@ -487,8 +485,9 @@ describe('codeRoutes branch coverage', () => {
 
       expect(response.statusCode).toBe(200);
       const body = JSON.parse(response.body);
-      // createdAt should fall back to '' since timestampToIso returns undefined
+      // Both should fall back to '' since timestampToIso returns undefined
       expect(body.data.createdAt).toBe('');
+      expect(body.data.updatedAt).toBe('');
     });
   });
 

--- a/apps/code-agent/src/__tests__/routes/codeRoutes.test.ts
+++ b/apps/code-agent/src/__tests__/routes/codeRoutes.test.ts
@@ -2395,6 +2395,36 @@ describe('codeRoutes', () => {
       expect(response.statusCode).toBe(401);
     });
 
+    it('returns 200 when authenticated via OIDC bearer token', async () => {
+      const mockDetectZombieTasks = vi.fn().mockResolvedValue({
+        ok: true,
+        value: {
+          detected: 0,
+          interrupted: 0,
+          errors: [],
+          locksToCleanup: [],
+        },
+      });
+
+      setServices({
+        ...getServices(),
+        detectZombieTasks: mockDetectZombieTasks as never,
+      });
+
+      const response = await server.inject({
+        method: 'POST',
+        url: '/internal/code/detect-zombies',
+        headers: {
+          authorization: 'Bearer fake-oidc-token',
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.success).toBe(true);
+      expect(mockDetectZombieTasks).toHaveBeenCalled();
+    });
+
     it('returns 500 when zombie detection fails', async () => {
       const mockDetectZombieTasks = vi.fn().mockResolvedValue({
         ok: false,

--- a/apps/code-agent/src/domain/usecases/drainRetryQueue.ts
+++ b/apps/code-agent/src/domain/usecases/drainRetryQueue.ts
@@ -381,6 +381,11 @@ async function handleNewTaskRetry(
   const updateResult = await codeTaskRepo.update(entry.taskId, {
     status: 'dispatched',
     dispatchedAt: new Date(),
+    // Seed lastHeartbeat at dispatch so findZombieTasks (which uses a Firestore
+    // inequality filter on lastHeartbeat) can sweep tasks that crash/fail
+    // before the worker ever sends its first real heartbeat. Without this,
+    // the field would be missing and the inequality filter would exclude the doc forever.
+    lastHeartbeat: new Date(),
     workerLocation: dispatchResult.value.workerLocation,
     cancelNonce,
     cancelNonceExpiresAt,

--- a/apps/code-agent/src/domain/usecases/drainTaskQueue.ts
+++ b/apps/code-agent/src/domain/usecases/drainTaskQueue.ts
@@ -509,6 +509,11 @@ export async function drainTaskQueue(
     const updateResult = await codeTaskRepo.update(task.id, {
       status: 'dispatched',
       dispatchedAt: new Date(),
+      // Seed lastHeartbeat at dispatch so findZombieTasks (which uses a Firestore
+      // inequality filter on lastHeartbeat) can sweep tasks that crash/fail
+      // before the worker ever sends its first real heartbeat. Without this,
+      // the field would be missing and the inequality filter would exclude the doc forever.
+      lastHeartbeat: new Date(),
       workerLocation: dispatchResult.value.workerLocation,
       cancelNonce,
       cancelNonceExpiresAt,

--- a/apps/code-agent/src/infra/repositories/firestoreCodeTaskRepository.ts
+++ b/apps/code-agent/src/infra/repositories/firestoreCodeTaskRepository.ts
@@ -663,10 +663,13 @@ export const createFirestoreCodeTaskRepository = (deps: {
     findZombieTasks: async (staleThreshold: Date): Promise<Result<CodeTask[], RepositoryError>> => {
       try {
         const snapshot = await collection
-          // Note: 'queued' excluded — queued tasks don't heartbeat (no updatedAt changes),
-          // so they'd be false positives. Queue TTL expiry in drainTaskQueue handles them.
+          // Query on lastHeartbeat, not updatedAt. updatedAt is falsely refreshed by
+          // unrelated writes (PR merge webhooks, Linear event ingestion, etc.) so a
+          // silent-but-running task can appear fresh indefinitely. lastHeartbeat is
+          // written only by the heartbeat endpoint and is the true staleness signal.
+          // 'queued' excluded — queued tasks don't heartbeat, queue TTL in drainTaskQueue handles them.
           .where('status', 'in', DISPATCHED_OR_RUNNING_STATUSES)
-          .where('updatedAt', '<', Timestamp.fromDate(staleThreshold))
+          .where('lastHeartbeat', '<', Timestamp.fromDate(staleThreshold))
           .get();
 
          

--- a/apps/code-agent/src/infra/webhookValidation.ts
+++ b/apps/code-agent/src/infra/webhookValidation.ts
@@ -77,7 +77,11 @@ export function validateOrchestratorSignature(
   }
 
   // Compute expected signature
-  const rawBody = JSON.stringify(request.body);
+  const attachedRaw = (request as unknown as { rawBody?: unknown }).rawBody;
+  const rawBody =
+    typeof attachedRaw === 'string'
+      ? attachedRaw
+      : JSON.stringify(request.body);
   /* v8 ignore start -- upstream: Fastify always produces non-empty header arrays — cannot simulate empty Array.isArray-true header @preserve */
   const timestampStr = Array.isArray(timestamp) ? timestamp[0] ?? '' : timestamp;
   /* v8 ignore stop @preserve */

--- a/apps/code-agent/src/routes/code/index.ts
+++ b/apps/code-agent/src/routes/code/index.ts
@@ -8,5 +8,12 @@ import githubPREventsRoute from './github-pre-events.js';
 import githubPRSummariesRoute from './github-pr-summaries.js';
 import githubEventLogRoute from './github-event-log.js';
 import issueGroupRoutes from './issueGroupRoutes.js';
+import updateTaskStatusRoute from './updateTaskStatusRoute.js';
 
-export { githubPREventsRoute, githubPRSummariesRoute, githubEventLogRoute, issueGroupRoutes };
+export {
+  githubPREventsRoute,
+  githubPRSummariesRoute,
+  githubEventLogRoute,
+  issueGroupRoutes,
+  updateTaskStatusRoute,
+};

--- a/apps/code-agent/src/routes/code/updateTaskStatusRoute.ts
+++ b/apps/code-agent/src/routes/code/updateTaskStatusRoute.ts
@@ -1,0 +1,219 @@
+/**
+ * PATCH /internal/code-tasks/:id/status
+ *
+ * Dedicated, minimal endpoint for the orchestrator to commit terminal task
+ * status directly to Firestore. Authed with:
+ *   1. X-Internal-Auth header (shared service token)
+ *   2. HMAC-SHA256 signature with the shared orchestratorSecret
+ *      (same scheme as /internal/code/heartbeat)
+ *
+ * Body schema is strict (`additionalProperties: false`, primitive types only,
+ * no arrays and no defaults) so Ajv cannot mutate the request body and the
+ * HMAC signature remains stable against the raw request bytes.
+ *
+ * Idempotent: if the task is already terminal, the handler returns 200 no-op
+ * without calling the repository.
+ *
+ * No side effects beyond persistence — Linear / WhatsApp / GitHub labelling
+ * stays on the existing `task-complete` webhook which fires after this.
+ */
+
+import type { FastifyPluginCallback, FastifyRequest, FastifyReply } from 'fastify';
+import Ajv from 'ajv';
+import addFormats from 'ajv-formats';
+import { logIncomingRequest, validateInternalAuth } from '@intexuraos/common-http';
+import { getServices } from '../../services.js';
+import { validateOrchestratorSignature } from '../../infra/webhookValidation.js';
+import { loadConfig } from '../../config.js';
+
+interface UpdateTaskStatusBody {
+  taskId: string;
+  status: 'completed' | 'failed' | 'interrupted' | 'cancelled';
+  completedAt: string;
+  error?: { code: string; message: string };
+  result?: { prUrl?: string; branch?: string; summary?: string };
+}
+
+const TERMINAL_STATUSES = new Set<string>([
+  'completed',
+  'failed',
+  'interrupted',
+  'cancelled',
+  'implemented',
+  'planned',
+  'reviewed',
+  'archived',
+]);
+
+const updateTaskStatusRoute: FastifyPluginCallback = (fastify, _opts, done) => {
+  // Fastify's default ajv has `removeAdditional: true`, which silently strips
+  // unknown properties before validation — so `additionalProperties: false` in
+  // the schema does NOT produce a 400 for unknown fields. Verified by removing
+  // this block: the "unexpected array field" regression guard test fails (200
+  // instead of 400). Keep the strict ajv so contract drift surfaces as a 400.
+  const strictAjv = new Ajv.default({
+    coerceTypes: false,
+    useDefaults: false,
+    removeAdditional: false,
+    allErrors: false,
+  });
+  addFormats.default(strictAjv);
+
+  fastify.setValidatorCompiler(({ schema }) => strictAjv.compile(schema));
+
+  fastify.patch<{ Params: { id: string }; Body: UpdateTaskStatusBody }>(
+    '/internal/code-tasks/:id/status',
+    {
+      schema: {
+        operationId: 'updateCodeTaskStatus',
+        summary: 'Orchestrator commits terminal task status to Firestore',
+        description:
+          'Dedicated endpoint for the orchestrator to commit terminal task status. ' +
+          'Authed with orchestratorSecret HMAC. Strict body schema so HMAC is stable.',
+        tags: ['internal'],
+        params: {
+          type: 'object',
+          additionalProperties: false,
+          required: ['id'],
+          properties: {
+            id: { type: 'string' },
+          },
+        },
+        body: {
+          type: 'object',
+          additionalProperties: false,
+          required: ['taskId', 'status', 'completedAt'],
+          properties: {
+            taskId: { type: 'string' },
+            status: {
+              type: 'string',
+              enum: ['completed', 'failed', 'interrupted', 'cancelled'],
+            },
+            completedAt: { type: 'string', format: 'date-time' },
+            error: {
+              type: 'object',
+              additionalProperties: false,
+              required: ['code', 'message'],
+              properties: {
+                code: { type: 'string' },
+                message: { type: 'string' },
+              },
+            },
+            result: {
+              type: 'object',
+              additionalProperties: false,
+              properties: {
+                prUrl: { type: 'string' },
+                branch: { type: 'string' },
+                summary: { type: 'string' },
+              },
+            },
+          },
+        },
+      },
+    },
+    async (
+      request: FastifyRequest<{ Params: { id: string }; Body: UpdateTaskStatusBody }>,
+      reply: FastifyReply
+    ) => {
+      logIncomingRequest(request, {
+        message: 'Received request to PATCH /internal/code-tasks/:id/status',
+      });
+
+      // Auth layer 1: shared internal service token
+      const authResult = validateInternalAuth(request);
+      if (!authResult.valid) {
+        request.log.warn(
+          { reason: authResult.reason },
+          'Internal auth failed for update-task-status'
+        );
+        return await reply.fail('UNAUTHORIZED', 'Unauthorized');
+      }
+
+      // Auth layer 2: orchestrator HMAC signature over rawBody (INT-1412 Task 1)
+      const signatureResult = validateOrchestratorSignature(request, {
+        orchestratorSecret: loadConfig().orchestratorSecret,
+      });
+      if (!signatureResult.ok) {
+        request.log.warn(
+          { error: signatureResult.error },
+          'Orchestrator signature validation failed for update-task-status'
+        );
+        return await reply.fail('UNAUTHORIZED', 'Unauthorized');
+      }
+
+      const { id } = request.params;
+      const { taskId, status, completedAt, error, result } = request.body;
+
+      if (taskId !== id) {
+        return await reply.fail(
+          'INVALID_REQUEST',
+          'taskId in body does not match :id path parameter'
+        );
+      }
+
+      const { codeTaskRepo, logger } = getServices();
+
+      const existing = await codeTaskRepo.findById(taskId);
+      if (!existing.ok) {
+        return await reply.fail('NOT_FOUND', 'Task not found');
+      }
+      const task = existing.value; // @allow-result-access -- narrowed by !existing.ok guard above
+
+      if (TERMINAL_STATUSES.has(task.status)) {
+        logger.info(
+          { taskId, currentStatus: task.status, requestedStatus: status },
+          'Task already terminal; no-op idempotent response'
+        );
+        return await reply.ok({ received: true });
+      }
+
+      // Map orchestrator-vocabulary 'completed' to code-agent's agent-type-specific
+      // terminal status, mirroring /internal/webhooks/task-complete (webhookRoutes.ts
+       // around line 1451). The Firestore TaskStatus type does not include 'completed';
+      // it uses 'planned' | 'implemented' | 'reviewed'. Other terminal values
+      // ('failed' | 'interrupted' | 'cancelled') pass through unchanged.
+      const resolvedStatus =
+        status === 'completed'
+          ? task.agentType === 'planning'
+            ? 'planned'
+            : task.agentType === 'review'
+              ? 'reviewed'
+              : 'implemented'
+          : status;
+
+      // Always write `error`: either the provided value or explicit null to
+      // clear any stale error captured during the `running` phase. Mirrors the
+      // existing /internal/webhooks/task-complete behavior this endpoint
+      // replaces as the primary status writer. `result` remains conditional —
+      // the existing pattern does not clear it on failure.
+      const updateFields: Record<string, unknown> = {
+        status: resolvedStatus,
+        completedAt: new Date(completedAt),
+        error: error ?? null,
+      };
+      if (result !== undefined) {
+        updateFields['result'] = result;
+      }
+
+      const updateResult = await codeTaskRepo.update(taskId, updateFields);
+      if (!updateResult.ok) {
+        request.log.error(
+          { taskId, error: updateResult.error },
+          'Failed to update task status'
+        );
+        return await reply.fail('INTERNAL_ERROR', 'Failed to update task status');
+      }
+
+      logger.info(
+        { taskId, requestedStatus: status, resolvedStatus, agentType: task.agentType },
+        'Task status committed via /internal/code-tasks/:id/status'
+      );
+      return await reply.ok({ received: true });
+    }
+  );
+
+  done();
+};
+
+export default updateTaskStatusRoute;

--- a/apps/code-agent/src/routes/codeRoutes.ts
+++ b/apps/code-agent/src/routes/codeRoutes.ts
@@ -3401,12 +3401,12 @@ export const codeRoutes: FastifyPluginCallback<CodeRoutesOptions> = (fastify, op
         message: 'Received request to POST /internal/code/detect-zombies',
       });
 
-      // Validate internal auth
-      const authResult = validateInternalAuth(request);
-      if (!authResult.valid) {
-        request.log.warn({ reason: authResult.reason }, 'Internal auth failed for zombie detection');
+      const authResult = authenticateInternalScheduler(request);
+      if (!authResult.authenticated) {
+        request.log.warn('Internal auth failed for zombie detection');
         return await reply.fail('UNAUTHORIZED', 'Unauthorized');
       }
+      request.log.info({ strategy: authResult.strategy }, 'Authenticated for zombie detection');
 
       const { detectZombieTasks } = getServices();
 

--- a/apps/code-agent/src/routes/index.ts
+++ b/apps/code-agent/src/routes/index.ts
@@ -4,7 +4,7 @@ import { codeRoutes } from './codeRoutes.js';
 import { webhookRoutes } from './webhookRoutes.js';
 import { workerSettingsRoutes } from './workerSettingsRoutes.js';
 import { webhooksRoutes } from './webhooks/index.js';
-import { githubEventLogRoute, githubPREventsRoute, githubPRSummariesRoute, issueGroupRoutes } from './code/index.js';
+import { githubEventLogRoute, githubPREventsRoute, githubPRSummariesRoute, issueGroupRoutes, updateTaskStatusRoute } from './code/index.js';
 import { internalRoutes } from './internalRoutes.js';
 import { internalUsageWebhookRoute } from './internalUsageWebhookRoute.js';
 import { mergeQueueRoutes, mergeQueueTickRoute } from './merge-queue/index.js';
@@ -24,6 +24,7 @@ export async function registerRoutes(app: FastifyInstance, deps: RoutesDeps): Pr
   await app.register(internalRoutes);
   await app.register(internalUsageWebhookRoute);
   await app.register(issueGroupRoutes, deps);
+  await app.register(updateTaskStatusRoute);
   await app.register(mergeQueueRoutes, deps);
   await app.register(mergeQueueTickRoute);
 }

--- a/docs/superpowers/plans/2026-04-17-robust-task-finalize.md
+++ b/docs/superpowers/plans/2026-04-17-robust-task-finalize.md
@@ -1,0 +1,1570 @@
+# Robust Task Finalization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate the class of "code task stuck in `running`" bugs by making the orchestrator block on a dedicated, minimal status-update endpoint owned by code-agent, and by turning on the existing zombie watchdog as a safety net.
+
+**Architecture:** A new `PATCH /internal/code-tasks/:id/status` endpoint in code-agent performs a single idempotent Firestore write of terminal status using the shared `orchestratorSecret` HMAC (same auth scheme as heartbeat — NOT per-task `webhookSecret` that caused signature drift). HMAC is verified over `request.rawBody` (already captured by the common-http content parser) instead of re-serializing `request.body` — this closes the schema-coerces-body → HMAC mismatch class of failure. The orchestrator's `finalizeTask` calls this endpoint with retry + persistent queue fallback before firing the existing `task-complete` webhook, which is demoted to side-effects only. `findZombieTasks` switches from `updatedAt` (corrupted by unrelated webhooks like PR merge) to `lastHeartbeat`, and a new Cloud Scheduler cron invokes `/internal/code/detect-zombies` every 5 minutes in dev.
+
+**Tech Stack:** TypeScript (strict), Fastify, Firestore, ajv, node-fetch, Terraform, Google Cloud Scheduler, Vitest.
+
+**Endpoint Changes:**
+- **Created:** `PATCH /internal/code-tasks/:id/status` (orchestrator-authenticated)
+- **Modified:** none (existing `task-complete` webhook unchanged, just no longer load-bearing for status)
+- **Removed:** none
+- **Unchanged:** all existing endpoints
+
+---
+
+## File Structure
+
+### New files
+
+- `apps/code-agent/src/routes/code/updateTaskStatusRoute.ts` — minimal `PATCH /internal/code-tasks/:id/status` route (additional_properties:false, no arrays, no defaults, enum-constrained status)
+- `apps/code-agent/src/__tests__/routes/code/updateTaskStatusRoute.test.ts` — route tests including HMAC round-trip test
+- `workers/orchestrator/src/services/status-update-client.ts` — HTTP client that calls the new endpoint with retry + persistent queue fallback
+- `workers/orchestrator/src/services/__tests__/status-update-client.test.ts` — unit tests for the client
+
+### Modified files
+
+- `apps/code-agent/src/infra/webhookValidation.ts` — `validateOrchestratorSignature` uses `request.rawBody` when present, falls back to `JSON.stringify(request.body)` for backward compatibility
+- `apps/code-agent/src/__tests__/infra/webhookValidation.test.ts` — new tests proving rawBody path is preferred
+- `apps/code-agent/src/routes/code/index.ts` — register the new route
+- `apps/code-agent/src/infra/repositories/firestoreCodeTaskRepository.ts` — `findZombieTasks` queries on `lastHeartbeat` instead of `updatedAt`
+- `apps/code-agent/src/__tests__/infra/repositories/firestoreCodeTaskRepository.test.ts` — update findZombieTasks tests
+- `workers/orchestrator/src/services/task-dispatcher.ts` — `finalizeTask` calls `statusUpdateClient` with retry before existing webhook; accepts `statusUpdateClient` via constructor
+- `workers/orchestrator/src/__tests__/task-dispatcher.test.ts` — test finalize blocks on status update success
+- `workers/orchestrator/src/start.ts` — wire `StatusUpdateClient` into `TaskDispatcher`
+- `terraform/environments/dev/main.tf` — add `google_cloud_scheduler_job` for zombie detection (dev only — per user instruction)
+
+---
+
+## Task 1: Fix `validateOrchestratorSignature` to prefer `rawBody`
+
+**Why first:** This is a tiny, self-contained fix that benefits every orchestrator-signed endpoint (heartbeat today, status-update next). Shipping it first means later tasks don't need to duplicate the logic.
+
+**Files:**
+- Modify: `apps/code-agent/src/infra/webhookValidation.ts:45-103`
+- Test: `apps/code-agent/src/__tests__/infra/webhookValidation.test.ts`
+
+- [ ] **Step 1: Read the current function and locate the line that stringifies `request.body`**
+
+Open `apps/code-agent/src/infra/webhookValidation.ts`. The target block is the `validateOrchestratorSignature` function, specifically line 80:
+
+```ts
+const rawBody = JSON.stringify(request.body);
+```
+
+- [ ] **Step 2: Write a failing test proving the rawBody path is used when available**
+
+Add to `apps/code-agent/src/__tests__/infra/webhookValidation.test.ts` (append to the existing `describe('validateOrchestratorSignature', ...)` block):
+
+```ts
+it('uses request.rawBody for HMAC when rawBody is attached, ignoring re-serialized body', () => {
+  const secret = 'shared-orch-secret';
+  // Simulate the bytes that the sender HMAC'd: a JSON string with key order and
+  // whitespace that JSON.stringify(request.body) would NOT reproduce.
+  const rawBody = '{"taskIds":["task_1","task_2"]}';
+  const timestamp = Math.floor(Date.now() / 1000);
+  const expected = crypto
+    .createHmac('sha256', secret)
+    .update(`${String(timestamp)}.${rawBody}`)
+    .digest('hex');
+
+  // Inject a body whose re-serialization would DIFFER (keys reversed).
+  const mutatedBody = { taskIds: ['task_1', 'task_2'], extraInjectedByAjv: true };
+
+  const request = {
+    headers: {
+      'x-request-timestamp': String(timestamp),
+      'x-request-signature': expected,
+    },
+    body: mutatedBody,
+    rawBody,
+  } as unknown as FastifyRequest;
+
+  const result = validateOrchestratorSignature(request, { orchestratorSecret: secret });
+
+  expect(result.ok).toBe(true);
+});
+
+it('falls back to JSON.stringify(body) when rawBody is absent', () => {
+  const secret = 'shared-orch-secret';
+  const body = { taskIds: ['a'] };
+  const rawBody = JSON.stringify(body);
+  const timestamp = Math.floor(Date.now() / 1000);
+  const expected = crypto
+    .createHmac('sha256', secret)
+    .update(`${String(timestamp)}.${rawBody}`)
+    .digest('hex');
+
+  const request = {
+    headers: {
+      'x-request-timestamp': String(timestamp),
+      'x-request-signature': expected,
+    },
+    body,
+    // no rawBody
+  } as unknown as FastifyRequest;
+
+  const result = validateOrchestratorSignature(request, { orchestratorSecret: secret });
+
+  expect(result.ok).toBe(true);
+});
+```
+
+Ensure `crypto` is imported at the top of the test file if not already.
+
+- [ ] **Step 3: Run the new tests; confirm the rawBody-preference test FAILS**
+
+```bash
+pnpm --filter @intexuraos/code-agent test src/__tests__/infra/webhookValidation.test.ts -- --run
+```
+
+Expected: the first new test fails because the current code uses `JSON.stringify(request.body)`, producing a signature computed over `{"taskIds":["task_1","task_2"],"extraInjectedByAjv":true}` ≠ the `rawBody` used on the sender side. The second new test already passes (fallback path is equivalent to current code when rawBody is absent).
+
+- [ ] **Step 4: Implement the minimal change**
+
+In `apps/code-agent/src/infra/webhookValidation.ts`, replace line 80 inside `validateOrchestratorSignature`:
+
+```ts
+const rawBody = JSON.stringify(request.body);
+```
+
+with:
+
+```ts
+const attachedRaw = (request as unknown as { rawBody?: unknown }).rawBody;
+const rawBody =
+  typeof attachedRaw === 'string'
+    ? attachedRaw
+    : JSON.stringify(request.body);
+```
+
+Do NOT change `validateWebhookSignature` (per-task secret flow) in this PR — scope is limited to orchestrator-signed endpoints.
+
+- [ ] **Step 5: Run tests; confirm PASS**
+
+```bash
+pnpm --filter @intexuraos/code-agent test src/__tests__/infra/webhookValidation.test.ts -- --run
+```
+
+Expected: all tests in file pass, including the two new ones.
+
+- [ ] **Step 6: Run the full code-agent workspace test suite**
+
+```bash
+pnpm run verify:workspace:tracked -- code-agent
+```
+
+Expected: green. Existing tests for `validateOrchestratorSignature` still pass (the fallback path is byte-identical to the prior behavior when no `rawBody` is attached).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/code-agent/src/infra/webhookValidation.ts apps/code-agent/src/__tests__/infra/webhookValidation.test.ts
+git commit -m "fix(code-agent): verify orchestrator HMAC over request.rawBody
+
+Use the raw request bytes captured by the common-http content parser
+instead of re-serializing the parsed body. Re-serialization is fragile
+because ajv schema validation (useDefaults, coerceTypes, removeAdditional)
+can mutate request.body in place, breaking signature verification silently.
+Falls back to JSON.stringify(body) when rawBody is absent, so behavior is
+unchanged for any callers that do not use the common-http plugin.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: New `updateTaskStatusRoute` in code-agent
+
+**Files:**
+- Create: `apps/code-agent/src/routes/code/updateTaskStatusRoute.ts`
+- Create: `apps/code-agent/src/__tests__/routes/code/updateTaskStatusRoute.test.ts`
+- Modify: `apps/code-agent/src/routes/code/index.ts`
+
+- [ ] **Step 1: Write failing route test**
+
+Create `apps/code-agent/src/__tests__/routes/code/updateTaskStatusRoute.test.ts`. Base it on the existing pattern in `apps/code-agent/src/__tests__/routes/code/github-event-log.test.ts` for `setServices` / `server.inject` / service construction. The test file MUST include:
+
+```ts
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+import crypto from 'node:crypto';
+import { createFastifyPlugin } from '@intexuraos/common-http';
+import { updateTaskStatusRoute } from '../../../routes/code/updateTaskStatusRoute.js';
+import { setServices, resetServices, getServices } from '../../../services.js';
+import { createFakeCodeTaskRepo } from '../../helpers/fakes.js'; // use the same fake pattern other tests use; if helper doesn't exist, inline a minimal in-memory fake — DO NOT mock Firestore directly
+// … other imports following the pattern in neighboring test files
+
+const ORCH_SECRET = 'test-orchestrator-secret';
+const INTERNAL_AUTH_TOKEN = 'test-internal-auth-token';
+
+function signRequest(rawBody: string, secret: string, timestamp: number): string {
+  return crypto.createHmac('sha256', secret).update(`${String(timestamp)}.${rawBody}`).digest('hex');
+}
+
+describe('PATCH /internal/code-tasks/:id/status', () => {
+  let server: FastifyInstance;
+
+  beforeEach(async () => {
+    resetServices();
+    // seed services per existing pattern in neighbor tests; include codeTaskRepo with a seeded task
+    // the task must exist with status='running' so the update has something to modify
+    const codeTaskRepo = createFakeCodeTaskRepo();
+    await codeTaskRepo.create({ /* … minimal fields, id='task_abc', userId, status='running', webhookSecret, webhookUrl, etc. as required by the model */ });
+    setServices({ ...getServices(), codeTaskRepo });
+
+    server = Fastify();
+    await server.register(createFastifyPlugin({ internalAuthToken: INTERNAL_AUTH_TOKEN }));
+    await server.register(updateTaskStatusRoute);
+    await server.ready();
+  });
+
+  afterEach(async () => {
+    await server.close();
+  });
+
+  it('returns 200 and writes terminal status to the repo', async () => {
+    const body = {
+      taskId: 'task_abc',
+      status: 'failed',
+      completedAt: '2026-04-17T18:10:27.316Z',
+      error: { code: 'TASK_COMPLETION_VERIFICATION_FAILED', message: 'Missing fields: memory_acknowledgment' },
+      result: { prUrl: 'https://github.com/example/repo/pull/1', branch: 'feature-branch' },
+    };
+    const rawBody = JSON.stringify(body);
+    const timestamp = Math.floor(Date.now() / 1000);
+    const signature = signRequest(rawBody, ORCH_SECRET, timestamp);
+
+    const response = await server.inject({
+      method: 'PATCH',
+      url: '/internal/code-tasks/task_abc/status',
+      headers: {
+        'content-type': 'application/json',
+        'x-internal-auth': INTERNAL_AUTH_TOKEN,
+        'x-request-timestamp': String(timestamp),
+        'x-request-signature': signature,
+      },
+      payload: rawBody,
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.body)).toEqual({ received: true });
+
+    const stored = await getServices().codeTaskRepo.findById('task_abc');
+    expect(stored.ok).toBe(true);
+    if (!stored.ok) return;
+    expect(stored.value.status).toBe('failed');
+    expect(stored.value.completedAt?.toISOString()).toBe('2026-04-17T18:10:27.316Z');
+    expect(stored.value.error?.code).toBe('TASK_COMPLETION_VERIFICATION_FAILED');
+  });
+
+  it('returns 200 no-op when task is already in a terminal state (idempotency)', async () => {
+    // first call transitions to failed
+    // second call with same or different terminal status should return 200 without changing status
+    // implement per the same signing pattern
+  });
+
+  it('returns 401 when X-Internal-Auth is missing', async () => {
+    const body = { taskId: 'task_abc', status: 'failed', completedAt: '2026-04-17T18:10:27.316Z' };
+    const rawBody = JSON.stringify(body);
+    const timestamp = Math.floor(Date.now() / 1000);
+    const signature = signRequest(rawBody, ORCH_SECRET, timestamp);
+
+    const response = await server.inject({
+      method: 'PATCH',
+      url: '/internal/code-tasks/task_abc/status',
+      headers: {
+        'content-type': 'application/json',
+        'x-request-timestamp': String(timestamp),
+        'x-request-signature': signature,
+      },
+      payload: rawBody,
+    });
+
+    expect(response.statusCode).toBe(401);
+  });
+
+  it('returns 401 when HMAC signature is invalid', async () => {
+    const body = { taskId: 'task_abc', status: 'failed', completedAt: '2026-04-17T18:10:27.316Z' };
+    const rawBody = JSON.stringify(body);
+    const timestamp = Math.floor(Date.now() / 1000);
+
+    const response = await server.inject({
+      method: 'PATCH',
+      url: '/internal/code-tasks/task_abc/status',
+      headers: {
+        'content-type': 'application/json',
+        'x-internal-auth': INTERNAL_AUTH_TOKEN,
+        'x-request-timestamp': String(timestamp),
+        'x-request-signature': 'deadbeef',
+      },
+      payload: rawBody,
+    });
+
+    expect(response.statusCode).toBe(401);
+  });
+
+  it('returns 404 when task does not exist', async () => {
+    const body = { taskId: 'task_missing', status: 'failed', completedAt: '2026-04-17T18:10:27.316Z' };
+    const rawBody = JSON.stringify(body);
+    const timestamp = Math.floor(Date.now() / 1000);
+    const signature = signRequest(rawBody, ORCH_SECRET, timestamp);
+
+    const response = await server.inject({
+      method: 'PATCH',
+      url: '/internal/code-tasks/task_missing/status',
+      headers: {
+        'content-type': 'application/json',
+        'x-internal-auth': INTERNAL_AUTH_TOKEN,
+        'x-request-timestamp': String(timestamp),
+        'x-request-signature': signature,
+      },
+      payload: rawBody,
+    });
+
+    expect(response.statusCode).toBe(404);
+  });
+
+  it('returns 400 when status is not a valid terminal status', async () => {
+    const body = { taskId: 'task_abc', status: 'running', completedAt: '2026-04-17T18:10:27.316Z' };
+    const rawBody = JSON.stringify(body);
+    const timestamp = Math.floor(Date.now() / 1000);
+    const signature = signRequest(rawBody, ORCH_SECRET, timestamp);
+
+    const response = await server.inject({
+      method: 'PATCH',
+      url: '/internal/code-tasks/task_abc/status',
+      headers: {
+        'content-type': 'application/json',
+        'x-internal-auth': INTERNAL_AUTH_TOKEN,
+        'x-request-timestamp': String(timestamp),
+        'x-request-signature': signature,
+      },
+      payload: rawBody,
+    });
+
+    expect(response.statusCode).toBe(400);
+  });
+
+  it('HMAC verification is stable for array-containing unknown fields (regression guard)', async () => {
+    // Simulate a future orchestrator body that includes an extra field with an array value.
+    // The route declares additionalProperties:false so the extra field is rejected with 400
+    // (NOT silently coerced). This proves the route will fail loudly instead of silently
+    // breaking HMAC via ajv coercion — the exact failure mode that produced the stuck task.
+    const body = {
+      taskId: 'task_abc',
+      status: 'failed',
+      completedAt: '2026-04-17T18:10:27.316Z',
+      unexpectedArrayField: ['one', 'two'],
+    };
+    const rawBody = JSON.stringify(body);
+    const timestamp = Math.floor(Date.now() / 1000);
+    const signature = signRequest(rawBody, ORCH_SECRET, timestamp);
+
+    const response = await server.inject({
+      method: 'PATCH',
+      url: '/internal/code-tasks/task_abc/status',
+      headers: {
+        'content-type': 'application/json',
+        'x-internal-auth': INTERNAL_AUTH_TOKEN,
+        'x-request-timestamp': String(timestamp),
+        'x-request-signature': signature,
+      },
+      payload: rawBody,
+    });
+
+    expect(response.statusCode).toBe(400);
+  });
+});
+```
+
+Implementer note: if `createFakeCodeTaskRepo` does not exist as a helper, build a minimal in-memory repo inline that implements only `findById`, `update`. Do NOT mock the real `FirestoreCodeTaskRepository` — follow the repo-wide in-memory-fakes rule.
+
+- [ ] **Step 2: Run tests; confirm all FAIL with "route not found" or "cannot find module"**
+
+```bash
+pnpm --filter @intexuraos/code-agent test src/__tests__/routes/code/updateTaskStatusRoute.test.ts -- --run
+```
+
+Expected: all fail.
+
+- [ ] **Step 3: Implement the route**
+
+Create `apps/code-agent/src/routes/code/updateTaskStatusRoute.ts` with:
+
+```ts
+/**
+ * PATCH /internal/code-tasks/:id/status
+ *
+ * Dedicated, minimal endpoint for the orchestrator to commit a terminal
+ * task status to Firestore. Authed with the shared orchestratorSecret HMAC
+ * (same scheme as /internal/code/heartbeat). Signature is verified over
+ * request.rawBody to avoid the schema-coerces-body → HMAC-mismatch class
+ * of failure that caused silent stuck tasks.
+ *
+ * Body schema is strict: primitives only, additionalProperties:false at
+ * every level, enum-constrained status, no arrays, no defaults. ajv
+ * cannot mutate the body.
+ *
+ * The handler performs one idempotent Firestore write. If the task is
+ * already in a terminal state, it returns 200 without modification.
+ */
+
+import type { FastifyPluginCallback, FastifyRequest, FastifyReply } from 'fastify';
+import { logIncomingRequest, validateInternalAuth } from '@intexuraos/common-http';
+import { getServices } from '../../services.js';
+import { validateOrchestratorSignature } from '../../infra/webhookValidation.js';
+import { loadConfig } from '../../config.js';
+
+interface UpdateTaskStatusBody {
+  taskId: string;
+  status: 'completed' | 'failed' | 'interrupted' | 'cancelled';
+  completedAt: string;
+  error?: { code: string; message: string };
+  result?: { prUrl?: string; branch?: string; summary?: string };
+}
+
+const TERMINAL_STATUSES = new Set(['completed', 'failed', 'interrupted', 'cancelled']);
+
+export const updateTaskStatusRoute: FastifyPluginCallback = (fastify, _opts, done) => {
+  fastify.patch<{ Params: { id: string }; Body: UpdateTaskStatusBody }>(
+    '/internal/code-tasks/:id/status',
+    {
+      schema: {
+        operationId: 'updateCodeTaskStatus',
+        summary: 'Orchestrator commits terminal task status to Firestore',
+        tags: ['internal'],
+        params: {
+          type: 'object',
+          properties: { id: { type: 'string' } },
+          required: ['id'],
+          additionalProperties: false,
+        },
+        body: {
+          type: 'object',
+          additionalProperties: false,
+          required: ['taskId', 'status', 'completedAt'],
+          properties: {
+            taskId: { type: 'string' },
+            status: { type: 'string', enum: ['completed', 'failed', 'interrupted', 'cancelled'] },
+            completedAt: { type: 'string', format: 'date-time' },
+            error: {
+              type: 'object',
+              additionalProperties: false,
+              required: ['code', 'message'],
+              properties: {
+                code: { type: 'string' },
+                message: { type: 'string' },
+              },
+            },
+            result: {
+              type: 'object',
+              additionalProperties: false,
+              properties: {
+                prUrl: { type: 'string' },
+                branch: { type: 'string' },
+                summary: { type: 'string' },
+              },
+            },
+          },
+        },
+      },
+    },
+    async (
+      request: FastifyRequest<{ Params: { id: string }; Body: UpdateTaskStatusBody }>,
+      reply: FastifyReply
+    ) => {
+      logIncomingRequest(request, { message: 'Received request to PATCH /internal/code-tasks/:id/status' });
+
+      const authResult = validateInternalAuth(request);
+      if (!authResult.valid) {
+        request.log.warn({ reason: authResult.reason }, 'Internal auth failed for update-task-status');
+        return await reply.fail('UNAUTHORIZED', 'Unauthorized');
+      }
+
+      const signatureResult = validateOrchestratorSignature(request, {
+        orchestratorSecret: loadConfig().orchestratorSecret,
+      });
+      if (!signatureResult.ok) {
+        request.log.warn({ error: signatureResult.error }, 'Orchestrator signature validation failed');
+        return await reply.fail('UNAUTHORIZED', 'Unauthorized');
+      }
+
+      const { id } = request.params;
+      const { taskId, status, completedAt, error, result } = request.body;
+
+      if (taskId !== id) {
+        return await reply.fail('INVALID_REQUEST', 'taskId in body does not match :id path parameter');
+      }
+
+      const { codeTaskRepo, logger } = getServices();
+
+      const existing = await codeTaskRepo.findById(taskId);
+      if (!existing.ok) {
+        return await reply.fail('NOT_FOUND', 'Task not found');
+      }
+      const task = existing.value;
+
+      if (TERMINAL_STATUSES.has(task.status)) {
+        logger.info(
+          { taskId, currentStatus: task.status, requestedStatus: status },
+          'Task already terminal; no-op idempotent response'
+        );
+        return await reply.ok({ received: true });
+      }
+
+      const updateFields: Record<string, unknown> = {
+        status,
+        completedAt: new Date(completedAt),
+      };
+      if (error !== undefined) updateFields.error = error;
+      if (result !== undefined) updateFields.result = result;
+
+      const updateResult = await codeTaskRepo.update(taskId, updateFields);
+      if (!updateResult.ok) {
+        request.log.error({ taskId, error: updateResult.error }, 'Failed to update task status');
+        return await reply.fail('INTERNAL_ERROR', 'Failed to update task status');
+      }
+
+      logger.info({ taskId, status }, 'Task status committed via /internal/code-tasks/:id/status');
+      return await reply.ok({ received: true });
+    }
+  );
+
+  done();
+};
+```
+
+Notes:
+- `reply.ok({ received: true })` / `reply.fail(...)` match the pattern used by `webhookRoutes.ts` and `taskEvent.ts`.
+- No response schema with `additionalProperties: false` — keep the response open so fastify does not strip fields.
+- `loadConfig().orchestratorSecret` is already used by the heartbeat route; reuse it verbatim.
+
+- [ ] **Step 4: Register the route**
+
+Edit `apps/code-agent/src/routes/code/index.ts` to export and register `updateTaskStatusRoute`. If the file uses a plugin-callback that registers multiple sub-routes, follow the existing pattern; otherwise export it alongside other routes and register from `apps/code-agent/src/routes/index.ts`. Exact edit:
+
+```ts
+// apps/code-agent/src/routes/code/index.ts
+export { updateTaskStatusRoute } from './updateTaskStatusRoute.js';
+```
+
+Then in `apps/code-agent/src/routes/index.ts`, add the import and registration line:
+
+```ts
+import { updateTaskStatusRoute } from './code/index.js';
+// …
+  await app.register(updateTaskStatusRoute);
+```
+
+- [ ] **Step 5: Run tests; confirm PASS**
+
+```bash
+pnpm --filter @intexuraos/code-agent test src/__tests__/routes/code/updateTaskStatusRoute.test.ts -- --run
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Run the full code-agent workspace test suite**
+
+```bash
+pnpm run verify:workspace:tracked -- code-agent
+```
+
+Expected: green. No regression in any other route.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/code-agent/src/routes/code/updateTaskStatusRoute.ts apps/code-agent/src/routes/code/index.ts apps/code-agent/src/routes/index.ts apps/code-agent/src/__tests__/routes/code/updateTaskStatusRoute.test.ts
+git commit -m "feat(code-agent): add PATCH /internal/code-tasks/:id/status endpoint
+
+Dedicated, minimal endpoint for the orchestrator to commit terminal task
+status directly to Firestore, authed with the shared orchestratorSecret
+HMAC (same scheme as /internal/code/heartbeat). Body schema uses
+additionalProperties:false with primitive types only, so ajv cannot
+mutate the body and HMAC is stable. Idempotent: returns 200 no-op when
+task is already terminal.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Orchestrator `StatusUpdateClient`
+
+**Files:**
+- Create: `workers/orchestrator/src/services/status-update-client.ts`
+- Create: `workers/orchestrator/src/services/__tests__/status-update-client.test.ts`
+
+- [ ] **Step 1: Write failing client tests**
+
+Create `workers/orchestrator/src/services/__tests__/status-update-client.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import nock from 'nock';
+import { pino } from 'pino';
+import { StatusUpdateClient } from '../status-update-client.js';
+
+const logger = pino({ level: 'silent' });
+
+describe('StatusUpdateClient.commit', () => {
+  beforeEach(() => {
+    nock.cleanAll();
+  });
+  afterEach(() => {
+    expect(nock.isDone()).toBe(true);
+  });
+
+  it('signs payload with orchestratorSecret and returns ok on 200', async () => {
+    const client = new StatusUpdateClient({
+      codeAgentUrl: 'https://code-agent.test',
+      orchestratorSecret: 'secret',
+      internalAuthToken: 'internal',
+      logger,
+    });
+
+    nock('https://code-agent.test')
+      .patch('/internal/code-tasks/task_1/status', (body) => body.taskId === 'task_1' && body.status === 'failed')
+      .matchHeader('x-internal-auth', 'internal')
+      .matchHeader('x-request-signature', /^[a-f0-9]{64}$/)
+      .matchHeader('x-request-timestamp', /^\d+$/)
+      .reply(200, { received: true });
+
+    const result = await client.commit({
+      taskId: 'task_1',
+      status: 'failed',
+      completedAt: new Date('2026-04-17T18:10:27.316Z'),
+      error: { code: 'X', message: 'y' },
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it('retries on 5xx with backoff and succeeds on eventual 200', async () => {
+    const client = new StatusUpdateClient({
+      codeAgentUrl: 'https://code-agent.test',
+      orchestratorSecret: 'secret',
+      internalAuthToken: 'internal',
+      logger,
+      retryDelaysMs: [1, 1], // tiny delays in tests
+    });
+
+    nock('https://code-agent.test').patch('/internal/code-tasks/task_1/status').reply(500);
+    nock('https://code-agent.test').patch('/internal/code-tasks/task_1/status').reply(200, { received: true });
+
+    const result = await client.commit({
+      taskId: 'task_1',
+      status: 'completed',
+      completedAt: new Date('2026-04-17T18:10:27.316Z'),
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it('does not retry on 4xx and returns err', async () => {
+    const client = new StatusUpdateClient({
+      codeAgentUrl: 'https://code-agent.test',
+      orchestratorSecret: 'secret',
+      internalAuthToken: 'internal',
+      logger,
+      retryDelaysMs: [1, 1],
+    });
+
+    nock('https://code-agent.test').patch('/internal/code-tasks/task_1/status').reply(404);
+
+    const result = await client.commit({
+      taskId: 'task_1',
+      status: 'failed',
+      completedAt: new Date('2026-04-17T18:10:27.316Z'),
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.type).toBe('4xx');
+    }
+  });
+
+  it('returns err after exhausting retries on persistent 5xx', async () => {
+    const client = new StatusUpdateClient({
+      codeAgentUrl: 'https://code-agent.test',
+      orchestratorSecret: 'secret',
+      internalAuthToken: 'internal',
+      logger,
+      retryDelaysMs: [1, 1],
+    });
+
+    nock('https://code-agent.test').patch('/internal/code-tasks/task_1/status').times(3).reply(503);
+
+    const result = await client.commit({
+      taskId: 'task_1',
+      status: 'failed',
+      completedAt: new Date('2026-04-17T18:10:27.316Z'),
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.type).toBe('5xx');
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run; confirm all FAIL with "cannot find module"**
+
+```bash
+pnpm --filter @intexuraos/orchestrator test src/services/__tests__/status-update-client.test.ts -- --run
+```
+
+- [ ] **Step 3: Implement the client**
+
+Create `workers/orchestrator/src/services/status-update-client.ts`:
+
+```ts
+import { createHmac } from 'node:crypto';
+import type { Logger } from 'pino';
+
+export interface StatusUpdateClientConfig {
+  codeAgentUrl: string;
+  orchestratorSecret: string;
+  internalAuthToken: string;
+  logger: Logger;
+  retryDelaysMs?: number[]; // for tests; defaults to [1000, 3000, 9000]
+  requestTimeoutMs?: number; // defaults to 15_000
+}
+
+export interface StatusUpdatePayload {
+  taskId: string;
+  status: 'completed' | 'failed' | 'interrupted' | 'cancelled';
+  completedAt: Date;
+  error?: { code: string; message: string };
+  result?: { prUrl?: string; branch?: string; summary?: string };
+}
+
+export type StatusUpdateError =
+  | { type: 'network'; message: string }
+  | { type: '4xx'; status: number; message: string }
+  | { type: '5xx'; status: number; message: string }
+  | { type: 'timeout'; message: string };
+
+export type StatusUpdateResult =
+  | { ok: true }
+  | { ok: false; error: StatusUpdateError };
+
+const DEFAULT_RETRY_DELAYS_MS = [1000, 3000, 9000];
+const DEFAULT_REQUEST_TIMEOUT_MS = 15_000;
+
+export class StatusUpdateClient {
+  private readonly codeAgentUrl: string;
+  private readonly orchestratorSecret: string;
+  private readonly internalAuthToken: string;
+  private readonly logger: Logger;
+  private readonly retryDelaysMs: number[];
+  private readonly requestTimeoutMs: number;
+
+  constructor(config: StatusUpdateClientConfig) {
+    this.codeAgentUrl = config.codeAgentUrl;
+    this.orchestratorSecret = config.orchestratorSecret;
+    this.internalAuthToken = config.internalAuthToken;
+    this.logger = config.logger;
+    this.retryDelaysMs = config.retryDelaysMs ?? DEFAULT_RETRY_DELAYS_MS;
+    this.requestTimeoutMs = config.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+  }
+
+  async commit(payload: StatusUpdatePayload): Promise<StatusUpdateResult> {
+    const body = {
+      taskId: payload.taskId,
+      status: payload.status,
+      completedAt: payload.completedAt.toISOString(),
+      ...(payload.error !== undefined && { error: payload.error }),
+      ...(payload.result !== undefined && { result: payload.result }),
+    };
+    const rawBody = JSON.stringify(body);
+
+    let lastError: StatusUpdateError = { type: 'network', message: 'unknown' };
+    const maxAttempts = this.retryDelaysMs.length + 1;
+
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      const outcome = await this.deliver(payload.taskId, rawBody);
+
+      if (outcome.ok) {
+        if (attempt > 0) {
+          this.logger.info(
+            { taskId: payload.taskId, attempts: attempt + 1 },
+            'Status update committed after retries'
+          );
+        }
+        return { ok: true };
+      }
+
+      lastError = outcome.error;
+
+      this.logger.warn(
+        { taskId: payload.taskId, attempt: attempt + 1, errorType: outcome.error.type, errorMessage: outcome.error.message },
+        'Status update attempt failed'
+      );
+
+      if (outcome.error.type === '4xx') {
+        return { ok: false, error: outcome.error };
+      }
+
+      if (attempt < maxAttempts - 1) {
+        const delay = this.retryDelaysMs[attempt] ?? 1000;
+        await new Promise((resolve) => setTimeout(resolve, delay));
+      }
+    }
+
+    return { ok: false, error: lastError };
+  }
+
+  private async deliver(
+    taskId: string,
+    rawBody: string
+  ): Promise<{ ok: true } | { ok: false; error: StatusUpdateError }> {
+    const timestamp = Math.floor(Date.now() / 1000);
+    const signature = createHmac('sha256', this.orchestratorSecret)
+      .update(`${String(timestamp)}.${rawBody}`)
+      .digest('hex');
+
+    const url = `${this.codeAgentUrl}/internal/code-tasks/${taskId}/status`;
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), this.requestTimeoutMs);
+
+    try {
+      const response = await fetch(url, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Request-Timestamp': String(timestamp),
+          'X-Request-Signature': signature,
+          'X-Internal-Auth': this.internalAuthToken,
+        },
+        body: rawBody,
+        signal: controller.signal,
+      });
+
+      if (response.ok) {
+        return { ok: true };
+      }
+
+      const text = await response.text().catch(() => '');
+      if (response.status >= 400 && response.status < 500) {
+        return { ok: false, error: { type: '4xx', status: response.status, message: text || `HTTP ${String(response.status)}` } };
+      }
+      return { ok: false, error: { type: '5xx', status: response.status, message: text || `HTTP ${String(response.status)}` } };
+    } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError') {
+        return { ok: false, error: { type: 'timeout', message: `Request timed out after ${String(this.requestTimeoutMs)}ms` } };
+      }
+      const message = err instanceof Error ? err.message : String(err);
+      return { ok: false, error: { type: 'network', message } };
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run; confirm PASS**
+
+```bash
+pnpm --filter @intexuraos/orchestrator test src/services/__tests__/status-update-client.test.ts -- --run
+```
+
+- [ ] **Step 5: Run the full orchestrator workspace test suite**
+
+```bash
+pnpm run verify:workspace:tracked -- orchestrator
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add workers/orchestrator/src/services/status-update-client.ts workers/orchestrator/src/services/__tests__/status-update-client.test.ts
+git commit -m "feat(orchestrator): add StatusUpdateClient for direct status commit
+
+HTTP client that commits terminal task status to the new code-agent
+endpoint with retry on 5xx/network/timeout, immediate failure on 4xx,
+and configurable retry delays for testability. Signs with the shared
+orchestratorSecret (same scheme as heartbeat), not per-task webhookSecret.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Wire `StatusUpdateClient` into `TaskDispatcher.finalizeTask`
+
+**Files:**
+- Modify: `workers/orchestrator/src/services/task-dispatcher.ts` (constructor signature + finalizeTask body)
+- Modify: `workers/orchestrator/src/start.ts` (construct StatusUpdateClient, inject into dispatcher)
+- Modify: `workers/orchestrator/src/__tests__/task-dispatcher.test.ts` (cover the new call path)
+
+- [ ] **Step 1: Write failing dispatcher test**
+
+Append to `workers/orchestrator/src/__tests__/task-dispatcher.test.ts` (inside the existing `describe('TaskDispatcher', …)` or a new `describe('finalizeTask with StatusUpdateClient', …)` block):
+
+```ts
+it('finalizeTask calls statusUpdateClient.commit BEFORE the task-complete webhook', async () => {
+  const commitCalls: Array<{ taskId: string; status: string }> = [];
+  const webhookCalls: Array<{ url: string; payload: unknown }> = [];
+
+  const fakeStatusClient = {
+    commit: vi.fn(async (p: { taskId: string; status: string }) => {
+      commitCalls.push(p);
+      return { ok: true } as const;
+    }),
+  };
+  const fakeWebhookClient = {
+    send: vi.fn(async (args: { url: string; payload: unknown }) => {
+      webhookCalls.push({ url: args.url, payload: args.payload });
+      return { ok: true, value: undefined } as const;
+    }),
+    retryPending: vi.fn(async () => { /* no-op */ }),
+    getPendingCount: vi.fn(async () => 0),
+  };
+
+  // Construct dispatcher with these fakes following the existing pattern.
+  // Invoke finalizeTask on a task that is dispatchedOrRunning.
+  // Assert commitCalls was populated first, then webhookCalls.
+
+  expect(commitCalls[0]?.taskId).toBe(/* task id under test */);
+  expect(commitCalls[0]?.status).toBe('failed');
+  // Verify webhook was called after (array order reflects call order because both are awaited sequentially)
+  expect(webhookCalls.length).toBeGreaterThan(0);
+});
+
+it('finalizeTask logs ERROR and still returns when statusUpdateClient.commit fails persistently', async () => {
+  const fakeStatusClient = {
+    commit: vi.fn(async () => ({ ok: false, error: { type: '5xx' as const, status: 503, message: 'svc unavailable' } })),
+  };
+  // remaining setup similar to the previous test
+  // Assert that finalizeTask:
+  //   - does not throw
+  //   - writes an ERROR-level log line containing a stable tag (e.g. 'STATUS_UPDATE_COMMIT_FAILED')
+  //   - still fires the task-complete webhook (best-effort side-effects)
+  //   - still saves local state
+});
+```
+
+- [ ] **Step 2: Run; confirm FAIL**
+
+```bash
+pnpm --filter @intexuraos/orchestrator test src/__tests__/task-dispatcher.test.ts -- --run
+```
+
+Expected: new tests fail because `TaskDispatcher` does not yet accept `statusUpdateClient`.
+
+- [ ] **Step 3: Extend `TaskDispatcher` constructor**
+
+In `workers/orchestrator/src/services/task-dispatcher.ts`, add to the constructor parameters a required `statusUpdateClient` dep with the shape `{ commit(payload): Promise<{ ok: true } | { ok: false; error: { type: '4xx'|'5xx'|'network'|'timeout'; … } }> }`. Define an interface `StatusUpdateClientShape` in the same file (or import the concrete type from `status-update-client.ts`).
+
+Exact shape to import (recommended — avoids duplicate typing):
+
+```ts
+import type { StatusUpdateClient, StatusUpdatePayload } from './status-update-client.js';
+```
+
+Add `private readonly statusUpdateClient: StatusUpdateClient` to the class and wire it through the constructor signature.
+
+- [ ] **Step 4: Update `finalizeTask` to call `statusUpdateClient.commit` before webhook**
+
+Locate the block inside `finalizeTask` immediately before:
+
+```ts
+await this.webhookClient.send({
+  url: task.webhookUrl,
+  secret: task.webhookSecret,
+  payload: { taskId: task.taskId, status: finalStatus, … },
+  taskId: task.taskId,
+});
+```
+
+(task-dispatcher.ts:2533). Insert ABOVE it:
+
+```ts
+const statusCommitResult = await this.statusUpdateClient.commit({
+  taskId: task.taskId,
+  status: finalStatus,
+  completedAt: new Date(task.completedAt),
+  ...(payload.error !== undefined && {
+    error: { code: payload.error.code, message: payload.error.message },
+  }),
+  ...(payload.result !== undefined && {
+    result: {
+      ...(payload.result.prUrl !== undefined && { prUrl: payload.result.prUrl }),
+      ...(payload.result.branch !== undefined && { branch: payload.result.branch }),
+      ...(payload.result.summary !== undefined && { summary: payload.result.summary }),
+    },
+  }),
+});
+if (!statusCommitResult.ok) {
+  this.logger.error(
+    {
+      taskId: task.taskId,
+      tag: 'STATUS_UPDATE_COMMIT_FAILED',
+      errorType: statusCommitResult.error.type,
+      errorMessage: statusCommitResult.error.message,
+    },
+    'Failed to commit terminal status via /internal/code-tasks/:id/status; zombie watchdog will recover'
+  );
+  this.appendOrchestratorTaskLog(
+    task.taskId,
+    `STATUS_UPDATE_COMMIT_FAILED: type=${statusCommitResult.error.type} — zombie watchdog will recover`
+  );
+}
+```
+
+Do NOT block finalize on commit failure. Rationale: the zombie watchdog cron (Task 6) is the safety net, and we must not leave the Docker worker state half-torn-down because of a transient HTTP error. The ERROR log with the stable `STATUS_UPDATE_COMMIT_FAILED` tag makes the regression visible without turning a retry loop into a stuck finalize.
+
+- [ ] **Step 5: Wire `StatusUpdateClient` construction in `start.ts`**
+
+In `workers/orchestrator/src/start.ts` (near where `WebhookClient` is constructed), add:
+
+```ts
+import { StatusUpdateClient } from './services/status-update-client.js';
+// …
+const statusUpdateClient = new StatusUpdateClient({
+  codeAgentUrl,
+  orchestratorSecret,
+  internalAuthToken,
+  logger,
+});
+```
+
+Pass it as a new constructor argument to `new TaskDispatcher(...)`. The three already-used values (`codeAgentUrl`, `orchestratorSecret`, `internalAuthToken`) are already loaded from env vars earlier in `start.ts` for the heartbeat manager.
+
+- [ ] **Step 6: Run; confirm PASS**
+
+```bash
+pnpm --filter @intexuraos/orchestrator test -- --run
+```
+
+- [ ] **Step 7: Run the full tracked CI locally**
+
+```bash
+pnpm run ci:tracked
+```
+
+Expected: full green. Fix any regressions (likely in tests that construct `TaskDispatcher` without the new dep — update those test-helper fakes to pass a `{ commit: async () => ({ ok: true }) }` shim).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add workers/orchestrator/src/services/task-dispatcher.ts workers/orchestrator/src/start.ts workers/orchestrator/src/__tests__/task-dispatcher.test.ts
+# Plus any test-helper updates that were needed.
+git commit -m "feat(orchestrator): commit terminal status via StatusUpdateClient in finalizeTask
+
+finalizeTask now calls the new /internal/code-tasks/:id/status endpoint
+before firing the existing task-complete webhook. This makes code-agent's
+Firestore the single source of truth for status, with the webhook demoted
+to side-effects (Linear labels, WhatsApp, etc.). If the commit fails,
+finalize still returns (Docker teardown must not be blocked by a
+transient HTTP error) and logs STATUS_UPDATE_COMMIT_FAILED — the zombie
+watchdog cron recovers any slip-through.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Switch `findZombieTasks` to query `lastHeartbeat`
+
+**Files:**
+- Modify: `apps/code-agent/src/infra/repositories/firestoreCodeTaskRepository.ts:663-685`
+- Modify: `apps/code-agent/src/__tests__/infra/repositories/firestoreCodeTaskRepository.test.ts` (findZombieTasks block at :1357)
+
+- [ ] **Step 1: Update the unit test to assert the new query behavior**
+
+In `firestoreCodeTaskRepository.test.ts` the existing `findZombieTasks` block seeds a task with `dispatchedAt` and tests "just the query works." Replace with an assertion that stale tasks ARE found by `lastHeartbeat`, and that tasks whose `updatedAt` was refreshed by an unrelated write but whose `lastHeartbeat` remains stale ARE still found:
+
+```ts
+describe('findZombieTasks', () => {
+  it('finds tasks whose lastHeartbeat is older than threshold even when updatedAt is recent', async () => {
+    const repo = createFirestoreCodeTaskRepository({
+      firestore: fakeFirestore as unknown as Firestore,
+      logger,
+    });
+
+    const created = await repo.create(createTaskInput());
+    expect(created.ok).toBe(true);
+    if (!created.ok) return;
+
+    // Simulate a running task with stale heartbeat but recently touched updatedAt
+    // (e.g. a PR merge webhook updated the task document).
+    await repo.update(created.value.id, {
+      status: 'running',
+      lastHeartbeat: new Date(Date.now() - 40 * 60 * 1000), // 40 min ago
+      updatedAt: new Date(), // just now (simulates unrelated write)
+    });
+
+    const staleThreshold = new Date(Date.now() - 30 * 60 * 1000);
+    const result = await repo.findZombieTasks(staleThreshold);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.map((t) => t.id)).toContain(created.value.id);
+  });
+
+  it('does NOT find tasks whose lastHeartbeat is recent', async () => {
+    const repo = createFirestoreCodeTaskRepository({
+      firestore: fakeFirestore as unknown as Firestore,
+      logger,
+    });
+
+    const created = await repo.create(createTaskInput());
+    expect(created.ok).toBe(true);
+    if (!created.ok) return;
+
+    await repo.update(created.value.id, {
+      status: 'running',
+      lastHeartbeat: new Date(), // fresh
+    });
+
+    const staleThreshold = new Date(Date.now() - 30 * 60 * 1000);
+    const result = await repo.findZombieTasks(staleThreshold);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.map((t) => t.id)).not.toContain(created.value.id);
+  });
+
+  it('returns empty array when no zombie tasks', async () => {
+    const repo = createFirestoreCodeTaskRepository({
+      firestore: fakeFirestore as unknown as Firestore,
+      logger,
+    });
+
+    const staleThreshold = new Date(Date.now() - 5 * 60 * 1000);
+    const result = await repo.findZombieTasks(staleThreshold);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toEqual([]);
+  });
+});
+```
+
+Implementer note: FakeFirestore used in these tests must support querying on `lastHeartbeat`. If it already supports querying on arbitrary fields (which it does based on the original test), no fake extension is needed — just verify.
+
+- [ ] **Step 2: Run; confirm first new test FAILS**
+
+```bash
+pnpm --filter @intexuraos/code-agent test src/__tests__/infra/repositories/firestoreCodeTaskRepository.test.ts -- --run -t findZombieTasks
+```
+
+Expected: the "recently updated" test fails because the current query filters on `updatedAt`.
+
+- [ ] **Step 3: Change the query**
+
+In `apps/code-agent/src/infra/repositories/firestoreCodeTaskRepository.ts`, locate `findZombieTasks` (around line 663). Replace:
+
+```ts
+.where('status', 'in', DISPATCHED_OR_RUNNING_STATUSES)
+.where('updatedAt', '<', Timestamp.fromDate(staleThreshold))
+```
+
+with:
+
+```ts
+.where('status', 'in', DISPATCHED_OR_RUNNING_STATUSES)
+.where('lastHeartbeat', '<', Timestamp.fromDate(staleThreshold))
+```
+
+Update the inline comment block directly above the query to explain why `lastHeartbeat` (written only by the heartbeat endpoint) is the correct staleness signal and `updatedAt` is not (it is written by unrelated events like PR merge webhooks).
+
+- [ ] **Step 4: Run; confirm PASS**
+
+```bash
+pnpm --filter @intexuraos/code-agent test src/__tests__/infra/repositories/firestoreCodeTaskRepository.test.ts -- --run -t findZombieTasks
+```
+
+- [ ] **Step 5: Create Firestore composite index migration**
+
+The new query is `status in [dispatched, running] AND lastHeartbeat <`. This is a composite query that requires an index. Migrations in this repo follow the pattern at `migrations/096_mobile-notifications-digest-time-range-index.mjs`.
+
+Create `migrations/097_code-tasks-zombie-lastHeartbeat-index.mjs`:
+
+```javascript
+/**
+ * Migration 097: Composite index for findZombieTasks on lastHeartbeat
+ *
+ * Required by code-agent findZombieTasks query:
+ *   where('status', 'in', ['dispatched', 'running'])
+ *   where('lastHeartbeat', '<', staleThreshold)
+ *
+ * Replaces the previous updatedAt-based staleness query, which was
+ * vulnerable to false refresh from unrelated writes (e.g. PR merge
+ * webhooks setting prMergedAt, which bumped updatedAt).
+ */
+
+export const metadata = {
+  id: '097',
+  name: 'code-tasks-zombie-lastHeartbeat-index',
+  description: 'Composite index for findZombieTasks(status, lastHeartbeat)',
+  createdAt: '2026-04-17',
+};
+
+export const indexes = [
+  {
+    collectionGroup: 'code_tasks',
+    queryScope: 'COLLECTION',
+    fields: [
+      { fieldPath: 'status', order: 'ASCENDING' },
+      { fieldPath: 'lastHeartbeat', order: 'ASCENDING' },
+    ],
+  },
+];
+
+export const collections = ['code_tasks'];
+
+export async function up(context) {
+  console.log('  Deploying code_tasks zombie-detection composite index...');
+  await context.deployIndexes();
+}
+
+export async function down() {
+  console.log('  Removing the composite index requires manual deletion via Firebase console');
+}
+```
+
+- [ ] **Step 6: Regenerate `firestore.indexes.json`**
+
+`firestore.indexes.json` is tracked in git (not gitignored; only `firestore.rules` is). Regenerate it from the aggregated migrations:
+
+```bash
+node scripts/generate-firestore-config.mjs
+```
+
+Expected stdout: `✓ Generated firestore.indexes.json`. The regenerated file will contain the new `code_tasks` composite index alongside all existing indexes.
+
+- [ ] **Step 7: Run full code-agent tracked CI**
+
+```bash
+pnpm run verify:workspace:tracked -- code-agent
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/code-agent/src/infra/repositories/firestoreCodeTaskRepository.ts \
+        apps/code-agent/src/__tests__/infra/repositories/firestoreCodeTaskRepository.test.ts \
+        migrations/097_code-tasks-zombie-lastHeartbeat-index.mjs \
+        firestore.indexes.json
+git commit -m "fix(code-agent): query findZombieTasks on lastHeartbeat instead of updatedAt
+
+updatedAt is refreshed by unrelated writes (PR merge webhooks, Linear
+event ingestion, etc.) so a running-but-silent task can mask as fresh
+indefinitely. lastHeartbeat is written only by the heartbeat endpoint
+and is the correct staleness signal. Adds migration 097 with composite
+index on (status, lastHeartbeat) and regenerated firestore.indexes.json.
+Migration auto-applies on PR merge.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Cloud Scheduler cron for `detect-zombies` (dev only)
+
+**Files:**
+- Modify: `terraform/environments/dev/main.tf`
+
+Per user instruction: this change goes in dev only. Prod and dev share Firestore, so a dev-triggered sweep recovers both environments' tasks when the orchestrator writes the shared collection. If prod operates independently, replicate this block in `terraform/environments/prod/main.tf` later — out of scope for this PR.
+
+- [ ] **Step 1: Read the existing schedulers in the file to match the pattern**
+
+Open `terraform/environments/dev/main.tf` and find the block around line 1789 (`google_cloud_scheduler_job "cron_agent_tick"`). Use this as the pattern. Also find the `google_cloud_run_service_iam_member` pattern that grants `scheduler@` invoker on each Cloud Run service — confirm a similar grant exists or must be added for `intexuraos-code-agent`.
+
+Search for existing code-agent scheduler invoker grant:
+
+```bash
+grep -n "scheduler.*code_agent\|code_agent.*scheduler" terraform/environments/dev/main.tf || echo "not found"
+```
+
+- [ ] **Step 2: Add the scheduler job (and invoker IAM if missing)**
+
+Append to `terraform/environments/dev/main.tf` (below the `cron_agent_tick` block is a good spot):
+
+```hcl
+# Grant the shared Cloud Scheduler SA invoker on code-agent (no-op if already granted).
+resource "google_cloud_run_service_iam_member" "scheduler_invokes_code_agent" {
+  project  = var.project_id
+  location = var.region
+  service  = local.services.code_agent.name
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:${google_service_account.cloud_scheduler.email}"
+
+  depends_on = [module.code_agent]
+}
+
+resource "google_cloud_scheduler_job" "code_tasks_zombie_sweep" {
+  name        = "intexuraos-code-tasks-zombie-sweep-${var.environment}"
+  description = "Sweep stuck code tasks (status in dispatched/running with stale lastHeartbeat) and mark them interrupted"
+  schedule    = "*/5 * * * *"
+  time_zone   = "UTC"
+  region      = var.region
+
+  http_target {
+    http_method = "POST"
+    uri         = "https://${local.services.code_agent.name}-${local.cloud_run_url_suffix}/internal/code/detect-zombies"
+    body        = base64encode("{}")
+
+    oidc_token {
+      service_account_email = google_service_account.cloud_scheduler.email
+      audience              = "https://${local.services.code_agent.name}-${local.cloud_run_url_suffix}"
+    }
+
+    headers = {
+      "Content-Type" = "application/json"
+      "X-Internal-Auth" = var.internal_auth_token
+    }
+  }
+
+  retry_config {
+    retry_count          = 1
+    min_backoff_duration = "30s"
+    max_backoff_duration = "120s"
+  }
+
+  depends_on = [
+    google_cloud_run_service_iam_member.scheduler_invokes_code_agent,
+    module.code_agent,
+  ]
+}
+```
+
+Implementer note: inspect the actual variable and local names in the file — `var.internal_auth_token`, `local.services.code_agent.name`, `local.cloud_run_url_suffix`, `google_service_account.cloud_scheduler`, `module.code_agent` may be named differently. Match the existing conventions used by `cron_agent_tick` and `linear_sync_hourly`. Do NOT duplicate the invoker IAM resource if one already exists for code-agent — reuse it.
+
+Also confirm how `X-Internal-Auth` is handled for other scheduler-invoked endpoints in this file. If the existing pattern relies on OIDC only and reads the header through a wrapper, adapt to match. The `/internal/code/detect-zombies` handler currently requires `X-Internal-Auth` (see `codeRoutes.ts:3405-3409`).
+
+- [ ] **Step 3: Validate Terraform**
+
+```bash
+cd terraform/environments/dev
+terraform fmt
+terraform validate
+cd - > /dev/null
+```
+
+Expected: formatted without changes, validate passes.
+
+- [ ] **Step 4: Plan against dev project**
+
+```bash
+cd terraform/environments/dev
+terraform plan -var-file=... # match existing pattern in repo
+cd - > /dev/null
+```
+
+Confirm the plan shows exactly two additions: the IAM member (if needed) and the scheduler job. Abort if anything else is modified. Do NOT apply from this plan — the PR review is the gate.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add terraform/environments/dev/main.tf
+git commit -m "chore(terraform/dev): schedule code-tasks zombie sweep every 5 minutes
+
+Cloud Scheduler hits /internal/code/detect-zombies every 5 minutes.
+Dev and prod share Firestore, so dev's scheduler recovers both. The
+endpoint already existed as dead code — this turns it on. Belt-and-
+suspenders under the new status-update endpoint from Tasks 1-4.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: End-to-end regression test
+
+**Why:** One test that would have caught the original `manualSteps` bug and its equivalents: a real `task-complete`-shaped payload, signed correctly, round-tripped through the code-agent route, landing in Firestore via the new endpoint.
+
+**Files:**
+- Create: `workers/orchestrator/src/__tests__/integration/status-update-e2e.test.ts`
+
+- [ ] **Step 1: Write the test**
+
+Create `workers/orchestrator/src/__tests__/integration/status-update-e2e.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Fastify from 'fastify';
+import { createFastifyPlugin } from '@intexuraos/common-http';
+import { updateTaskStatusRoute } from '../../../../apps/code-agent/src/routes/code/updateTaskStatusRoute.js';
+import { setServices, resetServices, getServices } from '../../../../apps/code-agent/src/services.js';
+import { StatusUpdateClient } from '../../services/status-update-client.js';
+import { pino } from 'pino';
+
+const ORCH_SECRET = 'shared-secret';
+const INTERNAL = 'internal-auth';
+
+describe('StatusUpdateClient ↔ updateTaskStatusRoute end-to-end', () => {
+  let server: Awaited<ReturnType<typeof startServer>>;
+
+  async function startServer(): Promise<{ url: string; close: () => Promise<void> }> {
+    const app = Fastify();
+    await app.register(createFastifyPlugin({ internalAuthToken: INTERNAL }));
+    await app.register(updateTaskStatusRoute);
+    await app.listen({ port: 0, host: '127.0.0.1' });
+    const address = app.server.address();
+    if (address === null || typeof address === 'string') {
+      throw new Error('unexpected server address');
+    }
+    return { url: `http://127.0.0.1:${String(address.port)}`, close: async () => await app.close() };
+  }
+
+  beforeEach(async () => {
+    resetServices();
+    // seed in-memory codeTaskRepo with a running task
+    const inMemoryRepo = /* construct a minimal fake — same helper pattern used in updateTaskStatusRoute.test.ts */;
+    await inMemoryRepo.create({ id: 'task_int', status: 'running', /* … */ });
+    setServices({ ...getServices(), codeTaskRepo: inMemoryRepo });
+    server = await startServer();
+  });
+
+  afterEach(async () => {
+    await server.close();
+  });
+
+  it('orchestrator client commits status and code-agent persists it', async () => {
+    const client = new StatusUpdateClient({
+      codeAgentUrl: server.url,
+      orchestratorSecret: ORCH_SECRET,
+      internalAuthToken: INTERNAL,
+      logger: pino({ level: 'silent' }),
+    });
+
+    const result = await client.commit({
+      taskId: 'task_int',
+      status: 'failed',
+      completedAt: new Date('2026-04-17T18:10:27.316Z'),
+      error: { code: 'TASK_COMPLETION_VERIFICATION_FAILED', message: 'Missing fields: memory_acknowledgment' },
+      result: { prUrl: 'https://github.com/x/y/pull/1', branch: 'fix/x' },
+    });
+
+    expect(result.ok).toBe(true);
+
+    const stored = await getServices().codeTaskRepo.findById('task_int');
+    expect(stored.ok).toBe(true);
+    if (!stored.ok) return;
+    expect(stored.value.status).toBe('failed');
+    expect(stored.value.error?.code).toBe('TASK_COMPLETION_VERIFICATION_FAILED');
+  });
+});
+```
+
+Implementer note: this test crosses package boundaries (orchestrator test importing from code-agent). If the monorepo's test config / path mapping does not allow that, either:
+- place the test inside `apps/code-agent/src/__tests__/integration/` and import `StatusUpdateClient` from `workers/orchestrator` instead, OR
+- keep it where it is and add a path mapping, OR
+- inline a minimal fake of the code-agent route using the same body schema and signature validation logic (acceptable as a fallback — the Task 2 test already covers the route in isolation; this integration test's value is the client-server round-trip).
+
+- [ ] **Step 2: Run; confirm PASS**
+
+Run whichever workspace the test ended up in.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add <paths>
+git commit -m "test: add end-to-end regression for status-update endpoint round-trip
+
+Signs a realistic task-complete payload with the orchestrator client and
+verifies the code-agent route persists it. Catches the whole class of
+'schema coerces body, HMAC mismatches, task stays running' bugs that
+the old task-complete webhook was vulnerable to.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Final Steps
+
+- [ ] **Step 1: Run the full tracked CI locally from repo root**
+
+```bash
+pnpm run ci:tracked 2>&1 | tee /tmp/ci-final.txt
+```
+
+Expected: complete green. Any failure in any workspace must be resolved before commit per the project's Commit Gate.
+
+- [ ] **Step 2: Push the feature branch and open the PR**
+
+Branch name: `fix/robust-task-finalize` (no INT-XXX prefix — user explicitly said no Linear issue). Target: `development`.
+
+PR title: `fix: make task finalization robust via dedicated status endpoint`
+
+PR body:
+
+```
+## Summary
+
+Eliminates the "stuck in `running`" class of bugs. Orchestrator now
+commits terminal task status via a new dedicated, minimal endpoint
+(`PATCH /internal/code-tasks/:id/status`) authed with the shared
+orchestratorSecret HMAC. The old `task-complete` webhook is demoted to
+side-effects (Linear labels, WhatsApp, etc.) and no longer load-bearing
+for status.
+
+Defense in depth: zombie watchdog cron now actually runs (every 5 min)
+and queries on `lastHeartbeat` instead of `updatedAt` (which was being
+falsely refreshed by unrelated webhooks like PR merges).
+
+Triggered by investigation of task_103bd7e0-5b25-4842-a493-a5ffdc8f3d46
+where `manualSteps: string[]` in the orchestrator payload was coerced
+to `string` by ajv on the receiving side, breaking the HMAC and
+returning 401 — silently dropped by the webhook client because 4xx is
+not retried. HMAC now verified against `request.rawBody`, so schema
+coercion can never break signatures again.
+
+## Changes
+
+- `fix(code-agent)`: `validateOrchestratorSignature` prefers `request.rawBody`
+- `feat(code-agent)`: new `PATCH /internal/code-tasks/:id/status` endpoint
+- `feat(orchestrator)`: `StatusUpdateClient` with retry + 4xx-no-retry
+- `feat(orchestrator)`: `finalizeTask` commits status before firing webhook
+- `fix(code-agent)`: `findZombieTasks` filters on `lastHeartbeat`
+- `chore(terraform/dev)`: Cloud Scheduler cron for `/internal/code/detect-zombies`
+- `test`: end-to-end regression for the orchestrator→code-agent round-trip
+
+## Endpoint Changes
+
+- **Created:** `PATCH /internal/code-tasks/:id/status`
+- **Modified:** none
+- **Removed:** none
+- **Unchanged:** all existing endpoints
+
+## Test plan
+
+- [x] Unit tests per task
+- [x] End-to-end integration test
+- [x] `pnpm run ci:tracked` green locally
+- [ ] After merge: manually resolve `task_103bd7e0-5b25-4842-a493-a5ffdc8f3d46` (set status=failed in Firestore — owner will do once PR merges)
+- [ ] After merge: Terraform apply for dev scheduler
+```
+
+---
+
+## Self-Review Checklist
+
+**Spec coverage:**
+- Dedicated endpoint → Task 2 ✓
+- Simple authorization with existing secrets → Tasks 1, 2 (validateOrchestratorSignature + internal auth, both already used by heartbeat) ✓
+- Orchestrator calls it from finalize → Task 4 ✓
+- Zombie watchdog turned on → Task 6 ✓
+- `lastHeartbeat` used for staleness → Task 5 ✓
+- Dev terraform only → Task 6 ✓
+- No INT-XXX → Final steps ✓
+- Commit + push + PR → Final steps ✓
+
+**Placeholder scan:** All steps include actual code or exact commands. No "TBD", no "add error handling as appropriate." A few places flag implementation discretion (e.g. fake helpers, terraform variable names, route-registration pattern) but they point at concrete existing files to mirror.
+
+**Type consistency:**
+- `StatusUpdatePayload` defined in Task 3, consumed in Task 4 — fields match.
+- `StatusUpdateError` defined in Task 3, consumed in Task 4 `statusCommitResult.error.type` check — union covers `4xx | 5xx | network | timeout`, matches.
+- `UpdateTaskStatusBody` (route) and `StatusUpdatePayload` (client): route body requires `taskId`, `status`, `completedAt`; client payload is `taskId`, `status`, `completedAt` (Date, ISO-stringified at call site) — match.

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -189,6 +189,38 @@
       ]
     },
     {
+      "collectionGroup": "custom_data_sources",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "userId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "composite_feeds",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "userId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "__name__",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
       "collectionGroup": "notes",
       "queryScope": "COLLECTION",
       "fields": [
@@ -226,6 +258,24 @@
         },
         {
           "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "composite_feed_snapshots",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "userId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "generatedAt",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "__name__",
           "order": "DESCENDING"
         }
       ]
@@ -319,6 +369,20 @@
       ]
     },
     {
+      "collectionGroup": "custom_data_sources",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "userId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "updatedAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
       "collectionGroup": "mobile_notifications",
       "queryScope": "COLLECTION",
       "fields": [
@@ -328,6 +392,24 @@
         },
         {
           "fieldPath": "updatedAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "composite_feeds",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "userId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "updatedAt",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "__name__",
           "order": "DESCENDING"
         }
       ]
@@ -608,6 +690,34 @@
         {
           "fieldPath": "createdAt",
           "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "visualizations",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "userId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "visualizations",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "feedId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "DESCENDING"
         }
       ]
     },
@@ -1598,6 +1708,42 @@
       ]
     },
     {
+      "collectionGroup": "notification_daily_digests",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "userId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "groupKey",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "date",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "notification_group_states",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "userId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "groupKey",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "date",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
       "collectionGroup": "mobile_notifications",
       "queryScope": "COLLECTION",
       "fields": [
@@ -1616,6 +1762,20 @@
         {
           "fieldPath": "timestamp",
           "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "code_tasks",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "lastHeartbeat",
+          "order": "ASCENDING"
         }
       ]
     }

--- a/migrations/097_code-tasks-zombie-lastHeartbeat-index.mjs
+++ b/migrations/097_code-tasks-zombie-lastHeartbeat-index.mjs
@@ -1,0 +1,40 @@
+/**
+ * Migration 097: Composite index for findZombieTasks on lastHeartbeat
+ *
+ * Required by code-agent findZombieTasks query:
+ *   where('status', 'in', ['dispatched', 'running'])
+ *   where('lastHeartbeat', '<', staleThreshold)
+ *
+ * Replaces the previous updatedAt-based staleness query, which was
+ * vulnerable to false refresh from unrelated writes (e.g. PR merge
+ * webhooks setting prMergedAt, which bumped updatedAt).
+ */
+
+export const metadata = {
+  id: '097',
+  name: 'code-tasks-zombie-lastHeartbeat-index',
+  description: 'Composite index for findZombieTasks(status, lastHeartbeat)',
+  createdAt: '2026-04-17',
+};
+
+export const indexes = [
+  {
+    collectionGroup: 'code_tasks',
+    queryScope: 'COLLECTION',
+    fields: [
+      { fieldPath: 'status', order: 'ASCENDING' },
+      { fieldPath: 'lastHeartbeat', order: 'ASCENDING' },
+    ],
+  },
+];
+
+export const collections = ['code_tasks'];
+
+export async function up(context) {
+  console.log('  Deploying code_tasks zombie-detection composite index...');
+  await context.deployIndexes();
+}
+
+export async function down() {
+  console.log('  Removing the composite index requires manual deletion via Firebase console');
+}

--- a/packages/infra-firestore/src/__tests__/firestoreFake.test.ts
+++ b/packages/infra-firestore/src/__tests__/firestoreFake.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { beforeEach, describe, expect, it } from 'vitest';
-import { FieldValue } from '@google-cloud/firestore';
+import { FieldValue, Timestamp } from '@google-cloud/firestore';
 import { createFakeFirestore, type FakeFirestore } from '../testing/firestoreFake.js';
 
 describe('FakeFirestore', () => {
@@ -219,6 +219,33 @@ describe('FakeFirestore', () => {
         const snapshot = await docRef.get();
         expect(snapshot.data()?.['options']).toEqual({ app: ['gmail', 'slack'] });
       });
+
+      it('preserves Timestamp field values passed to update() instead of deleting them', async () => {
+        const docRef = db.collection('test').doc('doc1');
+        await docRef.set({ name: 'alpha' });
+
+        const heartbeat = Timestamp.fromDate(new Date('2026-04-17T18:00:00Z'));
+        await docRef.update({ lastHeartbeat: heartbeat });
+
+        const snap = await docRef.get();
+        const data = snap.data();
+        expect(data?.['lastHeartbeat']).toBeDefined();
+        expect((data?.['lastHeartbeat'] as Timestamp).toMillis()).toBe(heartbeat.toMillis());
+      });
+
+      it('preserves arbitrary objects with isEqual method in update() (not treated as delete sentinels)', async () => {
+        const docRef = db.collection('test').doc('doc2');
+        await docRef.set({ name: 'alpha' });
+
+        // Any plain object with an `isEqual` method must NOT be treated as a delete sentinel;
+        // only real Firestore FieldValue.delete() sentinels should be removed.
+        const shaped = { isEqual: (): boolean => false, value: 42 };
+        await docRef.update({ custom: shaped });
+
+        const snap = await docRef.get();
+        const data = snap.data();
+        expect(data?.['custom']).toBe(shaped);
+      });
     });
 
     describe('delete', () => {
@@ -338,6 +365,42 @@ describe('FakeFirestore', () => {
           .get();
         expect(snapshot.size).toBe(1);
         expect(snapshot.docs[0]?.data()?.['name']).toBe('Charlie');
+      });
+
+      it('compares Timestamp field values correctly using < operator', async () => {
+        const collection = db.collection('tasks');
+
+        const older = Timestamp.fromDate(new Date('2026-04-17T17:00:00Z'));
+        const newer = Timestamp.fromDate(new Date('2026-04-17T18:00:00Z'));
+        const threshold = Timestamp.fromDate(new Date('2026-04-17T17:30:00Z'));
+
+        await collection.doc('a').set({ heartbeat: older });
+        await collection.doc('b').set({ heartbeat: newer });
+
+        const snapshot = await collection.where('heartbeat', '<', threshold).get();
+        const ids = snapshot.docs.map((doc) => doc.id);
+
+        expect(ids).toEqual(['a']);
+      });
+
+      it('compares Timestamp field values correctly using >= operator', async () => {
+        // Note: Date objects already coerce via valueOf() so <,>= work natively.
+        // Timestamp does NOT have valueOf(), so without getTimestampValue
+        // normalization the cast `(ts as number)` yields NaN, and NaN >= NaN
+        // is always false — this test would fail against the unfixed fake.
+        const collection = db.collection('tasks');
+
+        const older = Timestamp.fromDate(new Date('2026-04-17T17:00:00Z'));
+        const newer = Timestamp.fromDate(new Date('2026-04-17T18:00:00Z'));
+        const threshold = Timestamp.fromDate(new Date('2026-04-17T17:30:00Z'));
+
+        await collection.doc('a').set({ at: older });
+        await collection.doc('b').set({ at: newer });
+
+        const snapshot = await collection.where('at', '>=', threshold).get();
+        const ids = snapshot.docs.map((doc) => doc.id);
+
+        expect(ids).toEqual(['b']);
       });
     });
 

--- a/packages/infra-firestore/src/testing/firestoreFake.ts
+++ b/packages/infra-firestore/src/testing/firestoreFake.ts
@@ -15,6 +15,7 @@
  *   });
  */
 
+import { FieldValue } from '@google-cloud/firestore';
 import type { CollectionReference, DocumentData, WriteResult } from '@google-cloud/firestore';
 
 /**
@@ -24,11 +25,16 @@ type DocumentStore = Map<string, Map<string, DocumentData>>;
 
 /**
  * Check if a value is a FieldValue.delete() sentinel.
- * The actual FieldValue.delete() returns an object with isEqual method.
+ * The real FieldValue.delete() returns a DeleteTransform instance.
+ * We must NOT treat arbitrary objects-with-isEqual (e.g. Timestamp, Date,
+ * other FieldValue sentinels like increment) as delete sentinels, or we'll
+ * silently drop writes. Match by constructor name for resilience against
+ * SDK internals changes while still being specific to DeleteTransform.
  */
 function isFieldValueDelete(value: unknown): boolean {
   if (value === null || typeof value !== 'object') return false;
-  return 'isEqual' in value && typeof (value as { isEqual: unknown }).isEqual === 'function';
+  if (!(value instanceof FieldValue)) return false;
+  return value.constructor.name === 'DeleteTransform';
 }
 
 /**
@@ -368,19 +374,25 @@ class FakeQuery {
         const data = doc.data();
         if (data === undefined) return false;
         const fieldValue: unknown = data[filter.field];
+        // For ordinal comparisons, normalize Timestamp/Date to millis so the
+        // fake matches real Firestore semantics for time-based queries.
+        const fieldMillis = getTimestampValue(fieldValue);
+        const filterMillis = getTimestampValue(filter.value);
+        const aOrdinal = fieldMillis ?? (fieldValue as number);
+        const bOrdinal = filterMillis ?? (filter.value as number);
         switch (filter.op) {
           case '==':
             return fieldValue === filter.value;
           case '!=':
             return fieldValue !== filter.value;
           case '<':
-            return (fieldValue as number) < (filter.value as number);
+            return aOrdinal < bOrdinal;
           case '<=':
-            return (fieldValue as number) <= (filter.value as number);
+            return aOrdinal <= bOrdinal;
           case '>':
-            return (fieldValue as number) > (filter.value as number);
+            return aOrdinal > bOrdinal;
           case '>=':
-            return (fieldValue as number) >= (filter.value as number);
+            return aOrdinal >= bOrdinal;
           case 'array-contains':
             return Array.isArray(fieldValue) && fieldValue.includes(filter.value);
           case 'in':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -495,6 +495,12 @@ importers:
       '@intexuraos/llm-prompts':
         specifier: workspace:*
         version: link:../../packages/llm-prompts
+      ajv:
+        specifier: ^8.17.1
+        version: 8.17.1
+      ajv-formats:
+        specifier: ^3.0.1
+        version: 3.0.1(ajv@8.17.1)
       fastify:
         specifier: ^5.1.0
         version: 5.6.2

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -2074,6 +2074,38 @@ resource "google_cloud_scheduler_job" "merge_queue_tick" {
   ]
 }
 
+resource "google_cloud_scheduler_job" "code_tasks_zombie_sweep" {
+  name        = "intexuraos-code-tasks-zombie-sweep-${var.environment}"
+  description = "Sweep stuck code tasks with stale lastHeartbeat and mark them interrupted"
+  schedule    = "*/5 * * * *"
+  time_zone   = "UTC"
+  region      = var.region
+
+  http_target {
+    http_method = "POST"
+    uri         = "${module.code_agent.service_url}/internal/code/detect-zombies"
+    body        = base64encode("{}")
+
+    oidc_token {
+      service_account_email = google_service_account.cloud_scheduler.email
+      audience              = module.code_agent.service_url
+    }
+  }
+
+  retry_config {
+    retry_count          = 1
+    max_retry_duration   = "60s"
+    min_backoff_duration = "5s"
+    max_backoff_duration = "30s"
+  }
+
+  depends_on = [
+    google_project_service.apis,
+    google_cloud_run_service_iam_member.scheduler_invokes_code_agent,
+    module.code_agent,
+  ]
+}
+
 # -----------------------------------------------------------------------------
 # Cloud Scheduler - Archive Stale Issue Groups (Hourly)
 # -----------------------------------------------------------------------------

--- a/workers/orchestrator/src/__tests__/task-dispatcher.test.ts
+++ b/workers/orchestrator/src/__tests__/task-dispatcher.test.ts
@@ -11,6 +11,7 @@ import type { StatePersistence } from '../services/state-persistence.js';
 import type { WorktreeManager } from '../services/worktree-manager.js';
 import type { LogForwarder } from '../services/log-forwarder.js';
 import type { WebhookClient } from '../services/webhook-client.js';
+import type { StatusUpdateClient } from '../services/status-update-client.js';
 import type { GitHubTokenService } from '../github/token-service.js';
 import type { Logger } from '@intexuraos/common-core';
 import type { CreateTaskRequest } from '../types/api.js';
@@ -294,6 +295,11 @@ describe('TaskDispatcher', () => {
     getPendingCount: vi.fn(async () => 0),
   } as unknown as WebhookClient;
 
+  // Mock StatusUpdateClient
+  const mockStatusUpdateClient = {
+    commit: vi.fn(async () => ({ ok: true as const })),
+  } as unknown as StatusUpdateClient;
+
   // Mock GitHubTokenService
   const mockGitHubTokenService = {
     getToken: vi.fn(async () => ({ token: 'test-token', expiresAt: '2025-01-26T00:00:00Z' })),
@@ -361,6 +367,7 @@ describe('TaskDispatcher', () => {
       mockWorktreeManager,
       mockLogForwarder,
       mockWebhookClient,
+      mockStatusUpdateClient,
       mockGitHubTokenService,
       mockLogger,
       mockIsolationConfig,
@@ -715,6 +722,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         mockIsolationConfig,
@@ -902,6 +910,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         mockIsolationConfig,
@@ -1009,6 +1018,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         mockIsolationConfig,
@@ -1267,6 +1277,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         mockIsolationConfig,
@@ -1312,6 +1323,7 @@ describe('TaskDispatcher', () => {
         cleanupWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         failingIsolationConfig,
@@ -1421,6 +1433,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         mockIsolationConfig,
@@ -1484,6 +1497,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         mockIsolationConfig,
@@ -1572,6 +1586,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         mockIsolationConfig,
@@ -1679,6 +1694,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         mockIsolationConfig,
@@ -2568,6 +2584,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         mockIsolationConfig,
@@ -2722,6 +2739,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         mockIsolationConfig,
@@ -2893,6 +2911,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         mockIsolationConfig,
@@ -2949,6 +2968,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         mockIsolationConfig,
@@ -3047,6 +3067,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         mockIsolationConfig,
@@ -3150,6 +3171,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         localIsolation,
@@ -3231,6 +3253,7 @@ describe('TaskDispatcher', () => {
         localWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         localIsolation,
@@ -3293,6 +3316,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         localIsolation,
@@ -3375,6 +3399,7 @@ describe('TaskDispatcher', () => {
           mockWorktreeManager,
           mockLogForwarder,
           mockWebhookClient,
+          mockStatusUpdateClient,
           mockGitHubTokenService,
           mockLogger,
           localIsolation,
@@ -3460,6 +3485,7 @@ describe('TaskDispatcher', () => {
           mockWorktreeManager,
           mockLogForwarder,
           mockWebhookClient,
+          mockStatusUpdateClient,
           mockGitHubTokenService,
           mockLogger,
           localIsolation,
@@ -3534,6 +3560,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         localIsolation,
@@ -3609,6 +3636,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         localIsolation,
@@ -3693,6 +3721,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         isolation,
@@ -3882,6 +3911,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         isolation,
@@ -3990,6 +4020,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         isolation,
@@ -4072,6 +4103,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         isolation,
@@ -4154,6 +4186,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         isolation,
@@ -4228,6 +4261,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         mockIsolationConfig,
@@ -4353,6 +4387,7 @@ describe('TaskDispatcher', () => {
           mockWorktreeManager,
           mockLogForwarder,
           mockWebhookClient,
+          mockStatusUpdateClient,
           mockGitHubTokenService,
           mockLogger,
           localIsolation,
@@ -4431,6 +4466,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         mockIsolationConfig,
@@ -4503,6 +4539,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         unavailableIsolationConfig,
@@ -4563,6 +4600,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         unavailableIsolationConfig,
@@ -4617,6 +4655,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         { ...mockIsolationConfig, workerAuthRegistry: refreshableRegistry },
@@ -4654,6 +4693,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         { ...mockIsolationConfig, workerAuthRegistry: unavailableRegistry },
@@ -4735,6 +4775,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         drainLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         mockIsolationConfig,
@@ -5038,6 +5079,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         mockIsolationConfig,
@@ -5178,6 +5220,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         mockIsolationConfig,
@@ -5225,6 +5268,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         mockIsolationConfig,
@@ -5286,6 +5330,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         mockIsolationConfig,
@@ -5359,6 +5404,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         mockIsolationConfig,
@@ -5415,6 +5461,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         mockIsolationConfig,
@@ -5453,6 +5500,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         mockIsolationConfig,
@@ -5491,6 +5539,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         mockIsolationConfig,
@@ -5526,6 +5575,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         mockIsolationConfig,
@@ -5787,6 +5837,7 @@ describe('TaskDispatcher', () => {
           mockWorktreeManager,
           mockLogForwarder,
           mockWebhookClient,
+          mockStatusUpdateClient,
           mockGitHubTokenService,
           mockLogger,
           localIsolation,
@@ -5897,6 +5948,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         mockIsolationConfig,
@@ -6854,6 +6906,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         mockIsolationConfig,
@@ -7010,6 +7063,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         mockIsolationConfig,
@@ -7083,6 +7137,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         mockIsolationConfig,
@@ -7702,6 +7757,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         localIsolation,
@@ -7746,6 +7802,7 @@ describe('TaskDispatcher', () => {
         cleanupWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         mockIsolationConfig,
@@ -7775,6 +7832,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         mockIsolationConfig,
@@ -7827,6 +7885,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         mockIsolationConfig,
@@ -7863,6 +7922,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         mockIsolationConfig,
@@ -7949,6 +8009,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         mockIsolationConfig,
@@ -7989,6 +8050,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         mockIsolationConfig,
@@ -8056,6 +8118,7 @@ describe('TaskDispatcher', () => {
         localWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         mockIsolationConfig,
@@ -9116,6 +9179,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         isolationWithoutResume,
@@ -9210,6 +9274,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         mockIsolationConfig,
@@ -9251,6 +9316,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         mockIsolationConfig,
@@ -9296,6 +9362,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         mockIsolationConfig,
@@ -9341,6 +9408,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         mockIsolationConfig,
@@ -9383,6 +9451,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         mockIsolationConfig,
@@ -9427,6 +9496,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         mockIsolationConfig,
@@ -9476,6 +9546,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         mockIsolationConfig,
@@ -9529,6 +9600,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         mockIsolationConfig,
@@ -9624,6 +9696,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         mockIsolationConfig,
@@ -9689,6 +9762,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         mockIsolationConfig,
@@ -9816,6 +9890,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         mockIsolationConfig,
@@ -9876,6 +9951,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         mockIsolationConfig,
@@ -9951,6 +10027,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         mockIsolationConfig,
@@ -10012,6 +10089,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         mockIsolationConfig,
@@ -10091,6 +10169,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         mockIsolationConfig,
@@ -10148,6 +10227,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         mockIsolationConfig,
@@ -10199,6 +10279,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         mockIsolationConfig,
@@ -10262,6 +10343,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         mockIsolationConfig,
@@ -10357,6 +10439,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         mockIsolationConfig,
@@ -10428,6 +10511,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         mockIsolationConfig,
@@ -10554,6 +10638,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         mockIsolationConfig,
@@ -10639,6 +10724,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         mockIsolationConfig,
@@ -10679,6 +10765,265 @@ describe('TaskDispatcher', () => {
     });
   });
 
+  describe('finalizeTask status commit via StatusUpdateClient', () => {
+    // Build a minimal in-flight task record so we can drive finalizeTask directly
+    // (bypassing the dispatch pipeline). finalizeTask expects `startedAt` to be set.
+    const buildInflightTask = (taskId: string): Task =>
+      ({
+        taskId,
+        workerType: 'auto',
+        prompt: 'Test prompt',
+        webhookUrl: 'https://example.com/internal/webhooks/task-complete',
+        webhookSecret: 'secret',
+        status: 'running',
+        worktreePath: '/tmp/worktrees/status-commit',
+        baseBranch: 'development',
+        linearIssueLabels: [],
+        hasChildren: false,
+        repository: 'pbuchman/intexuraos',
+        containerId: 'container-status-commit',
+        startedAt: new Date(Date.now() - 1000).toISOString(),
+      }) as unknown as Task;
+
+    it('calls statusUpdateClient.commit before webhookClient.send with the expected payload', async () => {
+      const callOrder: string[] = [];
+      const commitSpy = vi.fn(async (_input: Record<string, unknown>) => {
+        callOrder.push('commit');
+        return { ok: true as const };
+      });
+      const sendSpy = vi.fn(async (_input: Record<string, unknown>) => {
+        callOrder.push('send');
+        return { ok: true, value: undefined };
+      });
+      const localStatusUpdate = {
+        commit: commitSpy,
+      } as unknown as StatusUpdateClient;
+      const localWebhook = {
+        send: sendSpy,
+        retryPending: vi.fn(async () => undefined),
+        getPendingCount: vi.fn(async () => 0),
+      } as unknown as WebhookClient;
+
+      const localDispatcher = new TaskDispatcher(
+        mockConfig,
+        createStatePersistence(),
+        mockWorktreeManager,
+        mockLogForwarder,
+        localWebhook,
+        localStatusUpdate,
+        mockGitHubTokenService,
+        mockLogger,
+        mockIsolationConfig,
+        singleAttemptCompletionControl
+      );
+
+      const task = buildInflightTask('status-commit-ok');
+      const internal = localDispatcher as unknown as {
+        finalizeTask: (
+          task: Task,
+          status: string,
+          payload: Record<string, unknown>,
+          keepLogOpen?: boolean
+        ) => Promise<void>;
+      };
+      await internal.finalizeTask(task, 'completed', {
+        result: {
+          prUrl: 'https://github.com/pbuchman/intexuraos/pull/42',
+          branch: 'feat/status-commit',
+          summary: 'Work done',
+        },
+      });
+
+      // Order: commit runs before the terminal task-complete webhook.
+      // (A task_completed lifecycle "task-event" send may also fire earlier
+      // via fire-and-forget; the terminal send is guaranteed after commit.)
+      const commitIdx = callOrder.indexOf('commit');
+      const lastSendIdx = callOrder.lastIndexOf('send');
+      expect(commitIdx).toBeGreaterThanOrEqual(0);
+      expect(lastSendIdx).toBeGreaterThan(commitIdx);
+
+      expect(commitSpy).toHaveBeenCalledTimes(1);
+      const commitArg = commitSpy.mock.calls[0]?.[0] as
+        | {
+            taskId: string;
+            status: string;
+            completedAt: Date;
+            error?: { code: string; message: string };
+            result?: { prUrl?: string; branch?: string; summary?: string };
+          }
+        | undefined;
+      expect(commitArg).toBeDefined();
+      if (commitArg === undefined) throw new Error('commit not called');
+      expect(commitArg.taskId).toBe('status-commit-ok');
+      expect(commitArg.status).toBe('completed');
+      expect(commitArg.completedAt).toBeInstanceOf(Date);
+      expect(commitArg.error).toBeUndefined();
+      expect(commitArg.result).toEqual({
+        prUrl: 'https://github.com/pbuchman/intexuraos/pull/42',
+        branch: 'feat/status-commit',
+        summary: 'Work done',
+      });
+
+      // Webhook still fired (demoted to side-effects).
+      const terminalCall = sendSpy.mock.calls.find((c) => {
+        const url = (c[0] as { url?: string } | undefined)?.url;
+        return url === task.webhookUrl;
+      });
+      expect(terminalCall).toBeDefined();
+    });
+
+    it('logs ERROR with STATUS_UPDATE_COMMIT_FAILED tag and continues when commit fails', async () => {
+      const commitSpy = vi.fn(async (_input: Record<string, unknown>) => ({
+        ok: false as const,
+        error: { type: '5xx' as const, status: 503, message: 'svc unavailable' },
+      }));
+      const sendSpy = vi.fn(async (_input: Record<string, unknown>) => ({
+        ok: true,
+        value: undefined,
+      }));
+      const localStatusUpdate = {
+        commit: commitSpy,
+      } as unknown as StatusUpdateClient;
+      const localWebhook = {
+        send: sendSpy,
+        retryPending: vi.fn(async () => undefined),
+        getPendingCount: vi.fn(async () => 0),
+      } as unknown as WebhookClient;
+      const errorSpy = vi.fn();
+      const localLogger: Logger = {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: errorSpy,
+        debug: vi.fn(),
+      };
+      const appendedLogs: string[] = [];
+
+      const localState = createStatePersistence();
+      const localDispatcher = new TaskDispatcher(
+        mockConfig,
+        localState,
+        mockWorktreeManager,
+        mockLogForwarder,
+        localWebhook,
+        localStatusUpdate,
+        mockGitHubTokenService,
+        localLogger,
+        mockIsolationConfig,
+        singleAttemptCompletionControl
+      );
+
+      // Spy on appendOrchestratorTaskLog (private) to capture the audit line.
+      const internal = localDispatcher as unknown as {
+        finalizeTask: (
+          task: Task,
+          status: string,
+          payload: Record<string, unknown>,
+          keepLogOpen?: boolean
+        ) => Promise<void>;
+        appendOrchestratorTaskLog: (taskId: string, msg: string) => void;
+        saveTask: (t: Task) => Promise<void>;
+      };
+      const origAppend = internal.appendOrchestratorTaskLog.bind(internal);
+      internal.appendOrchestratorTaskLog = (taskId: string, msg: string): void => {
+        appendedLogs.push(msg);
+        origAppend(taskId, msg);
+      };
+
+      const task = buildInflightTask('status-commit-fail');
+      // Seed the state with the task so saveTask can update it in place.
+      await localState.modify((s) => {
+        s.tasks[task.taskId] = task;
+      });
+
+      await internal.finalizeTask(task, 'failed', {
+        error: { code: 'exec_failed', message: 'boom' },
+      });
+
+      // logger.error was called with tag: 'STATUS_UPDATE_COMMIT_FAILED'
+      const taggedErrorCall = errorSpy.mock.calls.find((c) => {
+        const obj = c[0] as Record<string, unknown> | undefined;
+        return obj?.['tag'] === 'STATUS_UPDATE_COMMIT_FAILED';
+      });
+      expect(taggedErrorCall).toBeDefined();
+
+      // appendOrchestratorTaskLog called with STATUS_UPDATE_COMMIT_FAILED marker.
+      const markerLog = appendedLogs.find((m) => m.includes('STATUS_UPDATE_COMMIT_FAILED'));
+      expect(markerLog).toBeDefined();
+
+      // Webhook still fired (finalize continues — zombie watchdog is recovery).
+      expect(sendSpy).toHaveBeenCalled();
+
+      // Task state was still saved locally — task.status is the terminal one.
+      const saved = await localState.load();
+      expect(saved.tasks['status-commit-fail']?.status).toBe('failed');
+    });
+
+    it('propagates only prUrl/branch/summary from payload.result to commit (minimal schema invariant)', async () => {
+      const commitSpy = vi.fn(async (_input: Record<string, unknown>) => ({ ok: true as const }));
+      const localStatusUpdate = {
+        commit: commitSpy,
+      } as unknown as StatusUpdateClient;
+      const localWebhook = {
+        send: vi.fn(async () => ({ ok: true, value: undefined })),
+        retryPending: vi.fn(async () => undefined),
+        getPendingCount: vi.fn(async () => 0),
+      } as unknown as WebhookClient;
+
+      const localDispatcher = new TaskDispatcher(
+        mockConfig,
+        createStatePersistence(),
+        mockWorktreeManager,
+        mockLogForwarder,
+        localWebhook,
+        localStatusUpdate,
+        mockGitHubTokenService,
+        mockLogger,
+        mockIsolationConfig,
+        singleAttemptCompletionControl
+      );
+
+      const task = buildInflightTask('status-commit-whitelist');
+      const internal = localDispatcher as unknown as {
+        finalizeTask: (
+          task: Task,
+          status: string,
+          payload: Record<string, unknown>,
+          keepLogOpen?: boolean
+        ) => Promise<void>;
+      };
+      await internal.finalizeTask(task, 'completed', {
+        // Cast through unknown — this shape intentionally includes fields
+        // (commits, ciFailed) that must NOT leak into the commit call.
+        result: {
+          prUrl: 'https://github.com/pbuchman/intexuraos/pull/99',
+          branch: 'feat/whitelist',
+          summary: 'Only three make it through',
+          commits: 5,
+          ciFailed: true,
+          commitDetails: [{ sha: 'abc', message: 'm' }],
+        } as unknown as TaskResult,
+      });
+
+      expect(commitSpy).toHaveBeenCalledTimes(1);
+      const commitArg = commitSpy.mock.calls[0]?.[0] as
+        | { result?: Record<string, unknown> }
+        | undefined;
+      expect(commitArg?.result).toBeDefined();
+      expect(commitArg?.result).toEqual({
+        prUrl: 'https://github.com/pbuchman/intexuraos/pull/99',
+        branch: 'feat/whitelist',
+        summary: 'Only three make it through',
+      });
+      // Explicitly confirm excluded fields did not leak.
+      expect(Object.keys(commitArg?.result ?? {})).toEqual(
+        expect.arrayContaining(['prUrl', 'branch', 'summary'])
+      );
+      expect(commitArg?.result).not.toHaveProperty('commits');
+      expect(commitArg?.result).not.toHaveProperty('ciFailed');
+      expect(commitArg?.result).not.toHaveProperty('commitDetails');
+    });
+  });
+
   describe('Docker health gate', () => {
     let statePersistence: StatePersistence;
     let healthDispatcher: TaskDispatcher;
@@ -10700,6 +11045,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         unhealthyIsolation,
@@ -10790,6 +11136,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         hangingIsolation,
@@ -10845,6 +11192,7 @@ describe('TaskDispatcher', () => {
         mockWorktreeManager,
         mockLogForwarder,
         mockWebhookClient,
+        mockStatusUpdateClient,
         mockGitHubTokenService,
         mockLogger,
         hangingPullIsolation,

--- a/workers/orchestrator/src/services/__tests__/status-update-client.test.ts
+++ b/workers/orchestrator/src/services/__tests__/status-update-client.test.ts
@@ -1,0 +1,390 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import nock from 'nock';
+import { createHmac } from 'node:crypto';
+import type { Logger } from 'pino';
+
+import { StatusUpdateClient, type StatusUpdateClientConfig } from '../status-update-client.js';
+
+const codeAgentUrl = 'http://code-agent.test';
+const orchestratorSecret = 'orchestrator-secret-xyz';
+const internalAuthToken = 'internal-auth-token';
+
+interface LogCall {
+  level: string;
+  data: unknown;
+}
+
+function makeLogger(): { logger: Logger; calls: LogCall[] } {
+  const calls: LogCall[] = [];
+  const logger = {
+    info: (data: unknown) => {
+      calls.push({ level: 'info', data });
+    },
+    warn: (data: unknown) => {
+      calls.push({ level: 'warn', data });
+    },
+    error: (data: unknown) => {
+      calls.push({ level: 'error', data });
+    },
+    debug: (data: unknown) => {
+      calls.push({ level: 'debug', data });
+    },
+  } as unknown as Logger;
+  return { logger, calls };
+}
+
+function makeClient(overrides: Partial<StatusUpdateClientConfig> = {}): {
+  client: StatusUpdateClient;
+  calls: LogCall[];
+} {
+  const { logger, calls } = makeLogger();
+  const client = new StatusUpdateClient({
+    codeAgentUrl,
+    orchestratorSecret,
+    internalAuthToken,
+    logger,
+    retryDelaysMs: [1, 1, 1],
+    requestTimeoutMs: 15_000,
+    ...overrides,
+  });
+  return { client, calls };
+}
+
+describe('StatusUpdateClient', () => {
+  beforeEach(() => {
+    nock.cleanAll();
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  it('signs with orchestratorSecret and returns ok on 200', async () => {
+    const completedAt = new Date('2026-04-17T10:00:00.000Z');
+
+    nock(codeAgentUrl)
+      .patch('/internal/code-tasks/task_1/status')
+      .matchHeader('content-type', 'application/json')
+      .matchHeader('x-internal-auth', internalAuthToken)
+      .matchHeader('x-request-signature', /^[a-f0-9]{64}$/)
+      .matchHeader('x-request-timestamp', /^\d+$/)
+      .reply(200, { success: true });
+
+    const { client } = makeClient();
+    const result = await client.commit({
+      taskId: 'task_1',
+      status: 'completed',
+      completedAt,
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(nock.isDone()).toBe(true);
+  });
+
+  it('computes signature over the exact rawBody bytes sent', async () => {
+    let capturedBody: string | undefined;
+    let capturedTimestamp: string | undefined;
+    let capturedSignature: string | undefined;
+
+    nock(codeAgentUrl)
+      .patch('/internal/code-tasks/task_sig/status', (body) => {
+        capturedBody = JSON.stringify(body);
+        return true;
+      })
+      .reply(function () {
+        capturedTimestamp = this.req.headers['x-request-timestamp'] as string | undefined;
+        capturedSignature = this.req.headers['x-request-signature'] as string | undefined;
+        return [200, { success: true }];
+      });
+
+    const { client } = makeClient();
+    const completedAt = new Date('2026-04-17T10:00:00.000Z');
+    const result = await client.commit({
+      taskId: 'task_sig',
+      status: 'completed',
+      completedAt,
+      result: { prUrl: 'https://github.com/x/y/pull/1', branch: 'task_foo', summary: 'Done' },
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(capturedBody).toBeDefined();
+    expect(capturedTimestamp).toMatch(/^\d+$/);
+    expect(capturedSignature).toMatch(/^[a-f0-9]{64}$/);
+
+    const expected = createHmac('sha256', orchestratorSecret)
+      .update(`${String(capturedTimestamp)}.${String(capturedBody)}`)
+      .digest('hex');
+
+    expect(capturedSignature).toBe(expected);
+    expect(nock.isDone()).toBe(true);
+  });
+
+  it('returns ok on eventual 200 after 5xx retries', async () => {
+    nock(codeAgentUrl).patch('/internal/code-tasks/task_retry/status').reply(500, 'boom');
+    nock(codeAgentUrl)
+      .patch('/internal/code-tasks/task_retry/status')
+      .reply(200, { success: true });
+
+    const { client, calls } = makeClient({ retryDelaysMs: [1, 1] });
+    const result = await client.commit({
+      taskId: 'task_retry',
+      status: 'completed',
+      completedAt: new Date('2026-04-17T10:00:00.000Z'),
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(nock.isDone()).toBe(true);
+    // Exactly one warn for the failed attempt, and an info for the eventual recovery
+    expect(calls.filter((c) => c.level === 'warn')).toHaveLength(1);
+    expect(calls.filter((c) => c.level === 'info')).toHaveLength(1);
+  });
+
+  it('does not retry on 4xx and returns err with type "4xx"', async () => {
+    nock(codeAgentUrl).patch('/internal/code-tasks/task_404/status').reply(404, 'not found');
+
+    const { client, calls } = makeClient({ retryDelaysMs: [1, 1, 1] });
+    const result = await client.commit({
+      taskId: 'task_404',
+      status: 'completed',
+      completedAt: new Date('2026-04-17T10:00:00.000Z'),
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok === false) {
+      expect(result.error.type).toBe('4xx');
+      if (result.error.type === '4xx') {
+        expect(result.error.status).toBe(404);
+      }
+    }
+    expect(nock.isDone()).toBe(true);
+    // Only one attempt → one warn, no retries
+    expect(calls.filter((c) => c.level === 'warn')).toHaveLength(1);
+  });
+
+  it('returns err after exhausting retries on persistent 5xx', async () => {
+    nock(codeAgentUrl).patch('/internal/code-tasks/task_503/status').reply(503, 'unavailable');
+    nock(codeAgentUrl).patch('/internal/code-tasks/task_503/status').reply(503, 'unavailable');
+    nock(codeAgentUrl).patch('/internal/code-tasks/task_503/status').reply(503, 'unavailable');
+
+    const { client, calls } = makeClient({ retryDelaysMs: [1, 1] });
+    const result = await client.commit({
+      taskId: 'task_503',
+      status: 'failed',
+      completedAt: new Date('2026-04-17T10:00:00.000Z'),
+      error: { code: 'UPSTREAM', message: 'bad things' },
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok === false) {
+      expect(result.error.type).toBe('5xx');
+      if (result.error.type === '5xx') {
+        expect(result.error.status).toBe(503);
+      }
+    }
+    expect(nock.isDone()).toBe(true);
+    // Three attempts → three warns
+    expect(calls.filter((c) => c.level === 'warn')).toHaveLength(3);
+    // On retry exhaustion we escalate to a single error log so operators see
+    // the terminal failure even if the caller forgets to log.
+    const errors = calls.filter((c) => c.level === 'error');
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.data).toMatchObject({
+      taskId: 'task_503',
+      attempts: 3,
+      errorType: '5xx',
+    });
+  });
+
+  it('returns timeout error when request exceeds requestTimeoutMs', async () => {
+    nock(codeAgentUrl)
+      .patch('/internal/code-tasks/task_slow/status')
+      .delay(50)
+      .reply(200, { success: true });
+
+    const { client, calls } = makeClient({
+      retryDelaysMs: [],
+      requestTimeoutMs: 10,
+    });
+    const result = await client.commit({
+      taskId: 'task_slow',
+      status: 'completed',
+      completedAt: new Date('2026-04-17T10:00:00.000Z'),
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok === false) {
+      expect(result.error.type).toBe('timeout');
+    }
+    // Retry-exhaustion error log must also fire on timeout.
+    const errors = calls.filter((c) => c.level === 'error');
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.data).toMatchObject({
+      taskId: 'task_slow',
+      attempts: 1,
+      errorType: 'timeout',
+    });
+    // nock may or may not consider the interceptor "done" depending on when the abort
+    // fires relative to the response. Clear it so afterEach doesn't complain.
+    nock.cleanAll();
+  });
+
+  it('serializes completedAt to ISO string', async () => {
+    let capturedBody: unknown;
+
+    nock(codeAgentUrl)
+      .patch('/internal/code-tasks/task_iso/status', (body) => {
+        capturedBody = body;
+        return true;
+      })
+      .reply(200, { success: true });
+
+    const { client } = makeClient();
+    await client.commit({
+      taskId: 'task_iso',
+      status: 'completed',
+      completedAt: new Date('2026-04-17T10:11:12.345Z'),
+    });
+
+    expect(capturedBody).toMatchObject({
+      taskId: 'task_iso',
+      status: 'completed',
+      completedAt: '2026-04-17T10:11:12.345Z',
+    });
+    expect(nock.isDone()).toBe(true);
+  });
+
+  it('omits error/result from body when not provided', async () => {
+    let capturedBody: Record<string, unknown> | undefined;
+
+    nock(codeAgentUrl)
+      .patch('/internal/code-tasks/task_min/status', (body) => {
+        capturedBody = body as Record<string, unknown>;
+        return true;
+      })
+      .reply(200, { success: true });
+
+    const { client } = makeClient();
+    await client.commit({
+      taskId: 'task_min',
+      status: 'completed',
+      completedAt: new Date('2026-04-17T10:00:00.000Z'),
+    });
+
+    expect(capturedBody).toBeDefined();
+    expect(Object.keys(capturedBody ?? {}).sort()).toEqual(
+      ['completedAt', 'status', 'taskId'].sort()
+    );
+    expect('error' in (capturedBody ?? {})).toBe(false);
+    expect('result' in (capturedBody ?? {})).toBe(false);
+    expect(nock.isDone()).toBe(true);
+  });
+
+  it('uses default retry delays and timeout when not supplied', async () => {
+    nock(codeAgentUrl)
+      .patch('/internal/code-tasks/task_defaults/status')
+      .reply(200, { success: true });
+
+    const { logger } = makeLogger();
+    const client = new StatusUpdateClient({
+      codeAgentUrl,
+      orchestratorSecret,
+      internalAuthToken,
+      logger,
+      // No retryDelaysMs, no requestTimeoutMs → exercise default-fallback branches.
+    });
+
+    const result = await client.commit({
+      taskId: 'task_defaults',
+      status: 'completed',
+      completedAt: new Date('2026-04-17T10:00:00.000Z'),
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(nock.isDone()).toBe(true);
+  });
+
+  it('falls back to HTTP status string when 5xx body is empty', async () => {
+    nock(codeAgentUrl).patch('/internal/code-tasks/task_empty/status').reply(500, '');
+    nock(codeAgentUrl).patch('/internal/code-tasks/task_empty/status').reply(500, '');
+
+    const { client, calls } = makeClient({ retryDelaysMs: [1] });
+    const result = await client.commit({
+      taskId: 'task_empty',
+      status: 'failed',
+      completedAt: new Date('2026-04-17T10:00:00.000Z'),
+      error: { code: 'X', message: 'y' },
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok === false && result.error.type === '5xx') {
+      expect(result.error.message).toBe('HTTP 500');
+    }
+    expect(nock.isDone()).toBe(true);
+    const warns = calls.filter((c) => c.level === 'warn');
+    expect(warns).toHaveLength(2);
+  });
+
+  it('handles non-Error thrown values from fetch as network errors', async () => {
+    // Simulate an unusual throw (e.g. a plain string) that is NOT an Error instance.
+    // This exercises the `String(err)` fallback in the network-error branch.
+    const fetchFn: typeof fetch = () => {
+      throw 'exploded';
+    };
+
+    const { logger, calls } = makeLogger();
+    const client = new StatusUpdateClient({
+      codeAgentUrl,
+      orchestratorSecret,
+      internalAuthToken,
+      logger,
+      retryDelaysMs: [],
+      requestTimeoutMs: 1000,
+      fetchFn,
+    });
+
+    const result = await client.commit({
+      taskId: 'task_nonerror',
+      status: 'completed',
+      completedAt: new Date('2026-04-17T10:00:00.000Z'),
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok === false) {
+      expect(result.error.type).toBe('network');
+      if (result.error.type === 'network') {
+        expect(result.error.message).toBe('exploded');
+      }
+    }
+    // Retry-exhaustion error log must also fire on network-class errors.
+    const errors = calls.filter((c) => c.level === 'error');
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.data).toMatchObject({
+      taskId: 'task_nonerror',
+      attempts: 1,
+      errorType: 'network',
+      errorMessage: 'exploded',
+    });
+  });
+
+  it('retries on network error and eventually succeeds', async () => {
+    nock(codeAgentUrl)
+      .patch('/internal/code-tasks/task_net/status')
+      .replyWithError({ code: 'ECONNRESET', message: 'socket hang up' });
+    nock(codeAgentUrl).patch('/internal/code-tasks/task_net/status').reply(200, { success: true });
+
+    const { client, calls } = makeClient({ retryDelaysMs: [1] });
+    const result = await client.commit({
+      taskId: 'task_net',
+      status: 'completed',
+      completedAt: new Date('2026-04-17T10:00:00.000Z'),
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(nock.isDone()).toBe(true);
+    expect(calls.filter((c) => c.level === 'warn')).toHaveLength(1);
+    expect(calls.filter((c) => c.level === 'info')).toHaveLength(1);
+  });
+});
+
+// Silence unused warnings; vi is kept in case future tests need mocks
+void vi;

--- a/workers/orchestrator/src/services/status-update-client.ts
+++ b/workers/orchestrator/src/services/status-update-client.ts
@@ -1,0 +1,198 @@
+import { createHmac } from 'node:crypto';
+import type { Logger } from 'pino';
+
+/**
+ * Orchestrator-side HTTP client that commits a terminal task status to code-agent
+ * via `PATCH /internal/code-tasks/:id/status`.
+ *
+ * Signing scheme mirrors {@link createHeartbeatManager} (see `heartbeat.ts`):
+ * `HMAC-SHA256(orchestratorSecret, timestamp + "." + rawBody)`, with
+ * `X-Request-Timestamp`, `X-Request-Signature`, and `X-Internal-Auth` headers.
+ * Uses the shared orchestrator secret, NOT the per-task webhook secret.
+ *
+ * Design reference: INT-1413 finalize-task robustness plan (Task 3).
+ */
+
+export interface StatusUpdateClientConfig {
+  codeAgentUrl: string;
+  orchestratorSecret: string;
+  internalAuthToken: string;
+  logger: Logger;
+  retryDelaysMs?: number[];
+  requestTimeoutMs?: number;
+  /** Optional fetch override; primarily for tests (e.g. injecting non-Error throws). */
+  fetchFn?: typeof fetch;
+}
+
+export interface StatusUpdatePayload {
+  taskId: string;
+  status: 'completed' | 'failed' | 'interrupted' | 'cancelled';
+  completedAt: Date;
+  error?: { code: string; message: string };
+  result?: { prUrl?: string; branch?: string; summary?: string };
+}
+
+export type StatusUpdateError =
+  | { type: 'network'; message: string }
+  | { type: '4xx'; status: number; message: string }
+  | { type: '5xx'; status: number; message: string }
+  | { type: 'timeout'; message: string };
+
+export type StatusUpdateResult = { ok: true } | { ok: false; error: StatusUpdateError };
+
+const DEFAULT_RETRY_DELAYS_MS: readonly number[] = [1000, 3000, 9000];
+const DEFAULT_REQUEST_TIMEOUT_MS = 15_000;
+
+export class StatusUpdateClient {
+  private readonly codeAgentUrl: string;
+  private readonly orchestratorSecret: string;
+  private readonly internalAuthToken: string;
+  private readonly logger: Logger;
+  private readonly retryDelaysMs: readonly number[];
+  private readonly requestTimeoutMs: number;
+  private readonly fetchFn: typeof fetch;
+
+  constructor(config: StatusUpdateClientConfig) {
+    this.codeAgentUrl = config.codeAgentUrl.replace(/\/+$/, '');
+    this.orchestratorSecret = config.orchestratorSecret;
+    this.internalAuthToken = config.internalAuthToken;
+    this.logger = config.logger;
+    this.retryDelaysMs = config.retryDelaysMs ?? DEFAULT_RETRY_DELAYS_MS;
+    this.requestTimeoutMs = config.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+    this.fetchFn = config.fetchFn ?? fetch;
+  }
+
+  async commit(payload: StatusUpdatePayload): Promise<StatusUpdateResult> {
+    const body: Record<string, unknown> = {
+      taskId: payload.taskId,
+      status: payload.status,
+      completedAt: payload.completedAt.toISOString(),
+    };
+    if (payload.error !== undefined) {
+      body['error'] = payload.error;
+    }
+    if (payload.result !== undefined) {
+      body['result'] = payload.result;
+    }
+    const rawBody = JSON.stringify(body);
+
+    let lastError: StatusUpdateError = {
+      type: 'network',
+      message: 'no attempts were made',
+    };
+    const maxAttempts = this.retryDelaysMs.length + 1;
+
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      const outcome = await this.deliver(payload.taskId, rawBody);
+
+      if (outcome.ok) {
+        if (attempt > 0) {
+          this.logger.info(
+            { taskId: payload.taskId, attempts: attempt + 1 },
+            'Status update committed after retries'
+          );
+        }
+        return { ok: true };
+      }
+
+      lastError = outcome.error;
+
+      this.logger.warn(
+        {
+          taskId: payload.taskId,
+          attempt: attempt + 1,
+          errorType: outcome.error.type,
+          errorMessage: outcome.error.message,
+        },
+        'Status update attempt failed'
+      );
+
+      // 4xx responses are non-retryable — surface immediately so the caller
+      // can decide whether to escalate (e.g. log and mark task finalized anyway).
+      if (outcome.error.type === '4xx') {
+        return { ok: false, error: outcome.error };
+      }
+
+      // On the final attempt there is no matching delay entry (retryDelaysMs has
+      // length maxAttempts - 1). noUncheckedIndexedAccess makes that `undefined`
+      // explicit, so we simply skip waiting — no fallback constant needed.
+      const nextDelay = this.retryDelaysMs[attempt];
+      if (nextDelay !== undefined) {
+        await new Promise<void>((resolve) => setTimeout(resolve, nextDelay));
+      }
+    }
+
+    this.logger.error(
+      {
+        taskId: payload.taskId,
+        attempts: maxAttempts,
+        errorType: lastError.type,
+        errorMessage: lastError.message,
+      },
+      'Status update failed after exhausting retries'
+    );
+    return { ok: false, error: lastError };
+  }
+
+  private async deliver(
+    taskId: string,
+    rawBody: string
+  ): Promise<{ ok: true } | { ok: false; error: StatusUpdateError }> {
+    const timestamp = Math.floor(Date.now() / 1000);
+    const signature = createHmac('sha256', this.orchestratorSecret)
+      .update(`${String(timestamp)}.${rawBody}`)
+      .digest('hex');
+
+    const url = `${this.codeAgentUrl}/internal/code-tasks/${encodeURIComponent(taskId)}/status`;
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => {
+      controller.abort();
+    }, this.requestTimeoutMs);
+
+    try {
+      const response = await this.fetchFn(url, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Request-Timestamp': String(timestamp),
+          'X-Request-Signature': signature,
+          'X-Internal-Auth': this.internalAuthToken,
+        },
+        body: rawBody,
+        signal: controller.signal,
+      });
+
+      if (response.ok) {
+        return { ok: true };
+      }
+
+      const text = await response.text().catch(() => '');
+      const message = text !== '' ? text : `HTTP ${String(response.status)}`;
+      if (response.status >= 400 && response.status < 500) {
+        return {
+          ok: false,
+          error: { type: '4xx', status: response.status, message },
+        };
+      }
+      return {
+        ok: false,
+        error: { type: '5xx', status: response.status, message },
+      };
+    } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError') {
+        return {
+          ok: false,
+          error: {
+            type: 'timeout',
+            message: `Request timed out after ${String(this.requestTimeoutMs)}ms`,
+          },
+        };
+      }
+      const message = err instanceof Error ? err.message : String(err);
+      return { ok: false, error: { type: 'network', message } };
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+}

--- a/workers/orchestrator/src/services/task-dispatcher.ts
+++ b/workers/orchestrator/src/services/task-dispatcher.ts
@@ -9,13 +9,14 @@ import {
 } from '@intexuraos/common-core';
 import type { OrchestratorConfig } from '../types/config.js';
 import { withTimeout } from '../with-timeout.js';
-import type { Task, TaskStatus, TaskResult, TaskError } from '../types/task.js';
+import type { Task, TaskResult, TaskError } from '../types/task.js';
 import type { CreateTaskRequest } from '../types/api.js';
 import type { SendMessageResult, SendMessageError } from '../types/schemas.js';
 import type { StatePersistence } from './state-persistence.js';
 import type { WorktreeManager } from './worktree-manager.js';
 import type { LogForwarder } from './log-forwarder.js';
 import type { WebhookClient } from './webhook-client.js';
+import type { StatusUpdateClient } from './status-update-client.js';
 import type { GitHubTokenService } from '../github/token-service.js';
 import type { IsolationProvider, WorkerConfig, WorkerHandle } from './isolation/types.js';
 import { WORKER_TYPES } from './isolation/types.js';
@@ -195,6 +196,7 @@ export class TaskDispatcher {
     private readonly worktreeManager: WorktreeManager,
     private readonly logForwarder: LogForwarder,
     private readonly webhookClient: WebhookClient,
+    private readonly statusUpdateClient: StatusUpdateClient,
     _githubTokenService: GitHubTokenService,
     private readonly logger: Logger,
     private readonly isolation: IsolationConfig,
@@ -2381,7 +2383,7 @@ export class TaskDispatcher {
 
   private async finalizeTask(
     task: Task,
-    statusParam: TaskStatus,
+    statusParam: 'completed' | 'failed' | 'interrupted' | 'cancelled',
     payload: { result?: TaskResult; error?: TaskError; resumedCompletion?: boolean },
     keepLogForwarderOpen = false
   ): Promise<void> {
@@ -2528,6 +2530,53 @@ export class TaskDispatcher {
             'Failed to send task lifecycle event (best-effort)'
           );
         });
+    }
+
+    // Commit terminal status to code-agent's Firestore BEFORE firing the
+    // legacy task-complete webhook. Code-agent's Firestore is the single
+    // source of truth for status; the webhook is demoted to side-effects
+    // (Linear labels, WhatsApp, etc.). On commit failure, log + continue —
+    // the zombie watchdog (Task 6) is the recovery path. Do NOT block
+    // finalize: Docker teardown and local state cleanup already ran.
+    const statusCommitResult = await this.statusUpdateClient.commit({
+      taskId: task.taskId,
+      status: finalStatus,
+      // Defensive fallback mirrors the line ~2505 guard: task.completedAt is
+      // set above at line 2465, but test mocks or future refactors could
+      // bypass that assignment. Avoids RangeError inside .toISOString().
+      /* v8 ignore start -- ts-type: defensive fallback for optional Task.completedAt; production path at line 2465 always sets it before reaching here, mirrors the runtime guard at line ~2505 @preserve */
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- runtime guard: completedAt set above but test mocks may bypass assignment
+      completedAt: task.completedAt !== undefined ? new Date(task.completedAt) : new Date(),
+      /* v8 ignore stop @preserve */
+      ...(payload.error !== undefined && {
+        error: { code: payload.error.code, message: payload.error.message },
+      }),
+      ...(payload.result !== undefined && {
+        result: {
+          ...(payload.result.prUrl !== undefined && { prUrl: payload.result.prUrl }),
+          ...(payload.result.branch !== undefined && { branch: payload.result.branch }),
+          ...(payload.result.summary !== undefined && { summary: payload.result.summary }),
+        },
+      }),
+    });
+    if (!statusCommitResult.ok) {
+      this.logger.error(
+        {
+          taskId: task.taskId,
+          tag: 'STATUS_UPDATE_COMMIT_FAILED',
+          errorType: statusCommitResult.error.type,
+          errorMessage: statusCommitResult.error.message,
+          agentType: task.agentType,
+          prNumber: task.prNumber,
+          repository: task.repository,
+          finalStatus,
+        },
+        'Failed to commit terminal status via /internal/code-tasks/:id/status; zombie watchdog will recover'
+      );
+      this.appendOrchestratorTaskLog(
+        task.taskId,
+        `STATUS_UPDATE_COMMIT_FAILED: type=${statusCommitResult.error.type} — zombie watchdog will recover`
+      );
     }
 
     await this.webhookClient.send({

--- a/workers/orchestrator/src/start.ts
+++ b/workers/orchestrator/src/start.ts
@@ -21,6 +21,7 @@ import { StatePersistence } from './services/state-persistence.js';
 import { TaskDispatcher } from './services/task-dispatcher.js';
 import { GitHubTokenService } from './github/token-service.js';
 import { WebhookClient } from './services/webhook-client.js';
+import { StatusUpdateClient } from './services/status-update-client.js';
 import { WorktreeManager } from './services/worktree-manager.js';
 import { LogForwarder } from './services/log-forwarder.js';
 import { createHeartbeatManager } from './heartbeat.js';
@@ -549,6 +550,13 @@ async function bootstrap(): Promise<void> {
 
   const webhookClient = new WebhookClient(statePersistence, logger, config.internalAuthToken);
 
+  const statusUpdateClient = new StatusUpdateClient({
+    codeAgentUrl: config.codeAgentUrl,
+    orchestratorSecret: config.orchestratorSecret,
+    internalAuthToken: config.internalAuthToken,
+    logger,
+  });
+
   const worktreeManager = new WorktreeManager(
     {
       repositoryPath: repoPath,
@@ -831,6 +839,7 @@ async function bootstrap(): Promise<void> {
     worktreeManager,
     logForwarder,
     webhookClient,
+    statusUpdateClient,
     tokenService,
     logger,
     isolationConfig,


### PR DESCRIPTION
## Summary

Eliminates the "stuck in `running`" class of code-task bugs. Orchestrator now commits terminal status via a new dedicated endpoint (`PATCH /internal/code-tasks/:id/status`) authed with the shared `orchestratorSecret` HMAC. The old `task-complete` webhook is demoted to side-effects only.

Triggered by investigation of `task_103bd7e0-5b25-4842-a493-a5ffdc8f3d46` where `error.remediation.manualSteps: string[]` in the orchestrator payload was coerced to `string` by ajv on the receiving side, breaking the per-task HMAC and returning 401 — silently dropped because the webhook client never retries 4xx.

Defense in depth: zombie watchdog cron now actually runs (every 5 min, dev-only since dev and prod share Firestore) and queries on `lastHeartbeat` instead of `updatedAt` (which was falsely refreshed by unrelated webhooks like PR merge). `lastHeartbeat` is also stamped at dispatch time so tasks that die before ever heartbeating are still caught.

## Changes

- `fix(code-agent)`: `validateOrchestratorSignature` prefers `request.rawBody` (captured by common-http content parser) — any future schema coercion cannot break HMAC
- `feat(code-agent)`: new `PATCH /internal/code-tasks/:id/status` endpoint with strict primitive-only schema, `additionalProperties:false`, custom ajv preventing `removeAdditional`, status-mapping (`completed` → agent-type-specific), idempotent no-op on already-terminal, clears stale `error` on success
- `feat(orchestrator)`: `StatusUpdateClient` with 5xx/network/timeout retries (no retry on 4xx), error log on exhaustion
- `feat(orchestrator)`: `finalizeTask` commits status via client before firing the existing webhook — webhook demoted to side-effects. On commit failure: ERROR log with stable `STATUS_UPDATE_COMMIT_FAILED` tag + continue (watchdog recovers)
- `fix(code-agent)`: `findZombieTasks` queries `lastHeartbeat` (only written by heartbeat endpoint), not `updatedAt` (polluted by unrelated writes)
- `fix(code-agent)`: stamp `lastHeartbeat` at dispatch in `drainTaskQueue` and `drainRetryQueue` so tasks that die pre-heartbeat are still caught
- `chore(terraform/dev)`: Cloud Scheduler cron hitting `/internal/code/detect-zombies` every 5 min; switches handler to `authenticateInternalScheduler` to align with other code-agent scheduler endpoints
- `test`: end-to-end regression using real Fastify server on a real socket — signs with real `StatusUpdateClient`, hits real route, asserts persistence
- Side-fix: two latent bugs in shared `FakeFirestore` (dropped Timestamp values on `.update()`, NaN comparisons on range operators) discovered during red phase — fixed with boundary tests

## Migration

Migration `097_code-tasks-zombie-lastHeartbeat-index.mjs` adds composite index `(status ASC, lastHeartbeat ASC)` on `code_tasks`. `firestore.indexes.json` regenerated (also re-synced 8 previously-missing indexes from older migrations). Auto-applies on merge.

## Endpoint Changes

- **Created:** `PATCH /internal/code-tasks/:id/status`
- **Modified:** `POST /internal/code/detect-zombies` (auth strategy swapped to `authenticateInternalScheduler`, accepts OIDC; header auth still works)
- **Removed:** none
- **Unchanged:** `POST /internal/webhooks/task-complete`, `POST /internal/webhooks/task-event`, `POST /internal/code/heartbeat`, all other endpoints

## Test plan

- [x] Unit tests per task (~75 new tests across the PR)
- [x] End-to-end regression test (real HTTP socket, not server.inject)
- [x] `pnpm run ci:tracked` green locally (15083 tests, 22 static checks)
- [ ] After merge: manually resolve `task_103bd7e0-5b25-4842-a493-a5ffdc8f3d46` (set status=failed in Firestore)
- [ ] After merge: deploy the dev terraform changes to activate the scheduler cron
- [ ] After merge: migration 097 auto-runs

Plan: `docs/superpowers/plans/2026-04-17-robust-task-finalize.md`

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>