### PR TITLE
[INT-1560] fix(orchestrator): teach completion verifier the codex exec --json envelope

### DIFF
--- a/workers/orchestrator/src/__tests__/completion-verifier.test.ts
+++ b/workers/orchestrator/src/__tests__/completion-verifier.test.ts
@@ -269,6 +269,81 @@ describe('verifyCompletion — real-rawLogs regression (NDJSON-aware fallback)',
   });
 });
 
+describe('verifyCompletion — codex exec --json regression', () => {
+  // Fixture captured live on 2026-04-27 by running
+  //   docker exec <preserved-container> codex exec --json --skip-git-repo-check \
+  //     --dangerously-bypass-approvals-and-sandbox -
+  // against codex-cli 0.125.0 (the version baked into the production code-worker
+  // image), with a tiny prompt asking codex to emit a fixed PULL_REQUEST_AGENT_FINAL
+  // block. The thread_id was sanitized to all-zeros; everything else is real
+  // codex stdout, including the trailing `codex_core::session: failed to record
+  // rollout items` stderr line that codex emits after every turn.
+  //
+  // This is the exact byte shape the verifier consumes via `getWorkerLogs()`
+  // when the orchestrator dispatches a codex worker. Before the codex extractor
+  // shipped in `ndjson-extractor.ts`, the marker was buried inside
+  //   {"type":"item.completed","item":{"type":"agent_message","text":"...\\n..."}}
+  // — a shape the INT-1560 Claude-SDK fallback did not recognize — so the
+  // verifier returned hard-error and the orchestrator finalized the task as
+  // `failed` even though codex completed cleanly. Real production failure that
+  // motivated this fixture: task_70a75a13-b0fd-4607-aec6-7d1a375af9be.
+  const RAW_RAWLOGS_DIR = join(FIXTURE_ROOT, 'raw-rawlogs');
+  const codexRawLogs = readFileSync(
+    join(RAW_RAWLOGS_DIR, 'codex-pull-request-final.rawlogs.txt'),
+    'utf8'
+  );
+  const codexExpected = JSON.parse(
+    readFileSync(join(RAW_RAWLOGS_DIR, 'codex-pull-request-final.expected.json'), 'utf8')
+  ) as {
+    agentType: CompletionAgentType;
+    workerType: string;
+    postFixVerdict: {
+      kind: 'parsed';
+      missingRequired: string[];
+      dataAssertions: Record<string, string | number | boolean>;
+    };
+  };
+
+  it('parses real codex exec --json stdout without hard-error', () => {
+    const verdict = verifyCompletion({
+      transcript: codexRawLogs,
+      agentType: codexExpected.agentType,
+      workerType: codexExpected.workerType as never,
+      executionMemoryContext: undefined,
+      lastExitCode: 0,
+    });
+    expect(
+      verdict.kind,
+      'real codex stdout fixture MUST NOT produce a hard-error after the codex extractor ships — that is the entire fix'
+    ).toBe('parsed');
+    if (verdict.kind !== 'parsed') return;
+    expect(verdict.missingRequired).toEqual(codexExpected.postFixVerdict.missingRequired);
+    const a = codexExpected.postFixVerdict.dataAssertions;
+    expect(verdict.data['pr']).toBe(a['pr']);
+    expect(verdict.data['comment_replied']).toBe(a['comment_replied']);
+    expect(verdict.data['tracking_comment_id']).toBe(a['tracking_comment_id']);
+    expect(verdict.data['tracking_comment']).toBe(a['tracking_comment']);
+    expect(verdict.data['total_pr_comments_posted']).toBe(a['total_pr_comments_posted']);
+    expect(String(verdict.data['ci_evidence'])).toContain(String(a['ci_evidenceContains']));
+    expect(String(verdict.data['summary'])).toContain(String(a['summaryContains']));
+  });
+
+  it('regression document: confirms the marker is NOT on its own line in raw codex stdout', () => {
+    // The marker exists ONLY as the JSON-escaped text inside an
+    // item.completed/agent_message envelope. If a future change starts
+    // emitting the marker on its own line in the raw bytes, this assertion
+    // will fire and remind the reviewer to refresh the fixture.
+    const ownLineMarkerRegex = /^\s*PULL_REQUEST_AGENT_FINAL:\s*$/m;
+    expect(
+      ownLineMarkerRegex.test(codexRawLogs),
+      'codex stdout must keep the marker buried inside the item.completed JSON envelope'
+    ).toBe(false);
+    expect(codexRawLogs).toContain('PULL_REQUEST_AGENT_FINAL');
+    expect(codexRawLogs).toContain('"type":"item.completed"');
+    expect(codexRawLogs).toContain('"type":"agent_message"');
+  });
+});
+
 describe('verifyCompletion — full-fixture replay (Phase-5 regression guard)', () => {
   // Every real-production AGENT_FINAL transcript harvested into the fixture
   // corpus MUST either accept (kind='parsed' with missingRequired=[]) when

--- a/workers/orchestrator/src/__tests__/fixtures/completion-verifier/raw-rawlogs/codex-pull-request-final.expected.json
+++ b/workers/orchestrator/src/__tests__/fixtures/completion-verifier/raw-rawlogs/codex-pull-request-final.expected.json
@@ -1,0 +1,29 @@
+{
+  "agentType": "pull_request",
+  "workerType": "codex",
+  "marker": "PULL_REQUEST_AGENT_FINAL:",
+  "captureContext": {
+    "source": "live `docker exec code-worker-task_70a75a13-... codex exec --json --skip-git-repo-check --dangerously-bypass-approvals-and-sandbox` against codex-cli 0.125.0 (the version baked into the production code-worker image)",
+    "captureDate": "2026-04-27",
+    "probePromptShape": "single-turn prompt asking codex to emit a fixed PULL_REQUEST_AGENT_FINAL block with all required fields populated; codex returned the block in one item.completed/agent_message envelope without invoking any tools",
+    "redactions": "thread_id replaced with all-zero UUID; trailing `codex_core::session: failed to record rollout items` stderr line is real codex output and intentionally preserved to mirror the production transcript byte-for-byte"
+  },
+  "preFixVerdict": {
+    "kind": "hard-error",
+    "code": "TASK_RUNTIME_HARD_ERROR",
+    "messageContains": "No PULL_REQUEST_AGENT_FINAL: block in transcript"
+  },
+  "postFixVerdict": {
+    "kind": "parsed",
+    "missingRequired": [],
+    "dataAssertions": {
+      "pr": "https://github.com/example/repo/pull/1",
+      "comment_replied": "yes",
+      "tracking_comment_id": "42",
+      "tracking_comment": "updated",
+      "total_pr_comments_posted": 1,
+      "ci_evidenceContains": "pnpm run ci:tracked",
+      "summaryContains": "Fixture for codex extractor"
+    }
+  }
+}

--- a/workers/orchestrator/src/__tests__/fixtures/completion-verifier/raw-rawlogs/codex-pull-request-final.rawlogs.txt
+++ b/workers/orchestrator/src/__tests__/fixtures/completion-verifier/raw-rawlogs/codex-pull-request-final.rawlogs.txt
@@ -1,0 +1,5 @@
+{"type":"thread.started","thread_id":"00000000-0000-0000-0000-000000000000"}
+{"type":"turn.started"}
+{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"PULL_REQUEST_AGENT_FINAL:\n- pr: https://github.com/example/repo/pull/1\n- ci_evidence: pnpm run ci:tracked successful\n- linear_issue: https://linear.app/example/issue/INT-1\n- comment_replied: yes\n- tracking_comment_id: 42\n- tracking_comment: updated\n- total_pr_comments_posted: 1\n- memory_ids_used: none\n- memory_ids_rejected: none\n- memory_usage_summary: none\n- summary: Fixture for codex extractor unit tests."}}
+{"type":"turn.completed","usage":{"input_tokens":15530,"cached_input_tokens":2432,"output_tokens":134,"reasoning_output_tokens":14}}
+2026-04-27T15:07:23.143714Z ERROR codex_core::session: failed to record rollout items: thread 00000000-0000-0000-0000-000000000000 not found

--- a/workers/orchestrator/src/__tests__/services/completion-verifier/block-parser.test.ts
+++ b/workers/orchestrator/src/__tests__/services/completion-verifier/block-parser.test.ts
@@ -228,6 +228,85 @@ describe('locateFinalBlock', () => {
     expect(block).not.toBeNull();
     expect(block).toContain('- Outcome: planned');
   });
+
+  // Codex `exec --json` emits a different envelope shape than the Claude SDK:
+  //   {"type":"item.completed","item":{"id":"...","type":"agent_message","text":"..."}}
+  // The marker lives in `item.text` as a JSON-escaped string with literal `\n`
+  // sequences. Live captured shape — see
+  // src/__tests__/fixtures/completion-verifier/raw-rawlogs/codex-pull-request-final.rawlogs.txt
+  it('finds the marker in a codex item.completed/agent_message envelope', () => {
+    const event = JSON.stringify({
+      type: 'item.completed',
+      item: {
+        id: 'item_0',
+        type: 'agent_message',
+        text: 'PULL_REQUEST_AGENT_FINAL:\n- pr: https://github.com/x/y/pull/1\n- summary: ok',
+      },
+    });
+    const block = locateFinalBlock(event, 'PULL_REQUEST_AGENT_FINAL:');
+    expect(block).not.toBeNull();
+    expect(block).toContain('- pr: https://github.com/x/y/pull/1');
+  });
+
+  it.each([
+    ['PLANNING_AGENT_FINAL:', '- outcome: planned'],
+    ['EXECUTION_AGENT_FINAL:', '- outcome: implemented'],
+    ['REVIEW_AGENT_FINAL:', '- pr: https://github.com/x/y/pull/1'],
+    ['REMEDIATION_AGENT_FINAL:', '- outcome: implemented'],
+    ['PULL_REQUEST_AGENT_FINAL:', '- comment_replied: yes'],
+  ])(
+    'codex envelope works for marker %s (one extractor unlocks all agent types)',
+    (marker, sampleField) => {
+      const event = JSON.stringify({
+        type: 'item.completed',
+        item: { id: 'item_0', type: 'agent_message', text: `${marker}\n${sampleField}` },
+      });
+      const block = locateFinalBlock(event, marker);
+      expect(block).not.toBeNull();
+      expect(block).toContain(sampleField);
+    }
+  );
+
+  it('codex item.completed for command_execution does NOT spoof the marker even when the command output contains it', () => {
+    // A command whose stdout happens to mention the marker (e.g. `cat`-ing a
+    // doc) must not be mistaken for an agent-emitted block. Only
+    // `agent_message` items count.
+    const event = JSON.stringify({
+      type: 'item.completed',
+      item: {
+        id: 'item_0',
+        type: 'command_execution',
+        command: 'cat docs/agent-spec.md',
+        aggregated_output: 'PULL_REQUEST_AGENT_FINAL:\n- pr: https://x/y/1',
+        exit_code: 0,
+        status: 'completed',
+      },
+    });
+    expect(locateFinalBlock(event, 'PULL_REQUEST_AGENT_FINAL:')).toBeNull();
+  });
+
+  it('codex envelope: LAST agent_message wins when commentary precedes the final block', () => {
+    const earlier = JSON.stringify({
+      type: 'item.completed',
+      item: {
+        id: 'item_0',
+        type: 'agent_message',
+        text: 'Working on it…',
+      },
+    });
+    const later = JSON.stringify({
+      type: 'item.completed',
+      item: {
+        id: 'item_1',
+        type: 'agent_message',
+        text: 'PULL_REQUEST_AGENT_FINAL:\n- pr: https://x/y/2\n- summary: final',
+      },
+    });
+    const block = locateFinalBlock([earlier, later].join('\n'), 'PULL_REQUEST_AGENT_FINAL:');
+    expect(block).not.toBeNull();
+    expect(block).toContain('- summary: final');
+    expect(block).not.toContain('Working on it');
+  });
 });
 
 describe('parseKeyValues', () => {

--- a/workers/orchestrator/src/__tests__/services/completion-verifier/ndjson-extractor.test.ts
+++ b/workers/orchestrator/src/__tests__/services/completion-verifier/ndjson-extractor.test.ts
@@ -142,4 +142,94 @@ describe('extractAssistantText — pure NDJSON-aware text extractor', () => {
     expect(result).toBe('X');
     expect(result).not.toContain('"type":"assistant"');
   });
+
+  // Codex `exec --json` (codex-cli 0.125.0) emits a different envelope from
+  // the Claude SDK. Marker-bearing envelope captured live from a real codex
+  // run on 2026-04-27:
+  //   {"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"..."}}
+  // See src/__tests__/fixtures/completion-verifier/raw-rawlogs/codex-pull-request-final.rawlogs.txt
+  describe('codex exec --json envelope support', () => {
+    it('extracts text from an agent_message item', () => {
+      const event = JSON.stringify({
+        type: 'item.completed',
+        item: {
+          id: 'item_0',
+          type: 'agent_message',
+          text: 'PULL_REQUEST_AGENT_FINAL:\n- pr: https://x/y/1\n- summary: ok',
+        },
+      });
+      const lines = extractAssistantText(event).split('\n');
+      expect(lines).toContain('PULL_REQUEST_AGENT_FINAL:');
+      expect(lines).toContain('- pr: https://x/y/1');
+      expect(lines).toContain('- summary: ok');
+    });
+
+    it('does not extract from command_execution items (no false-positive on stdout text)', () => {
+      const event = JSON.stringify({
+        type: 'item.completed',
+        item: {
+          id: 'item_0',
+          type: 'command_execution',
+          command: 'cat README.md',
+          aggregated_output: 'PULL_REQUEST_AGENT_FINAL:\n- pr: https://x/y/1',
+          exit_code: 0,
+          status: 'completed',
+        },
+      });
+      // The aggregated_output field contains the marker substring, but a
+      // command_execution item is NOT an agent message — pass through so the
+      // locator never sees it on its own line.
+      expect(extractAssistantText(event)).toBe(event);
+    });
+
+    it('passes through preamble envelopes (thread.started, turn.started, turn.completed)', () => {
+      const events = [
+        JSON.stringify({
+          type: 'thread.started',
+          thread_id: '00000000-0000-0000-0000-000000000000',
+        }),
+        JSON.stringify({ type: 'turn.started' }),
+        JSON.stringify({
+          type: 'turn.completed',
+          usage: { input_tokens: 100, output_tokens: 10 },
+        }),
+      ];
+      const input = events.join('\n');
+      expect(extractAssistantText(input)).toBe(input);
+    });
+
+    it('emits multiple agent_message texts on separate lines when commentary precedes the final block', () => {
+      const events = [
+        JSON.stringify({
+          type: 'item.completed',
+          item: { id: 'item_0', type: 'agent_message', text: 'Working on it…' },
+        }),
+        JSON.stringify({
+          type: 'item.completed',
+          item: {
+            id: 'item_1',
+            type: 'agent_message',
+            text: 'PULL_REQUEST_AGENT_FINAL:\n- summary: final',
+          },
+        }),
+      ];
+      const lines = extractAssistantText(events.join('\n')).split('\n');
+      expect(lines).toContain('Working on it…');
+      expect(lines).toContain('PULL_REQUEST_AGENT_FINAL:');
+      expect(lines).toContain('- summary: final');
+    });
+
+    it('passes through agent_message item with non-string text (defensive against contract drift)', () => {
+      const event = JSON.stringify({
+        type: 'item.completed',
+        item: { id: 'item_0', type: 'agent_message', text: 42 },
+      });
+      expect(extractAssistantText(event)).toBe(event);
+    });
+
+    it('passes through item.completed envelope missing the item field entirely', () => {
+      const event = JSON.stringify({ type: 'item.completed' });
+      expect(extractAssistantText(event)).toBe(event);
+    });
+  });
 });

--- a/workers/orchestrator/src/services/completion-verifier/ndjson-extractor.ts
+++ b/workers/orchestrator/src/services/completion-verifier/ndjson-extractor.ts
@@ -1,33 +1,37 @@
 /**
- * [INT-1560] NDJSON-aware text extractor for the completion verifier.
+ * NDJSON-aware text extractor for the completion verifier.
  *
- * Why this exists. The deployed worker invokes Claude with
- * `--print --verbose --output-format stream-json` (see
- * `docker/code-worker/entrypoint.sh`). The agent's emitted assistant text —
- * including any `*_AGENT_FINAL:` block — therefore lives only inside Claude
- * SDK NDJSON events of the form
- *   `{"type":"assistant","message":{"content":[{"type":"text","text":"..."}]}}`
- * where `text` is a JSON-escaped string with literal `\n` two-character
- * sequences instead of real newlines. After `stripDockerHeaders`, the marker
- * is still buried inside that one big JSON line and never appears on its own
- * line, so the strict line-anchored regex in `locateFinalBlock` cannot match
- * it. Production verdict before this fallback shipped: `TASK_RUNTIME_HARD_ERROR
- * — No PLANNING_AGENT_FINAL: block in transcript`, even when the agent
- * emitted a perfectly valid block.
+ * Why this exists. The verifier reads the worker's raw stdout buffer, which
+ * for both runtimes is JSONL — the marker (`*_AGENT_FINAL:`) lives inside
+ * a JSON-escaped `text` field with literal `\n` two-character sequences and
+ * never appears on its own line. The strict line-anchored regex in
+ * `locateFinalBlock` therefore cannot match it without first un-escaping
+ * the JSON.
  *
- * Confirmed live by instrumenting `task-dispatcher.ts` on home-dev to dump
- * the exact `rawLogs` passed to `runVerification` (see the
- * `planning-probe-unclear.rawlogs.txt` fixture and INT-1560 evidence notes).
+ * Two runtimes, two envelope shapes the verifier must speak:
+ *
+ * 1. [INT-1560] **Claude SDK** (`claude --print --verbose --output-format
+ *    stream-json` — see `docker/code-worker/entrypoint.sh`):
+ *      `{"type":"assistant","message":{"content":[{"type":"text","text":"..."}]}}`
+ *    or terminal:
+ *      `{"type":"result","subtype":"success","result":"..."}`
+ *    Confirmed live via `planning-probe-unclear.rawlogs.txt`.
+ *
+ * 2. **Codex** (`codex exec --json`, codex-cli 0.125.0):
+ *      `{"type":"item.completed","item":{"id":"...","type":"agent_message","text":"..."}}`
+ *    Other codex envelopes (`thread.started`, `turn.started`, `turn.completed`,
+ *    and `item.completed` for `command_execution`/`reasoning` items) carry
+ *    no agent-emitted prose and pass through. Confirmed live via
+ *    `codex-pull-request-final.rawlogs.txt` — task_70a75a13 was the
+ *    production failure that forced this branch.
  *
  * What this does. Iterates the transcript line by line. When a line parses
- * as a Claude SDK assistant message with a `text` content block, the line
- * is REPLACED by the un-escaped text (so embedded `\n` become real newlines
- * the locator can split on). Same for terminal `result` events whose
- * `result` field carries the agent's final string. All other lines —
- * non-JSON, malformed JSON, system/user/rate-limit events, assistant events
- * with only tool_use blocks — pass through unchanged. The output is
- * therefore still aligned line-for-line with the input for every line that
- * isn't an extractable text-bearing event.
+ * as one of the supported envelopes, it is REPLACED by the un-escaped text
+ * (so embedded `\n` become real newlines the locator can split on). All
+ * other lines — non-JSON, malformed JSON, system/user/rate-limit events,
+ * assistant events with only tool_use blocks, codex preamble events,
+ * codex command_execution events — pass through unchanged. Output is
+ * line-for-line aligned with input for every non-extractable line.
  */
 
 interface AssistantContentBlock {
@@ -43,6 +47,11 @@ interface AssistantEvent {
 interface ResultEvent {
   type?: unknown;
   result?: unknown;
+}
+
+interface CodexItemCompletedEvent {
+  type?: unknown;
+  item?: { type?: unknown; text?: unknown };
 }
 
 function extractFromAssistantEvent(obj: AssistantEvent): string | null {
@@ -62,6 +71,12 @@ function extractFromAssistantEvent(obj: AssistantEvent): string | null {
 function extractFromResultEvent(obj: ResultEvent): string | null {
   if (obj.type !== 'result') return null;
   return typeof obj.result === 'string' ? obj.result : null;
+}
+
+function extractFromCodexAgentMessage(obj: CodexItemCompletedEvent): string | null {
+  if (obj.type !== 'item.completed') return null;
+  if (obj.item?.type !== 'agent_message') return null;
+  return typeof obj.item.text === 'string' ? obj.item.text : null;
 }
 
 /**
@@ -91,8 +106,11 @@ export function extractAssistantText(transcript: string): string {
     // beginning with `{` cannot return a non-object literal). No null check
     // here — `null` literally serializes as `null`, not `{...}`, so it can
     // never reach this point.
-    const obj = parsed as AssistantEvent & ResultEvent;
-    const extracted = extractFromAssistantEvent(obj) ?? extractFromResultEvent(obj);
+    const obj = parsed as AssistantEvent & ResultEvent & CodexItemCompletedEvent;
+    const extracted =
+      extractFromAssistantEvent(obj) ??
+      extractFromResultEvent(obj) ??
+      extractFromCodexAgentMessage(obj);
     if (extracted === null) {
       out.push(line);
       continue;


### PR DESCRIPTION
## Summary

- The orchestrator's completion verifier hard-errored on every codex worker even when the agent completed cleanly. Adds a third extractor to `ndjson-extractor.ts` that recognizes the `{"type":"item.completed","item":{"type":"agent_message","text":"…"}}` envelope codex `exec --json` emits.
- Single point of repair: the existing INT-1560 NDJSON cascade gains one branch. Locator regex, contracts, and dispatcher routing are envelope-agnostic once text is unwrapped, so this one fix unlocks all five marker types (planning, execution, review, remediation, pull_request) on all codex workers (`codex`, `codex-xhigh`).
- Tests use **real captured codex stdout** — a 5-line fixture from a live `docker exec ... codex exec --json` run on codex-cli 0.125.0 — plus parametric locator coverage for every marker.

## Root cause

`workers/orchestrator/src/services/completion-verifier/ndjson-extractor.ts` was written for the Claude SDK's `{"type":"assistant",...}` shape (INT-1560). Codex emits a different envelope:

```jsonl
{"type":"thread.started","thread_id":"…"}
{"type":"turn.started"}
{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"PULL_REQUEST_AGENT_FINAL:\\n…"}}
{"type":"turn.completed","usage":{…}}
```

`extractFromAssistantEvent` returned `null` for every codex line. The line passed through unchanged, the line-anchored regex couldn't match a single-line JSON object, and the verifier emitted `TASK_RUNTIME_HARD_ERROR — No PULL_REQUEST_AGENT_FINAL: block in transcript` even though codex exited 0.

Real production failure: task_70a75a13-b0fd-4607-aec6-7d1a375af9be (PR #2002). Codex finished, all PR work succeeded, task was still finalized as `failed`.

## Test plan

- [x] `pnpm --filter orchestrator test ndjson-extractor block-parser completion-verifier` (10 new tests; all pass — confirmed red→green via TDD)
- [x] `pnpm run verify:workspace:tracked orchestrator` (16909 tests pass)
- [x] `pnpm run ci:tracked` (all phases green)
- [ ] Live re-run of a codex pull_request task in dev orchestrator — confirm verdict flips from `failed` to `parsed`

## Out of scope (separate follow-up)

`TIER_BY_WORKER` lists codex as `'optional'` tier, but the marker-missing path in `verifyCompletion` hard-errors *before* any tier check. After this fix the bug stops manifesting in practice, but the underlying brittleness — optional-tier workers can still hard-fail tasks if codex's stdout schema ever changes again — remains. Worth a separate Linear issue.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>