### PR TITLE
[INT-1614] [codex] Fix Cloud Build worker and trigger configuration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -180,7 +180,7 @@ jobs:
             bash "cloudbuild/scripts/deploy-${svc}.sh" &
           done
           bash cloudbuild/scripts/deploy-function.sh vm-lifecycle &
-          bash cloudbuild/scripts/deploy-function.sh log-cleanup &
+          bash cloudbuild/scripts/deploy-function.sh transcription &
           wait
 
       - name: Fetch web config

--- a/cloudbuild/cloudbuild.yaml
+++ b/cloudbuild/cloudbuild.yaml
@@ -54,6 +54,7 @@
 # ├─────────────────────────────────────────────────────────────────────────┤
 # │ BATCH 9 - Cloud Functions Workers (parallel with Batch 1-8)             │
 # │   1. vm-lifecycle                                                       │
+# │   2. transcription                                                      │
 # ├─────────────────────────────────────────────────────────────────────────┤
 # │ BATCH 10 - Web Frontend                                                 │
 # │   1. web (frontend - after all services deployed)                       │
@@ -721,6 +722,7 @@ steps:
       - '-c'
       - |
         corepack enable
+        corepack prepare pnpm@10 --activate
         bash cloudbuild/scripts/build-all-workers.sh
 
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'

--- a/cloudbuild/scripts/build-all-workers.sh
+++ b/cloudbuild/scripts/build-all-workers.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/lib.sh"
 
-WORKERS=(vm-lifecycle)
+WORKERS=(vm-lifecycle transcription)
 
 log "Building all Cloud Function workers..."
 

--- a/cloudbuild/scripts/deploy-all-workers.sh
+++ b/cloudbuild/scripts/deploy-all-workers.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/lib.sh"
 
-WORKERS=(vm-lifecycle)
+WORKERS=(vm-lifecycle transcription)
 
 log "Deploying all Cloud Function workers..."
 

--- a/cloudbuild/scripts/deploy-function.sh
+++ b/cloudbuild/scripts/deploy-function.sh
@@ -65,6 +65,9 @@ case "${WORKER}" in
   vm-lifecycle)
     FUNCTIONS=("intexuraos-vm-start-${ENVIRONMENT}" "intexuraos-vm-stop-${ENVIRONMENT}")
     ;;
+  transcription)
+    FUNCTIONS=("intexuraos-transcription-${ENVIRONMENT}")
+    ;;
   *)
     log "WARNING: No function mapping found for worker: ${WORKER}"
     log "Source uploaded but functions not redeployed"

--- a/docker/code-worker/cloudbuild.yaml
+++ b/docker/code-worker/cloudbuild.yaml
@@ -14,4 +14,6 @@ steps:
 options:
   logging: CLOUD_LOGGING_ONLY
 
-timeout: '600s'
+# code-worker performs a multi-arch buildx export/push and regularly runs
+# close to the default 10 minute ceiling on cold cache days.
+timeout: '900s'

--- a/scripts/__tests__/artifact-registry-config.test.ts
+++ b/scripts/__tests__/artifact-registry-config.test.ts
@@ -19,6 +19,12 @@ describe('artifact registry prevention config', () => {
     expect(monolithCloudBuild).not.toContain("id: 'build-push-code-worker'");
   });
 
+  it('gives the standalone code-worker Cloud Build extra time for multi-arch export and push', () => {
+    const codeWorkerCloudBuild = readRepoFile('docker/code-worker/cloudbuild.yaml');
+
+    expect(codeWorkerCloudBuild).toContain("timeout: '900s'");
+  });
+
   it('defines active delete cleanup policies and aggressive env retention settings', () => {
     const moduleMain = readRepoFile('terraform/modules/artifact-registry/main.tf');
     const moduleVariables = readRepoFile('terraform/modules/artifact-registry/variables.tf');

--- a/scripts/__tests__/cloud-build-trigger-config.test.ts
+++ b/scripts/__tests__/cloud-build-trigger-config.test.ts
@@ -1,0 +1,65 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = process.cwd();
+
+function readRepoFile(relativePath: string): string {
+  return fs.readFileSync(path.join(REPO_ROOT, relativePath), 'utf8');
+}
+
+function extractTerraformStringList(content: string, listName: string): string[] {
+  const match = content.match(new RegExp(`${listName}\\s*=\\s*\\[(.*?)\\]`, 's'));
+
+  if (!match?.[1]) {
+    throw new Error(`Could not find Terraform list ${listName}`);
+  }
+
+  return Array.from(match[1].matchAll(/"([^"]+)"/g), (entry) => entry[1]).sort();
+}
+
+function listStandaloneAppBuildTargets(): string[] {
+  return fs
+    .readdirSync(path.join(REPO_ROOT, 'apps'))
+    .filter((name) => {
+      const appDir = path.join(REPO_ROOT, 'apps', name);
+      return (
+        fs.statSync(appDir).isDirectory() &&
+        name !== 'web' &&
+        fs.existsSync(path.join(appDir, 'Dockerfile')) &&
+        fs.existsSync(path.join(appDir, 'cloudbuild.yaml'))
+      );
+    })
+    .sort();
+}
+
+function listStandaloneWorkerBuildTargets(): string[] {
+  return fs
+    .readdirSync(path.join(REPO_ROOT, 'workers'))
+    .filter((name) => {
+      const workerDir = path.join(REPO_ROOT, 'workers', name);
+      return (
+        fs.statSync(workerDir).isDirectory() &&
+        fs.existsSync(path.join(workerDir, 'cloudbuild.yaml'))
+      );
+    })
+    .sort();
+}
+
+describe('Cloud Build trigger configuration', () => {
+  it('keeps Terraform docker service triggers aligned with standalone app Cloud Build configs', () => {
+    const cloudBuildModule = readRepoFile('terraform/modules/cloud-build/main.tf');
+    const dockerServices = extractTerraformStringList(cloudBuildModule, 'docker_services');
+
+    expect(dockerServices).toEqual(listStandaloneAppBuildTargets());
+    expect(dockerServices).not.toContain('promptvault-service');
+  });
+
+  it('keeps Terraform worker triggers aligned with standalone worker Cloud Build configs', () => {
+    const cloudBuildModule = readRepoFile('terraform/modules/cloud-build/main.tf');
+    const workerTargets = extractTerraformStringList(cloudBuildModule, 'cloud_function_workers');
+
+    expect(workerTargets).toEqual(listStandaloneWorkerBuildTargets());
+    expect(workerTargets).not.toContain('log-cleanup');
+  });
+});

--- a/scripts/__tests__/cloud-build-worker-config.test.ts
+++ b/scripts/__tests__/cloud-build-worker-config.test.ts
@@ -1,0 +1,48 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = process.cwd();
+
+function readRepoFile(relativePath: string): string {
+  return fs.readFileSync(path.join(REPO_ROOT, relativePath), 'utf8');
+}
+
+describe('Cloud Build worker configuration', () => {
+  it('registers the actual Cloud Function workers and removes stale log-cleanup references', () => {
+    const cloudBuildModule = readRepoFile('terraform/modules/cloud-build/main.tf');
+    const deployWorkflow = readRepoFile('.github/workflows/deploy.yml');
+
+    expect(cloudBuildModule).toContain('"vm-lifecycle"');
+    expect(cloudBuildModule).toContain('"transcription"');
+    expect(cloudBuildModule).not.toContain('"log-cleanup"');
+
+    expect(deployWorkflow).toContain('bash cloudbuild/scripts/deploy-function.sh transcription &');
+    expect(deployWorkflow).not.toContain(
+      'bash cloudbuild/scripts/deploy-function.sh log-cleanup &'
+    );
+  });
+
+  it('includes transcription in the consolidated worker scripts', () => {
+    const buildAllWorkers = readRepoFile('cloudbuild/scripts/build-all-workers.sh');
+    const deployAllWorkers = readRepoFile('cloudbuild/scripts/deploy-all-workers.sh');
+    const deployFunction = readRepoFile('cloudbuild/scripts/deploy-function.sh');
+
+    expect(buildAllWorkers).toContain('WORKERS=(vm-lifecycle transcription)');
+    expect(deployAllWorkers).toContain('WORKERS=(vm-lifecycle transcription)');
+    expect(deployFunction).toContain('transcription)');
+    expect(deployFunction).toContain('FUNCTIONS=("intexuraos-transcription-${ENVIRONMENT}")');
+  });
+
+  it('provides a standalone Cloud Build config for the transcription worker trigger', () => {
+    const transcriptionCloudBuild = readRepoFile('workers/transcription/cloudbuild.yaml');
+    const vmLifecycleCloudBuild = readRepoFile('workers/vm-lifecycle/cloudbuild.yaml');
+
+    expect(transcriptionCloudBuild).toContain('pnpm --filter @intexuraos/transcription build');
+    expect(transcriptionCloudBuild).toContain(
+      "args: ['cloudbuild/scripts/deploy-function.sh', 'transcription']"
+    );
+    expect(transcriptionCloudBuild).toContain('corepack prepare pnpm@10 --activate');
+    expect(vmLifecycleCloudBuild).toContain('corepack prepare pnpm@10 --activate');
+  });
+});

--- a/scripts/__tests__/cloud-function-packaging.test.ts
+++ b/scripts/__tests__/cloud-function-packaging.test.ts
@@ -1,0 +1,54 @@
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = process.cwd();
+
+function readRepoFile(relativePath: string): string {
+  return fs.readFileSync(path.join(REPO_ROOT, relativePath), 'utf8');
+}
+
+function buildWorker(workerPackage: string): void {
+  execSync(`pnpm --filter ${workerPackage} build`, {
+    cwd: REPO_ROOT,
+    stdio: 'pipe',
+    encoding: 'utf8',
+  });
+}
+
+function readBuiltPackageJson(relativePath: string): { dependencies?: Record<string, string> } {
+  return JSON.parse(readRepoFile(relativePath)) as { dependencies?: Record<string, string> };
+}
+
+function getCatalogVersion(depName: string): string {
+  const workspaceYaml = readRepoFile('pnpm-workspace.yaml');
+  const escaped = depName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = workspaceYaml.match(new RegExp(`^\\s*${escaped}:\\s*(.+)$`, 'm'));
+
+  if (!match?.[1]) {
+    throw new Error(`Missing catalog entry for ${depName}`);
+  }
+
+  return match[1].trim();
+}
+
+describe('Cloud Function production package generation', () => {
+  it('resolves pnpm catalog dependencies for vm-lifecycle dist/package.json', () => {
+    buildWorker('@intexuraos/vm-lifecycle');
+
+    const pkg = readBuiltPackageJson('workers/vm-lifecycle/dist/package.json');
+
+    expect(Object.values(pkg.dependencies ?? {})).not.toContain('catalog:');
+    expect(pkg.dependencies?.pino).toBe(getCatalogVersion('pino'));
+  });
+
+  it('resolves pnpm catalog dependencies for transcription dist/package.json', () => {
+    buildWorker('@intexuraos/transcription');
+
+    const pkg = readBuiltPackageJson('workers/transcription/dist/package.json');
+
+    expect(Object.values(pkg.dependencies ?? {})).not.toContain('catalog:');
+    expect(pkg.dependencies?.pino).toBe(getCatalogVersion('pino'));
+  });
+});

--- a/scripts/build-service.mjs
+++ b/scripts/build-service.mjs
@@ -13,6 +13,53 @@ if (!service) {
   process.exit(1);
 }
 
+function readCatalogVersions() {
+  const workspaceYaml = readFileSync(resolve(rootDir, 'pnpm-workspace.yaml'), 'utf8');
+  const lines = workspaceYaml.split('\n');
+  const catalog = new Map();
+  let inCatalog = false;
+
+  for (const line of lines) {
+    if (!inCatalog) {
+      if (line.trim() === 'catalog:') {
+        inCatalog = true;
+      }
+      continue;
+    }
+
+    if (!line.startsWith('  ')) {
+      break;
+    }
+
+    const match = line.match(/^\s{2}(?:'([^']+)'|([^:]+)):\s*(.+)$/);
+    if (!match) {
+      continue;
+    }
+
+    const key = match[1] ?? match[2]?.trim();
+    const value = match[3]?.trim();
+    if (key && value) {
+      catalog.set(key, value);
+    }
+  }
+
+  return catalog;
+}
+
+const catalogVersions = readCatalogVersions();
+
+function resolveDependencyVersion(dep, version) {
+  if (version === 'catalog:') {
+    const resolved = catalogVersions.get(dep);
+    if (!resolved) {
+      throw new Error(`Missing catalog version for dependency: ${dep}`);
+    }
+    return resolved;
+  }
+
+  return version;
+}
+
 /**
  * Recursively collect all pnpm dependencies from workspace packages.
  * @intexuraos/* packages are bundled, their pnpm deps must be external.
@@ -87,7 +134,7 @@ function collectExternalDepsWithVersions(pkgName, visited = new Set()) {
       const subExternals = collectExternalDepsWithVersions(dep, visited);
       subExternals.forEach((v, k) => externals.set(k, v));
     } else {
-      externals.set(dep, version);
+      externals.set(dep, resolveDependencyVersion(dep, version));
     }
   }
 

--- a/terraform/modules/cloud-build/main.tf
+++ b/terraform/modules/cloud-build/main.tf
@@ -170,6 +170,7 @@ locals {
     "linear-agent",
     "web-agent",
     "code-agent",
+    "chat-agent",
     "cron-agent",
     "hellscript-agent",
     "llm-usage-service",
@@ -178,7 +179,7 @@ locals {
   # Cloud Function workers (zip + upload to GCS)
   cloud_function_workers = [
     "vm-lifecycle",
-    "log-cleanup",
+    "transcription",
   ]
 }
 
@@ -271,7 +272,7 @@ resource "google_cloudbuild_trigger" "firestore" {
 # -----------------------------------------------------------------------------
 # Cloud Function Worker Triggers
 # -----------------------------------------------------------------------------
-# Individual triggers for Cloud Function workers (vm-lifecycle, log-cleanup).
+# Individual triggers for Cloud Function workers (vm-lifecycle, transcription).
 # These deploy function source to GCS without triggering on git push.
 
 resource "google_cloudbuild_trigger" "worker" {

--- a/workers/transcription/cloudbuild.yaml
+++ b/workers/transcription/cloudbuild.yaml
@@ -1,4 +1,4 @@
-# Manual trigger: Deploy vm-lifecycle Cloud Function only
+# Manual trigger: Deploy transcription Cloud Function only
 steps:
   - name: 'node:22-slim'
     id: 'install'
@@ -19,13 +19,13 @@ steps:
       - |
         corepack enable
         corepack prepare pnpm@10 --activate
-        pnpm --filter @intexuraos/vm-lifecycle build
+        pnpm --filter @intexuraos/transcription build
 
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     id: 'deploy'
     waitFor: ['build']
     entrypoint: 'bash'
-    args: ['cloudbuild/scripts/deploy-function.sh', 'vm-lifecycle']
+    args: ['cloudbuild/scripts/deploy-function.sh', 'transcription']
     env:
       - 'REGION=${_REGION}'
       - 'ENVIRONMENT=${_ENVIRONMENT}'


### PR DESCRIPTION
## Summary
- fix the standalone `code-worker` Cloud Build timeout for its multi-arch export/push path
- align Cloud Build worker/trigger configuration with the actual repo shape by replacing stale `log-cleanup` references with `transcription` and adding the missing `chat-agent` trigger coverage
- resolve `catalog:` dependency leakage in worker `dist/package.json` generation and add regression tests for worker packaging and trigger parity

## Why
Recent Cloud Build failures came from three separate configuration problems:
1. the `code-worker` image build was timing out at the default 10 minute ceiling
2. worker packaging emitted unresolved `catalog:` dependency versions, which broke Cloud Functions installs
3. repo and live Cloud Build trigger definitions had drifted from the actual set of standalone services/workers

## Impact
- standalone `code-worker` builds now complete with a longer timeout
- standalone worker builds for `vm-lifecycle` and `transcription` are defined and deployable
- the aggregate monolith Cloud Build now runs through workers, service/agent images, web config fetch, web build, and web deploy successfully
- Terraform and workflow config now stay aligned with standalone Cloud Build targets via regression tests

## Validation
- `pnpm run ci:tracked`
- `pnpm exec vitest run scripts/__tests__/cloud-build-trigger-config.test.ts scripts/__tests__/cloud-build-worker-config.test.ts scripts/__tests__/cloud-function-packaging.test.ts scripts/__tests__/artifact-registry-config.test.ts`
- GCP Cloud Build `77e2114a-bb10-48da-9474-866be367d782` (`code-worker`) → `SUCCESS`
- GCP Cloud Build `ddb59fbe-9301-4a45-9ecf-ddadbf106d67` (`vm-lifecycle`) → `SUCCESS`
- GCP Cloud Build `c036a415-6bc6-4139-9ac8-a4d8cd287c83` (`transcription`) → `SUCCESS`
- GCP Cloud Build `82842bff-8888-4338-a56f-8facaac387f5` (full monolith) → `SUCCESS`
