### PR TITLE
[INT-1609] [codex] fix orchestrator code-worker latest pull

### DIFF
--- a/docs/operations/artifact-registry-cleanup.md
+++ b/docs/operations/artifact-registry-cleanup.md
@@ -32,8 +32,6 @@ uname -n
 grep '^INTEXURAOS_CODE_WORKER_IMAGE=' ~/.code-orchestrator/env || true
 ```
 
-If `INTEXURAOS_CODE_WORKER_IMAGE` is missing, the orchestrator is still following the default `code-worker:latest` image and must be pinned before any aggressive `code-worker` prune.
-
 ## Export Live Images
 
 ```bash
@@ -101,7 +99,7 @@ node scripts/artifact-registry/apply-prune-plan.mjs \
   --batch-size=50
 ```
 
-`code-worker` after pinning the orchestrator:
+`code-worker` after confirming the orchestrator follows `code-worker:latest`:
 
 ```bash
 node scripts/artifact-registry/apply-prune-plan.mjs \
@@ -111,17 +109,20 @@ node scripts/artifact-registry/apply-prune-plan.mjs \
   --batch-size=50
 ```
 
-## Pin The Orchestrator Before Code-Worker Prune
+## Ensure The Orchestrator Follows Latest Before Code-Worker Prune
 
-Choose a retained `code-worker` digest from the prune plan and update the orchestrator env:
+The orchestrator should keep following `code-worker:latest` so each task pull
+refreshes to the newest worker image. Before pruning `code-worker`, make sure the
+env file does not pin an old digest:
 
 ```bash
 grep '^INTEXURAOS_CODE_WORKER_IMAGE=' ~/.code-orchestrator/env || true
-sed -i 's#^INTEXURAOS_CODE_WORKER_IMAGE=.*#INTEXURAOS_CODE_WORKER_IMAGE=europe-central2-docker.pkg.dev/intexuraos-dev-pbuchman/intexuraos-dev/code-worker@sha256:RETAINED_DIGEST#' ~/.code-orchestrator/env
+sed -i 's#^INTEXURAOS_CODE_WORKER_IMAGE=.*#INTEXURAOS_CODE_WORKER_IMAGE=europe-central2-docker.pkg.dev/intexuraos-dev-pbuchman/intexuraos-dev/code-worker:latest#' ~/.code-orchestrator/env
 sudo systemctl restart intexuraos-orchestrator@pbuchman
 ```
 
-Re-export live images after the restart and verify the pinned digest appears in `protected-digests.json`.
+Re-export live images after the restart and verify the current `latest` digest
+appears in `protected-digests.json`.
 
 ## Terraform Cleanup Policies
 

--- a/workers/orchestrator/DEPLOYMENT.md
+++ b/workers/orchestrator/DEPLOYMENT.md
@@ -78,10 +78,11 @@ Or via systemd (Linux) or macOS LaunchAgent (see `workers/orchestrator/README.md
 europe-central2-docker.pkg.dev/intexuraos-dev-pbuchman/intexuraos-dev/code-worker:latest
 ```
 
-For deterministic runtime behavior, prefer digest pinning in orchestrator env:
+The orchestrator should follow the mutable `:latest` tag so every worker launch
+pulls the newest published image:
 
 ```bash
-export INTEXURAOS_CODE_WORKER_IMAGE=europe-central2-docker.pkg.dev/intexuraos-dev-pbuchman/intexuraos-dev/code-worker@sha256:<digest>
+export INTEXURAOS_CODE_WORKER_IMAGE=europe-central2-docker.pkg.dev/intexuraos-dev-pbuchman/intexuraos-dev/code-worker:latest
 ```
 
 ### Build
@@ -107,7 +108,8 @@ PUSH=true ./scripts/build-worker-image.sh latest
 docker push europe-central2-docker.pkg.dev/intexuraos-dev-pbuchman/intexuraos-dev/code-worker:latest
 ```
 
-After push, capture digest and update `INTEXURAOS_CODE_WORKER_IMAGE` (digest form) on orchestrator host.
+No digest pin update is needed after push. The orchestrator should keep following
+`code-worker:latest`.
 
 ### Cache Busting
 
@@ -244,7 +246,7 @@ pnpm --filter orchestrator test:e2e
 
 1. Build image: `docker build --no-cache ...`
 2. Push image: `docker push europe-central2-docker.pkg.dev/intexuraos-dev-pbuchman/intexuraos-dev/code-worker:latest`
-3. Capture pushed digest and update `INTEXURAOS_CODE_WORKER_IMAGE` to that digest
+3. Ensure `INTEXURAOS_CODE_WORKER_IMAGE` still points at `code-worker:latest`
 4. Running containers use the old image until recreated (no hot reload)
 
 ### When Orchestrator Source Changes
@@ -261,7 +263,7 @@ pnpm --filter orchestrator test:e2e
 
 1. Commit and push code
 2. Build and push code-worker image (`--no-cache`)
-3. Update orchestrator env (`INTEXURAOS_CODE_WORKER_IMAGE=@sha256:...`)
+3. Ensure orchestrator env uses `INTEXURAOS_CODE_WORKER_IMAGE=.../code-worker:latest`
 4. Rebuild orchestrator: `pnpm --filter orchestrator build`
 5. Restart orchestrator process
 

--- a/workers/orchestrator/README.md
+++ b/workers/orchestrator/README.md
@@ -141,8 +141,8 @@ export INTEXURAOS_REPOSITORY_PATH=$HOME/.code-orchestrator/repo
 export INTEXURAOS_PROJECT_ID=$PROJECT_ID
 export INTEXURAOS_CODE_AGENT_URL=https://intexuraos-code-agent-cj44trunra-lm.a.run.app/
 export INTEXURAOS_USAGE_WEBHOOK_URL=https://intexuraos-code-agent-cj44trunra-lm.a.run.app/internal/webhooks/usage-events
-# Optional but recommended: pin to immutable digest
-# export INTEXURAOS_CODE_WORKER_IMAGE=europe-central2-docker.pkg.dev/.../code-worker@sha256:<digest>
+# Optional explicit override; the orchestrator follows :latest by default
+# export INTEXURAOS_CODE_WORKER_IMAGE=europe-central2-docker.pkg.dev/.../code-worker:latest
 export GOOGLE_APPLICATION_CREDENTIALS=$HOME/.config/gcloud/sa-key.json
 EOF
 

--- a/workers/orchestrator/src/__tests__/bootstrap/env-config.test.ts
+++ b/workers/orchestrator/src/__tests__/bootstrap/env-config.test.ts
@@ -159,6 +159,19 @@ describe('loadEnvConfig', () => {
     expect(config.preserveWorkerContainers).toBe(false);
   });
 
+  it('normalizes digest-pinned worker image overrides back to latest', () => {
+    const config = loadEnvConfig(
+      makeValidEnv({
+        INTEXURAOS_CODE_WORKER_IMAGE:
+          'europe-central2-docker.pkg.dev/intexuraos-dev-pbuchman/intexuraos-dev/code-worker@sha256:323593e1f8d4687612b42a8f7e94c3ba1d761407886d4cad9ae5f90ef1326f18',
+      })
+    );
+
+    expect(config.workerImage).toBe(
+      'europe-central2-docker.pkg.dev/intexuraos-dev-pbuchman/intexuraos-dev/code-worker:latest'
+    );
+  });
+
   it('surfaces optional string overrides', () => {
     const config = loadEnvConfig(
       makeValidEnv({

--- a/workers/orchestrator/src/bootstrap/env-config.ts
+++ b/workers/orchestrator/src/bootstrap/env-config.ts
@@ -122,6 +122,14 @@ function readOptionalString(env: EnvReader, name: string): string | undefined {
   return raw !== undefined && raw !== '' ? raw : undefined;
 }
 
+function normalizeWorkerImageRef(image: string): string {
+  const digestIndex = image.indexOf('@sha256:');
+  if (digestIndex < 0) {
+    return image;
+  }
+  return `${image.slice(0, digestIndex)}:latest`;
+}
+
 /**
  * Loads the full bootstrap configuration from the environment.
  *
@@ -161,7 +169,9 @@ export function loadEnvConfig(env: EnvReader = process.env): BootstrapEnvConfig 
     DEFAULT_VALIDATION_MODELS,
     env
   );
-  const workerImage = getOptionalEnv('INTEXURAOS_CODE_WORKER_IMAGE', DEFAULT_WORKER_IMAGE, env);
+  const workerImage = normalizeWorkerImageRef(
+    getOptionalEnv('INTEXURAOS_CODE_WORKER_IMAGE', DEFAULT_WORKER_IMAGE, env)
+  );
 
   const keepContainersAlive = env['KEEP_CONTAINERS_ALIVE'] === '1';
   const workerForensicsMode = getOptionalEnv('INTEXURAOS_CODE_WORKER_FORENSICS', '0', env) === '1';


### PR DESCRIPTION
Fixes INT-1609

## Summary
- normalize digest-pinned `INTEXURAOS_CODE_WORKER_IMAGE` values back to `code-worker:latest` during orchestrator bootstrap
- add a regression test covering the stale digest-pin case that kept `home-dev` on the broken worker image
- update orchestrator and Artifact Registry runbooks to stop recommending digest pinning for the code-worker runtime

## Root Cause
`home-dev` had `INTEXURAOS_CODE_WORKER_IMAGE` pinned to an old `code-worker@sha256:323593...` digest. The orchestrator pull policy was already `always`, but because the configured ref itself was stale, every task kept pulling the same broken image and dying during worker bootstrap. The repo docs and cleanup runbooks were still telling operators to pin that env var to digests, which reintroduced the failure mode.

## Impact
After this change, the orchestrator follows `code-worker:latest` again even if the env file contains a digest-pinned override, so new task containers and auth helper containers stop inheriting stale worker images.

## Verification
- [x] `pnpm run ci:tracked`
- [x] `pnpm --filter orchestrator exec vitest run src/__tests__/bootstrap/env-config.test.ts src/__tests__/start.test.ts src/__tests__/bootstrap/service-wiring.test.ts`
- [x] `pnpm --filter orchestrator build`
