### PR TITLE
[INT-1601] Fix common HTTP Zod runtime dependency

### DIFF
--- a/apps/actions-agent/package.json
+++ b/apps/actions-agent/package.json
@@ -34,7 +34,6 @@
     "@intexuraos/llm-prompts": "workspace:*",
     "@intexuraos/whatsapp-pubsub-client": "workspace:*",
     "fastify": "catalog:",
-    "pino": "catalog:",
-    "zod": "catalog:"
+    "pino": "catalog:"
   }
 }

--- a/apps/app-settings-service/package.json
+++ b/apps/app-settings-service/package.json
@@ -28,8 +28,7 @@
     "@intexuraos/infra-sentry": "workspace:*",
     "@intexuraos/llm-contract": "workspace:*",
     "fastify": "catalog:",
-    "pino": "catalog:",
-    "zod": "catalog:"
+    "pino": "catalog:"
   },
   "devDependencies": {
     "nock": "^14.0.0"

--- a/apps/bookmarks-agent/package.json
+++ b/apps/bookmarks-agent/package.json
@@ -34,8 +34,7 @@
     "@intexuraos/llm-pricing": "workspace:*",
     "@intexuraos/whatsapp-pubsub-client": "workspace:*",
     "fastify": "catalog:",
-    "pino": "catalog:",
-    "zod": "catalog:"
+    "pino": "catalog:"
   },
   "devDependencies": {
     "@vitest/coverage-v8": "^4.0.16",

--- a/apps/calendar-agent/package.json
+++ b/apps/calendar-agent/package.json
@@ -33,7 +33,6 @@
     "@intexuraos/llm-utils": "workspace:*",
     "fastify": "catalog:",
     "googleapis": "^144.0.0",
-    "pino": "catalog:",
-    "zod": "catalog:"
+    "pino": "catalog:"
   }
 }

--- a/apps/commands-agent/package.json
+++ b/apps/commands-agent/package.json
@@ -36,7 +36,6 @@
     "@intexuraos/llm-utils": "workspace:*",
     "fastify": "catalog:",
     "jose": "^5.9.6",
-    "pino": "catalog:",
-    "zod": "catalog:"
+    "pino": "catalog:"
   }
 }

--- a/apps/cron-agent/package.json
+++ b/apps/cron-agent/package.json
@@ -34,8 +34,7 @@
     "@intexuraos/llm-prompts": "workspace:*",
     "cron-parser": "^4.9.0",
     "fastify": "catalog:",
-    "pino": "catalog:",
-    "zod": "catalog:"
+    "pino": "catalog:"
   },
   "devDependencies": {
     "@vitest/coverage-v8": "^4.0.16",

--- a/apps/hellscript-agent/package.json
+++ b/apps/hellscript-agent/package.json
@@ -35,8 +35,7 @@
     "@intexuraos/llm-pricing": "workspace:*",
     "@intexuraos/llm-prompts": "workspace:*",
     "fastify": "catalog:",
-    "pino": "catalog:",
-    "zod": "catalog:"
+    "pino": "catalog:"
   },
   "devDependencies": {
     "@vitest/coverage-v8": "^4.0.16",

--- a/apps/image-service/package.json
+++ b/apps/image-service/package.json
@@ -34,8 +34,7 @@
     "@intexuraos/llm-prompts": "workspace:*",
     "fastify": "catalog:",
     "pino": "catalog:",
-    "sharp": "^0.33.5",
-    "zod": "catalog:"
+    "sharp": "^0.33.5"
   },
   "devDependencies": {
     "@intexuraos/llm-factory": "workspace:*",

--- a/apps/llm-usage-service/package.json
+++ b/apps/llm-usage-service/package.json
@@ -29,8 +29,7 @@
     "@intexuraos/infra-sentry": "workspace:*",
     "fastify": "catalog:",
     "firebase-admin": "^13.0.2",
-    "pino": "catalog:",
-    "zod": "catalog:"
+    "pino": "catalog:"
   },
   "devDependencies": {
     "nock": "^14.0.0"

--- a/apps/notes-agent/package.json
+++ b/apps/notes-agent/package.json
@@ -29,8 +29,7 @@
     "@intexuraos/infra-otel": "workspace:*",
     "@intexuraos/infra-sentry": "workspace:*",
     "fastify": "catalog:",
-    "pino": "catalog:",
-    "zod": "catalog:"
+    "pino": "catalog:"
   },
   "devDependencies": {
     "@vitest/coverage-v8": "^4.0.16",

--- a/apps/todos-agent/package.json
+++ b/apps/todos-agent/package.json
@@ -37,8 +37,7 @@
     "@intexuraos/llm-utils": "workspace:*",
     "@intexuraos/todos-pubsub-client": "workspace:*",
     "fastify": "catalog:",
-    "pino": "catalog:",
-    "zod": "catalog:"
+    "pino": "catalog:"
   },
   "devDependencies": {
     "@types/node": "^22.10.2",

--- a/packages/common-http/package.json
+++ b/packages/common-http/package.json
@@ -16,14 +16,13 @@
   "dependencies": {
     "@intexuraos/common-core": "workspace:*",
     "fastify-plugin": "^5.0.1",
-    "jose": "^5.9.6"
+    "jose": "^5.9.6",
+    "zod": "catalog:"
   },
   "peerDependencies": {
-    "fastify": "^5.1.0",
-    "zod": "^3.24.1"
+    "fastify": "^5.1.0"
   },
   "devDependencies": {
-    "fastify": "catalog:",
-    "zod": "catalog:"
+    "fastify": "catalog:"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -195,9 +195,6 @@ importers:
       pino:
         specifier: 'catalog:'
         version: 10.1.1
-      zod:
-        specifier: 'catalog:'
-        version: 3.25.76
 
   apps/api-docs-hub:
     dependencies:
@@ -270,9 +267,6 @@ importers:
       pino:
         specifier: 'catalog:'
         version: 10.1.1
-      zod:
-        specifier: 'catalog:'
-        version: 3.25.76
     devDependencies:
       nock:
         specifier: ^14.0.0
@@ -331,9 +325,6 @@ importers:
       pino:
         specifier: 'catalog:'
         version: 10.1.1
-      zod:
-        specifier: 'catalog:'
-        version: 3.25.76
     devDependencies:
       '@vitest/coverage-v8':
         specifier: ^4.0.16
@@ -401,9 +392,6 @@ importers:
       pino:
         specifier: 'catalog:'
         version: 10.1.1
-      zod:
-        specifier: 'catalog:'
-        version: 3.25.76
 
   apps/chat-agent:
     dependencies:
@@ -646,9 +634,6 @@ importers:
       pino:
         specifier: 'catalog:'
         version: 10.1.1
-      zod:
-        specifier: 'catalog:'
-        version: 3.25.76
 
   apps/cron-agent:
     dependencies:
@@ -703,9 +688,6 @@ importers:
       pino:
         specifier: 'catalog:'
         version: 10.1.1
-      zod:
-        specifier: 'catalog:'
-        version: 3.25.76
     devDependencies:
       '@vitest/coverage-v8':
         specifier: ^4.0.16
@@ -837,9 +819,6 @@ importers:
       pino:
         specifier: 'catalog:'
         version: 10.1.1
-      zod:
-        specifier: 'catalog:'
-        version: 3.25.76
     devDependencies:
       '@vitest/coverage-v8':
         specifier: ^4.0.16
@@ -913,9 +892,6 @@ importers:
       sharp:
         specifier: ^0.33.5
         version: 0.33.5
-      zod:
-        specifier: 'catalog:'
-        version: 3.25.76
     devDependencies:
       '@intexuraos/llm-factory':
         specifier: workspace:*
@@ -1043,9 +1019,6 @@ importers:
       pino:
         specifier: 'catalog:'
         version: 10.1.1
-      zod:
-        specifier: 'catalog:'
-        version: 3.25.76
     devDependencies:
       nock:
         specifier: ^14.0.0
@@ -1150,9 +1123,6 @@ importers:
       pino:
         specifier: 'catalog:'
         version: 10.1.1
-      zod:
-        specifier: 'catalog:'
-        version: 3.25.76
     devDependencies:
       '@vitest/coverage-v8':
         specifier: ^4.0.16
@@ -1368,9 +1338,6 @@ importers:
       pino:
         specifier: 'catalog:'
         version: 10.1.1
-      zod:
-        specifier: 'catalog:'
-        version: 3.25.76
     devDependencies:
       '@types/node':
         specifier: ^22.10.2
@@ -1781,13 +1748,13 @@ importers:
       jose:
         specifier: ^5.9.6
         version: 5.10.0
+      zod:
+        specifier: 'catalog:'
+        version: 3.25.76
     devDependencies:
       fastify:
         specifier: 'catalog:'
         version: 5.6.2
-      zod:
-        specifier: 'catalog:'
-        version: 3.25.76
 
   packages/common-metrics:
     dependencies:

--- a/scripts/__tests__/firestoreRuntimeDependency.test.ts
+++ b/scripts/__tests__/firestoreRuntimeDependency.test.ts
@@ -39,4 +39,12 @@ describe('Cloud Run runtime dependency declarations', () => {
     expect(pkg.devDependencies?.openai).toBeUndefined();
     expect(pkg.peerDependencies?.openai).toBeUndefined();
   });
+
+  it('keeps common-http production-installable in Cloud Run images', () => {
+    const pkg = readPackageJson('packages/common-http/package.json');
+
+    expect(pkg.dependencies?.zod).toBe('catalog:');
+    expect(pkg.devDependencies?.zod).toBeUndefined();
+    expect(pkg.peerDependencies?.zod).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Root cause

After the Firestore and OpenAI runtime dependency fixes deployed, Terraform progressed further and failed updating `intexuraos-api-docs-hub`. GCP logs for revision `intexuraos-api-docs-hub-00680-nfd` showed `Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'zod' imported from /app/dist/index.js`.

The runtime import is in `packages/common-http/src/http/validation.ts`, but `packages/common-http` declared `zod` only as peer/dev. Cloud Run production manifests install production dependencies, so services that consume `@intexuraos/common-http` without their own direct `zod` dependency can omit it.

## Changes

- Move `zod` into production dependencies for `packages/common-http`.
- Remove duplicate now-unused app-level `zod` dependencies reported by `knip`.
- Extend the Cloud Run runtime dependency regression test to cover `common-http`.
- Sync the `fishing-assistant-service` lockfile importer with its existing package manifest.

## Verification

- Watched the new test fail before the package change: `expected undefined to be 'catalog:'` for `packages/common-http` `dependencies.zod`.
- `pnpm install --frozen-lockfile`
- `pnpm exec vitest run scripts/__tests__/firestoreRuntimeDependency.test.ts`
- `pnpm exec vitest run scripts/__tests__/firestoreRuntimeDependency.test.ts scripts/__tests__/appDockerfiles.test.ts scripts/__tests__/verify-web-service-manifest.test.ts`
- `pnpm run verify:workspace-deps`
- `pnpm run verify:dead-code`
- `pnpm run ci:tracked`
- Production manifest check: `apps/api-docs-hub/dist/package.json` includes `zod`.

Linear: [INT-1601](https://linear.app/pbuchman/issue/INT-1601)
IntexuraOS Code Task: [View task](https://intexuraos.cloud/#/code-tasks/task_cd155bc5-e7ad-486b-902e-6f15d4fce62c)
Worker Type: `codex`
Model: `default`