### PR TITLE
[INT-1576] Preserve runtime rate-limit phrase in verifier-hard-error path

### DIFF
--- a/workers/orchestrator/src/__tests__/task-dispatcher.test.ts
+++ b/workers/orchestrator/src/__tests__/task-dispatcher.test.ts
@@ -2348,6 +2348,72 @@ describe('TaskDispatcher', () => {
       expect(failedPayload?.error?.message).toContain('rate limited');
     });
 
+    it('INT-1576: verifier-hard-error + claudeError rate-limit → TASK_RUNTIME_HARD_ERROR preserves runtime phrase', async () => {
+      // Production scenario: Claude hits the 5-hour usage limit and exits before
+      // emitting an EXECUTION_AGENT_FINAL block. The pure verifier returns
+      // {kind:'hard-error', message:'No EXECUTION_AGENT_FINAL: block in transcript'}
+      // and the dispatcher finalizes with that message verbatim. The runtime
+      // already populated `claudeErrors` with the rate-limit phrase via the
+      // attempt_failed event — that signal must survive into the finalized
+      // error.message so downstream classifyFailure routes the failure to
+      // 'retry_after_cooloff' (i.e., the cooloff scheduler engages instead of
+      // immediately re-dispatching into the same exhausted rate-limit window).
+      vi.mocked(singleAttemptCompletionControl.verifier.verify).mockResolvedValueOnce({
+        kind: 'hard-error',
+        code: 'TASK_RUNTIME_HARD_ERROR',
+        message: 'No EXECUTION_AGENT_FINAL: block in transcript',
+      });
+      const internalCheck = agentDispatcher as unknown as {
+        checkForResult: (task: unknown) => Promise<TaskResult | undefined>;
+      };
+      vi.spyOn(internalCheck, 'checkForResult').mockResolvedValue(undefined);
+      const request: CreateTaskRequest = {
+        taskId: 'int-1576-verifier-hard-error-rate-limit',
+        workerType: 'auto',
+        prompt: 'Trigger verifier-hard-error path while claudeErrors holds the rate-limit phrase',
+        webhookUrl: 'https://example.com/webhook',
+        webhookSecret: 'secret',
+        linearIssueLabels: ['code-task'],
+        hasChildren: false,
+        agentType: 'execution',
+      };
+
+      await agentDispatcher.submitTask(request);
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Feed the actual production rate-limit JSON shape so the runtime processor
+      // emits attempt_failed → claudeErrors.set(taskId, "You've hit your limit ...").
+      const createWorkerCall = vi.mocked(mockIsolationProvider.createWorker).mock.calls.at(-1);
+      const onLog = createWorkerCall?.[0]?.onLog;
+      const onComplete = createWorkerCall?.[0]?.onComplete;
+      expect(onLog).toBeDefined();
+      expect(onComplete).toBeDefined();
+      onLog?.(
+        '{"type":"result","is_error":true,"result":"You\'ve hit your limit · resets 12am (UTC)"}\n'
+      );
+      onComplete?.(1);
+
+      vi.mocked(mockIsolationProvider.isWorkerRunning).mockResolvedValue(false);
+      await vi.advanceTimersByTimeAsync(30 * 1000);
+
+      const sentCall = vi.mocked(mockWebhookClient.send).mock.calls.find((c) => {
+        const p = c[0]?.payload as { status?: string } | undefined;
+        return p?.status === 'failed';
+      });
+      const failedPayload = sentCall?.[0]?.payload as
+        | { error?: { code?: string; message?: string } }
+        | undefined;
+      expect(failedPayload?.error?.code).toBe('TASK_RUNTIME_HARD_ERROR');
+      expect(failedPayload?.error?.message).toContain('hit your limit');
+      expect(failedPayload?.error?.message).toContain('No EXECUTION_AGENT_FINAL');
+      // Mirrors the regex in apps/code-agent/src/domain/utils/classifyFailure.ts:74.
+      // If this match breaks, classifyFailure would return 'retry' instead of
+      // 'retry_after_cooloff' and the cooloff scheduler would not engage.
+      expect(failedPayload?.error?.message).toMatch(
+        /429|rate limit|hit your limit|usage limit|limit · resets/i
+      );
+    });
+
     it('INT-1457: normal-path generic runtime error + exit 1 → TASK_RUNTIME_HARD_ERROR', async () => {
       vi.mocked(singleAttemptCompletionControl.verifier.verify).mockResolvedValueOnce({
         passed: false,

--- a/workers/orchestrator/src/__tests__/task-dispatcher.test.ts
+++ b/workers/orchestrator/src/__tests__/task-dispatcher.test.ts
@@ -2349,15 +2349,11 @@ describe('TaskDispatcher', () => {
     });
 
     it('INT-1576: verifier-hard-error + claudeError rate-limit → TASK_RUNTIME_HARD_ERROR preserves runtime phrase', async () => {
-      // Production scenario: Claude hits the 5-hour usage limit and exits before
-      // emitting an EXECUTION_AGENT_FINAL block. The pure verifier returns
-      // {kind:'hard-error', message:'No EXECUTION_AGENT_FINAL: block in transcript'}
-      // and the dispatcher finalizes with that message verbatim. The runtime
-      // already populated `claudeErrors` with the rate-limit phrase via the
-      // attempt_failed event — that signal must survive into the finalized
-      // error.message so downstream classifyFailure routes the failure to
-      // 'retry_after_cooloff' (i.e., the cooloff scheduler engages instead of
-      // immediately re-dispatching into the same exhausted rate-limit window).
+      // When Claude exits before emitting an AGENT_FINAL block, the verifier
+      // returns hard-error with a generic "No FINAL block" message — but the
+      // runtime already captured the actual failure (e.g. rate-limit) into
+      // claudeErrors. That signal must reach error.message so downstream
+      // classifyFailure routes to 'retry_after_cooloff' instead of plain retry.
       vi.mocked(singleAttemptCompletionControl.verifier.verify).mockResolvedValueOnce({
         kind: 'hard-error',
         code: 'TASK_RUNTIME_HARD_ERROR',

--- a/workers/orchestrator/src/services/task-dispatcher.ts
+++ b/workers/orchestrator/src/services/task-dispatcher.ts
@@ -1707,9 +1707,25 @@ export class TaskDispatcher {
       /* v8 ignore stop @preserve */
       await this.flushTaskLogs(task.taskId);
       await this.collectTurnMetrics(task, attempt);
+      // [INT-1576] When the runtime captured a concrete failure phrase (e.g.
+      // Claude's "You've hit your limit · resets ...") via attempt_failed,
+      // surface it alongside the verifier's generic "No FINAL block" message.
+      // Without this, the rate-limit signal that classifyFailure looks for is
+      // dropped here and the cooloff scheduler never engages.
+      const claudeErrorForHardFailure = this.claudeErrors.get(task.taskId);
+      let hardErrorMessage = verification.message;
+      if (claudeErrorForHardFailure !== undefined && claudeErrorForHardFailure !== '') {
+        const runtimeName = this.getRuntimeDisplayName(task);
+        const runtimePrefix = buildRuntimeHardErrorMessage({
+          exitCode,
+          claudeError: claudeErrorForHardFailure,
+          runtimeName,
+        });
+        hardErrorMessage = `${runtimePrefix}; ${verification.message}`;
+      }
       const hardError: TaskError = {
         code: verification.code,
-        message: verification.message,
+        message: hardErrorMessage,
         remediation: { action: 'retry' },
       };
       await this.finalizeTask(task, 'failed', {

--- a/workers/orchestrator/src/services/task-dispatcher.ts
+++ b/workers/orchestrator/src/services/task-dispatcher.ts
@@ -1707,19 +1707,16 @@ export class TaskDispatcher {
       /* v8 ignore stop @preserve */
       await this.flushTaskLogs(task.taskId);
       await this.collectTurnMetrics(task, attempt);
-      // [INT-1576] When the runtime captured a concrete failure phrase (e.g.
-      // Claude's "You've hit your limit · resets ...") via attempt_failed,
-      // surface it alongside the verifier's generic "No FINAL block" message.
-      // Without this, the rate-limit signal that classifyFailure looks for is
-      // dropped here and the cooloff scheduler never engages.
+      // The runtime's rate-limit phrase is captured into `claudeErrors` via
+      // attempt_failed. Prepend it so downstream classifyFailure sees the
+      // signal it routes on; without this the cooloff scheduler never engages.
       const claudeErrorForHardFailure = this.claudeErrors.get(task.taskId);
       let hardErrorMessage = verification.message;
       if (claudeErrorForHardFailure !== undefined && claudeErrorForHardFailure !== '') {
-        const runtimeName = this.getRuntimeDisplayName(task);
         const runtimePrefix = buildRuntimeHardErrorMessage({
           exitCode,
           claudeError: claudeErrorForHardFailure,
-          runtimeName,
+          runtimeName: this.getRuntimeDisplayName(task),
         });
         hardErrorMessage = `${runtimePrefix}; ${verification.message}`;
       }


### PR DESCRIPTION
## Summary

* The verifier-hard-error path in `workers/orchestrator/src/services/task-dispatcher.ts` (line 1710) was finalizing failures with `verification.message` verbatim — e.g. `"No EXECUTION_AGENT_FINAL: block in transcript"` — and discarding any runtime evidence the runtime processor had already captured into `this.claudeErrors` via `attempt_failed`.
* This silently disabled the cooloff-retry feature: downstream `classifyFailure` in `apps/code-agent` looks for the rate-limit phrase (`/429|rate limit|hit your limit|usage limit|limit · resets/i`) in `error.message` to return `'retry_after_cooloff'`. With the phrase dropped here, the classifier fell through to plain `'retry'` and `autoRetryTask` was invoked without a `cooloffSchedule`, so retries hit the dispatch queue immediately and re-ran into the same exhausted 5-hour rate-limit window.
* When `claudeError` is non-empty, prepend `buildRuntimeHardErrorMessage({ exitCode, claudeError, runtimeName })` to `verification.message` — same pattern already used by the fail-exit-override branch (line 1976+) and the resumed-after-success path (line 2362).

## Production evidence (INT-1551 retry chain)

`task_87f28ea3-3c1f-456d-9d85-b135eb8e7acc` (execution agent for INT-1551) failed with `TASK_RUNTIME_HARD_ERROR: No EXECUTION_AGENT_FINAL: block in transcript`. Three auto-retry tasks immediately followed (`auto-retry-1777154952516`, `auto-retry-1777157367678`, `auto-retry-1777162093483`) — every one with `dispatchSchedule: null` despite the original failure being a rate-limit hit (per Firestore `executionMemoryPostRun.evaluationSummary`: *"the worker failed immediately due to an API rate limit error"*). The home-dev orchestrator journal confirms the runtime emitted `attempt_failed` (exitCode=1) at `00:08:48.636 UTC` — populating `claudeErrors` — but the finalized webhook payload at `00:09:11.996` carried only the verifier's generic message.

## Test plan

- [x] New regression test: `INT-1576: verifier-hard-error + claudeError rate-limit → TASK_RUNTIME_HARD_ERROR preserves runtime phrase` in `workers/orchestrator/src/__tests__/task-dispatcher.test.ts`. Mocks the verifier to return canonical `kind: 'hard-error'`, feeds the production rate-limit `result` JSON via `onLog`, asserts the finalized `error.message` contains both `'hit your limit'` and `'No EXECUTION_AGENT_FINAL'`, and matches the exact `classifyFailure` cooloff regex.
- [x] Confirmed test fails on `development` and passes on this branch.
- [x] `pnpm run verify:workspace:tracked orchestrator` — 854 files, 16597 tests passed, coverage threshold met.
- [x] `pnpm run ci:tracked` — green end-to-end.

Existing `classifyFailure` tests in `apps/code-agent/src/__tests__/domain/utils/classifyFailure.test.ts` (e.g. `"returns 'retry_after_cooloff' for production usage-limit message in TASK_RUNTIME_HARD_ERROR"`) already verify the downstream end of this contract — the orchestrator's combined message format `"Non-zero exit code: 1; Claude error: You've hit your limit · resets ...; ..."` is exactly what they assert against.

## Endpoint Changes

- **Modified:** none (orchestrator-internal failure path; webhook payload format is unchanged in shape, only `error.message` content is enriched).
- **Created:** none.
- **Removed:** none.
- **Unchanged:** `POST /tasks`, all webhook callbacks.

Fixes INT-1576

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>