### PR TITLE
[INT-1644] [codex] Fix fishing chat mobile overflow

### DIFF
--- a/apps/web/src/components/fishing/FishingChatPanel.tsx
+++ b/apps/web/src/components/fishing/FishingChatPanel.tsx
@@ -83,7 +83,7 @@ export function FishingChatPanel({
   return (
     <div
       data-testid="fishing-chat-panel"
-      className="grid min-w-0 gap-4 lg:grid-cols-[260px_minmax(0,1fr)]"
+      className="grid min-w-0 grid-cols-[minmax(0,1fr)] gap-4 lg:grid-cols-[260px_minmax(0,1fr)]"
     >
       <Card className="h-full min-w-0">
         <div className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">

--- a/apps/web/src/components/fishing/FishingReferencesPanel.tsx
+++ b/apps/web/src/components/fishing/FishingReferencesPanel.tsx
@@ -78,13 +78,13 @@ export function FishingReferencesPanel({
   };
 
   return (
-    <Card title="References" className="h-full">
+    <Card title="References" className="h-full min-w-0 overflow-hidden">
       {citations.length === 0 ? (
         <p className="text-sm text-slate-500 dark:text-slate-400">
           Select an assistant answer to inspect its evidence.
         </p>
       ) : (
-        <div className="space-y-3">
+        <div className="min-w-0 space-y-3">
           {citations.map((citation, index) => {
             const referenceKey = `${citation.sourceId}-${citation.usedFor}-${String(index)}`;
             const isExpanded = expanded[referenceKey] === true;
@@ -92,7 +92,7 @@ export function FishingReferencesPanel({
             return (
               <div
                 key={referenceKey}
-                className="rounded-lg border border-slate-200 bg-slate-50 dark:border-slate-700 dark:bg-slate-900/40"
+                className="min-w-0 overflow-hidden rounded-lg border border-slate-200 bg-slate-50 dark:border-slate-700 dark:bg-slate-900/40"
               >
                 <button
                   type="button"
@@ -102,9 +102,9 @@ export function FishingReferencesPanel({
                   }}
                   className="flex w-full min-w-0 items-center justify-between gap-3 p-3 text-left"
                 >
-                  <span className="flex min-w-0 items-center gap-2">
-                    {sourceIcon(citation.sourceType)}
-                    <span className="min-w-0">
+                  <span className="flex min-w-0 flex-1 items-center gap-2">
+                    <span className="shrink-0">{sourceIcon(citation.sourceType)}</span>
+                    <span className="min-w-0 flex-1">
                       <span className="block text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
                         {sourceLabel(citation.sourceType)}
                       </span>

--- a/apps/web/src/components/fishing/__tests__/FishingResponsiveContracts.test.tsx
+++ b/apps/web/src/components/fishing/__tests__/FishingResponsiveContracts.test.tsx
@@ -7,6 +7,7 @@ import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, it, vi } from 'vitest';
 import { FishingDigestList } from '../FishingDigestList.js';
 import { FishingChatPanel } from '../FishingChatPanel.js';
+import { FishingReferencesPanel } from '../FishingReferencesPanel.js';
 import { FishingKnowledgeTree } from '../FishingKnowledgeTree.js';
 import { FishingPageEditor } from '../FishingPageEditor.js';
 import type {
@@ -58,6 +59,9 @@ describe('Fishing responsive layout contracts', () => {
       </MemoryRouter>
     );
 
+    expect(screen.getByTestId('fishing-chat-panel')).toHaveClass(
+      'grid-cols-[minmax(0,1fr)]'
+    );
     const bubble = screen.getByTestId('fishing-chat-message-message-long');
     expect(bubble).toHaveClass('min-w-0', 'max-w-full', 'overflow-hidden');
     expect(bubble).toHaveClass('ring-2', 'ring-blue-500');
@@ -70,6 +74,35 @@ describe('Fishing responsive layout contracts', () => {
 
     bubble.click();
     expect(onSelectMessage).toHaveBeenCalledWith(assistantMessage.id);
+  });
+
+  it('contains long reference metadata inside the references panel', () => {
+    render(
+      <MemoryRouter>
+        <FishingReferencesPanel
+          citations={[
+            {
+              sourceId: 'chunk-long',
+              sourceType: 'knowledge_page',
+              title: 'VeryLongKnowledgePageTitleThatShouldStayInsideTheReferencePanel',
+              quote: 'VeryLongQuoteTextThatShouldStayInsideTheExpandedReferencePanel',
+              usedFor: 'VeryLongUsageReasonThatShouldStayInsideTheReferencePanel',
+              url: '/fishing-assistant/knowledge/pages/page-1',
+              pageId: 'page-1',
+            },
+          ]}
+        />
+      </MemoryRouter>
+    );
+
+    const card = screen.getByRole('heading', { name: /references/i }).parentElement;
+    expect(card).toHaveClass('min-w-0', 'overflow-hidden');
+
+    const button = screen.getByRole('button', {
+      name: /knowledge base verylongknowledgepagetitlethatshouldstay/i,
+    });
+    expect(button.parentElement).toHaveClass('min-w-0', 'overflow-hidden');
+    expect(button.firstElementChild).toHaveClass('min-w-0', 'flex-1');
   });
 
   it('keeps digest rows stackable on narrow screens', () => {

--- a/apps/web/src/pages/fishing/FishingChatPage.tsx
+++ b/apps/web/src/pages/fishing/FishingChatPage.tsx
@@ -48,7 +48,7 @@ export function FishingChatPage(): React.JSX.Element {
         </p>
       </div>
 
-      <div className="grid min-w-0 gap-4 2xl:grid-cols-[minmax(0,1fr)_360px]">
+      <div className="grid min-w-0 max-w-full grid-cols-[minmax(0,1fr)] gap-4 2xl:grid-cols-[minmax(0,1fr)_360px]">
         <FishingChatPanel
           chats={chat.chats}
           selectedChatId={chatId}


### PR DESCRIPTION
## Summary
- Contain the Fishing Assistant populated chat layout in a one-column mobile grid.
- Prevent references metadata from widening the page after an assistant response renders.
- Add responsive contract coverage for chat and references containment.

## Root Cause
Assistant responses render the references panel alongside markdown/citation content. The populated state did not fully declare shrinkable grid columns and references panel containment, so long citation metadata could widen the mobile grid and clip visible content.

## Validation
- `pnpm --dir apps/web exec vitest run src/components/fishing/__tests__/FishingResponsiveContracts.test.tsx`
- `pnpm --dir apps/web exec vitest run src/components/fishing/__tests__/FishingReferencesPanel.test.tsx src/components/fishing/__tests__/FishingChatPanel.test.tsx`
- `pnpm run verify:workspace:tracked web`
- `pnpm run ci:tracked`

Linear issue ID should be created automatically because this PR is opened ready for review.

Fixes INT-1644
