### PR TITLE
[INT-1611] Automate Artifact Registry cleanup

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -141,7 +141,6 @@ jobs:
         run: |
           bash cloudbuild/scripts/build-push-monitored.sh image-service apps/image-service/Dockerfile &
           bash cloudbuild/scripts/build-push-monitored.sh api-docs-hub apps/api-docs-hub/Dockerfile &
-          bash cloudbuild/scripts/build-push-monitored.sh code-worker docker/code-worker/Dockerfile &
           bash cloudbuild/scripts/build-push-monitored.sh notion-service apps/notion-service/Dockerfile &
           bash cloudbuild/scripts/build-push-monitored.sh user-service apps/user-service/Dockerfile &
           bash cloudbuild/scripts/build-push-monitored.sh whatsapp-service apps/whatsapp-service/Dockerfile &

--- a/cloudbuild/cloudbuild.yaml
+++ b/cloudbuild/cloudbuild.yaml
@@ -83,19 +83,6 @@ steps:
         npm install -g pnpm@10
         pnpm install --frozen-lockfile
 
-  # Build code-worker Docker image (no deploy, runs in parallel with pnpm-install)
-  - name: 'gcr.io/cloud-builders/docker'
-    id: 'build-push-code-worker'
-    waitFor: ['-'] # Start immediately, no dependencies
-    timeout: 900s
-    entrypoint: 'bash'
-    args:
-      ['cloudbuild/scripts/build-push-monitored.sh', 'code-worker', 'docker/code-worker/Dockerfile']
-    env:
-      - 'DOCKER_BUILDKIT=1'
-      - 'ARTIFACT_REGISTRY_URL=${_ARTIFACT_REGISTRY_URL}'
-      - 'COMMIT_SHA=$COMMIT_SHA'
-
   # ===========================================================================
   # BATCH 1 - Foundation (Firestore + 3 lightweight services)
   # ===========================================================================

--- a/docs/operations/artifact-registry-cleanup.md
+++ b/docs/operations/artifact-registry-cleanup.md
@@ -1,0 +1,163 @@
+# Artifact Registry Cleanup Runbook
+
+This runbook is for reducing Docker image storage in Artifact Registry without deleting live Cloud Run or orchestrator images.
+
+## Scope
+
+- Primary target: `europe-central2-docker.pkg.dev/intexuraos-dev-pbuchman/intexuraos-dev`
+- Explicit non-target for the first pass: `gcf-artifacts`
+
+## Preflight
+
+1. Verify GCP auth:
+
+```bash
+gcloud auth list
+gcloud config get-value project
+```
+
+2. Verify current repository size:
+
+```bash
+gcloud artifacts repositories list \
+  --location=europe-central2 \
+  --project=intexuraos-dev-pbuchman \
+  --format='table(name.basename(),sizeBytes,updateTime)'
+```
+
+3. Confirm the orchestrator host and env file:
+
+```bash
+uname -n
+grep '^INTEXURAOS_CODE_WORKER_IMAGE=' ~/.code-orchestrator/env || true
+```
+
+If `INTEXURAOS_CODE_WORKER_IMAGE` is missing, the orchestrator is still following the default `code-worker:latest` image and must be pinned before any aggressive `code-worker` prune.
+
+## Export Live Images
+
+```bash
+node scripts/artifact-registry/export-live-images.mjs \
+  --project=intexuraos-dev-pbuchman \
+  --region=europe-central2 \
+  --repository=intexuraos-dev \
+  --orchestrator-env-path='~/.code-orchestrator/env' \
+  --out-dir=/tmp/artifact-registry/live-$(date +%F)
+```
+
+Review:
+
+- `/tmp/artifact-registry/live-YYYY-MM-DD/cloud-run-images.json`
+- `/tmp/artifact-registry/live-YYYY-MM-DD/orchestrator-image.json`
+- `/tmp/artifact-registry/live-YYYY-MM-DD/protected-digests.json`
+- `/tmp/artifact-registry/live-YYYY-MM-DD/warnings.json`
+
+## Generate Prune Plan
+
+```bash
+node scripts/artifact-registry/generate-prune-plan.mjs \
+  --project=intexuraos-dev-pbuchman \
+  --location=europe-central2 \
+  --repository=intexuraos-dev \
+  --keep-count=3 \
+  --protected=/tmp/artifact-registry/live-$(date +%F)/protected-digests.json \
+  --retired-packages=claude-worker,commands-router,data-insights-service,llm-orchestrator,llm-orchestrator-service \
+  --out-dir=/tmp/artifact-registry/plan-$(date +%F)
+```
+
+Review:
+
+- `/tmp/artifact-registry/plan-YYYY-MM-DD/prune-plan.json`
+- `/tmp/artifact-registry/plan-YYYY-MM-DD/prune-summary.md`
+
+## Dry Run Deletes
+
+Retired packages only:
+
+```bash
+node scripts/artifact-registry/apply-prune-plan.mjs \
+  --plan=/tmp/artifact-registry/plan-$(date +%F)/prune-plan.json
+```
+
+Single package:
+
+```bash
+node scripts/artifact-registry/apply-prune-plan.mjs \
+  --plan=/tmp/artifact-registry/plan-$(date +%F)/prune-plan.json \
+  --scope=package:code-worker
+```
+
+The CLI prints the exact `gcloud artifacts docker images delete ... --delete-tags --quiet` commands and does not execute them unless `--execute` is supplied.
+
+## Execute Deletes
+
+Retired packages:
+
+```bash
+node scripts/artifact-registry/apply-prune-plan.mjs \
+  --plan=/tmp/artifact-registry/plan-$(date +%F)/prune-plan.json \
+  --scope=retired-packages \
+  --execute \
+  --batch-size=50
+```
+
+`code-worker` after pinning the orchestrator:
+
+```bash
+node scripts/artifact-registry/apply-prune-plan.mjs \
+  --plan=/tmp/artifact-registry/plan-$(date +%F)/prune-plan.json \
+  --scope=package:code-worker \
+  --execute \
+  --batch-size=50
+```
+
+## Pin The Orchestrator Before Code-Worker Prune
+
+Choose a retained `code-worker` digest from the prune plan and update the orchestrator env:
+
+```bash
+grep '^INTEXURAOS_CODE_WORKER_IMAGE=' ~/.code-orchestrator/env || true
+sed -i 's#^INTEXURAOS_CODE_WORKER_IMAGE=.*#INTEXURAOS_CODE_WORKER_IMAGE=europe-central2-docker.pkg.dev/intexuraos-dev-pbuchman/intexuraos-dev/code-worker@sha256:RETAINED_DIGEST#' ~/.code-orchestrator/env
+sudo systemctl restart intexuraos-orchestrator@pbuchman
+```
+
+Re-export live images after the restart and verify the pinned digest appears in `protected-digests.json`.
+
+## Terraform Cleanup Policies
+
+Dry-run first:
+
+```bash
+cd terraform/environments/dev
+STORAGE_EMULATOR_HOST= FIRESTORE_EMULATOR_HOST= PUBSUB_EMULATOR_HOST= \
+GOOGLE_APPLICATION_CREDENTIALS=$HOME/.config/gcloud/sa-key.json \
+terraform init
+
+STORAGE_EMULATOR_HOST= FIRESTORE_EMULATOR_HOST= PUBSUB_EMULATOR_HOST= \
+GOOGLE_APPLICATION_CREDENTIALS=$HOME/.config/gcloud/sa-key.json \
+terraform plan
+```
+
+The intended steady state is:
+
+- active cleanup policy after live digests are verified inside the newest-3 window
+- global keep count of `3`
+- general delete policy for images older than `86400s` (1 day)
+- `code-worker` delete policy for images older than `86400s` (1 day)
+
+If the exported prune plan shows no package with more than `3` retained digests, the live runtimes are already inside the retained window and the policy can be applied immediately.
+
+## Verification
+
+Immediate verification:
+
+```bash
+gcloud artifacts repositories list \
+  --location=europe-central2 \
+  --project=intexuraos-dev-pbuchman \
+  --format='table(name.basename(),sizeBytes,updateTime)'
+```
+
+Next-day verification:
+
+Google cleanup-policy processing is asynchronous. Re-run the repository-size command the next day to confirm the policy continued removing eligible artifacts.

--- a/docs/superpowers/plans/2026-05-07-artifact-registry-storage-cleanup.md
+++ b/docs/superpowers/plans/2026-05-07-artifact-registry-storage-cleanup.md
@@ -1,0 +1,834 @@
+# Artifact Registry Storage Cleanup Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reduce Artifact Registry storage safely and aggressively by deleting dead Docker image history, retaining only 3 recent versions per active package plus currently deployed digests, and preventing the buildup from returning.
+
+**Architecture:** Execute in two phases. First, add repo-tracked inventory and prune tooling that produces a protected-digest allowlist and a reviewed deletion plan instead of deleting from ad hoc shell loops. Second, remove dead packages immediately, update any live workloads that still reference old digests, then enable Terraform-managed cleanup policies and stop unnecessary `code-worker` rebuilds in monolith deploys.
+
+**Tech Stack:** Node.js 22, vitest, gcloud, Artifact Registry, Cloud Run, SSH/home-dev, Terraform, GitHub Actions, Cloud Build
+
+**Endpoint Changes:** Unchanged.
+
+---
+
+## Safety Rules
+
+- Never delete from `gcf-artifacts` in the first execution pass. It is only about `1.2 GB`; the problem repository is `intexuraos-dev`.
+- Never delete a digest until it is present in neither:
+  - current Cloud Run service images
+  - `INTEXURAOS_CODE_WORKER_IMAGE` in `~/.code-orchestrator/env` on `home-dev`
+- Keep `3` newest versions per active package, plus any extra currently deployed digest if it falls outside the newest `3`.
+- Delete retired packages entirely only after verifying they are absent from code references and live runtime references.
+- Run destructive deletions in bounded batches. Maximum `50` digests per execution batch.
+- Do not switch Artifact Registry cleanup out of dry-run mode until all live runtimes point at digests that are inside the retained window.
+
+## Current Evidence To Preserve In The Plan
+
+- Artifact Registry storage is dominated by `intexuraos-dev` at `203.978 GB`; `gcf-artifacts` is only `1.216 GB`.
+- `intexuraos-dev` contains `11,203` retained versions across `30` packages.
+- If retention were actually “keep 3”, steady state would be roughly `90` versions plus any extra deployed digests, not `11,203`.
+- Dead packages currently identified for likely full removal:
+  - `claude-worker`
+  - `commands-router`
+  - `data-insights-service`
+  - `llm-orchestrator`
+  - `llm-orchestrator-service`
+- `promptvault-service` looked retired during the initial billing investigation, but live inventory shows `intexuraos-promptvault-service` is still deployed, so it must follow active-package retention instead of full removal.
+- `code-worker` is the largest active storage source and also has a daily rebuild schedule.
+
+## File Map
+
+### New Files
+
+- `scripts/artifact-registry/lib.ts`
+  - Shared typed logic for parsing live image references, registry versions, retention selection, and prune-plan generation.
+- `scripts/artifact-registry/export-live-images.mjs`
+  - CLI that exports current Cloud Run and orchestrator image references into JSON files.
+- `scripts/artifact-registry/generate-prune-plan.mjs`
+  - CLI that combines live references with Artifact Registry contents and emits a reviewed prune plan.
+- `scripts/artifact-registry/apply-prune-plan.mjs`
+  - CLI that prints or executes exact deletion commands from a previously generated plan.
+- `scripts/__tests__/artifact-registry-lib.test.ts`
+  - Unit tests for retention logic and protected-digest handling.
+- `scripts/__tests__/artifact-registry-cli.test.ts`
+  - Tests for CLI parsing, plan generation behavior, and delete safeguards.
+- `docs/operations/artifact-registry-cleanup.md`
+  - Durable runbook for future cleanups after this one-time remediation.
+
+### Modified Files
+
+- `.github/workflows/deploy.yml`
+  - Remove `code-worker` from monolith local deploy builds.
+- `cloudbuild/cloudbuild.yaml`
+  - Remove the unconditional `build-push-code-worker` step from monolith Cloud Build.
+- `terraform/modules/artifact-registry/main.tf`
+  - Add delete cleanup policies and `cleanup_policy_dry_run`.
+- `terraform/modules/artifact-registry/variables.tf`
+  - Add configurable retention and dry-run variables.
+- `terraform/environments/dev/main.tf`
+  - Pass concrete cleanup variable values for this environment.
+- `scripts/README.md`
+  - Document the new Artifact Registry cleanup tooling.
+
+---
+
+## Chunk 1: Repo Tooling
+
+### Task 1: Add retention decision engine
+
+**Files:**
+- Create: `scripts/artifact-registry/lib.ts`
+- Test: `scripts/__tests__/artifact-registry-lib.test.ts`
+
+- [ ] **Step 1: Write failing tests for retention selection**
+
+Add test cases for:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import {
+  classifyPackages,
+  buildRetentionDecisions,
+  type LiveImageRef,
+  type RegistryVersion,
+} from '../artifact-registry/lib.js';
+
+describe('buildRetentionDecisions', () => {
+  it('keeps the newest 3 versions for an active package', () => {});
+  it('keeps a protected deployed digest even when it is older than the newest 3', () => {});
+  it('marks all versions of retired packages for deletion', () => {});
+  it('never returns a protected digest in deleteDigests', () => {});
+});
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+pnpm test -- scripts/__tests__/artifact-registry-lib.test.ts
+```
+
+Expected: FAIL because `scripts/artifact-registry/lib.ts` does not exist yet.
+
+- [ ] **Step 3: Implement minimal shared types and retention logic**
+
+Implement these core interfaces and functions:
+
+```ts
+export interface LiveImageRef {
+  source: 'cloud-run' | 'orchestrator';
+  runtimeName: string;
+  packageName: string;
+  digest: string;
+}
+
+export interface RegistryVersion {
+  packageName: string;
+  digest: string;
+  createTime: string;
+  tags: string[];
+  imageSizeBytes: number;
+}
+
+export interface PackageDecision {
+  packageName: string;
+  status: 'active' | 'retired';
+  keepDigests: string[];
+  deleteDigests: string[];
+}
+```
+
+Rules:
+
+- Sort versions newest-first by `createTime`.
+- For active packages, retain the newest `keepCount` digests.
+- Also retain any digest present in `LiveImageRef[]`.
+- For retired packages, mark all digests for deletion.
+- Throw if any protected digest would be deleted.
+
+- [ ] **Step 4: Re-run tests**
+
+Run:
+
+```bash
+pnpm test -- scripts/__tests__/artifact-registry-lib.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/artifact-registry/lib.ts scripts/__tests__/artifact-registry-lib.test.ts
+git commit -m "feat: add artifact registry retention planner"
+```
+
+### Task 2: Add inventory and prune-plan CLIs
+
+**Files:**
+- Create: `scripts/artifact-registry/export-live-images.mjs`
+- Create: `scripts/artifact-registry/generate-prune-plan.mjs`
+- Create: `scripts/artifact-registry/apply-prune-plan.mjs`
+- Test: `scripts/__tests__/artifact-registry-cli.test.ts`
+
+- [ ] **Step 1: Write failing CLI tests**
+
+Test the following behaviors:
+
+- `export-live-images` writes:
+  - `cloud-run-images.json`
+  - `orchestrator-image.json`
+  - `protected-digests.json`
+- `generate-prune-plan` emits:
+  - `prune-plan.json`
+  - `prune-summary.md`
+- `apply-prune-plan` defaults to dry-run and refuses to execute without `--execute`.
+- `apply-prune-plan` refuses to delete a digest marked `protected`.
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+pnpm test -- scripts/__tests__/artifact-registry-cli.test.ts
+```
+
+Expected: FAIL because the CLI files do not exist yet.
+
+- [ ] **Step 3: Implement `export-live-images.mjs`**
+
+Required flags and behavior:
+
+```bash
+node scripts/artifact-registry/export-live-images.mjs \
+  --project=intexuraos-dev-pbuchman \
+  --region=europe-central2 \
+  --orchestrator-host=home-dev \
+  --orchestrator-env-path='~/.code-orchestrator/env' \
+  --out-dir=/tmp/artifact-registry/live
+```
+
+Implementation requirements:
+
+- Query Cloud Run services with:
+
+```bash
+gcloud run services list --region=europe-central2 --project=intexuraos-dev-pbuchman --format=json
+```
+
+- For each service, capture the image string from `spec.template.spec.containers[0].image`.
+- Read the orchestrator image reference from `~/.code-orchestrator/env`.
+  - If running on `home-dev`, read directly.
+  - If not on `home-dev`, use `ssh home-dev 'grep "^INTEXURAOS_CODE_WORKER_IMAGE=" ~/.code-orchestrator/env'`.
+- Normalize every image reference into package name plus digest form.
+- Fail hard if the orchestrator image is tag-only and not digest-pinned.
+
+- [ ] **Step 4: Implement `generate-prune-plan.mjs`**
+
+Required command:
+
+```bash
+node scripts/artifact-registry/generate-prune-plan.mjs \
+  --project=intexuraos-dev-pbuchman \
+  --location=europe-central2 \
+  --repository=intexuraos-dev \
+  --keep-count=3 \
+  --protected=/tmp/artifact-registry/live/protected-digests.json \
+  --retired-packages=claude-worker,commands-router,data-insights-service,llm-orchestrator,llm-orchestrator-service \
+  --out-dir=/tmp/artifact-registry/plan
+```
+
+Implementation requirements:
+
+- Pull full registry inventory with:
+
+```bash
+gcloud artifacts docker images list \
+  europe-central2-docker.pkg.dev/intexuraos-dev-pbuchman/intexuraos-dev \
+  --include-tags \
+  --format=json
+```
+
+- Produce a stable plan JSON with:
+  - `generatedAt`
+  - `keepCount`
+  - `protectedDigests`
+  - `retiredPackages`
+  - `packageDecisions[]`
+  - `deleteDigestCount`
+  - `deletePackageCount`
+- Produce a human-readable markdown summary sorted by deletion count and estimated logical bytes.
+
+- [ ] **Step 5: Implement `apply-prune-plan.mjs`**
+
+Required dry-run command:
+
+```bash
+node scripts/artifact-registry/apply-prune-plan.mjs \
+  --plan=/tmp/artifact-registry/plan/prune-plan.json \
+  --scope=retired-packages
+```
+
+Required execute command:
+
+```bash
+node scripts/artifact-registry/apply-prune-plan.mjs \
+  --plan=/tmp/artifact-registry/plan/prune-plan.json \
+  --scope=retired-packages \
+  --execute \
+  --batch-size=50
+```
+
+Execution requirements:
+
+- Default mode prints exact `gcloud artifacts docker images delete ...@sha256:... --delete-tags` commands.
+- `--execute` runs them serially and stops on the first failure.
+- Support `--scope=retired-packages`, `--scope=package:<name>`, and `--scope=all`.
+- Before each delete, assert the digest is not in `protectedDigests`.
+
+- [ ] **Step 6: Re-run tests**
+
+Run:
+
+```bash
+pnpm test -- scripts/__tests__/artifact-registry-cli.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scripts/artifact-registry scripts/__tests__/artifact-registry-cli.test.ts
+git commit -m "feat: add artifact registry cleanup tooling"
+```
+
+### Task 3: Document the runbook
+
+**Files:**
+- Create: `docs/operations/artifact-registry-cleanup.md`
+- Modify: `scripts/README.md`
+
+- [ ] **Step 1: Write the runbook**
+
+Document:
+
+- preflight inventory
+- protected-digest export
+- prune plan generation
+- retired package deletion
+- live-digest reconciliation
+- cleanup-policy activation
+- verification commands
+
+- [ ] **Step 2: Add script discovery to `scripts/README.md`**
+
+Add one short section pointing to `scripts/artifact-registry/*.mjs`.
+
+- [ ] **Step 3: Verify docs formatting**
+
+Run:
+
+```bash
+pnpm format:check
+```
+
+Expected: PASS, or format only the touched markdown files if needed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/operations/artifact-registry-cleanup.md scripts/README.md
+git commit -m "docs: add artifact registry cleanup runbook"
+```
+
+---
+
+## Chunk 2: Stop New Unnecessary Growth
+
+### Task 4: Remove `code-worker` from monolith builds
+
+**Files:**
+- Modify: `.github/workflows/deploy.yml`
+- Modify: `cloudbuild/cloudbuild.yaml`
+
+- [ ] **Step 1: Write a failing regression test**
+
+Add a small text-based test in `scripts/__tests__/artifact-registry-cli.test.ts` or a dedicated new test file that asserts:
+
+- monolith local deploy does not invoke `build-push-monitored.sh code-worker`
+- monolith Cloud Build does not include `build-push-code-worker`
+- the dedicated `code-worker` trigger still exists untouched
+
+- [ ] **Step 2: Run the test to verify failure**
+
+Run:
+
+```bash
+pnpm test -- scripts/__tests__/artifact-registry-cli.test.ts
+```
+
+Expected: FAIL because the monolith configs still build `code-worker`.
+
+- [ ] **Step 3: Update workflow and Cloud Build**
+
+Required edits:
+
+- Remove this line from monolith local deploy:
+
+```bash
+bash cloudbuild/scripts/build-push-monitored.sh code-worker docker/code-worker/Dockerfile &
+```
+
+- Remove the unconditional `build-push-code-worker` step from `cloudbuild/cloudbuild.yaml`.
+- Keep the dedicated `code-worker` Cloud Build trigger and the daily scheduler intact.
+
+- [ ] **Step 4: Re-run the test**
+
+Run:
+
+```bash
+pnpm test -- scripts/__tests__/artifact-registry-cli.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/deploy.yml cloudbuild/cloudbuild.yaml scripts/__tests__/artifact-registry-cli.test.ts
+git commit -m "fix: stop monolith deploys from rebuilding code-worker"
+```
+
+### Task 5: Add Terraform cleanup policies in dry-run mode
+
+**Files:**
+- Modify: `terraform/modules/artifact-registry/main.tf`
+- Modify: `terraform/modules/artifact-registry/variables.tf`
+- Modify: `terraform/environments/dev/main.tf`
+
+- [ ] **Step 1: Add failing config test or validation guard**
+
+Add a text-level test or validation script assertion that the repository module includes:
+
+- `cleanup_policy_dry_run`
+- one general `DELETE` policy
+- one `KEEP` policy with `keep_count = 3`
+- one `code-worker`-specific `DELETE` policy
+
+- [ ] **Step 2: Run the failing test**
+
+Run:
+
+```bash
+pnpm test -- scripts/__tests__/artifact-registry-cli.test.ts
+```
+
+Expected: FAIL because only a keep policy exists today.
+
+- [ ] **Step 3: Modify the Terraform module**
+
+Add variables:
+
+```hcl
+variable "cleanup_policy_dry_run" {
+  type = bool
+}
+
+variable "cleanup_keep_count" {
+  type = number
+}
+
+variable "cleanup_delete_older_than" {
+  type = string
+}
+
+variable "code_worker_cleanup_delete_older_than" {
+  type = string
+}
+```
+
+Update the repository resource to include:
+
+```hcl
+cleanup_policy_dry_run = var.cleanup_policy_dry_run
+
+cleanup_policies {
+  id     = "delete-stale-images"
+  action = "DELETE"
+  condition {
+    tag_state  = "any"
+    older_than = var.cleanup_delete_older_than
+  }
+}
+
+cleanup_policies {
+  id     = "keep-recent"
+  action = "KEEP"
+  most_recent_versions {
+    keep_count = var.cleanup_keep_count
+  }
+}
+
+cleanup_policies {
+  id     = "delete-stale-code-worker"
+  action = "DELETE"
+  condition {
+    tag_state             = "any"
+    package_name_prefixes = ["code-worker"]
+    older_than            = var.code_worker_cleanup_delete_older_than
+  }
+}
+```
+
+Set environment values in `terraform/environments/dev/main.tf`:
+
+```hcl
+cleanup_policy_dry_run                = false
+cleanup_keep_count                    = 3
+cleanup_delete_older_than             = "86400s"
+code_worker_cleanup_delete_older_than = "86400s"
+```
+
+- [ ] **Step 4: Re-run the test**
+
+Run:
+
+```bash
+pnpm test -- scripts/__tests__/artifact-registry-cli.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Verify Terraform syntax**
+
+Run:
+
+```bash
+cd terraform/environments/dev
+STORAGE_EMULATOR_HOST= FIRESTORE_EMULATOR_HOST= PUBSUB_EMULATOR_HOST= \
+GOOGLE_APPLICATION_CREDENTIALS=$HOME/.config/gcloud/sa-key.json \
+terraform init
+
+STORAGE_EMULATOR_HOST= FIRESTORE_EMULATOR_HOST= PUBSUB_EMULATOR_HOST= \
+GOOGLE_APPLICATION_CREDENTIALS=$HOME/.config/gcloud/sa-key.json \
+terraform plan
+```
+
+Expected: plan shows Artifact Registry cleanup policy changes only. If the exported prune plan shows no package retaining more than 3 digests, apply with dry-run disabled.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add terraform/modules/artifact-registry/main.tf terraform/modules/artifact-registry/variables.tf terraform/environments/dev/main.tf scripts/__tests__/artifact-registry-cli.test.ts
+git commit -m "feat: add dry-run artifact registry cleanup policies"
+```
+
+---
+
+## Chunk 3: Post-Merge Operational Cleanup
+
+### Task 6: Generate immutable live-runtime inventory
+
+**Files:**
+- None. Uses the new scripts only.
+
+- [ ] **Step 1: Run inventory export**
+
+```bash
+node scripts/artifact-registry/export-live-images.mjs \
+  --project=intexuraos-dev-pbuchman \
+  --region=europe-central2 \
+  --orchestrator-host=home-dev \
+  --orchestrator-env-path='~/.code-orchestrator/env' \
+  --out-dir=/tmp/artifact-registry/live-$(date +%F)
+```
+
+- [ ] **Step 2: Verify outputs**
+
+Confirm the following files exist:
+
+- `/tmp/artifact-registry/live-YYYY-MM-DD/cloud-run-images.json`
+- `/tmp/artifact-registry/live-YYYY-MM-DD/orchestrator-image.json`
+- `/tmp/artifact-registry/live-YYYY-MM-DD/protected-digests.json`
+
+- [ ] **Step 3: Manually inspect the protected list**
+
+Reject the run if:
+
+- any Cloud Run service image is tag-only instead of digest-qualified
+- `INTEXURAOS_CODE_WORKER_IMAGE` is tag-only instead of digest-qualified
+- any duplicate package name has conflicting protected digests without explanation
+
+### Task 7: Generate and review the prune plan
+
+**Files:**
+- None. Uses the new scripts only.
+
+- [ ] **Step 1: Generate the plan**
+
+```bash
+node scripts/artifact-registry/generate-prune-plan.mjs \
+  --project=intexuraos-dev-pbuchman \
+  --location=europe-central2 \
+  --repository=intexuraos-dev \
+  --keep-count=3 \
+  --protected=/tmp/artifact-registry/live-$(date +%F)/protected-digests.json \
+  --retired-packages=claude-worker,commands-router,data-insights-service,llm-orchestrator,llm-orchestrator-service \
+  --out-dir=/tmp/artifact-registry/plan-$(date +%F)
+```
+
+- [ ] **Step 2: Review summary before any delete**
+
+Check `/tmp/artifact-registry/plan-YYYY-MM-DD/prune-summary.md` and confirm:
+
+- all `retiredPackages` have `status: retired`
+- no protected digest appears in a delete set
+- active packages retain `3` newest digests
+- `code-worker` retain set contains the orchestrator digest
+
+- [ ] **Step 3: Save the reviewed plan artifact**
+
+Copy the plan JSON to a dated backup path before executing:
+
+```bash
+mkdir -p ~/artifact-registry-cleanup-archive
+cp /tmp/artifact-registry/plan-$(date +%F)/prune-plan.json ~/artifact-registry-cleanup-archive/prune-plan-$(date +%F).json
+```
+
+### Task 8: Delete retired packages immediately
+
+**Files:**
+- None. Uses the new scripts only.
+
+- [ ] **Step 1: Dry-run retired package deletion**
+
+```bash
+node scripts/artifact-registry/apply-prune-plan.mjs \
+  --plan=/tmp/artifact-registry/plan-$(date +%F)/prune-plan.json \
+  --scope=retired-packages
+```
+
+- [ ] **Step 2: Execute retired package deletion**
+
+```bash
+node scripts/artifact-registry/apply-prune-plan.mjs \
+  --plan=/tmp/artifact-registry/plan-$(date +%F)/prune-plan.json \
+  --scope=retired-packages \
+  --execute \
+  --batch-size=50
+```
+
+- [ ] **Step 3: Verify retired packages are gone**
+
+Run:
+
+```bash
+gcloud artifacts packages list \
+  --repository=intexuraos-dev \
+  --location=europe-central2 \
+  --project=intexuraos-dev-pbuchman \
+  --format='value(name.basename())'
+```
+
+Expected: the retired package names are absent.
+
+### Task 9: Reconcile live runtimes into the retained window
+
+**Files:**
+- None, unless runtime configuration needs an image bump.
+
+- [ ] **Step 1: Detect protected digests outside newest-3**
+
+Use the prune plan summary. If any protected digest is only retained because of runtime protection and not because it is in the newest `3`, record it as a reconciliation target.
+
+- [ ] **Step 2: Update the orchestrator first if needed**
+
+If `code-worker` is pinned to an older digest:
+
+- choose a retained newest digest from the plan
+- update `INTEXURAOS_CODE_WORKER_IMAGE` in `~/.code-orchestrator/env`
+- restart the orchestrator service on `home-dev`
+
+Suggested commands on `home-dev`:
+
+```bash
+grep '^INTEXURAOS_CODE_WORKER_IMAGE=' ~/.code-orchestrator/env
+sed -i 's#^INTEXURAOS_CODE_WORKER_IMAGE=.*#INTEXURAOS_CODE_WORKER_IMAGE=europe-central2-docker.pkg.dev/intexuraos-dev-pbuchman/intexuraos-dev/code-worker@sha256:RETAINED_DIGEST#' ~/.code-orchestrator/env
+sudo systemctl restart intexuraos-orchestrator@pbuchman
+```
+
+- [ ] **Step 3: Redeploy any Cloud Run service still using an old protected digest**
+
+Use the existing individual deploy path after the prevention changes are merged. Only redeploy services identified by the prune plan as outside newest-3.
+
+Verification command:
+
+```bash
+gcloud run services describe intexuraos-SERVICE_NAME \
+  --region=europe-central2 \
+  --project=intexuraos-dev-pbuchman \
+  --format='value(spec.template.spec.containers[0].image)'
+```
+
+Expected: the live digest is one of the retained newest `3`.
+
+---
+
+## Chunk 4: Activate Policy And Final Prune
+
+### Task 10: Apply Terraform dry-run policy and inspect the resulting config
+
+**Files:**
+- None beyond merged Terraform changes.
+
+- [ ] **Step 1: Apply Terraform with dry-run still enabled**
+
+```bash
+cd terraform/environments/dev
+STORAGE_EMULATOR_HOST= FIRESTORE_EMULATOR_HOST= PUBSUB_EMULATOR_HOST= \
+GOOGLE_APPLICATION_CREDENTIALS=$HOME/.config/gcloud/sa-key.json \
+terraform apply
+```
+
+- [ ] **Step 2: Verify repository settings**
+
+```bash
+gcloud artifacts repositories describe intexuraos-dev \
+  --location=europe-central2 \
+  --project=intexuraos-dev-pbuchman \
+  --format=json
+```
+
+Expected:
+
+- `cleanupPolicyDryRun` is enabled
+- keep policy count is `3`
+- delete policies exist for general images and `code-worker`
+
+### Task 11: Manually prune `code-worker` to accelerate savings
+
+**Files:**
+- None. Uses the new scripts only.
+
+- [ ] **Step 1: Dry-run `code-worker` only**
+
+```bash
+node scripts/artifact-registry/apply-prune-plan.mjs \
+  --plan=/tmp/artifact-registry/plan-$(date +%F)/prune-plan.json \
+  --scope=package:code-worker
+```
+
+- [ ] **Step 2: Execute `code-worker` prune**
+
+```bash
+node scripts/artifact-registry/apply-prune-plan.mjs \
+  --plan=/tmp/artifact-registry/plan-$(date +%F)/prune-plan.json \
+  --scope=package:code-worker \
+  --execute \
+  --batch-size=50
+```
+
+- [ ] **Step 3: Re-export live inventory**
+
+Run `export-live-images.mjs` again and confirm the orchestrator digest is still present and protected.
+
+### Task 12: Flip cleanup policy from dry-run to active deletion
+
+**Files:**
+- Modify: `terraform/environments/dev/main.tf`
+
+- [ ] **Step 1: Change the single environment value**
+
+```hcl
+cleanup_policy_dry_run = false
+```
+
+- [ ] **Step 2: Run verification before apply**
+
+```bash
+cd terraform/environments/dev
+STORAGE_EMULATOR_HOST= FIRESTORE_EMULATOR_HOST= PUBSUB_EMULATOR_HOST= \
+GOOGLE_APPLICATION_CREDENTIALS=$HOME/.config/gcloud/sa-key.json \
+terraform plan
+```
+
+Expected: only the dry-run flag flips from `true` to `false`.
+
+- [ ] **Step 3: Apply**
+
+```bash
+cd terraform/environments/dev
+STORAGE_EMULATOR_HOST= FIRESTORE_EMULATOR_HOST= PUBSUB_EMULATOR_HOST= \
+GOOGLE_APPLICATION_CREDENTIALS=$HOME/.config/gcloud/sa-key.json \
+terraform apply
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add terraform/environments/dev/main.tf
+git commit -m "chore: enable artifact registry cleanup policy"
+```
+
+---
+
+## Chunk 5: Verification
+
+### Task 13: Verify storage and CI state before closing
+
+**Files:**
+- None.
+
+- [ ] **Step 1: Run targeted tests**
+
+```bash
+pnpm test -- scripts/__tests__/artifact-registry-lib.test.ts scripts/__tests__/artifact-registry-cli.test.ts
+```
+
+- [ ] **Step 2: Run tracked workspace verification**
+
+```bash
+pnpm run verify:workspace:tracked -- scripts
+```
+
+- [ ] **Step 3: Run full tracked CI**
+
+```bash
+pnpm run ci:tracked
+```
+
+- [ ] **Step 4: Verify repository size after deletes**
+
+```bash
+gcloud artifacts repositories list \
+  --location=europe-central2 \
+  --project=intexuraos-dev-pbuchman \
+  --format='table(name.basename(),sizeBytes,updateTime)'
+```
+
+Expected:
+
+- `intexuraos-dev` size is materially lower than the current `203978038140` bytes
+- `gcf-artifacts` is unchanged unless intentionally touched later
+
+- [ ] **Step 5: Re-check the next day**
+
+Google documents that cleanup-policy background processing can take about a day to take effect. Re-run the repository size command on the next calendar day and compare.
+
+## Expected End State
+
+- Dead packages are fully removed.
+- Active packages retain only `3` recent digests plus any temporarily necessary deployed digest.
+- `code-worker` is no longer rebuilt by every monolith deploy.
+- Artifact Registry cleanup is codified in Terraform.
+- Cleanup runs safely because active runtimes have been reconciled into the retained window before active deletion is enabled.
+
+## Execution Notes For This Harness
+
+- GCP read/write access is available through the configured service account.
+- Terraform verification requires `terraform init` inside `terraform/environments/dev` before planning if modules are not installed locally.
+- If SSH to `home-dev` is unavailable from the current machine, run the orchestrator-inventory step directly on `home-dev` and copy the resulting JSON artifact back into `/tmp/artifact-registry/...`.
+- Do not rely on the Google Cloud Console for safety checks that can be performed from the generated JSON artifacts; the JSON artifacts are the durable audit trail for the deletion run.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -164,6 +164,18 @@ Creates an isolated Docker network for code-worker containers with IP-level rest
 ./scripts/setup-worker-network.sh
 ```
 
+### Artifact Registry Cleanup Tools
+
+Safe inventory and prune tooling for `intexuraos-dev` lives under `scripts/artifact-registry/`.
+
+```bash
+node scripts/artifact-registry/export-live-images.mjs ...
+node scripts/artifact-registry/generate-prune-plan.mjs ...
+node scripts/artifact-registry/apply-prune-plan.mjs ...
+```
+
+See [docs/operations/artifact-registry-cleanup.md](../docs/operations/artifact-registry-cleanup.md) for the full runbook.
+
 ## Development Scripts
 
 ### dev-setup.mjs

--- a/scripts/__tests__/artifact-registry-cli.test.ts
+++ b/scripts/__tests__/artifact-registry-cli.test.ts
@@ -1,0 +1,114 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const REPO_ROOT = process.cwd();
+const APPLY_PLAN_PATH = path.join(
+  REPO_ROOT,
+  'scripts',
+  'artifact-registry',
+  'apply-prune-plan.mjs'
+);
+
+const tempDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'artifact-registry-cli-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function writePlan(dir: string, plan: object): string {
+  const planPath = path.join(dir, 'prune-plan.json');
+  fs.writeFileSync(planPath, JSON.stringify(plan, null, 2));
+  return planPath;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+describe('artifact registry cleanup CLI', () => {
+  it('prints delete commands without executing by default', () => {
+    const dir = makeTempDir();
+    const executionLogPath = path.join(dir, 'executed.log');
+    const fakeGcloudPath = path.join(dir, 'gcloud');
+    fs.writeFileSync(
+      fakeGcloudPath,
+      `#!/usr/bin/env bash\necho "$*" >> "${executionLogPath}"\nexit 0\n`,
+      'utf8'
+    );
+    fs.chmodSync(fakeGcloudPath, 0o755);
+
+    const planPath = writePlan(dir, {
+      deleteDigestCount: 1,
+      deletePackageCount: 1,
+      generatedAt: '2026-05-07T12:00:00.000Z',
+      keepCount: 3,
+      packageDecisions: [
+        {
+          deleteDigests: ['sha256:dead-a'],
+          keepDigests: [],
+          packageName: 'claude-worker',
+          status: 'retired',
+        },
+      ],
+      protectedDigests: [],
+      repository: 'intexuraos-dev',
+      retiredPackages: ['claude-worker'],
+    });
+
+    const result = spawnSync(process.execPath, [APPLY_PLAN_PATH, `--plan=${planPath}`], {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        PATH: `${dir}:${process.env.PATH}`,
+      },
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(result.stdout).toContain(
+      'gcloud artifacts docker images delete europe-central2-docker.pkg.dev/intexuraos-dev-pbuchman/intexuraos-dev/claude-worker@sha256:dead-a --delete-tags --quiet'
+    );
+    expect(fs.existsSync(executionLogPath)).toBe(false);
+  });
+
+  it('refuses to execute a plan that deletes a protected digest', () => {
+    const dir = makeTempDir();
+    const planPath = writePlan(dir, {
+      deleteDigestCount: 1,
+      deletePackageCount: 1,
+      generatedAt: '2026-05-07T12:00:00.000Z',
+      keepCount: 3,
+      packageDecisions: [
+        {
+          deleteDigests: ['sha256:protected'],
+          keepDigests: [],
+          packageName: 'code-worker',
+          status: 'active',
+        },
+      ],
+      protectedDigests: ['sha256:protected'],
+      repository: 'intexuraos-dev',
+      retiredPackages: [],
+    });
+
+    const result = spawnSync(
+      process.execPath,
+      [APPLY_PLAN_PATH, `--plan=${planPath}`, '--scope=all', '--execute'],
+      {
+        cwd: REPO_ROOT,
+        encoding: 'utf8',
+      }
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('Refusing to delete protected digest');
+  });
+});

--- a/scripts/__tests__/artifact-registry-config.test.ts
+++ b/scripts/__tests__/artifact-registry-config.test.ts
@@ -1,0 +1,44 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = process.cwd();
+
+function readRepoFile(relativePath: string): string {
+  return fs.readFileSync(path.join(REPO_ROOT, relativePath), 'utf8');
+}
+
+describe('artifact registry prevention config', () => {
+  it('does not rebuild code-worker inside monolith deploy flows', () => {
+    const deployWorkflow = readRepoFile('.github/workflows/deploy.yml');
+    const monolithCloudBuild = readRepoFile('cloudbuild/cloudbuild.yaml');
+
+    expect(deployWorkflow).not.toContain(
+      'bash cloudbuild/scripts/build-push-monitored.sh code-worker docker/code-worker/Dockerfile &'
+    );
+    expect(monolithCloudBuild).not.toContain("id: 'build-push-code-worker'");
+  });
+
+  it('defines active delete cleanup policies and aggressive env retention settings', () => {
+    const moduleMain = readRepoFile('terraform/modules/artifact-registry/main.tf');
+    const moduleVariables = readRepoFile('terraform/modules/artifact-registry/variables.tf');
+    const environmentMain = readRepoFile('terraform/environments/dev/main.tf');
+
+    expect(moduleMain).toContain('cleanup_policy_dry_run');
+    expect(moduleMain).toContain('action = "DELETE"');
+    expect(moduleMain).toContain('package_name_prefixes = ["code-worker"]');
+    expect(moduleMain).toContain('keep_count = var.cleanup_keep_count');
+    expect(moduleMain).toContain('tag_state  = "ANY"');
+    expect(moduleMain).toContain('tag_state             = "ANY"');
+
+    expect(moduleVariables).toContain('variable "cleanup_policy_dry_run"');
+    expect(moduleVariables).toContain('variable "cleanup_keep_count"');
+    expect(moduleVariables).toContain('variable "cleanup_delete_older_than"');
+    expect(moduleVariables).toContain('variable "code_worker_cleanup_delete_older_than"');
+
+    expect(environmentMain).toMatch(/cleanup_policy_dry_run\s*=\s*false/);
+    expect(environmentMain).toMatch(/cleanup_keep_count\s*=\s*3/);
+    expect(environmentMain).toMatch(/cleanup_delete_older_than\s*=\s*"86400s"/);
+    expect(environmentMain).toMatch(/code_worker_cleanup_delete_older_than\s*=\s*"86400s"/);
+  });
+});

--- a/scripts/__tests__/artifact-registry-lib.test.ts
+++ b/scripts/__tests__/artifact-registry-lib.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+import { buildRetentionDecisions, parseArtifactImageRef } from '../artifact-registry/lib.mjs';
+
+describe('artifact registry retention planner', () => {
+  it('keeps the newest 3 versions for active packages and preserves protected digests', () => {
+    const decisions = buildRetentionDecisions({
+      keepCount: 3,
+      protectedDigests: ['sha256:older-live'],
+      retiredPackages: [],
+      versions: [
+        {
+          createTime: '2026-05-06T21:25:05.027295Z',
+          digest: 'sha256:newest',
+          imageSizeBytes: 10,
+          packageName: 'code-worker',
+          tags: ['latest'],
+        },
+        {
+          createTime: '2026-05-05T21:25:05.027295Z',
+          digest: 'sha256:newer',
+          imageSizeBytes: 10,
+          packageName: 'code-worker',
+          tags: [],
+        },
+        {
+          createTime: '2026-05-04T21:25:05.027295Z',
+          digest: 'sha256:new',
+          imageSizeBytes: 10,
+          packageName: 'code-worker',
+          tags: [],
+        },
+        {
+          createTime: '2026-04-01T21:25:05.027295Z',
+          digest: 'sha256:older-live',
+          imageSizeBytes: 10,
+          packageName: 'code-worker',
+          tags: [],
+        },
+        {
+          createTime: '2026-03-01T21:25:05.027295Z',
+          digest: 'sha256:delete-me',
+          imageSizeBytes: 10,
+          packageName: 'code-worker',
+          tags: [],
+        },
+      ],
+    });
+
+    expect(decisions).toHaveLength(1);
+    expect(decisions[0]).toMatchObject({
+      deleteDigests: ['sha256:delete-me'],
+      keepDigests: ['sha256:newest', 'sha256:newer', 'sha256:new', 'sha256:older-live'],
+      packageName: 'code-worker',
+      status: 'active',
+    });
+  });
+
+  it('marks all versions of retired packages for deletion', () => {
+    const decisions = buildRetentionDecisions({
+      keepCount: 3,
+      protectedDigests: [],
+      retiredPackages: ['claude-worker'],
+      versions: [
+        {
+          createTime: '2026-03-26T15:19:35.270271Z',
+          digest: 'sha256:dead-a',
+          imageSizeBytes: 10,
+          packageName: 'claude-worker',
+          tags: ['latest'],
+        },
+        {
+          createTime: '2026-03-20T15:19:35.270271Z',
+          digest: 'sha256:dead-b',
+          imageSizeBytes: 10,
+          packageName: 'claude-worker',
+          tags: [],
+        },
+      ],
+    });
+
+    expect(decisions).toHaveLength(1);
+    expect(decisions[0]).toMatchObject({
+      deleteDigests: ['sha256:dead-a', 'sha256:dead-b'],
+      keepDigests: [],
+      packageName: 'claude-worker',
+      status: 'retired',
+    });
+  });
+
+  it('parses tag and digest image references', () => {
+    expect(
+      parseArtifactImageRef(
+        'europe-central2-docker.pkg.dev/intexuraos-dev-pbuchman/intexuraos-dev/user-service:45ae7a2fe7ef60578d59e25386cfdafa3d1bd8d2'
+      )
+    ).toMatchObject({
+      digest: null,
+      image:
+        'europe-central2-docker.pkg.dev/intexuraos-dev-pbuchman/intexuraos-dev/user-service:45ae7a2fe7ef60578d59e25386cfdafa3d1bd8d2',
+      packageName: 'user-service',
+      repository: 'intexuraos-dev',
+      tag: '45ae7a2fe7ef60578d59e25386cfdafa3d1bd8d2',
+    });
+
+    expect(
+      parseArtifactImageRef(
+        'europe-central2-docker.pkg.dev/intexuraos-dev-pbuchman/intexuraos-dev/user-service@sha256:732f2a90a076846ffa216f43c013fb5a6e156a22f640481ca2ceb785960edcfd'
+      )
+    ).toMatchObject({
+      digest: 'sha256:732f2a90a076846ffa216f43c013fb5a6e156a22f640481ca2ceb785960edcfd',
+      image:
+        'europe-central2-docker.pkg.dev/intexuraos-dev-pbuchman/intexuraos-dev/user-service@sha256:732f2a90a076846ffa216f43c013fb5a6e156a22f640481ca2ceb785960edcfd',
+      packageName: 'user-service',
+      repository: 'intexuraos-dev',
+      tag: null,
+    });
+  });
+});

--- a/scripts/artifact-registry/apply-prune-plan.mjs
+++ b/scripts/artifact-registry/apply-prune-plan.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { buildDeleteCommands, readJsonFile } from './lib.mjs';
+
+function parseArgs(argv) {
+  const options = {
+    batchSize: 50,
+    execute: false,
+    plan: null,
+    scope: 'retired-packages',
+  };
+
+  for (const arg of argv) {
+    if (arg === '--execute') {
+      options.execute = true;
+      continue;
+    }
+    if (arg.startsWith('--plan=')) {
+      options.plan = arg.slice('--plan='.length);
+      continue;
+    }
+    if (arg.startsWith('--scope=')) {
+      options.scope = arg.slice('--scope='.length);
+      continue;
+    }
+    if (arg.startsWith('--batch-size=')) {
+      options.batchSize = Number.parseInt(arg.slice('--batch-size='.length), 10);
+      continue;
+    }
+    if (arg === '--help') {
+      options.help = true;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return options;
+}
+
+export function printUsage() {
+  console.log(
+    `Usage: node scripts/artifact-registry/apply-prune-plan.mjs --plan=<path> [--scope=retired-packages|all|package:<name>] [--execute] [--batch-size=50]`
+  );
+}
+
+export function executePlan(plan, scope, { execute = false, batchSize = 50 } = {}) {
+  const commands = buildDeleteCommands(plan, scope).slice(0, batchSize);
+
+  if (!execute) {
+    for (const item of commands) {
+      console.log(item.command);
+    }
+    return commands.length;
+  }
+
+  for (const item of commands) {
+    execFileSync('bash', ['-lc', item.command], { stdio: 'inherit' });
+  }
+
+  return commands.length;
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv);
+  if (options.help || !options.plan) {
+    printUsage();
+    return options.help ? 0 : 1;
+  }
+
+  const plan = readJsonFile(options.plan);
+  executePlan(plan, options.scope, {
+    batchSize: options.batchSize,
+    execute: options.execute,
+  });
+  return 0;
+}
+
+const modulePath = fileURLToPath(import.meta.url);
+if (process.argv[1] && path.resolve(process.argv[1]) === modulePath) {
+  main().then(
+    (exitCode) => {
+      process.exit(exitCode);
+    },
+    (error) => {
+      console.error(error instanceof Error ? error.message : String(error));
+      process.exit(1);
+    }
+  );
+}

--- a/scripts/artifact-registry/export-live-images.mjs
+++ b/scripts/artifact-registry/export-live-images.mjs
@@ -1,0 +1,225 @@
+#!/usr/bin/env node
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  DEFAULT_LOCATION,
+  DEFAULT_ORCHESTRATOR_IMAGE,
+  DEFAULT_PROJECT_ID,
+  DEFAULT_REPOSITORY,
+  normalizeDigest,
+  parseArtifactImageRef,
+  parseCommaSeparatedList,
+  writeJsonFile,
+} from './lib.mjs';
+
+function parseArgs(argv) {
+  const options = {
+    location: DEFAULT_LOCATION,
+    orchestratorEnvPath: '~/.code-orchestrator/env',
+    outDir: null,
+    project: DEFAULT_PROJECT_ID,
+    repository: DEFAULT_REPOSITORY,
+  };
+
+  for (const arg of argv) {
+    if (arg.startsWith('--project=')) {
+      options.project = arg.slice('--project='.length);
+      continue;
+    }
+    if (arg.startsWith('--region=')) {
+      options.location = arg.slice('--region='.length);
+      continue;
+    }
+    if (arg.startsWith('--location=')) {
+      options.location = arg.slice('--location='.length);
+      continue;
+    }
+    if (arg.startsWith('--repository=')) {
+      options.repository = arg.slice('--repository='.length);
+      continue;
+    }
+    if (arg.startsWith('--out-dir=')) {
+      options.outDir = arg.slice('--out-dir='.length);
+      continue;
+    }
+    if (arg.startsWith('--orchestrator-env-path=')) {
+      options.orchestratorEnvPath = arg.slice('--orchestrator-env-path='.length);
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  if (!options.outDir) {
+    throw new Error('Missing required argument: --out-dir');
+  }
+
+  return options;
+}
+
+function runJsonCommand(command, args) {
+  return JSON.parse(execFileSync(command, args, { encoding: 'utf8' }));
+}
+
+function expandHome(pathname) {
+  if (pathname.startsWith('~/')) {
+    return path.join(os.homedir(), pathname.slice(2));
+  }
+  return pathname;
+}
+
+function readOrchestratorImageSetting(orchestratorEnvPath) {
+  const content = fs.readFileSync(expandHome(orchestratorEnvPath), 'utf8');
+  const line = content
+    .split('\n')
+    .map((entry) => entry.trim())
+    .find((entry) => entry.startsWith('INTEXURAOS_CODE_WORKER_IMAGE='));
+
+  if (!line) {
+    return {
+      image: DEFAULT_ORCHESTRATOR_IMAGE,
+      source: 'default',
+      warning:
+        'INTEXURAOS_CODE_WORKER_IMAGE is unset in ~/.code-orchestrator/env; orchestrator still follows code-worker:latest and must be pinned before code-worker prune execution.',
+    };
+  }
+
+  return {
+    image: line.slice('INTEXURAOS_CODE_WORKER_IMAGE='.length),
+    source: 'env',
+    warning: null,
+  };
+}
+
+function resolveDigestFromTag({ location, packageName, project, repository, tag }) {
+  const versions = runJsonCommand('gcloud', [
+    'artifacts',
+    'docker',
+    'images',
+    'list',
+    `${location}-docker.pkg.dev/${project}/${repository}/${packageName}`,
+    '--include-tags',
+    '--format=json',
+  ]);
+
+  const match = versions.find(
+    (version) => Array.isArray(version.tags) && version.tags.includes(tag)
+  );
+  if (!match) {
+    throw new Error(`Unable to resolve tag ${tag} for package ${packageName}`);
+  }
+
+  return normalizeDigest(match.version);
+}
+
+function resolveCloudRunImages({ location, project }) {
+  const services = runJsonCommand('gcloud', [
+    'run',
+    'services',
+    'list',
+    `--region=${location}`,
+    `--project=${project}`,
+    '--format=json',
+  ]);
+
+  return services.map((service) => {
+    const revisionName = service.status?.latestReadyRevisionName;
+    if (typeof revisionName !== 'string' || revisionName.length === 0) {
+      throw new Error(
+        `Service ${service.metadata?.name ?? 'unknown'} has no latest ready revision`
+      );
+    }
+
+    const revision = runJsonCommand('gcloud', [
+      'run',
+      'revisions',
+      'describe',
+      revisionName,
+      `--region=${location}`,
+      `--project=${project}`,
+      '--format=json',
+    ]);
+
+    const image = revision.spec?.containers?.[0]?.image;
+    if (typeof image !== 'string') {
+      throw new Error(`Revision ${revisionName} has no container image`);
+    }
+    const parsed = parseArtifactImageRef(image);
+    if (!parsed.digest) {
+      throw new Error(`Revision ${revisionName} is not digest-pinned: ${image}`);
+    }
+
+    return {
+      digest: parsed.digest,
+      image,
+      packageName: parsed.packageName,
+      runtimeName: service.metadata?.name ?? revisionName,
+      source: 'cloud-run',
+    };
+  });
+}
+
+function resolveOrchestratorImage({ location, orchestratorEnvPath, project, repository }) {
+  const setting = readOrchestratorImageSetting(orchestratorEnvPath);
+  const parsed = parseArtifactImageRef(setting.image);
+  const digest =
+    parsed.digest ??
+    resolveDigestFromTag({
+      location,
+      packageName: parsed.packageName,
+      project,
+      repository,
+      tag: parsed.tag,
+    });
+
+  return {
+    digest,
+    image: setting.image,
+    packageName: parsed.packageName,
+    runtimeName: 'orchestrator',
+    source: 'orchestrator',
+    warning: setting.warning,
+  };
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv);
+  fs.mkdirSync(options.outDir, { recursive: true });
+
+  const cloudRunImages = resolveCloudRunImages({
+    location: options.location,
+    project: options.project,
+  });
+  const orchestratorImage = resolveOrchestratorImage({
+    location: options.location,
+    orchestratorEnvPath: options.orchestratorEnvPath,
+    project: options.project,
+    repository: options.repository,
+  });
+
+  const warnings = parseCommaSeparatedList(orchestratorImage.warning ?? '');
+  const protectedDigests = [
+    ...new Set([...cloudRunImages, orchestratorImage].map((item) => item.digest)),
+  ].sort();
+
+  writeJsonFile(path.join(options.outDir, 'cloud-run-images.json'), cloudRunImages);
+  writeJsonFile(path.join(options.outDir, 'orchestrator-image.json'), orchestratorImage);
+  writeJsonFile(path.join(options.outDir, 'protected-digests.json'), protectedDigests);
+  writeJsonFile(path.join(options.outDir, 'warnings.json'), warnings);
+  return 0;
+}
+
+const modulePath = fileURLToPath(import.meta.url);
+if (process.argv[1] && path.resolve(process.argv[1]) === modulePath) {
+  main().then(
+    (exitCode) => {
+      process.exit(exitCode);
+    },
+    (error) => {
+      console.error(error instanceof Error ? error.message : String(error));
+      process.exit(1);
+    }
+  );
+}

--- a/scripts/artifact-registry/generate-prune-plan.mjs
+++ b/scripts/artifact-registry/generate-prune-plan.mjs
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import {
+  createPrunePlan,
+  DEFAULT_LOCATION,
+  DEFAULT_PROJECT_ID,
+  DEFAULT_REPOSITORY,
+  normalizeDigest,
+  parseCommaSeparatedList,
+  readJsonFile,
+  renderPrunePlanSummary,
+  writeJsonFile,
+} from './lib.mjs';
+
+function parseArgs(argv) {
+  const options = {
+    keepCount: 3,
+    location: DEFAULT_LOCATION,
+    outDir: null,
+    project: DEFAULT_PROJECT_ID,
+    protectedPath: null,
+    repository: DEFAULT_REPOSITORY,
+    retiredPackages: [],
+  };
+
+  for (const arg of argv) {
+    if (arg.startsWith('--project=')) {
+      options.project = arg.slice('--project='.length);
+      continue;
+    }
+    if (arg.startsWith('--location=')) {
+      options.location = arg.slice('--location='.length);
+      continue;
+    }
+    if (arg.startsWith('--repository=')) {
+      options.repository = arg.slice('--repository='.length);
+      continue;
+    }
+    if (arg.startsWith('--keep-count=')) {
+      options.keepCount = Number.parseInt(arg.slice('--keep-count='.length), 10);
+      continue;
+    }
+    if (arg.startsWith('--protected=')) {
+      options.protectedPath = arg.slice('--protected='.length);
+      continue;
+    }
+    if (arg.startsWith('--retired-packages=')) {
+      options.retiredPackages = parseCommaSeparatedList(arg.slice('--retired-packages='.length));
+      continue;
+    }
+    if (arg.startsWith('--out-dir=')) {
+      options.outDir = arg.slice('--out-dir='.length);
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  if (!options.protectedPath) {
+    throw new Error('Missing required argument: --protected');
+  }
+  if (!options.outDir) {
+    throw new Error('Missing required argument: --out-dir');
+  }
+
+  return options;
+}
+
+function loadRegistryVersions({ location, project, repository }) {
+  return JSON.parse(
+    execFileSync(
+      'gcloud',
+      [
+        'artifacts',
+        'docker',
+        'images',
+        'list',
+        `${location}-docker.pkg.dev/${project}/${repository}`,
+        '--include-tags',
+        '--format=json',
+      ],
+      { encoding: 'utf8', maxBuffer: 1024 * 1024 * 64 }
+    )
+  );
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv);
+  const protectedDigests = readJsonFile(options.protectedPath).map(normalizeDigest);
+  const warningsPath = path.join(path.dirname(options.protectedPath), 'warnings.json');
+  const warnings = fs.existsSync(warningsPath) ? readJsonFile(warningsPath) : [];
+
+  const plan = createPrunePlan({
+    keepCount: options.keepCount,
+    location: options.location,
+    projectId: options.project,
+    protectedDigests,
+    repository: options.repository,
+    retiredPackages: options.retiredPackages,
+    versions: loadRegistryVersions({
+      location: options.location,
+      project: options.project,
+      repository: options.repository,
+    }),
+    warnings,
+  });
+
+  fs.mkdirSync(options.outDir, { recursive: true });
+  writeJsonFile(path.join(options.outDir, 'prune-plan.json'), plan);
+  fs.writeFileSync(path.join(options.outDir, 'prune-summary.md'), renderPrunePlanSummary(plan));
+  return 0;
+}
+
+const modulePath = fileURLToPath(import.meta.url);
+if (process.argv[1] && path.resolve(process.argv[1]) === modulePath) {
+  main().then(
+    (exitCode) => {
+      process.exit(exitCode);
+    },
+    (error) => {
+      console.error(error instanceof Error ? error.message : String(error));
+      process.exit(1);
+    }
+  );
+}

--- a/scripts/artifact-registry/lib.mjs
+++ b/scripts/artifact-registry/lib.mjs
@@ -1,0 +1,320 @@
+import fs from 'node:fs';
+
+export const DEFAULT_PROJECT_ID = 'intexuraos-dev-pbuchman';
+export const DEFAULT_LOCATION = 'europe-central2';
+export const DEFAULT_REPOSITORY = 'intexuraos-dev';
+export const DEFAULT_ORCHESTRATOR_IMAGE =
+  'europe-central2-docker.pkg.dev/intexuraos-dev-pbuchman/intexuraos-dev/code-worker:latest';
+
+export function parseArtifactImageRef(image) {
+  const digestIndex = image.indexOf('@sha256:');
+  let base = image;
+  let digest = null;
+  let tag = null;
+
+  if (digestIndex >= 0) {
+    base = image.slice(0, digestIndex);
+    digest = image.slice(digestIndex + 1);
+  } else {
+    const lastSlashIndex = image.lastIndexOf('/');
+    const lastColonIndex = image.lastIndexOf(':');
+    if (lastColonIndex <= lastSlashIndex) {
+      throw new Error(`Artifact image must include a tag or digest: ${image}`);
+    }
+    base = image.slice(0, lastColonIndex);
+    tag = image.slice(lastColonIndex + 1);
+  }
+
+  const parts = base.split('/');
+  if (parts.length < 4) {
+    throw new Error(`Unexpected Artifact Registry image format: ${image}`);
+  }
+
+  return {
+    digest,
+    image,
+    packageName: parts.slice(3).join('/'),
+    projectId: parts[1],
+    registryHost: parts[0],
+    repository: parts[2],
+    tag,
+  };
+}
+
+export function normalizeRegistryVersion(version) {
+  const packageName = version.package.split('/').at(-1);
+  if (!packageName) {
+    throw new Error(
+      `Unable to determine package from Artifact Registry version: ${version.package}`
+    );
+  }
+
+  return {
+    createTime: version.createTime,
+    digest: normalizeDigest(version.version),
+    imageSizeBytes: Number.parseInt(version.metadata?.imageSizeBytes ?? '0', 10) || 0,
+    packageName,
+    tags: Array.isArray(version.tags) ? version.tags : [],
+  };
+}
+
+export function normalizeDigest(digest) {
+  if (!digest.startsWith('sha256:')) {
+    return `sha256:${digest.replace(/^sha256:/, '')}`;
+  }
+  return digest;
+}
+
+export function groupVersionsByPackage(versions) {
+  const grouped = new Map();
+
+  for (const version of versions) {
+    const existing = grouped.get(version.packageName) ?? [];
+    existing.push(version);
+    grouped.set(version.packageName, existing);
+  }
+
+  return grouped;
+}
+
+export function classifyPackages(packageNames, retiredPackages) {
+  const retiredSet = new Set(retiredPackages);
+  return packageNames.map((packageName) => ({
+    packageName,
+    status: retiredSet.has(packageName) ? 'retired' : 'active',
+  }));
+}
+
+export function buildRetentionDecisions({
+  keepCount,
+  protectedDigests,
+  retiredPackages,
+  versions,
+}) {
+  const protectedSet = new Set(protectedDigests.map(normalizeDigest));
+  const retiredSet = new Set(retiredPackages);
+  const grouped = groupVersionsByPackage(versions);
+  const decisions = [];
+
+  for (const [packageName, packageVersions] of [...grouped.entries()].sort(([left], [right]) =>
+    left.localeCompare(right)
+  )) {
+    const sortedVersions = [...packageVersions].sort((left, right) =>
+      right.createTime.localeCompare(left.createTime)
+    );
+    const sortedDigests = sortedVersions.map((version) => normalizeDigest(version.digest));
+    const status = retiredSet.has(packageName) ? 'retired' : 'active';
+
+    let keepDigests = [];
+    if (status === 'active') {
+      keepDigests = sortedDigests.slice(0, keepCount);
+      for (const digest of sortedDigests) {
+        if (protectedSet.has(digest) && !keepDigests.includes(digest)) {
+          keepDigests.push(digest);
+        }
+      }
+    }
+
+    const keepSet = new Set(keepDigests);
+    const deleteDigests =
+      status === 'retired' ? sortedDigests : sortedDigests.filter((digest) => !keepSet.has(digest));
+
+    for (const digest of deleteDigests) {
+      if (protectedSet.has(digest)) {
+        throw new Error(
+          `Refusing to delete protected digest ${digest} from package ${packageName}`
+        );
+      }
+    }
+
+    const deleteVersions = sortedVersions.filter((version) =>
+      deleteDigests.includes(normalizeDigest(version.digest))
+    );
+    const keepVersions = sortedVersions.filter((version) =>
+      keepSet.has(normalizeDigest(version.digest))
+    );
+
+    decisions.push({
+      deleteDigests,
+      deleteLogicalBytes: deleteVersions.reduce(
+        (total, version) => total + version.imageSizeBytes,
+        0
+      ),
+      deleteVersions,
+      keepDigests,
+      keepLogicalBytes: keepVersions.reduce((total, version) => total + version.imageSizeBytes, 0),
+      keepVersions,
+      packageName,
+      status,
+    });
+  }
+
+  return decisions;
+}
+
+export function createPrunePlan({
+  generatedAt = new Date().toISOString(),
+  keepCount,
+  location = DEFAULT_LOCATION,
+  projectId = DEFAULT_PROJECT_ID,
+  protectedDigests,
+  repository = DEFAULT_REPOSITORY,
+  retiredPackages,
+  versions,
+  warnings = [],
+}) {
+  const normalizedProtectedDigests = [...new Set(protectedDigests.map(normalizeDigest))].sort();
+  const normalizedVersions = versions.map(normalizeRegistryVersion);
+  const packageDecisions = buildRetentionDecisions({
+    keepCount,
+    protectedDigests: normalizedProtectedDigests,
+    retiredPackages,
+    versions: normalizedVersions,
+  });
+
+  return {
+    deleteDigestCount: packageDecisions.reduce(
+      (total, decision) => total + decision.deleteDigests.length,
+      0
+    ),
+    deleteLogicalBytes: packageDecisions.reduce(
+      (total, decision) => total + decision.deleteLogicalBytes,
+      0
+    ),
+    deletePackageCount: packageDecisions.filter((decision) => decision.deleteDigests.length > 0)
+      .length,
+    generatedAt,
+    keepCount,
+    location,
+    packageDecisions,
+    projectId,
+    protectedDigests: normalizedProtectedDigests,
+    repository,
+    retiredPackages: [...retiredPackages].sort(),
+    warnings,
+  };
+}
+
+export function renderPrunePlanSummary(plan) {
+  const lines = [
+    '# Artifact Registry Prune Summary',
+    '',
+    `Generated: ${plan.generatedAt}`,
+    `Repository: ${plan.location}-docker.pkg.dev/${plan.projectId}/${plan.repository}`,
+    `Keep count: ${String(plan.keepCount)}`,
+    `Protected digests: ${String(plan.protectedDigests.length)}`,
+    `Delete digests: ${String(plan.deleteDigestCount)}`,
+    `Delete logical bytes: ${formatBytes(plan.deleteLogicalBytes)}`,
+    '',
+    '| Package | Status | Keep | Delete | Logical Delete |',
+    '| --- | --- | ---: | ---: | ---: |',
+  ];
+
+  for (const decision of [...plan.packageDecisions].sort(
+    (left, right) => right.deleteLogicalBytes - left.deleteLogicalBytes
+  )) {
+    lines.push(
+      `| ${decision.packageName} | ${decision.status} | ${String(decision.keepDigests.length)} | ${String(
+        decision.deleteDigests.length
+      )} | ${formatBytes(decision.deleteLogicalBytes)} |`
+    );
+  }
+
+  if (plan.warnings.length > 0) {
+    lines.push('', '## Warnings', '');
+    for (const warning of plan.warnings) {
+      lines.push(`- ${warning}`);
+    }
+  }
+
+  return `${lines.join('\n')}\n`;
+}
+
+export function selectPackageDecisions(plan, scope) {
+  if (scope === 'all') {
+    return plan.packageDecisions;
+  }
+
+  if (scope === 'retired-packages') {
+    return plan.packageDecisions.filter((decision) => decision.status === 'retired');
+  }
+
+  if (scope.startsWith('package:')) {
+    const packageName = scope.slice('package:'.length);
+    return plan.packageDecisions.filter((decision) => decision.packageName === packageName);
+  }
+
+  throw new Error(`Unsupported prune scope: ${scope}`);
+}
+
+export function buildDeleteCommands(plan, scope = 'retired-packages') {
+  const protectedSet = new Set(plan.protectedDigests.map(normalizeDigest));
+  const selectedDecisions = selectPackageDecisions(plan, scope);
+  const commands = [];
+
+  for (const decision of selectedDecisions) {
+    for (const digest of decision.deleteDigests.map(normalizeDigest)) {
+      if (protectedSet.has(digest)) {
+        throw new Error(
+          `Refusing to delete protected digest ${digest} from package ${decision.packageName}`
+        );
+      }
+
+      commands.push({
+        command: renderDeleteCommand({
+          digest,
+          location: plan.location ?? DEFAULT_LOCATION,
+          packageName: decision.packageName,
+          projectId: plan.projectId ?? DEFAULT_PROJECT_ID,
+          repository: plan.repository ?? DEFAULT_REPOSITORY,
+        }),
+        digest,
+        packageName: decision.packageName,
+      });
+    }
+  }
+
+  return commands;
+}
+
+export function renderDeleteCommand({ digest, location, packageName, projectId, repository }) {
+  return [
+    'gcloud artifacts docker images delete',
+    `${location}-docker.pkg.dev/${projectId}/${repository}/${packageName}@${normalizeDigest(digest)}`,
+    '--delete-tags',
+    '--quiet',
+  ].join(' ');
+}
+
+export function readJsonFile(pathname) {
+  return JSON.parse(fs.readFileSync(pathname, 'utf8'));
+}
+
+export function writeJsonFile(pathname, value) {
+  fs.writeFileSync(pathname, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+export function parseCommaSeparatedList(value) {
+  if (!value) {
+    return [];
+  }
+  return value
+    .split(',')
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+}
+
+export function formatBytes(bytes) {
+  if (bytes === 0) {
+    return '0 B';
+  }
+
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  let value = bytes;
+  let unitIndex = 0;
+  while (value >= 1000 && unitIndex < units.length - 1) {
+    value /= 1000;
+    unitIndex += 1;
+  }
+  return `${value.toFixed(unitIndex === 0 ? 0 : 2)} ${units[unitIndex]}`;
+}

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -358,10 +358,14 @@ resource "google_project_service" "apis" {
 module "artifact_registry" {
   source = "../../modules/artifact-registry"
 
-  project_id  = var.project_id
-  region      = var.region
-  environment = var.environment
-  labels      = local.common_labels
+  project_id                              = var.project_id
+  region                                  = var.region
+  environment                             = var.environment
+  labels                                  = local.common_labels
+  cleanup_policy_dry_run                  = false
+  cleanup_keep_count                      = 3
+  cleanup_delete_older_than               = "86400s"
+  code_worker_cleanup_delete_older_than   = "86400s"
 
   depends_on = [google_project_service.apis]
 }

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -358,14 +358,14 @@ resource "google_project_service" "apis" {
 module "artifact_registry" {
   source = "../../modules/artifact-registry"
 
-  project_id                              = var.project_id
-  region                                  = var.region
-  environment                             = var.environment
-  labels                                  = local.common_labels
-  cleanup_policy_dry_run                  = false
-  cleanup_keep_count                      = 3
-  cleanup_delete_older_than               = "86400s"
-  code_worker_cleanup_delete_older_than   = "86400s"
+  project_id                            = var.project_id
+  region                                = var.region
+  environment                           = var.environment
+  labels                                = local.common_labels
+  cleanup_policy_dry_run                = false
+  cleanup_keep_count                    = 3
+  cleanup_delete_older_than             = "86400s"
+  code_worker_cleanup_delete_older_than = "86400s"
 
   depends_on = [google_project_service.apis]
 }

--- a/terraform/modules/artifact-registry/main.tf
+++ b/terraform/modules/artifact-registry/main.tf
@@ -2,19 +2,40 @@
 # Creates a Docker repository for Cloud Run service images.
 
 resource "google_artifact_registry_repository" "intexuraos" {
-  location      = var.region
-  repository_id = "intexuraos-${var.environment}"
-  description   = "Docker repository for IntexuraOS ${var.environment} services"
-  format        = "DOCKER"
-  labels        = var.labels
+  location               = var.region
+  repository_id          = "intexuraos-${var.environment}"
+  description            = "Docker repository for IntexuraOS ${var.environment} services"
+  format                 = "DOCKER"
+  labels                 = var.labels
+  cleanup_policy_dry_run = var.cleanup_policy_dry_run
+
+  cleanup_policies {
+    id     = "delete-stale-images"
+    action = "DELETE"
+
+    condition {
+      older_than = var.cleanup_delete_older_than
+      tag_state  = "ANY"
+    }
+  }
+
+  cleanup_policies {
+    id     = "delete-stale-code-worker"
+    action = "DELETE"
+
+    condition {
+      older_than            = var.code_worker_cleanup_delete_older_than
+      package_name_prefixes = ["code-worker"]
+      tag_state             = "ANY"
+    }
+  }
 
   cleanup_policies {
     id     = "keep-recent"
     action = "KEEP"
 
     most_recent_versions {
-      keep_count = 10
+      keep_count = var.cleanup_keep_count
     }
   }
 }
-

--- a/terraform/modules/artifact-registry/variables.tf
+++ b/terraform/modules/artifact-registry/variables.tf
@@ -19,3 +19,26 @@ variable "labels" {
   default     = {}
 }
 
+variable "cleanup_policy_dry_run" {
+  description = "If true, Artifact Registry cleanup policies log but do not delete."
+  type        = bool
+  default     = false
+}
+
+variable "cleanup_keep_count" {
+  description = "How many recent versions to keep per package."
+  type        = number
+  default     = 3
+}
+
+variable "cleanup_delete_older_than" {
+  description = "Age threshold for deleting stale images as a protobuf Duration string."
+  type        = string
+  default     = "86400s"
+}
+
+variable "code_worker_cleanup_delete_older_than" {
+  description = "Age threshold for deleting stale code-worker images as a protobuf Duration string."
+  type        = string
+  default     = "86400s"
+}


### PR DESCRIPTION
## Summary
- add Artifact Registry inventory, prune-plan, and execution tooling plus a durable cleanup runbook
- activate keep-3 Artifact Registry cleanup policies in Terraform and stop monolith deploy flows from rebuilding `code-worker`
- execute the first live remediation steps by deleting retired packages and pinning the orchestrator to a retained `code-worker` digest

## Validation
- `pnpm exec vitest run scripts/__tests__/artifact-registry-config.test.ts scripts/__tests__/artifact-registry-lib.test.ts scripts/__tests__/artifact-registry-cli.test.ts`
- `pnpm format:check`
- `terraform plan -input=false -target=module.artifact_registry -out=/tmp/artifact-registry-cleanup.tfplan`
- `terraform apply -input=false /tmp/artifact-registry-cleanup.tfplan`
- `pnpm run ci:tracked`

## Operational execution
- deleted retired packages: `claude-worker`, `commands-router`, `data-insights-service`, `llm-orchestrator`, `llm-orchestrator-service`
- pinned `INTEXURAOS_CODE_WORKER_IMAGE` to `code-worker@sha256:323593e1f8d4687612b42a8f7e94c3ba1d761407886d4cad9ae5f90ef1326f18`
- verified `intexuraos-dev` now has active cleanup policies: keep `3`, delete stale images older than `86400s`
