### PR TITLE
INT-1637 Fix Hetzner deploy cleanup and metadata

### DIFF
--- a/scripts/__tests__/hetzner-runtime.test.ts
+++ b/scripts/__tests__/hetzner-runtime.test.ts
@@ -251,11 +251,21 @@ describe('Hetzner web asset deployment', () => {
     expect(script).toContain('REMOTE_REPO_DIR="${REMOTE_REPO_DIR:-/opt/intexuraos}"');
     expect(script).toContain('rsync -az --delete');
     expect(script).toContain("--exclude '.git/'");
+    expect(script).toContain('RETIRED_REMOTE_PATHS=(');
+    expect(script).toContain('"packages/infra-otel"');
+    expect(script).toContain('cleanup_retired_remote_paths');
+    expect(script).toContain('Removing retired remote path');
     expect(script).toContain(
       'sudo -n INTEXURAOS_ENVIRONMENT=prod bash scripts/hetzner/load-secrets.sh'
     );
     expect(script).toContain('CI=true pnpm install --frozen-lockfile');
-    expect(script).not.toContain(`infra-o${'tel'}`);
+    expect(script).not.toContain(`pnpm --filter @intexuraos/infra-o${'tel'}`);
+    expect(script).toContain('resolve_commit_metadata');
+    expect(script).toContain('GITHUB_SHA');
+    expect(script).toContain('git rev-parse HEAD');
+    expect(script).toContain('git log -1 --pretty=%s');
+    expect(script).toContain('COMMIT_SHA=${commit_sha_quoted}');
+    expect(script).toContain('COMMIT_MESSAGE=${commit_message_quoted}');
     expect(script).toContain('INTEXURAOS_ENVIRONMENT=prod bash scripts/hetzner/deploy-web.sh');
     expect(script).toContain('INTEXURAOS_ENVIRONMENT=prod bash scripts/hetzner/reload-pm2.sh');
     expect(script).toContain(
@@ -388,6 +398,10 @@ describe('Hetzner web asset deployment', () => {
     expect(script).toContain('prepare_sanitized_web_env_file');
     expect(script).toContain('.env.production.local');
     expect(script).toContain('read_env_value "${key}"');
+    expect(script).toContain('export_build_metadata');
+    expect(script).toContain('COMMIT_SHA');
+    expect(script).toContain('COMMIT_MESSAGE');
+    expect(script).toContain('COMMIT_SHA is required when COMMIT_MESSAGE is set');
     expect(script).not.toContain('export_web_safe_secrets');
     expect(script).not.toContain('export "${key}=${value}"');
     expect(script).not.toContain('source "${ENV_FILE}"');
@@ -402,6 +416,29 @@ describe('Hetzner web asset deployment', () => {
     expect(script).toContain('apps/web/dist/index.html');
     expect(provision).toContain('rsync');
     expect(runbook).toContain('scripts/hetzner/deploy-web.sh');
+  });
+
+  it('installs nginx hash sizing in http context before testing and reloading nginx', () => {
+    const script = readRequired(resolve(repoRoot, 'scripts/hetzner/deploy-nginx.sh'));
+    const siteConfig = readRequired(nginxConfigPath);
+
+    expect(script).toContain('NGINX_HASH_CONFIG_TARGET="/etc/nginx/conf.d/intexuraos-hash.conf"');
+    expect(script).toContain('write_nginx_hash_config()');
+    expect(script).toContain('variables_hash_max_size 2048;');
+    expect(script).toContain('variables_hash_bucket_size 128;');
+    expect(script).toContain('install -d -m 755 "$(dirname "${NGINX_HASH_CONFIG_TARGET}")"');
+    expect(script).toContain('install -m 644');
+
+    const deployFlow = script.slice(script.indexOf('main() {'));
+    expect(deployFlow.indexOf('write_nginx_hash_config')).toBeGreaterThan(
+      deployFlow.indexOf('install -m 644 -o root -g root "${NGINX_SOURCE_DIR}/jwt-verify.lua"')
+    );
+    expect(deployFlow.indexOf('nginx -t')).toBeGreaterThan(
+      deployFlow.indexOf('write_nginx_hash_config')
+    );
+    expect(deployFlow.indexOf('reload_nginx')).toBeGreaterThan(deployFlow.indexOf('nginx -t'));
+    expect(siteConfig).not.toContain('variables_hash_max_size');
+    expect(siteConfig).not.toContain('variables_hash_bucket_size');
   });
 });
 
@@ -658,6 +695,10 @@ describe('Hetzner secret loader', () => {
     expect(hetznerBootstrap).toContain('scripts/hetzner/provision.sh --skip-certbot');
     expect(hetznerBootstrap).toContain('pnpm install --frozen-lockfile');
     expect(hetznerBootstrap).not.toContain(`infra-o${'tel'}`);
+    expect(hetznerBootstrap).toContain("git -C '${local.repo_root}' rev-parse HEAD");
+    expect(hetznerBootstrap).toContain("git -C '${local.repo_root}' log -1 --pretty=%s");
+    expect(hetznerBootstrap).toContain('COMMIT_SHA=$commit_sha_quoted');
+    expect(hetznerBootstrap).toContain('COMMIT_MESSAGE=$commit_message_quoted');
     expect(hetznerBootstrap).toContain('scripts/hetzner/deploy-web.sh');
     expect(hetznerBootstrap).toContain('scripts/hetzner/reload-pm2.sh');
     expect(hetznerBootstrap).toContain('scripts/hetzner/deploy-nginx.sh');

--- a/scripts/hetzner/deploy-nginx.sh
+++ b/scripts/hetzner/deploy-nginx.sh
@@ -8,6 +8,7 @@ NGINX_SOURCE_DIR="${SCRIPT_DIR}/nginx"
 SITE_TARGET="/etc/nginx/sites-available/intexuraos.conf"
 SITE_ENABLED="/etc/nginx/sites-enabled/intexuraos.conf"
 LUA_TARGET_DIR="/etc/nginx/lua"
+NGINX_HASH_CONFIG_TARGET="/etc/nginx/conf.d/intexuraos-hash.conf"
 RELOAD_NGINX=1
 
 usage() {
@@ -62,6 +63,19 @@ reload_nginx() {
   nginx -s reload
 }
 
+write_nginx_hash_config() {
+  local temp_file=""
+
+  install -d -m 755 "$(dirname "${NGINX_HASH_CONFIG_TARGET}")"
+  temp_file="$(mktemp "${TMPDIR:-/tmp}/intexuraos-nginx-hash.XXXXXX")"
+  cat > "${temp_file}" <<'EOF'
+variables_hash_max_size 2048;
+variables_hash_bucket_size 128;
+EOF
+  install -m 644 -o root -g root "${temp_file}" "${NGINX_HASH_CONFIG_TARGET}"
+  rm -f "${temp_file}"
+}
+
 main() {
   parse_args "$@"
   require_prod
@@ -74,6 +88,7 @@ main() {
   install -d -m 755 "$(dirname "${SITE_TARGET}")" "$(dirname "${SITE_ENABLED}")" "${LUA_TARGET_DIR}"
   install -m 644 -o root -g root "${NGINX_SOURCE_DIR}/intexuraos.conf" "${SITE_TARGET}"
   install -m 644 -o root -g root "${NGINX_SOURCE_DIR}/jwt-verify.lua" "${LUA_TARGET_DIR}/jwt-verify.lua"
+  write_nginx_hash_config
   ln -sfn "${SITE_TARGET}" "${SITE_ENABLED}"
   rm -f /etc/nginx/sites-enabled/default
 

--- a/scripts/hetzner/deploy-web.sh
+++ b/scripts/hetzner/deploy-web.sh
@@ -48,6 +48,21 @@ clear_intexuraos_env() {
   done < <(env)
 }
 
+export_build_metadata() {
+  if [[ -n "${COMMIT_MESSAGE:-}" && -z "${COMMIT_SHA:-}" ]]; then
+    fail "COMMIT_SHA is required when COMMIT_MESSAGE is set"
+  fi
+
+  if [[ -n "${COMMIT_SHA:-}" && -z "${COMMIT_MESSAGE:-}" ]]; then
+    fail "COMMIT_MESSAGE is required when COMMIT_SHA is set"
+  fi
+
+  if [[ -n "${COMMIT_SHA:-}" ]]; then
+    export COMMIT_SHA
+    export COMMIT_MESSAGE
+  fi
+}
+
 parse_args() {
   while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -247,6 +262,7 @@ main() {
   require_command rsync
   trap restore_web_env_files EXIT
   clear_intexuraos_env
+  export_build_metadata
   export INTEXURAOS_ENVIRONMENT=prod
   export_web_service_urls
   build_and_publish

--- a/scripts/hetzner/github-actions-deploy.sh
+++ b/scripts/hetzner/github-actions-deploy.sh
@@ -11,6 +11,11 @@ SSH_PORT="${SSH_PORT:-22}"
 DEPLOY_NGINX="${DEPLOY_NGINX:-true}"
 KEY_FILE=""
 KNOWN_HOSTS_FILE=""
+COMMIT_SHA_VALUE=""
+COMMIT_MESSAGE_VALUE=""
+RETIRED_REMOTE_PATHS=(
+  "packages/infra-otel"
+)
 
 fail() {
   printf 'ERROR: %s\n' "$1" >&2
@@ -39,6 +44,22 @@ validate_inputs() {
     true|false) ;;
     *) fail "DEPLOY_NGINX must be true or false" ;;
   esac
+}
+
+resolve_commit_metadata() {
+  COMMIT_SHA_VALUE="${GITHUB_SHA:-}"
+  COMMIT_MESSAGE_VALUE="${GITHUB_COMMIT_MESSAGE:-}"
+
+  if [[ -z "${COMMIT_SHA_VALUE}" ]]; then
+    COMMIT_SHA_VALUE="$(git rev-parse HEAD)"
+  fi
+
+  if [[ -z "${COMMIT_MESSAGE_VALUE}" ]]; then
+    COMMIT_MESSAGE_VALUE="$(git log -1 --pretty=%s)"
+  fi
+
+  [[ -n "${COMMIT_SHA_VALUE}" ]] || fail "Could not resolve COMMIT_SHA"
+  [[ -n "${COMMIT_MESSAGE_VALUE}" ]] || fail "Could not resolve COMMIT_MESSAGE"
 }
 
 setup_ssh() {
@@ -90,10 +111,29 @@ sync_repo() {
     ./ "${REMOTE_USER}@${HETZNER_PROD_HOST}:${REMOTE_REPO_DIR%/}/"
 }
 
+cleanup_retired_remote_paths() {
+  local path=""
+  local path_quoted=""
+
+  for path in "${RETIRED_REMOTE_PATHS[@]}"; do
+    printf -v path_quoted '%q' "${path}"
+    run_remote "if [[ -e ${path_quoted} || -L ${path_quoted} ]]; then printf 'Removing retired remote path: %s\n' ${path_quoted}; rm -rf -- ${path_quoted}; fi"
+  done
+}
+
+run_remote_deploy_web() {
+  local commit_sha_quoted=""
+  local commit_message_quoted=""
+
+  printf -v commit_sha_quoted '%q' "${COMMIT_SHA_VALUE}"
+  printf -v commit_message_quoted '%q' "${COMMIT_MESSAGE_VALUE}"
+  run_remote "COMMIT_SHA=${commit_sha_quoted} COMMIT_MESSAGE=${commit_message_quoted} INTEXURAOS_ENVIRONMENT=prod bash scripts/hetzner/deploy-web.sh"
+}
+
 deploy_runtime() {
   run_remote 'sudo -n INTEXURAOS_ENVIRONMENT=prod bash scripts/hetzner/load-secrets.sh'
   run_remote 'CI=true pnpm install --frozen-lockfile'
-  run_remote 'INTEXURAOS_ENVIRONMENT=prod bash scripts/hetzner/deploy-web.sh'
+  run_remote_deploy_web
   run_remote 'INTEXURAOS_ENVIRONMENT=prod bash scripts/hetzner/reload-pm2.sh'
 
   if [[ "${DEPLOY_NGINX}" == "true" ]]; then
@@ -120,9 +160,12 @@ main() {
   require_command rsync
   require_command ssh
   require_command ssh-keyscan
+  require_command git
   validate_inputs
+  resolve_commit_metadata
   setup_ssh
   sync_repo
+  cleanup_retired_remote_paths
   deploy_runtime
   verify_deployment
 

--- a/terraform/hetzner-prod/bootstrap.tf
+++ b/terraform/hetzner-prod/bootstrap.tf
@@ -94,7 +94,24 @@ resource "terraform_data" "bootstrap_prod" {
     inline = [
       "cd /opt/intexuraos && INTEXURAOS_ENVIRONMENT=prod bash scripts/hetzner/provision.sh --skip-certbot",
       "sudo -iu deploy bash -lc 'cd /opt/intexuraos && CI=true pnpm install --frozen-lockfile'",
-      "sudo -iu deploy bash -lc 'cd /opt/intexuraos && INTEXURAOS_ENVIRONMENT=prod bash scripts/hetzner/deploy-web.sh'",
+    ]
+  }
+
+  provisioner "local-exec" {
+    interpreter = ["/usr/bin/env", "bash", "-lc"]
+    command     = <<-EOT
+      set -euo pipefail
+      commit_sha="$(git -C '${local.repo_root}' rev-parse HEAD)"
+      commit_message="$(git -C '${local.repo_root}' log -1 --pretty=%s)"
+      printf -v commit_sha_quoted '%q' "$commit_sha"
+      printf -v commit_message_quoted '%q' "$commit_message"
+      ssh ${local.ssh_common_args} deploy@${hcloud_primary_ip.prod_ipv4.ip_address} \
+        "cd /opt/intexuraos && COMMIT_SHA=$commit_sha_quoted COMMIT_MESSAGE=$commit_message_quoted INTEXURAOS_ENVIRONMENT=prod bash scripts/hetzner/deploy-web.sh"
+    EOT
+  }
+
+  provisioner "remote-exec" {
+    inline = [
       "sudo -iu deploy bash -lc 'cd /opt/intexuraos && INTEXURAOS_ENVIRONMENT=prod bash scripts/hetzner/reload-pm2.sh'",
       "cd /opt/intexuraos && INTEXURAOS_ENVIRONMENT=prod bash scripts/hetzner/deploy-nginx.sh",
     ]


### PR DESCRIPTION
Fixes INT-1637

## Summary
- Adds a Hetzner deploy cleanup step for retired remote paths so deleted packages are removed from `/opt/intexuraos` after rsync.
- Passes `COMMIT_SHA` and `COMMIT_MESSAGE` into remote web builds from both GitHub Actions deploys and Terraform bootstrap runs while keeping `.git/` excluded from the server sync.
- Installs nginx `variables_hash_*` sizing through `scripts/hetzner/deploy-nginx.sh` in `/etc/nginx/conf.d/intexuraos-hash.conf`, before `nginx -t` and reload.

## Justification
This is a follow-up to the Hetzner migration deployment failure analysis. The migrated services do not need new GCP deployment behavior here; this PR only tightens the Hetzner deployment path so production deploys and fresh Terraform bootstraps are reproducible and do not retain removed runtime files.

## Terraform impact
`terraform -chdir=terraform/hetzner-prod plan -no-color -input=false` is valid and shows only `terraform_data.bootstrap_prod[0]` replacement from the bootstrap source hash. It does not force replacement of `hcloud_server.prod`.

## Validation
- `pnpm vitest run scripts/__tests__/hetzner-runtime.test.ts`
- `pnpm vitest run scripts/__tests__/otel-removal.test.ts`
- `bash -n scripts/hetzner/github-actions-deploy.sh scripts/hetzner/deploy-web.sh scripts/hetzner/deploy-nginx.sh`
- `terraform -chdir=terraform/hetzner-prod fmt -check`
- `STORAGE_EMULATOR_HOST= FIRESTORE_EMULATOR_HOST= PUBSUB_EMULATOR_HOST= GOOGLE_APPLICATION_CREDENTIALS=$HOME/.config/gcloud/sa-key.json terraform -chdir=terraform/hetzner-prod validate -no-color`
- `STORAGE_EMULATOR_HOST= FIRESTORE_EMULATOR_HOST= PUBSUB_EMULATOR_HOST= GOOGLE_APPLICATION_CREDENTIALS=$HOME/.config/gcloud/sa-key.json terraform -chdir=terraform/hetzner-prod plan -no-color -input=false`
- `pnpm run ci:tracked`
