### PR TITLE
[INT-1637] Add Hetzner production deploy workflow

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -57,7 +57,7 @@ All rules verified by `pnpm run ci:tracked`. If CI passes, rules are satisfied. 
 
 **Infrastructure:** ALL via Terraform. GCP project: `--project=intexuraos-dev-pbuchman`. SA key: `$HOME/.config/gcloud/sa-key.json`. Reference: `.claude/reference/infrastructure.md`
 
-**Environments:** dev=`dev.intexuraos.cloud` (PM2, home-dev) | prod=`intexuraos.cloud` (Cloud Run + Cloud Functions + GCS web bucket). No "local". Both environments are served from the SAME GCP project `intexuraos-dev-pbuchman` (the `-dev-pbuchman` suffix is legacy — there is no separate prod project). Only `terraform/environments/dev/` exists; it owns infrastructure for both domains. Firestore shared. Reference: `.claude/reference/environments.md`
+**Environments:** dev=`dev.intexuraos.cloud` (PM2, home-dev) | prod=`intexuraos.cloud` (Hetzner PM2/nginx + retained GCP data plane). No "local". Both environments use the SAME retained GCP project `intexuraos-dev-pbuchman` (the `-dev-pbuchman` suffix is legacy — there is no separate prod project). `terraform/environments/dev/` owns retained GCP resources; `terraform/hetzner-prod/` owns the production Hetzner host and Hetzner-targeted async/control-plane resources. Firestore shared. Reference: `.claude/reference/environments.md`
 
 **Code Task Investigation:** When user pastes `dev.intexuraos.cloud/#/code-tasks/task_*` or `intexuraos.cloud/#/code-tasks/task_*` URL — use `/debug-code-task` skill. NEVER WebFetch/curl the SPA URL (hash routing returns shell HTML). Data is in Firestore `code_tasks` collection.
 

--- a/.claude/reference/environments.md
+++ b/.claude/reference/environments.md
@@ -2,25 +2,25 @@
 
 ## Overview
 
-| Environment | Domain               | Infra                                        | Machine  | Deploy Target            |
-| ----------- | -------------------- | -------------------------------------------- | -------- | ------------------------ |
-| **dev**     | dev.intexuraos.cloud | PM2                                          | home-dev | `~/deploy/intexuraos`    |
-| **prod**    | intexuraos.cloud     | Cloud Run / Cloud Functions / GCS web bucket | GCloud   | CI/CD via GitHub Actions |
+| Environment | Domain               | Infra                                       | Machine  | Deploy Target                              |
+| ----------- | -------------------- | ------------------------------------------- | -------- | ------------------------------------------ |
+| **dev**     | dev.intexuraos.cloud | PM2                                         | home-dev | `~/deploy/intexuraos`                      |
+| **prod**    | intexuraos.cloud     | Hetzner PM2/nginx + retained GCP data plane | Hetzner  | GitHub Actions deploy to `/opt/intexuraos` |
 
 **⛔ There is NO "local" environment. Only dev and prod exist. If you think about local, STOP - you are wrong.**
 
-**Single GCP project.** Both `dev.intexuraos.cloud` and `intexuraos.cloud` are served from the SAME GCP project `intexuraos-dev-pbuchman`. The `-dev-pbuchman` suffix is legacy — there is no separate prod GCP project. The dev/prod distinction is about _deployment target_ (PM2 on `home-dev` vs Cloud Run / Cloud Functions / GCS bucket in `intexuraos-dev-pbuchman`), not about project ownership. Consequently, only `terraform/environments/dev/` exists in this repo; it manages all Cloud Run services, Cloud Functions, Pub/Sub topics, secrets, and the GCS bucket that backs the prod web bundle.
+**Single GCP project.** Both `dev.intexuraos.cloud` and `intexuraos.cloud` use the SAME retained GCP project `intexuraos-dev-pbuchman` for data-plane resources. The `-dev-pbuchman` suffix is legacy — there is no separate prod GCP project. The dev/prod distinction is about _deployment target_ (PM2 on `home-dev` vs PM2/nginx on Hetzner), not about project ownership. `terraform/environments/dev/` owns retained GCP resources; `terraform/hetzner-prod/` owns the production Hetzner host and Hetzner-targeted async/control-plane resources.
 
 ## Environment Detection Signals
 
-| Signal                           | dev                                      | prod                                |
-| -------------------------------- | ---------------------------------------- | ----------------------------------- |
-| URL (public)                     | `dev.intexuraos.cloud`                   | `intexuraos.cloud` (without `dev.`) |
-| URL (internal)                   | `localhost:*` (service URLs on home-dev) | `*.run.app`                         |
-| User says                        | "dev", "dev environment"                 | "prod", "production", "cloud"       |
-| `uname -n`                       | `home-dev`                               | N/A (Cloud Run)                     |
-| Logs via                         | `pm2 logs <name>`                        | `gcloud logging read`               |
-| `INTEXURAOS_ENVIRONMENT` env var | `dev`                                    | `prod`                              |
+| Signal                           | dev                                      | prod                                   |
+| -------------------------------- | ---------------------------------------- | -------------------------------------- |
+| URL (public)                     | `dev.intexuraos.cloud`                   | `intexuraos.cloud` (without `dev.`)    |
+| URL (internal)                   | `localhost:*` (service URLs on home-dev) | `127.0.0.1:*` on the Hetzner VM        |
+| User says                        | "dev", "dev environment"                 | "prod", "production", "cloud"          |
+| `uname -n`                       | `home-dev`                               | Hetzner VM hostname                    |
+| Logs via                         | `pm2 logs <name>`                        | SSH to Hetzner, then `pm2 logs <name>` |
+| `INTEXURAOS_ENVIRONMENT` env var | `dev`                                    | `prod`                                 |
 
 **Firestore is SHARED between both environments.** Same database, same collections.
 
@@ -35,9 +35,9 @@
 
 ```
 STEP 1: Check the URL/context. Does it contain dev.intexuraos.cloud or localhost? → dev
-STEP 2: Does it contain intexuraos.cloud (no dev.) or *.run.app? → prod
+STEP 2: Does it contain intexuraos.cloud (no dev.)? → prod
 STEP 3: For code tasks: check Firestore `code_tasks` collection for workerLocation field
-STEP 4: Check service status with the right tool (pm2 for dev, gcloud for prod)
+STEP 4: Check service status with the right tool (pm2 on home-dev for dev, SSH + pm2 on Hetzner for prod)
 ```
 
 ## On home-dev (dev environment)

--- a/.claude/reference/infrastructure.md
+++ b/.claude/reference/infrastructure.md
@@ -146,7 +146,14 @@ The service account `claude-code-dev@intexuraos-dev-pbuchman.iam.gserviceaccount
 
 **CI:** `.github/workflows/ci.yml` runs `pnpm run ci` on all branches (lint, typecheck, test, build)
 
-**Deploy:** `.github/workflows/deploy.yml` is manual-only and can trigger only retained GCP Cloud Build targets:
+**Deploy:** `.github/workflows/deploy.yml` automatically deploys production to Hetzner on every push to `development` and also supports manual `workflow_dispatch` target `hetzner-prod`. The Hetzner job uses `scripts/hetzner/github-actions-deploy.sh`, syncs the checked-out commit to `/opt/intexuraos`, refreshes secrets on the VM, rebuilds the web bundle, reloads PM2/nginx, and runs direct-origin health checks.
+
+Required GitHub configuration:
+
+- Secret: `HETZNER_DEPLOY_SSH_PRIVATE_KEY`
+- Optional variable: `HETZNER_PROD_HOST` (defaults to `162.55.210.48`)
+
+The same workflow can manually trigger only these retained GCP Cloud Build targets:
 
 - `firestore`
 - `vm-lifecycle`

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,25 +1,56 @@
-name: Deploy Retained GCP
+name: Deploy
 
 on:
+  push:
+    branches: [development]
   workflow_dispatch:
     inputs:
       target:
-        description: 'Retained GCP target to deploy'
+        description: 'Deployment target'
         required: true
+        default: hetzner-prod
         type: choice
         options:
+          - hetzner-prod
           - firestore
           - vm-lifecycle
           - transcription
           - code-worker
+      deploy_nginx:
+        description: 'Refresh and reload nginx during Hetzner deployment'
+        required: true
+        default: true
+        type: boolean
 
 permissions:
   contents: read
   id-token: write
 
+concurrency:
+  group: deploy-${{ github.event_name == 'push' && 'hetzner-prod' || inputs.target }}
+  cancel-in-progress: false
+
 jobs:
+  deploy-hetzner-prod:
+    name: Deploy Hetzner Production
+    if: ${{ github.event_name == 'push' || inputs.target == 'hetzner-prod' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      HETZNER_DEPLOY_SSH_PRIVATE_KEY: ${{ secrets.HETZNER_DEPLOY_SSH_PRIVATE_KEY }}
+      HETZNER_PROD_HOST: ${{ vars.HETZNER_PROD_HOST || '162.55.210.48' }}
+      DEPLOY_NGINX: ${{ github.event_name == 'push' && 'true' || inputs.deploy_nginx }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Deploy via Hetzner runtime scripts
+        run: bash scripts/hetzner/github-actions-deploy.sh
+
   deploy-retained-gcp:
-    name: Deploy ${{ inputs.target }}
+    name: Deploy Retained GCP ${{ inputs.target }}
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.target != 'hetzner-prod' }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
 

--- a/docs/operations/hetzner-prod-runbook.md
+++ b/docs/operations/hetzner-prod-runbook.md
@@ -55,6 +55,28 @@ runtime dependencies, loads secrets, builds the web bundle, starts PM2, and
 deploys nginx. Manual provisioning commands below are for repair or emergency
 operation, not the default path.
 
+## GitHub Actions Production Deployment
+
+Merging to `development` deploys production to Hetzner through
+`.github/workflows/deploy.yml`. The workflow syncs the checked-out commit to
+`/opt/intexuraos`, refreshes GCP Secret Manager material on the VM, installs
+dependencies, rebuilds `@intexuraos/infra-otel`, builds and publishes the web
+bundle, reloads PM2, reloads nginx, and verifies the Hetzner origin with
+`curl --resolve`.
+
+Required GitHub configuration:
+
+| Name | Type | Purpose |
+| --- | --- | --- |
+| `HETZNER_DEPLOY_SSH_PRIVATE_KEY` | repository secret | Private key matching `deploy_ssh_public_key` in `terraform/hetzner-prod/prod.auto.tfvars.json` |
+| `HETZNER_PROD_HOST` | repository variable, optional | Hetzner host/IP; defaults to `162.55.210.48` |
+
+Manual dispatch target `hetzner-prod` runs the same Hetzner deploy. Manual
+dispatch targets `firestore`, `vm-lifecycle`, `transcription`, and
+`code-worker` still trigger only the retained GCP Cloud Build targets. Migrated
+app/web services must not be redeployed through GCP Cloud Run or app Cloud
+Build triggers.
+
 ## Provisioning
 
 Run on the VM as root:

--- a/scripts/__tests__/hetzner-runtime.test.ts
+++ b/scripts/__tests__/hetzner-runtime.test.ts
@@ -12,9 +12,11 @@ const reloadPm2Path = resolve(repoRoot, 'scripts/hetzner/reload-pm2.sh');
 const cutoverEdgePath = resolve(repoRoot, 'scripts/hetzner/cutover-gcp-edge.sh');
 const installNginxPath = resolve(repoRoot, 'scripts/hetzner/install-nginx-and-cert.sh');
 const provisionPath = resolve(repoRoot, 'scripts/hetzner/provision.sh');
+const githubActionsDeployPath = resolve(repoRoot, 'scripts/hetzner/github-actions-deploy.sh');
 const runbookPath = resolve(repoRoot, 'docs/operations/hetzner-prod-runbook.md');
 const migrationPlanPath = resolve(repoRoot, 'docs/operations/hetzner-prod-migration-plan.md');
 const selfReviewPath = resolve(repoRoot, 'docs/operations/hetzner-prod-self-review.md');
+const deployWorkflowPath = resolve(repoRoot, '.github/workflows/deploy.yml');
 const terraformDevMainPath = resolve(repoRoot, 'terraform/environments/dev/main.tf');
 const terraformDevTfvarsExamplePath = resolve(
   repoRoot,
@@ -225,6 +227,46 @@ describe('Hetzner nginx runtime config', () => {
 });
 
 describe('Hetzner web asset deployment', () => {
+  it('deploys Hetzner production automatically after development receives a merge', () => {
+    const workflow = readRequired(deployWorkflowPath);
+    const script = readRequired(githubActionsDeployPath);
+
+    expect(workflow).toContain('name: Deploy');
+    expect(workflow).toContain('branches: [development]');
+    expect(workflow).toContain('hetzner-prod');
+    expect(workflow).toContain('deploy-hetzner-prod:');
+    expect(workflow).toContain("github.event_name == 'push'");
+    expect(workflow).toContain('HETZNER_DEPLOY_SSH_PRIVATE_KEY');
+    expect(workflow).toContain('HETZNER_PROD_HOST');
+    expect(workflow).toContain('scripts/hetzner/github-actions-deploy.sh');
+    expect(workflow).toContain('deploy-retained-gcp:');
+    expect(workflow).toContain("github.event_name == 'workflow_dispatch'");
+    expect(workflow).toContain('gcloud builds triggers run "$TARGET"');
+    expect(workflow).not.toContain('deploy-monolith');
+    expect(workflow).not.toContain('smart-dispatch');
+    expect(workflow).not.toContain('CLOUD_RUN_SERVICES=(');
+
+    expect(script).toContain('HETZNER_DEPLOY_SSH_PRIVATE_KEY');
+    expect(script).toContain('HETZNER_PROD_HOST');
+    expect(script).toContain('REMOTE_REPO_DIR="${REMOTE_REPO_DIR:-/opt/intexuraos}"');
+    expect(script).toContain('rsync -az --delete');
+    expect(script).toContain("--exclude '.git/'");
+    expect(script).toContain(
+      'sudo -n INTEXURAOS_ENVIRONMENT=prod bash scripts/hetzner/load-secrets.sh'
+    );
+    expect(script).toContain('CI=true pnpm install --frozen-lockfile');
+    expect(script).toContain('pnpm --filter @intexuraos/infra-otel build');
+    expect(script).toContain('INTEXURAOS_ENVIRONMENT=prod bash scripts/hetzner/deploy-web.sh');
+    expect(script).toContain('INTEXURAOS_ENVIRONMENT=prod bash scripts/hetzner/reload-pm2.sh');
+    expect(script).toContain(
+      'sudo -n INTEXURAOS_ENVIRONMENT=prod bash scripts/hetzner/deploy-nginx.sh'
+    );
+    expect(script).toContain('--resolve "${PUBLIC_DOMAIN}:443:${HETZNER_PROD_HOST}"');
+    expect(script).not.toContain('terraform apply');
+    expect(script).not.toContain('gcloud run deploy');
+    expect(script).not.toContain('gcloud builds triggers run');
+  });
+
   it('allowlists native dependency build scripts needed by clean production installs', () => {
     const packageJson = JSON.parse(readRequired(packageJsonPath)) as { packageManager?: string };
     const workspace = readRequired(pnpmWorkspacePath);

--- a/scripts/hetzner/github-actions-deploy.sh
+++ b/scripts/hetzner/github-actions-deploy.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+IFS=$'\n\t'
+
+HETZNER_PROD_HOST="${HETZNER_PROD_HOST:-162.55.210.48}"
+REMOTE_USER="${REMOTE_USER:-deploy}"
+REMOTE_REPO_DIR="${REMOTE_REPO_DIR:-/opt/intexuraos}"
+PUBLIC_DOMAIN="${PUBLIC_DOMAIN:-intexuraos.cloud}"
+SSH_PORT="${SSH_PORT:-22}"
+DEPLOY_NGINX="${DEPLOY_NGINX:-true}"
+KEY_FILE=""
+KNOWN_HOSTS_FILE=""
+
+fail() {
+  printf 'ERROR: %s\n' "$1" >&2
+  exit 1
+}
+
+cleanup() {
+  [[ -n "${KEY_FILE}" ]] && rm -f "${KEY_FILE}"
+  [[ -n "${KNOWN_HOSTS_FILE}" ]] && rm -f "${KNOWN_HOSTS_FILE}"
+}
+
+require_command() {
+  local command_name="$1"
+  command -v "${command_name}" >/dev/null 2>&1 || fail "${command_name} is required"
+}
+
+validate_inputs() {
+  [[ -n "${HETZNER_DEPLOY_SSH_PRIVATE_KEY:-}" ]] \
+    || fail "HETZNER_DEPLOY_SSH_PRIVATE_KEY is required"
+  [[ -n "${HETZNER_PROD_HOST}" ]] || fail "HETZNER_PROD_HOST is required"
+  [[ -n "${REMOTE_USER}" ]] || fail "REMOTE_USER is required"
+  [[ -n "${REMOTE_REPO_DIR}" ]] || fail "REMOTE_REPO_DIR is required"
+  [[ "${SSH_PORT}" =~ ^[0-9]+$ ]] || fail "SSH_PORT must be numeric"
+
+  case "${DEPLOY_NGINX}" in
+    true|false) ;;
+    *) fail "DEPLOY_NGINX must be true or false" ;;
+  esac
+}
+
+setup_ssh() {
+  KEY_FILE="$(mktemp "${TMPDIR:-/tmp}/intexuraos-hetzner-key.XXXXXX")"
+  KNOWN_HOSTS_FILE="$(mktemp "${TMPDIR:-/tmp}/intexuraos-hetzner-known-hosts.XXXXXX")"
+  chmod 600 "${KEY_FILE}" "${KNOWN_HOSTS_FILE}"
+
+  printf '%s\n' "${HETZNER_DEPLOY_SSH_PRIVATE_KEY}" | tr -d '\r' > "${KEY_FILE}"
+  chmod 600 "${KEY_FILE}"
+
+  ssh-keyscan -p "${SSH_PORT}" -H "${HETZNER_PROD_HOST}" >> "${KNOWN_HOSTS_FILE}"
+}
+
+ssh_command_string() {
+  printf 'ssh -i %q -p %q -o BatchMode=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile=%q' \
+    "${KEY_FILE}" \
+    "${SSH_PORT}" \
+    "${KNOWN_HOSTS_FILE}"
+}
+
+run_remote() {
+  local command="$1"
+  local quoted_repo_dir=""
+
+  printf -v quoted_repo_dir '%q' "${REMOTE_REPO_DIR}"
+  ssh -i "${KEY_FILE}" \
+    -p "${SSH_PORT}" \
+    -o BatchMode=yes \
+    -o StrictHostKeyChecking=yes \
+    -o UserKnownHostsFile="${KNOWN_HOSTS_FILE}" \
+    "${REMOTE_USER}@${HETZNER_PROD_HOST}" \
+    "cd ${quoted_repo_dir} && ${command}"
+}
+
+sync_repo() {
+  local ssh_command=""
+
+  ssh_command="$(ssh_command_string)"
+  rsync -az --delete \
+    --exclude '.git/' \
+    --exclude '.terraform/' \
+    --exclude '.env*' \
+    --exclude 'node_modules/' \
+    --exclude 'dist/' \
+    --exclude 'coverage/' \
+    --exclude '*.tfstate' \
+    --exclude '*.tfstate.*' \
+    -e "${ssh_command}" \
+    ./ "${REMOTE_USER}@${HETZNER_PROD_HOST}:${REMOTE_REPO_DIR%/}/"
+}
+
+deploy_runtime() {
+  run_remote 'sudo -n INTEXURAOS_ENVIRONMENT=prod bash scripts/hetzner/load-secrets.sh'
+  run_remote 'CI=true pnpm install --frozen-lockfile'
+  run_remote 'pnpm --filter @intexuraos/infra-otel build'
+  run_remote 'INTEXURAOS_ENVIRONMENT=prod bash scripts/hetzner/deploy-web.sh'
+  run_remote 'INTEXURAOS_ENVIRONMENT=prod bash scripts/hetzner/reload-pm2.sh'
+
+  if [[ "${DEPLOY_NGINX}" == "true" ]]; then
+    run_remote 'sudo -n INTEXURAOS_ENVIRONMENT=prod bash scripts/hetzner/deploy-nginx.sh'
+  fi
+}
+
+verify_deployment() {
+  run_remote 'curl --fail --silent --show-error --max-time 10 http://127.0.0.1/healthz >/dev/null'
+  curl --fail --silent --show-error --max-time 15 \
+    --resolve "${PUBLIC_DOMAIN}:443:${HETZNER_PROD_HOST}" \
+    "https://${PUBLIC_DOMAIN}/healthz" >/dev/null
+  curl --fail --silent --show-error --max-time 15 \
+    --resolve "${PUBLIC_DOMAIN}:443:${HETZNER_PROD_HOST}" \
+    "https://${PUBLIC_DOMAIN}/api/user/health" >/dev/null
+  curl --fail --silent --show-error --max-time 15 \
+    --resolve "${PUBLIC_DOMAIN}:443:${HETZNER_PROD_HOST}" \
+    "https://${PUBLIC_DOMAIN}/api/settings/health" >/dev/null
+}
+
+main() {
+  trap cleanup EXIT
+  require_command curl
+  require_command rsync
+  require_command ssh
+  require_command ssh-keyscan
+  validate_inputs
+  setup_ssh
+  sync_repo
+  deploy_runtime
+  verify_deployment
+
+  printf 'Hetzner production deployment completed for %s\n' "${PUBLIC_DOMAIN}"
+}
+
+main "$@"


### PR DESCRIPTION
Fixes INT-1637

## Summary
- Restores merge-to-development production deployment by adding the Hetzner production job to `.github/workflows/deploy.yml`.
- Adds `scripts/hetzner/github-actions-deploy.sh` to sync the checked-out commit to `/opt/intexuraos`, refresh secrets on the VM, install dependencies, rebuild `@intexuraos/infra-otel`, deploy the web bundle, reload PM2/nginx, and smoke-test the direct Hetzner origin.
- Keeps retained GCP targets manual-only and updates the runbook/project rules to document the new deployment ownership.

## Justification
The old GCP workflow deployed automatically when PRs merged to `development`. After the migration, app/web runtime deployment belongs on the Terraform-managed Hetzner VM, not Cloud Run or app Cloud Build. This preserves the previous user experience while using the current runtime scripts and retained-GCP boundary.

## GitHub Deployment Configuration
- Repository secret `HETZNER_DEPLOY_SSH_PRIVATE_KEY` is configured and matches `deploy_ssh_public_key` in `terraform/hetzner-prod/prod.auto.tfvars.json`.
- Repository variable `HETZNER_PROD_HOST` is configured as `162.55.210.48`.

## Verification
- `pnpm vitest run scripts/__tests__/hetzner-runtime.test.ts --testNamePattern "deploys Hetzner production automatically"` red first, then green.
- `pnpm vitest run scripts/__tests__/hetzner-runtime.test.ts scripts/__tests__/cloud-build-worker-config.test.ts scripts/__tests__/artifact-registry-config.test.ts scripts/__tests__/verify-web-service-manifest.test.ts`
- `bash -n scripts/hetzner/github-actions-deploy.sh scripts/hetzner/deploy-web.sh scripts/hetzner/reload-pm2.sh scripts/hetzner/load-secrets.sh scripts/hetzner/deploy-nginx.sh`
- `node scripts/verify-web-service-manifest.mjs`
- `pnpm run ci:tracked`
- GitHub PR checks are passing.
