### PR TITLE
[INT-1575] Fall back to base branch when continuation PR branch is gone

### DIFF
--- a/workers/orchestrator/src/__tests__/worktree-manager.test.ts
+++ b/workers/orchestrator/src/__tests__/worktree-manager.test.ts
@@ -249,6 +249,106 @@ describe('WorktreeManager', () => {
       expect(commands).toContain('git fetch origin "task_existing_branch"');
     });
 
+    it('should fall back to base branch when continuation PR branch no longer exists on origin', async () => {
+      // Real-world scenario: PR was merged + branch deleted between task submission
+      // and dispatch. `git fetch` fails with "couldn't find remote ref".
+      // Orchestrator should warn and create the worktree from base branch instead
+      // of failing the task outright.
+      const warnSpy = vi.spyOn(mockLogger, 'warn');
+      const commands: string[] = [];
+      mockExecAsyncImpl = async (
+        command: string,
+        _options: { cwd?: string; timeout?: number }
+      ): Promise<{ stdout: string; stderr: string }> => {
+        commands.push(command);
+        if (command === 'git fetch origin "feature/int-1561"') {
+          throw new Error(
+            'Command failed: git fetch origin "feature/int-1561"\nfatal: couldn\'t find remote ref feature/int-1561\n'
+          );
+        }
+        if (command.includes('git worktree add')) {
+          return { stdout: '', stderr: 'Preparing worktree' };
+        }
+        return { stdout: '', stderr: '' };
+      };
+
+      vi.resetModules();
+      const { WorktreeManager: WM } = await import('../services/worktree-manager.js');
+      const manager = new WM(mockConfig, mockLogger);
+
+      const worktreePath = await manager.createWorktree(
+        'task-gone-branch',
+        'development',
+        'feature/int-1561'
+      );
+
+      expect(worktreePath).toBe(join(worktreeBasePath, 'task-gone-branch'));
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          taskId: 'task-gone-branch',
+          continuationPrBranch: 'feature/int-1561',
+          baseBranch: 'development',
+        }),
+        expect.stringContaining('Continuation PR branch no longer exists on origin')
+      );
+      expect(commands).toContain(
+        `git worktree add -b "task-gone-branch" "${join(worktreeBasePath, 'task-gone-branch')}" "origin/development"`
+      );
+      expect(commands.some((c) => c.includes('origin/feature/int-1561'))).toBe(false);
+      warnSpy.mockRestore();
+    });
+
+    it('should re-throw when continuation PR fetch throws a non-Error value', async () => {
+      // Covers the `: 'Unknown error'` branch of the message coercion. A
+      // non-Error throw cannot match "couldn't find remote ref", so it must
+      // re-throw rather than silently fall back.
+      mockExecAsyncImpl = async (
+        command: string,
+        _options: { cwd?: string; timeout?: number }
+      ): Promise<{ stdout: string; stderr: string }> => {
+        if (command === 'git fetch origin "feature/non-error"') {
+          throw 'string-thrown-not-an-error';
+        }
+        if (command.includes('git worktree add')) {
+          return { stdout: '', stderr: 'Preparing worktree' };
+        }
+        return { stdout: '', stderr: '' };
+      };
+
+      vi.resetModules();
+      const { WorktreeManager: WM } = await import('../services/worktree-manager.js');
+      const manager = new WM(mockConfig, mockLogger);
+
+      await expect(
+        manager.createWorktree('task-non-err-fetch', 'development', 'feature/non-error')
+      ).rejects.toThrow(/Failed to create worktree/);
+    });
+
+    it('should re-throw when continuation PR fetch fails with non-missing-ref error', async () => {
+      // Transient errors (network, auth) should not silently degrade to base
+      // branch — dispatcher needs to see the failure so the task stays queued.
+      mockExecAsyncImpl = async (
+        command: string,
+        _options: { cwd?: string; timeout?: number }
+      ): Promise<{ stdout: string; stderr: string }> => {
+        if (command === 'git fetch origin "feature/network"') {
+          throw new Error('fatal: unable to access remote: Connection reset by peer');
+        }
+        if (command.includes('git worktree add')) {
+          return { stdout: '', stderr: 'Preparing worktree' };
+        }
+        return { stdout: '', stderr: '' };
+      };
+
+      vi.resetModules();
+      const { WorktreeManager: WM } = await import('../services/worktree-manager.js');
+      const manager = new WM(mockConfig, mockLogger);
+
+      await expect(
+        manager.createWorktree('task-net-err', 'development', 'feature/network')
+      ).rejects.toThrow(/Connection reset by peer/);
+    });
+
     it('should reject continuation branch names with shell metacharacters', async () => {
       const commands: string[] = [];
       mockExecAsyncImpl = async (

--- a/workers/orchestrator/src/services/worktree-manager.ts
+++ b/workers/orchestrator/src/services/worktree-manager.ts
@@ -102,54 +102,35 @@ export class WorktreeManager {
         // Create worktree with a new branch for the task
         // Using -b creates a local branch, avoiding detached HEAD state
         // which is required for Claude to create commits and PRs
-        let stderr: string;
-        if (continuationPrBranch === undefined) {
-          ({ stderr } = await execAsync(
-            `git worktree add -b "${taskId}" "${worktreePath}" "origin/${baseBranch}"`,
-            {
-              cwd: this.config.repositoryPath,
-            }
-          ));
-        } else {
-          let continuationBranchAvailable = true;
+        let useContinuation = false;
+        if (continuationPrBranch !== undefined) {
           try {
             await execAsync(`git fetch origin "${continuationPrBranch}"`, {
               cwd: this.config.repositoryPath,
             });
+            useContinuation = true;
           } catch (fetchError: unknown) {
+            // PR merged + branch auto-deleted between submission and dispatch:
+            // fall back to base branch instead of failing the task. Network/auth
+            // failures still re-throw so the dispatcher can retry.
             const message = fetchError instanceof Error ? fetchError.message : 'Unknown error';
-            // Branch was deleted on origin (typical case: PR merged + branch
-            // auto-deleted between task submission and dispatch). Fall back to
-            // base branch so the task can still run instead of hard-failing.
-            // Other failures (network, auth) keep the original throw — caller
-            // must see them so the task can be retried.
-            if (message.includes("couldn't find remote ref")) {
-              this.logger.warn(
-                { taskId, continuationPrBranch, baseBranch },
-                'Continuation PR branch no longer exists on origin (likely merged + deleted) — falling back to base branch'
-              );
-              continuationBranchAvailable = false;
-            } else {
+            if (!message.includes("couldn't find remote ref")) {
               throw fetchError;
             }
-          }
-
-          if (continuationBranchAvailable) {
-            ({ stderr } = await execAsync(
-              `git worktree add -B "${taskId}" "${worktreePath}" "origin/${continuationPrBranch}"`,
-              {
-                cwd: this.config.repositoryPath,
-              }
-            ));
-          } else {
-            ({ stderr } = await execAsync(
-              `git worktree add -b "${taskId}" "${worktreePath}" "origin/${baseBranch}"`,
-              {
-                cwd: this.config.repositoryPath,
-              }
-            ));
+            this.logger.warn(
+              { taskId, continuationPrBranch, baseBranch },
+              'Continuation PR branch no longer exists on origin (likely merged + deleted) — falling back to base branch'
+            );
           }
         }
+
+        const addCommand =
+          useContinuation && continuationPrBranch !== undefined
+            ? `git worktree add -B "${taskId}" "${worktreePath}" "origin/${continuationPrBranch}"`
+            : `git worktree add -b "${taskId}" "${worktreePath}" "origin/${baseBranch}"`;
+        const { stderr } = await execAsync(addCommand, {
+          cwd: this.config.repositoryPath,
+        });
 
         // git worktree add outputs to stderr even on success
         if (stderr && !stderr.includes('Preparing worktree')) {

--- a/workers/orchestrator/src/services/worktree-manager.ts
+++ b/workers/orchestrator/src/services/worktree-manager.ts
@@ -111,15 +111,44 @@ export class WorktreeManager {
             }
           ));
         } else {
-          await execAsync(`git fetch origin "${continuationPrBranch}"`, {
-            cwd: this.config.repositoryPath,
-          });
-          ({ stderr } = await execAsync(
-            `git worktree add -B "${taskId}" "${worktreePath}" "origin/${continuationPrBranch}"`,
-            {
+          let continuationBranchAvailable = true;
+          try {
+            await execAsync(`git fetch origin "${continuationPrBranch}"`, {
               cwd: this.config.repositoryPath,
+            });
+          } catch (fetchError: unknown) {
+            const message = fetchError instanceof Error ? fetchError.message : 'Unknown error';
+            // Branch was deleted on origin (typical case: PR merged + branch
+            // auto-deleted between task submission and dispatch). Fall back to
+            // base branch so the task can still run instead of hard-failing.
+            // Other failures (network, auth) keep the original throw — caller
+            // must see them so the task can be retried.
+            if (message.includes("couldn't find remote ref")) {
+              this.logger.warn(
+                { taskId, continuationPrBranch, baseBranch },
+                'Continuation PR branch no longer exists on origin (likely merged + deleted) — falling back to base branch'
+              );
+              continuationBranchAvailable = false;
+            } else {
+              throw fetchError;
             }
-          ));
+          }
+
+          if (continuationBranchAvailable) {
+            ({ stderr } = await execAsync(
+              `git worktree add -B "${taskId}" "${worktreePath}" "origin/${continuationPrBranch}"`,
+              {
+                cwd: this.config.repositoryPath,
+              }
+            ));
+          } else {
+            ({ stderr } = await execAsync(
+              `git worktree add -b "${taskId}" "${worktreePath}" "origin/${baseBranch}"`,
+              {
+                cwd: this.config.repositoryPath,
+              }
+            ));
+          }
         }
 
         // git worktree add outputs to stderr even on success


### PR DESCRIPTION
## Summary
- When a task's continuation PR has merged and its branch was deleted on origin between submission and dispatch, the orchestrator currently hard-fails task setup with `Failed to create worktree: ... fatal: couldn't find remote ref <branch>`.
- Catch that specific error in `WorktreeManager.createWorktree`, log a warning, and create the worktree from the base branch instead so the task can run.
- Other fetch failures (network, auth) still re-throw so transient errors remain visible to the caller.

## Caveats
- The task still carries the original `continuationPrNumber`. Anything downstream that tries to push to or comment on the merged PR will misbehave — out of scope for this PR; warrants a follow-up on the code-agent side (clear `continuationPrBranch`/`continuationPrNumber` when the PR is no longer open before dispatching).

## Test plan
- [x] New test: fetch returns "couldn't find remote ref" → worktree created from base branch with `-b`, warn logged, no `origin/<continuation>` worktree command issued.
- [x] New test: fetch fails with non-missing-ref network error → re-thrown.
- [x] New test: fetch throws non-Error value → re-thrown (covers the `'Unknown error'` ternary branch).
- [x] `pnpm run ci:tracked` passes.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>