### PR TITLE
[INT-1581] fix(ci): repair pino lockfile + add code_tasks_failed metric descriptor

### DIFF
--- a/docs/architecture/pubsub-standards.md
+++ b/docs/architecture/pubsub-standards.md
@@ -104,14 +104,14 @@ The wrapper also emits structured `worker_request_*` log entries on entry and ex
 
 The transcription worker historically used `return` (silent ACK) for every parse / schema / event-type failure, masking malformed messages from the DLQ. Under the consumer contract, each early return becomes an explicit `AckResult`:
 
-| Old behavior                                                                  | New behavior                                                               |
-| ----------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
-| `messageData === undefined` → `return` (silent ACK)                           | `return { decision: AckDecision.DeadLetter, reason: 'missing_message_data' }` |
-| JSON parse throws → `return` (silent ACK)                                     | `return { decision: AckDecision.DeadLetter, reason: 'parse_error' }`       |
+| Old behavior                                                                  | New behavior                                                                   |
+| ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| `messageData === undefined` → `return` (silent ACK)                           | `return { decision: AckDecision.DeadLetter, reason: 'missing_message_data' }`  |
+| JSON parse throws → `return` (silent ACK)                                     | `return { decision: AckDecision.DeadLetter, reason: 'parse_error' }`           |
 | `audioEvent.type !== 'whatsapp.audio.stored'` → `return` (silent ACK)         | `return { decision: AckDecision.DeadLetter, reason: 'unexpected_event_type' }` |
-| `!isAudioStoredEvent(audioEvent)` → `return` (silent ACK)                     | `return { decision: AckDecision.DeadLetter, reason: 'invalid_event_schema' }` |
-| Successful transcription publish                                              | `return { decision: AckDecision.Ack }`                                     |
-| Transcription or downstream throws                                            | Let it propagate → `withObservability` turns into Nack (redelivery)        |
+| `!isAudioStoredEvent(audioEvent)` → `return` (silent ACK)                     | `return { decision: AckDecision.DeadLetter, reason: 'invalid_event_schema' }`  |
+| Successful transcription publish                                              | `return { decision: AckDecision.Ack }`                                         |
+| Transcription or downstream throws                                            | Let it propagate → `withObservability` turns into Nack (redelivery)            |
 
 ## PublishError Codes
 

--- a/docs/packages/common-metrics/README.md
+++ b/docs/packages/common-metrics/README.md
@@ -1,0 +1,117 @@
+# @intexuraos/common-metrics
+
+Buffered Cloud Monitoring custom-metrics client for IntexuraOS services. Wraps `@google-cloud/monitoring`'s `MetricServiceClient` with a small, typed surface (`increment`, `record`, `flush`) and handles the cumulative-counter bookkeeping that Cloud Monitoring requires.
+
+**Type:** ESM
+**Node:** >=22.0.0
+
+## Why this package exists
+
+Cloud Monitoring's `createTimeSeries` API is awkward for application code:
+
+- `CUMULATIVE` counters require a stable `startTime` and a monotonically-increasing value at every flush — callers can't just emit deltas.
+- Each metric point needs a fully-formed `metric.type` string (`custom.googleapis.com/intexuraos/...`) and a `resource` descriptor.
+- Tests must not contact the network, so the underlying client has to be injectable.
+
+This package centralises that ceremony so every IntexuraOS service that needs custom metrics gets the same buffered-flush semantics, the same `custom.googleapis.com/intexuraos/<name>` namespace, and the same `service_name` label injected on every series.
+
+It also publishes the shared `CODE_TASK_METRICS` descriptor registry so the orchestrator and any downstream consumer agree on metric names without copying string literals.
+
+## Dependencies
+
+| Package                       | Purpose                                                  |
+| ----------------------------- | -------------------------------------------------------- |
+| `@google-cloud/monitoring`    | `MetricServiceClient` for `createTimeSeries` calls       |
+| `pino`                        | `Logger` type used by `MetricsClientConfig`              |
+
+The real `MetricServiceClient` is constructed lazily on the first `flush()` — importing this module has no GCP SDK side effects.
+
+## Exports
+
+- `createMetricsClient(config)` — factory returning a `MetricsClient` bound to a GCP project + service name.
+- `MetricsClient` — client surface: `increment(metric, labels, by?)`, `record(metric, labels, value)`, `flush()`.
+- `MetricsClientConfig` — `{ projectId, serviceName, logger, metricServiceClient? }`. Inject `metricServiceClient` in tests.
+- `CustomMetric<L>` — descriptor shape: `{ name, type, unit, description, __labels? }`. The phantom `__labels` field anchors the label type so `client.increment(METRIC, labels)` type-checks the labels argument; never read at runtime.
+- `MetricKind` — `'counter' | 'gauge' | 'distribution'`.
+- `MetricLabel` — `Record<string, string>`.
+- `MetricServiceClientLike` — minimal structural type for the GCP client (`createTimeSeries`); used for test fakes.
+- `CODE_TASK_METRICS` — frozen registry of code-task descriptors:
+  - `COMPLETED` — `code_tasks_completed` (counter, unit `1`)
+  - `FAILED` — `code_tasks_failed` (counter, unit `1`)
+  - `DURATION` — `code_task_duration` (distribution, unit `ms`)
+
+## Semantics
+
+### Metric namespace
+
+Every emitted series is published under `custom.googleapis.com/intexuraos/<metric.name>` with `resource = { type: 'global', labels: { project_id } }` and a `service_name` label injected from `config.serviceName`.
+
+### Counter bookkeeping
+
+Cloud Monitoring `CUMULATIVE` counters require a fixed `startTime` and a monotonically-increasing value. The client therefore keeps a running total per `(metric.name, sortedLabels)` tuple in memory, updated synchronously inside `increment()`, and emits the **current cumulative value** (not the delta) on every flush. The running total is never cleared — including across flush failures — so the next flush re-emits the same or higher value, which is what Cloud Monitoring expects.
+
+### Gauge / distribution bookkeeping
+
+Each `record(...)` call (and each non-counter `increment(...)` call) buffers an independent point with `endTime` only. On a successful flush the non-counter buffer is cleared; on a failed flush the buffer is preserved so the next flush retries those points. Counter totals are preserved on both paths.
+
+### Value type
+
+`distribution` metrics are emitted as `DOUBLE`; `counter` and `gauge` are emitted as `INT64`.
+
+### Failure isolation
+
+`flush()` rethrows on `createTimeSeries` failure after logging `metrics flush failed` at `error` level. Buffered state survives the failure as described above. Callers are expected to call `flush()` from a non-critical path (e.g. a periodic timer or an end-of-request hook) so a metrics outage does not crash the service.
+
+## Usage
+
+```ts
+import {
+  createMetricsClient,
+  CODE_TASK_METRICS,
+} from '@intexuraos/common-metrics';
+
+const metrics = createMetricsClient({
+  projectId: process.env['INTEXURAOS_GCP_PROJECT_ID']!,
+  serviceName: 'orchestrator',
+  logger,
+});
+
+// Counter — running total maintained internally.
+metrics.increment(CODE_TASK_METRICS.COMPLETED, { status: 'success' });
+
+// Distribution — each call buffers an independent sample.
+metrics.record(CODE_TASK_METRICS.DURATION, { status: 'success' }, 1820);
+
+// Flush periodically (e.g. every 30s) or at process shutdown.
+await metrics.flush();
+```
+
+For tests, inject a fake `MetricServiceClientLike` to capture `createTimeSeries` requests without contacting GCP:
+
+```ts
+const calls: unknown[] = [];
+const metrics = createMetricsClient({
+  projectId: 'test',
+  serviceName: 'test-service',
+  logger,
+  metricServiceClient: {
+    async createTimeSeries(req) {
+      calls.push(req);
+    },
+  },
+});
+```
+
+## Used By
+
+- `workers/orchestrator` — emits `CODE_TASK_METRICS` on every code-task terminal transition. The orchestrator currently still ships a local log-based shim (`workers/orchestrator/src/metrics.ts`) that mirrors this package's contract; the swap to the real client is tracked in `technical-debt.md`.
+
+## Source Files
+
+| File                              | Purpose                                                    |
+| --------------------------------- | ---------------------------------------------------------- |
+| `src/index.ts`                    | Public barrel                                              |
+| `src/client.ts`                   | `createMetricsClient` factory + counter bookkeeping        |
+| `src/types.ts`                    | `MetricsClient`, `CustomMetric`, `CODE_TASK_METRICS`       |
+| `src/__tests__/client.test.ts`    | Buffer / counter / flush behaviour tests                   |
+| `src/__tests__/index.test.ts`     | Public-surface smoke test                                  |

--- a/docs/packages/common-metrics/agent.md
+++ b/docs/packages/common-metrics/agent.md
@@ -1,0 +1,88 @@
+# Agent Reference — @intexuraos/common-metrics
+
+Machine-readable interface summary for autonomous agents working with this package.
+
+## Identity
+
+- **Package name:** `@intexuraos/common-metrics`
+- **Kind:** `package` (workspace-internal, `private: true`, source-exports)
+- **Module type:** ESM
+- **Node:** `>=22.0.0`
+- **Entry:** `./src/index.ts`
+- **Workspace path:** `packages/common-metrics`
+- **Long-form docs:** `docs/packages/common-metrics/README.md`
+
+## Public Exports
+
+| Symbol                            | Kind  | Signature / Shape                                                                                                                  |
+| --------------------------------- | ----- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `createMetricsClient`             | fn    | `(config: MetricsClientConfig) => MetricsClient`                                                                                   |
+| `MetricsClient`                   | type  | `{ increment(m, l, by?): void; record(m, l, v): void; flush(): Promise<void> }`                                                    |
+| `MetricsClientConfig`             | type  | `{ projectId: string; serviceName: string; logger: pino.Logger; metricServiceClient?: MetricServiceClientLike }`                   |
+| `CustomMetric<L>`                 | type  | `{ readonly name: string; readonly type: MetricKind; readonly unit: string; readonly description: string; readonly __labels?: L }` |
+| `MetricKind`                      | type  | `'counter' \                                                                                                                       | 'gauge' \ | 'distribution'` |
+| `MetricLabel`                     | type  | `Record<string, string>`                                                                                                           |
+| `MetricServiceClientLike`         | type  | `{ createTimeSeries(req: { name: string; timeSeries: unknown[] }): Promise<unknown> }`                                             |
+| `CODE_TASK_METRICS`               | const | `{ COMPLETED, FAILED, DURATION }` — see below                                                                                      |
+
+### `CODE_TASK_METRICS` registry
+
+| Key         | `name`                  | `type`         | `unit` |
+| ----------- | ----------------------- | -------------- | ------ |
+| `COMPLETED` | `code_tasks_completed`  | `counter`      | `1`    |
+| `FAILED`    | `code_tasks_failed`     | `counter`      | `1`    |
+| `DURATION`  | `code_task_duration`    | `distribution` | `ms`   |
+
+## Cloud Monitoring Mapping
+
+| Source                          | Cloud Monitoring                                                          |
+| ------------------------------- | ------------------------------------------------------------------------- |
+| `metric.name`                   | `metric.type = custom.googleapis.com/intexuraos/<name>`                   |
+| `metric.type = 'counter'`       | `metricKind = CUMULATIVE`, `valueType = INT64`                            |
+| `metric.type = 'gauge'`         | `metricKind = GAUGE`, `valueType = INT64`                                 |
+| `metric.type = 'distribution'`  | `metricKind = GAUGE`, `valueType = DOUBLE` (single-point, not bucketed)   |
+| `serviceName` (config)          | `metric.labels.service_name`                                              |
+| `projectId` (config)            | `resource.labels.project_id`, `resource.type = global`                    |
+| Counter `startTime`             | `nowSeconds()` at client construction (stable for the client's lifetime)  |
+
+## Invariants
+
+1. **Lazy GCP construction.** `new MetricServiceClient()` is not called until the first `flush()` that has data and no injected `metricServiceClient`. Importing the module is side-effect-free.
+2. **Counter monotonicity.** Per `(metric.name, sortedLabels)` the emitted value is the running total since client construction, never a delta.
+3. **Buffer preservation on failure.** `flush()` rethrows on `createTimeSeries` error; non-counter buffer is NOT cleared on failure; counter totals are NEVER cleared.
+4. **Labels copied, not aliased.** `increment` / `record` copy `labels` via spread before storing — caller mutations after the call do not affect emitted series.
+5. **No-op when empty.** `flush()` returns immediately if both the buffer and the counter map are empty (no GCP call).
+6. **Stable label ordering.** Counter keys sort label keys before `JSON.stringify` so `{ a:1, b:2 }` and `{ b:2, a:1 }` collapse to the same running total.
+
+## Dependencies
+
+| Package                       | Why                                            |
+| ----------------------------- | ---------------------------------------------- |
+| `@google-cloud/monitoring`    | `MetricServiceClient.createTimeSeries`         |
+| `pino`                        | `Logger` type only (peer-style import)         |
+
+No workspace dependencies — this is a leaf package.
+
+## Consumers
+
+- `workers/orchestrator` — imports `CODE_TASK_METRICS` types via local shim; not yet importing `createMetricsClient`. See `technical-debt.md` item #1.
+
+## Test Surface
+
+- `src/__tests__/client.test.ts` — covers buffer/flush, counter monotonicity, failure preservation, label-key stability.
+- `src/__tests__/index.test.ts` — barrel smoke test.
+
+Test pattern: inject a fake `MetricServiceClientLike` via `MetricsClientConfig.metricServiceClient`. Do not network-mock; the real `MetricServiceClient` should never be constructed in tests.
+
+## Common Tasks
+
+| Task                                                   | Approach                                                                                                                                                        |
+| ------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Add a new metric to a service                          | Define a `CustomMetric<LabelShape>` next to its emission site; only add to `CODE_TASK_METRICS` if it's part of the shared code-task family.                     |
+| Add a new metric kind (e.g. real `Distribution`)       | Extend `MetricKind`, update `METRIC_KIND_MAP` and `buildTimeSeries` value-type branch, add a regression test covering the new shape.                            |
+| Wire a service to emit metrics                         | `pnpm add @intexuraos/common-metrics --workspace`; call `createMetricsClient` once at startup; flush on a timer (`setInterval(() => flush(), 30_000).unref()`). |
+| Replace the orchestrator shim                          | See `technical-debt.md` item #1 — drop in a re-export, swap `createMetricsClient`, delete shim.                                                                 |
+
+## Cardinality Caution
+
+Cloud Monitoring custom metrics enforce a low cardinality budget on label values. Do not pass free-form strings (user IDs, error codes, URLs) as label values. Closed enums only. Enforcement is the caller's responsibility — this package does not validate cardinality.

--- a/docs/packages/common-metrics/technical-debt.md
+++ b/docs/packages/common-metrics/technical-debt.md
@@ -1,0 +1,55 @@
+# Technical Debt — @intexuraos/common-metrics
+
+Known issues, deferred work, and risks for the `@intexuraos/common-metrics` package.
+
+## Open Items
+
+### 1. Orchestrator still ships a local shim instead of importing this package
+
+**Location:** `workers/orchestrator/src/metrics.ts`
+**Status:** Open
+
+The orchestrator declares its own `createMetricsClient`, `MetricsClient`, `CustomMetric`, `MetricLabel`, and `CODE_TASK_METRICS` locally — duplicated structurally from this package. The shim publishes via `logger.info({ metric: ... })` rather than calling `MetricServiceClient.createTimeSeries`, so today no series actually land in Cloud Monitoring; the orchestrator only emits log-based metrics.
+
+Both files reference INT-1565 / S5–S8 in their headers, and the orchestrator file explicitly states "the parent plan's reconciliation commit replaces it with the real MetricsClient by swapping `createMetricsClient` for the package import." That swap has not happened.
+
+**Risk:** Two divergent definitions of the same contract. If a field is added here (e.g. a new `MetricKind`), the orchestrator silently keeps the old shape until someone notices. Also, the `__labels` phantom field is named `__label` (singular) on the orchestrator side — already drift.
+
+**Resolution:** Replace `workers/orchestrator/src/metrics.ts` exports with re-exports from `@intexuraos/common-metrics`, and switch `createMetricsClient` to the real client. Delete the shim. Update `noopMetricsClient` either to a re-export or keep it locally if no other service needs it.
+
+### 2. No retry / dead-letter for failed flushes
+
+**Location:** `src/client.ts` `flush()`
+**Status:** Open
+
+`flush()` rethrows on `createTimeSeries` failure and preserves buffered state, but there is no exponential-backoff retry or batch-size cap. A long GCP outage will grow the non-counter buffer unbounded (counter totals are O(distinct label combinations) and bounded by the metric's cardinality budget, so they are not a concern).
+
+**Risk:** Memory growth in a sustained outage. Low priority — services flush on a short cadence and Cloud Monitoring outages are rare, but worth a buffer-size cap before adding high-volume distribution metrics.
+
+**Resolution:** Add a `maxBufferSize` config option that drops oldest samples (with a single `warn` log per drop window) once exceeded. Consider exposing a `bufferStats()` accessor for service health endpoints.
+
+### 3. No `metricKind: GAUGE` distinction at the SDK level for distributions
+
+**Location:** `src/client.ts` `METRIC_KIND_MAP`
+**Status:** Accepted
+
+`distribution` is mapped to Cloud Monitoring's `GAUGE` metric kind because the client emits a single `DOUBLE` point per `record()` call rather than a `Distribution` aggregate. This is intentional — building a true `Distribution` (bucket counts) would require either client-side bucketing or per-flush server-side aggregation, neither of which is in scope.
+
+**Risk:** Histograms / percentiles are not directly available in Cloud Monitoring; consumers must use MQL `percentile()` over the raw GAUGE series, which is more expensive at query time.
+
+**Resolution:** None planned. Revisit if a service needs server-side percentile alerts.
+
+### 4. `MetricServiceClient` is constructed with no explicit credentials path
+
+**Location:** `src/client.ts` `defaultMetricServiceClientFactory`
+**Status:** Accepted
+
+`new MetricServiceClient()` relies on Application Default Credentials. This works in Cloud Run / Cloud Functions and on local machines that have run `gcloud auth application-default login`, but breaks silently in environments where ADC is not configured (the constructor succeeds; the first `createTimeSeries` call fails with an auth error).
+
+**Risk:** Confusing failure mode on first deploy of a new service.
+
+**Resolution:** None — matches the convention used by `infra-firestore` and `infra-pubsub`. The lazy construction on first `flush()` keeps the import side-effect-free.
+
+## Resolved Items
+
+_None yet._

--- a/packages/common-metrics/README.md
+++ b/packages/common-metrics/README.md
@@ -1,0 +1,40 @@
+# @intexuraos/common-metrics
+
+Buffered Cloud Monitoring custom-metrics client for IntexuraOS services.
+
+Wraps `@google-cloud/monitoring`'s `MetricServiceClient` with a small, typed surface (`increment`, `record`, `flush`) and handles the cumulative-counter bookkeeping that Cloud Monitoring requires (fixed `startTime`, monotonically-increasing values, label-keyed running totals).
+
+## Exports
+
+- `createMetricsClient(config)` — factory returning a `MetricsClient` bound to a GCP project + service name.
+- `MetricsClient` — client surface (`increment`, `record`, `flush`).
+- `MetricsClientConfig` — `{ projectId, serviceName, logger, metricServiceClient? }`. Inject `metricServiceClient` in tests.
+- `CustomMetric<L>` — descriptor shape `{ name, type, unit, description }` with a phantom `__labels` marker for type inference.
+- `MetricKind` — `'counter' | 'gauge' | 'distribution'`.
+- `MetricLabel` — `Record<string, string>`.
+- `MetricServiceClientLike` — minimal structural type used for test fakes.
+- `CODE_TASK_METRICS` — frozen registry of code-task descriptors (`COMPLETED`, `FAILED`, `DURATION`).
+
+## Dependencies
+
+- `@google-cloud/monitoring` — `MetricServiceClient` for `createTimeSeries` calls.
+- `pino` — `Logger` type used by `MetricsClientConfig`.
+
+## Usage
+
+```ts
+import { createMetricsClient, CODE_TASK_METRICS } from '@intexuraos/common-metrics';
+
+const metrics = createMetricsClient({
+  projectId: process.env['INTEXURAOS_GCP_PROJECT_ID']!,
+  serviceName: 'orchestrator',
+  logger,
+});
+
+metrics.increment(CODE_TASK_METRICS.COMPLETED, { status: 'success' });
+metrics.record(CODE_TASK_METRICS.DURATION, { status: 'success' }, 1820);
+
+await metrics.flush();
+```
+
+See [`docs/packages/common-metrics/README.md`](../../docs/packages/common-metrics/README.md) for the full reference (semantics, namespace, counter bookkeeping, failure isolation).

--- a/packages/common-metrics/package.json
+++ b/packages/common-metrics/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@google-cloud/monitoring": "^5.3.1",
-    "pino": "^9.0.0"
+    "pino": "catalog:"
   },
   "devDependencies": {
     "typescript": "^5.8.3",

--- a/packages/http-server/src/__tests__/startFastifyService.test.ts
+++ b/packages/http-server/src/__tests__/startFastifyService.test.ts
@@ -188,6 +188,38 @@ describe('startFastifyService', () => {
     expect(call).not.toHaveProperty('dsn');
   });
 
+  it('forwards INTEXURAOS_ENVIRONMENT to initSentry when set', async () => {
+    process.env['REQ_ENV_VAR'] = 'x';
+    process.env['INTEXURAOS_ENVIRONMENT'] = 'prod';
+    const { initSentry } = await import('@intexuraos/infra-sentry');
+    const app = fakeApp();
+    await startFastifyService({
+      serviceName: 'x',
+      requiredEnv: ['REQ_ENV_VAR'],
+      initServices: () => undefined,
+      buildServer: async () => app,
+      port: 0,
+    });
+    expect(initSentry).toHaveBeenCalledWith(expect.objectContaining({ environment: 'prod' }));
+  });
+
+  it('falls back to "development" environment when INTEXURAOS_ENVIRONMENT is unset', async () => {
+    process.env['REQ_ENV_VAR'] = 'x';
+    delete process.env['INTEXURAOS_ENVIRONMENT'];
+    const { initSentry } = await import('@intexuraos/infra-sentry');
+    const app = fakeApp();
+    await startFastifyService({
+      serviceName: 'x',
+      requiredEnv: ['REQ_ENV_VAR'],
+      initServices: () => undefined,
+      buildServer: async () => app,
+      port: 0,
+    });
+    expect(initSentry).toHaveBeenCalledWith(
+      expect.objectContaining({ environment: 'development' })
+    );
+  });
+
   it('registers SIGTERM and SIGINT handlers', async () => {
     process.env['REQ_ENV_VAR'] = 'x';
     const before = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1731,15 +1731,15 @@ importers:
         specifier: ^5.3.1
         version: 5.3.1
       pino:
-        specifier: ^9.0.0
-        version: 9.14.0
+        specifier: 'catalog:'
+        version: 10.1.1
     devDependencies:
       typescript:
         specifier: ^5.8.3
         version: 5.9.3
       vitest:
         specifier: ^4.0.16
-        version: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@22.19.5)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.17(@opentelemetry/api@1.9.0)(@types/node@22.19.5)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/http-contracts: {}
 
@@ -4874,7 +4874,6 @@ packages:
       }
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.0.5':
     resolution:
@@ -4883,7 +4882,6 @@ packages:
       }
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.0.4':
     resolution:
@@ -4892,7 +4890,6 @@ packages:
       }
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.0.4':
     resolution:
@@ -4901,7 +4898,6 @@ packages:
       }
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution:
@@ -4910,7 +4906,6 @@ packages:
       }
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
     resolution:
@@ -4919,7 +4914,6 @@ packages:
       }
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.0.4':
     resolution:
@@ -4928,7 +4922,6 @@ packages:
       }
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.33.5':
     resolution:
@@ -4938,7 +4931,6 @@ packages:
     engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.33.5':
     resolution:
@@ -4948,7 +4940,6 @@ packages:
     engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.33.5':
     resolution:
@@ -4958,7 +4949,6 @@ packages:
     engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.33.5':
     resolution:
@@ -4968,7 +4958,6 @@ packages:
     engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution:
@@ -4978,7 +4967,6 @@ packages:
     engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.33.5':
     resolution:
@@ -4988,7 +4976,6 @@ packages:
     engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.33.5':
     resolution:
@@ -4998,7 +4985,6 @@ packages:
     engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.33.5':
     resolution:
@@ -6374,7 +6360,6 @@ packages:
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-arm64-musl@0.127.0':
     resolution:
@@ -6384,7 +6369,6 @@ packages:
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-parser/binding-linux-ppc64-gnu@0.127.0':
     resolution:
@@ -6394,7 +6378,6 @@ packages:
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-gnu@0.127.0':
     resolution:
@@ -6404,7 +6387,6 @@ packages:
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-musl@0.127.0':
     resolution:
@@ -6414,7 +6396,6 @@ packages:
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-parser/binding-linux-s390x-gnu@0.127.0':
     resolution:
@@ -6424,7 +6405,6 @@ packages:
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-gnu@0.127.0':
     resolution:
@@ -6434,7 +6414,6 @@ packages:
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-musl@0.127.0':
     resolution:
@@ -6444,7 +6423,6 @@ packages:
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-parser/binding-openharmony-arm64@0.127.0':
     resolution:
@@ -6559,7 +6537,6 @@ packages:
       }
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-arm64-musl@11.19.1':
     resolution:
@@ -6568,7 +6545,6 @@ packages:
       }
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-linux-ppc64-gnu@11.19.1':
     resolution:
@@ -6577,7 +6553,6 @@ packages:
       }
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-gnu@11.19.1':
     resolution:
@@ -6586,7 +6561,6 @@ packages:
       }
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-musl@11.19.1':
     resolution:
@@ -6595,7 +6569,6 @@ packages:
       }
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-linux-s390x-gnu@11.19.1':
     resolution:
@@ -6604,7 +6577,6 @@ packages:
       }
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-gnu@11.19.1':
     resolution:
@@ -6613,7 +6585,6 @@ packages:
       }
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-musl@11.19.1':
     resolution:
@@ -6622,7 +6593,6 @@ packages:
       }
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-openharmony-arm64@11.19.1':
     resolution:
@@ -7148,7 +7118,6 @@ packages:
       }
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.55.1':
     resolution:
@@ -7157,7 +7126,6 @@ packages:
       }
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.55.1':
     resolution:
@@ -7166,7 +7134,6 @@ packages:
       }
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.55.1':
     resolution:
@@ -7175,7 +7142,6 @@ packages:
       }
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.55.1':
     resolution:
@@ -7184,7 +7150,6 @@ packages:
       }
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.55.1':
     resolution:
@@ -7193,7 +7158,6 @@ packages:
       }
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.55.1':
     resolution:
@@ -7202,7 +7166,6 @@ packages:
       }
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.55.1':
     resolution:
@@ -7211,7 +7174,6 @@ packages:
       }
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.55.1':
     resolution:
@@ -7220,7 +7182,6 @@ packages:
       }
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.55.1':
     resolution:
@@ -7229,7 +7190,6 @@ packages:
       }
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.55.1':
     resolution:
@@ -7238,7 +7198,6 @@ packages:
       }
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.55.1':
     resolution:
@@ -7247,7 +7206,6 @@ packages:
       }
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.55.1':
     resolution:
@@ -7256,7 +7214,6 @@ packages:
       }
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.55.1':
     resolution:
@@ -7468,7 +7425,6 @@ packages:
     engines: { node: '>= 10' }
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     resolution:
@@ -7478,7 +7434,6 @@ packages:
     engines: { node: '>= 10' }
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     resolution:
@@ -7488,7 +7443,6 @@ packages:
     engines: { node: '>= 10' }
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     resolution:
@@ -7498,7 +7452,6 @@ packages:
     engines: { node: '>= 10' }
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.18':
     resolution:
@@ -12437,7 +12390,6 @@ packages:
     engines: { node: '>= 12.0.0' }
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution:
@@ -12447,7 +12399,6 @@ packages:
     engines: { node: '>= 12.0.0' }
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution:
@@ -12457,7 +12408,6 @@ packages:
     engines: { node: '>= 12.0.0' }
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution:
@@ -12467,7 +12417,6 @@ packages:
     engines: { node: '>= 12.0.0' }
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution:

--- a/terraform/modules/monitoring/code-task-alerts.tf
+++ b/terraform/modules/monitoring/code-task-alerts.tf
@@ -104,6 +104,8 @@ resource "google_monitoring_alert_policy" "code_tasks_failed_rate" {
   display_name = "code_tasks_failed_rate"
   combiner     = "OR"
 
+  depends_on = [google_monitoring_metric_descriptor.code_tasks_failed]
+
   documentation {
     content   = "Code task failure rate exceeded threshold (~5 failures / 15 min). Investigate orchestrator and code-agent logs."
     mime_type = "text/markdown"

--- a/terraform/modules/monitoring/main.tf
+++ b/terraform/modules/monitoring/main.tf
@@ -119,6 +119,20 @@ resource "google_monitoring_metric_descriptor" "code_tasks_active" {
   }
 }
 
+resource "google_monitoring_metric_descriptor" "code_tasks_failed" {
+  description  = "Number of code tasks that ended in a non-success terminal state"
+  display_name = "Code Tasks Failed"
+  type         = "custom.googleapis.com/intexuraos/code_tasks_failed"
+  metric_kind  = "CUMULATIVE"
+  value_type   = "INT64"
+
+  labels {
+    key         = "reason"
+    value_type  = "STRING"
+    description = "Terminal failure reason (failed, interrupted, cancelled)"
+  }
+}
+
 resource "google_monitoring_metric_descriptor" "code_tasks_cost_dollars" {
   description  = "Estimated cost of code tasks in dollars"
   display_name = "Code Tasks Cost"

--- a/workers/vm-lifecycle/src/__tests__/logger.test.ts
+++ b/workers/vm-lifecycle/src/__tests__/logger.test.ts
@@ -87,4 +87,26 @@ describe('logger', () => {
     if (config === undefined) throw new Error('initWorker not called');
     expect(config.sentryDsn).toBeUndefined();
   });
+
+  it('forwards INTEXURAOS_ENVIRONMENT through to initWorker when set', async () => {
+    process.env['INTEXURAOS_ENVIRONMENT'] = 'prod';
+
+    await import('../logger.js');
+
+    expect(initWorker).toHaveBeenCalledOnce();
+    const config = initWorker.mock.calls[0]?.[0];
+    if (config === undefined) throw new Error('initWorker not called');
+    expect(config.environment).toBe('prod');
+  });
+
+  it('falls back to "development" when INTEXURAOS_ENVIRONMENT is unset', async () => {
+    delete process.env['INTEXURAOS_ENVIRONMENT'];
+
+    await import('../logger.js');
+
+    expect(initWorker).toHaveBeenCalledOnce();
+    const config = initWorker.mock.calls[0]?.[0];
+    if (config === undefined) throw new Error('initWorker not called');
+    expect(config.environment).toBe('development');
+  });
 });


### PR DESCRIPTION
## Summary

Two bundled fixes (no Linear issue per request — these unblock different things and don't share a ticket):

- **Repair the pino lockfile** so GitHub Actions `pnpm install --frozen-lockfile` stops failing with `ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY: no entry for 'pino@9.14.0'`. `packages/common-metrics` was the only workspace not on the `pino` catalog (`^9.0.0` instead of `catalog:`); a bad merge resolved its importer to `9.14.0` but dropped the matching snapshot block. Moved it onto the catalog (10.1.1) and regenerated the lockfile.
- **Make the dev infra apply succeed.** A bare `terraform plan/apply` in `terraform/environments/dev` failed with `404 Cannot find metric ... code_tasks_failed`: the `code_tasks_failed_rate` alert policy referenced a custom metric that had no `google_monitoring_metric_descriptor`. Added the descriptor (with the `reason` label, matching the `CODE_TASK_METRICS.FAILED` runtime contract) and a `depends_on` from the alert. Apply against dev was run after this fix — both resources now exist (`code_tasks_failed` descriptor, `code_tasks_failed_rate` alert).

While I had `ci:tracked` open I closed two pre-existing gaps it surfaced so the gate is fully green:

- `verify:package-exports` was failing because `@intexuraos/common-metrics` had no README. Generated full package docs (`packages/common-metrics/README.md`, `docs/packages/common-metrics/{README,technical-debt,agent}.md`) via the document-service skill. The technical-debt doc honestly notes that no service is currently importing this package — the orchestrator still ships a parallel local shim — which is worth a follow-up.
- `verify:v8-ignore` flagged two uncovered `?? 'development'` env-var fallback branches in `packages/http-server/src/startFastifyService.ts` and `workers/vm-lifecycle/src/logger.ts`. Added direct unit tests rather than `v8 ignore` exemptions (no testing-blocker reason existed).

Prettier also auto-formatted the column padding in `docs/architecture/pubsub-standards.md` during the `[format]` step — pure whitespace, included for honesty.

## Test plan

- [x] `pnpm install --frozen-lockfile` passes locally (verifies the GitHub Actions failure is gone)
- [x] `pnpm run ci:tracked` passes end-to-end (lint, typecheck, 17173 tests, package-exports, v8-ignore, format, build, all gates green)
- [x] `pnpm --filter @intexuraos/http-server test` and `pnpm --filter @intexuraos/vm-lifecycle-worker test` pass with the new env-fallback tests
- [x] `terraform plan` against the dev project shows 0 pending changes after apply
- [x] `terraform apply` against the dev project created the `code_tasks_failed` descriptor and the `code_tasks_failed_rate` alert (visible in GCP Cloud Monitoring)
- [ ] GitHub Actions CI / E2E Tests / Deploy go green on this PR (the original failure mode)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
