### PR TITLE
[INT-1612] [codex] Fix code-worker pnpm bootstrap failure

### DIFF
--- a/docker/code-worker/entrypoint.sh
+++ b/docker/code-worker/entrypoint.sh
@@ -510,9 +510,11 @@ emit_bootstrap_evidence
 # invocation. No background watcher needed.
 
 # ------------------------------------------------------------------------------
-# Configure pnpm to use persistent store (shared volume across containers)
+# Shared store path is already baked into /etc/npmrc and the restored ~/.npmrc.
+# Avoid pnpm global config writes here: newer pnpm releases fail fast when the
+# default global bin dir is not present on PATH, which kills bootstrap before
+# the worker reaches managed mode.
 # ------------------------------------------------------------------------------
-pnpm config set store-dir /home/claude/pnpm-store --global
 
 # ------------------------------------------------------------------------------
 # Install dependencies (Linux-native node_modules via shared pnpm store)

--- a/workers/orchestrator/src/services/isolation/__tests__/worker-image.test.ts
+++ b/workers/orchestrator/src/services/isolation/__tests__/worker-image.test.ts
@@ -76,6 +76,16 @@ describe('code-worker image Codex skill bootstrap', () => {
     expect(entrypoint).toContain('return "$raw_exit"');
   });
 
+  it('relies on the staged npmrc for pnpm store configuration instead of global config writes', () => {
+    const dockerfile = readFileSync(dockerfilePath, 'utf8');
+    const entrypoint = readFileSync(entrypointPath, 'utf8');
+
+    expect(dockerfile).toContain(
+      'COPY --chown=claude:claude docker/code-worker/.npmrc /opt/claude-defaults/.npmrc'
+    );
+    expect(entrypoint).not.toContain('pnpm config set store-dir /home/claude/pnpm-store --global');
+  });
+
   it('includes a codex stub in the test Dockerfile for E2E Codex-path coverage', () => {
     const dockerfileTest = readFileSync(dockerfileTestPath, 'utf8');
 


### PR DESCRIPTION
## What changed

- removed the redundant `pnpm config set store-dir /home/claude/pnpm-store --global` bootstrap step from the code-worker entrypoint
- added a regression test that locks in the intended contract: the worker image must rely on the staged `.npmrc` for the shared pnpm store instead of writing global pnpm config during startup

## Why this changed

Code-task workers on `home-dev` were failing during container bootstrap before managed mode came up. The worker image had moved onto a pnpm version that treats the missing global bin dir on `PATH` as a fatal error for `pnpm config set --global`, so the container exited before the orchestrator could run `/entrypoint.sh run-attempt`.

## Impact

- code-worker containers no longer die during bootstrap on the pnpm global-config step
- orchestrator-managed Codex tasks can reach readiness and start attempts again
- the regression test guards against reintroducing the same bootstrap failure path

## Root cause

The worker bootstrap path already had `store-dir=/home/claude/pnpm-store` baked into `docker/code-worker/.npmrc` and `/etc/npmrc`. The extra global pnpm config write was unnecessary, and with the current pnpm behavior it became fatal when `/home/claude/.local/share/pnpm/bin` was not on `PATH`.

## Validation

- `pnpm --filter orchestrator exec vitest run src/services/isolation/__tests__/worker-image.test.ts`
- `pnpm run ci:tracked`
