### PR TITLE
[INT-1643] Fix fishing assistant knowledge-base precedence

### DIFF
--- a/apps/fishing-assistant-service/src/__tests__/citationValidation.test.ts
+++ b/apps/fishing-assistant-service/src/__tests__/citationValidation.test.ts
@@ -14,6 +14,18 @@ const EVIDENCE = [
   },
 ];
 
+const DIGEST_EVIDENCE = [
+  {
+    id: 'digest:feeder:2026-05-01',
+    sourceType: 'digest' as const,
+    title: 'May 1 digest',
+    text: 'Members reported pinka.',
+    quote: 'Members reported pinka.',
+    score: 0.8,
+    metadata: { groupKey: 'feeder' },
+  },
+];
+
 describe('Fishing Assistant citation validation', () => {
   it('parses fenced JSON and accepts known citation ids', () => {
     const parsed = parseFishingAnswer(
@@ -53,7 +65,42 @@ describe('Fishing Assistant citation validation', () => {
         citations: [],
         confidence: 'low',
       },
-      EVIDENCE
+      EVIDENCE,
+      { requireKnowledgeBaseCitation: true }
+    );
+
+    expect(validated.ok).toBe(true);
+  });
+
+  it('rejects support-only citations when knowledge-base evidence is available', () => {
+    const validated = validateCitations(
+      {
+        answerMarkdown: 'Use pinka.',
+        citations: [{ sourceId: 'digest:feeder:2026-05-01', usedFor: 'supporting report' }],
+        confidence: 'medium',
+      },
+      [...EVIDENCE, ...DIGEST_EVIDENCE],
+      { requireKnowledgeBaseCitation: true }
+    );
+
+    expect(validated).toEqual({
+      ok: false,
+      error: {
+        code: 'CITATION_VALIDATION_FAILED',
+        message: 'Fishing Assistant answers must cite at least one knowledge-base source.',
+      },
+    });
+  });
+
+  it('accepts support-only citations when no knowledge-base evidence is available', () => {
+    const validated = validateCitations(
+      {
+        answerMarkdown: 'Use pinka.',
+        citations: [{ sourceId: 'digest:feeder:2026-05-01', usedFor: 'supporting report' }],
+        confidence: 'medium',
+      },
+      DIGEST_EVIDENCE,
+      { requireKnowledgeBaseCitation: true }
     );
 
     expect(validated.ok).toBe(true);

--- a/apps/fishing-assistant-service/src/__tests__/promptAndRanking.test.ts
+++ b/apps/fishing-assistant-service/src/__tests__/promptAndRanking.test.ts
@@ -55,6 +55,30 @@ describe('Fishing Assistant prompt and ranking helpers', () => {
     expect(prompt).toContain('[digest:feeder:2026-05-01] (digest) May 1 digest 2026-05-01');
   });
 
+  it('declares knowledge-base evidence authoritative over supporting chat evidence', () => {
+    const prompt = fishingAnswerPrompt.build({
+      question: 'What bait now?',
+      recentMessages: [],
+      evidence: [
+        ...EVIDENCE,
+        {
+          id: 'digest:feeder:2026-05-01',
+          sourceType: 'digest' as const,
+          title: 'May 1 digest',
+          date: '2026-05-01',
+          text: 'Members reported pinka.',
+          quote: 'Members reported pinka.',
+          score: 0.8,
+          metadata: { groupKey: 'feeder' },
+        },
+      ],
+    });
+
+    expect(fishingAnswerPrompt.version).toBe('4.0.0');
+    expect(prompt).toContain('Knowledge Base evidence (knowledge_page) is the authoritative base');
+    expect(prompt).toContain('Digest and raw message evidence are supporting context');
+  });
+
   it('neutralizes instruction-like content from stored conversation history', () => {
     const prompt = fishingAnswerPrompt.build({
       question: 'What bait now?',

--- a/apps/fishing-assistant-service/src/__tests__/retrieval.test.ts
+++ b/apps/fishing-assistant-service/src/__tests__/retrieval.test.ts
@@ -81,6 +81,70 @@ describe('retrieveEvidence', () => {
     expect(result.value[0]?.sourceType).toBe('knowledge_page');
   });
 
+  it('prioritizes knowledge-base evidence ahead of higher-scoring support evidence', async () => {
+    const embeddingClient = {
+      embedTexts: vi.fn().mockResolvedValue({ ok: true, value: [[0.1, 0.2, 0.3]] }),
+    };
+    const chunkRepository = makeChunkRepository({
+      ok: true,
+      value: [
+        makeChunk({
+          id: 'chunk-low-score',
+          text: 'The knowledge base recipe uses sweet biscuit crumb.',
+          searchableText: 'archived recipe',
+          vectorScore: 0.1,
+        }),
+      ],
+    });
+    const digestItems = Array.from({ length: 16 }, (_, index) => ({
+      groupKey: 'feeder',
+      date: `2026-05-${String(index + 1).padStart(2, '0')}`,
+      title: `May ${String(index + 1)} digest`,
+      summaryMarkdown: 'sweet biscuit crumb method feeder bait',
+      messageCount: 10,
+    }));
+    const mobileNotificationsClient = {
+      listDigestSubscriptions: vi.fn().mockResolvedValue({
+        ok: true,
+        value: { items: [{ groupKey: 'feeder', displayName: 'Feeder' }] },
+      }),
+      queryDigests: vi.fn().mockResolvedValue({
+        ok: true,
+        value: { items: digestItems, truncated: false },
+      }),
+      queryGroupMessages: vi.fn().mockResolvedValue({
+        ok: true,
+        value: {
+          messages: [],
+          totalRaw: 0,
+          totalCleaned: 0,
+          returned: 0,
+          truncated: false,
+        },
+      }),
+    };
+
+    const result = await retrieveEvidence(
+      {
+        embeddingClient,
+        chunkRepository,
+        mobileNotificationsClient,
+        now: new Date('2026-05-27T12:00:00Z'),
+      },
+      {
+        userId: 'user-1',
+        question: 'sweet biscuit crumb method feeder bait',
+      }
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toHaveLength(16);
+    expect(result.value[0]?.id).toBe('chunk-low-score');
+    expect(result.value[0]?.sourceType).toBe('knowledge_page');
+    expect(result.value.some((item) => item.sourceType === 'digest')).toBe(true);
+  });
+
   it('uses explicit date ranges for digest lookup and degrades to kb-only on digest failure', async () => {
     const embeddingClient = {
       embedTexts: vi.fn().mockResolvedValue({ ok: true, value: [[0.1, 0.2, 0.3]] }),

--- a/apps/fishing-assistant-service/src/__tests__/sendChatMessage.test.ts
+++ b/apps/fishing-assistant-service/src/__tests__/sendChatMessage.test.ts
@@ -525,6 +525,120 @@ describe('sendChatMessage', () => {
     });
   });
 
+  it('repairs support-only answers when knowledge-base evidence is available', async () => {
+    const ctx = createContext({
+      chat: makeChat({ title: 'Spring Session' }),
+      updatedChat: makeChat({ title: 'Spring Session' }),
+    });
+    ctx.chatRepository.createMessage.mockReset()
+      .mockResolvedValueOnce(
+        okResult(makeMessage({ id: 'message-user', role: 'user', content: 'Need the sweet recipe' }))
+      )
+      .mockResolvedValueOnce(
+        okResult(
+          makeMessage({
+            id: 'message-assistant',
+            content: 'Use the knowledge-base sweet biscuit recipe.',
+            citations: [
+              {
+                sourceId: 'chunk-low-score',
+                sourceType: 'knowledge_page',
+                title: 'Spring Bait',
+                quote: 'The knowledge base recipe uses sweet biscuit crumb.',
+                usedFor: 'base recipe',
+                url: '/fishing-assistant/knowledge/pages/page-1',
+                pageId: 'page-1',
+              },
+            ],
+            confidence: 'high',
+          })
+        )
+      );
+    ctx.chunkRepository.findNearestByUserId.mockResolvedValue(
+      okResult([
+        makeChunk({
+          id: 'chunk-low-score',
+          text: 'The knowledge base recipe uses sweet biscuit crumb.',
+          searchableText: 'archived recipe',
+          vectorScore: 0.1,
+        }),
+      ])
+    );
+    ctx.mobileNotificationsClient.listDigestSubscriptions.mockResolvedValue(
+      okResult({ items: [{ groupKey: 'feeder', displayName: 'Feeder Team' }] })
+    );
+    ctx.mobileNotificationsClient.queryDigests.mockResolvedValue(
+      okResult({
+        items: [
+          {
+            groupKey: 'feeder',
+            date: '2026-05-07',
+            title: 'May 7 digest',
+            summaryMarkdown: 'Members discussed sweet biscuit crumb method feeder bait.',
+            messageCount: 18,
+          },
+        ],
+        truncated: false,
+      })
+    );
+    ctx.mobileNotificationsClient.queryGroupMessages.mockResolvedValue(
+      okResult({
+        messages: [],
+        totalRaw: 0,
+        totalCleaned: 0,
+        returned: 0,
+        truncated: false,
+      })
+    );
+    ctx.llmClient.generate.mockReset()
+      .mockResolvedValueOnce(
+        okResult({
+          content:
+            '{"answerMarkdown":"Use the digest method feeder notes.","citations":[{"sourceId":"S2","usedFor":"supporting report"}],"confidence":"high"}',
+          usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30, costUsd: 0.01 },
+        })
+      )
+      .mockResolvedValueOnce(
+        okResult({
+          content:
+            '{"answerMarkdown":"Use the knowledge-base sweet biscuit recipe.","citations":[{"sourceId":"S1","usedFor":"base recipe"}],"confidence":"high"}',
+          usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30, costUsd: 0.01 },
+        })
+      );
+
+    const result = await sendChatMessage(ctx.deps, {
+      userId: 'user-1',
+      chatId: 'chat-1',
+      message: 'How should I use sweet biscuit crumb for method feeder bait?',
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(ctx.llmClient.generate).toHaveBeenCalledTimes(2);
+    expect(ctx.llmClient.generate.mock.calls[1]?.[0]).toContain(
+      'Fishing Assistant answers must cite at least one knowledge-base source.'
+    );
+    expect(ctx.chatRepository.createMessage).toHaveBeenNthCalledWith(2, {
+      id: 'message-assistant',
+      chatId: 'chat-1',
+      userId: 'user-1',
+      role: 'assistant',
+      content: 'Use the knowledge-base sweet biscuit recipe.',
+      confidence: 'high',
+      citations: [
+        {
+          sourceId: 'chunk-low-score',
+          sourceType: 'knowledge_page',
+          title: 'Spring Bait',
+          quote: 'The knowledge base recipe uses sweet biscuit crumb.',
+          usedFor: 'base recipe',
+          url: '/fishing-assistant/knowledge/pages/page-1',
+          pageId: 'page-1',
+        },
+      ],
+    });
+  });
+
   it('returns repository errors when recent messages cannot be listed', async () => {
     const ctx = createContext({
       chat: makeChat({ title: 'Spring Session' }),

--- a/apps/fishing-assistant-service/src/domain/prompts/buildFishingAnswerPrompt.ts
+++ b/apps/fishing-assistant-service/src/domain/prompts/buildFishingAnswerPrompt.ts
@@ -31,7 +31,7 @@ function sanitizeHistoryContent(content: string): string {
 export const fishingAnswerPrompt: PromptBuilder<BuildFishingAnswerPromptInput> = {
   name: 'fishing-assistant-answer',
   description: 'Builds a grounded JSON-answer prompt for Fishing Assistant chat responses',
-  version: '3.0.0',
+  version: '4.0.0',
 
   build(input: BuildFishingAnswerPromptInput): string {
     const history = input.recentMessages
@@ -46,6 +46,10 @@ export const fishingAnswerPrompt: PromptBuilder<BuildFishingAnswerPromptInput> =
 
     return [
       'Answer the fishing question using only the evidence below.',
+      'Knowledge Base evidence (knowledge_page) is the authoritative base for the answer.',
+      'Digest and raw message evidence are supporting context for recent group signals, confirmations, conflicts, and practical adaptations.',
+      'When knowledge_page evidence is present, build the core answer from it first, then use digest/raw_message evidence to support or update it.',
+      'If supporting evidence conflicts with Knowledge Base evidence, say so explicitly instead of silently replacing the Knowledge Base.',
       'Return strict JSON with shape {"answerMarkdown": string, "citations": [{"sourceId": string, "usedFor": string}], "confidence": "high"|"medium"|"low"}.',
       'In citations[].sourceId, copy one of the evidence sourceIds exactly as written in the square brackets. Never translate, shorten, reorder, or invent a sourceId.',
       input.evidence.length > 0

--- a/apps/fishing-assistant-service/src/domain/prompts/validateCitations.ts
+++ b/apps/fishing-assistant-service/src/domain/prompts/validateCitations.ts
@@ -2,6 +2,10 @@ import { err, ok, type Result } from '@intexuraos/common-core';
 import type { EvidenceItem } from '../retrieval/types.js';
 import type { ParsedFishingAnswer } from './parseFishingAnswer.js';
 
+export interface CitationValidationOptions {
+  requireKnowledgeBaseCitation?: boolean;
+}
+
 function isInsufficientEvidenceAnswer(answerMarkdown: string): boolean {
   const normalized = answerMarkdown.toLowerCase();
   return (
@@ -14,15 +18,16 @@ function isInsufficientEvidenceAnswer(answerMarkdown: string): boolean {
 
 export function validateCitations(
   answer: ParsedFishingAnswer,
-  evidence: EvidenceItem[]
+  evidence: EvidenceItem[],
+  options: CitationValidationOptions = {}
 ): Result<
   ParsedFishingAnswer,
   { code: 'CITATION_VALIDATION_FAILED'; message: string }
 > {
-  const evidenceIds = new Set(evidence.map((item) => item.id));
+  const evidenceById = new Map(evidence.map((item) => [item.id, item]));
 
   for (const citation of answer.citations) {
-    if (!evidenceIds.has(citation.sourceId)) {
+    if (!evidenceById.has(citation.sourceId)) {
       return err({
         code: 'CITATION_VALIDATION_FAILED',
         message: `Unknown citation sourceId: ${citation.sourceId}`,
@@ -30,10 +35,27 @@ export function validateCitations(
     }
   }
 
-  if (answer.citations.length === 0 && !isInsufficientEvidenceAnswer(answer.answerMarkdown)) {
+  const insufficientEvidenceAnswer = isInsufficientEvidenceAnswer(answer.answerMarkdown);
+  if (answer.citations.length === 0 && !insufficientEvidenceAnswer) {
     return err({
       code: 'CITATION_VALIDATION_FAILED',
       message: 'Fishing Assistant answers must cite at least one source.',
+    });
+  }
+
+  const hasKnowledgeBaseEvidence = evidence.some((item) => item.sourceType === 'knowledge_page');
+  const hasKnowledgeBaseCitation = answer.citations.some(
+    (citation) => evidenceById.get(citation.sourceId)?.sourceType === 'knowledge_page'
+  );
+  if (
+    options.requireKnowledgeBaseCitation === true &&
+    hasKnowledgeBaseEvidence &&
+    !hasKnowledgeBaseCitation &&
+    !insufficientEvidenceAnswer
+  ) {
+    return err({
+      code: 'CITATION_VALIDATION_FAILED',
+      message: 'Fishing Assistant answers must cite at least one knowledge-base source.',
     });
   }
 

--- a/apps/fishing-assistant-service/src/domain/retrieval/retrieveEvidence.ts
+++ b/apps/fishing-assistant-service/src/domain/retrieval/retrieveEvidence.ts
@@ -29,6 +29,7 @@ const HISTORICAL_DATE_FLOOR = '1970-01-01';
 const DIGEST_PAGE_LIMIT = 100;
 const RAW_MESSAGE_PAGE_LIMIT = 500;
 const FINAL_EVIDENCE_LIMIT = 16;
+const KNOWLEDGE_EVIDENCE_LIMIT = 12;
 
 function extractDateRange(question: string, now: Date): { dateFrom: string; dateTo: string } {
   const matches = [...question.matchAll(/\b\d{4}-\d{2}-\d{2}\b/g)].map((match) => match[0]);
@@ -139,7 +140,8 @@ export async function retrieveEvidence(
   input: RetrieveEvidenceInput
 ): Promise<{ ok: true; value: EvidenceItem[] } | { ok: false; error: RetrievalError }> {
   const terms = extractSearchTerms(input.question);
-  const evidence: EvidenceItem[] = [];
+  const knowledgeEvidence: EvidenceItem[] = [];
+  const supportingEvidence: EvidenceItem[] = [];
 
   const embeddingResult = await deps.embeddingClient.embedTexts({
     userId: input.userId,
@@ -152,11 +154,10 @@ export async function retrieveEvidence(
       limit: 20,
     });
     if (chunkResult.ok) {
-      evidence.push(
+      knowledgeEvidence.push(
         ...chunkResult.value
           .filter((chunk) => chunk.userId === input.userId)
           .map((chunk) => rankKnowledgeChunk(chunk, terms))
-          .slice(0, 12)
       );
     }
   }
@@ -190,14 +191,19 @@ export async function retrieveEvidence(
         }),
       ]);
       digestEvidence.push(...groupDigestEvidence);
-      evidence.push(...rawMessageEvidence);
+      supportingEvidence.push(...rawMessageEvidence);
     }
   }
-  evidence.push(...digestEvidence);
+  supportingEvidence.push(...digestEvidence);
 
-  const ranked = evidence
+  const rankedKnowledge = knowledgeEvidence
     .sort((left, right) => right.score - left.score)
-    .slice(0, FINAL_EVIDENCE_LIMIT);
+    .slice(0, KNOWLEDGE_EVIDENCE_LIMIT);
+  const supportingSlots = Math.max(0, FINAL_EVIDENCE_LIMIT - rankedKnowledge.length);
+  const rankedSupporting = supportingEvidence
+    .sort((left, right) => right.score - left.score)
+    .slice(0, supportingSlots);
+  const ranked = [...rankedKnowledge, ...rankedSupporting];
 
   if (ranked.length === 0) {
     return {

--- a/apps/fishing-assistant-service/src/domain/usecases/sendChatMessage.ts
+++ b/apps/fishing-assistant-service/src/domain/usecases/sendChatMessage.ts
@@ -167,6 +167,9 @@ async function generateValidatedAnswer(input: {
   }
 
   const parsed = parseFishingAnswer(first.value.content);
+  const requireKnowledgeBaseCitation = input.evidence.some(
+    (item) => item.sourceType === 'knowledge_page'
+  );
   let repairReason = parsed.ok
     ? 'Fishing Assistant response failed citation validation.'
     : parsed.error.message;
@@ -176,7 +179,8 @@ async function generateValidatedAnswer(input: {
         ...parsed.value,
         citations: remapCitationAliases(parsed.value.citations, input.sourceIdAliases),
       },
-      input.evidence
+      input.evidence,
+      { requireKnowledgeBaseCitation }
     );
     if (validated.ok) {
       return ok({
@@ -218,7 +222,8 @@ async function generateValidatedAnswer(input: {
       ...reparsed.value,
       citations: remapCitationAliases(reparsed.value.citations, input.sourceIdAliases),
     },
-    input.evidence
+    input.evidence,
+    { requireKnowledgeBaseCitation }
   );
   if (!revalidated.ok) {
     return revalidated;


### PR DESCRIPTION
## Summary
- Prioritize knowledge-base evidence before digest/raw-message support when assembling Fishing Assistant prompt evidence.
- Bump the Fishing Assistant answer prompt to v4.0.0 with explicit KB-authoritative guidance.
- Require a knowledge-base citation when KB evidence is available, including the repair retry path.

## Validation
- `pnpm --filter @intexuraos/fishing-assistant-service test -- src/__tests__/retrieval.test.ts src/__tests__/promptAndRanking.test.ts src/__tests__/citationValidation.test.ts src/__tests__/sendChatMessage.test.ts`
- `pnpm run verify:workspace:tracked fishing-assistant-service`
- `pnpm run ci:tracked`
