### PR TITLE
[INT-1619] Fix fishing assistant citation source validation

### DIFF
--- a/apps/fishing-assistant-service/src/__tests__/promptAndRanking.test.ts
+++ b/apps/fishing-assistant-service/src/__tests__/promptAndRanking.test.ts
@@ -93,6 +93,17 @@ describe('Fishing Assistant prompt and ranking helpers', () => {
     expect(extractSearchTerms('123 !!!')).toEqual([]);
   });
 
+  it('omits allowed citation ids when no evidence is available', () => {
+    const prompt = fishingAnswerPrompt.build({
+      question: 'What changed today?',
+      recentMessages: [],
+      evidence: [],
+    });
+
+    expect(prompt).not.toContain('Allowed citation sourceIds:');
+    expect(prompt).toContain('Evidence:\n');
+  });
+
   it('parses invalid JSON and schema failures explicitly', () => {
     expect(parseFishingAnswer('not-json')).toEqual({
       ok: false,

--- a/apps/fishing-assistant-service/src/__tests__/sendChatMessage.test.ts
+++ b/apps/fishing-assistant-service/src/__tests__/sendChatMessage.test.ts
@@ -395,6 +395,101 @@ describe('sendChatMessage', () => {
     ]);
   });
 
+  it('maps prompt citation aliases back to canonical digest source ids without invoking repair', async () => {
+    const ctx = createContext({
+      chat: makeChat({ title: 'Spring Session' }),
+      updatedChat: makeChat({ title: 'Spring Session' }),
+    });
+    ctx.chatRepository.createMessage.mockReset()
+      .mockResolvedValueOnce(
+        okResult(makeMessage({ id: 'message-user', role: 'user', content: 'Need the coconut recipe' }))
+      )
+      .mockResolvedValueOnce(
+        okResult(
+          makeMessage({
+            id: 'message-assistant',
+            citations: [
+              {
+                sourceId: 'digest:feeder:2026-05-07',
+                sourceType: 'digest',
+                title: 'May 7 digest',
+                quote: 'Members recommended krill extract for the hemp-coconut base.',
+                usedFor: 'method-feeder modification',
+                date: '2026-05-07',
+                url: '/fishing-assistant/digests/feeder/2026-05-07',
+              },
+            ],
+            confidence: 'high',
+          })
+        )
+      );
+    ctx.chunkRepository.findNearestByUserId.mockResolvedValue(okResult([]));
+    ctx.mobileNotificationsClient.listDigestSubscriptions.mockResolvedValue(
+      okResult({ items: [{ groupKey: 'feeder', displayName: 'Feeder Team' }] })
+    );
+    ctx.mobileNotificationsClient.queryDigests.mockResolvedValue(
+      okResult({
+        items: [
+          {
+            groupKey: 'feeder',
+            date: '2026-05-07',
+            title: 'May 7 digest',
+            summaryMarkdown: 'Members recommended krill extract for the hemp-coconut base.',
+            messageCount: 18,
+          },
+        ],
+        truncated: false,
+      })
+    );
+    ctx.mobileNotificationsClient.queryGroupMessages.mockResolvedValue(
+      okResult({
+        messages: [],
+        totalRaw: 0,
+        totalCleaned: 0,
+        returned: 0,
+        truncated: false,
+      })
+    );
+    ctx.llmClient.generate.mockReset()
+      .mockResolvedValueOnce(
+        okResult({
+          content:
+            '{"answerMarkdown":"Add krill extract to the hemp-coconut base.","citations":[{"sourceId":"S1","usedFor":"method-feeder modification"}],"confidence":"high"}',
+          usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30, costUsd: 0.01 },
+        })
+      )
+      .mockResolvedValueOnce(errResult({ code: 'DOWNSTREAM_ERROR', message: 'repair should not run' }));
+
+    const result = await sendChatMessage(ctx.deps, {
+      userId: 'user-1',
+      chatId: 'chat-1',
+      message: 'How should I adapt the coconut recipe for method feeder?',
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(ctx.llmClient.generate).toHaveBeenCalledTimes(1);
+    expect(ctx.chatRepository.createMessage).toHaveBeenNthCalledWith(2, {
+      id: 'message-assistant',
+      chatId: 'chat-1',
+      userId: 'user-1',
+      role: 'assistant',
+      content: 'Add krill extract to the hemp-coconut base.',
+      confidence: 'high',
+      citations: [
+        {
+          sourceId: 'digest:feeder:2026-05-07',
+          sourceType: 'digest',
+          title: 'May 7 digest',
+          quote: 'Members recommended krill extract for the hemp-coconut base.',
+          usedFor: 'method-feeder modification',
+          date: '2026-05-07',
+          url: '/fishing-assistant/digests/feeder/2026-05-07',
+        },
+      ],
+    });
+  });
+
   it('returns repository errors when recent messages cannot be listed', async () => {
     const ctx = createContext({
       chat: makeChat({ title: 'Spring Session' }),

--- a/apps/fishing-assistant-service/src/domain/prompts/buildFishingAnswerPrompt.ts
+++ b/apps/fishing-assistant-service/src/domain/prompts/buildFishingAnswerPrompt.ts
@@ -31,7 +31,7 @@ function sanitizeHistoryContent(content: string): string {
 export const fishingAnswerPrompt: PromptBuilder<BuildFishingAnswerPromptInput> = {
   name: 'fishing-assistant-answer',
   description: 'Builds a grounded JSON-answer prompt for Fishing Assistant chat responses',
-  version: '2.0.0',
+  version: '3.0.0',
 
   build(input: BuildFishingAnswerPromptInput): string {
     const history = input.recentMessages
@@ -47,6 +47,10 @@ export const fishingAnswerPrompt: PromptBuilder<BuildFishingAnswerPromptInput> =
     return [
       'Answer the fishing question using only the evidence below.',
       'Return strict JSON with shape {"answerMarkdown": string, "citations": [{"sourceId": string, "usedFor": string}], "confidence": "high"|"medium"|"low"}.',
+      'In citations[].sourceId, copy one of the evidence sourceIds exactly as written in the square brackets. Never translate, shorten, reorder, or invent a sourceId.',
+      input.evidence.length > 0
+        ? `Allowed citation sourceIds: ${input.evidence.map((item) => item.id).join(', ')}`
+        : '',
       history !== '' ? `Conversation history:\n${history}` : '',
       `Question:\n${input.question}`,
       `Evidence:\n${evidenceBlocks}`,

--- a/apps/fishing-assistant-service/src/domain/usecases/sendChatMessage.ts
+++ b/apps/fishing-assistant-service/src/domain/usecases/sendChatMessage.ts
@@ -51,9 +51,66 @@ export interface SendChatMessageInput {
   message: string;
 }
 
+interface PromptEvidenceContext {
+  promptEvidence: EvidenceItem[];
+  promptSourceIds: string[];
+  sourceIdAliases: ReadonlyMap<string, string>;
+}
+
 function deriveChatTitle(input: string): string {
   const trimmed = input.trim().replace(/\s+/g, ' ');
   return trimmed === '' ? DEFAULT_CHAT_TITLE : trimmed.slice(0, 120);
+}
+
+function createPromptEvidenceContext(evidence: EvidenceItem[]): PromptEvidenceContext {
+  const sourceIdAliases = new Map<string, string>();
+  const promptEvidence = evidence.map((item, index) => {
+    const alias = `S${String(index + 1)}`;
+    sourceIdAliases.set(alias, item.id);
+    return {
+      ...item,
+      id: alias,
+    };
+  });
+
+  return {
+    promptEvidence,
+    promptSourceIds: promptEvidence.map((item) => item.id),
+    sourceIdAliases,
+  };
+}
+
+function remapCitationAliases(
+  citations: { sourceId: string; usedFor: string }[],
+  sourceIdAliases: ReadonlyMap<string, string>
+): { sourceId: string; usedFor: string }[] {
+  return citations.map((citation) => {
+    const canonicalSourceId = sourceIdAliases.get(citation.sourceId);
+    if (canonicalSourceId === undefined) {
+      return citation;
+    }
+    return {
+      ...citation,
+      sourceId: canonicalSourceId,
+    };
+  });
+}
+
+function buildRepairPrompt(input: {
+  prompt: string;
+  previousAnswer: string;
+  failureMessage: string;
+  promptSourceIds: string[];
+}): string {
+  return [
+    input.prompt,
+    'The previous answer was invalid.',
+    `Validation error: ${input.failureMessage}`,
+    `Allowed citation sourceIds: ${input.promptSourceIds.join(', ')}`,
+    'Return strict JSON only.',
+    'In citations[].sourceId, copy one allowed sourceId exactly as written. Do not translate, shorten, reorder, or invent sourceIds.',
+    `Previous invalid answer:\n${input.previousAnswer}`,
+  ].join('\n\n');
 }
 
 function buildCitations(
@@ -85,6 +142,8 @@ async function generateValidatedAnswer(input: {
   llmClient: LlmGenerateClient;
   prompt: string;
   evidence: EvidenceItem[];
+  promptSourceIds: string[];
+  sourceIdAliases: ReadonlyMap<string, string>;
   chatId: string;
 }): Promise<
   Result<
@@ -108,8 +167,17 @@ async function generateValidatedAnswer(input: {
   }
 
   const parsed = parseFishingAnswer(first.value.content);
+  let repairReason = parsed.ok
+    ? 'Fishing Assistant response failed citation validation.'
+    : parsed.error.message;
   if (parsed.ok) {
-    const validated = validateCitations(parsed.value, input.evidence);
+    const validated = validateCitations(
+      {
+        ...parsed.value,
+        citations: remapCitationAliases(parsed.value.citations, input.sourceIdAliases),
+      },
+      input.evidence
+    );
     if (validated.ok) {
       return ok({
         answerMarkdown: validated.value.answerMarkdown,
@@ -117,9 +185,15 @@ async function generateValidatedAnswer(input: {
         citations: buildCitations(validated.value.citations, input.evidence),
       });
     }
+    repairReason = validated.error.message;
   }
 
-  const repairPrompt = `${input.prompt}\n\nRepair the previous answer so it is valid JSON and only cites known sourceIds.`;
+  const repairPrompt = buildRepairPrompt({
+    prompt: input.prompt,
+    previousAnswer: first.value.content,
+    failureMessage: repairReason,
+    promptSourceIds: input.promptSourceIds,
+  });
   const repair = await input.llmClient.generate(repairPrompt, {
     promptType: 'fishing-assistant-chat-repair',
     correlation: { sessionId: input.chatId },
@@ -139,7 +213,13 @@ async function generateValidatedAnswer(input: {
     });
   }
 
-  const revalidated = validateCitations(reparsed.value, input.evidence);
+  const revalidated = validateCitations(
+    {
+      ...reparsed.value,
+      citations: remapCitationAliases(reparsed.value.citations, input.sourceIdAliases),
+    },
+    input.evidence
+  );
   if (!revalidated.ok) {
     return revalidated;
   }
@@ -239,14 +319,17 @@ export async function sendChatMessage(
   let citations: FishingMessageCitation[] = [];
 
   if (evidence.length > 0) {
+    const promptEvidence = createPromptEvidenceContext(evidence);
     const answerResult = await generateValidatedAnswer({
       llmClient: chatClientResult.value,
       prompt: fishingAnswerPrompt.build({
         question: input.message,
         recentMessages: recentMessages.value,
-        evidence,
+        evidence: promptEvidence.promptEvidence,
       }),
       evidence,
+      promptSourceIds: promptEvidence.promptSourceIds,
+      sourceIdAliases: promptEvidence.sourceIdAliases,
       chatId: input.chatId,
     });
     if (!answerResult.ok) return answerResult;


### PR DESCRIPTION
## Summary
- map model-facing citation aliases back to canonical evidence ids before validation and storage
- harden the fishing assistant prompt and repair prompt against invented citation ids
- add regressions for digest alias remapping and the empty-evidence prompt branch

## Verification
- pnpm run verify:workspace:tracked fishing-assistant-service
- pnpm run ci:tracked