### PR TITLE
[INT-1564] fix(orchestrator): declare pino-opentelemetry-transport + harden build check

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -17,6 +17,7 @@
     "nock",
     "memfs",
     "pino",
+    "pino-opentelemetry-transport",
     "pino-pretty",
     "openai",
     "fastify-server",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2277,6 +2277,9 @@ importers:
       pino:
         specifier: 'catalog:'
         version: 10.1.1
+      pino-opentelemetry-transport:
+        specifier: ^2.0.0
+        version: 2.0.0(@opentelemetry/api@1.9.0)(pino@10.1.1)
       pino-pretty:
         specifier: ^13.0.0
         version: 13.1.3

--- a/scripts/build-service.mjs
+++ b/scripts/build-service.mjs
@@ -150,6 +150,78 @@ if (bundledNpmPackages.size > 0) {
   process.exit(1);
 }
 
+// Detect external packages that are referenced by the bundle but not
+// resolvable from `<serviceDir>/dist/` via Node's module resolution.
+//
+// This check applies ONLY to services that run `node dist/index.js`
+// directly from the source tree (e.g. orchestrator on home-dev systemd),
+// where there is no separate `pnpm install` step from the generated
+// `dist/package.json`. Cloud Functions / Cloud Run paths are exempt
+// because their deploy pipelines run a fresh install inside the deployed
+// `dist/`.
+//
+// For source-tree-run services, every referenced external must be hoisted
+// into the service's own `node_modules` tree. Under pnpm strict isolation,
+// only direct deps are hoisted — transitive deps from @intexuraos/infra-*
+// workspace packages (e.g. `@sentry/node`, `pino-opentelemetry-transport`)
+// are NOT symlinked, so Node throws ERR_MODULE_NOT_FOUND at startup.
+//
+// We scan the bundle source for string-literal references rather than the
+// esbuild metafile because the failure mode covers both static imports and
+// dynamic targets passed as strings (e.g.
+// `pino.transport({ target: 'pino-opentelemetry-transport' })`), which
+// never appear in metafile.outputs.imports.
+
+/**
+ * Services that run `node dist/index.js` directly from the source tree
+ * with no separate install step. Add a service here when it adopts a
+ * deploy path that does not run `pnpm install --prod` inside `dist/`.
+ */
+const SOURCE_TREE_RUN_SERVICES = new Set(['orchestrator']);
+function canResolveFrom(pkg, fromDir) {
+  let dir = fromDir;
+  while (true) {
+    if (existsSync(resolve(dir, 'node_modules', pkg, 'package.json'))) return true;
+    const parent = dirname(dir);
+    if (parent === dir) return false;
+    dir = parent;
+  }
+}
+
+if (SOURCE_TREE_RUN_SERVICES.has(service)) {
+  const distDir = resolve(rootDir, `${serviceDir}/dist`);
+  const distOutputPath = resolve(rootDir, `${serviceDir}/dist/index.js`);
+  const bundleSource = readFileSync(distOutputPath, 'utf8');
+
+  // A package is "referenced" if its exact name appears as a quoted string
+  // in the bundle. Quoted-only matching avoids substring false positives
+  // from unrelated specifiers (e.g. `@sentry/node-foo` matching `@sentry/node`).
+  function isReferenced(pkg, source) {
+    const patterns = [`"${pkg}"`, `'${pkg}'`, `\`${pkg}\``];
+    return patterns.some((p) => source.includes(p));
+  }
+
+  const referencedExternals = externalPackages.filter((pkg) => isReferenced(pkg, bundleSource));
+  const unresolvable = referencedExternals.filter((pkg) => !canResolveFrom(pkg, distDir));
+  if (unresolvable.length > 0) {
+    console.error(
+      '\nERROR: external packages referenced by dist/index.js not resolvable from dist/:'
+    );
+    for (const pkg of unresolvable) {
+      console.error(`  - ${pkg}`);
+    }
+    console.error(
+      `\nThese packages are referenced by the bundle but pnpm has not symlinked` +
+        ` them into ${serviceDir}/node_modules. Under strict isolation, only` +
+        ` direct dependencies of the service are hoisted there — transitive` +
+        ` deps from @intexuraos/infra-* workspace packages are not.` +
+        `\n\nFix: Add the package(s) to ${serviceDir}/package.json dependencies` +
+        ` so pnpm symlinks them where Node ESM can resolve them.\n`
+    );
+    process.exit(1);
+  }
+}
+
 // Generate production package.json with all pnpm dependencies (including transitive)
 const depsWithVersions = collectExternalDepsWithVersions(`@intexuraos/${service}`);
 // Always include infra-otel's deps for the OTel preload module

--- a/workers/orchestrator/package.json
+++ b/workers/orchestrator/package.json
@@ -42,6 +42,7 @@
     "minimatch": "^10.1.1",
     "openai": "catalog:",
     "pino": "catalog:",
+    "pino-opentelemetry-transport": "^2.0.0",
     "pino-pretty": "^13.0.0",
     "yaml": "^2.8.3",
     "zod": "catalog:"


### PR DESCRIPTION
## Summary
Third recurrence of the same root cause that hit @opentelemetry/api (INT-1564, d4e3bf1b0) and @sentry/node (#2020). Home-dev systemd is currently crash-looping at restart counter 702:

\`\`\`
PRECONDITION FAILED: unable to determine transport target for "pino-opentelemetry-transport"
\`\`\`

\`packages/infra-sentry\` declares \`pino-opentelemetry-transport\` as its dep. Under pnpm strict isolation it lives at \`node_modules/.pnpm/.../node_modules/pino-opentelemetry-transport\` — NOT symlinked into \`workers/orchestrator/node_modules\`. When pino's transport loader tries to resolve \`'pino-opentelemetry-transport'\` from the orchestrator's tree, it fails.

## Changes

**1. Immediate fix (\`workers/orchestrator/package.json\`)**
Declare \`pino-opentelemetry-transport\` as a direct dep so pnpm symlinks it where Node ESM can resolve it.

**2. \`knip.json\`** — allowlist (orchestrator source never imports it directly).

**3. Structural fix (\`scripts/build-service.mjs\`)**
Extend the existing "bundled instead of external" detection with the inverse check: fail the build when any external referenced by the bundle isn't resolvable from the service's \`dist/\` tree.

- Scoped to **source-tree-run services** via \`SOURCE_TREE_RUN_SERVICES = new Set(['orchestrator'])\`. Cloud Functions / Cloud Run services are exempt because their deploy pipelines run a fresh install from the generated \`dist/package.json\`.
- Uses **string-literal scanning** of the bundle source (not the esbuild metafile) so it catches both static \`import 'x'\` AND dynamic string targets like \`pino.transport({ target: 'pino-opentelemetry-transport' })\`. The metafile-based variant misses the latter.

This would have caught all three of the recent bugs at build time instead of at runtime.

## Verification

- Removed \`pino-opentelemetry-transport\` direct-dep symlink → build fails with:
  \`\`\`
  ERROR: external packages referenced by dist/index.js not resolvable from dist/:
    - pino-opentelemetry-transport
  Fix: Add the package(s) to workers/orchestrator/package.json dependencies...
  \`\`\`
- With the dep declared → build passes.
- \`pnpm -w run ci:tracked\` ✅ (17186 tests + all gates).
- The build-script change DID surface pre-existing flags in \`workers/transcription\` and \`workers/vm-lifecycle\` for the same class of bug; those are Cloud Functions and unaffected at runtime, hence the scoping to \`SOURCE_TREE_RUN_SERVICES\` rather than churning their \`package.json\`s.

## Test plan
- [x] \`pnpm -w run ci:tracked\` passed
- [x] Build fails loudly when dep is missing (verified by removing symlink)
- [ ] After merge + redeploy on home-dev, \`systemctl status intexuraos-orchestrator@pbuchman\` reports \`active (running)\`