### PR TITLE
[INT-1564] fix(orchestrator): declare @sentry/node as direct dependency

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -21,6 +21,7 @@
     "openai",
     "fastify-server",
     "@google/genai",
+    "@sentry/node",
     "react",
     "react-dom",
     "vibe-kanban-web-companion",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2247,6 +2247,9 @@ importers:
       '@opentelemetry/api':
         specifier: ^1.9.0
         version: 1.9.0
+      '@sentry/node':
+        specifier: ^8.42.0
+        version: 8.55.0
       async-mutex:
         specifier: ^0.5.0
         version: 0.5.0

--- a/workers/orchestrator/package.json
+++ b/workers/orchestrator/package.json
@@ -21,6 +21,7 @@
     "@google-cloud/firestore": "catalog:",
     "@google/genai": "^1.0.0",
     "@opentelemetry/api": "^1.9.0",
+    "@sentry/node": "^8.42.0",
     "@intexuraos/code-task-domain": "workspace:*",
     "@intexuraos/common-core": "workspace:*",
     "@intexuraos/infra-sentry": "workspace:*",


### PR DESCRIPTION
## Summary
- home-dev systemd unit \`intexuraos-orchestrator@pbuchman.service\` is crash-looping with \`ERR_MODULE_NOT_FOUND: Cannot find package '@sentry/node'\` (570+ restarts).
- The bundled \`workers/orchestrator/dist/index.js\` imports \`@sentry/node\` transitively through \`@intexuraos/infra-sentry\`, but pnpm strict-isolation does not symlink it into \`workers/orchestrator/node_modules\`, and the home-dev deploy path runs \`node dist/index.js\` directly without installing from the generated \`dist/package.json\`.
- Fix: declare \`@sentry/node\` as a direct dep so pnpm symlinks it where Node ESM resolves it. Allowlist in \`knip.json\` because no source file imports it directly.

This is the **second occurrence** of the same bug class — commit \`d4e3bf1b0\` ([INT-1564]) applied the identical fix for \`@opentelemetry/api\` two days ago.

## Verification
- \`pnpm install\` → \`workers/orchestrator/node_modules/@sentry/node\` symlink created (verified resolves to \`.pnpm/@sentry+node@8.55.0\`).
- \`node -e "import('@sentry/node').then(s => console.log(typeof s.init))"\` from \`workers/orchestrator/\` → \`function\` (was \`ERR_MODULE_NOT_FOUND\`).
- \`pnpm -w run ci:tracked\` → ✅ passed (17186 tests, all gates green).

## Follow-up (not in this PR)
\`scripts/build-service.mjs\` already detects the inverse class of bug ("pnpm packages bundled instead of external"), but does **not** validate that every external bare import is reachable from the service's \`node_modules\` tree. That's why this exact bug recurred. Suggested follow-up: walk Node's resolution algorithm for each external from \`<serviceDir>/dist/\` and fail the build if any external is unresolvable. Happy to do that as a separate PR if you want.

## Deploy note
After merge, home-dev needs a \`git pull\` + \`pnpm install\` + \`pnpm --filter orchestrator build\` + \`systemctl restart intexuraos-orchestrator@pbuchman\` to recover. The systemd unit will keep crash-looping until then.

## Test plan
- [x] CI green
- [ ] After merge + deploy, confirm \`systemctl status intexuraos-orchestrator@pbuchman\` reports \`active (running)\` on home-dev

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>