### PR TITLE
[INT-1584] fix(orchestrator): pretty logs on home-dev systemd (NODE_ENV default)

### DIFF
--- a/workers/orchestrator/src/__tests__/bootstrap/node-env.test.ts
+++ b/workers/orchestrator/src/__tests__/bootstrap/node-env.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { defaultNodeEnv } from '../../bootstrap/node-env.js';
+
+describe('defaultNodeEnv', () => {
+  let original: string | undefined;
+
+  beforeEach(() => {
+    original = process.env['NODE_ENV'];
+  });
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env['NODE_ENV'];
+    } else {
+      process.env['NODE_ENV'] = original;
+    }
+  });
+
+  it('sets NODE_ENV to development when unset', () => {
+    delete process.env['NODE_ENV'];
+    defaultNodeEnv();
+    expect(process.env['NODE_ENV']).toBe('development');
+  });
+
+  it('leaves an explicitly-set NODE_ENV untouched', () => {
+    process.env['NODE_ENV'] = 'production';
+    defaultNodeEnv();
+    expect(process.env['NODE_ENV']).toBe('production');
+  });
+
+  it('leaves an explicitly-set empty NODE_ENV untouched (only nullish triggers default)', () => {
+    process.env['NODE_ENV'] = '';
+    defaultNodeEnv();
+    expect(process.env['NODE_ENV']).toBe('');
+  });
+});

--- a/workers/orchestrator/src/bootstrap/node-env.ts
+++ b/workers/orchestrator/src/bootstrap/node-env.ts
@@ -1,0 +1,21 @@
+/**
+ * Default `NODE_ENV=development` when the host hasn't set it.
+ *
+ * The orchestrator only runs on dev hosts (home-dev VM, dev macOS) — never
+ * on Cloud Run — so a hard default is safe. This mirrors the inline
+ * `NODE_ENV=development` in the `pnpm dev` script (orchestrator
+ * package.json) but covers launchers that bypass pnpm: the home-dev
+ * systemd unit (`ExecStart=node dist/index.js`) and the macOS
+ * LaunchAgent. PM2-managed apps already pass NODE_ENV via
+ * `ecosystem.config.cjs`; the orchestrator is not under PM2.
+ *
+ * Without this default, `createAppLogger()` (packages/infra-sentry) takes
+ * the JSON-stdout branch (`isDev = NODE_ENV === 'development'` is false)
+ * and journalctl shows raw JSON instead of the pino-pretty stream.
+ *
+ * Must be invoked before `initWorker()` so the gating decision picks up
+ * the defaulted value.
+ */
+export function defaultNodeEnv(): void {
+  process.env['NODE_ENV'] ??= 'development';
+}

--- a/workers/orchestrator/src/start.ts
+++ b/workers/orchestrator/src/start.ts
@@ -30,6 +30,7 @@ import {
   startCredentialRefreshLoop,
 } from './bootstrap/service-wiring.js';
 import { ensureDirectoryExists } from './bootstrap/fs-utils.js';
+import { defaultNodeEnv } from './bootstrap/node-env.js';
 
 function buildOrchestratorConfig(
   env: BootstrapEnvConfig,
@@ -80,6 +81,13 @@ function readCodeVersion(): string {
  * `await flush()` before exit.
  */
 export async function start(): Promise<void> {
+  // Mirror `pnpm --filter orchestrator dev` (which inlines
+  // NODE_ENV=development) for hosts that launch us via `node dist/index.js`
+  // — the home-dev systemd unit and the macOS LaunchAgent. Required before
+  // initWorker() so createAppLogger() takes the pino-pretty branch instead
+  // of raw JSON stdout (which is unreadable in journalctl).
+  defaultNodeEnv();
+
   const home = homedir();
   const orchestratorDir = join(home, '.code-orchestrator');
   const worktreeDir = join(home, 'code-workers', 'worktrees');


### PR DESCRIPTION
## Summary

- Mirror the `pnpm dev` log fix (#2022, commit 23d81b738) for hosts that launch the orchestrator via `node dist/index.js` directly — the home-dev systemd unit (`intexuraos-orchestrator@pbuchman.service`) and the macOS LaunchAgent.
- Add a tiny `bootstrap/node-env.ts` helper that defaults `process.env.NODE_ENV` to `development` when unset, called at the very top of `start()` before `initWorker()` so `createAppLogger()` (`packages/infra-sentry/src/appLogger.ts:64`) takes the pino-pretty branch instead of raw JSON stdout.
- Hardcoded default is safe: the orchestrator only runs on dev hosts (home-dev VM, dev macOS) — never on Cloud Run. PM2 apps already inject `NODE_ENV=development` via `ecosystem.config.cjs` and are unaffected.

## Why a code-side fix instead of editing the systemd unit

The unit file lives in a separate `pbuchman-dev/machine-setup` repo and the macOS LaunchAgent plists are user-managed. Defaulting at bootstrap covers every launcher in one place and survives future re-provisioning.

## Endpoint Changes

- Modified: none
- Created: none
- Removed: none
- Unchanged: all (logging-only change)

## Test plan

- [x] New unit tests in `workers/orchestrator/src/__tests__/bootstrap/node-env.test.ts` cover both `??=` branches (unset → defaults to `development`; set → untouched) plus the empty-string edge case.
- [x] `pnpm -w run verify:workspace:tracked orchestrator` passes (920 test files, 17 189 tests).
- [x] `pnpm -w run ci:tracked` passes (typecheck, lint, tests, coverage, all static validation phases).
- [ ] After deploy: `journalctl -u intexuraos-orchestrator@pbuchman -f` shows pino-pretty colored output instead of raw JSON.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>