### PR TITLE
[INT-1642] Fix Claude runtime footer leaking into task summaries

### DIFF
--- a/workers/orchestrator/src/__tests__/services/completion-verifier/block-parser.test.ts
+++ b/workers/orchestrator/src/__tests__/services/completion-verifier/block-parser.test.ts
@@ -365,6 +365,30 @@ describe('locateFinalBlock', () => {
     const parsed = parseKeyValues(block ?? '');
     expect(parsed['Summary']).toBe('* Reviewed the plan-only PR.');
   });
+
+  it.each([0, 1])(
+    'stops a Claude final block before entrypoint completion line with exit code %i',
+    (exitCode) => {
+      const transcript = [
+        '[claude] REVIEW_AGENT_FINAL:',
+        '[claude] - PR: https://github.com/pbuchman/intexuraos/pull/2099',
+        '[claude] - review_id: 4372176918',
+        '[claude] - Summary: * Re-review found no new issues.',
+        '* Persistent CI failure remains unresolved.',
+        `[entrypoint] Claude attempt finished with exit code: ${String(exitCode)}`,
+      ].join('\n');
+
+      const block = locateFinalBlock(transcript, 'REVIEW_AGENT_FINAL:');
+
+      expect(block).not.toBeNull();
+      expect(block).not.toContain('Claude attempt finished');
+
+      const parsed = parseKeyValues(block ?? '');
+      expect(parsed['Summary']).toBe(
+        '* Re-review found no new issues.\n* Persistent CI failure remains unresolved.'
+      );
+    }
+  );
 });
 
 describe('verifyCompletion summary boundaries', () => {
@@ -408,6 +432,40 @@ describe('verifyCompletion summary boundaries', () => {
     expect(verdict.missingRequired).toEqual([]);
     expect(verdict.data['summary']).toBe(
       '* Reviewed the plan-only PR.\n* GH Actions are all passed.'
+    );
+  });
+
+  it('does not include Claude runtime completion footer in verified Kimi review summaries', () => {
+    const transcript = [
+      '[claude] REVIEW_AGENT_FINAL:',
+      '[claude] - PR: https://github.com/pbuchman/intexuraos/pull/2099',
+      '[claude] - review_id: 4372176918',
+      '[claude] - review_comments_posted: 0',
+      '[claude] - review_types: code_quality,security,architecture,test_quality',
+      '[claude] - requirements_tracker_updated: yes',
+      '[claude] - gh_actions_status: 1 failed',
+      '[claude] - needs_remediation: 0',
+      '[claude] - memory_ids_used: none',
+      '[claude] - memory_ids_rejected: none',
+      '[claude] - memory_usage_summary: none',
+      '[claude] - Summary: * Re-review found no new issues.',
+      '* Persistent CI failure remains unresolved.',
+      '[entrypoint] Claude attempt finished with exit code: 0',
+    ].join('\n');
+
+    const verdict = verifyCompletion({
+      transcript,
+      agentType: 'review',
+      workerType: 'kimi',
+      executionMemoryContext: undefined,
+      lastExitCode: undefined,
+    });
+
+    expect(verdict.kind).toBe('parsed');
+    if (verdict.kind !== 'parsed') return;
+    expect(verdict.missingRequired).toEqual([]);
+    expect(verdict.data['summary']).toBe(
+      '* Re-review found no new issues.\n* Persistent CI failure remains unresolved.'
     );
   });
 });

--- a/workers/orchestrator/src/services/completion-verifier/block-parser.ts
+++ b/workers/orchestrator/src/services/completion-verifier/block-parser.ts
@@ -43,6 +43,9 @@ const KNOWN_MARKER_ALTERNATION = KNOWN_MARKERS.map((m) =>
   m.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 ).join('|');
 
+const RUNTIME_ATTEMPT_FINISHED_PATTERN =
+  /^(?:Claude|Codex) attempt finished with exit code:\s*-?\d+\s*$/;
+
 /**
  * Locate the last standalone `<MARKER>` line in the transcript and return
  * everything from that line to the end of the block, stripped of log-driver
@@ -77,7 +80,7 @@ function isPostFinalRuntimeBoundary(line: string): boolean {
   const trimmed = line.trim().replace(/^\[[^\]]+\]\s+/, '');
   if (trimmed === '') return false;
 
-  if (trimmed.startsWith('Codex attempt finished with exit code:')) {
+  if (RUNTIME_ATTEMPT_FINISHED_PATTERN.test(trimmed)) {
     return true;
   }
 
@@ -119,7 +122,7 @@ function locateBlockInLines(lines: readonly string[], marker: string): string | 
   // End-of-block triggers (take the first one hit):
   //   - closing code fence ``` on its own line
   //   - another *_AGENT_FINAL: line
-  //   - Codex post-final runtime lifecycle telemetry
+  //   - runtime post-final lifecycle telemetry
   //   - EOF
   const body: string[] = [];
   // [INT-1470] Restrict end-of-block detection to the known real markers


### PR DESCRIPTION
## Summary

- Treat Claude runtime completion lines as post-final lifecycle boundaries in the completion verifier.
- Add regression coverage for Kimi review tasks running through the Claude runtime so `[entrypoint] Claude attempt finished with exit code: 0` cannot leak into parsed summaries.

## Root cause

`locateFinalBlock` already stopped on Codex completion telemetry and `turn.completed` JSON events, but it did not recognize the equivalent Claude-runtime footer. Because `parseKeyValues` appends non-key lines to the currently open field, the footer became part of `summary` for Kimi review tasks executed through the Claude runtime.

## Verification

- `pnpm vitest run workers/orchestrator/src/__tests__/services/completion-verifier/block-parser.test.ts`
- `pnpm run verify:workspace:tracked orchestrator`
- `pnpm run ci:tracked`