### PR TITLE
[INT-1599] Fix Firestore runtime dependency manifests

### DIFF
--- a/apps/code-agent/package.json
+++ b/apps/code-agent/package.json
@@ -18,6 +18,7 @@
     "@fastify/cors": "^10.0.1",
     "@fastify/swagger": "^9.4.2",
     "@fastify/swagger-ui": "^5.2.1",
+    "@google-cloud/firestore": "catalog:",
     "@google-cloud/monitoring": "^5.3.1",
     "@intexuraos/code-task-domain": "workspace:*",
     "@intexuraos/common-core": "workspace:*",
@@ -47,7 +48,6 @@
     "zod": "catalog:"
   },
   "devDependencies": {
-    "@google-cloud/firestore": "catalog:",
     "@types/node": "^22.10.5",
     "pino-pretty": "^13.0.0",
     "typescript": "^5.7.3",

--- a/packages/infra-firestore/package.json
+++ b/packages/infra-firestore/package.json
@@ -14,12 +14,7 @@
     "lint:local": "eslint src --max-warnings 0"
   },
   "dependencies": {
+    "@google-cloud/firestore": "catalog:",
     "@intexuraos/common-core": "workspace:*"
-  },
-  "peerDependencies": {
-    "@google-cloud/firestore": "^7.10.0"
-  },
-  "devDependencies": {
-    "@google-cloud/firestore": "catalog:"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -480,6 +480,9 @@ importers:
       '@fastify/swagger-ui':
         specifier: ^5.2.1
         version: 5.2.4
+      '@google-cloud/firestore':
+        specifier: 'catalog:'
+        version: 7.11.6(encoding@0.1.13)
       '@google-cloud/monitoring':
         specifier: ^5.3.1
         version: 5.3.1
@@ -562,9 +565,6 @@ importers:
         specifier: 'catalog:'
         version: 3.25.76
     devDependencies:
-      '@google-cloud/firestore':
-        specifier: 'catalog:'
-        version: 7.11.6(encoding@0.1.13)
       '@types/node':
         specifier: ^22.10.5
         version: 22.19.5
@@ -1893,13 +1893,12 @@ importers:
 
   packages/infra-firestore:
     dependencies:
-      '@intexuraos/common-core':
-        specifier: workspace:*
-        version: link:../common-core
-    devDependencies:
       '@google-cloud/firestore':
         specifier: 'catalog:'
         version: 7.11.6(encoding@0.1.13)
+      '@intexuraos/common-core':
+        specifier: workspace:*
+        version: link:../common-core
 
   packages/infra-gemini:
     dependencies:

--- a/scripts/__tests__/firestoreRuntimeDependency.test.ts
+++ b/scripts/__tests__/firestoreRuntimeDependency.test.ts
@@ -1,0 +1,34 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = process.cwd();
+
+function readPackageJson(relativePath: string): {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+} {
+  return JSON.parse(fs.readFileSync(path.join(REPO_ROOT, relativePath), 'utf8')) as {
+    dependencies?: Record<string, string>;
+    devDependencies?: Record<string, string>;
+    peerDependencies?: Record<string, string>;
+  };
+}
+
+describe('Firestore runtime dependency declarations', () => {
+  it('keeps infra-firestore production-installable in Cloud Run images', () => {
+    const pkg = readPackageJson('packages/infra-firestore/package.json');
+
+    expect(pkg.dependencies?.['@google-cloud/firestore']).toBe('catalog:');
+    expect(pkg.devDependencies?.['@google-cloud/firestore']).toBeUndefined();
+    expect(pkg.peerDependencies?.['@google-cloud/firestore']).toBeUndefined();
+  });
+
+  it('keeps code-agent direct Firestore runtime imports in production dependencies', () => {
+    const pkg = readPackageJson('apps/code-agent/package.json');
+
+    expect(pkg.dependencies?.['@google-cloud/firestore']).toBe('catalog:');
+    expect(pkg.devDependencies?.['@google-cloud/firestore']).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Root cause

Cloud Run revisions were failing startup probes because the containers exited before listening. GCP logs showed `Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@google-cloud/firestore' imported from /app/dist/index.js`.

The generated Cloud Run production manifests only include package `dependencies`. `@google-cloud/firestore` was declared as a peer/dev dependency in `packages/infra-firestore`, and as a dev dependency in `apps/code-agent`, so the production images omitted it even though runtime code imports it.

## Changes

- Move `@google-cloud/firestore` into production dependencies for `packages/infra-firestore`.
- Move `@google-cloud/firestore` into production dependencies for `apps/code-agent`.
- Add a regression test that prevents moving this runtime dependency back into dev/peer dependencies.

## Verification

- `pnpm exec vitest run scripts/__tests__/firestoreRuntimeDependency.test.ts`
- `pnpm run verify:workspace-deps`
- `pnpm exec vitest run scripts/__tests__/firestoreRuntimeDependency.test.ts scripts/__tests__/appDockerfiles.test.ts scripts/__tests__/verify-web-service-manifest.test.ts`
- `pnpm run ci:tracked`
- Production manifest check: `apps/mobile-notifications-service/dist/package.json` includes `@google-cloud/firestore`.
- Production manifest check: `apps/code-agent/dist/package.json` includes `@google-cloud/firestore`.


---

- Linear: [INT-1599](https://linear.app/pbuchman/issue/INT-1599)
- IntexuraOS Code Task: [View task](https://intexuraos.cloud/#/code-tasks/task_ab31ba48-0660-49a3-8c65-2ea8eef9b6de)
- Worker Type: `codex`
- Model: `default`
