### PR TITLE
[INT-1616] [codex] Fix fishing knowledge page load loop

### DIFF
--- a/apps/web/src/pages/fishing/FishingKnowledgePageEditor.tsx
+++ b/apps/web/src/pages/fishing/FishingKnowledgePageEditor.tsx
@@ -9,7 +9,14 @@ import type { FishingKnowledgePage } from '@/types/fishingAssistant';
 export function FishingKnowledgePageEditor(): React.JSX.Element {
   const { pageId } = useParams<{ pageId: string }>();
   const navigate = useNavigate();
-  const knowledge = useFishingKnowledge();
+  const {
+    folders,
+    error: knowledgeError,
+    loadPage: loadKnowledgePage,
+    updatePage,
+    reindexPage,
+    deletePage,
+  } = useFishingKnowledge();
   const [page, setPage] = useState<FishingKnowledgePage | null>(null);
   const [rawText, setRawText] = useState('');
   const [loading, setLoading] = useState(true);
@@ -28,7 +35,7 @@ export function FishingKnowledgePageEditor(): React.JSX.Element {
     setLoading(true);
     setError(null);
     try {
-      const nextPage = await knowledge.loadPage(pageId);
+      const nextPage = await loadKnowledgePage(pageId);
       setPage(nextPage);
       setRawText(nextPage.rawText);
     } catch (err: unknown) {
@@ -36,7 +43,7 @@ export function FishingKnowledgePageEditor(): React.JSX.Element {
     } finally {
       setLoading(false);
     }
-  }, [knowledge, pageId]);
+  }, [loadKnowledgePage, pageId]);
 
   useEffect(() => {
     void loadPage();
@@ -46,8 +53,8 @@ export function FishingKnowledgePageEditor(): React.JSX.Element {
     if (page === null) {
       return 'Unknown folder';
     }
-    return knowledge.folders.find((folder) => folder.id === page.folderId)?.name ?? page.folderId;
-  }, [knowledge.folders, page]);
+    return folders.find((folder) => folder.id === page.folderId)?.name ?? page.folderId;
+  }, [folders, page]);
 
   return (
     <Layout>
@@ -67,13 +74,13 @@ export function FishingKnowledgePageEditor(): React.JSX.Element {
           saving={saving}
           reindexing={reindexing}
           deleting={deleting}
-          error={error ?? knowledge.error}
+          error={error ?? knowledgeError}
           onRawTextChange={setRawText}
           onSave={async (): Promise<void> => {
             setSaving(true);
             setError(null);
             try {
-              const updated = await knowledge.updatePage(page.id, rawText);
+              const updated = await updatePage(page.id, rawText);
               setPage(updated);
               setRawText(updated.rawText);
             } catch (err: unknown) {
@@ -86,7 +93,7 @@ export function FishingKnowledgePageEditor(): React.JSX.Element {
             setReindexing(true);
             setError(null);
             try {
-              const updated = await knowledge.reindexPage(page.id);
+              const updated = await reindexPage(page.id);
               setPage(updated);
             } catch (err: unknown) {
               setError(getErrorMessage(err, 'Failed to reindex knowledge page'));
@@ -101,7 +108,7 @@ export function FishingKnowledgePageEditor(): React.JSX.Element {
             setDeleting(true);
             setError(null);
             try {
-              await knowledge.deletePage(page.id);
+              await deletePage(page.id);
               void navigate('/fishing-assistant/knowledge');
             } catch (err: unknown) {
               setError(getErrorMessage(err, 'Failed to delete knowledge page'));

--- a/apps/web/src/pages/fishing/__tests__/FishingKnowledgePageEditor.test.tsx
+++ b/apps/web/src/pages/fishing/__tests__/FishingKnowledgePageEditor.test.tsx
@@ -1,0 +1,142 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { act, render } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { UseFishingKnowledgeResult } from '@/hooks/useFishingKnowledge';
+import type {
+  FishingKnowledgeFolder,
+  FishingKnowledgePage,
+} from '@/types/fishingAssistant';
+import { FishingKnowledgePageEditor } from '../FishingKnowledgePageEditor.js';
+
+const { mockLoadPage, mockUseFishingKnowledge } = vi.hoisted(() => ({
+  mockLoadPage: vi.fn(),
+  mockUseFishingKnowledge: vi.fn(),
+}));
+
+vi.mock('@/hooks', () => ({
+  useFishingKnowledge: mockUseFishingKnowledge,
+}));
+
+vi.mock('@/components', () => ({
+  Layout: ({ children }: { children: React.ReactNode }): React.JSX.Element => <div>{children}</div>,
+}));
+
+vi.mock('@/components/fishing', () => ({
+  FishingPageEditor: ({ page }: { page: FishingKnowledgePage }): React.JSX.Element => (
+    <div data-testid="fishing-page-editor">{page.title}</div>
+  ),
+}));
+
+vi.mock('@intexuraos/common-core/errors', () => ({
+  getErrorMessage: (err: unknown, defaultMsg: string): string =>
+    err instanceof Error ? err.message : defaultMsg,
+}));
+
+const folder: FishingKnowledgeFolder = {
+  id: 'folder-1',
+  name: 'Recipes',
+  userId: 'user-1',
+  parentId: null,
+  sortOrder: 0,
+  pageCount: 1,
+  createdAt: '2026-05-08T10:00:00.000Z',
+  updatedAt: '2026-05-08T10:00:00.000Z',
+};
+
+const page: FishingKnowledgePage = {
+  id: 'page-1',
+  userId: 'user-1',
+  folderId: 'folder-1',
+  title: 'Spring Bait',
+  rawText: 'raw',
+  normalizedText: 'normalized',
+  contentType: 'recipe',
+  indexingStatus: 'ready',
+  chunkCount: 1,
+  createdAt: '2026-05-08T10:00:00.000Z',
+  updatedAt: '2026-05-08T10:00:00.000Z',
+};
+
+function createDeferred<T>(): {
+  readonly promise: Promise<T>;
+  readonly resolve: (value: T) => void;
+} {
+  let resolvePromise: ((value: T) => void) | undefined;
+  const promise = new Promise<T>((resolve) => {
+    resolvePromise = resolve;
+  });
+
+  return {
+    promise,
+    resolve: (value: T): void => {
+      if (resolvePromise === undefined) {
+        throw new Error('Deferred promise resolver was not initialized');
+      }
+      resolvePromise(value);
+    },
+  };
+}
+
+function createKnowledgeResult(): UseFishingKnowledgeResult {
+  return {
+    folders: [folder],
+    pages: [],
+    loading: false,
+    mutating: false,
+    error: null,
+    refresh: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+    createFolder: vi.fn<UseFishingKnowledgeResult['createFolder']>(),
+    renameFolder: vi.fn<UseFishingKnowledgeResult['renameFolder']>(),
+    deleteFolder: vi.fn<UseFishingKnowledgeResult['deleteFolder']>(),
+    createPage: vi.fn<UseFishingKnowledgeResult['createPage']>(),
+    loadPage: mockLoadPage,
+    updatePage: vi.fn<UseFishingKnowledgeResult['updatePage']>(),
+    deletePage: vi.fn<UseFishingKnowledgeResult['deletePage']>(),
+    reindexPage: vi.fn<UseFishingKnowledgeResult['reindexPage']>(),
+  };
+}
+
+describe('FishingKnowledgePageEditor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseFishingKnowledge.mockImplementation(createKnowledgeResult);
+  });
+
+  it('loads the routed knowledge page once after page state settles', async () => {
+    const firstLoad = createDeferred<FishingKnowledgePage>();
+    const pendingPageLoad = new Promise<FishingKnowledgePage>((resolve) => {
+      void resolve;
+    });
+    mockLoadPage
+      .mockImplementationOnce((): Promise<FishingKnowledgePage> => firstLoad.promise)
+      .mockImplementation((): Promise<FishingKnowledgePage> => pendingPageLoad);
+
+    render(
+      <MemoryRouter initialEntries={['/fishing-assistant/knowledge/pages/page-1']}>
+        <Routes>
+          <Route
+            path="/fishing-assistant/knowledge/pages/:pageId"
+            element={<FishingKnowledgePageEditor />}
+          />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(mockLoadPage).toHaveBeenCalledWith('page-1');
+    expect(mockLoadPage).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      firstLoad.resolve(page);
+      await firstLoad.promise;
+    });
+    await act(async () => {
+      await new Promise((resolve) => window.setTimeout(resolve, 0));
+    });
+
+    expect(mockLoadPage).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Stop `FishingKnowledgePageEditor` from depending on the recreated `useFishingKnowledge()` result object in its page-loading effect.
- Use the stable hook callbacks and state slices needed by the editor.
- Add a regression test proving the routed knowledge page is fetched only once after page state settles.

## Root Cause
The page editor included the entire `knowledge` hook result in the `loadPage` callback dependencies. That object is recreated on render, so resolving the page load updated state, rebuilt the callback, reran the effect, and triggered repeated page fetches.

## Validation
- `pnpm --dir apps/web exec vitest run src/pages/fishing/__tests__/FishingKnowledgePageEditor.test.tsx`
- `pnpm run verify:workspace:tracked web`
- `pnpm run ci:tracked`