### PR TITLE
[INT-1639] [codex] Fix CI failure follow-up tasks missing webhook secrets

### DIFF
--- a/apps/code-agent/src/__tests__/domain/services/gitHubDispatch/ciFailureDispatch.test.ts
+++ b/apps/code-agent/src/__tests__/domain/services/gitHubDispatch/ciFailureDispatch.test.ts
@@ -6,6 +6,7 @@ import {
 } from '../../../../domain/services/gitHubDispatch/ciFailureDispatch.js';
 import type { WebhookDispatchServiceDeps } from '../../../../domain/services/gitHubDispatch/types.js';
 import type { GitHubPREvent } from '../../../../domain/models/gitHubPREvent.js';
+import { generateWebhookSecret } from '../../../../domain/utils/secrets.js';
 
 const mockLogger: Logger = {
   info: vi.fn(),
@@ -196,6 +197,12 @@ describe('executeCIFailureDispatch', () => {
       expect.objectContaining({ type: 'fix_task_dispatched', parentTaskId: 'task-parent', fixTaskId: 'task-fix' }),
       'user-1',
     );
+
+    const createCall = vi.mocked(deps.codeTaskRepo.create).mock.calls[0]?.[0];
+    expect(createCall?.id).toMatch(/^task_/);
+    expect(createCall?.webhookSecret).toBe(
+      generateWebhookSecret(deps.orchestratorSecret, createCall?.id ?? '')
+    );
   });
 
   it('returns failure when create fails', async () => {
@@ -237,6 +244,12 @@ describe('executeCIFailureDispatch', () => {
       expect.anything(),
       expect.objectContaining({ checkName: 'Unknown Check', headBranch: 'unknown', headSha: 'unknown', checkSuiteId: 0 }),
       'user-1',
+    );
+
+    const createCall = vi.mocked(deps.codeTaskRepo.create).mock.calls[0]?.[0];
+    expect(createCall?.id).toMatch(/^task_/);
+    expect(createCall?.webhookSecret).toBe(
+      generateWebhookSecret(deps.orchestratorSecret, createCall?.id ?? '')
     );
   });
 

--- a/apps/code-agent/src/__tests__/infra/services/taskDispatcherImpl.test.ts
+++ b/apps/code-agent/src/__tests__/infra/services/taskDispatcherImpl.test.ts
@@ -434,6 +434,58 @@ describe('taskDispatcherImpl', () => {
     });
   });
 
+  describe('dispatch non-OK response handling', () => {
+    it('returns dispatch_failed with worker error message for non-retryable status 400', async () => {
+      const probeAllWorkers = deps.workerHealthProbe.probeAllWorkers as ReturnType<typeof vi.fn>;
+      probeAllWorkers.mockResolvedValueOnce({
+        'default': {
+          _tag: 'healthy',
+          healthy: true,
+          capacity: 2,
+          running: 0,
+          available: 2,
+          responseTimeMs: 50,
+        },
+      });
+
+      const service = createTaskDispatcherService(deps);
+
+      nock(WORKER_URL)
+        .post('/tasks')
+        .reply(400, { error: 'String must contain at least 1 character(s)' });
+
+      const result = await service.dispatch({
+        taskId: 'task-validation-failure',
+        prompt: 'Fix CI',
+        systemPromptHash: 'hash-123',
+        repository: 'test/repo',
+        baseBranch: 'main',
+        workerType: 'codex',
+        webhookUrl: 'https://example.com/webhook',
+        webhookSecret: '',
+        linearIssueLabels: [],
+        hasChildren: false,
+        agentType: 'pull_request',
+        workerCredentials: {
+          workers: [{
+            name: 'default',
+            url: WORKER_URL,
+            cfAccessClientId: 'test-client-id',
+            cfAccessClientSecret: 'test-client-secret',
+            dispatchSigningSecret: 'test-signing-secret-at-least-32-chars-long',
+          }],
+        },
+      });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe('dispatch_failed');
+        expect(result.error.message).toContain('400');
+        expect(result.error.message).toContain('String must contain at least 1 character(s)');
+      }
+    });
+  });
+
   describe('failedWorkerLocation filtering', () => {
     const WORKER_B_URL = 'https://worker-b.example.com';
 

--- a/apps/code-agent/src/domain/services/gitHubDispatch/ciFailureDispatch.ts
+++ b/apps/code-agent/src/domain/services/gitHubDispatch/ciFailureDispatch.ts
@@ -1,5 +1,8 @@
+import { randomUUID } from 'node:crypto';
 import { getErrorMessage } from '@intexuraos/common-core';
 import type { PromptBuilder } from '@intexuraos/llm-prompts';
+import type { CreateTaskInput } from '../../repositories/codeTaskRepository.js';
+import { generateWebhookSecret } from '../../utils/secrets.js';
 import type {
   CIFailureDispatchContext,
   CIFailureDispatchResult,
@@ -103,25 +106,10 @@ export async function executeCIFailureDispatch(
     });
 
     // Create follow-up task
-    const createInput: {
-      id?: string;
-      userId: string;
-      prompt: string;
-      sanitizedPrompt: string;
-      systemPromptHash: string;
-      workerType: typeof originalTask.workerType;
-      workerLocation: string;
-      repository: string;
-      baseBranch: string;
-      traceId: string;
-      parentTaskId: string;
-      followUpReason: 'ci_failure';
-      agentType: 'pull_request';
-      initialStatus: 'queued';
-      prNumber: number;
-      prBranch?: string;
-      linearIssueId?: string;
-    } = {
+    const taskId = `task_${randomUUID()}`;
+    const webhookSecret = generateWebhookSecret(deps.orchestratorSecret, taskId);
+    const createInput: CreateTaskInput = {
+      id: taskId,
       userId: originalTask.userId,
       prompt: fixPrompt,
       sanitizedPrompt: fixPrompt,
@@ -136,6 +124,7 @@ export async function executeCIFailureDispatch(
       agentType: 'pull_request',
       initialStatus: 'queued',
       prNumber: event.pullRequestNumber,
+      webhookSecret,
       ...(event.baseBranch !== null && { prBranch: event.baseBranch }),
       ...(originalTask.linearIssueId !== undefined && { linearIssueId: originalTask.linearIssueId }),
     };

--- a/apps/code-agent/src/infra/services/taskDispatcherImpl.ts
+++ b/apps/code-agent/src/infra/services/taskDispatcherImpl.ts
@@ -388,9 +388,17 @@ class TaskDispatcherImpl implements TaskDispatcherService {
         throw error;
       }
 
+      const errorText = typeof response.text === 'function'
+        ? await response.text().catch(() => '')
+        : '';
+      const errorMessage = extractErrorMessage(errorText);
+
       return err({
         code: 'dispatch_failed',
-        message: `Worker returned HTTP ${String(response.status)}`,
+        message:
+          errorMessage.length > 0
+            ? `Worker returned HTTP ${String(response.status)}: ${errorMessage}`
+            : `Worker returned HTTP ${String(response.status)}`,
       });
     }
 


### PR DESCRIPTION
## Summary
- pre-generate CI-failure follow-up task IDs and per-task webhook secrets before persistence
- persist that secret on the follow-up task so queue dispatch and callback auth have the expected state
- include worker 4xx response bodies in `dispatch_failed` errors
- add regression tests for follow-up task creation and dispatcher 4xx handling

## Root Cause
- PR #2096's failed follow-up task `task_f86f0105-5827-424a-89f6-383a2f98ab01` was created without `webhookSecret`, recorded zero task logs, and stored `Drain dispatch failed: Worker returned HTTP 400`
- `ciFailureDispatch.ts` was the only audited production `codeTaskRepo.create(...)` path that did not set a per-task webhook secret
- queue dispatch sent `task.webhookSecret ?? ''`, and orchestrator validation rejects empty `webhookSecret`

## Behavior Changes
- CI-failure follow-up tasks now persist a per-task webhook secret and can be accepted by orchestrator
- future non-retryable worker 4xx dispatch failures retain the worker validation message instead of collapsing to a bare HTTP status

## Validation
- `pnpm --dir apps/code-agent exec vitest run src/__tests__/domain/services/gitHubDispatch/ciFailureDispatch.test.ts src/__tests__/infra/services/taskDispatcher.test.ts src/__tests__/infra/services/taskDispatcherImpl.test.ts`
- `pnpm run verify:workspace:tracked code-agent`
- `pnpm run ci:tracked`