### PR TITLE
[INT-1600] Fix OpenAI runtime dependency manifest

### DIFF
--- a/packages/infra-gpt/package.json
+++ b/packages/infra-gpt/package.json
@@ -18,14 +18,11 @@
     "@intexuraos/llm-prompts": "workspace:*",
     "@intexuraos/llm-contract": "workspace:*",
     "@intexuraos/llm-pricing": "workspace:*",
-    "@intexuraos/llm-utils": "workspace:*"
-  },
-  "peerDependencies": {
-    "openai": "^6.15.0"
+    "@intexuraos/llm-utils": "workspace:*",
+    "openai": "catalog:"
   },
   "devDependencies": {
     "@opentelemetry/api": "^1.9.0",
-    "@opentelemetry/sdk-trace-base": "^1.30.0",
-    "openai": "catalog:"
+    "@opentelemetry/sdk-trace-base": "^1.30.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1945,6 +1945,9 @@ importers:
       '@intexuraos/llm-utils':
         specifier: workspace:*
         version: link:../llm-utils
+      openai:
+        specifier: 'catalog:'
+        version: 6.16.0(ws@8.19.0)(zod@4.3.6)
     devDependencies:
       '@opentelemetry/api':
         specifier: ^1.9.0
@@ -1952,9 +1955,6 @@ importers:
       '@opentelemetry/sdk-trace-base':
         specifier: ^1.30.0
         version: 1.30.1(@opentelemetry/api@1.9.0)
-      openai:
-        specifier: 'catalog:'
-        version: 6.16.0(ws@8.19.0)(zod@4.3.6)
 
   packages/infra-notion:
     dependencies:

--- a/scripts/__tests__/firestoreRuntimeDependency.test.ts
+++ b/scripts/__tests__/firestoreRuntimeDependency.test.ts
@@ -16,7 +16,7 @@ function readPackageJson(relativePath: string): {
   };
 }
 
-describe('Firestore runtime dependency declarations', () => {
+describe('Cloud Run runtime dependency declarations', () => {
   it('keeps infra-firestore production-installable in Cloud Run images', () => {
     const pkg = readPackageJson('packages/infra-firestore/package.json');
 
@@ -30,5 +30,13 @@ describe('Firestore runtime dependency declarations', () => {
 
     expect(pkg.dependencies?.['@google-cloud/firestore']).toBe('catalog:');
     expect(pkg.devDependencies?.['@google-cloud/firestore']).toBeUndefined();
+  });
+
+  it('keeps infra-gpt production-installable in Cloud Run images', () => {
+    const pkg = readPackageJson('packages/infra-gpt/package.json');
+
+    expect(pkg.dependencies?.openai).toBe('catalog:');
+    expect(pkg.devDependencies?.openai).toBeUndefined();
+    expect(pkg.peerDependencies?.openai).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Root cause

After the Firestore dependency fix deployed, the new Cloud Run revisions progressed to the next startup failure. GCP logs for the failed revisions showed `Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'openai' imported from /app/dist/index.js`.

`packages/infra-gpt` imports `openai` at runtime, but declared it only as a peer/dev dependency. The Cloud Run production manifest generator installs production `dependencies`, so services that include `@intexuraos/llm-factory` -> `@intexuraos/infra-gpt` could build images that omit `openai`.

## Changes

- Move `openai` into production dependencies for `packages/infra-gpt`.
- Extend the runtime dependency regression test to cover `infra-gpt`.

## Verification

- Watched the new test fail before the package change: `expected undefined to be 'catalog:'` for `packages/infra-gpt` `dependencies.openai`.
- `pnpm install --frozen-lockfile`
- `pnpm exec vitest run scripts/__tests__/firestoreRuntimeDependency.test.ts`
- `pnpm exec vitest run scripts/__tests__/firestoreRuntimeDependency.test.ts scripts/__tests__/appDockerfiles.test.ts scripts/__tests__/verify-web-service-manifest.test.ts`
- `pnpm run verify:workspace-deps`
- `pnpm run ci:tracked`
- Production manifest checks: every service that failed with missing `openai` now has `openai` in its generated `dist/package.json`.
Linear: [INT-1600](https://linear.app/pbuchman/issue/INT-1600)
IntexuraOS Code Task: [View task](https://intexuraos.cloud/#/code-tasks/task_cda73eb0-6ef7-412b-bc06-adfd3cd91a89)
Worker Type: `codex`
Model: `default`
