### PR TITLE
[INT-1613] [codex] Repair code task group listing

### DIFF
--- a/apps/code-agent/src/__tests__/domain/useCases/createTaskForPR.test.ts
+++ b/apps/code-agent/src/__tests__/domain/useCases/createTaskForPR.test.ts
@@ -86,6 +86,9 @@ function createMockCodeTaskRepo(): CodeTaskRepository {
     async findByPR(): ReturnType<CodeTaskRepository['findByPR']> {
       return ok(null);
     },
+    async findRecentTasksByPR(): ReturnType<CodeTaskRepository['findRecentTasksByPR']> {
+      return ok([]);
+    },
     async findActiveReviewForPR(): ReturnType<CodeTaskRepository['findActiveReviewForPR']> {
       return ok(null);
     },

--- a/apps/code-agent/src/__tests__/domain/utils/resolveCompletedTaskStatus.test.ts
+++ b/apps/code-agent/src/__tests__/domain/utils/resolveCompletedTaskStatus.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { resolveCompletedTaskStatus } from '../../../domain/utils/resolveCompletedTaskStatus.js';
+
+describe('resolveCompletedTaskStatus', () => {
+  it.each([
+    ['planning', 'planned'],
+    ['review', 'reviewed'],
+    ['execution', 'implemented'],
+    ['remediation', 'implemented'],
+    ['pull_request', 'implemented'],
+  ] as const)('maps %s to %s', (agentType, expectedStatus) => {
+    expect(resolveCompletedTaskStatus(agentType)).toBe(expectedStatus);
+  });
+});

--- a/apps/code-agent/src/__tests__/fakes/fakeTaskGroupSummaryRepository.ts
+++ b/apps/code-agent/src/__tests__/fakes/fakeTaskGroupSummaryRepository.ts
@@ -301,10 +301,14 @@ export function createFakeTaskGroupSummaryRepository(): FakeTaskGroupSummaryRepo
       return ok({ summaries: page, ...(nextCursor !== undefined && { nextCursor }) });
     },
 
-    async recomputeGroupFromTasks(userId: string, groupKey: string, tasks: CodeTask[]): Promise<void> {
+    async recomputeGroupFromTasks(
+      userId: string,
+      groupKey: string,
+      tasks: CodeTask[],
+    ): Promise<Result<void, GroupSummaryError>> {
       if (tasks.length === 0) {
         removeSummary(userId, groupKey);
-        return;
+        return ok(undefined);
       }
       const current = summaries.get(summaryKey(userId, groupKey));
       const next = computeSummaryFromTasks(userId, groupKey, tasks);
@@ -321,6 +325,7 @@ export function createFakeTaskGroupSummaryRepository(): FakeTaskGroupSummaryRepo
         next.aggregateStatus = deriveAggregateStatusFromSummary(next);
       }
       upsertSummary(next);
+      return ok(undefined);
     },
 
     async recomputeWithLabels(

--- a/apps/code-agent/src/__tests__/infra/firestore/taskGroupSummary/serializer.test.ts
+++ b/apps/code-agent/src/__tests__/infra/firestore/taskGroupSummary/serializer.test.ts
@@ -432,6 +432,21 @@ describe('serializer: applyIncrementalCreateUpdate', () => {
     );
     expect(updated.mostRecentDispatchedAt?.toMillis()).toBe(100);
   });
+
+  it('repairs missing linear sort fields on legacy summaries', () => {
+    const legacy = { ...base, linearIssueId: 'INT-1606', groupKey: 'INT-1606' } as TaskGroupSummary;
+    delete (legacy as unknown as Record<string, unknown>)['linearIssueNumber'];
+    delete (legacy as unknown as Record<string, unknown>)['linearIssueSortKey'];
+
+    const updated = applyIncrementalCreateUpdate(
+      legacy,
+      makeTask({ status: 'planned', linearIssueId: 'INT-1606', createdAt: t2, updatedAt: t2 }),
+      t2,
+    );
+
+    expect(updated.linearIssueNumber).toBe(1606);
+    expect(updated.linearIssueSortKey).toBe(1606);
+  });
 });
 
 describe('serializer: applyStatusChangeUpdate', () => {
@@ -527,6 +542,22 @@ describe('serializer: applyStatusChangeUpdate', () => {
     );
     expect(updated.mostRecentDispatchedAt?.toMillis()).toBe(100);
   });
+
+  it('repairs missing linear sort fields on legacy summaries during status change', () => {
+    const legacy = { ...base, linearIssueId: 'INT-1606', groupKey: 'INT-1606' } as TaskGroupSummary;
+    delete (legacy as unknown as Record<string, unknown>)['linearIssueNumber'];
+    delete (legacy as unknown as Record<string, unknown>)['linearIssueSortKey'];
+
+    const { updated } = applyStatusChangeUpdate(
+      legacy,
+      makeTask({ status: 'running', linearIssueId: 'INT-1606' }),
+      makeTask({ status: 'archived', linearIssueId: 'INT-1606', updatedAt: t2 }),
+      t2,
+    );
+
+    expect(updated.linearIssueNumber).toBe(1606);
+    expect(updated.linearIssueSortKey).toBe(1606);
+  });
 });
 
 describe('serializer: applyDeleteUpdate', () => {
@@ -557,6 +588,22 @@ describe('serializer: applyDeleteUpdate', () => {
   it('does not decrement for archived task', () => {
     const { updated } = applyDeleteUpdate(base, makeTask({ status: 'archived' }), now);
     expect(updated.taskCount).toBe(2);
+  });
+
+  it('repairs missing linear sort fields on legacy summaries during delete', () => {
+    const legacy = { ...base, linearIssueId: 'INT-1606', groupKey: 'INT-1606' } as TaskGroupSummary;
+    delete (legacy as unknown as Record<string, unknown>)['linearIssueNumber'];
+    delete (legacy as unknown as Record<string, unknown>)['linearIssueSortKey'];
+
+    const { updated, shouldDelete } = applyDeleteUpdate(
+      legacy,
+      makeTask({ status: 'planned', linearIssueId: 'INT-1606' }),
+      now,
+    );
+
+    expect(shouldDelete).toBe(false);
+    expect(updated.linearIssueNumber).toBe(1606);
+    expect(updated.linearIssueSortKey).toBe(1606);
   });
 });
 

--- a/apps/code-agent/src/__tests__/infra/firestore/taskGroupSummaryFirestoreRepository.test.ts
+++ b/apps/code-agent/src/__tests__/infra/firestore/taskGroupSummaryFirestoreRepository.test.ts
@@ -764,6 +764,61 @@ describe('taskGroupSummaryFirestoreRepository', () => {
       expect(countsAfterRevive.get('archived')).toBe(0);
       expect(countsAfterRevive.get('totalGroups')).toBe(1);
     });
+
+    it('repairs missing linear sort fields when a legacy summary receives a new task', async () => {
+      const repo = createTaskGroupSummaryFirestoreRepository({
+        firestore: fakeFirestore as unknown as Firestore,
+        logger,
+      });
+      const now = Timestamp.now();
+
+      await fakeFirestore.collection('task_group_summaries').doc('user-legacy_INT-1606').set({
+        userId: 'user-legacy',
+        linearIssueId: 'INT-1606',
+        groupKey: 'INT-1606',
+        taskCount: 1,
+        activeTaskCount: 0,
+        latestTaskStatus: 'planned',
+        latestTaskUpdatedAt: now,
+        agentTypesPresent: ['planning'],
+        hasCompletedPlanning: true,
+        hasCompletedExecution: false,
+        hasCompletedExecutionAgent: false,
+        hasImplementationTaskId: false,
+        hasPrUrl: false,
+        prNumber: null,
+        latestReviewNeedsRemediation: null,
+        oldestTaskCreatedAt: now,
+        mostRecentDispatchedAt: null,
+        aggregateStatus: 'needs-action',
+        updatedAt: now,
+      });
+
+      await fakeFirestore.collection('user_group_counts').doc('user-legacy').set({
+        userId: 'user-legacy',
+        active: 0,
+        needsAction: 1,
+        done: 0,
+        failed: 0,
+        archived: 0,
+        totalGroups: 1,
+        updatedAt: now,
+      });
+
+      await repo.updateAfterCreate(makeTask({
+        id: 'task-legacy-2',
+        userId: 'user-legacy',
+        linearIssueId: 'INT-1606',
+        status: 'implemented',
+        agentType: 'execution',
+        createdAt: now,
+        updatedAt: now,
+      }));
+
+      const doc = await fakeFirestore.collection('task_group_summaries').doc('user-legacy_INT-1606').get();
+      expect(doc.get('linearIssueNumber')).toBe(1606);
+      expect(doc.get('linearIssueSortKey')).toBe(1606);
+    });
   });
 
   describe('updateAfterStatusChange', () => {

--- a/apps/code-agent/src/__tests__/infra/repositories/codeTaskRepositoryWithGroupUpdates.test.ts
+++ b/apps/code-agent/src/__tests__/infra/repositories/codeTaskRepositoryWithGroupUpdates.test.ts
@@ -67,6 +67,7 @@ function createFakeInnerRepo(): CodeTaskRepository {
     findZombieTasks: vi.fn(),
     countByUserToday: vi.fn(),
     findByPR: vi.fn(),
+    findRecentTasksByPR: vi.fn(),
     findActiveReviewForPR: vi.fn(),
     hasDispatchedOrRunningForPR: vi.fn(),
     hasOtherDispatchedOrRunningForLinearIssue: vi.fn(),

--- a/apps/code-agent/src/__tests__/routes/code/issueGroups.test.ts
+++ b/apps/code-agent/src/__tests__/routes/code/issueGroups.test.ts
@@ -48,6 +48,11 @@ import type { TaskGroupSummaryRepository } from '../../../domain/ports/taskGroup
 import type { UserGroupCounts, TaskGroupSummary } from '../../../domain/models/taskGroupSummary.js';
 import { createFakeTaskGroupSummaryRepository } from '../../fakes/fakeTaskGroupSummaryRepository.js';
 import type { FakeTaskGroupSummaryRepository } from '../../fakes/fakeTaskGroupSummaryRepository.js';
+import { createTaskGroupSummaryFirestoreRepository } from '../../../infra/firestore/taskGroupSummaryFirestoreRepository.js';
+import {
+  createRepairArchivedOpenPrGroupsUseCase,
+  type RepairArchivedOpenPrGroupsDeps,
+} from '../../../domain/usecases/repairArchivedOpenPrGroups.js';
 
 function makeLinearAgentClient(): LinearAgentClient {
   const client: LinearAgentClient = {
@@ -95,7 +100,7 @@ function makeGroupSummaryRepo(overrides: Partial<TaskGroupSummaryRepository> = {
     updateAfterDelete: async (): Promise<void> => { return; },
     getUserGroupCounts: async (): ReturnType<TaskGroupSummaryRepository['getUserGroupCounts']> => ok(defaultCounts),
     listGroupSummaries: async (): ReturnType<TaskGroupSummaryRepository['listGroupSummaries']> => ok({ summaries: [] }),
-    recomputeGroupFromTasks: async (): Promise<void> => { return; },
+    recomputeGroupFromTasks: async (): ReturnType<TaskGroupSummaryRepository['recomputeGroupFromTasks']> => ok(undefined),
     recomputeWithLabels: async (): ReturnType<TaskGroupSummaryRepository['recomputeWithLabels']> => ok(undefined),
     setImportant: async (): ReturnType<TaskGroupSummaryRepository['setImportant']> => ok(undefined),
     ...overrides,
@@ -2348,6 +2353,165 @@ describe('GET /code/issue-groups', () => {
       };
       // Task is not a phantom (it exists), so done count stays at 1
       expect(body.data.counts['done']).toBe(1);
+    });
+
+    it('returns archived groups for archived linear-id queries when summary sort keys exist', async () => {
+      const summaryRepo = createTaskGroupSummaryFirestoreRepository({
+        firestore: fakeFirestore as unknown as Firestore,
+        logger,
+      });
+
+      async function createArchivedGroup(linearIssueId: string, traceId: string): Promise<void> {
+        const createResult = await codeTaskRepo.create(makeTaskInput({
+          linearIssueId,
+          traceId,
+          agentType: 'planning',
+        }));
+        expect(createResult.ok).toBe(true);
+        if (!createResult.ok) {
+          return;
+        }
+
+        await summaryRepo.updateAfterCreate(createResult.value);
+        const archivedResult = await codeTaskRepo.update(createResult.value.id, { status: 'archived' });
+        expect(archivedResult.ok).toBe(true);
+        if (!archivedResult.ok) {
+          return;
+        }
+        await summaryRepo.updateAfterStatusChange(createResult.value, archivedResult.value);
+      }
+
+      await createArchivedGroup('INT-1606', 'trace-archived-1606');
+      await createArchivedGroup('INT-1607', 'trace-archived-1607');
+
+      setServices(makeBaseServices({
+        groupSummaryRepo: summaryRepo as unknown as ReturnType<typeof makeGroupSummaryRepo>,
+      }));
+      await server.close();
+      server = await buildServer();
+
+      const response = await server.inject({
+        method: 'GET',
+        url: '/code/issue-groups?groupStatus=archived&sortBy=linear-id',
+        headers: { authorization: 'Bearer test-token' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body) as {
+        data: {
+          groups: { linearIssueId: string | null }[];
+          counts: Record<string, number>;
+          totalGroups: number;
+        };
+      };
+      expect(body.data.groups.map((group) => group.linearIssueId)).toEqual(['INT-1607', 'INT-1606']);
+      expect(body.data.counts['archived']).toBe(2);
+      expect(body.data.totalGroups).toBe(2);
+    });
+
+    it('shows a repaired open PR group in the default non-archived view', async () => {
+      const summaryRepo = createTaskGroupSummaryFirestoreRepository({
+        firestore: fakeFirestore as unknown as Firestore,
+        logger,
+      });
+
+      async function createArchivedTask(
+        traceId: string,
+        agentType: 'planning' | 'review',
+        updatedAt: Date,
+      ): Promise<void> {
+        const createResult = await codeTaskRepo.create(makeTaskInput({
+          linearIssueId: 'INT-1423',
+          traceId,
+          agentType,
+          repository: 'pbuchman/intexuraos',
+          baseBranch: 'development',
+          prNumber: 1903,
+        }));
+        expect(createResult.ok).toBe(true);
+        if (!createResult.ok) {
+          return;
+        }
+
+        await summaryRepo.updateAfterCreate(createResult.value);
+        const archivedResult = await codeTaskRepo.update(createResult.value.id, {
+          status: 'archived',
+          updatedAt,
+        });
+        expect(archivedResult.ok).toBe(true);
+        if (!archivedResult.ok) {
+          return;
+        }
+        await summaryRepo.updateAfterStatusChange(createResult.value, archivedResult.value);
+      }
+
+      await createArchivedTask('trace-int-1423-planning', 'planning', new Date('2026-05-07T08:00:00Z'));
+      await createArchivedTask('trace-int-1423-review', 'review', new Date('2026-05-07T09:00:00Z'));
+
+      const repairUseCase = createRepairArchivedOpenPrGroupsUseCase({
+        codeTaskRepo: codeTaskRepo as unknown as RepairArchivedOpenPrGroupsDeps['codeTaskRepo'],
+        gitHubPRSummaryRepo: {
+          findAllOpen: async () => ok([{
+            repository: 'pbuchman/intexuraos',
+            pullRequestNumber: 1903,
+            title: 'Open PR',
+            state: 'open',
+            mergedAt: null,
+            baseBranch: 'development',
+            authorLogin: 'pbuchman',
+            headBranch: 'worker/int-1423',
+            mergeConflictStatus: null,
+            lastConflictCheckedAt: null,
+            conflictEpisodeStartedAt: null,
+            conflictResolvedAt: null,
+            managedConflictCommentId: null,
+            managedConflictTaskId: null,
+            managedConflictTaskOwnerUserId: null,
+            lastActivityAt: new Date('2026-05-07T10:00:00Z'),
+            firstSeenAt: new Date('2026-05-07T10:00:00Z'),
+            lastReviewedCommitSha: null,
+            lastReviewNeedsRemediation: null,
+          }]),
+        },
+        groupSummaryRepo: summaryRepo,
+        logger,
+      });
+
+      const repairResult = await repairUseCase();
+      expect(repairResult.ok).toBe(true);
+
+      setServices(makeBaseServices({
+        groupSummaryRepo: summaryRepo as unknown as ReturnType<typeof makeGroupSummaryRepo>,
+      }));
+      await server.close();
+      server = await buildServer();
+
+      const response = await server.inject({
+        method: 'GET',
+        url: '/code/issue-groups',
+        headers: { authorization: 'Bearer test-token' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body) as {
+        data: {
+          groups: {
+            linearIssueId: string | null;
+            aggregateStatus: string;
+            tasks: { status: string }[];
+          }[];
+          counts: Record<string, number>;
+          totalGroups: number;
+        };
+      };
+      const repairedGroup = body.data.groups.find((group) => group.linearIssueId === 'INT-1423');
+      expect(repairedGroup).toBeDefined();
+      expect(repairedGroup?.aggregateStatus).toBe('done');
+      expect(repairedGroup?.tasks).toEqual([
+        expect.objectContaining({ status: 'reviewed' }),
+      ]);
+      expect(body.data.counts['done']).toBe(1);
+      expect(body.data.totalGroups).toBe(1);
     });
   });
 });

--- a/apps/code-agent/src/__tests__/routes/webhooks/github.test.ts
+++ b/apps/code-agent/src/__tests__/routes/webhooks/github.test.ts
@@ -132,6 +132,7 @@ describe('POST /webhooks/github', () => {
       findZombieTasks: vi.fn().mockResolvedValue(ok([])),
       countByUserToday: vi.fn().mockResolvedValue(ok(0)),
       findByPR: vi.fn().mockResolvedValue(ok(null)),
+      findRecentTasksByPR: vi.fn().mockResolvedValue(ok([])),
       findActiveReviewForPR: vi.fn().mockResolvedValue(ok(null)),
       hasDispatchedOrRunningForPR: vi.fn().mockResolvedValue(ok({ hasActive: false })),
       hasOtherDispatchedOrRunningForLinearIssue: vi.fn().mockResolvedValue(ok({ hasActive: false })),

--- a/apps/code-agent/src/__tests__/scripts/lib/backfillTaskGroupSummarySortKeys.test.ts
+++ b/apps/code-agent/src/__tests__/scripts/lib/backfillTaskGroupSummarySortKeys.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createFakeFirestore } from '@intexuraos/infra-firestore';
+import type { Firestore } from '@google-cloud/firestore';
+import { runTaskGroupSummarySortKeyBackfill } from '../../../scripts/lib/backfillTaskGroupSummarySortKeys.js';
+
+describe('backfillTaskGroupSummarySortKeys', () => {
+  it('updates only legacy summaries that need repaired sort-key fields', async () => {
+    const fakeFirestore = createFakeFirestore();
+    await fakeFirestore.collection('task_group_summaries').doc('user-1_INT-123').set({
+      userId: 'user-1',
+      groupKey: 'INT-123',
+      linearIssueId: 'INT-123',
+      linearIssueNumber: 999,
+      linearIssueSortKey: 123,
+    });
+    await fakeFirestore.collection('task_group_summaries').doc('user-1_INT-456').set({
+      userId: 'user-1',
+      groupKey: 'INT-456',
+      linearIssueId: 'INT-456',
+      linearIssueNumber: 456,
+      linearIssueSortKey: 999,
+    });
+    await fakeFirestore.collection('task_group_summaries').doc('user-1_INT-789').set({
+      userId: 'user-1',
+      groupKey: 'INT-789',
+      linearIssueId: 'INT-789',
+      linearIssueNumber: 789,
+      linearIssueSortKey: 789,
+    });
+
+    const result = await runTaskGroupSummarySortKeyBackfill({
+      firestore: fakeFirestore as unknown as Firestore,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.updated).toBe(2);
+    }
+
+    const repairedNumberDoc = await fakeFirestore.collection('task_group_summaries').doc('user-1_INT-123').get();
+    const repairedSortKeyDoc = await fakeFirestore.collection('task_group_summaries').doc('user-1_INT-456').get();
+    const untouchedDoc = await fakeFirestore.collection('task_group_summaries').doc('user-1_INT-789').get();
+
+    expect(repairedNumberDoc.get('linearIssueNumber')).toBe(123);
+    expect(repairedNumberDoc.get('linearIssueSortKey')).toBe(123);
+    expect(repairedSortKeyDoc.get('linearIssueNumber')).toBe(456);
+    expect(repairedSortKeyDoc.get('linearIssueSortKey')).toBe(456);
+    expect(untouchedDoc.get('linearIssueNumber')).toBe(789);
+    expect(untouchedDoc.get('linearIssueSortKey')).toBe(789);
+  });
+
+  it('supports dry-run mode and normalizes non-string linearIssueId values to null', async () => {
+    const fakeFirestore = createFakeFirestore();
+    await fakeFirestore.collection('task_group_summaries').doc('user-1_invalid').set({
+      userId: 'user-1',
+      groupKey: 'invalid',
+      linearIssueId: 123,
+      linearIssueNumber: 5,
+      linearIssueSortKey: 5,
+    });
+
+    const result = await runTaskGroupSummarySortKeyBackfill({
+      firestore: fakeFirestore as unknown as Firestore,
+      dryRun: true,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.updated).toBe(1);
+      expect(result.value.updates).toEqual([
+        expect.objectContaining({
+          linearIssueId: null,
+          after: {
+            linearIssueNumber: null,
+            linearIssueSortKey: Number.MAX_SAFE_INTEGER,
+          },
+        }),
+      ]);
+    }
+
+    const doc = await fakeFirestore.collection('task_group_summaries').doc('user-1_invalid').get();
+    expect(doc.get('linearIssueNumber')).toBe(5);
+    expect(doc.get('linearIssueSortKey')).toBe(5);
+  });
+
+  it('returns an error when the Firestore scan fails', async () => {
+    const firestore = {
+      collection: vi.fn(() => {
+        throw new Error('scan failed');
+      }),
+    } as unknown as Firestore;
+
+    const result = await runTaskGroupSummarySortKeyBackfill({ firestore });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toBe('scan failed');
+    }
+  });
+});

--- a/apps/code-agent/src/__tests__/scripts/lib/runIssueGroupListingRepair.test.ts
+++ b/apps/code-agent/src/__tests__/scripts/lib/runIssueGroupListingRepair.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi } from 'vitest';
+import { err, ok } from '@intexuraos/common-core';
+import type { RepairArchivedOpenPrGroupsResult } from '../../../domain/usecases/repairArchivedOpenPrGroups.js';
+import {
+  createRunIssueGroupListingRepair,
+  type TaskGroupSummarySortKeyBackfillResult,
+} from '../../../scripts/lib/runIssueGroupListingRepair.js';
+
+function makeBackfillResult(overrides: Partial<TaskGroupSummarySortKeyBackfillResult> = {}): TaskGroupSummarySortKeyBackfillResult {
+  return {
+    dryRun: false,
+    scanned: 783,
+    updated: 780,
+    updates: [],
+    ...overrides,
+  };
+}
+
+function makeArchivedRepairResult(
+  overrides: Partial<RepairArchivedOpenPrGroupsResult> = {},
+): RepairArchivedOpenPrGroupsResult {
+  return {
+    dryRun: false,
+    totalOpenPrsScanned: 12,
+    totalPrTasksFetched: 40,
+    groupsEvaluated: 9,
+    groupsRepaired: 2,
+    groupsSkippedAlreadyVisible: 4,
+    groupsSkippedScanLimit: 0,
+    prsSkippedScanLimit: 0,
+    tasksRestored: 2,
+    tasksFailed: 0,
+    summaryRecomputeFailures: 0,
+    durationMs: 1500,
+    warnings: [],
+    ...overrides,
+  };
+}
+
+describe('runIssueGroupListingRepair', () => {
+  it('runs the sort-key backfill before archived-open-PR repair and forwards flags', async () => {
+    const callOrder: string[] = [];
+    const backfillTaskGroupSummarySortKeys = vi.fn(async (input?: { dryRun?: boolean }) => {
+      callOrder.push(`backfill:${JSON.stringify(input ?? {})}`);
+      return ok(makeBackfillResult({ dryRun: true }));
+    });
+    const repairArchivedOpenPrGroups = vi.fn(async (input?: { dryRun?: boolean; scanLimit?: number }) => {
+      callOrder.push(`repair:${JSON.stringify(input ?? {})}`);
+      return ok(makeArchivedRepairResult({ dryRun: true }));
+    });
+
+    const runRepair = createRunIssueGroupListingRepair({
+      backfillTaskGroupSummarySortKeys,
+      repairArchivedOpenPrGroups,
+    });
+    const result = await runRepair({ dryRun: true, scanLimit: 75 });
+
+    expect(callOrder).toEqual([
+      'backfill:{"dryRun":true}',
+      'repair:{"dryRun":true,"scanLimit":75}',
+    ]);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toEqual({
+        dryRun: true,
+        sortKeyBackfill: makeBackfillResult({ dryRun: true }),
+        archivedOpenPrRepair: makeArchivedRepairResult({ dryRun: true }),
+      });
+    }
+  });
+
+  it('stops immediately when the sort-key backfill fails', async () => {
+    const backfillTaskGroupSummarySortKeys = vi.fn().mockResolvedValue(
+      err(new Error('backfill failed')),
+    );
+    const repairArchivedOpenPrGroups = vi.fn();
+
+    const runRepair = createRunIssueGroupListingRepair({
+      backfillTaskGroupSummarySortKeys,
+      repairArchivedOpenPrGroups,
+    });
+    const result = await runRepair();
+
+    expect(result.ok).toBe(false);
+    expect(repairArchivedOpenPrGroups).not.toHaveBeenCalled();
+  });
+
+  it('returns the archived-open-PR repair failure after a successful backfill', async () => {
+    const backfillTaskGroupSummarySortKeys = vi.fn().mockResolvedValue(
+      ok(makeBackfillResult()),
+    );
+    const repairArchivedOpenPrGroups = vi.fn().mockResolvedValue(
+      err(new Error('archived repair failed')),
+    );
+
+    const runRepair = createRunIssueGroupListingRepair({
+      backfillTaskGroupSummarySortKeys,
+      repairArchivedOpenPrGroups,
+    });
+    const result = await runRepair({ scanLimit: 25 });
+
+    expect(result.ok).toBe(false);
+    expect(backfillTaskGroupSummarySortKeys).toHaveBeenCalledWith({ dryRun: false });
+    expect(repairArchivedOpenPrGroups).toHaveBeenCalledWith({ dryRun: false, scanLimit: 25 });
+  });
+
+  it('omits scanLimit when it is not provided', async () => {
+    const backfillTaskGroupSummarySortKeys = vi.fn().mockResolvedValue(
+      ok(makeBackfillResult({ dryRun: true })),
+    );
+    const repairArchivedOpenPrGroups = vi.fn().mockResolvedValue(
+      ok(makeArchivedRepairResult({ dryRun: true })),
+    );
+
+    const runRepair = createRunIssueGroupListingRepair({
+      backfillTaskGroupSummarySortKeys,
+      repairArchivedOpenPrGroups,
+    });
+    const result = await runRepair({ dryRun: true });
+
+    expect(result.ok).toBe(true);
+    expect(repairArchivedOpenPrGroups).toHaveBeenCalledWith({ dryRun: true });
+  });
+});

--- a/apps/code-agent/src/__tests__/usecases/repairArchivedOpenPrGroups.test.ts
+++ b/apps/code-agent/src/__tests__/usecases/repairArchivedOpenPrGroups.test.ts
@@ -1,0 +1,653 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { MockedFunction } from 'vitest';
+import { err, ok } from '@intexuraos/common-core';
+import { Timestamp } from '@google-cloud/firestore';
+import type { CodeTask } from '../../domain/models/codeTask.js';
+import type { GitHubPRSummary } from '../../domain/models/gitHubPRSummary.js';
+import {
+  createRepairArchivedOpenPrGroupsUseCase,
+  type RepairArchivedOpenPrGroupsDeps,
+} from '../../domain/usecases/repairArchivedOpenPrGroups.js';
+import { createMockLogger } from '../helpers/mockLogger.js';
+
+function makeTask(overrides: Partial<CodeTask> & { id: string }): CodeTask {
+  const { id, ...taskOverrides } = overrides;
+  const updatedAt = overrides.updatedAt instanceof Timestamp
+    ? overrides.updatedAt
+    : Timestamp.fromDate(new Date('2026-05-07T10:00:00Z'));
+  const createdAt = overrides.createdAt instanceof Timestamp
+    ? overrides.createdAt
+    : updatedAt;
+
+  return {
+    id,
+    userId: 'user-1',
+    prompt: 'prompt',
+    sanitizedPrompt: 'prompt',
+    systemPromptHash: 'hash',
+    workerType: 'auto',
+    workerLocation: 'mac-dev',
+    status: 'archived',
+    repository: 'pbuchman/intexuraos',
+    baseBranch: 'development',
+    createdAt,
+    updatedAt,
+    traceId: `trace-${id}`,
+    dedupKey: `dedup-${id}`,
+    callbackReceived: false,
+    linearIssueId: 'INT-1423',
+    prNumber: 1903,
+    agentType: 'review',
+    ...taskOverrides,
+  };
+}
+
+function makeOpenPrSummary(overrides: Partial<GitHubPRSummary> = {}): GitHubPRSummary {
+  const now = new Date('2026-05-07T10:00:00Z');
+  return {
+    repository: 'pbuchman/intexuraos',
+    pullRequestNumber: 1903,
+    title: 'Open PR',
+    state: 'open',
+    mergedAt: null,
+    baseBranch: 'development',
+    authorLogin: 'pbuchman',
+    headBranch: 'worker/int-1423',
+    mergeConflictStatus: null,
+    lastConflictCheckedAt: null,
+    conflictEpisodeStartedAt: null,
+    conflictResolvedAt: null,
+    managedConflictCommentId: null,
+    managedConflictTaskId: null,
+    managedConflictTaskOwnerUserId: null,
+    lastActivityAt: now,
+    firstSeenAt: now,
+    lastReviewedCommitSha: null,
+    lastReviewNeedsRemediation: null,
+    ...overrides,
+  };
+}
+
+class DateWithToMillis extends Date {
+  toMillis(): number {
+    return this.getTime();
+  }
+}
+
+describe('repairArchivedOpenPrGroups', () => {
+  let deps: RepairArchivedOpenPrGroupsDeps;
+  let findAllOpenMock: MockedFunction<RepairArchivedOpenPrGroupsDeps['gitHubPRSummaryRepo']['findAllOpen']>;
+  let findRecentTasksByPRMock: MockedFunction<RepairArchivedOpenPrGroupsDeps['codeTaskRepo']['findRecentTasksByPR']>;
+  let findRecentTasksByLinearIssueMock: MockedFunction<RepairArchivedOpenPrGroupsDeps['codeTaskRepo']['findRecentTasksByLinearIssue']>;
+  let updateMock: MockedFunction<RepairArchivedOpenPrGroupsDeps['codeTaskRepo']['update']>;
+  let recomputeGroupFromTasksMock: MockedFunction<RepairArchivedOpenPrGroupsDeps['groupSummaryRepo']['recomputeGroupFromTasks']>;
+
+  beforeEach(() => {
+    findAllOpenMock = vi.fn().mockResolvedValue(ok([makeOpenPrSummary()])) as MockedFunction<
+      RepairArchivedOpenPrGroupsDeps['gitHubPRSummaryRepo']['findAllOpen']
+    >;
+    findRecentTasksByPRMock = vi.fn() as MockedFunction<
+      RepairArchivedOpenPrGroupsDeps['codeTaskRepo']['findRecentTasksByPR']
+    >;
+    findRecentTasksByLinearIssueMock = vi.fn() as MockedFunction<
+      RepairArchivedOpenPrGroupsDeps['codeTaskRepo']['findRecentTasksByLinearIssue']
+    >;
+    updateMock = vi.fn() as MockedFunction<
+      RepairArchivedOpenPrGroupsDeps['codeTaskRepo']['update']
+    >;
+    recomputeGroupFromTasksMock = vi.fn().mockResolvedValue(ok(undefined)) as MockedFunction<
+      RepairArchivedOpenPrGroupsDeps['groupSummaryRepo']['recomputeGroupFromTasks']
+    >;
+
+    deps = {
+      codeTaskRepo: {
+        findRecentTasksByPR: findRecentTasksByPRMock,
+        findRecentTasksByLinearIssue: findRecentTasksByLinearIssueMock,
+        update: updateMock,
+      },
+      gitHubPRSummaryRepo: {
+        findAllOpen: findAllOpenMock,
+      },
+      groupSummaryRepo: {
+        recomputeGroupFromTasks: recomputeGroupFromTasksMock,
+      },
+      logger: createMockLogger(),
+    };
+  });
+
+  it('returns an error when open PR listing fails', async () => {
+    findAllOpenMock.mockResolvedValue(err({
+      code: 'FIRESTORE_ERROR',
+      message: 'open PR list failed',
+    }));
+
+    const useCase = createRepairArchivedOpenPrGroupsUseCase(deps);
+    const result = await useCase();
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toBe('open PR list failed');
+    }
+  });
+
+  it('returns an error when fetching PR-scoped tasks fails', async () => {
+    findRecentTasksByPRMock.mockResolvedValue(err(new Error('PR task fetch failed')));
+
+    const useCase = createRepairArchivedOpenPrGroupsUseCase(deps);
+    const result = await useCase();
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toBe('PR task fetch failed');
+    }
+  });
+
+  it('restores the newest archived review task for an open PR group and preserves updatedAt', async () => {
+    const olderArchived = makeTask({
+      id: 'task-older',
+      agentType: 'planning',
+      status: 'archived',
+      updatedAt: Timestamp.fromDate(new Date('2026-05-07T08:00:00Z')),
+    });
+    const latestArchivedReview = makeTask({
+      id: 'task-latest-review',
+      agentType: 'review',
+      status: 'archived',
+      updatedAt: Timestamp.fromDate(new Date('2026-05-07T09:00:00Z')),
+    });
+
+    findRecentTasksByPRMock.mockResolvedValue(ok([latestArchivedReview, olderArchived]));
+    findRecentTasksByLinearIssueMock.mockResolvedValue(ok([latestArchivedReview, olderArchived]));
+    updateMock.mockResolvedValue(ok({
+      ...latestArchivedReview,
+      status: 'reviewed',
+    }));
+
+    const useCase = createRepairArchivedOpenPrGroupsUseCase(deps);
+    const result = await useCase();
+
+    expect(result.ok).toBe(true);
+    expect(updateMock).toHaveBeenCalledWith('task-latest-review', {
+      status: 'reviewed',
+      updatedAt: new Date('2026-05-07T09:00:00Z'),
+    });
+    expect(recomputeGroupFromTasksMock).toHaveBeenCalledWith(
+      'user-1',
+      'INT-1423',
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'task-latest-review',
+          status: 'reviewed',
+          updatedAt: latestArchivedReview.updatedAt,
+        }),
+      ]),
+    );
+    if (result.ok) {
+      expect(result.value.groupsRepaired).toBe(1);
+      expect(result.value.tasksRestored).toBe(1);
+    }
+  });
+
+  it('repairs standalone archived tasks and converts Date-like updatedAt values before update', async () => {
+    const dateWithToMillis = new DateWithToMillis('2026-05-07T09:00:00Z');
+    const standaloneTask = {
+      ...makeTask({
+        id: 'task-standalone',
+        agentType: 'review',
+        status: 'archived',
+      }),
+      createdAt: dateWithToMillis as unknown as Timestamp,
+      updatedAt: dateWithToMillis as unknown as Timestamp,
+    } as CodeTask & { linearIssueId?: string };
+    delete standaloneTask.linearIssueId;
+
+    findRecentTasksByPRMock.mockResolvedValue(ok([standaloneTask]));
+    updateMock.mockResolvedValue(ok({
+      ...standaloneTask,
+      status: 'reviewed',
+    }));
+
+    const useCase = createRepairArchivedOpenPrGroupsUseCase(deps);
+    const result = await useCase();
+
+    expect(result.ok).toBe(true);
+    expect(findRecentTasksByLinearIssueMock).not.toHaveBeenCalled();
+    expect(updateMock).toHaveBeenCalledWith('task-standalone', {
+      status: 'reviewed',
+      updatedAt: new Date('2026-05-07T09:00:00Z'),
+    });
+    expect(recomputeGroupFromTasksMock).toHaveBeenCalledWith(
+      'user-1',
+      'standalone_task-standalone',
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'task-standalone',
+          status: 'reviewed',
+        }),
+      ]),
+    );
+  });
+
+  it('restores the newest archived task from the full group, not just the open PR slice', async () => {
+    const archivedOpenPrTask = makeTask({
+      id: 'task-open-pr-review',
+      agentType: 'review',
+      prNumber: 1903,
+      status: 'archived',
+      updatedAt: Timestamp.fromDate(new Date('2026-05-07T08:00:00Z')),
+    });
+    const newerArchivedSibling = makeTask({
+      id: 'task-newer-sibling',
+      agentType: 'pull_request',
+      prNumber: 1994,
+      status: 'archived',
+      updatedAt: Timestamp.fromDate(new Date('2026-05-07T09:00:00Z')),
+    });
+
+    findRecentTasksByPRMock.mockResolvedValue(ok([archivedOpenPrTask]));
+    findRecentTasksByLinearIssueMock.mockResolvedValue(ok([archivedOpenPrTask, newerArchivedSibling]));
+    updateMock.mockResolvedValue(ok({
+      ...newerArchivedSibling,
+      status: 'implemented',
+    }));
+
+    const useCase = createRepairArchivedOpenPrGroupsUseCase(deps);
+    const result = await useCase();
+
+    expect(result.ok).toBe(true);
+    expect(updateMock).toHaveBeenCalledWith('task-newer-sibling', {
+      status: 'implemented',
+      updatedAt: new Date('2026-05-07T09:00:00Z'),
+    });
+    expect(recomputeGroupFromTasksMock).toHaveBeenCalledWith(
+      'user-1',
+      'INT-1423',
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'task-newer-sibling',
+          status: 'implemented',
+        }),
+      ]),
+    );
+  });
+
+  it('restores pull_request tasks to implemented', async () => {
+    const latestPullRequestTask = makeTask({
+      id: 'task-pr',
+      agentType: 'pull_request',
+      status: 'archived',
+      updatedAt: Timestamp.fromDate(new Date('2026-05-07T09:00:00Z')),
+    });
+
+    findRecentTasksByPRMock.mockResolvedValue(ok([latestPullRequestTask]));
+    findRecentTasksByLinearIssueMock.mockResolvedValue(ok([latestPullRequestTask]));
+    updateMock.mockResolvedValue(ok({
+      ...latestPullRequestTask,
+      status: 'implemented',
+    }));
+
+    const useCase = createRepairArchivedOpenPrGroupsUseCase(deps);
+    const result = await useCase();
+
+    expect(result.ok).toBe(true);
+    expect(updateMock).toHaveBeenCalledWith('task-pr', {
+      status: 'implemented',
+      updatedAt: new Date('2026-05-07T09:00:00Z'),
+    });
+  });
+
+  it('marks standalone archived tasks as repaired during dry-run without writing', async () => {
+    const standaloneTask = makeTask({
+      id: 'task-dry-run-standalone',
+      agentType: 'review',
+      status: 'archived',
+    }) as CodeTask & { linearIssueId?: string };
+    delete standaloneTask.linearIssueId;
+
+    findRecentTasksByPRMock.mockResolvedValue(ok([standaloneTask]));
+
+    const useCase = createRepairArchivedOpenPrGroupsUseCase(deps);
+    const result = await useCase({ dryRun: true });
+
+    expect(result.ok).toBe(true);
+    expect(findRecentTasksByLinearIssueMock).not.toHaveBeenCalled();
+    expect(updateMock).not.toHaveBeenCalled();
+    if (result.ok) {
+      expect(result.value.groupsRepaired).toBe(1);
+      expect(result.value.tasksRestored).toBe(1);
+    }
+  });
+
+  it('does not count a group as repaired when summary recompute fails', async () => {
+    const latestArchivedReview = makeTask({
+      id: 'task-latest-review',
+      agentType: 'review',
+      status: 'archived',
+      updatedAt: Timestamp.fromDate(new Date('2026-05-07T09:00:00Z')),
+    });
+
+    findRecentTasksByPRMock.mockResolvedValue(ok([latestArchivedReview]));
+    findRecentTasksByLinearIssueMock.mockResolvedValue(ok([latestArchivedReview]));
+    updateMock
+      .mockResolvedValueOnce(ok({
+        ...latestArchivedReview,
+        status: 'reviewed',
+      }))
+      .mockResolvedValueOnce(ok(latestArchivedReview));
+    recomputeGroupFromTasksMock.mockResolvedValue(err({
+      code: 'FIRESTORE_ERROR',
+      message: 'recompute failed',
+    }));
+
+    const useCase = createRepairArchivedOpenPrGroupsUseCase(deps);
+    const result = await useCase();
+
+    expect(result.ok).toBe(true);
+    expect(updateMock).toHaveBeenNthCalledWith(1, 'task-latest-review', {
+      status: 'reviewed',
+      updatedAt: new Date('2026-05-07T09:00:00Z'),
+    });
+    expect(updateMock).toHaveBeenNthCalledWith(2, 'task-latest-review', {
+      status: 'archived',
+      updatedAt: new Date('2026-05-07T09:00:00Z'),
+    });
+    if (result.ok) {
+      expect(result.value.groupsRepaired).toBe(0);
+      expect(result.value.tasksRestored).toBe(0);
+      expect(result.value.summaryRecomputeFailures).toBe(1);
+    }
+  });
+
+  it('increments tasksFailed when rollback after recompute failure also fails', async () => {
+    const latestArchivedReview = makeTask({
+      id: 'task-rollback-fail',
+      agentType: 'review',
+      status: 'archived',
+      updatedAt: Timestamp.fromDate(new Date('2026-05-07T09:00:00Z')),
+    });
+
+    findRecentTasksByPRMock.mockResolvedValue(ok([latestArchivedReview]));
+    findRecentTasksByLinearIssueMock.mockResolvedValue(ok([latestArchivedReview]));
+    updateMock
+      .mockResolvedValueOnce(ok({
+        ...latestArchivedReview,
+        status: 'reviewed',
+      }))
+      .mockResolvedValueOnce(err(new Error('rollback failed')));
+    recomputeGroupFromTasksMock.mockResolvedValue(err({
+      code: 'FIRESTORE_ERROR',
+      message: 'recompute failed',
+    }));
+
+    const useCase = createRepairArchivedOpenPrGroupsUseCase(deps);
+    const result = await useCase();
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.summaryRecomputeFailures).toBe(1);
+      expect(result.value.tasksFailed).toBe(1);
+    }
+  });
+
+  it('skips repair when the latest PR task is already non-archived', async () => {
+    const visibleTask = makeTask({
+      id: 'task-visible',
+      status: 'implemented',
+      updatedAt: Timestamp.fromDate(new Date('2026-05-07T09:00:00Z')),
+    });
+    const olderArchived = makeTask({
+      id: 'task-older',
+      status: 'archived',
+      updatedAt: Timestamp.fromDate(new Date('2026-05-07T08:00:00Z')),
+    });
+
+    findRecentTasksByPRMock.mockResolvedValue(ok([visibleTask, olderArchived]));
+
+    const useCase = createRepairArchivedOpenPrGroupsUseCase(deps);
+    const result = await useCase();
+
+    expect(result.ok).toBe(true);
+    expect(findRecentTasksByLinearIssueMock).not.toHaveBeenCalled();
+    expect(updateMock).not.toHaveBeenCalled();
+    if (result.ok) {
+      expect(result.value.groupsSkippedAlreadyVisible).toBe(1);
+    }
+  });
+
+  it('skips repair when the full group already has a non-archived sibling', async () => {
+    const archivedPrTask = makeTask({
+      id: 'task-archived-pr',
+      status: 'archived',
+      updatedAt: Timestamp.fromDate(new Date('2026-05-07T09:00:00Z')),
+    });
+    const visibleSibling = makeTask({
+      id: 'task-visible-sibling',
+      status: 'implemented',
+      prNumber: 1994,
+      updatedAt: Timestamp.fromDate(new Date('2026-05-07T09:30:00Z')),
+    });
+
+    findRecentTasksByPRMock.mockResolvedValue(ok([archivedPrTask]));
+    findRecentTasksByLinearIssueMock.mockResolvedValue(ok([archivedPrTask, visibleSibling]));
+
+    const useCase = createRepairArchivedOpenPrGroupsUseCase(deps);
+    const result = await useCase();
+
+    expect(result.ok).toBe(true);
+    expect(updateMock).not.toHaveBeenCalled();
+    expect(recomputeGroupFromTasksMock).not.toHaveBeenCalled();
+    if (result.ok) {
+      expect(result.value.groupsSkippedAlreadyVisible).toBe(1);
+    }
+  });
+
+  it('returns an error when fetching full group tasks fails', async () => {
+    const archivedPrTask = makeTask({
+      id: 'task-group-fetch-fail',
+      status: 'archived',
+      updatedAt: Timestamp.fromDate(new Date('2026-05-07T09:00:00Z')),
+    });
+
+    findRecentTasksByPRMock.mockResolvedValue(ok([archivedPrTask]));
+    findRecentTasksByLinearIssueMock.mockResolvedValue(err(new Error('group task fetch failed')));
+
+    const useCase = createRepairArchivedOpenPrGroupsUseCase(deps);
+    const result = await useCase();
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toBe('group task fetch failed');
+    }
+  });
+
+  it('skips repair when no matching tasks remain after group filtering', async () => {
+    const archivedPrTask = makeTask({
+      id: 'task-filtered-out',
+      status: 'archived',
+      updatedAt: Timestamp.fromDate(new Date('2026-05-07T09:00:00Z')),
+    });
+    const otherUsersTask = makeTask({
+      id: 'task-other-user',
+      userId: 'user-2',
+      status: 'archived',
+      updatedAt: Timestamp.fromDate(new Date('2026-05-07T09:30:00Z')),
+    });
+
+    findRecentTasksByPRMock.mockResolvedValue(ok([archivedPrTask]));
+    findRecentTasksByLinearIssueMock.mockResolvedValue(ok([otherUsersTask]));
+
+    const useCase = createRepairArchivedOpenPrGroupsUseCase(deps);
+    const result = await useCase();
+
+    expect(result.ok).toBe(true);
+    expect(updateMock).not.toHaveBeenCalled();
+    if (result.ok) {
+      expect(result.value.groupsEvaluated).toBe(1);
+      expect(result.value.groupsRepaired).toBe(0);
+    }
+  });
+
+  it('skips repair and records a warning when the group scan exceeds the cap', async () => {
+    const prTask = makeTask({
+      id: 'task-pr',
+      status: 'archived',
+      updatedAt: Timestamp.fromDate(new Date('2026-05-07T09:00:00Z')),
+    });
+    const extraTasks = [
+      prTask,
+      makeTask({ id: 'task-2', status: 'archived' }),
+      makeTask({ id: 'task-3', status: 'archived' }),
+    ];
+
+    findRecentTasksByPRMock.mockResolvedValue(ok([prTask]));
+    findRecentTasksByLinearIssueMock.mockResolvedValue(ok(extraTasks));
+
+    const useCase = createRepairArchivedOpenPrGroupsUseCase(deps);
+    const result = await useCase({ scanLimit: 2 });
+
+    expect(result.ok).toBe(true);
+    expect(updateMock).not.toHaveBeenCalled();
+    if (result.ok) {
+      expect(result.value.groupsSkippedScanLimit).toBe(1);
+      expect(result.value.warnings).toEqual([
+        expect.objectContaining({
+          repository: 'pbuchman/intexuraos',
+          prNumber: 1903,
+          userId: 'user-1',
+          groupKey: 'INT-1423',
+          reason: 'group_task_window_capped',
+        }),
+      ]);
+    }
+  });
+
+  it('uses the open PR number in scan-cap warnings when the task has no PR number', async () => {
+    const prTask = makeTask({
+      id: 'task-pr-no-number',
+      status: 'archived',
+      updatedAt: Timestamp.fromDate(new Date('2026-05-07T09:00:00Z')),
+    }) as CodeTask & { prNumber?: number };
+    delete prTask.prNumber;
+    const extraTaskOne = makeTask({
+      id: 'task-extra-1',
+      status: 'archived',
+    }) as CodeTask & { prNumber?: number };
+    delete extraTaskOne.prNumber;
+    const extraTaskTwo = makeTask({
+      id: 'task-extra-2',
+      status: 'archived',
+    }) as CodeTask & { prNumber?: number };
+    delete extraTaskTwo.prNumber;
+    const extraTasks = [
+      prTask,
+      extraTaskOne,
+      extraTaskTwo,
+    ];
+
+    findRecentTasksByPRMock.mockResolvedValue(ok([prTask]));
+    findRecentTasksByLinearIssueMock.mockResolvedValue(ok(extraTasks));
+
+    const useCase = createRepairArchivedOpenPrGroupsUseCase(deps);
+    const result = await useCase({ scanLimit: 2 });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.warnings).toEqual([
+        expect.objectContaining({
+          prNumber: 1903,
+          reason: 'group_task_window_capped',
+        }),
+      ]);
+    }
+  });
+
+  it('skips repair and records a warning when the PR scan exceeds the cap', async () => {
+    const prTasks = [
+      makeTask({ id: 'task-1', status: 'archived' }),
+      makeTask({ id: 'task-2', status: 'archived', updatedAt: Timestamp.fromDate(new Date('2026-05-07T09:00:00Z')) }),
+    ];
+
+    findRecentTasksByPRMock.mockResolvedValue(ok(prTasks));
+
+    const useCase = createRepairArchivedOpenPrGroupsUseCase(deps);
+    const result = await useCase({ scanLimit: 1 });
+
+    expect(result.ok).toBe(true);
+    expect(findRecentTasksByLinearIssueMock).not.toHaveBeenCalled();
+    expect(updateMock).not.toHaveBeenCalled();
+    if (result.ok) {
+      expect(result.value.prsSkippedScanLimit).toBe(1);
+      expect(result.value.warnings).toEqual([
+        expect.objectContaining({
+          repository: 'pbuchman/intexuraos',
+          prNumber: 1903,
+          reason: 'pr_task_window_capped',
+        }),
+      ]);
+    }
+  });
+
+  it('dedupes the same user and group across multiple open PR summaries', async () => {
+    const olderOpenPrTask = makeTask({
+      id: 'task-open-pr-1',
+      prNumber: 1903,
+      status: 'archived',
+      updatedAt: Timestamp.fromDate(new Date('2026-05-07T08:00:00Z')),
+    });
+    const newerOpenPrTask = makeTask({
+      id: 'task-open-pr-2',
+      prNumber: 1994,
+      status: 'archived',
+      updatedAt: Timestamp.fromDate(new Date('2026-05-07T09:00:00Z')),
+      agentType: 'pull_request',
+    });
+
+    findAllOpenMock.mockResolvedValue(ok([
+      makeOpenPrSummary({ pullRequestNumber: 1903 }),
+      makeOpenPrSummary({ pullRequestNumber: 1994 }),
+    ]));
+    findRecentTasksByPRMock
+      .mockResolvedValueOnce(ok([olderOpenPrTask]))
+      .mockResolvedValueOnce(ok([newerOpenPrTask]));
+    findRecentTasksByLinearIssueMock.mockResolvedValue(ok([olderOpenPrTask, newerOpenPrTask]));
+    updateMock.mockResolvedValue(ok({
+      ...newerOpenPrTask,
+      status: 'implemented',
+    }));
+
+    const useCase = createRepairArchivedOpenPrGroupsUseCase(deps);
+    const result = await useCase();
+
+    expect(result.ok).toBe(true);
+    expect(updateMock).toHaveBeenCalledTimes(1);
+    expect(updateMock).toHaveBeenCalledWith('task-open-pr-2', {
+      status: 'implemented',
+      updatedAt: new Date('2026-05-07T09:00:00Z'),
+    });
+    if (result.ok) {
+      expect(result.value.groupsEvaluated).toBe(1);
+      expect(result.value.groupsRepaired).toBe(1);
+    }
+  });
+
+  it('counts failed task restores when the status update fails', async () => {
+    const archivedTask = makeTask({
+      id: 'task-update-fail',
+      status: 'archived',
+      updatedAt: Timestamp.fromDate(new Date('2026-05-07T09:00:00Z')),
+    });
+
+    findRecentTasksByPRMock.mockResolvedValue(ok([archivedTask]));
+    findRecentTasksByLinearIssueMock.mockResolvedValue(ok([archivedTask]));
+    updateMock.mockResolvedValue(err(new Error('update failed')));
+
+    const useCase = createRepairArchivedOpenPrGroupsUseCase(deps);
+    const result = await useCase();
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.tasksFailed).toBe(1);
+      expect(result.value.groupsRepaired).toBe(0);
+    }
+  });
+});

--- a/apps/code-agent/src/domain/ports/taskGroupSummaryRepository.ts
+++ b/apps/code-agent/src/domain/ports/taskGroupSummaryRepository.ts
@@ -27,7 +27,7 @@ export interface TaskGroupSummaryRepository {
   listGroupSummaries(input: ListGroupSummariesInput): Promise<Result<ListGroupSummariesOutput, GroupSummaryError>>;
 
   /** Full recompute of a group from its tasks (for backfill/repair). */
-  recomputeGroupFromTasks(userId: string, groupKey: string, tasks: CodeTask[]): Promise<void>;
+  recomputeGroupFromTasks(userId: string, groupKey: string, tasks: CodeTask[]): Promise<Result<void, GroupSummaryError>>;
 
   /**
    * Recompute aggregateStatus and persist label flags for the group identified by

--- a/apps/code-agent/src/domain/repositories/codeTaskRepository.ts
+++ b/apps/code-agent/src/domain/repositories/codeTaskRepository.ts
@@ -223,6 +223,16 @@ export interface CodeTaskRepository {
   ): Promise<Result<CodeTask | null, RepositoryError>>;
 
   /**
+   * Find newest tasks for a PR, ordered by createdAt descending.
+   * Used by archived-open-PR repair to inspect the recent task window safely.
+   */
+  findRecentTasksByPR(
+    repository: string,
+    prNumber: number,
+    limit: number,
+  ): Promise<Result<CodeTask[], RepositoryError>>;
+
+  /**
    * Find an active review task for a PR.
    * Used to deduplicate review-task creation for rapid synchronize events.
    * Returns null if no queued/dispatched/running review task exists.

--- a/apps/code-agent/src/domain/usecases/handleTaskCompletion.ts
+++ b/apps/code-agent/src/domain/usecases/handleTaskCompletion.ts
@@ -58,6 +58,7 @@ import { drainTaskQueue } from './drainTaskQueue.js';
 import { triageFailedTask } from './triageFailedTask.js';
 import { deletePRTaskLock } from '../utils/prTaskLock.js';
 import { fetchGitHubToken } from '../utils/gitHubTokenResolver.js';
+import { resolveCompletedTaskStatus } from '../utils/resolveCompletedTaskStatus.js';
 import { validatePrUrl } from '../utils/validatePrUrl.js';
 import {
   flushPendingTaskLogLines,
@@ -1249,9 +1250,7 @@ export async function handleTaskCompletion(
           prNumber = task.prNumber;
         }
 
-        const resolvedStatus =
-          task.agentType === 'planning' ? 'planned' :
-          task.agentType === 'review' ? 'reviewed' : 'implemented';
+        const resolvedStatus = resolveCompletedTaskStatus(task.agentType);
         const executionMemoryPostRun = shouldQueueExecutionMemoryPostRun({
           agentType: task.agentType,
           existingStatus: task.executionMemoryPostRun?.status,

--- a/apps/code-agent/src/domain/usecases/repairArchivedOpenPrGroups.ts
+++ b/apps/code-agent/src/domain/usecases/repairArchivedOpenPrGroups.ts
@@ -1,0 +1,315 @@
+import type { Result } from '@intexuraos/common-core';
+import { err, getErrorMessage, ok } from '@intexuraos/common-core';
+import type { Logger } from 'pino';
+import type { CodeTask } from '../models/codeTask.js';
+import type { GitHubPRSummaryRepository } from '../repositories/gitHubPRSummaryRepository.js';
+import type { TaskGroupSummaryRepository } from '../ports/taskGroupSummaryRepository.js';
+import { resolveCompletedTaskStatus } from '../utils/resolveCompletedTaskStatus.js';
+
+export interface RepairArchivedOpenPrGroupsDeps {
+  codeTaskRepo: {
+    findRecentTasksByPR(
+      repository: string,
+      prNumber: number,
+      limit: number,
+    ): Promise<Result<CodeTask[]>>;
+    findRecentTasksByLinearIssue(
+      linearIssueId: string,
+      limit: number,
+    ): Promise<Result<CodeTask[]>>;
+    update(
+      taskId: string,
+      input: { status: CodeTask['status']; updatedAt: Date },
+    ): Promise<Result<CodeTask>>;
+  };
+  gitHubPRSummaryRepo: Pick<GitHubPRSummaryRepository, 'findAllOpen'>;
+  groupSummaryRepo: Pick<TaskGroupSummaryRepository, 'recomputeGroupFromTasks'>;
+  logger: Logger;
+}
+
+export interface RepairArchivedOpenPrGroupsInput {
+  dryRun?: boolean;
+  scanLimit?: number;
+}
+
+export interface RepairArchivedOpenPrGroupsWarning {
+  repository: string;
+  prNumber: number;
+  userId?: string;
+  groupKey?: string;
+  reason: 'pr_task_window_capped' | 'group_task_window_capped';
+}
+
+export interface RepairArchivedOpenPrGroupsResult {
+  dryRun: boolean;
+  totalOpenPrsScanned: number;
+  totalPrTasksFetched: number;
+  groupsEvaluated: number;
+  groupsRepaired: number;
+  groupsSkippedAlreadyVisible: number;
+  groupsSkippedScanLimit: number;
+  prsSkippedScanLimit: number;
+  tasksRestored: number;
+  tasksFailed: number;
+  summaryRecomputeFailures: number;
+  durationMs: number;
+  warnings: RepairArchivedOpenPrGroupsWarning[];
+}
+
+const DEFAULT_SCAN_LIMIT = 50;
+
+function groupKeyOf(task: CodeTask): string {
+  return task.linearIssueId ?? `standalone_${task.id}`;
+}
+
+function toDate(value: CodeTask['updatedAt']): Date {
+  return value instanceof Date ? value : value.toDate();
+}
+
+function isNonArchived(task: CodeTask): boolean {
+  return task.status !== 'archived';
+}
+
+function compareByUpdatedAtDesc(left: CodeTask, right: CodeTask): number {
+  return right.updatedAt.toMillis() - left.updatedAt.toMillis();
+}
+
+export function createRepairArchivedOpenPrGroupsUseCase(
+  deps: RepairArchivedOpenPrGroupsDeps,
+): (
+  input?: RepairArchivedOpenPrGroupsInput
+) => Promise<Result<RepairArchivedOpenPrGroupsResult>> {
+  const { codeTaskRepo, gitHubPRSummaryRepo, groupSummaryRepo, logger } = deps;
+
+  return async (input?: RepairArchivedOpenPrGroupsInput): Promise<Result<RepairArchivedOpenPrGroupsResult>> => {
+    const startedAt = Date.now();
+    const dryRun = input?.dryRun === true;
+    const scanLimit = input?.scanLimit ?? DEFAULT_SCAN_LIMIT;
+
+    const openPrResult = await gitHubPRSummaryRepo.findAllOpen();
+    if (!openPrResult.ok) {
+      logger.error({ error: openPrResult.error }, 'Failed to list open PR summaries for archived-group repair');
+      return err(new Error(openPrResult.error.message));
+    }
+
+    let totalPrTasksFetched = 0;
+    let groupsEvaluated = 0;
+    let groupsRepaired = 0;
+    let groupsSkippedAlreadyVisible = 0;
+    let groupsSkippedScanLimit = 0;
+    let prsSkippedScanLimit = 0;
+    let tasksRestored = 0;
+    let tasksFailed = 0;
+    let summaryRecomputeFailures = 0;
+    const warnings: RepairArchivedOpenPrGroupsWarning[] = [];
+    const seenGroups = new Set<string>();
+
+    for (const openPr of openPrResult.value) {
+      const prTasksResult = await codeTaskRepo.findRecentTasksByPR(
+        openPr.repository,
+        openPr.pullRequestNumber,
+        scanLimit + 1,
+      );
+      if (!prTasksResult.ok) {
+        logger.error(
+          {
+            repository: openPr.repository,
+            prNumber: openPr.pullRequestNumber,
+            error: prTasksResult.error,
+          },
+          'Failed to fetch PR-scoped tasks for archived-group repair',
+        );
+        return err(new Error(prTasksResult.error.message));
+      }
+
+      totalPrTasksFetched += prTasksResult.value.length;
+
+      if (prTasksResult.value.length > scanLimit) {
+        prsSkippedScanLimit++;
+        warnings.push({
+          repository: openPr.repository,
+          prNumber: openPr.pullRequestNumber,
+          reason: 'pr_task_window_capped',
+        });
+        logger.warn(
+          {
+            repository: openPr.repository,
+            prNumber: openPr.pullRequestNumber,
+            docsScanned: prTasksResult.value.length,
+            scanLimit,
+          },
+          'Skipping open PR repair because the PR task window hit the scan cap',
+        );
+        continue;
+      }
+
+      const tasksByGroup = new Map<string, CodeTask[]>();
+      for (const task of prTasksResult.value) {
+        const key = `${task.userId}_${groupKeyOf(task)}`;
+        const existing = tasksByGroup.get(key) ?? [];
+        existing.push(task);
+        tasksByGroup.set(key, existing);
+      }
+
+      for (const [groupIdentity, prGroupTasks] of tasksByGroup) {
+        const latestPrTask = [...prGroupTasks].sort(compareByUpdatedAtDesc)[0];
+        if (latestPrTask === undefined || seenGroups.has(groupIdentity)) {
+          continue;
+        }
+        seenGroups.add(groupIdentity);
+
+        groupsEvaluated++;
+
+        if (isNonArchived(latestPrTask)) {
+          groupsSkippedAlreadyVisible++;
+          continue;
+        }
+
+        let groupTasks: CodeTask[];
+        if (latestPrTask.linearIssueId === undefined) {
+          groupTasks = [latestPrTask];
+        } else {
+          const groupTasksResult = await codeTaskRepo.findRecentTasksByLinearIssue(
+            latestPrTask.linearIssueId,
+            scanLimit + 1,
+          );
+          if (!groupTasksResult.ok) {
+            logger.error(
+              {
+                linearIssueId: latestPrTask.linearIssueId,
+                userId: latestPrTask.userId,
+                error: groupTasksResult.error,
+              },
+              'Failed to fetch group tasks for archived-group repair',
+            );
+            return err(new Error(groupTasksResult.error.message));
+          }
+
+          if (groupTasksResult.value.length > scanLimit) {
+            groupsSkippedScanLimit++;
+            warnings.push({
+              repository: latestPrTask.repository,
+              prNumber: latestPrTask.prNumber ?? openPr.pullRequestNumber,
+              userId: latestPrTask.userId,
+              groupKey: groupKeyOf(latestPrTask),
+              reason: 'group_task_window_capped',
+            });
+            logger.warn(
+              {
+                linearIssueId: latestPrTask.linearIssueId,
+                userId: latestPrTask.userId,
+                docsScanned: groupTasksResult.value.length,
+                scanLimit,
+              },
+              'Skipping open PR repair because the group task window hit the scan cap',
+            );
+            continue;
+          }
+
+          groupTasks = groupTasksResult.value.filter((task) =>
+            task.userId === latestPrTask.userId &&
+            groupKeyOf(task) === groupKeyOf(latestPrTask),
+          );
+        }
+
+        if (groupTasks.some(isNonArchived)) {
+          groupsSkippedAlreadyVisible++;
+          continue;
+        }
+
+        const latestGroupTask = [...groupTasks].sort(compareByUpdatedAtDesc)[0];
+        if (latestGroupTask === undefined) {
+          continue;
+        }
+
+        const restoredStatus = resolveCompletedTaskStatus(latestGroupTask.agentType);
+        const repairedGroupTasks = groupTasks.map((task) =>
+          task.id === latestGroupTask.id
+            ? { ...task, status: restoredStatus }
+            : task,
+        );
+
+        if (dryRun) {
+          groupsRepaired++;
+          tasksRestored++;
+          continue;
+        }
+
+        const updateResult = await codeTaskRepo.update(latestGroupTask.id, {
+          status: restoredStatus,
+          updatedAt: toDate(latestGroupTask.updatedAt),
+        });
+        if (!updateResult.ok) {
+          tasksFailed++;
+          logger.error(
+            {
+              taskId: latestGroupTask.id,
+              repository: latestGroupTask.repository,
+              prNumber: latestGroupTask.prNumber,
+              error: updateResult.error,
+            },
+            'Failed to restore archived task for open PR group',
+          );
+          continue;
+        }
+
+        const recomputeResult = await groupSummaryRepo.recomputeGroupFromTasks(
+          latestGroupTask.userId,
+          groupKeyOf(latestGroupTask),
+          repairedGroupTasks,
+        );
+        if (!recomputeResult.ok) {
+          summaryRecomputeFailures++;
+          logger.error(
+            {
+              taskId: latestGroupTask.id,
+              userId: latestGroupTask.userId,
+              groupKey: groupKeyOf(latestGroupTask),
+              error: recomputeResult.error,
+            },
+            'Failed to recompute group summary after restoring archived open PR task',
+          );
+          const rollbackResult = await codeTaskRepo.update(latestGroupTask.id, {
+            status: latestGroupTask.status,
+            updatedAt: toDate(latestGroupTask.updatedAt),
+          });
+          if (!rollbackResult.ok) {
+            tasksFailed++;
+            logger.error(
+              {
+                taskId: latestGroupTask.id,
+                userId: latestGroupTask.userId,
+                groupKey: groupKeyOf(latestGroupTask),
+                error: rollbackResult.error,
+              },
+              'Failed to roll back archived open PR task after summary recompute failure',
+            );
+          }
+          continue;
+        }
+        groupsRepaired++;
+        tasksRestored++;
+      }
+    }
+
+    return ok({
+      dryRun,
+      totalOpenPrsScanned: openPrResult.value.length,
+      totalPrTasksFetched,
+      groupsEvaluated,
+      groupsRepaired,
+      groupsSkippedAlreadyVisible,
+      groupsSkippedScanLimit,
+      prsSkippedScanLimit,
+      tasksRestored,
+      tasksFailed,
+      summaryRecomputeFailures,
+      durationMs: Date.now() - startedAt,
+      warnings,
+    });
+  };
+}
+
+export function formatRepairArchivedOpenPrGroupsError(error: unknown): string {
+  return getErrorMessage(error, 'Unknown error');
+}

--- a/apps/code-agent/src/domain/utils/resolveCompletedTaskStatus.ts
+++ b/apps/code-agent/src/domain/utils/resolveCompletedTaskStatus.ts
@@ -1,0 +1,13 @@
+import type { AgentType } from '../models/codeTask.js';
+
+export type CompletedTaskStatus = 'planned' | 'reviewed' | 'implemented';
+
+export function resolveCompletedTaskStatus(agentType: AgentType | undefined): CompletedTaskStatus {
+  if (agentType === 'planning') {
+    return 'planned';
+  }
+  if (agentType === 'review') {
+    return 'reviewed';
+  }
+  return 'implemented';
+}

--- a/apps/code-agent/src/infra/firestore/task-query-builder.ts
+++ b/apps/code-agent/src/infra/firestore/task-query-builder.ts
@@ -57,13 +57,14 @@ export async function buildListQuery(
 export function prTasksByCreatedAt(
   collection: CollectionReference,
   repository: string,
-  prNumber: number
+  prNumber: number,
+  limit = 50,
 ): Query {
   return collection
     .where('repository', '==', repository)
     .where('prNumber', '==', prNumber)
     .orderBy('createdAt', 'desc')
-    .limit(50);
+    .limit(limit);
 }
 
 /** Active review task for a PR (limit 1). */

--- a/apps/code-agent/src/infra/firestore/taskGroupSummary/serializer.ts
+++ b/apps/code-agent/src/infra/firestore/taskGroupSummary/serializer.ts
@@ -100,6 +100,13 @@ export function hasImplementationLink(task: CodeTask): boolean {
   return task.implementationTaskId !== undefined || (task.fanOutChildTaskIds !== undefined && task.fanOutChildTaskIds.length > 0);
 }
 
+function normalizeSummarySortFields(summary: TaskGroupSummary): TaskGroupSummary {
+  return {
+    ...summary,
+    ...getLinearIssueSortFields(summary.linearIssueId),
+  };
+}
+
 // =============================================================================
 // Timestamp helper (pure)
 // =============================================================================
@@ -343,7 +350,7 @@ export function applyIncrementalCreateUpdate(current: TaskGroupSummary, task: Co
   }
 
   updated.aggregateStatus = deriveAggregateStatusFromSummary(updated);
-  return updated;
+  return normalizeSummarySortFields(updated);
 }
 
 /**
@@ -405,7 +412,7 @@ export function applyStatusChangeUpdate(
     if (updated.taskCount <= 0) {
       // All tasks archived — preserve summary with 'archived' status instead of deleting
       updated.aggregateStatus = 'archived';
-      return { updated, allArchived: true };
+      return { updated: normalizeSummarySortFields(updated), allArchived: true };
     }
   }
 
@@ -429,7 +436,7 @@ export function applyStatusChangeUpdate(
   }
 
   updated.aggregateStatus = deriveAggregateStatusFromSummary(updated);
-  return { updated, allArchived: false };
+  return { updated: normalizeSummarySortFields(updated), allArchived: false };
 }
 
 /**
@@ -465,7 +472,7 @@ export function applyDeleteUpdate(
   };
 
   updated.aggregateStatus = deriveAggregateStatusFromSummary(updated);
-  return { updated, shouldDelete: false };
+  return { updated: normalizeSummarySortFields(updated), shouldDelete: false };
 }
 
 /**

--- a/apps/code-agent/src/infra/firestore/taskGroupSummaryFirestoreRepository.ts
+++ b/apps/code-agent/src/infra/firestore/taskGroupSummaryFirestoreRepository.ts
@@ -178,12 +178,16 @@ export function createTaskGroupSummaryFirestoreRepository(deps: { firestore: Fir
       }
     },
 
-    async recomputeGroupFromTasks(userId: string, groupKey: string, tasks: CodeTask[]): Promise<void> {
+    async recomputeGroupFromTasks(
+      userId: string,
+      groupKey: string,
+      tasks: CodeTask[],
+    ): Promise<Result<void, GroupSummaryError>> {
       try {
-        if (tasks.length === 0) return;
+        if (tasks.length === 0) return ok(undefined);
         const now = Timestamp.fromDate(new Date());
         const summary = computeSummaryFromTasks(userId, groupKey, tasks, now);
-        if (summary === null) return;
+        if (summary === null) return ok(undefined);
 
         const summaryRef = summaryDocRef(firestore, userId, groupKey);
         await firestore.runTransaction(async (tx) => {
@@ -216,11 +220,16 @@ export function createTaskGroupSummaryFirestoreRepository(deps: { firestore: Fir
             writeCounts(tx, userId, applyStatusChangeDelta(existingCounts, existingSummary.aggregateStatus, summary.aggregateStatus), now);
           }
         });
+        return ok(undefined);
       } catch (error) {
         logger.warn(
           { userId, groupKey, error: getErrorMessage(error, 'Unknown error') },
           'recomputeGroupFromTasks: failed to recompute group summary (non-critical)',
         );
+        return err({
+          code: 'FIRESTORE_ERROR',
+          message: getErrorMessage(error, 'Failed to recompute group summary'),
+        });
       }
     },
 

--- a/apps/code-agent/src/infra/repositories/firestoreCodeTaskRepository.ts
+++ b/apps/code-agent/src/infra/repositories/firestoreCodeTaskRepository.ts
@@ -215,6 +215,10 @@ export const createFirestoreCodeTaskRepository = (deps: {
       ),
       { repository, prNumber }, 'Failed to find task by PR',
     ),
+    findRecentTasksByPR: (repository, prNumber, limit) => guarded(
+      () => docsToTasks(prTasksByCreatedAt(collection, repository, prNumber, limit)),
+      { repository, prNumber, limit }, 'Failed to find recent tasks by PR',
+    ),
     findActiveReviewForPR: (repository, prNumber) => guarded(
       () => firstOrNull(activeReviewForPR(collection, repository, prNumber)),
       { repository, prNumber }, 'Failed to find active review task by PR',

--- a/apps/code-agent/src/routes/code/updateTaskStatusRoute.ts
+++ b/apps/code-agent/src/routes/code/updateTaskStatusRoute.ts
@@ -25,6 +25,7 @@ import { logIncomingRequest, validateInternalAuth } from '@intexuraos/common-htt
 import { getServices } from '../../services.js';
 import { validateOrchestratorSignature } from '../../infra/webhookValidation.js';
 import { loadConfig } from '../../config.js';
+import { resolveCompletedTaskStatus } from '../../domain/utils/resolveCompletedTaskStatus.js';
 
 interface UpdateTaskStatusBody {
   taskId: string;
@@ -170,16 +171,12 @@ const updateTaskStatusRoute: FastifyPluginCallback = (fastify, _opts, done) => {
 
       // Map orchestrator-vocabulary 'completed' to code-agent's agent-type-specific
       // terminal status, mirroring /internal/webhooks/task-complete (webhookRoutes.ts
-       // around line 1451). The Firestore TaskStatus type does not include 'completed';
+      // around line 1451). The Firestore TaskStatus type does not include 'completed';
       // it uses 'planned' | 'implemented' | 'reviewed'. Other terminal values
       // ('failed' | 'interrupted' | 'cancelled') pass through unchanged.
       const resolvedStatus =
         status === 'completed'
-          ? task.agentType === 'planning'
-            ? 'planned'
-            : task.agentType === 'review'
-              ? 'reviewed'
-              : 'implemented'
+          ? resolveCompletedTaskStatus(task.agentType)
           : status;
 
       // Always write `error`: either the provided value or explicit null to

--- a/apps/code-agent/src/scripts/backfillTaskGroupSummarySortKeys.ts
+++ b/apps/code-agent/src/scripts/backfillTaskGroupSummarySortKeys.ts
@@ -9,80 +9,25 @@
  */
 
 import { Firestore } from '@google-cloud/firestore';
-import { getLinearIssueSortFields } from '../infra/firestore/taskGroupSummary/serializer.js';
+import { runTaskGroupSummarySortKeyBackfill } from './lib/backfillTaskGroupSummarySortKeys.js';
 /* v8 ignore start -- module-init: standalone backfill script is never imported by test suites; cannot be unit-tested without a live Firestore connection @preserve */
-
-const SUMMARIES_COLLECTION = 'task_group_summaries';
-const BATCH_SIZE = 500;
-
-interface PendingUpdate {
-  docId: string;
-  linearIssueId: string | null;
-  before: {
-    linearIssueNumber: unknown;
-    linearIssueSortKey: unknown;
-  };
-  after: {
-    linearIssueNumber: number | null;
-    linearIssueSortKey: number;
-  };
-}
 
 function parseDryRun(argv: string[]): boolean {
   return argv.includes('--dry-run');
 }
 
-function normalizeLinearIssueId(value: unknown): string | null {
-  return typeof value === 'string' ? value : null;
-}
-
-function needsUpdate(data: Record<string, unknown>, expected: PendingUpdate['after']): boolean {
-  return data['linearIssueNumber'] !== expected.linearIssueNumber ||
-    data['linearIssueSortKey'] !== expected.linearIssueSortKey;
-}
-
 async function main(): Promise<void> {
   const dryRun = parseDryRun(process.argv.slice(2));
   const db = new Firestore();
-  const snapshot = await db.collection(SUMMARIES_COLLECTION).get();
-  const updates: PendingUpdate[] = [];
-
-  for (const doc of snapshot.docs) {
-    const data = doc.data() as Record<string, unknown>;
-    const linearIssueId = normalizeLinearIssueId(data['linearIssueId']);
-    const expected = getLinearIssueSortFields(linearIssueId);
-
-    if (!needsUpdate(data, expected)) {
-      continue;
-    }
-
-    updates.push({
-      docId: doc.id,
-      linearIssueId,
-      before: {
-        linearIssueNumber: data['linearIssueNumber'],
-        linearIssueSortKey: data['linearIssueSortKey'],
-      },
-      after: expected,
-    });
-  }
-
-  if (!dryRun) {
-    for (let i = 0; i < updates.length; i += BATCH_SIZE) {
-      const batch = db.batch();
-      for (const update of updates.slice(i, i + BATCH_SIZE)) {
-        batch.set(db.collection(SUMMARIES_COLLECTION).doc(update.docId), update.after, { merge: true });
-      }
-      await batch.commit();
-    }
-  }
-
-  process.stdout.write(`${JSON.stringify({
+  const result = await runTaskGroupSummarySortKeyBackfill({
+    firestore: db,
     dryRun,
-    scanned: snapshot.size,
-    updated: updates.length,
-    updates,
-  }, null, 2)}\n`);
+  });
+  if (!result.ok) {
+    throw new Error(result.error.message);
+  }
+
+  process.stdout.write(`${JSON.stringify(result.value, null, 2)}\n`);
 }
 
 main().catch((error: unknown) => {

--- a/apps/code-agent/src/scripts/lib/backfillTaskGroupSummarySortKeys.ts
+++ b/apps/code-agent/src/scripts/lib/backfillTaskGroupSummarySortKeys.ts
@@ -1,0 +1,100 @@
+import type { Firestore } from '@google-cloud/firestore';
+import type { Result } from '@intexuraos/common-core';
+import { err, getErrorMessage, ok } from '@intexuraos/common-core';
+import { getLinearIssueSortFields } from '../../infra/firestore/taskGroupSummary/serializer.js';
+
+const SUMMARIES_COLLECTION = 'task_group_summaries';
+const DEFAULT_BATCH_SIZE = 500;
+
+export interface TaskGroupSummarySortKeyBackfillUpdate {
+  docId: string;
+  linearIssueId: string | null;
+  before: {
+    linearIssueNumber: unknown;
+    linearIssueSortKey: unknown;
+  };
+  after: {
+    linearIssueNumber: number | null;
+    linearIssueSortKey: number;
+  };
+}
+
+export interface TaskGroupSummarySortKeyBackfillResult {
+  dryRun: boolean;
+  scanned: number;
+  updated: number;
+  updates: TaskGroupSummarySortKeyBackfillUpdate[];
+}
+
+export interface RunTaskGroupSummarySortKeyBackfillInput {
+  firestore: Firestore;
+  dryRun?: boolean;
+  batchSize?: number;
+}
+
+function normalizeLinearIssueId(value: unknown): string | null {
+  return typeof value === 'string' ? value : null;
+}
+
+function needsUpdate(
+  data: Record<string, unknown>,
+  expected: TaskGroupSummarySortKeyBackfillUpdate['after'],
+): boolean {
+  return data['linearIssueNumber'] !== expected.linearIssueNumber ||
+    data['linearIssueSortKey'] !== expected.linearIssueSortKey;
+}
+
+export async function runTaskGroupSummarySortKeyBackfill(
+  input: RunTaskGroupSummarySortKeyBackfillInput,
+): Promise<Result<TaskGroupSummarySortKeyBackfillResult>> {
+  const dryRun = input.dryRun === true;
+  const batchSize = input.batchSize ?? DEFAULT_BATCH_SIZE;
+
+  try {
+    const snapshot = await input.firestore.collection(SUMMARIES_COLLECTION).get();
+    const updates: TaskGroupSummarySortKeyBackfillUpdate[] = [];
+
+    for (const doc of snapshot.docs) {
+      const data = doc.data() as Record<string, unknown>;
+      const linearIssueId = normalizeLinearIssueId(data['linearIssueId']);
+      const expected = getLinearIssueSortFields(linearIssueId);
+
+      if (!needsUpdate(data, expected)) {
+        continue;
+      }
+
+      updates.push({
+        docId: doc.id,
+        linearIssueId,
+        before: {
+          linearIssueNumber: data['linearIssueNumber'],
+          linearIssueSortKey: data['linearIssueSortKey'],
+        },
+        after: expected,
+      });
+    }
+
+    if (!dryRun) {
+      for (let i = 0; i < updates.length; i += batchSize) {
+        const batch = input.firestore.batch();
+        for (const update of updates.slice(i, i + batchSize)) {
+          batch.set(
+            input.firestore.collection(SUMMARIES_COLLECTION).doc(update.docId),
+            update.after,
+            { merge: true },
+          );
+        }
+        await batch.commit();
+      }
+    }
+
+    return ok({
+      dryRun,
+      scanned: snapshot.size,
+      updated: updates.length,
+      updates,
+    });
+  } catch (error) {
+    return err(new Error(getErrorMessage(error, 'Failed to backfill task group summary sort keys')));
+  }
+}

--- a/apps/code-agent/src/scripts/lib/runIssueGroupListingRepair.ts
+++ b/apps/code-agent/src/scripts/lib/runIssueGroupListingRepair.ts
@@ -1,0 +1,57 @@
+import type { Result } from '@intexuraos/common-core';
+import { err, ok } from '@intexuraos/common-core';
+import type {
+  RepairArchivedOpenPrGroupsInput,
+  RepairArchivedOpenPrGroupsResult,
+} from '../../domain/usecases/repairArchivedOpenPrGroups.js';
+import type { TaskGroupSummarySortKeyBackfillResult } from './backfillTaskGroupSummarySortKeys.js';
+export type { TaskGroupSummarySortKeyBackfillResult } from './backfillTaskGroupSummarySortKeys.js';
+
+export interface RunIssueGroupListingRepairDeps {
+  backfillTaskGroupSummarySortKeys(
+    input?: { dryRun?: boolean },
+  ): Promise<Result<TaskGroupSummarySortKeyBackfillResult>>;
+  repairArchivedOpenPrGroups(
+    input?: RepairArchivedOpenPrGroupsInput,
+  ): Promise<Result<RepairArchivedOpenPrGroupsResult>>;
+}
+
+export interface RunIssueGroupListingRepairInput extends RepairArchivedOpenPrGroupsInput {
+  dryRun?: boolean;
+}
+
+export interface RunIssueGroupListingRepairResult {
+  dryRun: boolean;
+  sortKeyBackfill: TaskGroupSummarySortKeyBackfillResult;
+  archivedOpenPrRepair: RepairArchivedOpenPrGroupsResult;
+}
+
+export function createRunIssueGroupListingRepair(
+  deps: RunIssueGroupListingRepairDeps,
+): (
+  input?: RunIssueGroupListingRepairInput
+) => Promise<Result<RunIssueGroupListingRepairResult>> {
+  return async (input?: RunIssueGroupListingRepairInput): Promise<Result<RunIssueGroupListingRepairResult>> => {
+    const dryRun = input?.dryRun === true;
+
+    const backfillResult = await deps.backfillTaskGroupSummarySortKeys({ dryRun });
+    if (!backfillResult.ok) {
+      return err(new Error(backfillResult.error.message));
+    }
+
+    const repairInput: RepairArchivedOpenPrGroupsInput = {
+      dryRun,
+      ...(input?.scanLimit !== undefined ? { scanLimit: input.scanLimit } : {}),
+    };
+    const archivedOpenPrRepairResult = await deps.repairArchivedOpenPrGroups(repairInput);
+    if (!archivedOpenPrRepairResult.ok) {
+      return err(new Error(archivedOpenPrRepairResult.error.message));
+    }
+
+    return ok({
+      dryRun,
+      sortKeyBackfill: backfillResult.value,
+      archivedOpenPrRepair: archivedOpenPrRepairResult.value,
+    });
+  };
+}

--- a/apps/code-agent/src/scripts/repairArchivedOpenPrGroups.ts
+++ b/apps/code-agent/src/scripts/repairArchivedOpenPrGroups.ts
@@ -1,0 +1,76 @@
+/**
+ * Repair archived task groups that still belong to open PRs.
+ *
+ * Usage:
+ *   npx tsx apps/code-agent/src/scripts/repairArchivedOpenPrGroups.ts
+ *   npx tsx apps/code-agent/src/scripts/repairArchivedOpenPrGroups.ts --dry-run
+ *   npx tsx apps/code-agent/src/scripts/repairArchivedOpenPrGroups.ts --scan-limit=100
+ */
+
+import { Firestore } from '@google-cloud/firestore';
+import { createAppLogger } from '@intexuraos/infra-sentry';
+import { setFirestore } from '@intexuraos/infra-firestore';
+import { createFirestoreCodeTaskRepository } from '../infra/repositories/firestoreCodeTaskRepository.js';
+import { createFirestoreGitHubPRSummariesRepository } from '../infra/firestore/gitHubPRSummariesRepository.js';
+import { createTaskGroupSummaryFirestoreRepository } from '../infra/firestore/taskGroupSummaryFirestoreRepository.js';
+import {
+  createRepairArchivedOpenPrGroupsUseCase,
+  formatRepairArchivedOpenPrGroupsError,
+  type RepairArchivedOpenPrGroupsDeps,
+} from '../domain/usecases/repairArchivedOpenPrGroups.js';
+/* v8 ignore start -- module-init: standalone repair script is never imported by test suites; cannot be unit-tested without a live Firestore connection @preserve */
+
+function parseDryRun(argv: string[]): boolean {
+  return argv.includes('--dry-run');
+}
+
+function parseScanLimit(argv: string[]): number | undefined {
+  const flag = argv.find((arg) => arg.startsWith('--scan-limit='));
+  if (flag === undefined) {
+    return undefined;
+  }
+
+  const raw = flag.slice('--scan-limit='.length);
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`Invalid --scan-limit value: ${raw}`);
+  }
+  return parsed;
+}
+
+async function main(): Promise<void> {
+  const argv = process.argv.slice(2);
+  const dryRun = parseDryRun(argv);
+  const scanLimit = parseScanLimit(argv);
+
+  const logger = createAppLogger({ name: 'repair-archived-open-pr-groups' });
+  const firestore = new Firestore();
+  setFirestore(firestore);
+
+  const codeTaskRepo = createFirestoreCodeTaskRepository({ firestore, logger });
+  const gitHubPRSummaryRepo = createFirestoreGitHubPRSummariesRepository({ logger });
+  const groupSummaryRepo = createTaskGroupSummaryFirestoreRepository({ firestore, logger });
+  const useCase = createRepairArchivedOpenPrGroupsUseCase({
+    codeTaskRepo: codeTaskRepo as unknown as RepairArchivedOpenPrGroupsDeps['codeTaskRepo'],
+    gitHubPRSummaryRepo,
+    groupSummaryRepo,
+    logger,
+  });
+
+  const result = await useCase({
+    dryRun,
+    ...(scanLimit !== undefined ? { scanLimit } : {}),
+  });
+  if (!result.ok) {
+    throw new Error(result.error.message);
+  }
+
+  process.stdout.write(`${JSON.stringify(result.value, null, 2)}\n`);
+}
+
+main().catch((error: unknown) => {
+  process.stderr.write(`${formatRepairArchivedOpenPrGroupsError(error)}\n`);
+  process.exit(1);
+});
+
+/* v8 ignore stop @preserve */

--- a/apps/code-agent/src/scripts/repairIssueGroupListing.ts
+++ b/apps/code-agent/src/scripts/repairIssueGroupListing.ts
@@ -1,0 +1,89 @@
+/**
+ * Repair both known code-task group listing issues:
+ * 1. missing sort keys on legacy task_group_summaries
+ * 2. archived groups that still belong to open PRs
+ *
+ * Usage:
+ *   npx tsx apps/code-agent/src/scripts/repairIssueGroupListing.ts
+ *   npx tsx apps/code-agent/src/scripts/repairIssueGroupListing.ts --dry-run
+ *   npx tsx apps/code-agent/src/scripts/repairIssueGroupListing.ts --scan-limit=100
+ */
+
+import { Firestore } from '@google-cloud/firestore';
+import { createAppLogger } from '@intexuraos/infra-sentry';
+import { setFirestore } from '@intexuraos/infra-firestore';
+import { createFirestoreCodeTaskRepository } from '../infra/repositories/firestoreCodeTaskRepository.js';
+import { createFirestoreGitHubPRSummariesRepository } from '../infra/firestore/gitHubPRSummariesRepository.js';
+import { createTaskGroupSummaryFirestoreRepository } from '../infra/firestore/taskGroupSummaryFirestoreRepository.js';
+import {
+  createRepairArchivedOpenPrGroupsUseCase,
+  formatRepairArchivedOpenPrGroupsError,
+  type RepairArchivedOpenPrGroupsDeps,
+} from '../domain/usecases/repairArchivedOpenPrGroups.js';
+import { runTaskGroupSummarySortKeyBackfill } from './lib/backfillTaskGroupSummarySortKeys.js';
+import { createRunIssueGroupListingRepair } from './lib/runIssueGroupListingRepair.js';
+/* v8 ignore start -- module-init: standalone repair script is never imported by test suites; cannot be unit-tested without a live Firestore connection @preserve */
+
+function parseDryRun(argv: string[]): boolean {
+  return argv.includes('--dry-run');
+}
+
+function parseScanLimit(argv: string[]): number | undefined {
+  const flag = argv.find((arg) => arg.startsWith('--scan-limit='));
+  if (flag === undefined) {
+    return undefined;
+  }
+
+  const raw = flag.slice('--scan-limit='.length);
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`Invalid --scan-limit value: ${raw}`);
+  }
+  return parsed;
+}
+
+async function main(): Promise<void> {
+  const argv = process.argv.slice(2);
+  const dryRun = parseDryRun(argv);
+  const scanLimit = parseScanLimit(argv);
+
+  const logger = createAppLogger({ name: 'repair-issue-group-listing' });
+  const firestore = new Firestore();
+  setFirestore(firestore);
+
+  const codeTaskRepo = createFirestoreCodeTaskRepository({ firestore, logger });
+  const gitHubPRSummaryRepo = createFirestoreGitHubPRSummariesRepository({ logger });
+  const groupSummaryRepo = createTaskGroupSummaryFirestoreRepository({ firestore, logger });
+  const repairArchivedOpenPrGroups = createRepairArchivedOpenPrGroupsUseCase({
+    codeTaskRepo: codeTaskRepo as unknown as RepairArchivedOpenPrGroupsDeps['codeTaskRepo'],
+    gitHubPRSummaryRepo,
+    groupSummaryRepo,
+    logger,
+  });
+  const runRepair = createRunIssueGroupListingRepair({
+    backfillTaskGroupSummarySortKeys: async (
+      input?: { dryRun?: boolean },
+    ) => await runTaskGroupSummarySortKeyBackfill({
+        firestore,
+        dryRun: input?.dryRun === true,
+      }),
+    repairArchivedOpenPrGroups,
+  });
+
+  const result = await runRepair({
+    dryRun,
+    ...(scanLimit !== undefined ? { scanLimit } : {}),
+  });
+  if (!result.ok) {
+    throw new Error(result.error.message);
+  }
+
+  process.stdout.write(`${JSON.stringify(result.value, null, 2)}\n`);
+}
+
+main().catch((error: unknown) => {
+  process.stderr.write(`${formatRepairArchivedOpenPrGroupsError(error)}\n`);
+  process.exit(1);
+});
+
+/* v8 ignore stop @preserve */

--- a/apps/code-agent/src/scripts/reportIssueGroupRouteView.ts
+++ b/apps/code-agent/src/scripts/reportIssueGroupRouteView.ts
@@ -1,0 +1,281 @@
+/**
+ * Read-only route-shaped verification for GET /code/issue-groups.
+ *
+ * Usage:
+ *   npx tsx apps/code-agent/src/scripts/reportIssueGroupRouteView.ts --user-id=<userId>
+ *   npx tsx apps/code-agent/src/scripts/reportIssueGroupRouteView.ts --user-id=<userId> --group-status=archived --sort-by=linear-id
+ */
+
+import { Firestore } from '@google-cloud/firestore';
+import { createAppLogger } from '@intexuraos/infra-sentry';
+import { createFirestoreCodeTaskRepository } from '../infra/repositories/firestoreCodeTaskRepository.js';
+import { createTaskGroupSummaryFirestoreRepository } from '../infra/firestore/taskGroupSummaryFirestoreRepository.js';
+import type { GroupStatus, SortOption } from '../domain/issueGrouping/index.js';
+import type { CodeTask } from '../domain/models/codeTask.js';
+import type { TaskGroupSummary } from '../domain/models/taskGroupSummary.js';
+/* v8 ignore start -- module-init: standalone verification script is never imported by test suites; cannot be unit-tested without a live Firestore connection @preserve */
+
+const VALID_GROUP_STATUSES: ReadonlySet<GroupStatus> = new Set([
+  'active',
+  'needs-action',
+  'done',
+  'failed',
+  'archived',
+]);
+const VALID_SORT_OPTIONS: ReadonlySet<SortOption> = new Set([
+  'linear-id',
+  'pr-number',
+  'dispatched',
+  'last-updated',
+]);
+const TASKS_PER_GROUP_LIMIT = 50;
+
+function parseRequiredFlag(argv: string[], name: string): string {
+  const flag = argv.find((arg) => arg.startsWith(`--${name}=`));
+  if (flag === undefined) {
+    throw new Error(`Missing required --${name}=... flag`);
+  }
+  return flag.slice(name.length + 3);
+}
+
+function parseOptionalFlag(argv: string[], name: string): string | undefined {
+  const flag = argv.find((arg) => arg.startsWith(`--${name}=`));
+  return flag === undefined ? undefined : flag.slice(name.length + 3);
+}
+
+function parseLimit(argv: string[]): number {
+  const raw = parseOptionalFlag(argv, 'limit');
+  if (raw === undefined) {
+    return 20;
+  }
+
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`Invalid --limit value: ${raw}`);
+  }
+  return parsed;
+}
+
+function parseSortBy(argv: string[]): SortOption {
+  const raw = parseOptionalFlag(argv, 'sort-by');
+  if (raw === undefined) {
+    return 'linear-id';
+  }
+  if (VALID_SORT_OPTIONS.has(raw as SortOption)) {
+    return raw as SortOption;
+  }
+  throw new Error(`Invalid --sort-by value: ${raw}`);
+}
+
+function parseStatusFilter(argv: string[]): GroupStatus[] | undefined {
+  const raw = parseOptionalFlag(argv, 'group-status');
+  if (raw === undefined || raw === '') {
+    return undefined;
+  }
+
+  const parsed = raw
+    .split(',')
+    .map((value) => value.trim())
+    .filter((value): value is GroupStatus => VALID_GROUP_STATUSES.has(value as GroupStatus));
+
+  return parsed.length === 0 ? undefined : parsed;
+}
+
+function groupKeyForTask(task: CodeTask): string {
+  return task.linearIssueId ?? `standalone_${task.id}`;
+}
+
+interface SummaryDisplayInfo {
+  groupKey: string;
+  linearIssueId: string | null;
+  aggregateStatus: GroupStatus;
+  linearIssueSortKey: number;
+  rawTaskCount: number;
+  displayableTaskCount: number;
+  displayableTaskIds: string[];
+  displayableStatuses: string[];
+  taskFetchError?: string;
+}
+
+async function buildSummaryDisplayInfo(
+  summary: TaskGroupSummary,
+  userId: string,
+  includeArchived: boolean,
+  codeTaskRepo: ReturnType<typeof createFirestoreCodeTaskRepository>,
+): Promise<SummaryDisplayInfo> {
+  if (summary.linearIssueId !== null) {
+    const tasksResult = await codeTaskRepo.findRecentTasksByLinearIssue(
+      summary.linearIssueId,
+      TASKS_PER_GROUP_LIMIT,
+    );
+    if (!tasksResult.ok) {
+      return {
+        groupKey: summary.groupKey,
+        linearIssueId: summary.linearIssueId,
+        aggregateStatus: summary.aggregateStatus,
+        linearIssueSortKey: summary.linearIssueSortKey,
+        taskFetchError: tasksResult.error.message,
+        rawTaskCount: 0,
+        displayableTaskCount: 0,
+        displayableTaskIds: [],
+        displayableStatuses: [],
+      };
+    }
+
+    const displayableTasks = tasksResult.value.filter((task) =>
+      task.userId === userId &&
+      (includeArchived || task.status !== 'archived') &&
+      task.agentType !== 'ask_agent' &&
+      groupKeyForTask(task) === summary.groupKey,
+    );
+
+    return {
+      groupKey: summary.groupKey,
+      linearIssueId: summary.linearIssueId,
+      aggregateStatus: summary.aggregateStatus,
+      linearIssueSortKey: summary.linearIssueSortKey,
+      rawTaskCount: tasksResult.value.length,
+      displayableTaskCount: displayableTasks.length,
+      displayableTaskIds: displayableTasks.map((task) => task.id),
+      displayableStatuses: displayableTasks.map((task) => task.status),
+    };
+  }
+
+  const taskId = summary.groupKey.replace(/^standalone_/, '');
+  const taskResult = await codeTaskRepo.findById(taskId);
+  if (!taskResult.ok) {
+    return {
+      groupKey: summary.groupKey,
+      linearIssueId: null,
+      aggregateStatus: summary.aggregateStatus,
+      linearIssueSortKey: summary.linearIssueSortKey,
+      taskFetchError: taskResult.error.message,
+      rawTaskCount: 0,
+      displayableTaskCount: 0,
+      displayableTaskIds: [],
+      displayableStatuses: [],
+    };
+  }
+
+  const task = taskResult.value;
+  const displayable = task.userId === userId &&
+    (includeArchived || task.status !== 'archived') &&
+    task.agentType !== 'ask_agent';
+
+  return {
+    groupKey: summary.groupKey,
+    linearIssueId: null,
+    aggregateStatus: summary.aggregateStatus,
+    linearIssueSortKey: summary.linearIssueSortKey,
+    rawTaskCount: 1,
+    displayableTaskCount: displayable ? 1 : 0,
+    displayableTaskIds: displayable ? [task.id] : [],
+    displayableStatuses: displayable ? [task.status] : [],
+  };
+}
+
+async function main(): Promise<void> {
+  const argv = process.argv.slice(2);
+  const userId = parseRequiredFlag(argv, 'user-id');
+  const statusFilter = parseStatusFilter(argv);
+  const sortBy = parseSortBy(argv);
+  const limit = parseLimit(argv);
+  const includeArchived = statusFilter?.includes('archived') === true;
+
+  const logger = createAppLogger({ name: 'report-issue-group-route-view' });
+  const firestore = new Firestore();
+  const codeTaskRepo = createFirestoreCodeTaskRepository({ firestore, logger });
+  const groupSummaryRepo = createTaskGroupSummaryFirestoreRepository({ firestore, logger });
+
+  const [countsResult, summariesResult] = await Promise.all([
+    groupSummaryRepo.getUserGroupCounts(userId),
+    groupSummaryRepo.listGroupSummaries({
+      userId,
+      sortBy,
+      limit,
+      ...(statusFilter !== undefined ? { statusFilter } : {}),
+    }),
+  ]);
+  if (!countsResult.ok) {
+    throw new Error(countsResult.error.message);
+  }
+  if (!summariesResult.ok) {
+    throw new Error(summariesResult.error.message);
+  }
+  const countsValue = countsResult.value;
+  let phantomCheckSummaries: TaskGroupSummary[] = [];
+  if (statusFilter !== undefined) {
+    const statusesWithCounts: GroupStatus[] = [];
+    if (countsValue.active > 0 && !statusFilter.includes('active')) statusesWithCounts.push('active');
+    if (countsValue.needsAction > 0 && !statusFilter.includes('needs-action')) statusesWithCounts.push('needs-action');
+    if (countsValue.done > 0 && !statusFilter.includes('done')) statusesWithCounts.push('done');
+    if (countsValue.failed > 0 && !statusFilter.includes('failed')) statusesWithCounts.push('failed');
+
+    if (statusesWithCounts.length > 0) {
+      const phantomResult = await groupSummaryRepo.listGroupSummaries({
+        userId,
+        sortBy,
+        limit: 100,
+        statusFilter: statusesWithCounts,
+      });
+      if (!phantomResult.ok) {
+        throw new Error(phantomResult.error.message);
+      }
+      phantomCheckSummaries = phantomResult.value.summaries;
+    }
+  }
+
+  const groups = await Promise.all(summariesResult.value.summaries.map((summary) =>
+    buildSummaryDisplayInfo(summary, userId, includeArchived, codeTaskRepo),
+  ));
+  const phantomCheckGroups = await Promise.all(phantomCheckSummaries.map((summary) =>
+    buildSummaryDisplayInfo(summary, userId, includeArchived, codeTaskRepo),
+  ));
+
+  const phantomStatusDeltas: Partial<Record<GroupStatus, number>> = {};
+  for (const group of groups) {
+    if (group.displayableTaskCount === 0) {
+      phantomStatusDeltas[group.aggregateStatus] = (phantomStatusDeltas[group.aggregateStatus] ?? 0) + 1;
+    }
+  }
+  for (const group of phantomCheckGroups) {
+    if (group.displayableTaskCount === 0) {
+      phantomStatusDeltas[group.aggregateStatus] = (phantomStatusDeltas[group.aggregateStatus] ?? 0) + 1;
+    }
+  }
+
+  const correctedCounts = {
+    active: Math.max(0, countsValue.active - (phantomStatusDeltas.active ?? 0)),
+    'needs-action': Math.max(0, countsValue.needsAction - (phantomStatusDeltas['needs-action'] ?? 0)),
+    done: Math.max(0, countsValue.done - (phantomStatusDeltas.done ?? 0)),
+    failed: Math.max(0, countsValue.failed - (phantomStatusDeltas.failed ?? 0)),
+    archived: Math.max(0, countsValue.archived - (phantomStatusDeltas.archived ?? 0)),
+  };
+
+  const totalGroups = statusFilter !== undefined
+    ? statusFilter.reduce((sum, status) => sum + correctedCounts[status], 0)
+    : Object.values(correctedCounts).reduce((sum, count) => sum + count, 0);
+
+  process.stdout.write(`${JSON.stringify({
+    input: {
+      userId,
+      statusFilter: statusFilter ?? null,
+      sortBy,
+      limit,
+    },
+    rawCounts: countsValue,
+    correctedCounts,
+    totalGroups,
+    summariesReturned: summariesResult.value.summaries.length,
+    nextCursor: summariesResult.value.nextCursor ?? null,
+    groups,
+    phantomCheckGroups,
+  }, null, 2)}\n`);
+}
+
+main().catch((error: unknown) => {
+  process.stderr.write(`${error instanceof Error ? error.stack ?? error.message : String(error)}\n`);
+  process.exit(1);
+});
+
+/* v8 ignore stop @preserve */

--- a/scripts/__tests__/verify-package-exports.test.ts
+++ b/scripts/__tests__/verify-package-exports.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import type { Stats } from 'node:fs';
+import { listPackageDirs } from '../lib/package-export-utils.mjs';
+
+function makeDirectoryStats(): Stats {
+  return {
+    isDirectory: () => true,
+  } as Stats;
+}
+
+function makeFileStats(): Stats {
+  return {
+    isDirectory: () => false,
+  } as Stats;
+}
+
+describe('listPackageDirs', () => {
+  it('returns only directories that contain package.json', () => {
+    const result = listPackageDirs('/repo/packages', {
+      readdirSync: () => ['good-package', 'missing-package-json', 'README.md'],
+      statSync: (path) => {
+        if (path.endsWith('README.md')) {
+          return makeFileStats();
+        }
+        return makeDirectoryStats();
+      },
+      existsSync: (path) => path.endsWith('good-package/package.json'),
+    });
+
+    expect(result).toEqual(['good-package']);
+  });
+
+  it('skips package entries that disappear between readdir and stat', () => {
+    const result = listPackageDirs('/repo/packages', {
+      readdirSync: () => ['stable-package', 'orphan'],
+      statSync: (path) => {
+        if (path.endsWith('/orphan')) {
+          const error = new Error('missing') as NodeJS.ErrnoException;
+          error.code = 'ENOENT';
+          throw error;
+        }
+        return makeDirectoryStats();
+      },
+      existsSync: () => true,
+    });
+
+    expect(result).toEqual(['stable-package']);
+  });
+});

--- a/scripts/lib/package-export-utils.mjs
+++ b/scripts/lib/package-export-utils.mjs
@@ -1,0 +1,27 @@
+import { readdirSync, statSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+export function listPackageDirs(
+  packagesRoot,
+  fsOps = {
+    readdirSync,
+    statSync,
+    existsSync,
+  }
+) {
+  return fsOps
+    .readdirSync(packagesRoot)
+    .filter((name) => {
+      const full = join(packagesRoot, name);
+      try {
+        if (!fsOps.statSync(full).isDirectory()) return false;
+      } catch (error) {
+        if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
+          return false;
+        }
+        throw error;
+      }
+      return fsOps.existsSync(join(full, 'package.json'));
+    })
+    .sort();
+}

--- a/scripts/verify-package-exports.mjs
+++ b/scripts/verify-package-exports.mjs
@@ -19,8 +19,9 @@
  * See `docs/architecture/package-build-output.md` for the full rationale.
  */
 
-import { readFileSync, readdirSync, existsSync, statSync } from 'node:fs';
+import { readFileSync, existsSync } from 'node:fs';
 import { resolve, join } from 'node:path';
+import { listPackageDirs } from './lib/package-export-utils.mjs';
 
 const repoRoot = resolve(import.meta.dirname, '..');
 const packagesRoot = join(repoRoot, 'packages');
@@ -94,13 +95,7 @@ function stripJsonComments(src) {
   return out;
 }
 
-const packageDirs = readdirSync(packagesRoot)
-  .filter((name) => {
-    const full = join(packagesRoot, name);
-    if (!statSync(full).isDirectory()) return false;
-    return existsSync(join(full, 'package.json'));
-  })
-  .sort();
+const packageDirs = listPackageDirs(packagesRoot);
 
 const violations = [];
 let checkedPackages = 0;


### PR DESCRIPTION
## Summary

- repair task-group summary writes so legacy summaries always persist `linearIssueNumber` and `linearIssueSortKey`
- add idempotent archived-open-PR repair tooling plus a combined issue-group listing repair entrypoint
- add route-level and use-case regressions for `linear-id` sorting, archived visibility repair, and the CI package-export race

## Root Cause

- incremental task-group summary updates were not rewriting the Linear sort fields, so `linear-id` Firestore ordering excluded most legacy docs
- some groups with still-open PRs had already been archived end-to-end, so non-archived issue-group views could never surface them without a data repair
- `verify-package-exports` could race with `verify-boundaries` temporary fixture directories during parallel static validation

## Validation

- `pnpm run verify:workspace:tracked code-agent`
- `pnpm run ci:tracked`
