### PR TITLE
Fix mobile notifications webhook docs

### DIFF
--- a/apps/mobile-notifications-service/src/domain/notifications/ports/notificationRepository.ts
+++ b/apps/mobile-notifications-service/src/domain/notifications/ports/notificationRepository.ts
@@ -22,9 +22,9 @@ export interface FilterOptions {
   source?: string[];
   app?: string[];
   title?: string;
-  /** Inclusive lower bound on notification `timestamp` (stored as milliseconds). Unit: seconds. */
+  /** Inclusive lower bound on notification `timestamp` (stored as Unix seconds). */
   postTimeSecFrom?: number;
-  /** Exclusive upper bound on notification `timestamp`. Unit: seconds. */
+  /** Exclusive upper bound on notification `timestamp` (stored as Unix seconds). */
   postTimeSecTo?: number;
 }
 

--- a/docs/services/mobile-notifications-service/agent.md
+++ b/docs/services/mobile-notifications-service/agent.md
@@ -12,6 +12,7 @@
 | Role      | Mobile notification capture, storage, and WhatsApp group digest generation                                                 |
 | Goal      | Capture device notifications, query them for analysis, and produce AI-generated daily digests from WhatsApp group messages |
 | Port      | 8114                                                                                                                       |
+| Public URL | `https://intexuraos.cloud/api/notifications`                                                                              |
 
 ---
 
@@ -119,7 +120,7 @@ interface MobileNotification {
   app: string;
   title: string;
   text: string;
-  timestamp: number;   // Unix milliseconds from device
+  timestamp: number;   // Unix seconds from device
   postTime: string;
   receivedAt: string;  // ISO 8601 server-side receipt time
 }
@@ -171,6 +172,8 @@ interface StatusOutput {
 
 **Endpoint:** `POST /webhooks`
 
+**Public URL:** `https://intexuraos.cloud/api/notifications/webhooks`
+
 **When to use:** Called by mobile automation apps (Tasker/Automate) to forward device notifications.
 
 **Auth:** `X-Mobile-Notifications-Signature` header (plaintext — hashed server-side)
@@ -185,8 +188,8 @@ interface WebhookPayload {
   notification_id: string;
   title: string;
   text: string;
-  timestamp: number;
-  post_time: string;
+  timestamp: number;   // Unix seconds from device
+  post_time: string;   // Unix seconds as string
 }
 ```
 

--- a/docs/services/mobile-notifications-service/technical.md
+++ b/docs/services/mobile-notifications-service/technical.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Mobile-notifications-service receives push notification data from Android devices via webhook, validates device signatures using SHA-256 hash comparison, deduplicates notifications, and stores them in Firestore. It also runs a WhatsApp group digest pipeline that aggregates daily messages into AI-generated summaries using LLM calls, persists group state across days, and delivers digest-ready notifications via Pub/Sub to WhatsApp. Runs on Cloud Run with Fastify. Local port: 8114.
+Mobile-notifications-service receives push notification data from Android devices via webhook, validates device signatures using SHA-256 hash comparison, deduplicates notifications, and stores them in Firestore. It also runs a WhatsApp group digest pipeline that aggregates daily messages into AI-generated summaries using LLM calls, persists group state across days, and delivers digest-ready notifications via Pub/Sub to WhatsApp. Production runs behind Hetzner nginx at `https://intexuraos.cloud/api/notifications`; development runs at `https://dev.intexuraos.cloud/api/notifications`. Service port: 8114.
 
 ## Architecture
 
@@ -67,7 +67,7 @@ sequenceDiagram
     participant Firestore
 
     Device->>Tasker: Notification event
-    Tasker->>+Service: POST /webhooks (signature header)
+    Tasker->>+Service: POST /api/notifications/webhooks (signature header)
     Service->>Service: SHA-256 hash signature
     Service->>Firestore: Lookup signatureHash
     Firestore-->>Service: SignatureConnection (userId)
@@ -202,8 +202,8 @@ interface WebhookPayload {
   notification_id: string; // Idempotency key (unique per user)
   title: string;           // Notification title
   text: string;            // Notification body/content
-  timestamp: number;       // Unix milliseconds from device
-  post_time: string;       // Post time string from device
+  timestamp: number;       // Unix seconds from device
+  post_time: string;       // Unix seconds as string from device
 }
 ```
 
@@ -248,8 +248,8 @@ Internal response maps `text` to `body` and `receivedAt` to `timestamp` for comp
 | `app`            | string | App package name                       |
 | `title`          | string | Notification title                     |
 | `text`           | string | Notification body content              |
-| `timestamp`      | number | Unix milliseconds from device          |
-| `postTime`       | string | Post time string from device           |
+| `timestamp`      | number | Unix seconds from device               |
+| `postTime`       | string | Unix seconds as string from device     |
 | `receivedAt`     | string | ISO 8601 server-side receipt timestamp |
 | `notificationId` | string | Idempotency key (device-provided)      |
 
@@ -432,7 +432,7 @@ After changing digest prompt language behavior, rerun the affected date range th
 
 - **Digest subscriptions are hard-coded** — `DIGEST_SUBSCRIPTIONS` is a constant array in `digestSubscriptions.ts`. Adding a group requires a code change.
 
-- **run-yesterday dual auth** — The daily cron endpoint accepts both OIDC Bearer tokens (Cloud Scheduler) and `x-internal-auth` header (direct internal calls). The OIDC check validates JWT structure as defence-in-depth; actual Cloud Run IAM binding handles the primary auth.
+- **run-yesterday dual auth** — The daily cron endpoint accepts both OIDC Bearer tokens (Cloud Scheduler) and `x-internal-auth` header (direct internal calls). Production nginx verifies scheduler OIDC tokens at the edge for `/internal/notifications/*`.
 
 - **Backfill chain self-calls** — Backfill uses `INTEXURAOS_MOBILE_NOTIFICATIONS_SERVICE_URL` to POST to itself. If the URL is misconfigured, backfill silently fails after the first day.
 

--- a/docs/services/mobile-notifications-service/tutorial.md
+++ b/docs/services/mobile-notifications-service/tutorial.md
@@ -26,9 +26,13 @@ Before starting, ensure you have:
 - [ ] Auth0 access token (Bearer JWT) for public endpoints
 - [ ] Internal auth token (for internal query endpoint only)
 - [ ] Android device with Tasker or Automate installed
-- [ ] Access to the IntexuraOS environment (local or Cloud Run)
+- [ ] Access to the IntexuraOS production or development environment
 
-**Base URL (local):** `http://localhost:8114`
+```bash
+export BASE_URL="https://intexuraos.cloud/api/notifications"
+# Development environment:
+# export BASE_URL="https://dev.intexuraos.cloud/api/notifications"
+```
 
 ---
 
@@ -39,7 +43,7 @@ Register your device to receive a signature token.
 ### Step 1.1: Create a Connection
 
 ```bash
-curl -X POST http://localhost:8114/connect \
+curl -X POST "$BASE_URL/connect" \
   -H "Authorization: Bearer YOUR_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
@@ -64,7 +68,7 @@ curl -X POST http://localhost:8114/connect \
 ### Step 1.2: Verify Connection Status
 
 ```bash
-curl http://localhost:8114/status \
+curl "$BASE_URL/status" \
   -H "Authorization: Bearer YOUR_TOKEN"
 ```
 
@@ -95,7 +99,7 @@ Simulate what Tasker/Automate sends when a notification appears on your device.
 ### Step 2.1: Post to the Webhook
 
 ```bash
-curl -X POST http://localhost:8114/webhooks \
+curl -X POST "$BASE_URL/webhooks" \
   -H "X-Mobile-Notifications-Signature: a1b2c3d4e5f6...your-signature-here" \
   -H "Content-Type: application/json" \
   -d '{
@@ -105,8 +109,8 @@ curl -X POST http://localhost:8114/webhooks \
     "notification_id": "test-notif-001",
     "title": "Alice: hey!",
     "text": "are you free tonight?",
-    "timestamp": 1708345200000,
-    "post_time": "2026-02-22 12:00:00"
+    "timestamp": 1771761600,
+    "post_time": "1771761600"
   }'
 ```
 
@@ -127,7 +131,7 @@ curl -X POST http://localhost:8114/webhooks \
 Send the same request again with the same `notification_id`:
 
 ```bash
-curl -X POST http://localhost:8114/webhooks \
+curl -X POST "$BASE_URL/webhooks" \
   -H "X-Mobile-Notifications-Signature: a1b2c3d4e5f6...your-signature-here" \
   -H "Content-Type: application/json" \
   -d '{
@@ -137,8 +141,8 @@ curl -X POST http://localhost:8114/webhooks \
     "notification_id": "test-notif-001",
     "title": "Alice: hey!",
     "text": "are you free tonight?",
-    "timestamp": 1708345200000,
-    "post_time": "2026-02-22 12:00:00"
+    "timestamp": 1771761600,
+    "post_time": "1771761600"
   }'
 ```
 
@@ -165,7 +169,7 @@ The duplicate is silently ignored. No error, no duplicate entry.
 ### Step 3.1: List All Notifications
 
 ```bash
-curl "http://localhost:8114/" \
+curl "$BASE_URL/" \
   -H "Authorization: Bearer YOUR_TOKEN"
 ```
 
@@ -183,8 +187,8 @@ curl "http://localhost:8114/" \
         "app": "com.whatsapp",
         "title": "Alice: hey!",
         "text": "are you free tonight?",
-        "timestamp": 1708345200000,
-        "postTime": "2026-02-22 12:00:00",
+        "timestamp": 1771761600,
+        "postTime": "1771761600",
         "receivedAt": "2026-02-22T12:00:00.123Z"
       }
     ]
@@ -195,7 +199,7 @@ curl "http://localhost:8114/" \
 ### Step 3.2: Filter by App
 
 ```bash
-curl "http://localhost:8114/mobile-notifications?app=com.whatsapp" \
+curl "$BASE_URL/?app=com.whatsapp" \
   -H "Authorization: Bearer YOUR_TOKEN"
 ```
 
@@ -204,7 +208,7 @@ Multiple apps use comma separation: `?app=com.whatsapp,com.telegram`
 ### Step 3.3: Search by Title
 
 ```bash
-curl "http://localhost:8114/mobile-notifications?title=alice" \
+curl "$BASE_URL/?title=alice" \
   -H "Authorization: Bearer YOUR_TOKEN"
 ```
 
@@ -213,14 +217,14 @@ Title search is case-insensitive partial match performed in memory after the Fir
 ### Step 3.4: Paginate Results
 
 ```bash
-curl "http://localhost:8114/mobile-notifications?limit=2" \
+curl "$BASE_URL/?limit=2" \
   -H "Authorization: Bearer YOUR_TOKEN"
 ```
 
 If the response includes `nextCursor`, pass it to get the next page:
 
 ```bash
-curl "http://localhost:8114/mobile-notifications?limit=2&cursor=CURSOR_VALUE" \
+curl "$BASE_URL/?limit=2&cursor=CURSOR_VALUE" \
   -H "Authorization: Bearer YOUR_TOKEN"
 ```
 
@@ -231,7 +235,7 @@ curl "http://localhost:8114/mobile-notifications?limit=2&cursor=CURSOR_VALUE" \
 ### Step 4.1: View Available Filter Options
 
 ```bash
-curl "http://localhost:8114/filters" \
+curl "$BASE_URL/filters" \
   -H "Authorization: Bearer YOUR_TOKEN"
 ```
 
@@ -259,7 +263,7 @@ The `options` arrays auto-populate from received notifications as they arrive.
 ### Step 4.2: Create a Saved Filter
 
 ```bash
-curl -X POST "http://localhost:8114/filters/saved" \
+curl -X POST "$BASE_URL/filters/saved" \
   -H "Authorization: Bearer YOUR_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
@@ -285,7 +289,7 @@ curl -X POST "http://localhost:8114/filters/saved" \
 ### Step 4.3: Delete a Saved Filter
 
 ```bash
-curl -X DELETE "http://localhost:8114/filters/saved/uuid-of-saved-filter" \
+curl -X DELETE "$BASE_URL/filters/saved/uuid-of-saved-filter" \
   -H "Authorization: Bearer YOUR_TOKEN"
 ```
 
@@ -300,7 +304,7 @@ If the digest pipeline is configured for your user and group, you can browse AI-
 ### Step 5.1: List Digests for a Date Range
 
 ```bash
-curl "http://localhost:8114/digests?groupKey=my-group&fromDate=2026-04-14&toDate=2026-04-21&limit=7" \
+curl "$BASE_URL/digests?groupKey=my-group&fromDate=2026-04-14&toDate=2026-04-21&limit=7" \
   -H "Authorization: Bearer YOUR_TOKEN"
 ```
 
@@ -339,7 +343,7 @@ curl "http://localhost:8114/digests?groupKey=my-group&fromDate=2026-04-14&toDate
 ### Step 5.2: Get a Single Digest
 
 ```bash
-curl "http://localhost:8114/digests/my-group/2026-04-21" \
+curl "$BASE_URL/digests/my-group/2026-04-21" \
   -H "Authorization: Bearer YOUR_TOKEN"
 ```
 
@@ -348,7 +352,7 @@ Returns the full digest for that specific day, or 404 if none exists.
 ### Step 5.3: Regenerate a Digest
 
 ```bash
-curl -X POST "http://localhost:8114/digests/run" \
+curl -X POST "$BASE_URL/digests/run" \
   -H "Authorization: Bearer YOUR_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
@@ -379,7 +383,7 @@ The `generation` field increments on each regeneration. WhatsApp notifications a
 ## Part 6: Delete a Notification (2 minutes)
 
 ```bash
-curl -X DELETE "http://localhost:8114/firestore-doc-id" \
+curl -X DELETE "$BASE_URL/firestore-doc-id" \
   -H "Authorization: Bearer YOUR_TOKEN"
 ```
 
@@ -401,9 +405,9 @@ Returns 404 if not found, 403 if the notification belongs to another user.
 ### Missing Signature Header
 
 ```bash
-curl -X POST http://localhost:8114/webhooks \
+curl -X POST "$BASE_URL/webhooks" \
   -H "Content-Type: application/json" \
-  -d '{ "source": "tasker", "device": "Test", "app": "com.test", "notification_id": "1", "title": "t", "text": "b", "timestamp": 0, "post_time": "now" }'
+  -d '{ "source": "tasker", "device": "Test", "app": "com.test", "notification_id": "1", "title": "t", "text": "b", "timestamp": 0, "post_time": "0" }'
 ```
 
 **Response (400):**
@@ -490,20 +494,20 @@ Test your understanding:
 
 ```bash
 # Connect
-curl -X POST http://localhost:8114/connect \
+curl -X POST "$BASE_URL/connect" \
   -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
   -d '{"deviceLabel": "Test Device"}'
 
 # Save the signature from the response, then send 3 notifications from different apps
 for APP in com.whatsapp com.telegram com.slack; do
-  curl -X POST http://localhost:8114/webhooks \
+  curl -X POST "$BASE_URL/webhooks" \
     -H "X-Mobile-Notifications-Signature: $SIGNATURE" \
     -H "Content-Type: application/json" \
-    -d "{\"source\":\"tasker\",\"device\":\"Test\",\"app\":\"$APP\",\"notification_id\":\"$APP-001\",\"title\":\"Test\",\"text\":\"Hello\",\"timestamp\":$(date +%s)000,\"post_time\":\"$(date)\"}"
+    -d "{\"source\":\"tasker\",\"device\":\"Test\",\"app\":\"$APP\",\"notification_id\":\"$APP-001\",\"title\":\"Test\",\"text\":\"Hello\",\"timestamp\":$(date +%s),\"post_time\":\"$(date +%s)\"}"
 done
 
 # Filter by one app
-curl "http://localhost:8114/mobile-notifications?app=com.whatsapp" \
+curl "$BASE_URL/?app=com.whatsapp" \
   -H "Authorization: Bearer $TOKEN"
 ```
 
@@ -511,24 +515,24 @@ curl "http://localhost:8114/mobile-notifications?app=com.whatsapp" \
 
 ```bash
 # List with limit=2
-curl "http://localhost:8114/mobile-notifications?limit=2" -H "Authorization: Bearer $TOKEN"
+curl "$BASE_URL/?limit=2" -H "Authorization: Bearer $TOKEN"
 # Copy nextCursor from response, then get next page
-curl "http://localhost:8114/mobile-notifications?limit=2&cursor=CURSOR" -H "Authorization: Bearer $TOKEN"
+curl "$BASE_URL/?limit=2&cursor=CURSOR" -H "Authorization: Bearer $TOKEN"
 ```
 
 ### Exercise 3: Saved Filters
 
 ```bash
 # Create saved filter
-curl -X POST "http://localhost:8114/filters/saved" \
+curl -X POST "$BASE_URL/filters/saved" \
   -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
   -d '{"name":"Messaging","app":["com.whatsapp","com.telegram"]}'
 
 # Verify it appears
-curl "http://localhost:8114/filters" -H "Authorization: Bearer $TOKEN"
+curl "$BASE_URL/filters" -H "Authorization: Bearer $TOKEN"
 
 # Delete it (use the id from the create response)
-curl -X DELETE "http://localhost:8114/filters/saved/FILTER_ID" \
+curl -X DELETE "$BASE_URL/filters/saved/FILTER_ID" \
   -H "Authorization: Bearer $TOKEN"
 ```
 

--- a/docs/setup/08-mobile-notifications-xiaomi.md
+++ b/docs/setup/08-mobile-notifications-xiaomi.md
@@ -122,7 +122,8 @@ This task handles data transmission to the backend with error handling and local
 ### 5.2. HTTP Request Configuration
 
 - **Method:** `POST`
-- **URL:** `https://YOUR_SERVICE_URL/mobile-notifications/webhooks`
+- **Production URL:** `https://intexuraos.cloud/api/notifications/webhooks`
+- **Development URL:** `https://dev.intexuraos.cloud/api/notifications/webhooks`
 - **Headers:**
   - `Content-Type: application/json`
   - `X-Mobile-Notifications-Signature: YOUR_SIGNATURE`
@@ -137,6 +138,7 @@ To prevent WhatsApp updates from being treated as duplicates, the `notification_
   "device": "redmi-note-13-pro",
   "timestamp": %TIMES,
   "notification_id": "%ankey_%TIMES",
+  "post_time": "%TIMES",
   "app": "%anpackage",
   "title": "%antitle",
   "text": "%antext"
@@ -147,13 +149,13 @@ To prevent WhatsApp updates from being treated as duplicates, the `notification_
 
 **Variables:**
 
-| Variable     | Description                                 |
-| ------------ | ------------------------------------------- |  |  |
-| `%TIMES`     | Current Unix timestamp (seconds)            |
-| `%ankey`     | Unique notification key (e.g., `0\          | com.whatsapp.w4b\ | 101...`) |
-| `%anpackage` | App package name (e.g., `com.whatsapp.w4b`) |
-| `%antitle`   | Notification title (sanitized)              |
-| `%antext`    | Notification text content (sanitized)       |
+| Variable     | Description                                                  |
+| ------------ | ------------------------------------------------------------ |
+| `%TIMES`     | Current Unix timestamp in seconds; send it as both numeric `timestamp` and string `post_time` |
+| `%ankey`     | Unique notification key (for example, `0|com.whatsapp.w4b|101...`) |
+| `%anpackage` | App package name (for example, `com.whatsapp.w4b`)           |
+| `%antitle`   | Notification title (sanitized)                               |
+| `%antext`    | Notification text content (sanitized)                        |
 
 ---
 
@@ -192,7 +194,7 @@ To ensure the service remains alive on HyperOS:
 
 1. Log in to IntexuraOS web app.
 2. Navigate to **Mobile Notifications** in the sidebar.
-3. Click **Connect Device** and follow the instructions.
+3. Click **Generate Signature** and follow the instructions.
 4. Copy the generated signature and paste it into your Tasker HTTP Request header.
 
 **Important:** The signature is only shown once. If you lose it, you'll need to disconnect and reconnect to generate a new one.


### PR DESCRIPTION
## Summary

- Updates the mobile notifications setup guide to use the production and development public webhook URLs:
  - `https://intexuraos.cloud/api/notifications/webhooks`
  - `https://dev.intexuraos.cloud/api/notifications/webhooks`
- Updates the mobile notifications service tutorial to use `BASE_URL=https://intexuraos.cloud/api/notifications` instead of stale local or `/mobile-notifications` examples.
- Aligns webhook payload examples and technical docs with the current contract: `timestamp` is Unix seconds and `post_time` is Unix seconds as a string.
- Corrects the repository port comment for timestamp range filters to match the Unix-seconds implementation.

## Root Cause

The active mobile-notifications docs still mixed older local/service-local URL examples with the current Hetzner public API prefix. The setup guide also omitted required `post_time` from the Tasker payload, and several docs still described the device timestamp as milliseconds even though the implementation stores and filters Unix seconds.

## Validation

- `rg -n "YOUR_SERVICE_URL|localhost:8114|/mobile-notifications\\?|api/mobile-notifications|mobile-notifications/webhooks|Unix milliseconds|stored as milliseconds|local or Cloud Run|post_time\\\": \\\"now\\\"" docs/setup/08-mobile-notifications-xiaomi.md docs/services/mobile-notifications-service apps/mobile-notifications-service/src/domain/notifications/ports/notificationRepository.ts -S` returned no matches
- `git diff --check`
- `pnpm run verify:workspace:tracked mobile-notifications-service` passed, including 18,104 tests
- `pnpm run ci:tracked` passed, including 18,104 tests, static validation, build, format, and post-build checks
