### PR TITLE
[INT-1565] fix(orchestrator): set NODE_ENV=development in dev script

### DIFF
--- a/workers/orchestrator/package.json
+++ b/workers/orchestrator/package.json
@@ -11,7 +11,7 @@
     "typecheck": "tsc --noEmit",
     "lint:local": "eslint src --max-warnings 0",
     "start": "node dist/index.js",
-    "dev": "tsx watch src/index.ts",
+    "dev": "NODE_ENV=development tsx watch src/index.ts",
     "test": "vitest run --exclude '**/e2e*.test.ts'",
     "test:watch": "vitest",
     "test:e2e": "vitest run --config vitest.e2e.config.ts"


### PR DESCRIPTION
## Summary
Running \`pnpm --filter orchestrator dev\` was emitting raw pino JSON instead of the formatted dev output (\`HH:mm:ss | LEVEL | name | msg | key=val\`).

**Cause:** INT-1565 (commit \`a70727ceb\`) replaced orchestrator's local \`createLogger()\` — which wired \`pino-pretty\` unconditionally — with \`initWorker()\` → \`createAppLogger()\`. The new path gates the dev pretty stream behind \`NODE_ENV === 'development'\` (\`packages/infra-sentry/src/appLogger.ts:62\`). The orchestrator's dev script did not set \`NODE_ENV\`, so \`createDevOutputStream()\` was skipped.

PM2-managed apps were unaffected because \`ecosystem.config.cjs\` sets \`NODE_ENV=development\` for them. Orchestrator is not in PM2.

## Change
\`\`\`diff
- "dev": "tsx watch src/index.ts",
+ "dev": "NODE_ENV=development tsx watch src/index.ts",
\`\`\`

Smallest possible change — restores pre-INT-1565 behavior. Production paths (\`node dist/index.js\` via systemd / Cloud Run) still produce JSON because they don't set NODE_ENV=development. Tests still short-circuit to silent because \`NODE_ENV === 'test'\` is checked first.

## Test plan
- [x] \`pnpm -w run ci:tracked\` passed (17186 tests + all gates)
- [ ] After merge, \`pnpm --filter orchestrator dev\` shows formatted log lines instead of JSON