### PR TITLE
[INT-1640] [codex] Bind worker package-manager caches outside tmpfs

### DIFF
--- a/workers/orchestrator/src/services/isolation/__tests__/docker-provider.test.ts
+++ b/workers/orchestrator/src/services/isolation/__tests__/docker-provider.test.ts
@@ -3091,6 +3091,20 @@ describe('DockerProvider', () => {
       });
     });
 
+    it('creates host cache directories used by package-manager bind mounts', async () => {
+      const fsModule = await import('node:fs');
+      (fsModule.mkdirSync as Mock).mockClear();
+
+      await provider.createWorker(createTestConfig());
+
+      expect(fsModule.mkdirSync).toHaveBeenCalledWith(expect.stringContaining('cache/pnpm'), {
+        recursive: true,
+      });
+      expect(fsModule.mkdirSync).toHaveBeenCalledWith(expect.stringContaining('cache/corepack'), {
+        recursive: true,
+      });
+    });
+
     it('sets capAdd to NET_RAW only when forensicsMode is false', async () => {
       await provider.createWorker(createTestConfig());
 

--- a/workers/orchestrator/src/services/isolation/__tests__/docker-volume.test.ts
+++ b/workers/orchestrator/src/services/isolation/__tests__/docker-volume.test.ts
@@ -150,6 +150,25 @@ describe('DockerVolume', () => {
     expect(volume.getPnpmStorePath()).toBe(path.join('/tmp', 'pnpm-store'));
   });
 
+  it('binds package-manager caches outside the /home/claude tmpfs', () => {
+    const volume = makeVolume(mockDocker);
+    const binds = volume.buildBinds({
+      worktreePath: '/worktree',
+      taskSecretsPath: '/tmp/claude-secrets/task-1',
+      pnpmStorePath: '/tmp/pnpm-store',
+      taskRuntimeHomePath: '/tmp/claude-secrets/codex-state-task-1',
+      containerRuntimeHome: '/home/claude/.codex',
+      mainGitDir: null,
+      useSharedCreds: false,
+      useSharedCodexAuth: false,
+      taskForensicsPath: null,
+    });
+
+    expect(binds).toContain('/tmp/pnpm-store:/home/claude/pnpm-store:rw');
+    expect(binds).toContain('/tmp/pnpm-store/cache/pnpm:/home/claude/.cache/pnpm:rw');
+    expect(binds).toContain('/tmp/pnpm-store/cache/corepack:/home/claude/.cache/node/corepack:rw');
+  });
+
   it('buildTmpfs keeps exec on /repo/node_modules — required by pnpm .bin shims (INT-1524)', () => {
     const volume = makeVolume(mockDocker);
     const tmpfs = volume.buildTmpfs();

--- a/workers/orchestrator/src/services/isolation/docker-volume.ts
+++ b/workers/orchestrator/src/services/isolation/docker-volume.ts
@@ -6,6 +6,7 @@ import { IntexuraOSError, type Logger } from '@intexuraos/common-core';
 import type { WorkerRuntime } from '../runtime/types.js';
 
 export const PNPM_STORE_DIR_NAME = 'pnpm-store';
+export const PACKAGE_MANAGER_CACHE_DIR_NAME = 'cache';
 export const CLAUDE_SESSION_DIR_PREFIX = 'claude-session';
 export const CODEX_STATE_DIR_PREFIX = 'codex-state';
 export const RUNTIME_STATE_MAX_AGE_MS = 24 * 60 * 60 * 1000;
@@ -115,6 +116,14 @@ export class DockerVolume {
 
   getPnpmStorePath(): string {
     return path.join(path.dirname(this.config.secretsBasePath), PNPM_STORE_DIR_NAME);
+  }
+
+  getPnpmCachePath(): string {
+    return path.join(this.getPnpmStorePath(), PACKAGE_MANAGER_CACHE_DIR_NAME, 'pnpm');
+  }
+
+  getCorepackCachePath(): string {
+    return path.join(this.getPnpmStorePath(), PACKAGE_MANAGER_CACHE_DIR_NAME, 'corepack');
   }
 
   assertResumeRuntimeStateAvailable(
@@ -263,6 +272,8 @@ export class DockerVolume {
       `${worktreePath}:/repo:rw`,
       `${taskSecretsPath}:/secrets:ro`,
       `${pnpmStorePath}:/home/claude/pnpm-store:rw`,
+      `${path.join(pnpmStorePath, PACKAGE_MANAGER_CACHE_DIR_NAME, 'pnpm')}:/home/claude/.cache/pnpm:rw`,
+      `${path.join(pnpmStorePath, PACKAGE_MANAGER_CACHE_DIR_NAME, 'corepack')}:/home/claude/.cache/node/corepack:rw`,
       `${taskRuntimeHomePath}:${containerRuntimeHome}:rw`,
       ...(useSharedCreds && this.config.sharedCredsPath !== undefined
         ? [

--- a/workers/orchestrator/src/services/isolation/worker-create.ts
+++ b/workers/orchestrator/src/services/isolation/worker-create.ts
@@ -564,6 +564,8 @@ export async function createWorkerOrchestration(
     // ordering: log → mkdir → spec → createContainer.
     const pnpmStorePath = volume.getPnpmStorePath();
     fs.mkdirSync(pnpmStorePath, { recursive: true });
+    fs.mkdirSync(volume.getPnpmCachePath(), { recursive: true });
+    fs.mkdirSync(volume.getCorepackCachePath(), { recursive: true });
 
     const { spec } = buildCreateContainerSpec({
       taskId,


### PR DESCRIPTION
## Summary
- Bind worker pnpm and Corepack caches under the host-backed pnpm store instead of `/home/claude` tmpfs.
- Create those host cache directories before container creation.
- Add tests covering the new bind mounts and directory creation.

## Evidence
- Red test before implementation failed because cache bind mounts/directories were absent.
- Focused orchestrator test run passed: 91 test files, 2400 tests.
- Runtime repro with final bind paths passed: `/home/claude` stayed at 0/500M, pnpm cache used 857.9M, Corepack cache used 18.2M, and `git config --global` succeeded.
- `pnpm run verify:workspace:tracked orchestrator` passed: typecheck, lint, 1015 test files, 18085 tests.
- `pnpm run ci:tracked` passed: typecheck, lint, tests, static validation, build, format, and post-build checks.

No Linear issue.