### PR TITLE
[INT-1615] [codex] restore home-dev Pub/Sub aliases for WhatsApp webhooks

### DIFF
--- a/.claude/reference/environments.md
+++ b/.claude/reference/environments.md
@@ -52,6 +52,8 @@ STEP 4: Check service status with the right tool (pm2 for dev, gcloud for prod)
 
 **Auto-deploy via webhook handler.** A GitHub webhook at `~/tools/webhook-handler/` receives push events to `development`, detects changed files, and restarts affected services. PM2 services restart via `pm2 restart`; the orchestrator rebuilds (`pnpm --filter orchestrator build`) then restarts via `systemctl restart`. PM2 file watching is disabled (`watch: false`).
 
+**Pub/Sub on home-dev uses emulator aliases, not Terraform topic names.** PM2 services publish to `PUBSUB_EMULATOR_HOST=localhost:8102`, so `ecosystem.config.cjs` fallbacks MUST match the aliases configured in `tools/pubsub-ui/server.mjs` (for WhatsApp: `whatsapp-send-message`, `whatsapp-media-cleanup`, `whatsapp-webhook-process`, `whatsapp-transcription`, `commands-ingest`, `approval-reply`). Do NOT use Terraform-managed `intexuraos-*-dev` topic names as PM2 fallbacks on home-dev; those names exist in Cloud Run/GCP, not in the local emulator.
+
 **Port reference:** See `ecosystem.config.cjs` for the full port map of all dev services.
 
 ## Development Machines

--- a/.envrc.local.example
+++ b/.envrc.local.example
@@ -65,14 +65,15 @@ export INTEXURAOS_IMAGE_BUCKET=intexuraos-images
 # Start with: pnpm run emulators:start
 # The pubsub-ui container bridges emulator messages to local service endpoints.
 
-# Required by whatsapp-service for media cleanup events
-export INTEXURAOS_PUBSUB_MEDIA_CLEANUP_TOPIC=media-cleanup
-export INTEXURAOS_PUBSUB_MEDIA_CLEANUP_SUBSCRIPTION=media-cleanup-sub
+# Required by whatsapp-service for media cleanup events.
+# Keep in sync with tools/pubsub-ui/server.mjs aliases.
+export INTEXURAOS_PUBSUB_MEDIA_CLEANUP_TOPIC=whatsapp-media-cleanup
+export INTEXURAOS_PUBSUB_MEDIA_CLEANUP_SUBSCRIPTION=whatsapp-media-cleanup-push
 
 # Required for WhatsApp message sending via Pub/Sub
 # research-agent publishes, whatsapp-service subscribes
 export INTEXURAOS_PUBSUB_WHATSAPP_SEND_TOPIC=whatsapp-send-message
-export INTEXURAOS_PUBSUB_WHATSAPP_SEND_SUBSCRIPTION=whatsapp-send-message-sub
+export INTEXURAOS_PUBSUB_WHATSAPP_SEND_SUBSCRIPTION=whatsapp-send-message-push
 
 # Required for todos processing (todos-agent publishes and subscribes)
 export INTEXURAOS_TODOS_PROCESSING_TOPIC=todos-processing

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -102,18 +102,18 @@ const SERVICE_ENV_MAPPINGS = {
     INTEXURAOS_PUBSUB_LLM_CALL_TOPIC: process.env.INTEXURAOS_PUBSUB_LLM_CALL_TOPIC ?? 'llm-call',
   },
   'whatsapp-service': {
-    // INT-1451: fallbacks MUST match the Terraform-managed topic names
-    // (`intexuraos-*-dev`). Mismatched fallbacks silently break audio
-    // transcription when the home-dev shell does not export the topic env vars.
+    // home-dev publishes to the local Pub/Sub emulator on localhost:8102.
+    // These fallbacks must match the emulator topic aliases configured in
+    // tools/pubsub-ui/server.mjs, not the Terraform-managed Cloud Run topic
+    // names (`intexuraos-*-dev`), or inbound webhooks fail before processing.
     INTEXURAOS_PUBSUB_WHATSAPP_SEND_TOPIC:
-      process.env.INTEXURAOS_PUBSUB_WHATSAPP_SEND_TOPIC ?? 'intexuraos-whatsapp-send-dev',
+      process.env.INTEXURAOS_PUBSUB_WHATSAPP_SEND_TOPIC ?? 'whatsapp-send-message',
     INTEXURAOS_PUBSUB_WHATSAPP_SEND_SUBSCRIPTION:
-      process.env.INTEXURAOS_PUBSUB_WHATSAPP_SEND_SUBSCRIPTION ??
-      'intexuraos-whatsapp-send-dev-push',
+      process.env.INTEXURAOS_PUBSUB_WHATSAPP_SEND_SUBSCRIPTION ?? 'whatsapp-send-message-push',
     INTEXURAOS_PUBSUB_MEDIA_CLEANUP_TOPIC:
-      process.env.INTEXURAOS_PUBSUB_MEDIA_CLEANUP_TOPIC ?? 'intexuraos-whatsapp-media-cleanup-dev',
+      process.env.INTEXURAOS_PUBSUB_MEDIA_CLEANUP_TOPIC ?? 'whatsapp-media-cleanup',
     INTEXURAOS_PUBSUB_COMMANDS_INGEST_TOPIC:
-      process.env.INTEXURAOS_PUBSUB_COMMANDS_INGEST_TOPIC ?? 'intexuraos-commands-ingest-dev',
+      process.env.INTEXURAOS_PUBSUB_COMMANDS_INGEST_TOPIC ?? 'commands-ingest',
     INTEXURAOS_WHATSAPP_ACCESS_TOKEN: process.env.INTEXURAOS_WHATSAPP_ACCESS_TOKEN,
     INTEXURAOS_WHATSAPP_APP_SECRET: process.env.INTEXURAOS_WHATSAPP_APP_SECRET,
     INTEXURAOS_WHATSAPP_WABA_ID: process.env.INTEXURAOS_WHATSAPP_WABA_ID,
@@ -122,15 +122,13 @@ const SERVICE_ENV_MAPPINGS = {
     INTEXURAOS_WHATSAPP_MEDIA_BUCKET:
       process.env.INTEXURAOS_WHATSAPP_MEDIA_BUCKET ?? 'intexuraos-whatsapp-media-dev',
     INTEXURAOS_PUBSUB_MEDIA_CLEANUP_SUBSCRIPTION:
-      process.env.INTEXURAOS_PUBSUB_MEDIA_CLEANUP_SUBSCRIPTION ??
-      'intexuraos-whatsapp-media-cleanup-dev-push',
+      process.env.INTEXURAOS_PUBSUB_MEDIA_CLEANUP_SUBSCRIPTION ?? 'whatsapp-media-cleanup-push',
     INTEXURAOS_PUBSUB_WEBHOOK_PROCESS_TOPIC:
-      process.env.INTEXURAOS_PUBSUB_WEBHOOK_PROCESS_TOPIC ??
-      'intexuraos-whatsapp-webhook-process-dev',
+      process.env.INTEXURAOS_PUBSUB_WEBHOOK_PROCESS_TOPIC ?? 'whatsapp-webhook-process',
     INTEXURAOS_PUBSUB_AUDIO_STORED_TOPIC:
-      process.env.INTEXURAOS_PUBSUB_AUDIO_STORED_TOPIC ?? 'intexuraos-audio-stored-dev',
+      process.env.INTEXURAOS_PUBSUB_AUDIO_STORED_TOPIC ?? 'whatsapp-transcription',
     INTEXURAOS_PUBSUB_APPROVAL_REPLY_TOPIC:
-      process.env.INTEXURAOS_PUBSUB_APPROVAL_REPLY_TOPIC ?? 'intexuraos-approval-reply-dev',
+      process.env.INTEXURAOS_PUBSUB_APPROVAL_REPLY_TOPIC ?? 'approval-reply',
   },
   'actions-agent': {
     INTEXURAOS_PUBSUB_ACTIONS_QUEUE: process.env.INTEXURAOS_PUBSUB_ACTIONS_QUEUE ?? 'actions-queue',

--- a/scripts/__tests__/ecosystem.config.test.ts
+++ b/scripts/__tests__/ecosystem.config.test.ts
@@ -1,0 +1,65 @@
+import { execFileSync } from 'node:child_process';
+import { describe, expect, it } from 'vitest';
+
+interface WhatsAppPubSubEnv {
+  INTEXURAOS_PUBSUB_WHATSAPP_SEND_TOPIC: string;
+  INTEXURAOS_PUBSUB_WHATSAPP_SEND_SUBSCRIPTION: string;
+  INTEXURAOS_PUBSUB_MEDIA_CLEANUP_TOPIC: string;
+  INTEXURAOS_PUBSUB_MEDIA_CLEANUP_SUBSCRIPTION: string;
+  INTEXURAOS_PUBSUB_COMMANDS_INGEST_TOPIC: string;
+  INTEXURAOS_PUBSUB_WEBHOOK_PROCESS_TOPIC: string;
+  INTEXURAOS_PUBSUB_AUDIO_STORED_TOPIC: string;
+  INTEXURAOS_PUBSUB_APPROVAL_REPLY_TOPIC: string;
+}
+
+function loadWhatsAppPubSubEnv(): WhatsAppPubSubEnv {
+  const stdout = execFileSync(
+    process.execPath,
+    [
+      '-e',
+      `
+        const config = require('./ecosystem.config.cjs');
+        const app = config.apps.find((entry) => entry.name === 'whatsapp-service');
+        if (!app) {
+          throw new Error('whatsapp-service missing from ecosystem config');
+        }
+
+        const env = app.env;
+        process.stdout.write(JSON.stringify({
+          INTEXURAOS_PUBSUB_WHATSAPP_SEND_TOPIC: env.INTEXURAOS_PUBSUB_WHATSAPP_SEND_TOPIC,
+          INTEXURAOS_PUBSUB_WHATSAPP_SEND_SUBSCRIPTION: env.INTEXURAOS_PUBSUB_WHATSAPP_SEND_SUBSCRIPTION,
+          INTEXURAOS_PUBSUB_MEDIA_CLEANUP_TOPIC: env.INTEXURAOS_PUBSUB_MEDIA_CLEANUP_TOPIC,
+          INTEXURAOS_PUBSUB_MEDIA_CLEANUP_SUBSCRIPTION: env.INTEXURAOS_PUBSUB_MEDIA_CLEANUP_SUBSCRIPTION,
+          INTEXURAOS_PUBSUB_COMMANDS_INGEST_TOPIC: env.INTEXURAOS_PUBSUB_COMMANDS_INGEST_TOPIC,
+          INTEXURAOS_PUBSUB_WEBHOOK_PROCESS_TOPIC: env.INTEXURAOS_PUBSUB_WEBHOOK_PROCESS_TOPIC,
+          INTEXURAOS_PUBSUB_AUDIO_STORED_TOPIC: env.INTEXURAOS_PUBSUB_AUDIO_STORED_TOPIC,
+          INTEXURAOS_PUBSUB_APPROVAL_REPLY_TOPIC: env.INTEXURAOS_PUBSUB_APPROVAL_REPLY_TOPIC,
+        }));
+      `,
+    ],
+    {
+      cwd: process.cwd(),
+      env: {
+        HOME: process.env.HOME ?? '/tmp',
+        PATH: process.env.PATH ?? '',
+      },
+    }
+  );
+
+  return JSON.parse(stdout.toString()) as WhatsAppPubSubEnv;
+}
+
+describe('ecosystem.config.cjs', () => {
+  it('uses home-dev Pub/Sub emulator aliases for whatsapp-service fallbacks', () => {
+    expect(loadWhatsAppPubSubEnv()).toEqual({
+      INTEXURAOS_PUBSUB_WHATSAPP_SEND_TOPIC: 'whatsapp-send-message',
+      INTEXURAOS_PUBSUB_WHATSAPP_SEND_SUBSCRIPTION: 'whatsapp-send-message-push',
+      INTEXURAOS_PUBSUB_MEDIA_CLEANUP_TOPIC: 'whatsapp-media-cleanup',
+      INTEXURAOS_PUBSUB_MEDIA_CLEANUP_SUBSCRIPTION: 'whatsapp-media-cleanup-push',
+      INTEXURAOS_PUBSUB_COMMANDS_INGEST_TOPIC: 'commands-ingest',
+      INTEXURAOS_PUBSUB_WEBHOOK_PROCESS_TOPIC: 'whatsapp-webhook-process',
+      INTEXURAOS_PUBSUB_AUDIO_STORED_TOPIC: 'whatsapp-transcription',
+      INTEXURAOS_PUBSUB_APPROVAL_REPLY_TOPIC: 'approval-reply',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- restore `whatsapp-service` PM2 Pub/Sub fallbacks to the home-dev emulator aliases from `tools/pubsub-ui/server.mjs`
- add a regression test that loads `ecosystem.config.cjs` in a clean process and asserts the WhatsApp fallback topic set
- update the local env example and home-dev environment rules so emulator aliases stay aligned

## Root Cause
A WhatsApp webhook received on May 7, 2026 was persisted as `whatsapp_webhook_events/977ac7e7-fff4-42b7-82de-fed8ad319619`, then failed with `Topic intexuraos-whatsapp-webhook-process-dev not found`.

The regression came from commit `b6ac63922`, which changed `whatsapp-service` PM2 fallbacks to Terraform-managed `intexuraos-*-dev` topic names. On home-dev, `whatsapp-service` publishes to `PUBSUB_EMULATOR_HOST=localhost:8102`, where the available topics are the local aliases like `whatsapp-webhook-process`, `commands-ingest`, and `whatsapp-transcription`.

## Impact
This restores inbound WhatsApp processing on home-dev so calendar requests and other asynchronous follow-up actions reach the command and action pipeline instead of failing at webhook publish time.

## Validation
- `pnpm vitest run scripts/__tests__/ecosystem.config.test.ts`
- `pnpm run verify:workspace:tracked whatsapp-service`
- `pnpm run ci:tracked`
- replayed the failed webhook payload against `http://localhost:8113/whatsapp/webhooks` with a valid signature; the replay completed, produced action `7e1e71c3-c339-4c8d-8586-8eb25ee1003c`, and created Google Calendar event `kcudjnc9df1hbou9dg0vb6fv44`
