### PR TITLE
[INT-1577] Suppress LLM review when latest origin task failed

### DIFF
--- a/apps/code-agent/src/__tests__/domain/services/unifiedEvaluator.test.ts
+++ b/apps/code-agent/src/__tests__/domain/services/unifiedEvaluator.test.ts
@@ -1788,12 +1788,15 @@ describe('LLM retry for pull_request events', () => {
     }
 
     function createRemediationCodeTaskRepo(task: { status: string; completedAt?: Date; requiresReReview?: boolean } | null): Partial<CodeTaskRepository> {
+      const findOriginTaskByPR = vi.fn().mockResolvedValue(ok(null));
       if (task === null) {
         return {
+          findOriginTaskByPR,
           findRecentRemediationForPR: vi.fn().mockResolvedValue(ok(null)),
         };
       }
       return {
+        findOriginTaskByPR,
         findRecentRemediationForPR: vi.fn().mockResolvedValue(ok({
           id: 'task-rem-1',
           agentType: 'remediation',
@@ -2033,6 +2036,7 @@ describe('LLM retry for pull_request events', () => {
 
     it('proceeds with review when codeTaskRepo query fails', async () => {
       const codeTaskRepo: Partial<CodeTaskRepository> = {
+        findOriginTaskByPR: vi.fn().mockResolvedValue(ok(null)),
         findRecentRemediationForPR: vi.fn().mockResolvedValue(err({ code: 'FIRESTORE_ERROR', message: 'Connection failed' })),
       };
       const deps = createFakeDeps({

--- a/apps/code-agent/src/__tests__/domain/services/unifiedEvaluator/criteria.test.ts
+++ b/apps/code-agent/src/__tests__/domain/services/unifiedEvaluator/criteria.test.ts
@@ -20,6 +20,7 @@ import {
   handleCheckSuiteCIFailure,
   handleHardRules,
   shouldSkipReviewForRemediation,
+  shouldSkipReviewForFailedOrigin,
   REMEDIATION_RECENCY_MS,
 } from '../../../../domain/services/unifiedEvaluator/criteria.js';
 import { createDeps as createBaseDeps, createFakeEvent, createFakeLogger } from './_fixtures.js';
@@ -248,5 +249,52 @@ describe('criteria/shouldSkipReviewForRemediation', () => {
     const recent = Timestamp.fromMillis(Date.now() - 1000);
     const repo = createCodeTaskRepo(ok({ status: 'completed', completedAt: recent, requiresReReview: false }));
     expect(await shouldSkipReviewForRemediation(repo, 'o/r', 1, 'evt-1', logger)).toBe(true);
+  });
+});
+
+describe('criteria/shouldSkipReviewForFailedOrigin', () => {
+  let logger: Logger;
+  beforeEach(() => { logger = createFakeLogger(); });
+
+  function createCodeTaskRepo(result: unknown): CodeTaskRepository {
+    return {
+      findOriginTaskByPR: vi.fn().mockResolvedValue(result),
+    } as unknown as CodeTaskRepository;
+  }
+
+  it.each([
+    ['failed', 'execution'],
+    ['interrupted', 'execution'],
+    ['cancelled', 'execution'],
+    ['failed', 'planning'],
+    ['failed', 'pull_request'],
+  ] as const)('returns skip=true with origin metadata when status=%s, agentType=%s', async (status, agentType) => {
+    const repo = createCodeTaskRepo(ok({ id: 't-1', status, agentType }));
+    const result = await shouldSkipReviewForFailedOrigin(repo, 'o/r', 1, 'evt-1', logger);
+    expect(result).toEqual({ skip: true, origin: { taskId: 't-1', agentType, status } });
+  });
+
+  it.each([
+    ['implemented'],
+    ['planned'],
+    ['reviewed'],
+    ['queued'],
+    ['dispatched'],
+    ['running'],
+    ['archived'],
+  ] as const)('returns skip=false for non-terminal-failure status %s (allow-list: only failed|interrupted|cancelled gate)', async (status) => {
+    const repo = createCodeTaskRepo(ok({ id: 't-1', status, agentType: 'execution' }));
+    expect(await shouldSkipReviewForFailedOrigin(repo, 'o/r', 1, 'evt-1', logger)).toEqual({ skip: false });
+  });
+
+  it('returns skip=false when no origin task found', async () => {
+    const repo = createCodeTaskRepo(ok(null));
+    expect(await shouldSkipReviewForFailedOrigin(repo, 'o/r', 1, 'evt-1', logger)).toEqual({ skip: false });
+  });
+
+  it('returns skip=false and warns when repository call fails (fail-open)', async () => {
+    const repo = createCodeTaskRepo(err({ code: 'X', message: 'firestore down' }));
+    expect(await shouldSkipReviewForFailedOrigin(repo, 'o/r', 1, 'evt-1', logger)).toEqual({ skip: false });
+    expect(logger.warn).toHaveBeenCalled();
   });
 });

--- a/apps/code-agent/src/__tests__/domain/services/unifiedEvaluator/scoring.test.ts
+++ b/apps/code-agent/src/__tests__/domain/services/unifiedEvaluator/scoring.test.ts
@@ -183,6 +183,7 @@ describe('scoring/handleLlmTriage', () => {
 
   it('skips review when recent remediation indicates no re-review needed on synchronize', async () => {
     const codeTaskRepo = {
+      findOriginTaskByPR: vi.fn().mockResolvedValue(ok(null)),
       findRecentRemediationForPR: vi.fn().mockResolvedValue(ok({
         status: 'running',
         requiresReReview: false,
@@ -211,6 +212,7 @@ describe('scoring/handleLlmTriage', () => {
 
   it('proceeds with review when remediation check fails open (no task found)', async () => {
     const codeTaskRepo = {
+      findOriginTaskByPR: vi.fn().mockResolvedValue(ok(null)),
       findRecentRemediationForPR: vi.fn().mockResolvedValue(ok(null)),
     } as unknown as CodeTaskRepository;
     const evaluateEvent = vi.fn().mockResolvedValue(ok({
@@ -226,6 +228,114 @@ describe('scoring/handleLlmTriage', () => {
       logger,
     );
     expect(deps.createReviewTask).toHaveBeenCalled();
+  });
+
+  it('skips review when latest origin task ended in terminal failure', async () => {
+    const findOriginTaskByPR = vi.fn().mockResolvedValue(ok({
+      id: 'task-failed-1', status: 'failed', agentType: 'execution',
+    }));
+    const findRecentRemediationForPR = vi.fn().mockResolvedValue(ok(null));
+    const codeTaskRepo = { findOriginTaskByPR, findRecentRemediationForPR } as unknown as CodeTaskRepository;
+    const onReviewSkipped = vi.fn().mockResolvedValue(undefined);
+    const evaluateEvent = vi.fn().mockResolvedValue(ok({
+      triage: { action: 'request_review', reviewTypes: ['code_review'] },
+      usage: { costUsd: 0.01, model: 'claude-opus', toolCalls: [] },
+      reasoning: 'would-be review',
+    }));
+    const deps = createDeps({ evaluateEvent, codeTaskRepo, onReviewSkipped });
+    await handleLlmTriage(
+      deps,
+      createFakeEvent({ eventType: 'pull_request', action: 'synchronize' }),
+      Date.now(),
+      logger,
+    );
+    expect(deps.createReviewTask).not.toHaveBeenCalled();
+    expect(findRecentRemediationForPR).not.toHaveBeenCalled();
+    expect(deps.eventDecisionRepo.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        decidedBy: 'github_agent',
+        decision: 'skip',
+        reason: expect.stringContaining('failed_origin_no_review'),
+        llmModel: 'claude-opus',
+        llmCostUsd: 0.01,
+      }),
+    );
+    expect(deps.automationLog.record).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        type: 'skipped',
+        decidedBy: 'llm_triage',
+        reason: 'failed_origin_no_review',
+      }),
+      undefined,
+    );
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        originTaskId: 'task-failed-1',
+        originAgentType: 'execution',
+        originStatus: 'failed',
+      }),
+      'Skipping review: latest origin task ended in terminal failure',
+    );
+    // onReviewSkipped (which sets ready-to-merge) MUST NOT be invoked for failed origins
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(onReviewSkipped).not.toHaveBeenCalled();
+  });
+
+  it('failed-origin gate fires for non-synchronize events too (issue_comment)', async () => {
+    const codeTaskRepo = {
+      findOriginTaskByPR: vi.fn().mockResolvedValue(ok({
+        id: 'task-int-1', status: 'interrupted', agentType: 'planning',
+      })),
+      findRecentRemediationForPR: vi.fn().mockResolvedValue(ok(null)),
+    } as unknown as CodeTaskRepository;
+    const evaluateEvent = vi.fn().mockResolvedValue(ok({
+      triage: { action: 'request_review', reviewTypes: ['code_review'] },
+      usage: { costUsd: 0.01, toolCalls: [] },
+      reasoning: '',
+    }));
+    const deps = createDeps({ evaluateEvent, codeTaskRepo });
+    await handleLlmTriage(
+      deps,
+      createFakeEvent({ eventType: 'issue_comment', body: 'looks good' }),
+      Date.now(),
+      logger,
+    );
+    expect(deps.createReviewTask).not.toHaveBeenCalled();
+  });
+
+  it('proceeds with review when origin task is implemented', async () => {
+    const codeTaskRepo = {
+      findOriginTaskByPR: vi.fn().mockResolvedValue(ok({
+        id: 'task-ok', status: 'implemented', agentType: 'execution',
+      })),
+      findRecentRemediationForPR: vi.fn().mockResolvedValue(ok(null)),
+    } as unknown as CodeTaskRepository;
+    const evaluateEvent = vi.fn().mockResolvedValue(ok({
+      triage: { action: 'request_review', reviewTypes: ['code_review'] },
+      usage: { costUsd: 0.01, toolCalls: [] },
+      reasoning: '',
+    }));
+    const deps = createDeps({ evaluateEvent, codeTaskRepo });
+    await handleLlmTriage(deps, createFakeEvent(), Date.now(), logger);
+    expect(deps.createReviewTask).toHaveBeenCalled();
+  });
+
+  it('proceeds (fail-open) when findOriginTaskByPR errors', async () => {
+    const codeTaskRepo = {
+      findOriginTaskByPR: vi.fn().mockResolvedValue(err({ code: 'X', message: 'firestore down' })),
+      findRecentRemediationForPR: vi.fn().mockResolvedValue(ok(null)),
+    } as unknown as CodeTaskRepository;
+    const evaluateEvent = vi.fn().mockResolvedValue(ok({
+      triage: { action: 'request_review', reviewTypes: ['code_review'] },
+      usage: { costUsd: 0.01, toolCalls: [] },
+      reasoning: '',
+    }));
+    const deps = createDeps({ evaluateEvent, codeTaskRepo });
+    await handleLlmTriage(deps, createFakeEvent(), Date.now(), logger);
+    expect(deps.createReviewTask).toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalled();
   });
 
   it('records skip for triage.action === "skip"', async () => {
@@ -334,6 +444,7 @@ describe('scoring/handleLlmTriage', () => {
 
   it('includes llmModel when usage.model is present on remediation skip', async () => {
     const codeTaskRepo = {
+      findOriginTaskByPR: vi.fn().mockResolvedValue(ok(null)),
       findRecentRemediationForPR: vi.fn().mockResolvedValue(ok({
         status: 'completed',
         completedAt: Timestamp.fromMillis(Date.now()),

--- a/apps/code-agent/src/domain/repositories/codeTaskRepository.ts
+++ b/apps/code-agent/src/domain/repositories/codeTaskRepository.ts
@@ -287,9 +287,11 @@ export interface CodeTaskRepository {
   ): Promise<Result<CodeTask | null, RepositoryError>>;
 
   /**
-   * Find the latest planning or execution origin task for a PR.
-   * Excludes review, remediation, and pull_request tasks.
-   * Used to resolve the true origin task for review-outcome labeling.
+   * Find the latest origin task for a PR. Prefers `planning` or `execution`
+   * tasks; falls back to the most recent `pull_request` task when neither
+   * exists. Excludes `review`, `remediation`, and merge-conflict follow-up
+   * tasks. Used to resolve the true origin task for review-outcome labeling
+   * and to gate review creation when the latest origin failed.
    */
   findOriginTaskByPR(
     repository: string,

--- a/apps/code-agent/src/domain/services/unifiedEvaluator/criteria.ts
+++ b/apps/code-agent/src/domain/services/unifiedEvaluator/criteria.ts
@@ -8,7 +8,7 @@
 import type { Logger } from '@intexuraos/common-core';
 import type { GitHubPREvent } from '../../models/gitHubPREvent.js';
 import type { CodeTaskRepository } from '../../repositories/codeTaskRepository.js';
-import type { CodeTask } from '../../models/codeTask.js';
+import type { AgentType, CodeTask, TaskStatus } from '../../models/codeTask.js';
 import type { CIFailureDispatchService } from '../gitHubDispatchService.js';
 import { CIFailureRule } from '../gitHubWebhookRules.js';
 import type { UnifiedEvaluatorDeps } from './types.js';
@@ -174,4 +174,47 @@ export async function shouldSkipReviewForRemediation(
 
   // Only an explicit false suppresses a fresh review. Undefined fails open to review.
   return task.requiresReReview === false;
+}
+
+const TERMINAL_FAILURE_STATUSES = new Set<TaskStatus>(['failed', 'interrupted', 'cancelled']);
+
+export const FAILED_ORIGIN_NO_REVIEW_REASON = 'failed_origin_no_review';
+
+export type FailedOriginGateResult =
+  | { skip: false }
+  | { skip: true; origin: { taskId: string; agentType: AgentType; status: TaskStatus } };
+
+/**
+ * Suppress LLM-triggered review when the PR's latest planning/execution
+ * (or pull_request fallback) origin task ended in a terminal failure
+ * status — `failed`, `interrupted`, or `cancelled`. A retry produces a new
+ * latest origin task, so the gate self-clears once the user re-runs.
+ *
+ * Fail-open: any repo error or non-failure status returns skip=false.
+ */
+export async function shouldSkipReviewForFailedOrigin(
+  codeTaskRepo: CodeTaskRepository,
+  repository: string,
+  prNumber: number,
+  eventId: string,
+  logger: Logger,
+): Promise<FailedOriginGateResult> {
+  const result = await codeTaskRepo.findOriginTaskByPR(repository, prNumber);
+  if (!result.ok) {
+    logger.warn(
+      { eventId, error: result.error },
+      'Failed to look up origin task for failed-origin gate, proceeding with review',
+    );
+    return { skip: false };
+  }
+
+  const task: CodeTask | null = result.value;
+  if (task?.agentType === undefined || !TERMINAL_FAILURE_STATUSES.has(task.status)) {
+    return { skip: false };
+  }
+
+  return {
+    skip: true,
+    origin: { taskId: task.id, agentType: task.agentType, status: task.status },
+  };
 }

--- a/apps/code-agent/src/domain/services/unifiedEvaluator/scoring.ts
+++ b/apps/code-agent/src/domain/services/unifiedEvaluator/scoring.ts
@@ -12,7 +12,7 @@ import { resolveLoginForTaskCreation } from '../gitHubDispatchService.js';
 import { isReviewCommandComment, extractReviewWorkerType } from '../../utils/reviewTriage.js';
 import type { UnifiedEvaluatorDeps } from './types.js';
 import { deduplicateToolCalls, recordDecision, recordLog, resolveUserId } from './reporting.js';
-import { shouldSkipReviewForRemediation } from './criteria.js';
+import { FAILED_ORIGIN_NO_REVIEW_REASON, shouldSkipReviewForFailedOrigin, shouldSkipReviewForRemediation } from './criteria.js';
 
 /**
  * Event-type-aware fallback when LLM is unavailable or fails.
@@ -179,6 +179,47 @@ export async function handleLlmTriage(
   }
 
   if (triage.action === 'request_review') {
+    // Failed-origin gate: if the PR's latest planning/execution origin task
+    // ended in a terminal failure (failed/interrupted/cancelled), suppress the
+    // review for ANY event type. Runs before the synchronize-only remediation
+    // check so it short-circuits without an extra Firestore lookup.
+    if (deps.codeTaskRepo !== undefined) {
+      const failedOrigin = await shouldSkipReviewForFailedOrigin(
+        deps.codeTaskRepo, event.repository, event.pullRequestNumber, event.id, logger,
+      );
+      if (failedOrigin.skip) {
+        const { origin } = failedOrigin;
+        const userId = await resolveUserId(deps, event);
+        logger.info(
+          {
+            eventId: event.id,
+            originTaskId: origin.taskId,
+            originAgentType: origin.agentType,
+            originStatus: origin.status,
+          },
+          'Skipping review: latest origin task ended in terminal failure',
+        );
+        recordLog(deps, event, {
+          type: 'skipped',
+          decidedBy: 'llm_triage',
+          reason: FAILED_ORIGIN_NO_REVIEW_REASON,
+          cost: usage.costUsd,
+          reasoning,
+          toolCalls: toolCallSummaries,
+        }, userId);
+        await recordDecision(deps, event, {
+          decidedBy: 'github_agent',
+          decision: 'skip',
+          reason: `${FAILED_ORIGIN_NO_REVIEW_REASON}: latest origin task (${origin.agentType}, ${origin.status}) ended in terminal failure — retry the task before requesting review`,
+          llmCostUsd: usage.costUsd,
+          ...(usage.model !== undefined && { llmModel: usage.model }),
+          llmToolCalls: usage.toolCalls,
+          llmReasoning: reasoning,
+        }, startTime, logger);
+        return;
+      }
+    }
+
     // Synchronize remediation interception:
     // Before triggering a review for a synchronize event, check if a recent
     // remediation task already determined that no re-review is needed.


### PR DESCRIPTION
Fixes INT-1577

## Summary

When a code task with `agentType: 'execution'` (or `'planning'`, or `'pull_request'` fallback) ends in a terminal failure (`failed` / `interrupted` / `cancelled`), any subsequent GitHub event on its PR currently flows through LLM triage and frequently produces `request_review`, dispatching a wasted review code-task. Concrete incident: INT-1546 (api-docs-hub validateRequiredEnv) failed at execution time but spawned a follow-up review task on PR #1995.

## Approach

- New helper `shouldSkipReviewForFailedOrigin` in `unifiedEvaluator/criteria.ts` mirroring `shouldSkipReviewForRemediation`. Reuses the existing `CodeTaskRepository.findOriginTaskByPR` (no new repo method, no new Firestore index).
- Wired into the top of the `request_review` LLM-triage branch in `unifiedEvaluator/scoring.ts`, BEFORE the existing synchronize-only remediation check (short-circuits the extra Firestore lookup on the bad-PR path).
- Applies to ALL event types reaching `request_review` — a broken PR should not auto-spawn a review whether the trigger was `pull_request.synchronize`, `pull_request.opened`, `issue_comment`, or `pull_request_review`.
- Records `recordLog({ type: 'skipped', decidedBy: 'llm_triage', reason: 'failed_origin_no_review', ... })` and `recordDecision({ decision: 'skip', reason: 'failed_origin_no_review: latest origin task (<agentType>, <status>) ended in terminal failure — retry the task before requesting review', ... })`.
- Early-returns inside `request_review` so the `onReviewSkipped` callback (which sets `ready-to-merge` Linear label) is NOT invoked — a failed origin must not be labeled ready-to-merge.
- Fail-open: any Firestore error in `findOriginTaskByPR` returns `{ skip: false }` and lets the review proceed.
- Allow-list-based status check (`failed | interrupted | cancelled`) so future status additions default to fail-open.
- Docstring on `findOriginTaskByPR` tightened to mention the `pull_request` fallback (it already had this behavior via `selectOriginTask` but the doc said otherwise).

## Endpoint Changes

- **Modified:** none
- **Created:** none
- **Removed:** none
- **Unchanged:** all GitHub-webhook routes and `/internal/*` endpoints. Visible behavior change is only in the automation-log/decision records (new `failed_origin_no_review` skip reason).

## Test Plan

- [x] `pnpm vitest run` (apps/code-agent) — 4995 passed, 0 failed
- [x] `pnpm run verify:workspace:tracked code-agent` — 16596 tests passed
- [x] `pnpm run ci:tracked` — all 4 phases passed
- [x] New unit tests for `shouldSkipReviewForFailedOrigin` cover: failed/interrupted/cancelled × execution/planning/pull_request, every non-failure status (implemented/planned/reviewed/queued/dispatched/running/archived), null task, repo error fail-open
- [x] New scoring tests cover: skip on failed origin (records correct decision + log + suppresses `findRecentRemediationForPR` lookup + does NOT invoke `onReviewSkipped`), gate fires for non-synchronize events, proceeds when origin implemented, fail-open on repo error, logs origin identity (`originTaskId`/`originAgentType`/`originStatus`)
- [x] Existing remediation-gate tests updated with `findOriginTaskByPR: ok(null)` mocks and pass green

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>