### PR TITLE
[codex] Fix Codex quota retry scheduling

### DIFF
--- a/apps/code-agent/src/__tests__/domain/prompts/cooloffRetryPrompt.test.ts
+++ b/apps/code-agent/src/__tests__/domain/prompts/cooloffRetryPrompt.test.ts
@@ -18,7 +18,7 @@ const PRODUCTION_RESET_TEXT = "You've hit your limit · resets 10pm (UTC)";
 describe('cooloffRetryPrompt', () => {
   describe('COOLOFF_RETRY_PROMPT_VERSION', () => {
     it('is a semver string', () => {
-      expect(COOLOFF_RETRY_PROMPT_VERSION).toBe('1.0.0');
+      expect(COOLOFF_RETRY_PROMPT_VERSION).toBe('1.1.0');
     });
   });
 
@@ -51,6 +51,22 @@ describe('cooloffRetryPrompt', () => {
       expect(prompt).toContain(now.toISOString());
       // Must tell the LLM to emit an ISO-8601 UTC timestamp.
       expect(prompt).toMatch(/ISO-8601 UTC/i);
+    });
+
+    it('includes Codex usage-limit wording and runtime-neutral instructions', () => {
+      const prompt = cooloffRetryPrompt.build({
+        errorCode: 'TASK_RUNTIME_HARD_ERROR',
+        errorMessage:
+          "Codex error: You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again at 6:14 PM.",
+        recentLogLines: [],
+        userTimezone: 'Europe/Warsaw',
+        now: new Date('2026-05-05T17:44:20Z'),
+      });
+
+      expect(prompt).toContain('try again at 6:14 PM');
+      expect(prompt).toContain('Codex');
+      expect(prompt).toMatch(/usage-limit failures/i);
+      expect(prompt).not.toMatch(/Claude usage-limit failures/i);
     });
 
     it('falls back to a UTC note when userTimezone is missing', () => {

--- a/apps/code-agent/src/__tests__/domain/usecases/drainTaskQueue.test.ts
+++ b/apps/code-agent/src/__tests__/domain/usecases/drainTaskQueue.test.ts
@@ -2911,6 +2911,50 @@ describe('drainTaskQueue', () => {
       expect(mockCodeTaskRepo.update).not.toHaveBeenCalled();
     });
 
+    it('logs future-scheduled eligibility as the all-candidates reason instead of active-resource blocking', async () => {
+      const now = Date.now();
+      const task = createMockTask({
+        id: 'cooloff-retry-waiting',
+        queuedAt: Timestamp.fromDate(new Date(now - 60 * 1000)),
+        dispatchSchedule: {
+          notBeforeAt: Timestamp.fromDate(new Date(now + 5 * 60 * 1000)),
+          source: 'retry_cooloff',
+          derivedBy: 'fallback',
+        },
+      });
+      const laterTask = createMockTask({
+        id: 'cooloff-retry-waiting-later',
+        createdAt: Timestamp.fromDate(new Date(now + 1)),
+        queuedAt: Timestamp.fromDate(new Date(now - 30 * 1000)),
+        dispatchSchedule: {
+          notBeforeAt: Timestamp.fromDate(new Date(now + 10 * 60 * 1000)),
+          source: 'retry_cooloff',
+          derivedBy: 'fallback',
+        },
+      });
+      mockCodeTaskRepo.listQueuedByAge.mockResolvedValue(ok([task, laterTask]));
+      setupWorkerSettings();
+
+      const result = await drainTaskQueue(createDeps());
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value).toEqual({ action: 'still_busy' });
+      }
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        expect.objectContaining({
+          candidateCount: 2,
+          futureScheduledCount: 2,
+          nextEligibleAt: expect.any(String),
+        }),
+        'All queued tasks are future-scheduled and not yet eligible',
+      );
+      expect(mockLogger.info).not.toHaveBeenCalledWith(
+        expect.anything(),
+        'All queued tasks blocked by active resources',
+      );
+    });
+
     it('dispatches an eligible unscheduled task ahead of an older future-scheduled row', async () => {
       const now = Date.now();
       const olderScheduled = createMockTask({

--- a/apps/code-agent/src/__tests__/domain/usecases/triageFailedTask.test.ts
+++ b/apps/code-agent/src/__tests__/domain/usecases/triageFailedTask.test.ts
@@ -135,12 +135,10 @@ describe('triageFailedTask', () => {
   });
 
   describe('retry_after_cooloff verdict', () => {
-    // Production evidence: task_ac5fb880-... and task_8f4bc53b-... (INT-1463).
-    // The verbatim production message — classifyFailure's regex recognizes
-    // Claude's "hit your limit · resets …" wording directly, so no synthetic
-    // "rate limited" phrasing is needed.
-    const PRODUCTION_MESSAGE =
-      "Non-zero exit code: 1; Claude error: You've hit your limit · resets 10pm (UTC)";
+    const CODEX_PRODUCTION_MESSAGE =
+      "Non-zero exit code: 1; Codex error: You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again at 6:14 PM.; No EXECUTION_AGENT_FINAL: block in transcript";
+    const UNPARSEABLE_RATE_LIMIT_MESSAGE =
+      'Non-zero exit code: 1; Runtime error: API returned 429 Too Many Requests';
 
     it('auto-retries rate-limit failures (429 → action: retried_after_cooloff)', async () => {
       const task = buildTask({ id: 'task_ratelimit' });
@@ -165,11 +163,52 @@ describe('triageFailedTask', () => {
       expect(mockCodeTaskRepo.create).toHaveBeenCalledOnce();
     });
 
+    it('parses Codex try-again reset times deterministically without calling the user LLM', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-05-05T17:44:20.623Z'));
+      mockUserServiceClient.getUserTimezone.mockResolvedValue('Europe/Warsaw');
+      mockUserServiceClient.getLlmClient.mockResolvedValue(
+        err({ code: 'NO_API_KEY', message: 'should not be used' })
+      );
+
+      try {
+        const task = buildTask({ id: 'task_codex_cooloff', workerType: 'codex' });
+        const taskError: TaskError = {
+          code: 'TASK_RUNTIME_HARD_ERROR',
+          message: CODEX_PRODUCTION_MESSAGE,
+        };
+
+        const result = await triageFailedTask(buildDeps(), {
+          task,
+          completedAt: new Date(),
+          taskError,
+        });
+
+        expect(result.action).toBe('retried_after_cooloff');
+        expect(mockUserServiceClient.getUserTimezone).toHaveBeenCalledWith('user_123');
+        expect(mockUserServiceClient.getLlmClient).not.toHaveBeenCalled();
+
+        const createInput = mockCodeTaskRepo.create.mock.calls[0]?.[0] as
+          | { dispatchSchedule?: Record<string, unknown> }
+          | undefined;
+        expect(createInput?.dispatchSchedule).toBeDefined();
+        expect(createInput?.dispatchSchedule?.['derivedBy']).toBe('parser');
+        expect(createInput?.dispatchSchedule?.['source']).toBe('retry_cooloff');
+        expect(createInput?.dispatchSchedule?.['timezone']).toBe('UTC');
+        expect(createInput?.dispatchSchedule?.['sourceText']).toBe('try again at 6:14 PM');
+        const persisted = createInput?.dispatchSchedule?.['notBeforeAt'];
+        expect(persisted).toBeInstanceOf(Date);
+        expect((persisted as Date).toISOString()).toBe('2026-05-05T18:14:00.000Z');
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it('passes cooloffSchedule with derivedBy "llm" when the LLM returns a valid future timestamp', async () => {
       const task = buildTask({ id: 'task_cooloff_prod' });
       const taskError: TaskError = {
         code: 'TASK_RUNTIME_HARD_ERROR',
-        message: PRODUCTION_MESSAGE,
+        message: UNPARSEABLE_RATE_LIMIT_MESSAGE,
       };
 
       // Future reset ~10 hours away.
@@ -213,7 +252,7 @@ describe('triageFailedTask', () => {
       const task = buildTask({ id: 'task_cooloff_badjson' });
       const taskError: TaskError = {
         code: 'TASK_RUNTIME_HARD_ERROR',
-        message: PRODUCTION_MESSAGE,
+        message: UNPARSEABLE_RATE_LIMIT_MESSAGE,
       };
 
       const mockGenerate = vi.fn().mockResolvedValue(
@@ -247,7 +286,7 @@ describe('triageFailedTask', () => {
       const task = buildTask({ id: 'task_cooloff_nokey' });
       const taskError: TaskError = {
         code: 'TASK_RUNTIME_HARD_ERROR',
-        message: PRODUCTION_MESSAGE,
+        message: UNPARSEABLE_RATE_LIMIT_MESSAGE,
       };
 
       // Timezone is known, but LLM client is unavailable — fallback path
@@ -275,7 +314,7 @@ describe('triageFailedTask', () => {
       const task = buildTask({ id: 'task_cooloff_logfail' });
       const taskError: TaskError = {
         code: 'TASK_RUNTIME_HARD_ERROR',
-        message: PRODUCTION_MESSAGE,
+        message: UNPARSEABLE_RATE_LIMIT_MESSAGE,
       };
 
       mockLogLineRepo.listRecent.mockResolvedValue(
@@ -302,7 +341,7 @@ describe('triageFailedTask', () => {
       const task = buildTask({ id: 'task_cooloff_tz_throw' });
       const taskError: TaskError = {
         code: 'TASK_RUNTIME_HARD_ERROR',
-        message: PRODUCTION_MESSAGE,
+        message: UNPARSEABLE_RATE_LIMIT_MESSAGE,
       };
 
       mockUserServiceClient.getUserTimezone.mockRejectedValue(new Error('tz boom'));
@@ -338,7 +377,7 @@ describe('triageFailedTask', () => {
       const task = buildTask({ id: 'task_cooloff_gen_err' });
       const taskError: TaskError = {
         code: 'TASK_RUNTIME_HARD_ERROR',
-        message: PRODUCTION_MESSAGE,
+        message: UNPARSEABLE_RATE_LIMIT_MESSAGE,
       };
 
       const mockGenerate = vi.fn().mockResolvedValue(

--- a/apps/code-agent/src/__tests__/domain/utils/cooloffResetParser.test.ts
+++ b/apps/code-agent/src/__tests__/domain/utils/cooloffResetParser.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+import { parseCooloffResetTime } from '../../../domain/utils/cooloffResetParser.js';
+
+describe('parseCooloffResetTime', () => {
+  it('parses Codex try-again AM/PM times as UTC', () => {
+    const result = parseCooloffResetTime({
+      text: "Codex error: You've hit your usage limit. Visit settings or try again at 6:14 PM.",
+      now: new Date('2026-05-05T17:44:20.623Z'),
+    });
+
+    expect(result).not.toBeNull();
+    if (result === null) return;
+    expect(result.notBeforeAt.toISOString()).toBe('2026-05-05T18:14:00.000Z');
+    expect(result.timezone).toBe('UTC');
+    expect(result.sourceText).toBe('try again at 6:14 PM');
+  });
+
+  it('parses Codex 24-hour try-again times as UTC', () => {
+    const result = parseCooloffResetTime({
+      text: 'Codex error: try again at 18:14.',
+      now: new Date('2026-05-05T17:44:20.623Z'),
+    });
+
+    expect(result).not.toBeNull();
+    if (result === null) return;
+    expect(result.notBeforeAt.toISOString()).toBe('2026-05-05T18:14:00.000Z');
+    expect(result.timezone).toBe('UTC');
+    expect(result.sourceText).toBe('try again at 18:14');
+  });
+
+  it('normalizes explicit GMT try-again times to UTC', () => {
+    const result = parseCooloffResetTime({
+      text: 'Codex error: try again at 18:14 GMT.',
+      now: new Date('2026-05-05T17:44:20.623Z'),
+    });
+
+    expect(result).not.toBeNull();
+    if (result === null) return;
+    expect(result.notBeforeAt.toISOString()).toBe('2026-05-05T18:14:00.000Z');
+    expect(result.timezone).toBe('UTC');
+  });
+
+  it('handles 12 AM and 12 PM boundaries', () => {
+    const midnight = parseCooloffResetTime({
+      text: 'Codex error: try again at 12:00 AM.',
+      now: new Date('2026-05-05T23:00:00.000Z'),
+    });
+    const noon = parseCooloffResetTime({
+      text: 'Codex error: try again at 12:00 PM.',
+      now: new Date('2026-05-05T11:00:00.000Z'),
+    });
+
+    expect(midnight?.notBeforeAt.toISOString()).toBe('2026-05-06T00:00:00.000Z');
+    expect(noon?.notBeforeAt.toISOString()).toBe('2026-05-05T12:00:00.000Z');
+  });
+
+  it('rejects invalid AM/PM hours', () => {
+    expect(
+      parseCooloffResetTime({
+        text: 'Codex error: try again at 13:14 PM.',
+        now: new Date('2026-05-05T17:44:20.623Z'),
+      })
+    ).toBeNull();
+  });
+
+  it('rolls past same-day Codex times to the next UTC day when still within 24 hours', () => {
+    const result = parseCooloffResetTime({
+      text: 'Codex error: try again at 6:14 PM.',
+      now: new Date('2026-05-05T18:14:01.000Z'),
+    });
+
+    expect(result).not.toBeNull();
+    if (result === null) return;
+    expect(result.notBeforeAt.toISOString()).toBe('2026-05-06T18:14:00.000Z');
+  });
+
+  it('parses explicit Claude UTC reset times', () => {
+    const result = parseCooloffResetTime({
+      text: "Claude error: You've hit your limit · resets 10pm (UTC)",
+      now: new Date('2026-04-23T12:00:00.000Z'),
+    });
+
+    expect(result).not.toBeNull();
+    if (result === null) return;
+    expect(result.notBeforeAt.toISOString()).toBe('2026-04-23T22:00:00.000Z');
+    expect(result.timezone).toBe('UTC');
+    expect(result.sourceText).toBe('resets 10pm (UTC)');
+  });
+
+  it('parses singular explicit GMT reset times', () => {
+    const result = parseCooloffResetTime({
+      text: 'Claude error: limit reset 9am GMT',
+      now: new Date('2026-04-23T08:00:00.000Z'),
+    });
+
+    expect(result).not.toBeNull();
+    if (result === null) return;
+    expect(result.notBeforeAt.toISOString()).toBe('2026-04-23T09:00:00.000Z');
+    expect(result.timezone).toBe('UTC');
+    expect(result.sourceText).toBe('reset 9am GMT');
+  });
+
+  it('rejects invalid explicit reset hours', () => {
+    expect(
+      parseCooloffResetTime({
+        text: 'Claude error: limit resets 25 UTC',
+        now: new Date('2026-04-23T08:00:00.000Z'),
+      })
+    ).toBeNull();
+  });
+
+  it('returns null when no known reset wording is present', () => {
+    expect(
+      parseCooloffResetTime({
+        text: 'TASK_RUNTIME_HARD_ERROR: usage limit reached',
+        now: new Date('2026-05-05T17:44:20.623Z'),
+      })
+    ).toBeNull();
+  });
+});

--- a/apps/code-agent/src/domain/models/codeTask.ts
+++ b/apps/code-agent/src/domain/models/codeTask.ts
@@ -149,7 +149,7 @@ export interface DispatchSchedule {
   /** Raw text we parsed the schedule from (e.g. Claude usage-limit message). */
   sourceText?: string;
   /** How notBeforeAt was derived. */
-  derivedBy: 'user_input' | 'llm' | 'fallback';
+  derivedBy: 'user_input' | 'parser' | 'llm' | 'fallback';
   /** Task that produced this schedule (set for retry_cooloff chains). */
   derivedFromTaskId?: string;
 }

--- a/apps/code-agent/src/domain/prompts/cooloffRetryPrompt.ts
+++ b/apps/code-agent/src/domain/prompts/cooloffRetryPrompt.ts
@@ -1,5 +1,5 @@
 /**
- * Prompt for extracting Claude usage-limit reset times from failed tasks.
+ * Prompt for extracting usage-limit reset times from failed tasks.
  *
  * A single user-scoped LLM call (not an agent with tools) that reads the
  * error message and recent log lines to extract exactly one absolute UTC
@@ -11,7 +11,7 @@
 
 import type { PromptBuilder } from '@intexuraos/llm-prompts';
 
-export const COOLOFF_RETRY_PROMPT_VERSION = '1.0.0';
+export const COOLOFF_RETRY_PROMPT_VERSION = '1.1.0';
 
 const MAX_LOG_LINES = 20;
 
@@ -36,8 +36,8 @@ export interface CooloffParsedResponse {
 export const cooloffRetryPrompt: PromptBuilder<CooloffPromptInput> = {
   name: 'cooloff-retry',
   description:
-    'Extracts an absolute UTC retry timestamp from Claude usage-limit failure messages',
-  version: '1.0.0',
+    'Extracts an absolute UTC retry timestamp from usage-limit failure messages',
+  version: '1.1.0',
 
   build(input: CooloffPromptInput): string {
     const logLines = input.recentLogLines.slice(-MAX_LOG_LINES);
@@ -50,7 +50,7 @@ export const cooloffRetryPrompt: PromptBuilder<CooloffPromptInput> = {
         ? `- **User timezone:** ${input.userTimezone} (use this to disambiguate reset strings that lack an explicit timezone).`
         : `- **User timezone:** (not provided — if the reset string is ambiguous and has no explicit timezone, assume UTC).`;
 
-    return `You are a cooldown parser for Claude usage-limit failures. A task failed because the user hit a Claude API usage limit, and the error message usually contains the next reset time (for example: "You've hit your limit · resets 10pm (UTC)"). Your job is to extract exactly ONE absolute UTC timestamp for when the task can be retried.
+    return `You are a cooldown parser for usage-limit failures. A task failed because the user hit a runtime usage limit, and the error message may contain the next reset time (for example: Claude: "You've hit your limit · resets 10pm (UTC)" or Codex: "try again at 6:14 PM"). Your job is to extract exactly ONE absolute UTC timestamp for when the task can be retried.
 
 ## Anchor
 - **Now (UTC):** ${nowIso}
@@ -66,7 +66,7 @@ ${logSection}
 \`\`\`
 
 ## Your Task
-1. Find the reset time mentioned in the error or logs (e.g. "resets 10pm (UTC)", "retry after 3:00 PM PST").
+1. Find the reset time mentioned in the error or logs (e.g. "resets 10pm (UTC)", "try again at 6:14 PM", "retry after 3:00 PM PST").
 2. Convert it to an absolute UTC ISO-8601 timestamp that is in the FUTURE relative to the Now anchor above, and no more than 24 hours from now.
 3. If the reset string has no explicit timezone, use the user timezone above; if none provided, assume UTC.
 4. Pick the single next occurrence — do not return past times or times more than a day away.
@@ -77,7 +77,7 @@ Respond with ONLY a JSON object and nothing else:
   "notBeforeAt": "2026-04-23T22:00:00Z",
   "timezone": "UTC",
   "sourceText": "resets 10pm (UTC)",
-  "reason": "Claude usage limit resets at 10:00 PM UTC"
+  "reason": "Usage limit resets at 10:00 PM UTC"
 }
 \`\`\`
 

--- a/apps/code-agent/src/domain/usecases/autoRetryTask.ts
+++ b/apps/code-agent/src/domain/usecases/autoRetryTask.ts
@@ -28,13 +28,13 @@ export interface AutoRetryTaskRequest {
    * Optional cooloff dispatch schedule (INT-1463). Only set when the failure
    * verdict is `retry_after_cooloff`; the retry task will be queued but
    * ineligible for dispatch until `notBeforeAt`. Fallback-derived schedules
-   * use a fixed 60-minute wait; LLM-derived ones use the parsed reset time.
+   * use a fixed 60-minute wait; parser/LLM-derived ones use the parsed reset time.
    */
   cooloffSchedule?: {
     notBeforeAt: Date;
     timezone?: string;
     sourceText?: string;
-    derivedBy: 'llm' | 'fallback';
+    derivedBy: 'parser' | 'llm' | 'fallback';
   };
 }
 

--- a/apps/code-agent/src/domain/usecases/drainTaskQueue.ts
+++ b/apps/code-agent/src/domain/usecases/drainTaskQueue.ts
@@ -192,16 +192,24 @@ export async function drainTaskQueue(
 
     // Find first dispatchable candidate with per-PR guard + TTL check
     let task: CodeTask | null = null;
+    let futureScheduledCount = 0;
+    let activeResourceBlockedCount = 0;
+    let nextEligibleAt: Date | undefined;
     for (const candidate of roundRobinCandidates) {
       // INT-1463: schedule-aware skip — if the task is not yet eligible for dispatch,
       // skip BEFORE the PR-lock check and BEFORE the TTL check. Do not touch queuedAt
       // (TTL must remain independent of the schedule wait — see notBeforeAt branch below).
       const notBeforeAt = candidate.dispatchSchedule?.notBeforeAt;
       if (notBeforeAt !== undefined && notBeforeAt.toMillis() > Date.now()) {
+        futureScheduledCount += 1;
+        const notBeforeDate = notBeforeAt.toDate();
+        if (nextEligibleAt === undefined || notBeforeDate.getTime() < nextEligibleAt.getTime()) {
+          nextEligibleAt = notBeforeDate;
+        }
         logger.info(
           {
             taskId: candidate.id,
-            notBeforeAt: notBeforeAt.toDate().toISOString(),
+            notBeforeAt: notBeforeDate.toISOString(),
             source: candidate.dispatchSchedule?.source,
           },
           'Skipping future-scheduled task — not yet eligible',
@@ -213,6 +221,7 @@ export async function drainTaskQueue(
       if (candidate.prNumber !== undefined) {
         const prActiveResult = await codeTaskRepo.hasDispatchedOrRunningForPR(candidate.repository, candidate.prNumber);
         if (prActiveResult.ok && prActiveResult.value.hasActive) {
+          activeResourceBlockedCount += 1;
           logger.info({
             taskId: candidate.id,
             repository: candidate.repository,
@@ -242,6 +251,7 @@ export async function drainTaskQueue(
           candidate.linearIssueId,
         );
         if (siblingResult.ok && siblingResult.value.hasActive) {
+          activeResourceBlockedCount += 1;
           logger.info(
             {
               taskId: candidate.id,
@@ -302,7 +312,25 @@ export async function drainTaskQueue(
     }
 
     if (task === null) {
-      logger.info({ candidateCount: roundRobinCandidates.length }, 'All queued tasks blocked by active resources');
+      if (futureScheduledCount === roundRobinCandidates.length && futureScheduledCount > 0) {
+        logger.info(
+          {
+            candidateCount: roundRobinCandidates.length,
+            futureScheduledCount,
+            ...(nextEligibleAt !== undefined && { nextEligibleAt: nextEligibleAt.toISOString() }),
+          },
+          'All queued tasks are future-scheduled and not yet eligible'
+        );
+      } else {
+        logger.info(
+          {
+            candidateCount: roundRobinCandidates.length,
+            futureScheduledCount,
+            activeResourceBlockedCount,
+          },
+          'All queued tasks blocked by active resources'
+        );
+      }
       return ok({ action: 'still_busy' });
     }
 

--- a/apps/code-agent/src/domain/usecases/triageFailedTask.ts
+++ b/apps/code-agent/src/domain/usecases/triageFailedTask.ts
@@ -21,6 +21,7 @@ import {
   cooloffRetryPrompt,
   parseCooloffResponse,
 } from '../prompts/cooloffRetryPrompt.js';
+import { parseCooloffResetTime } from '../utils/cooloffResetParser.js';
 
 export type TriageAction = 'retried' | 'retried_after_cooloff' | 'permanent_failure';
 
@@ -206,6 +207,25 @@ async function resolveCooloffSchedule(
     sourceText: taskError.message.slice(0, 200),
     ...(userTimezone !== undefined && { timezone: userTimezone }),
   };
+
+  const deterministic = parseCooloffResetTime({ text: taskError.message, now });
+  if (deterministic !== null) {
+    logger.info(
+      {
+        taskId: task.id,
+        notBeforeAt: deterministic.notBeforeAt.toISOString(),
+        timezone: deterministic.timezone,
+        sourceText: deterministic.sourceText,
+      },
+      'Cooloff reset time extracted deterministically'
+    );
+    return {
+      notBeforeAt: deterministic.notBeforeAt,
+      derivedBy: 'parser' as const,
+      timezone: deterministic.timezone,
+      sourceText: deterministic.sourceText,
+    };
+  }
 
   // Resolve LLM client.
   const llmClientResult = await userServiceClient.getLlmClient(task.userId);

--- a/apps/code-agent/src/domain/utils/cooloffResetParser.ts
+++ b/apps/code-agent/src/domain/utils/cooloffResetParser.ts
@@ -1,0 +1,154 @@
+const MAX_FUTURE_MS = 24 * 60 * 60 * 1000;
+
+export interface CooloffResetParseInput {
+  text: string;
+  now: Date;
+}
+
+export interface CooloffResetParseResult {
+  notBeforeAt: Date;
+  timezone: string;
+  sourceText: string;
+  reason: string;
+}
+
+interface TimeParts {
+  hour: number;
+  minute: number;
+  timezone: string;
+  sourceText: string;
+  reasonPrefix: string;
+}
+
+const AM_PM_PATTERN = String.raw`((?:a|p)\.?m\.?)`;
+
+function normalizeSourceText(value: string): string {
+  return value.trim().replace(/[.,;:]+$/u, '');
+}
+
+function normalizeTimezone(value: string | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  const upper = value.toUpperCase();
+  return upper === 'GMT' ? 'UTC' : upper;
+}
+
+function toHour24(hourRaw: string, meridiemRaw: string | undefined): number | null {
+  const hour = Number.parseInt(hourRaw, 10);
+
+  if (meridiemRaw === undefined) {
+    /* v8 ignore start -- upstream: defensive 24h bound retained for explicit reset parsing; parser-level null behavior is tested @preserve */
+    if (hour > 23) return null;
+    /* v8 ignore stop @preserve */
+    return hour;
+  }
+
+  if (hour < 1 || hour > 12) return null;
+  const meridiem = meridiemRaw.toLowerCase().replaceAll('.', '');
+  if (meridiem === 'am') {
+    return hour === 12 ? 0 : hour;
+  }
+  return hour === 12 ? 12 : hour + 12;
+}
+
+function buildNextUtcInstant(now: Date, hour: number, minute: number): Date | null {
+  const candidate = new Date(Date.UTC(
+    now.getUTCFullYear(),
+    now.getUTCMonth(),
+    now.getUTCDate(),
+    hour,
+    minute,
+    0,
+    0,
+  ));
+  if (candidate.getTime() <= now.getTime()) {
+    candidate.setUTCDate(candidate.getUTCDate() + 1);
+  }
+  /* v8 ignore start -- upstream: UTC same-clock next occurrence is never more than 24h away; guard retained for policy symmetry @preserve */
+  if (candidate.getTime() - now.getTime() > MAX_FUTURE_MS) {
+    return null;
+  }
+  /* v8 ignore stop @preserve */
+  return candidate;
+}
+
+function parseMinute(minuteRaw: string | undefined): number {
+  if (minuteRaw === undefined) return 0;
+  return Number.parseInt(minuteRaw, 10);
+}
+
+function parseCodexTryAgain(text: string): TimeParts | null {
+  const amPmMatch = new RegExp(String.raw`\btry again at\s+(\d{1,2})(?::(\d{2}))?\s*${AM_PM_PATTERN}\b`, 'iu')
+    .exec(text);
+  if (amPmMatch !== null) {
+    const hour = toHour24(amPmMatch[1] as string, amPmMatch[3]);
+    const minute = parseMinute(amPmMatch[2]);
+    if (hour === null || !Number.isInteger(minute) || minute < 0 || minute > 59) {
+      return null;
+    }
+    return {
+      hour,
+      minute,
+      timezone: 'UTC',
+      sourceText: normalizeSourceText(amPmMatch[0]),
+      reasonPrefix: 'Codex usage limit reset time',
+    };
+  }
+
+  const twentyFourHourMatch = /\btry again at\s+([01]?\d|2[0-3]):([0-5]\d)(?:\s*(UTC|GMT))?\b/iu.exec(text);
+  if (twentyFourHourMatch === null) {
+    return null;
+  }
+
+  return {
+    hour: Number.parseInt(twentyFourHourMatch[1] as string, 10),
+    minute: Number.parseInt(twentyFourHourMatch[2] as string, 10),
+    timezone: normalizeTimezone(twentyFourHourMatch[3]) ?? 'UTC',
+    sourceText: normalizeSourceText(twentyFourHourMatch[0]),
+    reasonPrefix: 'Codex usage limit reset time',
+  };
+}
+
+function parseExplicitUtcReset(text: string): TimeParts | null {
+  const resetMatch = new RegExp(
+    String.raw`\bresets?\s+(\d{1,2})(?::(\d{2}))?\s*(?:${AM_PM_PATTERN})?\s*(?:\((UTC|GMT)\)|(UTC|GMT)\b)`,
+    'iu',
+  ).exec(text);
+  if (resetMatch === null) {
+    return null;
+  }
+
+  const hour = toHour24(resetMatch[1] as string, resetMatch[3]);
+  const minute = parseMinute(resetMatch[2]);
+  if (hour === null || !Number.isInteger(minute) || minute < 0 || minute > 59) {
+    return null;
+  }
+
+  return {
+    hour,
+    minute,
+    timezone: normalizeTimezone((resetMatch[4] ?? resetMatch[5]) as string) as string,
+    sourceText: normalizeSourceText(resetMatch[0]),
+    reasonPrefix: 'Usage limit reset time',
+  };
+}
+
+export function parseCooloffResetTime(input: CooloffResetParseInput): CooloffResetParseResult | null {
+  const parsed = parseCodexTryAgain(input.text) ?? parseExplicitUtcReset(input.text);
+  if (parsed === null) {
+    return null;
+  }
+
+  const notBeforeAt = buildNextUtcInstant(input.now, parsed.hour, parsed.minute);
+  /* v8 ignore start -- upstream: buildNextUtcInstant only returns null for the retained >24h policy guard @preserve */
+  if (notBeforeAt === null) {
+    return null;
+  }
+  /* v8 ignore stop @preserve */
+
+  return {
+    notBeforeAt,
+    timezone: parsed.timezone,
+    sourceText: parsed.sourceText,
+    reason: `${parsed.reasonPrefix} parsed as ${notBeforeAt.toISOString()}`,
+  };
+}

--- a/workers/orchestrator/src/__tests__/task-dispatcher.test.ts
+++ b/workers/orchestrator/src/__tests__/task-dispatcher.test.ts
@@ -2542,6 +2542,13 @@ describe('TaskDispatcher', () => {
       expect(failedPayload?.error?.message).toMatch(
         /429|rate limit|hit your limit|usage limit|limit · resets/i
       );
+      const appendedLogs = vi
+        .mocked(mockLogForwarder.appendChunk)
+        .mock.calls.map((call) => String(call[1]))
+        .join('\n');
+      expect(appendedLogs).toContain('Task failed: TASK_RUNTIME_HARD_ERROR');
+      expect(appendedLogs).toContain('hit your limit');
+      expect(appendedLogs).toContain('No EXECUTION_AGENT_FINAL');
     });
 
     it('INT-1457: normal-path generic runtime error + exit 1 → TASK_RUNTIME_HARD_ERROR', async () => {

--- a/workers/orchestrator/src/services/task-dispatcher/completion-pipeline.ts
+++ b/workers/orchestrator/src/services/task-dispatcher/completion-pipeline.ts
@@ -1202,6 +1202,12 @@ export class CompletionPipeline {
       task.taskId,
       `Finalizing task: status=${finalStatus} hasResult=${String(payload.result !== undefined)} hasError=${String(payload.error !== undefined)}`
     );
+    if (finalStatus === 'failed' && payload.error !== undefined) {
+      ctx.appendOrchestratorTaskLog(
+        task.taskId,
+        `Task failed: ${payload.error.code} — ${payload.error.message}`
+      );
+    }
 
     try {
       await ctx.logForwarder.flush(task.taskId);


### PR DESCRIPTION
## Summary

Fixes the Codex quota retry incident path by making reset-time extraction deterministic before the existing LLM/fallback path.

## Root Cause

Codex usage-limit failures were classified correctly as `retry_after_cooloff`, but reset-time extraction rejected the Codex wording `try again at 6:14 PM` and used the hard-coded `now + 60m` fallback. Queue drain logs then made future-scheduled retries look like active-resource blocking, and task transcripts did not show the final combined runtime error.

## Changes

- Add a deterministic cooloff reset parser for Codex `try again at ...` messages and explicit UTC/GMT reset messages.
- Persist parser-derived retry schedules as `derivedBy: parser` for auditability.
- Keep the existing LLM parser and fallback path for unparseable rate-limit messages.
- Make the cooloff prompt runtime-neutral and bump its version to `1.1.0`.
- Distinguish all-future-scheduled queue candidates from active-resource blocking in drain logs.
- Append final failed task errors into the orchestrator log stream so transcripts show the quota reason.

## Validation

- `pnpm vitest run apps/code-agent/src/__tests__/domain/utils/cooloffResetParser.test.ts apps/code-agent/src/__tests__/domain/useCases/triageFailedTask.test.ts apps/code-agent/src/__tests__/domain/prompts/cooloffRetryPrompt.test.ts apps/code-agent/src/__tests__/domain/useCases/drainTaskQueue.test.ts apps/code-agent/src/__tests__/domain/utils/classifyFailure.test.ts apps/code-agent/src/__tests__/domain/useCases/autoRetryTask.test.ts workers/orchestrator/src/__tests__/task-dispatcher.test.ts`
- `pnpm --filter @intexuraos/code-agent typecheck`
- `pnpm --filter @intexuraos/orchestrator typecheck`
- `pnpm --filter @intexuraos/code-agent lint:local`
- `pnpm --filter @intexuraos/orchestrator lint:local`
- `pnpm run ci:tracked`