### PR TITLE
[INT-1423] [codex] Fix remaining open PR issue group visibility repair

### DIFF
--- a/apps/code-agent/src/__tests__/domain/issueGrouping/groupByLinearIssue.test.ts
+++ b/apps/code-agent/src/__tests__/domain/issueGrouping/groupByLinearIssue.test.ts
@@ -385,6 +385,19 @@ describe('deriveAggregateStatus', () => {
     expect(deriveAggregateStatus(tasks, pipeline)).toBe('needs-action');
   });
 
+  it('returns active when execution completed and no review cleared it yet', () => {
+    const tasks = [
+      makeTask({
+        id: 'task-execution',
+        agentType: 'execution',
+        status: 'implemented',
+        updatedAt: '2026-03-05T10:00:00.000Z',
+      }),
+    ];
+    const pipeline = derivePipeline(tasks);
+    expect(deriveAggregateStatus(tasks, pipeline)).toBe('active');
+  });
+
   it('returns failed when latest non-archived task is failed', () => {
     const tasks = [
       makeTask({ id: 'task-1', status: 'failed', updatedAt: '2026-03-05T10:00:00.000Z' }),

--- a/apps/code-agent/src/__tests__/infra/firestore/taskGroupSummaryFirestoreRepository.test.ts
+++ b/apps/code-agent/src/__tests__/infra/firestore/taskGroupSummaryFirestoreRepository.test.ts
@@ -2431,6 +2431,68 @@ describe('taskGroupSummaryFirestoreRepository', () => {
     });
   });
 
+  describe('getSummary', () => {
+    it('returns null when the summary document does not exist', async () => {
+      const repo = createTaskGroupSummaryFirestoreRepository({
+        firestore: fakeFirestore as unknown as Firestore,
+        logger,
+      });
+
+      const result = await repo.getSummary('missing-user', 'INT-404');
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value).toBeNull();
+      }
+    });
+
+    it('returns an existing summary document', async () => {
+      const repo = createTaskGroupSummaryFirestoreRepository({
+        firestore: fakeFirestore as unknown as Firestore,
+        logger,
+      });
+      const now = Timestamp.now();
+
+      await fakeFirestore.collection('task_group_summaries').doc('user-1_INT-321').set({
+        userId: 'user-1',
+        linearIssueId: 'INT-321',
+        groupKey: 'INT-321',
+        linearIssueNumber: 321,
+        linearIssueSortKey: 321,
+        taskCount: 1,
+        activeTaskCount: 0,
+        latestTaskStatus: 'planned',
+        latestTaskUpdatedAt: now,
+        agentTypesPresent: ['planning'],
+        hasCompletedPlanning: true,
+        hasCompletedExecution: false,
+        hasCompletedExecutionAgent: false,
+        hasImplementationTaskId: false,
+        hasPrUrl: false,
+        prNumber: null,
+        latestReviewNeedsRemediation: null,
+        oldestTaskCreatedAt: now,
+        mostRecentDispatchedAt: null,
+        aggregateStatus: 'needs-action',
+        updatedAt: now,
+      });
+
+      const result = await repo.getSummary('user-1', 'INT-321');
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value).toMatchObject({
+          userId: 'user-1',
+          groupKey: 'INT-321',
+          linearIssueId: 'INT-321',
+          linearIssueNumber: 321,
+          linearIssueSortKey: 321,
+          aggregateStatus: 'needs-action',
+        });
+      }
+    });
+  });
+
   describe('recomputeGroupFromTasks', () => {
     it('builds summary from task array', async () => {
       const repo = createTaskGroupSummaryFirestoreRepository({

--- a/apps/code-agent/src/__tests__/routes/code/issueGroups.test.ts
+++ b/apps/code-agent/src/__tests__/routes/code/issueGroups.test.ts
@@ -2513,6 +2513,134 @@ describe('GET /code/issue-groups', () => {
       expect(body.data.counts['done']).toBe(1);
       expect(body.data.totalGroups).toBe(1);
     });
+
+    it('restores a mixed open PR group back into the active view with a stable execution sibling', async () => {
+      const summaryRepo = createTaskGroupSummaryFirestoreRepository({
+        firestore: fakeFirestore as unknown as Firestore,
+        logger,
+      });
+
+      async function createArchivedTask(input: {
+        traceId: string;
+        agentType: 'execution' | 'review';
+        updatedAt: Date;
+        prNumber?: number;
+        prMergedAt?: Date;
+      }): Promise<void> {
+        const createResult = await codeTaskRepo.create(makeTaskInput({
+          linearIssueId: 'INT-1423',
+          traceId: input.traceId,
+          agentType: input.agentType,
+          repository: 'pbuchman/intexuraos',
+          baseBranch: 'development',
+          ...(input.prNumber !== undefined ? { prNumber: input.prNumber } : {}),
+        }));
+        expect(createResult.ok).toBe(true);
+        if (!createResult.ok) {
+          return;
+        }
+
+        await summaryRepo.updateAfterCreate(createResult.value);
+        const archivedResult = await codeTaskRepo.update(createResult.value.id, {
+          status: 'archived',
+          updatedAt: input.updatedAt,
+          ...(input.prMergedAt !== undefined ? { prMergedAt: input.prMergedAt } : {}),
+        });
+        expect(archivedResult.ok).toBe(true);
+        if (!archivedResult.ok) {
+          return;
+        }
+        await summaryRepo.updateAfterStatusChange(createResult.value, archivedResult.value);
+      }
+
+      await createArchivedTask({
+        traceId: 'trace-int-1423-stable-execution',
+        agentType: 'execution',
+        updatedAt: new Date('2026-05-07T08:00:00Z'),
+      });
+      await createArchivedTask({
+        traceId: 'trace-int-1423-open-pr-review',
+        agentType: 'review',
+        prNumber: 1903,
+        updatedAt: new Date('2026-05-07T09:00:00Z'),
+      });
+      await createArchivedTask({
+        traceId: 'trace-int-1423-merged-execution',
+        agentType: 'execution',
+        prNumber: 1994,
+        prMergedAt: new Date('2026-04-30T12:00:05Z'),
+        updatedAt: new Date('2026-05-07T10:00:00Z'),
+      });
+
+      const repairUseCase = createRepairArchivedOpenPrGroupsUseCase({
+        codeTaskRepo: codeTaskRepo as unknown as RepairArchivedOpenPrGroupsDeps['codeTaskRepo'],
+        gitHubPRSummaryRepo: {
+          findAllOpen: async () => ok([{
+            repository: 'pbuchman/intexuraos',
+            pullRequestNumber: 1903,
+            title: 'Open PR',
+            state: 'open',
+            mergedAt: null,
+            baseBranch: 'development',
+            authorLogin: 'pbuchman',
+            headBranch: 'worker/int-1423',
+            mergeConflictStatus: null,
+            lastConflictCheckedAt: null,
+            conflictEpisodeStartedAt: null,
+            conflictResolvedAt: null,
+            managedConflictCommentId: null,
+            managedConflictTaskId: null,
+            managedConflictTaskOwnerUserId: null,
+            lastActivityAt: new Date('2026-05-07T10:00:00Z'),
+            firstSeenAt: new Date('2026-05-07T10:00:00Z'),
+            lastReviewedCommitSha: null,
+            lastReviewNeedsRemediation: null,
+          }]),
+        },
+        groupSummaryRepo: summaryRepo,
+        logger,
+      });
+
+      const repairResult = await repairUseCase();
+      expect(repairResult.ok).toBe(true);
+
+      setServices(makeBaseServices({
+        groupSummaryRepo: summaryRepo as unknown as ReturnType<typeof makeGroupSummaryRepo>,
+      }));
+      await server.close();
+      server = await buildServer();
+
+      const response = await server.inject({
+        method: 'GET',
+        url: '/code/issue-groups?groupStatus=active,needs-action',
+        headers: { authorization: 'Bearer test-token' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body) as {
+        data: {
+          groups: {
+            linearIssueId: string | null;
+            aggregateStatus: string;
+            tasks: { status: string; agentType?: string }[];
+          }[];
+          counts: Record<string, number>;
+          totalGroups: number;
+        };
+      };
+
+      const repairedGroup = body.data.groups.find((group) => group.linearIssueId === 'INT-1423');
+      expect(repairedGroup).toBeDefined();
+      expect(repairedGroup?.aggregateStatus).toBe('active');
+      expect(repairedGroup?.tasks).toEqual([
+        expect.objectContaining({
+          status: 'implemented',
+          agentType: 'execution',
+        }),
+      ]);
+      expect(body.data.counts['active']).toBe(1);
+      expect(body.data.totalGroups).toBe(1);
+    });
   });
 });
 

--- a/apps/code-agent/src/__tests__/usecases/repairArchivedOpenPrGroups.test.ts
+++ b/apps/code-agent/src/__tests__/usecases/repairArchivedOpenPrGroups.test.ts
@@ -4,6 +4,7 @@ import { err, ok } from '@intexuraos/common-core';
 import { Timestamp } from '@google-cloud/firestore';
 import type { CodeTask } from '../../domain/models/codeTask.js';
 import type { GitHubPRSummary } from '../../domain/models/gitHubPRSummary.js';
+import type { TaskGroupSummary } from '../../domain/models/taskGroupSummary.js';
 import {
   createRepairArchivedOpenPrGroupsUseCase,
   type RepairArchivedOpenPrGroupsDeps,
@@ -81,6 +82,7 @@ describe('repairArchivedOpenPrGroups', () => {
   let findRecentTasksByLinearIssueMock: MockedFunction<RepairArchivedOpenPrGroupsDeps['codeTaskRepo']['findRecentTasksByLinearIssue']>;
   let updateMock: MockedFunction<RepairArchivedOpenPrGroupsDeps['codeTaskRepo']['update']>;
   let recomputeGroupFromTasksMock: MockedFunction<RepairArchivedOpenPrGroupsDeps['groupSummaryRepo']['recomputeGroupFromTasks']>;
+  let getSummaryMock: MockedFunction<NonNullable<RepairArchivedOpenPrGroupsDeps['groupSummaryRepo']['getSummary']>>;
 
   beforeEach(() => {
     findAllOpenMock = vi.fn().mockResolvedValue(ok([makeOpenPrSummary()])) as MockedFunction<
@@ -98,6 +100,9 @@ describe('repairArchivedOpenPrGroups', () => {
     recomputeGroupFromTasksMock = vi.fn().mockResolvedValue(ok(undefined)) as MockedFunction<
       RepairArchivedOpenPrGroupsDeps['groupSummaryRepo']['recomputeGroupFromTasks']
     >;
+    getSummaryMock = vi.fn().mockResolvedValue(ok(null)) as MockedFunction<
+      NonNullable<RepairArchivedOpenPrGroupsDeps['groupSummaryRepo']['getSummary']>
+    >;
 
     deps = {
       codeTaskRepo: {
@@ -109,6 +114,7 @@ describe('repairArchivedOpenPrGroups', () => {
         findAllOpen: findAllOpenMock,
       },
       groupSummaryRepo: {
+        getSummary: getSummaryMock,
         recomputeGroupFromTasks: recomputeGroupFromTasksMock,
       },
       logger: createMockLogger(),
@@ -228,26 +234,36 @@ describe('repairArchivedOpenPrGroups', () => {
     );
   });
 
-  it('restores the newest archived task from the full group, not just the open PR slice', async () => {
+  it('prefers a stable execution sibling over a newer merged-PR sibling when repairing visibility', async () => {
     const archivedOpenPrTask = makeTask({
       id: 'task-open-pr-review',
       agentType: 'review',
       prNumber: 1903,
       status: 'archived',
-      updatedAt: Timestamp.fromDate(new Date('2026-05-07T08:00:00Z')),
-    });
-    const newerArchivedSibling = makeTask({
-      id: 'task-newer-sibling',
-      agentType: 'pull_request',
-      prNumber: 1994,
-      status: 'archived',
       updatedAt: Timestamp.fromDate(new Date('2026-05-07T09:00:00Z')),
     });
+    const newerMergedSibling = makeTask({
+      id: 'task-newer-merged-sibling',
+      agentType: 'execution',
+      prNumber: 1994,
+      status: 'archived',
+      prMergedAt: Timestamp.fromDate(new Date('2026-04-30T12:00:05Z')),
+      updatedAt: Timestamp.fromDate(new Date('2026-05-07T10:00:00Z')),
+    });
+    const stableExecutionSibling = makeTask({
+      id: 'task-stable-execution-sibling',
+      agentType: 'execution',
+      status: 'archived',
+      updatedAt: Timestamp.fromDate(new Date('2026-05-07T08:00:00Z')),
+    }) as CodeTask & { prNumber?: number };
+    delete stableExecutionSibling.prNumber;
 
     findRecentTasksByPRMock.mockResolvedValue(ok([archivedOpenPrTask]));
-    findRecentTasksByLinearIssueMock.mockResolvedValue(ok([archivedOpenPrTask, newerArchivedSibling]));
+    findRecentTasksByLinearIssueMock.mockResolvedValue(
+      ok([archivedOpenPrTask, newerMergedSibling, stableExecutionSibling]),
+    );
     updateMock.mockResolvedValue(ok({
-      ...newerArchivedSibling,
+      ...stableExecutionSibling,
       status: 'implemented',
     }));
 
@@ -255,8 +271,83 @@ describe('repairArchivedOpenPrGroups', () => {
     const result = await useCase();
 
     expect(result.ok).toBe(true);
-    expect(updateMock).toHaveBeenCalledWith('task-newer-sibling', {
+    expect(updateMock).toHaveBeenCalledWith('task-stable-execution-sibling', {
       status: 'implemented',
+      updatedAt: new Date('2026-05-07T08:00:00Z'),
+    });
+    expect(recomputeGroupFromTasksMock).toHaveBeenCalledWith(
+      'user-1',
+      'INT-1423',
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'task-stable-execution-sibling',
+          status: 'implemented',
+        }),
+      ]),
+    );
+  });
+
+  it('prefers a merge-ready review sibling over an execution sibling when the cached summary already marks merge readiness', async () => {
+    const mergeReadyReview = makeTask({
+      id: 'task-merge-ready-review',
+      agentType: 'review',
+      prNumber: 1903,
+      status: 'archived',
+      updatedAt: Timestamp.fromDate(new Date('2026-05-07T09:00:00Z')),
+      result: {
+        prUrl: 'https://github.com/pbuchman/intexuraos/pull/1903',
+        needs_remediation: '0',
+      },
+    });
+    const stableExecutionSibling = makeTask({
+      id: 'task-stable-execution',
+      agentType: 'execution',
+      status: 'archived',
+      updatedAt: Timestamp.fromDate(new Date('2026-05-07T08:00:00Z')),
+    }) as CodeTask & { prNumber?: number };
+    delete stableExecutionSibling.prNumber;
+    const archivedSummary: TaskGroupSummary = {
+      userId: 'user-1',
+      linearIssueId: 'INT-1423',
+      groupKey: 'INT-1423',
+      linearIssueNumber: 1423,
+      linearIssueSortKey: 1423,
+      taskCount: 0,
+      activeTaskCount: 0,
+      latestTaskStatus: 'reviewed',
+      latestTaskUpdatedAt: Timestamp.fromDate(new Date('2026-05-07T09:00:00Z')),
+      agentTypesPresent: ['review', 'execution'],
+      hasCompletedPlanning: false,
+      hasCompletedExecution: true,
+      hasCompletedExecutionAgent: true,
+      hasImplementationTaskId: false,
+      hasPrUrl: true,
+      prNumber: 1903,
+      latestReviewNeedsRemediation: false,
+      oldestTaskCreatedAt: Timestamp.fromDate(new Date('2026-05-07T07:00:00Z')),
+      mostRecentDispatchedAt: null,
+      aggregateStatus: 'archived',
+      hasImplementationReadyLabel: true,
+      hasMergeReadyLabel: true,
+      updatedAt: Timestamp.fromDate(new Date('2026-05-07T10:00:01Z')),
+    };
+
+    findRecentTasksByPRMock.mockResolvedValue(ok([mergeReadyReview]));
+    findRecentTasksByLinearIssueMock.mockResolvedValue(
+      ok([mergeReadyReview, stableExecutionSibling]),
+    );
+    getSummaryMock.mockResolvedValue(ok(archivedSummary));
+    updateMock.mockResolvedValue(ok({
+      ...mergeReadyReview,
+      status: 'reviewed',
+    }));
+
+    const useCase = createRepairArchivedOpenPrGroupsUseCase(deps);
+    const result = await useCase();
+
+    expect(result.ok).toBe(true);
+    expect(updateMock).toHaveBeenCalledWith('task-merge-ready-review', {
+      status: 'reviewed',
       updatedAt: new Date('2026-05-07T09:00:00Z'),
     });
     expect(recomputeGroupFromTasksMock).toHaveBeenCalledWith(
@@ -264,8 +355,8 @@ describe('repairArchivedOpenPrGroups', () => {
       'INT-1423',
       expect.arrayContaining([
         expect.objectContaining({
-          id: 'task-newer-sibling',
-          status: 'implemented',
+          id: 'task-merge-ready-review',
+          status: 'reviewed',
         }),
       ]),
     );

--- a/apps/code-agent/src/__tests__/usecases/repairArchivedOpenPrGroups.test.ts
+++ b/apps/code-agent/src/__tests__/usecases/repairArchivedOpenPrGroups.test.ts
@@ -362,6 +362,140 @@ describe('repairArchivedOpenPrGroups', () => {
     );
   });
 
+  it('prefers a planning sibling over weaker candidates when the cached summary marks implementation readiness', async () => {
+    const archivedOpenPrTask = makeTask({
+      id: 'task-open-pr-review',
+      agentType: 'review',
+      prNumber: 1903,
+      status: 'archived',
+      updatedAt: Timestamp.fromDate(new Date('2026-05-07T09:00:00Z')),
+    });
+    const planningSibling = makeTask({
+      id: 'task-planning-sibling',
+      agentType: 'planning',
+      status: 'archived',
+      updatedAt: Timestamp.fromDate(new Date('2026-05-07T08:00:00Z')),
+    }) as CodeTask & { prNumber?: number };
+    delete planningSibling.prNumber;
+    const weakerSibling = makeTask({
+      id: 'task-weaker-sibling',
+      agentType: 'pull_request',
+      status: 'archived',
+      updatedAt: Timestamp.fromDate(new Date('2026-05-07T10:00:00Z')),
+    }) as CodeTask & { prNumber?: number };
+    delete weakerSibling.prNumber;
+    const archivedSummary: TaskGroupSummary = {
+      userId: 'user-1',
+      linearIssueId: 'INT-1423',
+      groupKey: 'INT-1423',
+      linearIssueNumber: 1423,
+      linearIssueSortKey: 1423,
+      taskCount: 0,
+      activeTaskCount: 0,
+      latestTaskStatus: 'planned',
+      latestTaskUpdatedAt: Timestamp.fromDate(new Date('2026-05-07T10:00:00Z')),
+      agentTypesPresent: ['review', 'planning', 'pull_request'],
+      hasCompletedPlanning: true,
+      hasCompletedExecution: false,
+      hasCompletedExecutionAgent: false,
+      hasImplementationTaskId: false,
+      hasPrUrl: true,
+      prNumber: 1903,
+      latestReviewNeedsRemediation: null,
+      oldestTaskCreatedAt: Timestamp.fromDate(new Date('2026-05-07T07:00:00Z')),
+      mostRecentDispatchedAt: null,
+      aggregateStatus: 'archived',
+      hasImplementationReadyLabel: true,
+      hasMergeReadyLabel: false,
+      updatedAt: Timestamp.fromDate(new Date('2026-05-07T10:00:01Z')),
+    };
+
+    findRecentTasksByPRMock.mockResolvedValue(ok([archivedOpenPrTask]));
+    findRecentTasksByLinearIssueMock.mockResolvedValue(
+      ok([archivedOpenPrTask, planningSibling, weakerSibling]),
+    );
+    getSummaryMock.mockResolvedValue(ok(archivedSummary));
+    updateMock.mockResolvedValue(ok({
+      ...planningSibling,
+      status: 'planned',
+    }));
+
+    const useCase = createRepairArchivedOpenPrGroupsUseCase(deps);
+    const result = await useCase();
+
+    expect(result.ok).toBe(true);
+    expect(updateMock).toHaveBeenCalledWith('task-planning-sibling', {
+      status: 'planned',
+      updatedAt: new Date('2026-05-07T08:00:00Z'),
+    });
+  });
+
+  it('repairs archived groups when getSummary is not implemented on the repository adapter', async () => {
+    const archivedOpenPrTask = makeTask({
+      id: 'task-open-pr-review',
+      agentType: 'review',
+      prNumber: 1903,
+      status: 'archived',
+      updatedAt: Timestamp.fromDate(new Date('2026-05-07T09:00:00Z')),
+    });
+    const stableExecutionSibling = makeTask({
+      id: 'task-stable-execution-sibling',
+      agentType: 'execution',
+      status: 'archived',
+      updatedAt: Timestamp.fromDate(new Date('2026-05-07T08:00:00Z')),
+    }) as CodeTask & { prNumber?: number };
+    delete stableExecutionSibling.prNumber;
+
+    findRecentTasksByPRMock.mockResolvedValue(ok([archivedOpenPrTask]));
+    findRecentTasksByLinearIssueMock.mockResolvedValue(
+      ok([archivedOpenPrTask, stableExecutionSibling]),
+    );
+    updateMock.mockResolvedValue(ok({
+      ...stableExecutionSibling,
+      status: 'implemented',
+    }));
+
+    const useCase = createRepairArchivedOpenPrGroupsUseCase({
+      ...deps,
+      groupSummaryRepo: {
+        recomputeGroupFromTasks: recomputeGroupFromTasksMock,
+      },
+    });
+    const result = await useCase();
+
+    expect(result.ok).toBe(true);
+    expect(updateMock).toHaveBeenCalledWith('task-stable-execution-sibling', {
+      status: 'implemented',
+      updatedAt: new Date('2026-05-07T08:00:00Z'),
+    });
+  });
+
+  it('returns an error when fetching the existing summary for repair fails', async () => {
+    const archivedOpenPrTask = makeTask({
+      id: 'task-open-pr-review',
+      agentType: 'review',
+      prNumber: 1903,
+      status: 'archived',
+      updatedAt: Timestamp.fromDate(new Date('2026-05-07T09:00:00Z')),
+    });
+
+    findRecentTasksByPRMock.mockResolvedValue(ok([archivedOpenPrTask]));
+    findRecentTasksByLinearIssueMock.mockResolvedValue(ok([archivedOpenPrTask]));
+    getSummaryMock.mockResolvedValue(err({
+      code: 'FIRESTORE_ERROR',
+      message: 'summary read failed',
+    }));
+
+    const useCase = createRepairArchivedOpenPrGroupsUseCase(deps);
+    const result = await useCase();
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toBe('summary read failed');
+    }
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
   it('restores pull_request tasks to implemented', async () => {
     const latestPullRequestTask = makeTask({
       id: 'task-pr',

--- a/apps/code-agent/src/domain/issueGrouping/groupByLinearIssue.ts
+++ b/apps/code-agent/src/domain/issueGrouping/groupByLinearIssue.ts
@@ -202,6 +202,31 @@ export function deriveAggregateStatus(tasks: SerializedTask[], pipeline: Pipelin
     return 'active';
   }
 
+  // Active: execution completed but review has not explicitly cleared it yet.
+  // Keep this aligned with summary-based status derivation so repaired groups do
+  // not disappear from the active filter after the route re-groups tasks.
+  const hasActionableMerge = pipeline.steps.some(
+    (step) => step.agentType === 'merge' && step.state === 'actionable',
+  );
+  const latestCompletedExecution = tasks.find(
+    (task) =>
+      task.status !== 'archived' &&
+      task.agentType === 'execution' &&
+      (task.status === 'implemented' || task.status === 'reviewed'),
+  );
+  const latestNonArchivedReview = tasks.find(
+    (task) => task.status !== 'archived' && task.agentType === 'review',
+  );
+  if (
+    latestCompletedExecution !== undefined &&
+    !hasActionableMerge &&
+    pipeline.pr?.status !== 'closed' &&
+    pipeline.pr?.status !== 'merged' &&
+    latestNonArchivedReview?.result?.needs_remediation !== REMEDIATION_NOT_NEEDED
+  ) {
+    return 'active';
+  }
+
   // Needs-action: has actionable step
   if (pipeline.steps.some((s) => s.state === 'actionable')) {
     return 'needs-action';

--- a/apps/code-agent/src/domain/usecases/repairArchivedOpenPrGroups.ts
+++ b/apps/code-agent/src/domain/usecases/repairArchivedOpenPrGroups.ts
@@ -2,8 +2,9 @@ import type { Result } from '@intexuraos/common-core';
 import { err, getErrorMessage, ok } from '@intexuraos/common-core';
 import type { Logger } from 'pino';
 import type { CodeTask } from '../models/codeTask.js';
+import type { TaskGroupSummary } from '../models/taskGroupSummary.js';
 import type { GitHubPRSummaryRepository } from '../repositories/gitHubPRSummaryRepository.js';
-import type { TaskGroupSummaryRepository } from '../ports/taskGroupSummaryRepository.js';
+import type { GroupSummaryError, TaskGroupSummaryRepository } from '../ports/taskGroupSummaryRepository.js';
 import { resolveCompletedTaskStatus } from '../utils/resolveCompletedTaskStatus.js';
 
 export interface RepairArchivedOpenPrGroupsDeps {
@@ -23,7 +24,12 @@ export interface RepairArchivedOpenPrGroupsDeps {
     ): Promise<Result<CodeTask>>;
   };
   gitHubPRSummaryRepo: Pick<GitHubPRSummaryRepository, 'findAllOpen'>;
-  groupSummaryRepo: Pick<TaskGroupSummaryRepository, 'recomputeGroupFromTasks'>;
+  groupSummaryRepo: Pick<TaskGroupSummaryRepository, 'recomputeGroupFromTasks'> & {
+    getSummary?: (
+      userId: string,
+      groupKey: string,
+    ) => Promise<Result<TaskGroupSummary | null, GroupSummaryError>>;
+  };
   logger: Logger;
 }
 
@@ -72,6 +78,53 @@ function isNonArchived(task: CodeTask): boolean {
 
 function compareByUpdatedAtDesc(left: CodeTask, right: CodeTask): number {
   return right.updatedAt.toMillis() - left.updatedAt.toMillis();
+}
+
+function hasClosedOrMergedPr(task: CodeTask): boolean {
+  return task.prMergedAt !== undefined || task.prClosedAt !== undefined;
+}
+
+function candidateVisibilityRank(
+  task: CodeTask,
+  existingSummary: TaskGroupSummary | null,
+): number {
+  if (task.agentType === 'planning') {
+    return existingSummary?.hasImplementationReadyLabel === true ? 2 : 1;
+  }
+
+  if (
+    task.agentType === 'review' &&
+    task.result?.needs_remediation !== '1' &&
+    existingSummary?.hasMergeReadyLabel === true
+  ) {
+    return 4;
+  }
+
+  if (task.agentType === 'execution') {
+    return 3;
+  }
+
+  return 1;
+}
+
+function compareRepairCandidates(
+  left: CodeTask,
+  right: CodeTask,
+  existingSummary: TaskGroupSummary | null,
+): number {
+  const leftStable = hasClosedOrMergedPr(left) ? 0 : 1;
+  const rightStable = hasClosedOrMergedPr(right) ? 0 : 1;
+  if (leftStable !== rightStable) {
+    return rightStable - leftStable;
+  }
+
+  const leftVisibility = candidateVisibilityRank(left, existingSummary);
+  const rightVisibility = candidateVisibilityRank(right, existingSummary);
+  if (leftVisibility !== rightVisibility) {
+    return rightVisibility - leftVisibility;
+  }
+
+  return compareByUpdatedAtDesc(left, right);
 }
 
 export function createRepairArchivedOpenPrGroupsUseCase(
@@ -217,7 +270,29 @@ export function createRepairArchivedOpenPrGroupsUseCase(
           continue;
         }
 
-        const latestGroupTask = [...groupTasks].sort(compareByUpdatedAtDesc)[0];
+        let existingSummary: TaskGroupSummary | null = null;
+        if (groupSummaryRepo.getSummary !== undefined) {
+          const summaryResult = await groupSummaryRepo.getSummary(
+            latestPrTask.userId,
+            groupKeyOf(latestPrTask),
+          );
+          if (!summaryResult.ok) {
+            logger.error(
+              {
+                userId: latestPrTask.userId,
+                groupKey: groupKeyOf(latestPrTask),
+                error: summaryResult.error,
+              },
+              'Failed to fetch existing summary for archived-group repair',
+            );
+            return err(new Error(summaryResult.error.message));
+          }
+          existingSummary = summaryResult.value;
+        }
+
+        const latestGroupTask = [...groupTasks].sort((left, right) =>
+          compareRepairCandidates(left, right, existingSummary),
+        )[0];
         if (latestGroupTask === undefined) {
           continue;
         }

--- a/apps/code-agent/src/infra/firestore/taskGroupSummaryFirestoreRepository.ts
+++ b/apps/code-agent/src/infra/firestore/taskGroupSummaryFirestoreRepository.ts
@@ -20,7 +20,13 @@ import {
 } from './taskGroupSummary/serializer.js';
 import { SUMMARIES_COLLECTION, buildListQuery, countsDocRef, summaryDocRef } from './taskGroupSummary/queries.js';
 
-export function createTaskGroupSummaryFirestoreRepository(deps: { firestore: Firestore; logger: Logger }): TaskGroupSummaryRepository {
+export interface RepairReadableTaskGroupSummaryRepository extends TaskGroupSummaryRepository {
+  getSummary(userId: string, groupKey: string): Promise<Result<TaskGroupSummary | null, GroupSummaryError>>;
+}
+
+export function createTaskGroupSummaryFirestoreRepository(
+  deps: { firestore: Firestore; logger: Logger }
+): RepairReadableTaskGroupSummaryRepository {
   const { firestore, logger } = deps;
 
   async function loadCounts(tx: Transaction, userId: string): Promise<UserGroupCounts> {
@@ -175,6 +181,18 @@ export function createTaskGroupSummaryFirestoreRepository(deps: { firestore: Fir
         return ok({ summaries, nextCursor });
       } catch (error) {
         return err({ code: 'FIRESTORE_ERROR', message: getErrorMessage(error, 'Failed to list group summaries') });
+      }
+    },
+
+    async getSummary(userId: string, groupKey: string): Promise<Result<TaskGroupSummary | null, GroupSummaryError>> {
+      try {
+        const snapshot = await summaryDocRef(firestore, userId, groupKey).get();
+        if (!snapshot.exists) {
+          return ok(null);
+        }
+        return ok(docToSummary(snapshot.data() as Record<string, unknown>));
+      } catch (error) {
+        return err({ code: 'FIRESTORE_ERROR', message: getErrorMessage(error, 'Failed to get group summary') });
       }
     },
 


### PR DESCRIPTION
## Summary
- fix archived-open-PR repair so it restores a stable visible sibling instead of blindly choosing the newest archived sibling
- align route-level issue-group status derivation with summary status derivation so repaired execution groups stay visible in `active`
- add regressions for the repair use case, route grouping, and `/code/issue-groups`

## Root Cause
Open PR groups could still disappear after repair for two reasons:
1. the repair use case could restore the wrong archived sibling from the full Linear issue history, including a merged PR sibling unrelated to the still-open PR
2. the route regrouping logic could classify a repaired completed execution task as `done` even though the summary logic treated the same shape as `active`

## Impact
Open GitHub PR-backed issue groups stay visible again in the `active` / `needs-action` list after repair instead of dropping out of the UI.

## Validation
- `pnpm run verify:workspace:tracked code-agent`
- live Firestore check: `reportArchivedOpenPrGroups.ts` returned `openPrGroupsArchived: []`
- live route-shaped check: `reportIssueGroupRouteView.ts --group-status=active,needs-action --sort-by=linear-id`
  - `INT-1423` returned as `active`
  - `INT-750` returned as `needs-action`
