### PR TITLE
[INT-1646] Fix Hetzner PR triage provisioning

### DIFF
--- a/docs/operations/hetzner-prod-runbook.md
+++ b/docs/operations/hetzner-prod-runbook.md
@@ -86,8 +86,18 @@ INTEXURAOS_ENVIRONMENT=prod bash scripts/hetzner/provision.sh --email ops@exampl
 ```
 
 Provisioning installs Node 22, PM2, Google Cloud CLI, nginx with Lua support,
-certbot with the Cloudflare DNS plugin, loads secrets, installs certificates,
-and deploys the nginx config.
+`lua-cjson`, certbot with the Cloudflare DNS plugin, loads secrets, installs
+certificates, and deploys the nginx config. A provisioned host must pass the
+nginx JWT Lua dependency check before nginx is reloaded:
+
+```bash
+lua5.1 <<'LUA'
+local ok, cjson = pcall(require, "cjson.safe")
+if not ok or cjson == nil then error("missing cjson.safe") end
+local loader, err = package.loaders[2]("resty.openidc")
+if type(loader) ~= "function" then error(err or "missing resty.openidc") end
+LUA
+```
 
 Certbot uses `INTEXURAOS_CLOUDFLARE_DNS_API_TOKEN`, a dedicated Cloudflare
 token with Zone DNS Edit permission for the `intexuraos.cloud` zone. Do not
@@ -143,7 +153,8 @@ Sentry values plus generated public API paths, so ignored local env files
 cannot leak backend secrets into Vite.
 `reload-pm2.sh` renders the CommonJS ecosystem config to a private JSON file
 before starting PM2, because PM2 treats `ecosystem.config.prod.cjs` as a plain
-script on the Hetzner host. `deploy-nginx.sh` runs `nginx -t` before reload. If the VM is not available,
+script on the Hetzner host. `deploy-nginx.sh` verifies `cjson.safe` and
+`resty.openidc`, then runs `nginx -t` before reload. If the VM is not available,
 validate an equivalent generated config in a container or staging VM that has
 nginx Lua/OpenResty modules installed, then record the command output in the
 cutover notes.
@@ -221,6 +232,54 @@ On 2026-05-31 this check destroyed server `134626820`, created server
 `134635829`, retained primary IPv4 `162.55.210.48`, completed Terraform
 bootstrap, and a follow-up `terraform -chdir=terraform/hetzner-prod plan`
 reported no changes.
+
+For runtime-dependency fixes, run two consecutive replacement cycles. After
+each cycle, verify:
+
+```bash
+ssh -i ~/.ssh/intexuraos_hetzner_deploy deploy@162.55.210.48 \
+  'lua5.1 -e '\''local ok,cjson=pcall(require,"cjson.safe"); if not ok or cjson == nil then error("missing cjson.safe") end; local loader,err=package.loaders[2]("resty.openidc"); if type(loader) ~= "function" then error(err or "missing resty.openidc") end'\'' && sudo nginx -t && pm2 status'
+
+curl --fail --silent --show-error --max-time 15 \
+  --resolve intexuraos.cloud:443:162.55.210.48 \
+  https://intexuraos.cloud/healthz
+
+STORAGE_EMULATOR_HOST= FIRESTORE_EMULATOR_HOST= PUBSUB_EMULATOR_HOST= \
+GOOGLE_APPLICATION_CREDENTIALS=$HOME/.config/gcloud/sa-key.json \
+terraform -chdir=terraform/hetzner-prod plan -detailed-exitcode
+```
+
+The final `plan -detailed-exitcode` must return `0`.
+
+## PR Triage Replay
+
+After repairing the Hetzner internal edge, replay a stuck PR-triage event by
+publishing a `code.pr.triage.requested` message whose `eventId` is the
+normalized `github-pr-events` document id:
+
+```bash
+PR_TRIAGE_PAYLOAD="$(
+  node - <<'NODE'
+process.stdout.write(JSON.stringify({
+  type: 'code.pr.triage.requested',
+  eventId: 'f5fc5d26-97d8-41a5-998e-a87205496d0f',
+  repository: 'pbuchman/intexuraos',
+  pullRequestNumber: 2113,
+  correlationId: 'manual-replay-pr-2113',
+  timestamp: new Date().toISOString(),
+}));
+NODE
+)"
+
+GOOGLE_APPLICATION_CREDENTIALS=$HOME/.config/gcloud/sa-key.json \
+gcloud pubsub topics publish intexuraos-pr-triage-dev \
+  --project=intexuraos-dev-pbuchman \
+  --message="${PR_TRIAGE_PAYLOAD}"
+```
+
+For PR `2113`, verify `github-event-log-entries/RnT6AeqqF2o2zrVPvadO` moves to
+`decisionState: completed`, `event_decisions/ed_RnT6AeqqF2o2zrVPvadO` exists,
+and the expected code-task or explicit skip decision is visible.
 
 ## Async Edge Cutover
 

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -10,6 +10,9 @@
  */
 const { COMMON_SERVICE_URLS_GENERATED } = require('./ecosystem.generated.cjs');
 
+const PM2_BASE_ENV = { ...process.env };
+delete PM2_BASE_ENV.NODE_OPTIONS;
+
 // Common auth secrets for all services (mirrors Terraform local.common_service_secrets)
 const COMMON_SERVICE_ENV = {
   HOME: process.env.HOME ?? '/root',
@@ -223,7 +226,7 @@ function createServiceConfig(name, port, options = {}) {
     script: TSX_CLI,
     interpreter: 'node',
     env: {
-      ...process.env,
+      ...PM2_BASE_ENV,
       ...COMMON_SERVICE_ENV,
       ...COMMON_SERVICE_URLS,
       ...(SERVICE_ENV_MAPPINGS[name] ?? {}),
@@ -295,7 +298,7 @@ module.exports = {
       args: ['--mode', 'development'],
       interpreter: 'node',
       env: {
-        ...process.env,
+        ...PM2_BASE_ENV,
         ...COMMON_SERVICE_ENV,
         ...COMMON_SERVICE_URLS,
         NODE_ENV: 'development',

--- a/scripts/__tests__/ecosystem.config.test.ts
+++ b/scripts/__tests__/ecosystem.config.test.ts
@@ -80,6 +80,34 @@ function loadWhatsAppLinkProducerWebAppEnv(): Record<string, string | undefined>
   return JSON.parse(stdout.toString()) as Record<string, string | undefined>;
 }
 
+function loadInheritedNodeOptions(): Record<string, string | undefined> {
+  const stdout = execFileSync(
+    process.execPath,
+    [
+      '-e',
+      `
+        process.env.NODE_OPTIONS = process.env.FAKE_NODE_OPTIONS;
+        const config = require('./ecosystem.config.cjs');
+        const result = {};
+        for (const app of config.apps) {
+          result[app.name] = app.env.NODE_OPTIONS;
+        }
+        process.stdout.write(JSON.stringify(result));
+      `,
+    ],
+    {
+      cwd: process.cwd(),
+      env: {
+        HOME: process.env.HOME ?? '/tmp',
+        PATH: process.env.PATH ?? '',
+        FAKE_NODE_OPTIONS: '--import ./removed-preload/register',
+      },
+    }
+  );
+
+  return JSON.parse(stdout.toString()) as Record<string, string | undefined>;
+}
+
 describe('ecosystem.config.cjs', () => {
   it('uses home-dev Pub/Sub emulator aliases for whatsapp-service fallbacks', () => {
     expect(loadWhatsAppPubSubEnv()).toEqual({
@@ -101,5 +129,9 @@ describe('ecosystem.config.cjs', () => {
       'mobile-notifications-service': 'https://dev.intexuraos.cloud',
       'research-agent': 'https://dev.intexuraos.cloud',
     });
+  });
+
+  it('does not inherit NODE_OPTIONS into PM2 service environments', () => {
+    expect(loadInheritedNodeOptions()).toEqual({});
   });
 });

--- a/scripts/__tests__/hetzner-runtime.test.ts
+++ b/scripts/__tests__/hetzner-runtime.test.ts
@@ -57,6 +57,11 @@ const terraformHetznerProdAutoTfvarsPath = resolve(
   repoRoot,
   'terraform/hetzner-prod/prod.auto.tfvars.json'
 );
+const terraformMonitoringCodeTaskAlertsPath = resolve(
+  repoRoot,
+  'terraform/modules/monitoring/code-task-alerts.tf'
+);
+const terraformMonitoringOutputsPath = resolve(repoRoot, 'terraform/modules/monitoring/outputs.tf');
 const manifestPath = resolve(repoRoot, 'apps/web/service-manifest.json');
 const pnpmWorkspacePath = resolve(repoRoot, 'pnpm-workspace.yaml');
 
@@ -439,6 +444,48 @@ describe('Hetzner web asset deployment', () => {
     expect(deployFlow.indexOf('reload_nginx')).toBeGreaterThan(deployFlow.indexOf('nginx -t'));
     expect(siteConfig).not.toContain('variables_hash_max_size');
     expect(siteConfig).not.toContain('variables_hash_bucket_size');
+  });
+
+  it('installs and verifies Lua modules required by the nginx JWT verifier before reload', () => {
+    const jwtVerifier = readRequired(jwtVerifierPath);
+    const installNginx = readRequired(installNginxPath);
+    const provision = readRequired(provisionPath);
+    const deployNginx = readRequired(resolve(repoRoot, 'scripts/hetzner/deploy-nginx.sh'));
+
+    expect(jwtVerifier).toContain('require("cjson.safe")');
+    expect(jwtVerifier).toContain('require("resty.openidc")');
+    expect(installNginx).toContain('lua-cjson');
+    expect(provision).toContain('lua-cjson');
+    expect(deployNginx).toContain('verify_lua_jwt_dependencies()');
+    expect(deployNginx).toContain('lua5.1 <<');
+    expect(deployNginx).toContain('pcall(require, "cjson.safe")');
+    expect(deployNginx).toContain('package.loaders[2]("resty.openidc")');
+    expect(deployNginx).not.toContain('require("cjson.safe"); require("resty.openidc")');
+
+    const deployFlow = deployNginx.slice(deployNginx.indexOf('main() {'));
+    expect(deployFlow.indexOf('verify_lua_jwt_dependencies')).toBeGreaterThan(
+      deployFlow.indexOf('ln -sfn "${SITE_TARGET}" "${SITE_ENABLED}"')
+    );
+    expect(deployFlow.indexOf('nginx -t')).toBeGreaterThan(
+      deployFlow.indexOf('verify_lua_jwt_dependencies')
+    );
+    expect(deployFlow.indexOf('reload_nginx')).toBeGreaterThan(deployFlow.indexOf('nginx -t'));
+  });
+});
+
+describe('Code-task automation monitoring', () => {
+  it('alerts specifically when Hetzner PR-triage Pub/Sub push delivery fails', () => {
+    const alerts = readRequired(terraformMonitoringCodeTaskAlertsPath);
+    const outputs = readRequired(terraformMonitoringOutputsPath);
+
+    expect(alerts).toContain('code_pr_triage_hetzner_push_5xx');
+    expect(alerts).toContain('code_pr_triage_hetzner_backlog');
+    expect(alerts).toContain('intexuraos-pr-triage-prod-hetzner');
+    expect(alerts).toContain('pubsub.googleapis.com/subscription/push_request_count');
+    expect(alerts).toContain('metric.labels.response_class="remote_server_5xx"');
+    expect(alerts).toContain('pubsub.googleapis.com/subscription/num_undelivered_messages');
+    expect(outputs).toContain('code_pr_triage_hetzner_push_5xx');
+    expect(outputs).toContain('code_pr_triage_hetzner_backlog');
   });
 });
 

--- a/scripts/hetzner/deploy-nginx.sh
+++ b/scripts/hetzner/deploy-nginx.sh
@@ -76,6 +76,21 @@ EOF
   rm -f "${temp_file}"
 }
 
+verify_lua_jwt_dependencies() {
+  command -v lua5.1 >/dev/null 2>&1 || fail "lua5.1 is required for nginx JWT verification"
+  lua5.1 <<'LUA' || fail "nginx Lua JWT dependencies are missing"
+local ok, cjson = pcall(require, "cjson.safe")
+if not ok or cjson == nil then
+  error("missing cjson.safe")
+end
+
+local openidc_loader, openidc_error = package.loaders[2]("resty.openidc")
+if type(openidc_loader) ~= "function" then
+  error(openidc_error or "missing resty.openidc")
+end
+LUA
+}
+
 main() {
   parse_args "$@"
   require_prod
@@ -92,6 +107,7 @@ main() {
   ln -sfn "${SITE_TARGET}" "${SITE_ENABLED}"
   rm -f /etc/nginx/sites-enabled/default
 
+  verify_lua_jwt_dependencies
   nginx -t
   reload_nginx
 

--- a/scripts/hetzner/install-nginx-and-cert.sh
+++ b/scripts/hetzner/install-nginx-and-cert.sh
@@ -91,6 +91,7 @@ install_packages() {
     liblua5.1-0-dev \
     libnginx-mod-http-lua \
     lua5.1 \
+    lua-cjson \
     luarocks \
     nginx-extras \
     python3-certbot-dns-cloudflare

--- a/scripts/hetzner/provision.sh
+++ b/scripts/hetzner/provision.sh
@@ -89,6 +89,8 @@ install_base_packages() {
     gnupg \
     jq \
     libnginx-mod-http-lua \
+    lua5.1 \
+    lua-cjson \
     nginx-extras \
     rsync \
     ufw

--- a/terraform/modules/monitoring/code-task-alerts.tf
+++ b/terraform/modules/monitoring/code-task-alerts.tf
@@ -134,6 +134,99 @@ resource "google_monitoring_alert_policy" "code_tasks_failed_rate" {
 }
 
 # =============================================================================
+# ALERT: Hetzner PR Triage Push 5xx
+# Fires on any Pub/Sub push attempt to the Hetzner PR-triage consumer that the
+# remote server classifies as 5xx. This catches nginx-edge failures before the
+# low-volume automation path reaches the generic backlog threshold.
+# =============================================================================
+resource "google_monitoring_alert_policy" "code_pr_triage_hetzner_push_5xx" {
+  count        = var.alert_email != null ? 1 : 0
+  display_name = "Code PR Triage Hetzner Push 5xx"
+  combiner     = "OR"
+
+  documentation {
+    content   = "Pub/Sub push delivery to `intexuraos-pr-triage-prod-hetzner` is receiving remote 5xx responses. Check Hetzner nginx `/internal/code/pubsub/pr-triage` and code-agent logs."
+    mime_type = "text/markdown"
+  }
+
+  conditions {
+    display_name = "PR triage push remote_server_5xx > 0"
+    condition_threshold {
+      filter          = <<-EOT
+        resource.type="pubsub_subscription"
+        resource.label.subscription_id="intexuraos-pr-triage-prod-hetzner"
+        metric.type="pubsub.googleapis.com/subscription/push_request_count"
+        metric.labels.response_class="remote_server_5xx"
+      EOT
+      comparison      = "COMPARISON_GT"
+      threshold_value = 0
+      duration        = "60s"
+
+      aggregations {
+        alignment_period     = "60s"
+        per_series_aligner   = "ALIGN_SUM"
+        cross_series_reducer = "REDUCE_SUM"
+      }
+    }
+  }
+
+  notification_channels = concat(
+    [google_monitoring_notification_channel.email[0].name],
+    var.slack_auth_token != null ? [google_monitoring_notification_channel.slack[0].name] : [],
+  )
+
+  alert_strategy {
+    auto_close = "1800s"
+  }
+}
+
+# =============================================================================
+# ALERT: Hetzner PR Triage Backlog
+# Fires when the PR-triage subscription has unacked messages for 5 minutes.
+# The generic backlog alert is intentionally much higher and can miss this
+# low-volume automation path.
+# =============================================================================
+resource "google_monitoring_alert_policy" "code_pr_triage_hetzner_backlog" {
+  count        = var.alert_email != null ? 1 : 0
+  display_name = "Code PR Triage Hetzner Backlog"
+  combiner     = "OR"
+
+  documentation {
+    content   = "`intexuraos-pr-triage-prod-hetzner` has unacked messages for more than 5 minutes. Check Pub/Sub delivery attempts, DLQ state, and code-agent PR triage logs."
+    mime_type = "text/markdown"
+  }
+
+  conditions {
+    display_name = "PR triage unacked messages > 0"
+    condition_threshold {
+      filter          = <<-EOT
+        resource.type="pubsub_subscription"
+        resource.label.subscription_id="intexuraos-pr-triage-prod-hetzner"
+        metric.type="pubsub.googleapis.com/subscription/num_undelivered_messages"
+      EOT
+      comparison      = "COMPARISON_GT"
+      threshold_value = 0
+      duration        = "300s"
+
+      aggregations {
+        alignment_period     = "60s"
+        per_series_aligner   = "ALIGN_MEAN"
+        cross_series_reducer = "REDUCE_SUM"
+      }
+    }
+  }
+
+  notification_channels = concat(
+    [google_monitoring_notification_channel.email[0].name],
+    var.slack_auth_token != null ? [google_monitoring_notification_channel.slack[0].name] : [],
+  )
+
+  alert_strategy {
+    auto_close = "1800s"
+  }
+}
+
+# =============================================================================
 # ALERT: High Daily Cost
 # Triggers when daily code task cost exceeds $50
 # =============================================================================

--- a/terraform/modules/monitoring/outputs.tf
+++ b/terraform/modules/monitoring/outputs.tf
@@ -42,8 +42,10 @@ output "code_task_dashboard_id" {
 output "code_task_alert_policies" {
   description = "Code task alert policies"
   value = {
-    high_failure_rate  = var.alert_email != null ? try(google_monitoring_alert_policy.code_task_high_failure_rate[0].name, null) : null
-    high_daily_cost    = var.alert_email != null ? try(google_monitoring_alert_policy.code_task_high_daily_cost[0].name, null) : null
-    capacity_exhausted = var.alert_email != null ? try(google_monitoring_alert_policy.code_task_capacity_exhausted[0].name, null) : null
+    high_failure_rate               = var.alert_email != null ? try(google_monitoring_alert_policy.code_task_high_failure_rate[0].name, null) : null
+    high_daily_cost                 = var.alert_email != null ? try(google_monitoring_alert_policy.code_task_high_daily_cost[0].name, null) : null
+    capacity_exhausted              = var.alert_email != null ? try(google_monitoring_alert_policy.code_task_capacity_exhausted[0].name, null) : null
+    code_pr_triage_hetzner_push_5xx = var.alert_email != null ? try(google_monitoring_alert_policy.code_pr_triage_hetzner_push_5xx[0].name, null) : null
+    code_pr_triage_hetzner_backlog  = var.alert_email != null ? try(google_monitoring_alert_policy.code_pr_triage_hetzner_backlog[0].name, null) : null
   }
 }


### PR DESCRIPTION
## Summary

- Install the missing Lua runtime dependency needed by nginx JWT verification on Hetzner.
- Add a deploy-time Lua dependency check before nginx reloads.
- Prevent PM2 apps from inheriting stale NODE_OPTIONS preloads.
- Add PR-triage-specific Pub/Sub 5xx and backlog alert policies.
- Document the reprovision and PR-triage replay procedure.

## Root Cause

GitHub webhooks were received and normalized, but Pub/Sub push delivery to Hetzner /internal/code/pubsub/pr-triage failed because nginx Lua JWT verification required cjson.safe and lua-cjson was not installed by provisioning.

## Validation

- pnpm run ci:tracked passed with 18,107 tests.
- Two consecutive Hetzner replacement cycles completed successfully.
- Final terraform -chdir=terraform/hetzner-prod plan -detailed-exitcode returned 0.
- https://intexuraos.cloud/healthz returned ok after reprovision.
- On-host nginx -t passed and all 22 PM2 apps were online with no inherited NODE_OPTIONS.
- Pub/Sub pr-triage backlog drained to 0 and recent push attempts acked without 5xx.

## Operations

- Applied two targeted Cloud Monitoring alert policies for pr-triage 5xx and backlog.
- Avoided applying unrelated dev Terraform drift that wanted to destroy Dash0 resources.