### PR TITLE
[INT-1650] Improve code task dispatch failure handling

### DIFF
--- a/apps/code-agent/src/__tests__/domain/services/codeTaskDispatchBlockers.test.ts
+++ b/apps/code-agent/src/__tests__/domain/services/codeTaskDispatchBlockers.test.ts
@@ -122,14 +122,14 @@ describe('classifyCodeTaskDispatchability', () => {
       reason: 'workers_at_capacity',
     },
     {
-      name: 'codex auth unavailable',
+      name: 'codex auth unavailable when expired auth is not refreshable',
       workerType: 'codex-xhigh',
       workers: [worker('home-dev')],
       health: {
         'home-dev': healthy({
           workerAuths: {
             claude: { status: 'active' },
-            codex: { status: 'expired', message: 'Codex token expired' },
+            codex: { status: 'expired', refreshSupported: false, message: 'Codex token expired' },
           },
         }),
       },
@@ -218,6 +218,26 @@ describe('classifyCodeTaskDispatchability', () => {
     expect(result).toEqual({
       dispatchable: true,
       workerNames: ['ready'],
+    });
+  });
+
+  it('is dispatchable for Codex when expired auth can be refreshed by the worker', () => {
+    const result = classifyCodeTaskDispatchability({
+      workerType: 'codex-xhigh',
+      workers: [worker('refreshable-codex')],
+      healthByWorkerName: {
+        'refreshable-codex': healthy({
+          workerAuths: {
+            claude: { status: 'active' },
+            codex: { status: 'expired', refreshSupported: true, message: 'refresh available' },
+          },
+        }),
+      },
+    });
+
+    expect(result).toEqual({
+      dispatchable: true,
+      workerNames: ['refreshable-codex'],
     });
   });
 

--- a/apps/code-agent/src/__tests__/domain/services/codeTaskDispatchProblems.test.ts
+++ b/apps/code-agent/src/__tests__/domain/services/codeTaskDispatchProblems.test.ts
@@ -1,0 +1,463 @@
+import { describe, expect, it, vi } from 'vitest';
+import { err, ok } from '@intexuraos/common-core';
+import type { Logger } from '@intexuraos/common-core';
+import { Timestamp } from '@google-cloud/firestore';
+import type { CodeTask } from '../../../domain/models/codeTask.js';
+import {
+  buildDispatchStatusForProblem,
+  dispatchProblemFromError,
+  missingPrBranchDispatchProblem,
+  notifyDispatchProblemForTask,
+  taskErrorFromDispatchStatus,
+  type DispatchProblem,
+} from '../../../domain/services/codeTaskDispatchProblems.js';
+
+function createTask(overrides: Partial<CodeTask> = {}): CodeTask {
+  const now = Timestamp.fromDate(new Date('2026-06-06T10:00:00.000Z'));
+  return {
+    id: 'task-123',
+    userId: 'user-456',
+    traceId: 'trace-789',
+    prompt: 'Fix the bug',
+    sanitizedPrompt: 'Fix the bug',
+    systemPromptHash: 'hash',
+    workerType: 'auto',
+    workerLocation: 'pending',
+    repository: 'pbuchman/intexuraos',
+    baseBranch: 'development',
+    status: 'queued',
+    callbackReceived: false,
+    dedupKey: 'dedup-123',
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+function createLogger(): Logger {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  } as unknown as Logger;
+}
+
+describe('codeTaskDispatchProblems', () => {
+  it('builds missing PR branch task errors as terminal retryable failures', () => {
+    const problem = missingPrBranchDispatchProblem({ agentType: 'review', prNumber: 42 });
+    const status = buildDispatchStatusForProblem({
+      task: createTask(),
+      problem,
+      now: new Date('2026-06-06T11:00:00.000Z'),
+    });
+
+    expect(status).toEqual(expect.objectContaining({
+      state: 'terminal',
+      reason: 'missing_pr_branch',
+      terminal: true,
+      nextAction: 'retry_after_fix',
+      message: 'prBranch required for review task (PR #42)',
+    }));
+    expect(taskErrorFromDispatchStatus(status)).toEqual({
+      code: 'dispatch_blocked_missing_pr_branch',
+      message: 'prBranch required for review task (PR #42)',
+      remediation: {
+        action: 'retry',
+        manualSteps: 'Retry after the PR branch is available on the task payload.',
+      },
+    });
+  });
+
+  it('preserves firstSeenAt and notified reasons for repeated recoverable problems', () => {
+    const firstSeenAt = Timestamp.fromDate(new Date('2026-06-06T09:00:00.000Z'));
+    const notifiedAt = Timestamp.fromDate(new Date('2026-06-06T09:05:00.000Z'));
+    const problem: DispatchProblem = {
+      reason: 'worker_unavailable',
+      severity: 'warning',
+      message: 'Dispatch is temporarily blocked: no reachable worker',
+      remediation: 'The scheduler will retry this task automatically while workers recover.',
+      workerNames: [],
+      terminal: false,
+    };
+    const task = createTask({
+      dispatchStatus: {
+        state: 'waiting',
+        reason: 'worker_unavailable',
+        terminal: false,
+        severity: 'warning',
+        message: 'Previous worker outage',
+        remediation: 'Wait for recovery.',
+        workerNames: [],
+        firstSeenAt,
+        lastSeenAt: firstSeenAt,
+        nextAction: 'will_retry_automatically',
+        notifiedReasons: {
+          worker_unavailable: notifiedAt,
+        },
+      },
+    });
+
+    const status = buildDispatchStatusForProblem({
+      task,
+      problem,
+      now: new Date('2026-06-06T10:00:00.000Z'),
+    });
+
+    expect(status.firstSeenAt).toBe(firstSeenAt);
+    expect(status.notifiedReasons).toEqual({ worker_unavailable: notifiedAt });
+    expect(taskErrorFromDispatchStatus(status).remediation).toEqual(expect.objectContaining({
+      action: 'wait',
+    }));
+  });
+
+  it('uses recoverable messaging for retryable dispatch errors', () => {
+    expect(dispatchProblemFromError({ code: 'network_error', message: 'ECONNRESET' })).toEqual(
+      expect.objectContaining({
+        reason: 'network_error',
+        terminal: false,
+        severity: 'warning',
+        message: 'Dispatch is temporarily blocked: ECONNRESET',
+      }),
+    );
+  });
+
+  it('does not resend WhatsApp notifications for a reason already in the task ledger', async () => {
+    const problem: DispatchProblem = {
+      reason: 'queue_full',
+      severity: 'critical',
+      message: 'Queue is full.',
+      remediation: 'Try again later.',
+      workerNames: [],
+      terminal: true,
+    };
+    const dispatchStatus = buildDispatchStatusForProblem({
+      task: createTask({
+        dispatchStatus: {
+          state: 'terminal',
+          reason: 'queue_full',
+          terminal: true,
+          severity: 'critical',
+          message: 'Queue is full.',
+          remediation: 'Try again later.',
+          workerNames: [],
+          firstSeenAt: Timestamp.fromDate(new Date('2026-06-06T09:00:00.000Z')),
+          lastSeenAt: Timestamp.fromDate(new Date('2026-06-06T09:00:00.000Z')),
+          nextAction: 'retry_after_fix',
+          notifiedReasons: {
+            queue_full: Timestamp.fromDate(new Date('2026-06-06T09:01:00.000Z')),
+          },
+        },
+      }),
+      problem,
+    });
+    const whatsappNotifier = { notifyTaskDispatchBlocked: vi.fn() };
+    const codeTaskRepo = { update: vi.fn() };
+
+    await notifyDispatchProblemForTask({
+      task: createTask(),
+      dispatchStatus,
+      problem,
+      whatsappNotifier: whatsappNotifier as never,
+      codeTaskRepo: codeTaskRepo as never,
+      logger: createLogger(),
+      affectedTaskCount: 1,
+    });
+
+    expect(whatsappNotifier.notifyTaskDispatchBlocked).not.toHaveBeenCalled();
+    expect(codeTaskRepo.update).not.toHaveBeenCalled();
+  });
+
+  it('does not resurrect dispatchStatus when transactional ledger persistence sees a changed status', async () => {
+    const problem: DispatchProblem = {
+      reason: 'workers_at_capacity',
+      severity: 'warning',
+      message: 'All workers are busy.',
+      remediation: 'Wait for a worker.',
+      workerNames: ['home-mac'],
+      terminal: false,
+    };
+    const task = createTask();
+    const dispatchStatus = buildDispatchStatusForProblem({ task, problem });
+    const transaction = {} as never;
+    const whatsappNotifier = {
+      notifyTaskDispatchBlocked: vi.fn().mockResolvedValue(ok(undefined)),
+    };
+    const codeTaskRepo = {
+      runInTransaction: vi.fn(async (operation: (tx: never) => unknown) => await operation(transaction)),
+      findById: vi.fn().mockResolvedValue(ok(createTask())),
+      update: vi.fn(),
+    };
+
+    await notifyDispatchProblemForTask({
+      task,
+      dispatchStatus,
+      problem,
+      whatsappNotifier: whatsappNotifier as never,
+      codeTaskRepo: codeTaskRepo as never,
+      logger: createLogger(),
+      affectedTaskCount: 1,
+    });
+
+    expect(whatsappNotifier.notifyTaskDispatchBlocked).not.toHaveBeenCalled();
+    expect(codeTaskRepo.findById).toHaveBeenCalledWith('task-123', { transaction });
+    expect(codeTaskRepo.update).not.toHaveBeenCalled();
+  });
+
+  it('reserves transactional ledger before sending WhatsApp notification', async () => {
+    const problem: DispatchProblem = {
+      reason: 'workers_at_capacity',
+      severity: 'warning',
+      message: 'All workers are busy.',
+      remediation: 'Wait for a worker.',
+      workerNames: ['home-mac'],
+      terminal: false,
+    };
+    const task = createTask();
+    const dispatchStatus = buildDispatchStatusForProblem({ task, problem });
+    const currentTask = createTask({ dispatchStatus });
+    const transaction = {} as never;
+    const whatsappNotifier = {
+      notifyTaskDispatchBlocked: vi.fn().mockResolvedValue(ok(undefined)),
+    };
+    const codeTaskRepo = {
+      runInTransaction: vi.fn(async (operation: (tx: never) => unknown) => await operation(transaction)),
+      findById: vi.fn().mockResolvedValue(ok(currentTask)),
+      update: vi.fn().mockResolvedValue(ok(currentTask)),
+    };
+
+    await notifyDispatchProblemForTask({
+      task,
+      dispatchStatus,
+      problem,
+      whatsappNotifier: whatsappNotifier as never,
+      codeTaskRepo: codeTaskRepo as never,
+      logger: createLogger(),
+      affectedTaskCount: 1,
+      now: new Date('2026-06-06T10:30:00.000Z'),
+    });
+
+    expect(codeTaskRepo.update).toHaveBeenCalledWith('task-123', {
+      dispatchStatus: expect.objectContaining({
+        notifiedReasons: expect.objectContaining({
+          workers_at_capacity: Timestamp.fromDate(new Date('2026-06-06T10:30:00.000Z')),
+        }),
+      }),
+    }, { transaction });
+    expect(whatsappNotifier.notifyTaskDispatchBlocked).toHaveBeenCalledTimes(1);
+    expect(whatsappNotifier.notifyTaskDispatchBlocked.mock.invocationCallOrder[0]).toBeGreaterThan(
+      codeTaskRepo.update.mock.invocationCallOrder[0] ?? 0,
+    );
+  });
+
+  it('logs and does not send when transactional ledger update fails', async () => {
+    const problem: DispatchProblem = {
+      reason: 'workers_at_capacity',
+      severity: 'warning',
+      message: 'All workers are busy.',
+      remediation: 'Wait for a worker.',
+      workerNames: ['home-mac'],
+      terminal: false,
+    };
+    const task = createTask();
+    const dispatchStatus = buildDispatchStatusForProblem({ task, problem });
+    const currentTask = createTask({ dispatchStatus });
+    const transaction = {} as never;
+    const logger = createLogger();
+    const whatsappNotifier = {
+      notifyTaskDispatchBlocked: vi.fn().mockResolvedValue(ok(undefined)),
+    };
+    const codeTaskRepo = {
+      runInTransaction: vi.fn(async (operation: (tx: never) => unknown) => await operation(transaction)),
+      findById: vi.fn().mockResolvedValue(ok(currentTask)),
+      update: vi.fn().mockResolvedValue(err({ code: 'FIRESTORE_ERROR', message: 'write failed' })),
+    };
+
+    await notifyDispatchProblemForTask({
+      task,
+      dispatchStatus,
+      problem,
+      whatsappNotifier: whatsappNotifier as never,
+      codeTaskRepo: codeTaskRepo as never,
+      logger,
+      affectedTaskCount: 1,
+    });
+
+    expect(whatsappNotifier.notifyTaskDispatchBlocked).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ taskId: 'task-123', reason: 'workers_at_capacity' }),
+      'Failed to persist code task dispatch notification ledger',
+    );
+  });
+
+  it('logs when transactional ledger persistence cannot read the current task', async () => {
+    const problem: DispatchProblem = {
+      reason: 'workers_at_capacity',
+      severity: 'warning',
+      message: 'All workers are busy.',
+      remediation: 'Wait for a worker.',
+      workerNames: ['home-mac'],
+      terminal: false,
+    };
+    const task = createTask();
+    const dispatchStatus = buildDispatchStatusForProblem({ task, problem });
+    const transaction = {} as never;
+    const logger = createLogger();
+    const whatsappNotifier = {
+      notifyTaskDispatchBlocked: vi.fn().mockResolvedValue(ok(undefined)),
+    };
+    const codeTaskRepo = {
+      runInTransaction: vi.fn(async (operation: (tx: never) => unknown) => await operation(transaction)),
+      findById: vi.fn().mockResolvedValue(err({ code: 'FIRESTORE_ERROR', message: 'read failed' })),
+      update: vi.fn(),
+    };
+
+    await notifyDispatchProblemForTask({
+      task,
+      dispatchStatus,
+      problem,
+      whatsappNotifier: whatsappNotifier as never,
+      codeTaskRepo: codeTaskRepo as never,
+      logger,
+      affectedTaskCount: 1,
+    });
+
+    expect(codeTaskRepo.update).not.toHaveBeenCalled();
+    expect(whatsappNotifier.notifyTaskDispatchBlocked).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ taskId: 'task-123', reason: 'workers_at_capacity' }),
+      'Failed to persist code task dispatch notification ledger',
+    );
+  });
+
+  it('skips transactional ledger write when current dispatch status already recorded the notification', async () => {
+    const notifiedAt = Timestamp.fromDate(new Date('2026-06-06T10:20:00.000Z'));
+    const problem: DispatchProblem = {
+      reason: 'workers_at_capacity',
+      severity: 'warning',
+      message: 'All workers are busy.',
+      remediation: 'Wait for a worker.',
+      workerNames: ['home-mac'],
+      terminal: false,
+    };
+    const task = createTask();
+    const dispatchStatus = buildDispatchStatusForProblem({ task, problem });
+    const currentTask = createTask({
+      dispatchStatus: {
+        ...dispatchStatus,
+        notifiedReasons: {
+          workers_at_capacity: notifiedAt,
+        },
+      },
+    });
+    const transaction = {} as never;
+    const whatsappNotifier = {
+      notifyTaskDispatchBlocked: vi.fn().mockResolvedValue(ok(undefined)),
+    };
+    const codeTaskRepo = {
+      runInTransaction: vi.fn(async (operation: (tx: never) => unknown) => await operation(transaction)),
+      findById: vi.fn().mockResolvedValue(ok(currentTask)),
+      update: vi.fn(),
+    };
+
+    await notifyDispatchProblemForTask({
+      task,
+      dispatchStatus,
+      problem,
+      whatsappNotifier: whatsappNotifier as never,
+      codeTaskRepo: codeTaskRepo as never,
+      logger: createLogger(),
+      affectedTaskCount: 1,
+    });
+
+    expect(codeTaskRepo.update).not.toHaveBeenCalled();
+    expect(whatsappNotifier.notifyTaskDispatchBlocked).not.toHaveBeenCalled();
+  });
+
+  it('reserves the ledger before sending WhatsApp and logs when notification fails', async () => {
+    const problem: DispatchProblem = {
+      reason: 'no_enabled_workers',
+      severity: 'critical',
+      message: 'No enabled workers.',
+      remediation: 'Enable a worker.',
+      workerNames: [],
+      terminal: true,
+    };
+    const task = createTask();
+    const dispatchStatus = buildDispatchStatusForProblem({ task, problem });
+    const logger = createLogger();
+    const whatsappNotifier = {
+      notifyTaskDispatchBlocked: vi.fn().mockResolvedValue(err({ code: 'publish_failed', message: 'pubsub down' })),
+    };
+    const codeTaskRepo = { update: vi.fn().mockResolvedValue(ok(createTask())) };
+
+    await notifyDispatchProblemForTask({
+      task,
+      dispatchStatus,
+      problem,
+      whatsappNotifier: whatsappNotifier as never,
+      codeTaskRepo: codeTaskRepo as never,
+      logger,
+      affectedTaskCount: 1,
+    });
+
+    expect(codeTaskRepo.update).toHaveBeenCalledWith('task-123', {
+      dispatchStatus: expect.objectContaining({
+        notifiedReasons: expect.objectContaining({
+          no_enabled_workers: expect.any(Timestamp),
+        }),
+      }),
+    });
+    expect(whatsappNotifier.notifyTaskDispatchBlocked.mock.invocationCallOrder[0]).toBeGreaterThan(
+      codeTaskRepo.update.mock.invocationCallOrder[0] ?? 0,
+    );
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ taskId: 'task-123', reason: 'no_enabled_workers' }),
+      'Failed to notify user about code task dispatch blocker',
+    );
+  });
+
+  it('logs and does not send when notification ledger persistence fails', async () => {
+    const problem: DispatchProblem = {
+      reason: 'dispatch_failed',
+      severity: 'critical',
+      message: 'Dispatch failed.',
+      remediation: 'Retry after fixing worker dispatch.',
+      workerNames: [],
+      terminal: true,
+    };
+    const task = createTask();
+    const dispatchStatus = buildDispatchStatusForProblem({ task, problem });
+    const logger = createLogger();
+    const whatsappNotifier = {
+      notifyTaskDispatchBlocked: vi.fn().mockResolvedValue(ok(undefined)),
+    };
+    const codeTaskRepo = {
+      update: vi.fn().mockResolvedValue(err({ code: 'FIRESTORE_ERROR', message: 'write failed' })),
+    };
+
+    await notifyDispatchProblemForTask({
+      task,
+      dispatchStatus,
+      problem,
+      whatsappNotifier: whatsappNotifier as never,
+      codeTaskRepo: codeTaskRepo as never,
+      logger,
+      affectedTaskCount: 1,
+      now: new Date('2026-06-06T10:15:00.000Z'),
+    });
+
+    expect(codeTaskRepo.update).toHaveBeenCalledWith('task-123', {
+      dispatchStatus: expect.objectContaining({
+        notifiedReasons: expect.objectContaining({
+          dispatch_failed: Timestamp.fromDate(new Date('2026-06-06T10:15:00.000Z')),
+        }),
+      }),
+    });
+    expect(whatsappNotifier.notifyTaskDispatchBlocked).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ taskId: 'task-123', reason: 'dispatch_failed' }),
+      'Failed to persist code task dispatch notification ledger',
+    );
+  });
+});

--- a/apps/code-agent/src/__tests__/domain/services/codeTaskDispatchStatusService.test.ts
+++ b/apps/code-agent/src/__tests__/domain/services/codeTaskDispatchStatusService.test.ts
@@ -8,7 +8,6 @@ import type {
   CodeTaskSystemStatusRepositoryError,
   ResolveCodeTaskSystemStatusesInput,
 } from '../../../domain/repositories/codeTaskSystemStatusRepository.js';
-import type { WhatsAppNotifier } from '../../../domain/services/whatsappNotifier.js';
 
 const BLOCKER = {
   dispatchable: false as const,
@@ -41,19 +40,13 @@ function makeStatus(overrides: Partial<CodeTaskSystemStatus> = {}): CodeTaskSyst
 
 describe('CodeTaskDispatchStatusService', () => {
   let upsertedStatus: CodeTaskSystemStatus;
-  let markNotifiedCalls: { id: string; notifiedAt: Date }[];
   let resolveCalls: ResolveCodeTaskSystemStatusesInput[];
-  let notifier: WhatsAppNotifier;
   let logger: Logger;
   let statusRepo: CodeTaskSystemStatusRepository;
 
   beforeEach(() => {
     upsertedStatus = makeStatus();
-    markNotifiedCalls = [];
     resolveCalls = [];
-    notifier = {
-      notifyTaskDispatchBlocked: vi.fn(async () => ok(undefined)),
-    } as unknown as WhatsAppNotifier;
     logger = {
       info: vi.fn(),
       warn: vi.fn(),
@@ -67,19 +60,16 @@ describe('CodeTaskDispatchStatusService', () => {
         resolveCalls.push(input);
         return ok(1);
       }),
-      markNotified: vi.fn(async (id: string, notifiedAt: Date): Promise<Result<void, CodeTaskSystemStatusRepositoryError>> => {
-        markNotifiedCalls.push({ id, notifiedAt });
+      markNotified: vi.fn(async (): Promise<Result<void, CodeTaskSystemStatusRepositoryError>> => {
         return ok(undefined);
       }),
     };
   });
 
-  it('upserts an active status and sends the first WhatsApp notification', async () => {
+  it('upserts an active status without marking aggregate notifications', async () => {
     const service = createCodeTaskDispatchStatusService({
       statusRepo,
-      whatsappNotifier: notifier,
       logger,
-      now: () => new Date('2026-06-05T12:00:00.000Z'),
     });
 
     await service.recordDispatchBlocked({
@@ -101,52 +91,13 @@ describe('CodeTaskDispatchStatusService', () => {
       exampleTaskIds: ['task-1', 'task-2'],
       workerNames: ['home-dev'],
     });
-    expect(notifier.notifyTaskDispatchBlocked).toHaveBeenCalledWith('user-1', {
-      workerType: 'codex-xhigh',
-      reason: 'codex_auth_unavailable',
-      affectedTaskCount: 2,
-      exampleTaskId: 'task-1',
-      message: BLOCKER.message,
-      remediation: BLOCKER.remediation,
-      workerNames: ['home-dev'],
-    });
-    expect(markNotifiedCalls).toEqual([
-      { id: 'status-1', notifiedAt: new Date('2026-06-05T12:00:00.000Z') },
-    ]);
-  });
-
-  it('uses the default clock when no now override is provided', async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date('2026-06-05T13:00:00.000Z'));
-    const service = createCodeTaskDispatchStatusService({
-      statusRepo,
-      whatsappNotifier: notifier,
-      logger,
-    });
-
-    await service.recordDispatchBlocked({
-      userId: 'user-1',
-      workerType: 'codex-xhigh',
-      blocker: BLOCKER,
-      affectedTaskCount: 2,
-      exampleTaskIds: [],
-    });
-
-    expect(notifier.notifyTaskDispatchBlocked).toHaveBeenCalledWith('user-1', expect.objectContaining({
-      workerType: 'codex-xhigh',
-    }));
-    expect(markNotifiedCalls).toEqual([
-      { id: 'status-1', notifiedAt: new Date('2026-06-05T13:00:00.000Z') },
-    ]);
-
-    vi.useRealTimers();
+    expect(statusRepo.markNotified).not.toHaveBeenCalled();
   });
 
   it('logs and exits when status persistence fails', async () => {
     statusRepo.upsertActive = vi.fn(async () => err({ code: 'FIRESTORE_ERROR' as const, message: 'unavailable' }));
     const service = createCodeTaskDispatchStatusService({
       statusRepo,
-      whatsappNotifier: notifier,
       logger,
     });
 
@@ -162,18 +113,15 @@ describe('CodeTaskDispatchStatusService', () => {
       expect.objectContaining({ error: expect.objectContaining({ message: 'unavailable' }) }),
       'Failed to persist code task dispatch system status'
     );
-    expect(notifier.notifyTaskDispatchBlocked).not.toHaveBeenCalled();
   });
 
-  it('suppresses repeated notifications inside the resend interval', async () => {
+  it('ignores aggregate lastNotifiedAt when recording status because task-level state owns notification dedupe', async () => {
     upsertedStatus = makeStatus({
       lastNotifiedAt: new Date('2026-06-05T09:00:00.000Z'),
     });
     const service = createCodeTaskDispatchStatusService({
       statusRepo,
-      whatsappNotifier: notifier,
       logger,
-      now: () => new Date('2026-06-05T12:00:00.000Z'),
     });
 
     await service.recordDispatchBlocked({
@@ -184,64 +132,14 @@ describe('CodeTaskDispatchStatusService', () => {
       exampleTaskIds: ['task-1'],
     });
 
-    expect(notifier.notifyTaskDispatchBlocked).not.toHaveBeenCalled();
-    expect(markNotifiedCalls).toEqual([]);
+    expect(statusRepo.markNotified).not.toHaveBeenCalled();
   });
 
-  it('resends notification after the resend interval elapses', async () => {
-    upsertedStatus = makeStatus({
-      lastNotifiedAt: new Date('2026-06-05T05:59:59.000Z'),
-    });
-    const service = createCodeTaskDispatchStatusService({
-      statusRepo,
-      whatsappNotifier: notifier,
-      logger,
-      now: () => new Date('2026-06-05T12:00:00.000Z'),
-    });
-
-    await service.recordDispatchBlocked({
-      userId: 'user-1',
-      workerType: 'codex-xhigh',
-      blocker: BLOCKER,
-      affectedTaskCount: 2,
-      exampleTaskIds: ['task-1'],
-    });
-
-    expect(notifier.notifyTaskDispatchBlocked).toHaveBeenCalledTimes(1);
-    expect(markNotifiedCalls).toHaveLength(1);
-  });
-
-  it('logs and exits when WhatsApp notification fails', async () => {
-    notifier.notifyTaskDispatchBlocked = vi.fn(async () => err({ code: 'notification_failed' as const, message: 'publish failed' }));
-    const service = createCodeTaskDispatchStatusService({
-      statusRepo,
-      whatsappNotifier: notifier,
-      logger,
-      now: () => new Date('2026-06-05T12:00:00.000Z'),
-    });
-
-    await service.recordDispatchBlocked({
-      userId: 'user-1',
-      workerType: 'codex-xhigh',
-      blocker: BLOCKER,
-      affectedTaskCount: 2,
-      exampleTaskIds: ['task-1'],
-    });
-
-    expect(logger.warn).toHaveBeenCalledWith(
-      expect.objectContaining({ error: expect.objectContaining({ message: 'publish failed' }) }),
-      'Failed to notify user about code task dispatch blocker'
-    );
-    expect(markNotifiedCalls).toEqual([]);
-  });
-
-  it('logs when marking the status as notified fails', async () => {
+  it('does not mark aggregate status as notified', async () => {
     statusRepo.markNotified = vi.fn(async () => err({ code: 'FIRESTORE_ERROR' as const, message: 'write failed' }));
     const service = createCodeTaskDispatchStatusService({
       statusRepo,
-      whatsappNotifier: notifier,
       logger,
-      now: () => new Date('2026-06-05T12:00:00.000Z'),
     });
 
     await service.recordDispatchBlocked({
@@ -252,16 +150,12 @@ describe('CodeTaskDispatchStatusService', () => {
       exampleTaskIds: ['task-1'],
     });
 
-    expect(logger.warn).toHaveBeenCalledWith(
-      expect.objectContaining({ error: expect.objectContaining({ message: 'write failed' }) }),
-      'Failed to mark code task dispatch blocker as notified'
-    );
+    expect(statusRepo.markNotified).not.toHaveBeenCalled();
   });
 
   it('resolves active statuses for the user and worker type', async () => {
     const service = createCodeTaskDispatchStatusService({
       statusRepo,
-      whatsappNotifier: notifier,
       logger,
     });
 
@@ -277,7 +171,6 @@ describe('CodeTaskDispatchStatusService', () => {
     statusRepo.resolveActive = vi.fn(async () => err({ code: 'FIRESTORE_ERROR' as const, message: 'resolve failed' }));
     const service = createCodeTaskDispatchStatusService({
       statusRepo,
-      whatsappNotifier: notifier,
       logger,
     });
 

--- a/apps/code-agent/src/__tests__/domain/usecases/drainRetryQueue.test.ts
+++ b/apps/code-agent/src/__tests__/domain/usecases/drainRetryQueue.test.ts
@@ -83,12 +83,14 @@ describe('drainRetryQueue', () => {
   let mockLogger: Logger;
   let mockDispatchRetryRepo: {
     findOldest: ReturnType<typeof vi.fn>;
+    claimForProcessing: ReturnType<typeof vi.fn>;
     delete: ReturnType<typeof vi.fn>;
     update: ReturnType<typeof vi.fn>;
     create: ReturnType<typeof vi.fn>;
   };
   let mockCodeTaskRepo: {
     findById: ReturnType<typeof vi.fn>;
+    claimForDispatch: ReturnType<typeof vi.fn>;
     update: ReturnType<typeof vi.fn>;
   };
   let mockTaskDispatcher: {
@@ -101,6 +103,7 @@ describe('drainRetryQueue', () => {
   let mockWhatsappNotifier: {
     notifyDispatchRetryExhausted: ReturnType<typeof vi.fn>;
     notifyTaskStarted: ReturnType<typeof vi.fn>;
+    notifyTaskDispatchBlocked: ReturnType<typeof vi.fn>;
   };
   let mockWorkerSettingsRepo: {
     getSettings: ReturnType<typeof vi.fn>;
@@ -218,6 +221,7 @@ describe('drainRetryQueue', () => {
 
     mockDispatchRetryRepo = {
       findOldest: vi.fn(),
+      claimForProcessing: vi.fn().mockResolvedValue(ok(true)),
       delete: vi.fn().mockResolvedValue(ok(undefined)),
       update: vi.fn().mockResolvedValue(ok(undefined)),
       create: vi.fn(),
@@ -225,6 +229,7 @@ describe('drainRetryQueue', () => {
 
     mockCodeTaskRepo = {
       findById: vi.fn().mockResolvedValue(ok(sampleTask)),
+      claimForDispatch: vi.fn().mockResolvedValue(ok(true)),
       update: vi.fn().mockResolvedValue(ok(sampleTask)),
     };
 
@@ -240,6 +245,7 @@ describe('drainRetryQueue', () => {
     mockWhatsappNotifier = {
       notifyDispatchRetryExhausted: vi.fn().mockResolvedValue(ok(undefined)),
       notifyTaskStarted: vi.fn().mockResolvedValue(ok(undefined)),
+      notifyTaskDispatchBlocked: vi.fn().mockResolvedValue(ok(undefined)),
     };
 
     mockWorkerSettingsRepo = {
@@ -578,6 +584,38 @@ describe('drainRetryQueue', () => {
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     expect(result.value.action).toBe('empty');
+    expect(mockDispatchRetryRepo.claimForProcessing).not.toHaveBeenCalled();
+  });
+
+  it('skips when the retry entry is already claimed by another drain', async () => {
+    mockDispatchRetryRepo.findOldest.mockResolvedValue(ok(sampleNewTaskRetry));
+    mockDispatchRetryRepo.claimForProcessing.mockResolvedValue(ok(false));
+
+    const result = await drainRetryQueue(buildDeps());
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toEqual({ action: 'skipped', taskId: 'task_xyz' });
+    expect(mockCodeTaskRepo.findById).not.toHaveBeenCalled();
+    expect(mockTaskDispatcher.dispatch).not.toHaveBeenCalled();
+  });
+
+  it('returns internal_error when the retry entry claim fails', async () => {
+    mockDispatchRetryRepo.findOldest.mockResolvedValue(ok(sampleNewTaskRetry));
+    mockDispatchRetryRepo.claimForProcessing.mockResolvedValue(err({
+      code: 'FIRESTORE_ERROR',
+      message: 'transaction failed',
+    }));
+
+    const result = await drainRetryQueue(buildDeps());
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toEqual({
+      code: 'internal_error',
+      message: 'Failed to claim retry entry for processing',
+    });
+    expect(mockCodeTaskRepo.findById).not.toHaveBeenCalled();
   });
 
   it('returns skipped on concurrent drain', async () => {
@@ -608,8 +646,74 @@ describe('drainRetryQueue', () => {
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     expect(result.value.action).toBe('expired');
+    expect(mockCodeTaskRepo.update).toHaveBeenCalledWith('task_xyz', expect.objectContaining({
+      status: 'failed',
+      error: { code: 'retry_expired', message: 'Dispatch retry expired after 10 minutes' },
+      dispatchStatus: expect.objectContaining({
+        state: 'terminal',
+        reason: 'retry_expired',
+        terminal: true,
+        nextAction: 'retry_after_fix',
+      }),
+    }));
     expect(mockDispatchRetryRepo.delete).toHaveBeenCalledWith('dr_abc');
-    expect(mockWhatsappNotifier.notifyDispatchRetryExhausted).toHaveBeenCalled();
+    expect(mockCodeTaskRepo.update.mock.invocationCallOrder[0]).toBeLessThan(
+      mockDispatchRetryRepo.delete.mock.invocationCallOrder[0] ?? 0,
+    );
+    expect(mockWhatsappNotifier.notifyTaskDispatchBlocked).toHaveBeenCalledWith('user_123', expect.objectContaining({
+      reason: 'retry_expired',
+      exampleTaskId: 'task_xyz',
+    }));
+    expect(mockCodeTaskRepo.update).toHaveBeenCalledWith('task_xyz', {
+      dispatchStatus: expect.objectContaining({
+        notifiedReasons: expect.objectContaining({
+          retry_expired: expect.any(Timestamp),
+        }),
+      }),
+    });
+    expect(mockWhatsappNotifier.notifyDispatchRetryExhausted).not.toHaveBeenCalled();
+  });
+
+  it('keeps retry entry when expired new-task failure status cannot be persisted', async () => {
+    const expiredRetry = {
+      ...sampleNewTaskRetry,
+      createdAt: Timestamp.fromDate(new Date(Date.now() - 20 * 60 * 1000)),
+    };
+    mockDispatchRetryRepo.findOldest.mockResolvedValue(ok(expiredRetry));
+    mockCodeTaskRepo.update.mockResolvedValue(err({ code: 'FIRESTORE_ERROR', message: 'write failed' }));
+
+    const result = await drainRetryQueue(buildDeps());
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toEqual({
+        code: 'internal_error',
+        message: 'Failed to persist retry dispatch failure status',
+      });
+    }
+    expect(mockDispatchRetryRepo.delete).not.toHaveBeenCalled();
+    expect(mockWhatsappNotifier.notifyDispatchRetryExhausted).not.toHaveBeenCalled();
+  });
+
+  it('returns internal_error when expired retry entry cannot be deleted after task notification', async () => {
+    const expiredRetry = {
+      ...sampleNewTaskRetry,
+      createdAt: Timestamp.fromDate(new Date(Date.now() - 20 * 60 * 1000)),
+    };
+    mockDispatchRetryRepo.findOldest.mockResolvedValue(ok(expiredRetry));
+    mockDispatchRetryRepo.delete.mockResolvedValue(err({ code: 'FIRESTORE_ERROR', message: 'delete failed' }));
+
+    const result = await drainRetryQueue(buildDeps());
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toEqual({
+      code: 'internal_error',
+      message: 'Failed to delete expired retry entry',
+    });
+    expect(mockWhatsappNotifier.notifyTaskDispatchBlocked).toHaveBeenCalledWith('user_123', expect.objectContaining({
+      reason: 'retry_expired',
+    }));
   });
 
   it('exhausts entry when max attempts exceeded', async () => {
@@ -625,8 +729,76 @@ describe('drainRetryQueue', () => {
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     expect(result.value.action).toBe('exhausted');
+    expect(mockCodeTaskRepo.update).toHaveBeenCalledWith('task_xyz', expect.objectContaining({
+      status: 'failed',
+      error: { code: 'retry_exhausted', message: 'Dispatch retry exhausted after 3 attempts: worker_unavailable' },
+      dispatchStatus: expect.objectContaining({
+        state: 'terminal',
+        reason: 'retry_exhausted',
+        terminal: true,
+        nextAction: 'retry_after_fix',
+      }),
+    }));
     expect(mockDispatchRetryRepo.delete).toHaveBeenCalledWith('dr_abc');
-    expect(mockWhatsappNotifier.notifyDispatchRetryExhausted).toHaveBeenCalled();
+    expect(mockCodeTaskRepo.update.mock.invocationCallOrder[0]).toBeLessThan(
+      mockDispatchRetryRepo.delete.mock.invocationCallOrder[0] ?? 0,
+    );
+    expect(mockWhatsappNotifier.notifyTaskDispatchBlocked).toHaveBeenCalledWith('user_123', expect.objectContaining({
+      reason: 'retry_exhausted',
+      exampleTaskId: 'task_xyz',
+    }));
+    expect(mockCodeTaskRepo.update).toHaveBeenCalledWith('task_xyz', {
+      dispatchStatus: expect.objectContaining({
+        notifiedReasons: expect.objectContaining({
+          retry_exhausted: expect.any(Timestamp),
+        }),
+      }),
+    });
+    expect(mockWhatsappNotifier.notifyDispatchRetryExhausted).not.toHaveBeenCalled();
+  });
+
+  it('keeps retry entry when exhausted new-task failure status cannot be persisted', async () => {
+    const exhaustedRetry = {
+      ...sampleNewTaskRetry,
+      attempts: 3,
+      maxAttempts: 3,
+    };
+    mockDispatchRetryRepo.findOldest.mockResolvedValue(ok(exhaustedRetry));
+    mockCodeTaskRepo.update.mockResolvedValue(err({ code: 'FIRESTORE_ERROR', message: 'write failed' }));
+
+    const result = await drainRetryQueue(buildDeps());
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toEqual({
+        code: 'internal_error',
+        message: 'Failed to persist retry dispatch failure status',
+      });
+    }
+    expect(mockDispatchRetryRepo.delete).not.toHaveBeenCalled();
+    expect(mockWhatsappNotifier.notifyDispatchRetryExhausted).not.toHaveBeenCalled();
+  });
+
+  it('returns internal_error when exhausted retry entry cannot be deleted after task notification', async () => {
+    const exhaustedRetry = {
+      ...sampleNewTaskRetry,
+      attempts: 3,
+      maxAttempts: 3,
+    };
+    mockDispatchRetryRepo.findOldest.mockResolvedValue(ok(exhaustedRetry));
+    mockDispatchRetryRepo.delete.mockResolvedValue(err({ code: 'FIRESTORE_ERROR', message: 'delete failed' }));
+
+    const result = await drainRetryQueue(buildDeps());
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toEqual({
+      code: 'internal_error',
+      message: 'Failed to delete exhausted retry entry',
+    });
+    expect(mockWhatsappNotifier.notifyTaskDispatchBlocked).toHaveBeenCalledWith('user_123', expect.objectContaining({
+      reason: 'retry_exhausted',
+    }));
   });
 
   describe('new_task retry', () => {
@@ -641,7 +813,11 @@ describe('drainRetryQueue', () => {
       if (!result.ok) return;
       expect(result.value.action).toBe('dispatched');
       expect(mockDispatchRetryRepo.delete).toHaveBeenCalledWith('dr_abc');
-      expect(mockCodeTaskRepo.update).toHaveBeenCalledWith('task_xyz', expect.objectContaining({ status: 'dispatched' }));
+      expect(mockCodeTaskRepo.claimForDispatch).toHaveBeenCalledWith('task_xyz');
+      expect(mockCodeTaskRepo.update).toHaveBeenCalledWith('task_xyz', expect.objectContaining({
+        dispatchStatus: null,
+        workerLocation: 'home-mac',
+      }));
       expect(mockTaskDispatcher.dispatch).toHaveBeenCalledWith(
         expect.objectContaining({
           webhookUrl: 'https://callback.test/internal/webhooks/task-complete',
@@ -651,6 +827,74 @@ describe('drainRetryQueue', () => {
         userId: 'user_123',
         workerType: 'opus',
       });
+    });
+
+    it('returns internal_error when retry entry cannot be deleted after successful dispatch', async () => {
+      mockDispatchRetryRepo.findOldest.mockResolvedValue(ok(sampleNewTaskRetry));
+      mockCodeTaskRepo.findById.mockResolvedValue(ok(sampleTask));
+      mockTaskDispatcher.dispatch.mockResolvedValue(ok({ dispatched: true, workerLocation: 'home-mac' }));
+      mockDispatchRetryRepo.delete.mockResolvedValue(err({ code: 'FIRESTORE_ERROR', message: 'delete failed' }));
+
+      const result = await drainRetryQueue(buildDeps());
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toEqual({
+        code: 'internal_error',
+        message: 'Failed to delete retry entry after successful dispatch',
+      });
+      expect(mockCodeTaskRepo.update).toHaveBeenCalledWith('task_xyz', expect.objectContaining({
+        dispatchStatus: null,
+        workerLocation: 'home-mac',
+      }));
+      expect(mockTaskDispatcher.dispatch).toHaveBeenCalledTimes(1);
+    });
+
+    it('skips without dispatching when the task cannot be claimed', async () => {
+      mockDispatchRetryRepo.findOldest.mockResolvedValue(ok(sampleNewTaskRetry));
+      mockCodeTaskRepo.findById.mockResolvedValue(ok(sampleTask));
+      mockCodeTaskRepo.claimForDispatch.mockResolvedValue(ok(false));
+
+      const result = await drainRetryQueue(buildDeps());
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value).toEqual({ action: 'skipped', taskId: 'task_xyz' });
+      expect(mockTaskDispatcher.dispatch).not.toHaveBeenCalled();
+      expect(mockDispatchRetryRepo.delete).not.toHaveBeenCalled();
+    });
+
+    it('returns internal_error when claiming the task for retry dispatch fails', async () => {
+      mockDispatchRetryRepo.findOldest.mockResolvedValue(ok(sampleNewTaskRetry));
+      mockCodeTaskRepo.findById.mockResolvedValue(ok(sampleTask));
+      mockCodeTaskRepo.claimForDispatch.mockResolvedValue(err({
+        code: 'FIRESTORE_ERROR',
+        message: 'claim failed',
+      }));
+
+      const result = await drainRetryQueue(buildDeps());
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toEqual({
+        code: 'internal_error',
+        message: 'Failed to claim retry task for dispatch',
+      });
+      expect(mockTaskDispatcher.dispatch).not.toHaveBeenCalled();
+      expect(mockDispatchRetryRepo.delete).not.toHaveBeenCalled();
+    });
+
+    it('deletes stale retry entry without dispatching when task is no longer queued', async () => {
+      mockDispatchRetryRepo.findOldest.mockResolvedValue(ok(sampleNewTaskRetry));
+      mockCodeTaskRepo.findById.mockResolvedValue(ok({ ...sampleTask, status: 'dispatched' }));
+
+      const result = await drainRetryQueue(buildDeps());
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.action).toBe('failed');
+      expect(mockDispatchRetryRepo.delete).toHaveBeenCalledWith('dr_abc');
+      expect(mockTaskDispatcher.dispatch).not.toHaveBeenCalled();
     });
 
     it('dispatches successfully when dispatch status service is omitted', async () => {
@@ -698,6 +942,21 @@ describe('drainRetryQueue', () => {
       expect(result.value.action).toBe('dispatched');
       expect(mockTaskDispatcher.dispatch).toHaveBeenCalledWith(
         expect.not.objectContaining({ prNumber: expect.anything() })
+      );
+    });
+
+    it('does not include reviewTypes in dispatch request when task has none', async () => {
+      mockDispatchRetryRepo.findOldest.mockResolvedValue(ok(sampleNewTaskRetry));
+      mockCodeTaskRepo.findById.mockResolvedValue(ok({ ...sampleTask, reviewTypes: undefined }));
+      mockTaskDispatcher.dispatch.mockResolvedValue(ok({ dispatched: true, workerLocation: 'home-mac' }));
+
+      const result = await drainRetryQueue(buildDeps());
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.action).toBe('dispatched');
+      expect(mockTaskDispatcher.dispatch).toHaveBeenCalledWith(
+        expect.not.objectContaining({ reviewTypes: expect.anything() })
       );
     });
 
@@ -847,6 +1106,26 @@ describe('drainRetryQueue', () => {
       expect(mockDispatchRetryRepo.delete).not.toHaveBeenCalled();
     });
 
+    it('returns internal_error when retry metadata cannot be persisted after retryable dispatch failure', async () => {
+      mockDispatchRetryRepo.findOldest.mockResolvedValue(ok(sampleNewTaskRetry));
+      mockCodeTaskRepo.findById.mockResolvedValue(ok(sampleTask));
+      mockTaskDispatcher.dispatch.mockResolvedValue(err({ code: 'worker_unavailable', message: 'connection refused' }));
+      mockDispatchRetryRepo.update.mockResolvedValue(err({
+        code: 'FIRESTORE_ERROR',
+        message: 'retry update failed',
+      }));
+
+      const result = await drainRetryQueue(buildDeps());
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toEqual({
+        code: 'internal_error',
+        message: 'Failed to update retry entry',
+      });
+      expect(mockDispatchRetryRepo.delete).not.toHaveBeenCalled();
+    });
+
     it('deletes entry and fails task on non-retryable error', async () => {
       mockDispatchRetryRepo.findOldest.mockResolvedValue(ok(sampleNewTaskRetry));
       mockCodeTaskRepo.findById.mockResolvedValue(ok(sampleTask));
@@ -858,7 +1137,57 @@ describe('drainRetryQueue', () => {
       if (!result.ok) return;
       expect(result.value.action).toBe('failed');
       expect(mockDispatchRetryRepo.delete).toHaveBeenCalledWith('dr_abc');
-      expect(mockCodeTaskRepo.update).toHaveBeenCalledWith('task_xyz', expect.objectContaining({ status: 'failed' }));
+      expect(mockCodeTaskRepo.update).toHaveBeenCalledWith('task_xyz', expect.objectContaining({
+        status: 'failed',
+        dispatchStatus: expect.objectContaining({
+          state: 'terminal',
+          reason: 'dispatch_failed',
+          terminal: true,
+          nextAction: 'retry_after_fix',
+        }),
+      }));
+    });
+
+    it('returns internal_error when terminal retry dispatch failure cannot be persisted', async () => {
+      mockDispatchRetryRepo.findOldest.mockResolvedValue(ok(sampleNewTaskRetry));
+      mockCodeTaskRepo.findById.mockResolvedValue(ok(sampleTask));
+      mockTaskDispatcher.dispatch.mockResolvedValue(err({ code: 'dispatch_failed', message: 'bad payload' }));
+      mockCodeTaskRepo.update.mockResolvedValue(
+        err({ code: 'FIRESTORE_ERROR', message: 'write failed' }),
+      );
+
+      const result = await drainRetryQueue(buildDeps());
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toEqual({
+        code: 'internal_error',
+        message: 'Failed to persist retry dispatch failure status',
+      });
+      expect(mockDispatchRetryRepo.delete).not.toHaveBeenCalled();
+      expect(mockWhatsappNotifier.notifyTaskDispatchBlocked).not.toHaveBeenCalled();
+    });
+
+    it('returns internal_error when retry entry cannot be deleted after terminal dispatch failure', async () => {
+      mockDispatchRetryRepo.findOldest.mockResolvedValue(ok(sampleNewTaskRetry));
+      mockCodeTaskRepo.findById.mockResolvedValue(ok(sampleTask));
+      mockTaskDispatcher.dispatch.mockResolvedValue(err({ code: 'dispatch_failed', message: 'bad payload' }));
+      mockDispatchRetryRepo.delete.mockResolvedValue(err({ code: 'FIRESTORE_ERROR', message: 'delete failed' }));
+
+      const result = await drainRetryQueue(buildDeps());
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toEqual({
+        code: 'internal_error',
+        message: 'Failed to delete retry entry after terminal dispatch failure',
+      });
+      expect(mockCodeTaskRepo.update).toHaveBeenCalledWith('task_xyz', expect.objectContaining({
+        status: 'failed',
+      }));
+      expect(mockWhatsappNotifier.notifyTaskDispatchBlocked).toHaveBeenCalledWith('user_123', expect.objectContaining({
+        reason: 'dispatch_failed',
+      }));
     });
 
     it('returns failed when new_task entry has no taskId', async () => {
@@ -876,6 +1205,24 @@ describe('drainRetryQueue', () => {
       expect(mockDispatchRetryRepo.delete).toHaveBeenCalledWith('dr_abc');
     });
 
+    it('returns internal_error when malformed new_task retry entry cannot be deleted', async () => {
+      const entryWithoutTaskId = {
+        ...sampleNewTaskRetry,
+        taskId: undefined,
+      };
+      mockDispatchRetryRepo.findOldest.mockResolvedValue(ok(entryWithoutTaskId));
+      mockDispatchRetryRepo.delete.mockResolvedValue(err({ code: 'FIRESTORE_ERROR', message: 'delete failed' }));
+
+      const result = await drainRetryQueue(buildDeps());
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toEqual({
+        code: 'internal_error',
+        message: 'Failed to delete malformed new-task retry entry',
+      });
+    });
+
     it('returns failed when task lookup fails for retry', async () => {
       mockDispatchRetryRepo.findOldest.mockResolvedValue(ok(sampleNewTaskRetry));
       mockCodeTaskRepo.findById.mockResolvedValue(err({ code: 'not_found', message: 'task not found' }));
@@ -886,6 +1233,52 @@ describe('drainRetryQueue', () => {
       if (!result.ok) return;
       expect(result.value.action).toBe('failed');
       expect(mockDispatchRetryRepo.delete).toHaveBeenCalledWith('dr_abc');
+    });
+
+    it('returns internal_error when missing-task retry entry cannot be deleted', async () => {
+      mockDispatchRetryRepo.findOldest.mockResolvedValue(ok(sampleNewTaskRetry));
+      mockCodeTaskRepo.findById.mockResolvedValue(err({ code: 'not_found', message: 'task not found' }));
+      mockDispatchRetryRepo.delete.mockResolvedValue(err({ code: 'FIRESTORE_ERROR', message: 'delete failed' }));
+
+      const result = await drainRetryQueue(buildDeps());
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toEqual({
+        code: 'internal_error',
+        message: 'Failed to delete retry entry after missing task lookup',
+      });
+    });
+
+    it('keeps retry entry when task lookup fails transiently for retry', async () => {
+      mockDispatchRetryRepo.findOldest.mockResolvedValue(ok(sampleNewTaskRetry));
+      mockCodeTaskRepo.findById.mockResolvedValue(err({ code: 'FIRESTORE_ERROR', message: 'read failed' }));
+
+      const result = await drainRetryQueue(buildDeps());
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toEqual({
+        code: 'internal_error',
+        message: 'Failed to find task for retry',
+      });
+      expect(mockDispatchRetryRepo.delete).not.toHaveBeenCalled();
+    });
+
+    it('returns internal_error when stale retry entry cannot be deleted', async () => {
+      mockDispatchRetryRepo.findOldest.mockResolvedValue(ok(sampleNewTaskRetry));
+      mockCodeTaskRepo.findById.mockResolvedValue(ok({ ...sampleTask, status: 'dispatched' }));
+      mockDispatchRetryRepo.delete.mockResolvedValue(err({ code: 'FIRESTORE_ERROR', message: 'delete failed' }));
+
+      const result = await drainRetryQueue(buildDeps());
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toEqual({
+        code: 'internal_error',
+        message: 'Failed to delete stale new-task retry entry',
+      });
+      expect(mockTaskDispatcher.dispatch).not.toHaveBeenCalled();
     });
 
     it('returns retry_failed when worker settings fetch fails', async () => {
@@ -904,7 +1297,26 @@ describe('drainRetryQueue', () => {
       }));
     });
 
-    it('returns retry_failed when worker settings value is null', async () => {
+    it('returns internal_error when worker settings failure cannot update retry metadata', async () => {
+      mockDispatchRetryRepo.findOldest.mockResolvedValue(ok(sampleNewTaskRetry));
+      mockCodeTaskRepo.findById.mockResolvedValue(ok(sampleTask));
+      mockWorkerSettingsRepo.getSettings.mockResolvedValue(err({ code: 'not_found', message: 'no settings' }));
+      mockDispatchRetryRepo.update.mockResolvedValue(err({
+        code: 'FIRESTORE_ERROR',
+        message: 'retry update failed',
+      }));
+
+      const result = await drainRetryQueue(buildDeps());
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toEqual({
+        code: 'internal_error',
+        message: 'Failed to update retry entry',
+      });
+    });
+
+    it('deletes retry entry and fails task immediately when worker settings value is null', async () => {
       mockDispatchRetryRepo.findOldest.mockResolvedValue(ok(sampleNewTaskRetry));
       mockCodeTaskRepo.findById.mockResolvedValue(ok(sampleTask));
       mockWorkerSettingsRepo.getSettings.mockResolvedValue(ok(null));
@@ -913,13 +1325,21 @@ describe('drainRetryQueue', () => {
 
       expect(result.ok).toBe(true);
       if (!result.ok) return;
-      expect(result.value.action).toBe('retry_failed');
-      expect(mockDispatchRetryRepo.update).toHaveBeenCalledWith('dr_abc', expect.objectContaining({
-        lastError: 'Failed to fetch worker settings',
+      expect(result.value.action).toBe('failed');
+      expect(mockDispatchRetryRepo.delete).toHaveBeenCalledWith('dr_abc');
+      expect(mockCodeTaskRepo.update).toHaveBeenCalledWith('task_xyz', expect.objectContaining({
+        status: 'failed',
+        error: expect.objectContaining({
+          code: 'dispatch_blocked_no_enabled_workers',
+        }),
+        dispatchStatus: expect.objectContaining({
+          state: 'terminal',
+          reason: 'no_enabled_workers',
+        }),
       }));
     });
 
-    it('returns retry_failed when no enabled workers exist', async () => {
+    it('deletes retry entry and fails task immediately when no enabled workers exist', async () => {
       mockDispatchRetryRepo.findOldest.mockResolvedValue(ok(sampleNewTaskRetry));
       mockCodeTaskRepo.findById.mockResolvedValue(ok(sampleTask));
       mockWorkerSettingsRepo.getSettings.mockResolvedValue(ok({ workers: [{ ...workerConfig, enabled: false }] }));
@@ -928,10 +1348,71 @@ describe('drainRetryQueue', () => {
 
       expect(result.ok).toBe(true);
       if (!result.ok) return;
-      expect(result.value.action).toBe('retry_failed');
-      expect(mockDispatchRetryRepo.update).toHaveBeenCalledWith('dr_abc', expect.objectContaining({
-        lastError: 'No enabled workers',
+      expect(result.value.action).toBe('failed');
+      expect(mockDispatchRetryRepo.delete).toHaveBeenCalledWith('dr_abc');
+      expect(mockCodeTaskRepo.update).toHaveBeenCalledWith('task_xyz', expect.objectContaining({
+        status: 'failed',
+        error: expect.objectContaining({
+          code: 'dispatch_blocked_no_enabled_workers',
+        }),
+        dispatchStatus: expect.objectContaining({
+          state: 'terminal',
+          reason: 'no_enabled_workers',
+          terminal: true,
+          nextAction: 'retry_after_fix',
+        }),
       }));
+      expect(mockWhatsappNotifier.notifyTaskDispatchBlocked).toHaveBeenCalledWith('user_123', expect.objectContaining({
+        reason: 'no_enabled_workers',
+        exampleTaskId: 'task_xyz',
+      }));
+      expect(mockCodeTaskRepo.update).toHaveBeenCalledWith('task_xyz', {
+        dispatchStatus: expect.objectContaining({
+          notifiedReasons: expect.objectContaining({
+            no_enabled_workers: expect.any(Timestamp),
+          }),
+        }),
+      });
+    });
+
+    it('returns internal_error when retry entry cannot be deleted after no enabled workers', async () => {
+      mockDispatchRetryRepo.findOldest.mockResolvedValue(ok(sampleNewTaskRetry));
+      mockCodeTaskRepo.findById.mockResolvedValue(ok(sampleTask));
+      mockWorkerSettingsRepo.getSettings.mockResolvedValue(ok({ workers: [{ ...workerConfig, enabled: false }] }));
+      mockDispatchRetryRepo.delete.mockResolvedValue(err({ code: 'FIRESTORE_ERROR', message: 'delete failed' }));
+
+      const result = await drainRetryQueue(buildDeps());
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toEqual({
+        code: 'internal_error',
+        message: 'Failed to delete retry entry after no enabled workers',
+      });
+      expect(mockCodeTaskRepo.update).toHaveBeenCalledWith('task_xyz', expect.objectContaining({
+        status: 'failed',
+      }));
+      expect(mockWhatsappNotifier.notifyTaskDispatchBlocked).toHaveBeenCalledWith('user_123', expect.objectContaining({
+        reason: 'no_enabled_workers',
+      }));
+    });
+
+    it('returns internal_error and keeps retry entry when terminal task failure persistence fails', async () => {
+      mockDispatchRetryRepo.findOldest.mockResolvedValue(ok(sampleNewTaskRetry));
+      mockCodeTaskRepo.findById.mockResolvedValue(ok(sampleTask));
+      mockWorkerSettingsRepo.getSettings.mockResolvedValue(ok({ workers: [{ ...workerConfig, enabled: false }] }));
+      mockCodeTaskRepo.update.mockResolvedValue(err({ code: 'FIRESTORE_ERROR', message: 'write failed' }));
+
+      const result = await drainRetryQueue(buildDeps());
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toEqual({
+          code: 'internal_error',
+          message: 'Failed to persist retry dispatch failure status',
+        });
+      }
+      expect(mockDispatchRetryRepo.delete).not.toHaveBeenCalled();
     });
 
     it('records dispatch system status when no enabled workers exist', async () => {
@@ -953,7 +1434,7 @@ describe('drainRetryQueue', () => {
       });
     });
 
-    it('updates retry entry when no enabled workers exist and dispatch status service is omitted', async () => {
+    it('still fails and notifies when no enabled workers exist and dispatch status service is omitted', async () => {
       mockDispatchRetryRepo.findOldest.mockResolvedValue(ok(sampleNewTaskRetry));
       mockCodeTaskRepo.findById.mockResolvedValue(ok(sampleTask));
       mockWorkerSettingsRepo.getSettings.mockResolvedValue(ok({ workers: [{ ...workerConfig, enabled: false }] }));
@@ -964,8 +1445,12 @@ describe('drainRetryQueue', () => {
 
       expect(result.ok).toBe(true);
       if (!result.ok) return;
-      expect(result.value.action).toBe('retry_failed');
+      expect(result.value.action).toBe('failed');
       expect(mockDispatchStatusService.recordDispatchBlocked).not.toHaveBeenCalled();
+      expect(mockWhatsappNotifier.notifyTaskDispatchBlocked).toHaveBeenCalledWith('user_123', expect.objectContaining({
+        reason: 'no_enabled_workers',
+        exampleTaskId: 'task_xyz',
+      }));
     });
 
     it('fetches Linear metadata when task has linearIssueId', async () => {
@@ -1015,6 +1500,69 @@ describe('drainRetryQueue', () => {
         attempts: 1,
         lastError: 'all workers busy',
       }));
+    });
+
+    it('records task-level waiting status and sends one notification for recoverable dispatcher blockers', async () => {
+      const blocker = {
+        dispatchable: false as const,
+        reason: 'workers_at_capacity' as const,
+        severity: 'warning' as const,
+        message: 'All capable workers for opus are currently at capacity.',
+        remediation: 'Wait for a running task to finish or add worker capacity.',
+        workerNames: ['home-mac'],
+      };
+      mockDispatchRetryRepo.findOldest.mockResolvedValue(ok(sampleNewTaskRetry));
+      mockCodeTaskRepo.findById.mockResolvedValue(ok(sampleTask));
+      mockTaskDispatcher.dispatch.mockResolvedValue(
+        err({ code: 'at_capacity', message: blocker.message, blocker })
+      );
+
+      const result = await drainRetryQueue(buildDeps());
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.action).toBe('retry_failed');
+      expect(mockCodeTaskRepo.update).toHaveBeenCalledWith('task_xyz', expect.objectContaining({
+        dispatchStatus: expect.objectContaining({
+          state: 'waiting',
+          reason: 'workers_at_capacity',
+          terminal: false,
+          nextAction: 'will_retry_automatically',
+        }),
+      }));
+      expect(mockWhatsappNotifier.notifyTaskDispatchBlocked).toHaveBeenCalledWith('user_123', expect.objectContaining({
+        workerType: 'opus',
+        reason: 'workers_at_capacity',
+        affectedTaskCount: 1,
+        exampleTaskId: 'task_xyz',
+      }));
+      expect(mockCodeTaskRepo.update).toHaveBeenCalledWith('task_xyz', {
+        dispatchStatus: expect.objectContaining({
+          notifiedReasons: expect.objectContaining({
+            workers_at_capacity: expect.any(Timestamp),
+          }),
+        }),
+      });
+    });
+
+    it('returns internal_error and does not increment attempts when recoverable dispatch status persistence fails', async () => {
+      mockDispatchRetryRepo.findOldest.mockResolvedValue(ok(sampleNewTaskRetry));
+      mockCodeTaskRepo.findById.mockResolvedValue(ok(sampleTask));
+      mockTaskDispatcher.dispatch.mockResolvedValue(
+        err({ code: 'at_capacity', message: 'all workers busy' })
+      );
+      mockCodeTaskRepo.update.mockResolvedValue(err({ code: 'FIRESTORE_ERROR', message: 'write failed' }));
+
+      const result = await drainRetryQueue(buildDeps());
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toEqual({
+          code: 'internal_error',
+          message: 'Failed to persist retry dispatch status',
+        });
+      }
+      expect(mockDispatchRetryRepo.update).not.toHaveBeenCalled();
     });
 
     it('records dispatch system status when dispatcher returns blocker metadata', async () => {
@@ -1074,7 +1622,7 @@ describe('drainRetryQueue', () => {
       }));
     });
 
-    it('skips notification when task update fails after successful dispatch', async () => {
+    it('returns internal_error and keeps retry entry when successful dispatch metadata cannot be persisted', async () => {
       mockDispatchRetryRepo.findOldest.mockResolvedValue(ok(sampleNewTaskRetry));
       mockCodeTaskRepo.findById.mockResolvedValue(ok(sampleTask));
       mockTaskDispatcher.dispatch.mockResolvedValue(ok({ dispatched: true, workerLocation: 'home-mac' }));
@@ -1082,10 +1630,14 @@ describe('drainRetryQueue', () => {
 
       const result = await drainRetryQueue(buildDeps());
 
-      expect(result.ok).toBe(true);
-      if (!result.ok) return;
-      expect(result.value.action).toBe('dispatched');
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toEqual({
+        code: 'internal_error',
+        message: 'Failed to persist successful retry dispatch metadata',
+      });
       expect(mockWhatsappNotifier.notifyTaskStarted).not.toHaveBeenCalled();
+      expect(mockDispatchRetryRepo.delete).not.toHaveBeenCalled();
     });
   });
 
@@ -1102,7 +1654,7 @@ describe('drainRetryQueue', () => {
   });
 
   describe('TTL expired edge cases', () => {
-    it('expires new_task and falls through to userId notification when task lookup fails', async () => {
+    it('expires new_task without notification when task lookup fails', async () => {
       const expiredRetry = {
         ...sampleNewTaskRetry,
         userId: 'user_123',
@@ -1117,10 +1669,33 @@ describe('drainRetryQueue', () => {
       if (!result.ok) return;
       expect(result.value.action).toBe('expired');
       expect(result.value.taskId).toBe('task_xyz');
-      // Falls through to userId notification since task lookup failed
-      expect(mockWhatsappNotifier.notifyDispatchRetryExhausted).toHaveBeenCalledWith('user_123', expect.objectContaining({
-        repository: 'intexuraos/test-repo',
-      }));
+      expect(mockDispatchRetryRepo.delete).toHaveBeenCalledWith('dr_abc');
+      expect(mockWhatsappNotifier.notifyDispatchRetryExhausted).not.toHaveBeenCalled();
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ retryId: 'dr_abc', taskId: 'task_xyz' }),
+        'Expired new-task retry target was not found; skipping task-level dispatch notification'
+      );
+    });
+
+    it('keeps expired new_task retry entry when task lookup fails transiently', async () => {
+      const expiredRetry = {
+        ...sampleNewTaskRetry,
+        userId: 'user_123',
+        createdAt: Timestamp.fromDate(new Date(Date.now() - 20 * 60 * 1000)),
+      };
+      mockDispatchRetryRepo.findOldest.mockResolvedValue(ok(expiredRetry));
+      mockCodeTaskRepo.findById.mockResolvedValue(err({ code: 'FIRESTORE_ERROR', message: 'read failed' }));
+
+      const result = await drainRetryQueue(buildDeps());
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toEqual({
+        code: 'internal_error',
+        message: 'Failed to find expired retry task',
+      });
+      expect(mockDispatchRetryRepo.delete).not.toHaveBeenCalled();
+      expect(mockWhatsappNotifier.notifyDispatchRetryExhausted).not.toHaveBeenCalled();
     });
 
     it('expires task_message type with userId notification', async () => {
@@ -1139,6 +1714,60 @@ describe('drainRetryQueue', () => {
       expect(mockWhatsappNotifier.notifyDispatchRetryExhausted).toHaveBeenCalledWith('user_123', expect.objectContaining({
         repository: 'intexuraos/test-repo',
       }));
+    });
+
+    it('expires task_message without userId and without notification', async () => {
+      const expiredMessage = {
+        ...sampleTaskMessageRetry,
+        userId: undefined,
+        createdAt: Timestamp.fromDate(new Date(Date.now() - 20 * 60 * 1000)),
+      };
+      mockDispatchRetryRepo.findOldest.mockResolvedValue(ok(expiredMessage));
+
+      const result = await drainRetryQueue(buildDeps());
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.action).toBe('expired');
+      expect(result.value.taskId).toBe('task_xyz');
+      expect(mockDispatchRetryRepo.delete).toHaveBeenCalledWith('dr_def');
+      expect(mockWhatsappNotifier.notifyDispatchRetryExhausted).not.toHaveBeenCalled();
+    });
+
+    it('returns an error when deleting expired task_message retry fails', async () => {
+      const expiredMessage = {
+        ...sampleTaskMessageRetry,
+        createdAt: Timestamp.fromDate(new Date(Date.now() - 20 * 60 * 1000)),
+      };
+      mockDispatchRetryRepo.findOldest.mockResolvedValue(ok(expiredMessage));
+      mockDispatchRetryRepo.delete.mockResolvedValue(err({ code: 'FIRESTORE_ERROR', message: 'delete failed' }));
+
+      const result = await drainRetryQueue(buildDeps());
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toEqual({ code: 'internal_error', message: 'Failed to delete expired retry entry' });
+      expect(mockWhatsappNotifier.notifyDispatchRetryExhausted).not.toHaveBeenCalled();
+    });
+
+    it('logs when expired task_message notification fails after cleanup', async () => {
+      const expiredMessage = {
+        ...sampleTaskMessageRetry,
+        createdAt: Timestamp.fromDate(new Date(Date.now() - 20 * 60 * 1000)),
+      };
+      mockDispatchRetryRepo.findOldest.mockResolvedValue(ok(expiredMessage));
+      mockWhatsappNotifier.notifyDispatchRetryExhausted.mockResolvedValue(err({
+        code: 'notification_failed',
+        message: 'wa down',
+      }));
+
+      const result = await drainRetryQueue(buildDeps());
+
+      expect(result.ok).toBe(true);
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ retryId: 'dr_def', userId: 'user_123' }),
+        'Failed to notify user about expired message retry'
+      );
     });
 
     it('expires entry without userId and without notification', async () => {
@@ -1161,7 +1790,7 @@ describe('drainRetryQueue', () => {
   });
 
   describe('max attempts exhausted edge cases', () => {
-    it('exhausts new_task and falls through to userId notification when task lookup fails', async () => {
+    it('exhausts new_task without notification when task lookup fails', async () => {
       const exhaustedRetry = {
         ...sampleNewTaskRetry,
         userId: 'user_123',
@@ -1177,10 +1806,34 @@ describe('drainRetryQueue', () => {
       if (!result.ok) return;
       expect(result.value.action).toBe('exhausted');
       expect(result.value.taskId).toBe('task_xyz');
-      expect(mockWhatsappNotifier.notifyDispatchRetryExhausted).toHaveBeenCalledWith('user_123', expect.objectContaining({
-        repository: 'intexuraos/test-repo',
-        lastError: 'worker_unavailable',
-      }));
+      expect(mockDispatchRetryRepo.delete).toHaveBeenCalledWith('dr_abc');
+      expect(mockWhatsappNotifier.notifyDispatchRetryExhausted).not.toHaveBeenCalled();
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ retryId: 'dr_abc', taskId: 'task_xyz' }),
+        'Exhausted new-task retry target was not found; skipping task-level dispatch notification'
+      );
+    });
+
+    it('keeps exhausted new_task retry entry when task lookup fails transiently', async () => {
+      const exhaustedRetry = {
+        ...sampleNewTaskRetry,
+        userId: 'user_123',
+        attempts: 3,
+        maxAttempts: 3,
+      };
+      mockDispatchRetryRepo.findOldest.mockResolvedValue(ok(exhaustedRetry));
+      mockCodeTaskRepo.findById.mockResolvedValue(err({ code: 'FIRESTORE_ERROR', message: 'read failed' }));
+
+      const result = await drainRetryQueue(buildDeps());
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toEqual({
+        code: 'internal_error',
+        message: 'Failed to find exhausted retry task',
+      });
+      expect(mockDispatchRetryRepo.delete).not.toHaveBeenCalled();
+      expect(mockWhatsappNotifier.notifyDispatchRetryExhausted).not.toHaveBeenCalled();
     });
 
     it('exhausts task_message type with userId notification', async () => {
@@ -1200,6 +1853,63 @@ describe('drainRetryQueue', () => {
       expect(mockWhatsappNotifier.notifyDispatchRetryExhausted).toHaveBeenCalledWith('user_123', expect.objectContaining({
         repository: 'intexuraos/test-repo',
       }));
+    });
+
+    it('exhausts task_message without userId and without notification', async () => {
+      const exhaustedMessage = {
+        ...sampleTaskMessageRetry,
+        userId: undefined,
+        attempts: 3,
+        maxAttempts: 3,
+      };
+      mockDispatchRetryRepo.findOldest.mockResolvedValue(ok(exhaustedMessage));
+
+      const result = await drainRetryQueue(buildDeps());
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.value.action).toBe('exhausted');
+      expect(result.value.taskId).toBe('task_xyz');
+      expect(mockDispatchRetryRepo.delete).toHaveBeenCalledWith('dr_def');
+      expect(mockWhatsappNotifier.notifyDispatchRetryExhausted).not.toHaveBeenCalled();
+    });
+
+    it('returns an error when deleting exhausted task_message retry fails', async () => {
+      const exhaustedMessage = {
+        ...sampleTaskMessageRetry,
+        attempts: 3,
+        maxAttempts: 3,
+      };
+      mockDispatchRetryRepo.findOldest.mockResolvedValue(ok(exhaustedMessage));
+      mockDispatchRetryRepo.delete.mockResolvedValue(err({ code: 'FIRESTORE_ERROR', message: 'delete failed' }));
+
+      const result = await drainRetryQueue(buildDeps());
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toEqual({ code: 'internal_error', message: 'Failed to delete exhausted retry entry' });
+      expect(mockWhatsappNotifier.notifyDispatchRetryExhausted).not.toHaveBeenCalled();
+    });
+
+    it('logs when exhausted task_message notification fails after cleanup', async () => {
+      const exhaustedMessage = {
+        ...sampleTaskMessageRetry,
+        attempts: 3,
+        maxAttempts: 3,
+      };
+      mockDispatchRetryRepo.findOldest.mockResolvedValue(ok(exhaustedMessage));
+      mockWhatsappNotifier.notifyDispatchRetryExhausted.mockResolvedValue(err({
+        code: 'notification_failed',
+        message: 'wa down',
+      }));
+
+      const result = await drainRetryQueue(buildDeps());
+
+      expect(result.ok).toBe(true);
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ retryId: 'dr_def', userId: 'user_123' }),
+        'Failed to notify user about exhausted message retry'
+      );
     });
 
     it('exhausts entry without userId and without notification', async () => {
@@ -1237,6 +1947,26 @@ describe('drainRetryQueue', () => {
       expect(mockLogLineRepo.storeBatch).toHaveBeenCalled();
     });
 
+    it('returns internal_error when successful message retry cleanup fails', async () => {
+      mockDispatchRetryRepo.findOldest.mockResolvedValue(ok(sampleTaskMessageRetry));
+      mockWorkerSettingsRepo.getSettings.mockResolvedValue(ok({ workers: [workerConfig] }));
+      mockTaskDispatcher.sendMessageToWorker.mockResolvedValue(ok({ action: 'resumed' }));
+      mockDispatchRetryRepo.delete.mockResolvedValue(err({
+        code: 'FIRESTORE_ERROR',
+        message: 'delete failed',
+      }));
+
+      const result = await drainRetryQueue(buildDeps());
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toEqual({
+        code: 'internal_error',
+        message: 'Failed to delete retry entry after successful message delivery',
+      });
+      expect(mockLogLineRepo.storeBatch).not.toHaveBeenCalled();
+    });
+
     it('increments attempts on retryable failure', async () => {
       mockDispatchRetryRepo.findOldest.mockResolvedValue(ok(sampleTaskMessageRetry));
       mockWorkerSettingsRepo.getSettings.mockResolvedValue(ok({ workers: [workerConfig] }));
@@ -1248,6 +1978,26 @@ describe('drainRetryQueue', () => {
       if (!result.ok) return;
       expect(result.value.action).toBe('retry_failed');
       expect(mockDispatchRetryRepo.update).toHaveBeenCalledWith('dr_def', expect.objectContaining({ attempts: 1 }));
+    });
+
+    it('returns internal_error when retryable message failure cannot update retry metadata', async () => {
+      mockDispatchRetryRepo.findOldest.mockResolvedValue(ok(sampleTaskMessageRetry));
+      mockWorkerSettingsRepo.getSettings.mockResolvedValue(ok({ workers: [workerConfig] }));
+      mockTaskDispatcher.sendMessageToWorker.mockResolvedValue(err({ code: 'worker_unavailable', message: 'connection refused' }));
+      mockDispatchRetryRepo.update.mockResolvedValue(err({
+        code: 'FIRESTORE_ERROR',
+        message: 'retry update failed',
+      }));
+
+      const result = await drainRetryQueue(buildDeps());
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toEqual({
+        code: 'internal_error',
+        message: 'Failed to update retry entry',
+      });
+      expect(mockDispatchRetryRepo.delete).not.toHaveBeenCalled();
     });
 
     it('returns failed when required fields are missing', async () => {
@@ -1267,6 +2017,29 @@ describe('drainRetryQueue', () => {
       expect(mockDispatchRetryRepo.delete).toHaveBeenCalledWith('dr_def');
     });
 
+    it('returns internal_error when malformed task-message retry cleanup fails', async () => {
+      const entryMissingFields = {
+        ...sampleTaskMessageRetry,
+        userId: undefined,
+        taskId: undefined,
+        message: undefined,
+      };
+      mockDispatchRetryRepo.findOldest.mockResolvedValue(ok(entryMissingFields));
+      mockDispatchRetryRepo.delete.mockResolvedValue(err({
+        code: 'FIRESTORE_ERROR',
+        message: 'delete failed',
+      }));
+
+      const result = await drainRetryQueue(buildDeps());
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toEqual({
+        code: 'internal_error',
+        message: 'Failed to delete malformed task-message retry entry',
+      });
+    });
+
     it('returns retry_failed when worker settings fetch fails', async () => {
       mockDispatchRetryRepo.findOldest.mockResolvedValue(ok(sampleTaskMessageRetry));
       mockWorkerSettingsRepo.getSettings.mockResolvedValue(err({ code: 'internal_error', message: 'db error' }));
@@ -1279,6 +2052,24 @@ describe('drainRetryQueue', () => {
       expect(mockDispatchRetryRepo.update).toHaveBeenCalledWith('dr_def', expect.objectContaining({
         lastError: 'Failed to fetch worker settings',
       }));
+    });
+
+    it('returns internal_error when task-message settings failure cannot update retry metadata', async () => {
+      mockDispatchRetryRepo.findOldest.mockResolvedValue(ok(sampleTaskMessageRetry));
+      mockWorkerSettingsRepo.getSettings.mockResolvedValue(err({ code: 'internal_error', message: 'db error' }));
+      mockDispatchRetryRepo.update.mockResolvedValue(err({
+        code: 'FIRESTORE_ERROR',
+        message: 'retry update failed',
+      }));
+
+      const result = await drainRetryQueue(buildDeps());
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toEqual({
+        code: 'internal_error',
+        message: 'Failed to update retry entry',
+      });
     });
 
     it('returns retry_failed when worker settings value is null', async () => {
@@ -1309,6 +2100,24 @@ describe('drainRetryQueue', () => {
       }));
     });
 
+    it('returns internal_error when no-worker task-message retry metadata cannot be updated', async () => {
+      mockDispatchRetryRepo.findOldest.mockResolvedValue(ok(sampleTaskMessageRetry));
+      mockWorkerSettingsRepo.getSettings.mockResolvedValue(ok({ workers: [{ ...workerConfig, enabled: false }] }));
+      mockDispatchRetryRepo.update.mockResolvedValue(err({
+        code: 'FIRESTORE_ERROR',
+        message: 'retry update failed',
+      }));
+
+      const result = await drainRetryQueue(buildDeps());
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toEqual({
+        code: 'internal_error',
+        message: 'Failed to update retry entry',
+      });
+    });
+
     it('deletes entry on non-retryable send failure', async () => {
       mockDispatchRetryRepo.findOldest.mockResolvedValue(ok(sampleTaskMessageRetry));
       mockWorkerSettingsRepo.getSettings.mockResolvedValue(ok({ workers: [workerConfig] }));
@@ -1321,6 +2130,25 @@ describe('drainRetryQueue', () => {
       expect(result.value.action).toBe('failed');
       expect(result.value.taskId).toBe('task_xyz');
       expect(mockDispatchRetryRepo.delete).toHaveBeenCalledWith('dr_def');
+    });
+
+    it('returns internal_error when permanent message failure cleanup fails', async () => {
+      mockDispatchRetryRepo.findOldest.mockResolvedValue(ok(sampleTaskMessageRetry));
+      mockWorkerSettingsRepo.getSettings.mockResolvedValue(ok({ workers: [workerConfig] }));
+      mockTaskDispatcher.sendMessageToWorker.mockResolvedValue(err({ code: 'dispatch_failed', message: 'bad payload' }));
+      mockDispatchRetryRepo.delete.mockResolvedValue(err({
+        code: 'FIRESTORE_ERROR',
+        message: 'delete failed',
+      }));
+
+      const result = await drainRetryQueue(buildDeps());
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toEqual({
+        code: 'internal_error',
+        message: 'Failed to delete retry entry after permanent message failure',
+      });
     });
 
     it('creates new task when message retry fails with stale task error (worker_error + Task not found)', async () => {
@@ -1343,6 +2171,28 @@ describe('drainRetryQueue', () => {
         senderLogin: 'testuser',
         comment: 'please also fix tests',
       }));
+    });
+
+    it('returns internal_error and does not create fallback task when stale retry cleanup fails', async () => {
+      mockDispatchRetryRepo.findOldest.mockResolvedValue(ok(sampleTaskMessageRetry));
+      mockWorkerSettingsRepo.getSettings.mockResolvedValue(ok({ workers: [workerConfig] }));
+      mockTaskDispatcher.sendMessageToWorker.mockResolvedValue(
+        err({ code: 'worker_error', message: 'Worker returned HTTP 404: Task not found' })
+      );
+      mockDispatchRetryRepo.delete.mockResolvedValue(err({
+        code: 'FIRESTORE_ERROR',
+        message: 'delete failed',
+      }));
+
+      const result = await drainRetryQueue(buildDeps());
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toEqual({
+        code: 'internal_error',
+        message: 'Failed to delete retry entry before stale task fallback',
+      });
+      expect(mockCreateTaskForPRFn).not.toHaveBeenCalled();
     });
 
     it('creates new task when message retry fails with task_not_found code', async () => {

--- a/apps/code-agent/src/__tests__/domain/usecases/drainTaskQueue.test.ts
+++ b/apps/code-agent/src/__tests__/domain/usecases/drainTaskQueue.test.ts
@@ -5,7 +5,7 @@
  *
  * Test Requirements:
  * 1. Empty queue → returns { action: 'empty' }
- * 2. TTL expired → marks task failed with queue_timeout, calls notifyTaskQueueExpired
+ * 2. TTL expired → marks task failed with queue_timeout, calls notifyTaskDispatchBlocked
  * 3. Workers still busy (dispatch error) → returns { action: 'still_busy', taskId }
  * 4. Successful dispatch → updates to dispatched, sets cancel nonce, calls notifyTaskStarted
  * 5. Concurrent drain → second call returns { action: 'skipped' }
@@ -103,6 +103,7 @@ describe('drainTaskQueue', () => {
   let mockWhatsappNotifier: {
     notifyTaskStarted: ReturnType<typeof vi.fn>;
     notifyTaskQueueExpired: ReturnType<typeof vi.fn>;
+    notifyTaskDispatchBlocked: ReturnType<typeof vi.fn>;
   };
   let mockWorkerSettingsRepo: {
     getSettings: ReturnType<typeof vi.fn>;
@@ -141,7 +142,7 @@ describe('drainTaskQueue', () => {
       hasOtherDispatchedOrRunningForLinearIssue: vi.fn().mockResolvedValue(ok({ hasActive: false })),
       claimForDispatch: vi.fn().mockResolvedValue(ok(true)),
       findById: vi.fn(),
-      update: vi.fn(),
+      update: vi.fn().mockResolvedValue(ok(createMockTask())),
       countQueued: vi.fn(),
       create: vi.fn(),
     };
@@ -159,6 +160,7 @@ describe('drainTaskQueue', () => {
     mockWhatsappNotifier = {
       notifyTaskStarted: vi.fn().mockResolvedValue(ok(undefined)),
       notifyTaskQueueExpired: vi.fn().mockResolvedValue(ok(undefined)),
+      notifyTaskDispatchBlocked: vi.fn().mockResolvedValue(ok(undefined)),
     };
 
     mockWorkerSettingsRepo = {
@@ -289,10 +291,47 @@ describe('drainTaskQueue', () => {
         code: 'queue_timeout',
         message: 'Task expired in queue after 1440 minutes. Workers were still busy.',
       },
+      dispatchStatus: expect.objectContaining({
+        state: 'terminal',
+        reason: 'queue_timeout',
+        terminal: true,
+        nextAction: 'retry_after_fix',
+      }),
     });
 
-    // Verify notification sent
-    expect(mockWhatsappNotifier.notifyTaskQueueExpired).toHaveBeenCalledWith('user-456', task);
+    // Verify dispatch-blocked notification sent and recorded
+    expect(mockWhatsappNotifier.notifyTaskDispatchBlocked).toHaveBeenCalledWith('user-456', expect.objectContaining({
+      reason: 'queue_timeout',
+      exampleTaskId: 'task-123',
+    }));
+    expect(mockCodeTaskRepo.update).toHaveBeenCalledWith('task-123', {
+      dispatchStatus: expect.objectContaining({
+        notifiedReasons: expect.objectContaining({
+          queue_timeout: expect.any(Timestamp),
+        }),
+      }),
+    });
+  });
+
+  it('returns internal_error and does not notify when queue timeout failure cannot be persisted', async () => {
+    const beyondTtl = new Date(Date.now() - 1441 * 60 * 1000);
+    const task = createMockTask({
+      queuedAt: Timestamp.fromDate(beyondTtl),
+    });
+    mockCodeTaskRepo.listQueuedByAge.mockResolvedValue(ok([task]));
+    mockCodeTaskRepo.update.mockResolvedValue(
+      err({ code: 'FIRESTORE_ERROR', message: 'write failed' }),
+    );
+
+    const result = await drainTaskQueue(createDeps());
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toEqual({
+      code: 'internal_error',
+      message: 'Failed to persist queue timeout status',
+    });
+    expect(mockWhatsappNotifier.notifyTaskDispatchBlocked).not.toHaveBeenCalled();
   });
 
   it('prepares and threads execution memory context for execution-agent dispatches', async () => {
@@ -789,7 +828,7 @@ describe('drainTaskQueue', () => {
     );
   });
 
-  it('logs warning when notifyTaskQueueExpired fails', async () => {
+  it('logs warning when queue timeout dispatch notification fails', async () => {
     const beyondTtl = new Date(Date.now() - 1441 * 60 * 1000);
     const task = createMockTask({
       queuedAt: Timestamp.fromDate(beyondTtl),
@@ -797,7 +836,7 @@ describe('drainTaskQueue', () => {
 
     mockCodeTaskRepo.listQueuedByAge.mockResolvedValue(ok([task]));
     mockCodeTaskRepo.update.mockResolvedValue(ok(task));
-    mockWhatsappNotifier.notifyTaskQueueExpired.mockResolvedValue(
+    mockWhatsappNotifier.notifyTaskDispatchBlocked.mockResolvedValue(
       err({ code: 'SEND_FAILED', message: 'WhatsApp down' })
     );
 
@@ -811,7 +850,7 @@ describe('drainTaskQueue', () => {
     // Verify warning was logged about notification failure
     expect(mockLogger.warn).toHaveBeenCalledWith(
       expect.objectContaining({ taskId: 'task-123' }),
-      'Failed to send queue expired notification'
+      'Failed to notify user about code task dispatch blocker'
     );
   });
 
@@ -851,24 +890,35 @@ describe('drainTaskQueue', () => {
     }
   });
 
-  it('returns err with internal_error when worker settings returns null', async () => {
+  it('fails immediately when worker settings returns null', async () => {
     const task = createMockTask();
     mockCodeTaskRepo.listQueuedByAge.mockResolvedValue(ok([task]));
+    mockCodeTaskRepo.update.mockResolvedValue(ok(task));
 
     mockWorkerSettingsRepo.getSettings.mockResolvedValue(ok(null));
 
     const result = await drainTaskQueue(createDeps());
 
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.error.code).toBe('internal_error');
-      expect(result.error.message).toBe('Failed to fetch worker settings');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toEqual(expect.objectContaining({ action: 'failed', taskId: 'task-123' }));
     }
+    expect(mockCodeTaskRepo.update).toHaveBeenCalledWith('task-123', expect.objectContaining({
+      status: 'failed',
+      error: expect.objectContaining({
+        code: 'dispatch_blocked_no_enabled_workers',
+      }),
+      dispatchStatus: expect.objectContaining({
+        state: 'terminal',
+        reason: 'no_enabled_workers',
+      }),
+    }));
   });
 
-  it('returns still_busy when user has no enabled workers', async () => {
+  it('fails immediately when user has no enabled workers', async () => {
     const task = createMockTask();
     mockCodeTaskRepo.listQueuedByAge.mockResolvedValue(ok([task]));
+    mockCodeTaskRepo.update.mockResolvedValue(ok(task));
 
     setupWorkerSettings([{ ...workerConfig, enabled: false }]);
 
@@ -876,13 +926,46 @@ describe('drainTaskQueue', () => {
 
     expect(result.ok).toBe(true);
     if (result.ok) {
-      expect(result.value).toEqual({ action: 'still_busy', taskId: 'task-123' });
+      expect(result.value).toEqual(expect.objectContaining({ action: 'failed', taskId: 'task-123' }));
     }
+    expect(mockCodeTaskRepo.update).toHaveBeenCalledWith('task-123', expect.objectContaining({
+      status: 'failed',
+      error: expect.objectContaining({
+        code: 'dispatch_blocked_no_enabled_workers',
+        remediation: expect.objectContaining({
+          action: 'retry',
+          manualSteps: expect.stringContaining('Enable or add a worker'),
+        }),
+      }),
+      dispatchStatus: expect.objectContaining({
+        state: 'terminal',
+        reason: 'no_enabled_workers',
+        terminal: true,
+        nextAction: 'retry_after_fix',
+      }),
+    }));
+    expect(mockWhatsappNotifier.notifyTaskDispatchBlocked).toHaveBeenCalledWith('user-456', expect.objectContaining({
+      workerType: 'auto',
+      reason: 'no_enabled_workers',
+      affectedTaskCount: 1,
+      exampleTaskId: 'task-123',
+    }));
+    expect(mockCodeTaskRepo.update).toHaveBeenCalledWith('task-123', {
+      dispatchStatus: expect.objectContaining({
+        notifiedReasons: expect.objectContaining({
+          no_enabled_workers: expect.any(Timestamp),
+        }),
+      }),
+    });
+    expect(mockCodeTaskRepo.update.mock.invocationCallOrder[0]).toBeLessThan(
+      mockWhatsappNotifier.notifyTaskDispatchBlocked.mock.invocationCallOrder[0] ?? 0,
+    );
   });
 
   it('records a dispatch system status when user has no enabled workers', async () => {
     const task = createMockTask();
     mockCodeTaskRepo.listQueuedByAge.mockResolvedValue(ok([task]));
+    mockCodeTaskRepo.update.mockResolvedValue(ok(task));
     setupWorkerSettings([{ ...workerConfig, enabled: false }]);
 
     await drainTaskQueue(createDeps());
@@ -899,9 +982,10 @@ describe('drainTaskQueue', () => {
     });
   });
 
-  it('keeps queued task busy when no enabled workers exist and dispatch status service is omitted', async () => {
+  it('still fails and notifies when no enabled workers exist and dispatch status service is omitted', async () => {
     const task = createMockTask();
     mockCodeTaskRepo.listQueuedByAge.mockResolvedValue(ok([task]));
+    mockCodeTaskRepo.update.mockResolvedValue(ok(task));
     setupWorkerSettings([{ ...workerConfig, enabled: false }]);
     const deps = createDeps();
     delete (deps as Partial<DrainTaskQueueDeps>).codeTaskDispatchStatusService;
@@ -910,9 +994,69 @@ describe('drainTaskQueue', () => {
 
     expect(result.ok).toBe(true);
     if (result.ok) {
-      expect(result.value).toEqual({ action: 'still_busy', taskId: 'task-123' });
+      expect(result.value).toEqual(expect.objectContaining({ action: 'failed', taskId: 'task-123' }));
     }
     expect(mockDispatchStatusService.recordDispatchBlocked).not.toHaveBeenCalled();
+    expect(mockWhatsappNotifier.notifyTaskDispatchBlocked).toHaveBeenCalledWith('user-456', expect.objectContaining({
+      reason: 'no_enabled_workers',
+      exampleTaskId: 'task-123',
+    }));
+  });
+
+  it('does not notify or fail no-worker task when another drain already claimed it', async () => {
+    const task = createMockTask();
+    mockCodeTaskRepo.listQueuedByAge.mockResolvedValue(ok([task]));
+    mockCodeTaskRepo.claimForDispatch.mockResolvedValue(ok(false));
+    setupWorkerSettings([{ ...workerConfig, enabled: false }]);
+
+    const result = await drainTaskQueue(createDeps());
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toEqual({ action: 'still_busy', taskId: 'task-123' });
+    }
+    expect(mockCodeTaskRepo.update).not.toHaveBeenCalled();
+    expect(mockDispatchStatusService.recordDispatchBlocked).not.toHaveBeenCalled();
+    expect(mockWhatsappNotifier.notifyTaskDispatchBlocked).not.toHaveBeenCalled();
+  });
+
+  it('does not notify or fail no-worker task when dispatch claim fails', async () => {
+    const task = createMockTask();
+    mockCodeTaskRepo.listQueuedByAge.mockResolvedValue(ok([task]));
+    mockCodeTaskRepo.claimForDispatch.mockResolvedValue(
+      err({ code: 'FIRESTORE_ERROR', message: 'transaction aborted' }),
+    );
+    setupWorkerSettings([{ ...workerConfig, enabled: false }]);
+
+    const result = await drainTaskQueue(createDeps());
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toEqual({ action: 'still_busy', taskId: 'task-123' });
+    }
+    expect(mockCodeTaskRepo.update).not.toHaveBeenCalled();
+    expect(mockDispatchStatusService.recordDispatchBlocked).not.toHaveBeenCalled();
+    expect(mockWhatsappNotifier.notifyTaskDispatchBlocked).not.toHaveBeenCalled();
+  });
+
+  it('returns internal_error when no-worker task failure cannot be persisted', async () => {
+    const task = createMockTask();
+    mockCodeTaskRepo.listQueuedByAge.mockResolvedValue(ok([task]));
+    mockCodeTaskRepo.claimForDispatch.mockResolvedValue(ok(true));
+    mockCodeTaskRepo.update.mockResolvedValue(
+      err({ code: 'FIRESTORE_ERROR', message: 'write failed' }),
+    );
+    setupWorkerSettings([{ ...workerConfig, enabled: false }]);
+
+    const result = await drainTaskQueue(createDeps());
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toEqual({
+      code: 'internal_error',
+      message: 'Failed to persist dispatch failure status',
+    });
+    expect(mockWhatsappNotifier.notifyTaskDispatchBlocked).not.toHaveBeenCalled();
   });
 
   it('returns still_busy when dispatch fails (workers busy)', async () => {
@@ -963,6 +1107,105 @@ describe('drainTaskQueue', () => {
     });
   });
 
+  it('records task-level waiting status and sends one notification for recoverable dispatcher blockers', async () => {
+    const task = createMockTask({ workerType: 'codex-xhigh' });
+    const blocker = {
+      dispatchable: false as const,
+      reason: 'workers_at_capacity' as const,
+      severity: 'warning' as const,
+      message: 'All capable workers for codex-xhigh are currently at capacity.',
+      remediation: 'Wait for a running task to finish or add worker capacity.',
+      workerNames: ['home-mac'],
+    };
+    mockCodeTaskRepo.listQueuedByAge.mockResolvedValue(ok([task]));
+    setupWorkerSettings();
+    mockCodeTaskRepo.claimForDispatch.mockResolvedValue(ok(true));
+    mockCodeTaskRepo.update.mockResolvedValue(ok(task));
+    mockTaskDispatcher.dispatch.mockResolvedValue(
+      err({ code: 'at_capacity', message: blocker.message, blocker })
+    );
+
+    const result = await drainTaskQueue(createDeps());
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toEqual({ action: 'still_busy', taskId: 'task-123' });
+    }
+    expect(mockCodeTaskRepo.update).toHaveBeenCalledWith('task-123', expect.objectContaining({
+      status: 'queued',
+      dispatchStatus: expect.objectContaining({
+        state: 'waiting',
+        reason: 'workers_at_capacity',
+        terminal: false,
+        nextAction: 'will_retry_automatically',
+      }),
+    }));
+    expect(mockWhatsappNotifier.notifyTaskDispatchBlocked).toHaveBeenCalledWith('user-456', expect.objectContaining({
+      workerType: 'codex-xhigh',
+      reason: 'workers_at_capacity',
+      affectedTaskCount: 1,
+      exampleTaskId: 'task-123',
+    }));
+    expect(mockCodeTaskRepo.update).toHaveBeenCalledWith('task-123', {
+      dispatchStatus: expect.objectContaining({
+        notifiedReasons: expect.objectContaining({
+          workers_at_capacity: expect.any(Timestamp),
+        }),
+      }),
+    });
+  });
+
+  it('suppresses repeated WhatsApp notifications for the same task and dispatch reason', async () => {
+    const notifiedAt = Timestamp.fromDate(new Date('2026-06-05T12:00:00.000Z'));
+    const task = {
+      ...createMockTask({
+      workerType: 'codex-xhigh',
+      }),
+      dispatchStatus: {
+        state: 'waiting',
+        reason: 'workers_at_capacity',
+        terminal: false,
+        severity: 'warning',
+        message: 'All capable workers for codex-xhigh are currently at capacity.',
+        remediation: 'Wait for a running task to finish or add worker capacity.',
+        workerNames: ['home-mac'],
+        firstSeenAt: notifiedAt,
+        lastSeenAt: notifiedAt,
+        nextAction: 'will_retry_automatically',
+        notifiedReasons: {
+          workers_at_capacity: notifiedAt,
+        },
+      },
+    } as CodeTask;
+    const blocker = {
+      dispatchable: false as const,
+      reason: 'workers_at_capacity' as const,
+      severity: 'warning' as const,
+      message: 'All capable workers for codex-xhigh are currently at capacity.',
+      remediation: 'Wait for a running task to finish or add worker capacity.',
+      workerNames: ['home-mac'],
+    };
+    mockCodeTaskRepo.listQueuedByAge.mockResolvedValue(ok([task]));
+    setupWorkerSettings();
+    mockCodeTaskRepo.claimForDispatch.mockResolvedValue(ok(true));
+    mockCodeTaskRepo.update.mockResolvedValue(ok(task));
+    mockTaskDispatcher.dispatch.mockResolvedValue(
+      err({ code: 'at_capacity', message: blocker.message, blocker })
+    );
+
+    await drainTaskQueue(createDeps());
+
+    expect(mockWhatsappNotifier.notifyTaskDispatchBlocked).not.toHaveBeenCalled();
+    expect(mockCodeTaskRepo.update).toHaveBeenCalledWith('task-123', expect.objectContaining({
+      status: 'queued',
+      dispatchStatus: expect.objectContaining({
+        notifiedReasons: {
+          workers_at_capacity: notifiedAt,
+        },
+      }),
+    }));
+  });
+
   it('fails task when dispatch returns permanent error', async () => {
     const task = createMockTask();
     mockCodeTaskRepo.listQueuedByAge.mockResolvedValue(ok([task]));
@@ -983,16 +1226,25 @@ describe('drainTaskQueue', () => {
     }
 
     // Verify task was marked as failed with the dispatch error
-    expect(mockCodeTaskRepo.update).toHaveBeenCalledWith('task-123', {
+    expect(mockCodeTaskRepo.update).toHaveBeenCalledWith('task-123', expect.objectContaining({
       status: 'failed',
       error: {
-        code: 'dispatch_failed',
+        code: 'dispatch_blocked_dispatch_failed',
         message: expect.stringContaining('Bad worker response'),
+        remediation: expect.objectContaining({
+          action: 'retry',
+        }),
       },
-    });
+      dispatchStatus: expect.objectContaining({
+        state: 'terminal',
+        reason: 'dispatch_failed',
+        terminal: true,
+        nextAction: 'retry_after_fix',
+      }),
+    }));
   });
 
-  it('logs error when fail-status update itself fails during permanent dispatch error', async () => {
+  it('returns internal_error when fail-status update itself fails during permanent dispatch error', async () => {
     const task = createMockTask();
     mockCodeTaskRepo.listQueuedByAge.mockResolvedValue(ok([task]));
     setupWorkerSettings();
@@ -1008,16 +1260,18 @@ describe('drainTaskQueue', () => {
 
     const result = await drainTaskQueue(createDeps());
 
-    // Still returns failed action even if update didn't persist
-    expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.value).toEqual(expect.objectContaining({ action: 'failed', taskId: 'task-123' }));
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toEqual({
+        code: 'internal_error',
+        message: 'Failed to persist dispatch failure status',
+      });
     }
 
     // Verify error was logged about the failed update
     expect(mockLogger.error).toHaveBeenCalledWith(
       expect.objectContaining({ taskId: 'task-123' }),
-      'Failed to persist failed status during drain'
+      'Failed to persist failed status during dispatch blocker handling'
     );
   });
 
@@ -1049,6 +1303,7 @@ describe('drainTaskQueue', () => {
       workerLocation: 'home-mac',
       cancelNonce: 'abcd1234',
       cancelNonceExpiresAt: expect.any(String),
+      dispatchStatus: null,
     });
 
     // Verify notification sent
@@ -1164,7 +1419,7 @@ describe('drainTaskQueue', () => {
     );
   });
 
-  it('fails task with MISSING_PR_BRANCH when review task has prNumber but no prBranch', async () => {
+  it('fails task with dispatch status when review task has prNumber but no prBranch', async () => {
     const task = createMockTask({ prNumber: 42, agentType: 'review' });
     mockCodeTaskRepo.listQueuedByAge.mockResolvedValue(ok([task]));
     setupWorkerSettings();
@@ -1185,10 +1440,39 @@ describe('drainTaskQueue', () => {
       expect.objectContaining({
         status: 'failed',
         error: expect.objectContaining({
-          code: 'MISSING_PR_BRANCH',
+          code: 'dispatch_blocked_missing_pr_branch',
+        }),
+        dispatchStatus: expect.objectContaining({
+          state: 'terminal',
+          reason: 'missing_pr_branch',
+          nextAction: 'retry_after_fix',
         }),
       })
     );
+    expect(mockWhatsappNotifier.notifyTaskDispatchBlocked).toHaveBeenCalledWith('user-456', expect.objectContaining({
+      reason: 'missing_pr_branch',
+      exampleTaskId: task.id,
+    }));
+  });
+
+  it('returns internal_error when missing PR branch task failure cannot be persisted', async () => {
+    const task = createMockTask({ prNumber: 42, agentType: 'review' });
+    mockCodeTaskRepo.listQueuedByAge.mockResolvedValue(ok([task]));
+    setupWorkerSettings();
+    mockCodeTaskRepo.update.mockResolvedValue(
+      err({ code: 'FIRESTORE_ERROR', message: 'write failed' }),
+    );
+
+    const result = await drainTaskQueue(createDeps());
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toEqual({
+      code: 'internal_error',
+      message: 'Failed to persist dispatch failure status',
+    });
+    expect(mockTaskDispatcher.dispatch).not.toHaveBeenCalled();
+    expect(mockWhatsappNotifier.notifyTaskDispatchBlocked).not.toHaveBeenCalled();
   });
 
   it('does not include prNumber in dispatch request when task has no prNumber', async () => {
@@ -1679,10 +1963,15 @@ describe('drainTaskQueue', () => {
         expect(result.value).toEqual(expect.objectContaining({ action: 'still_busy' }));
       }
 
-      // Verify queuedAt was reset
-      expect(mockCodeTaskRepo.update).toHaveBeenCalledWith('task-123', {
+      // Verify queuedAt was reset and the task page can explain the active PR wait.
+      expect(mockCodeTaskRepo.update).toHaveBeenCalledWith('task-123', expect.objectContaining({
         queuedAt: expect.any(Date),
-      });
+        dispatchStatus: expect.objectContaining({
+          state: 'waiting',
+          reason: 'active_task_blocked',
+          nextAction: 'wait_for_active_task',
+        }),
+      }));
     });
 
     it('logs warning and continues when queuedAt reset fails for PR-locked task', async () => {
@@ -1734,9 +2023,9 @@ describe('drainTaskQueue', () => {
       }
 
       // Verify queuedAt was reset (NOT marked as failed)
-      expect(mockCodeTaskRepo.update).toHaveBeenCalledWith('task-123', {
+      expect(mockCodeTaskRepo.update).toHaveBeenCalledWith('task-123', expect.objectContaining({
         queuedAt: expect.any(Date),
-      });
+      }));
       expect(mockCodeTaskRepo.update).not.toHaveBeenCalledWith('task-123', expect.objectContaining({
         status: 'failed',
       }));
@@ -1929,6 +2218,12 @@ describe('drainTaskQueue', () => {
           code: 'queue_timeout',
           message: 'Task expired in queue after 1440 minutes. Workers were still busy.',
         },
+        dispatchStatus: expect.objectContaining({
+          state: 'terminal',
+          reason: 'queue_timeout',
+          terminal: true,
+          nextAction: 'retry_after_fix',
+        }),
       });
 
       // Verify per-PR guard WAS called (it runs before TTL in the new ordering)
@@ -2579,9 +2874,15 @@ describe('drainTaskQueue', () => {
         }
 
         // Claim was rolled back to queued so the next drain cycle can retry.
-        expect(mockCodeTaskRepo.update).toHaveBeenCalledWith('task-123', {
+        expect(mockCodeTaskRepo.update).toHaveBeenCalledWith('task-123', expect.objectContaining({
           status: 'queued',
-        });
+          dispatchStatus: expect.objectContaining({
+            state: 'waiting',
+            reason: code,
+            terminal: false,
+            nextAction: 'will_retry_automatically',
+          }),
+        }));
 
         // queuedAt MUST NOT be reset — TTL must still bound the queue lifetime.
         const queuedAtResetCall = mockCodeTaskRepo.update.mock.calls.find(
@@ -2624,13 +2925,22 @@ describe('drainTaskQueue', () => {
           );
         }
 
-        expect(mockCodeTaskRepo.update).toHaveBeenCalledWith('task-123', {
+        expect(mockCodeTaskRepo.update).toHaveBeenCalledWith('task-123', expect.objectContaining({
           status: 'failed',
           error: {
-            code,
+            code: `dispatch_blocked_${code}`,
             message: expect.stringContaining(`Permanent: ${code}`),
+            remediation: expect.objectContaining({
+              action: 'retry',
+            }),
           },
-        });
+          dispatchStatus: expect.objectContaining({
+            state: 'terminal',
+            reason: code,
+            terminal: true,
+            nextAction: 'retry_after_fix',
+          }),
+        }));
       },
     );
   });
@@ -2673,6 +2983,42 @@ describe('drainTaskQueue', () => {
         },
       );
       expect(queuedAtResetCall).toBeUndefined();
+      expect(mockCodeTaskRepo.update).toHaveBeenCalledWith('review-task', {
+        dispatchStatus: expect.objectContaining({
+          state: 'waiting',
+          reason: 'active_task_blocked',
+          nextAction: 'wait_for_active_task',
+        }),
+      });
+    });
+
+    it('logs warning and continues when active Linear issue wait status persistence fails', async () => {
+      const reviewTask = createMockTask({
+        id: 'review-task',
+        agentType: 'review',
+        prNumber: 1,
+        prBranch: 'fix/branch',
+        repository: 'pbuchman/intexuraos',
+        linearIssueId: 'INT-1529',
+      });
+      mockCodeTaskRepo.listQueuedByAge.mockResolvedValue(ok([reviewTask]));
+      mockCodeTaskRepo.hasOtherDispatchedOrRunningForLinearIssue.mockResolvedValue(
+        ok({ hasActive: true, taskId: 'planning-running' }),
+      );
+      mockCodeTaskRepo.update.mockResolvedValue(
+        err({ code: 'FIRESTORE_ERROR', message: 'write failed' }),
+      );
+
+      const result = await drainTaskQueue(createDeps());
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value).toEqual(expect.objectContaining({ action: 'still_busy' }));
+      }
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ taskId: 'review-task', activeTaskId: 'planning-running' }),
+        'Failed to persist active-task dispatch wait status',
+      );
     });
 
     it('two queued reviews on same Linear issue do NOT deadlock — one dispatches', async () => {
@@ -2915,10 +3261,16 @@ describe('drainTaskQueue', () => {
 
       expect(mockCodeTaskRepo.claimForDispatch).toHaveBeenCalledWith('task-123');
       // Rollback: claim was atomically dispatched; on retryable error we put it back to queued.
-      expect(mockCodeTaskRepo.update).toHaveBeenCalledWith('task-123', { status: 'queued' });
+      expect(mockCodeTaskRepo.update).toHaveBeenCalledWith('task-123', expect.objectContaining({
+        status: 'queued',
+        dispatchStatus: expect.objectContaining({
+          state: 'waiting',
+          reason: 'worker_unavailable',
+        }),
+      }));
     });
 
-    it('logs warning when claim rollback fails after retryable dispatch error', async () => {
+    it('returns internal_error when claim rollback fails after retryable dispatch error', async () => {
       const task = createMockTask();
       mockCodeTaskRepo.listQueuedByAge.mockResolvedValue(ok([task]));
       setupWorkerSettings();
@@ -2932,10 +3284,12 @@ describe('drainTaskQueue', () => {
 
       const result = await drainTaskQueue(createDeps());
 
-      // Still returns still_busy even if rollback fails — TTL is the safety net.
-      expect(result.ok).toBe(true);
-      if (result.ok) {
-        expect(result.value).toEqual({ action: 'still_busy', taskId: 'task-123' });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toEqual({
+          code: 'internal_error',
+          message: 'Failed to persist recoverable dispatch status',
+        });
       }
 
       expect(mockLogger.warn).toHaveBeenCalledWith(
@@ -2973,18 +3327,25 @@ describe('drainTaskQueue', () => {
       expect(queuedRollbackCall).toBeUndefined();
 
       // Failure path overwrites status to 'failed'.
-      expect(mockCodeTaskRepo.update).toHaveBeenCalledWith('task-123', {
+      expect(mockCodeTaskRepo.update).toHaveBeenCalledWith('task-123', expect.objectContaining({
         status: 'failed',
         error: {
-          code: 'dispatch_failed',
+          code: 'dispatch_blocked_dispatch_failed',
           message: expect.stringContaining('bad worker response'),
+          remediation: expect.objectContaining({
+            action: 'retry',
+          }),
         },
-      });
+        dispatchStatus: expect.objectContaining({
+          reason: 'dispatch_failed',
+          terminal: true,
+        }),
+      }));
     });
   });
 
   describe('schedule-aware draining (INT-1463)', () => {
-    it('skips a scheduled task that is not yet eligible without dispatching or updating it', async () => {
+    it('skips a scheduled task that is not yet eligible and records a scheduled wait status', async () => {
       const now = Date.now();
       const task = createMockTask({
         id: 'scheduled-task',
@@ -3005,9 +3366,89 @@ describe('drainTaskQueue', () => {
         expect(result.value).toEqual({ action: 'still_busy' });
       }
 
-      // Not dispatched, not updated (no queuedAt reset, no status change).
+      // Not dispatched, no queuedAt reset/status change; only the dispatch wait explanation is recorded.
       expect(mockTaskDispatcher.dispatch).not.toHaveBeenCalled();
-      expect(mockCodeTaskRepo.update).not.toHaveBeenCalled();
+      expect(mockCodeTaskRepo.update).toHaveBeenCalledWith('scheduled-task', {
+        dispatchStatus: expect.objectContaining({
+          state: 'waiting',
+          reason: 'scheduled_wait',
+          nextAction: 'wait_until_scheduled',
+        }),
+      });
+    });
+
+    it('preserves scheduled wait firstSeenAt and notification ledger when the task is still waiting', async () => {
+      const now = Date.now();
+      const firstSeenAt = Timestamp.fromDate(new Date(now - 30 * 60 * 1000));
+      const notifiedAt = Timestamp.fromDate(new Date(now - 29 * 60 * 1000));
+      const task = createMockTask({
+        id: 'scheduled-task',
+        queuedAt: Timestamp.fromDate(new Date(now - 60 * 1000)),
+        dispatchSchedule: {
+          notBeforeAt: Timestamp.fromDate(new Date(now + 10 * 60 * 1000)),
+          source: 'user_scheduled',
+          derivedBy: 'user_input',
+        },
+        dispatchStatus: {
+          state: 'waiting',
+          reason: 'scheduled_wait',
+          terminal: false,
+          severity: 'info',
+          message: 'Already waiting.',
+          remediation: 'Wait.',
+          workerNames: [],
+          firstSeenAt,
+          lastSeenAt: firstSeenAt,
+          nextAction: 'wait_until_scheduled',
+          notifiedReasons: {
+            queue_full: notifiedAt,
+          },
+        },
+      });
+      mockCodeTaskRepo.listQueuedByAge.mockResolvedValue(ok([task]));
+      setupWorkerSettings();
+
+      const result = await drainTaskQueue(createDeps());
+
+      expect(result.ok).toBe(true);
+      expect(mockCodeTaskRepo.update).toHaveBeenCalledWith('scheduled-task', {
+        dispatchStatus: expect.objectContaining({
+          reason: 'scheduled_wait',
+          firstSeenAt,
+          notifiedReasons: {
+            queue_full: notifiedAt,
+          },
+        }),
+      });
+    });
+
+    it('logs and continues when scheduled wait status persistence fails', async () => {
+      const now = Date.now();
+      const task = createMockTask({
+        id: 'scheduled-task',
+        queuedAt: Timestamp.fromDate(new Date(now - 60 * 1000)),
+        dispatchSchedule: {
+          notBeforeAt: Timestamp.fromDate(new Date(now + 10 * 60 * 1000)),
+          source: 'user_scheduled',
+          derivedBy: 'user_input',
+        },
+      });
+      mockCodeTaskRepo.listQueuedByAge.mockResolvedValue(ok([task]));
+      mockCodeTaskRepo.update.mockResolvedValue(
+        err({ code: 'FIRESTORE_ERROR', message: 'write failed' }),
+      );
+      setupWorkerSettings();
+
+      const result = await drainTaskQueue(createDeps());
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value).toEqual({ action: 'still_busy' });
+      }
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ taskId: 'scheduled-task' }),
+        'Failed to persist scheduled dispatch wait status',
+      );
     });
 
     it('logs future-scheduled eligibility as the all-candidates reason instead of active-resource blocking', async () => {
@@ -3151,7 +3592,54 @@ describe('drainTaskQueue', () => {
           code: 'queue_timeout',
           message: 'Task expired in queue after 1440 minutes. Workers were still busy.',
         },
+        dispatchStatus: expect.objectContaining({
+          state: 'terminal',
+          reason: 'queue_timeout',
+          terminal: true,
+          nextAction: 'retry_after_fix',
+        }),
       });
+    });
+
+    it('preserves queue timeout firstSeenAt and notification ledger when timeout was already recorded', async () => {
+      const now = Date.now();
+      const firstSeenAt = Timestamp.fromDate(new Date(now - 2 * 60 * 60 * 1000));
+      const notifiedAt = Timestamp.fromDate(new Date(now - 90 * 60 * 1000));
+      const task = createMockTask({
+        id: 'stale-queued',
+        queuedAt: Timestamp.fromDate(new Date(now - 25 * 60 * 60 * 1000)),
+        dispatchStatus: {
+          state: 'terminal',
+          reason: 'queue_timeout',
+          terminal: true,
+          severity: 'critical',
+          message: 'Already timed out.',
+          remediation: 'Retry.',
+          workerNames: [],
+          firstSeenAt,
+          lastSeenAt: firstSeenAt,
+          nextAction: 'retry_after_fix',
+          notifiedReasons: {
+            no_enabled_workers: notifiedAt,
+          },
+        },
+      });
+      mockCodeTaskRepo.listQueuedByAge.mockResolvedValue(ok([task]));
+      mockCodeTaskRepo.update.mockResolvedValue(ok(task));
+
+      const result = await drainTaskQueue(createDeps());
+
+      expect(result.ok).toBe(true);
+      expect(mockCodeTaskRepo.update).toHaveBeenCalledWith('stale-queued', expect.objectContaining({
+        status: 'failed',
+        dispatchStatus: expect.objectContaining({
+          reason: 'queue_timeout',
+          firstSeenAt,
+          notifiedReasons: {
+            no_enabled_workers: notifiedAt,
+          },
+        }),
+      }));
     });
 
     it('dispatches a scheduled task normally once notBeforeAt has passed, without resetting queuedAt', async () => {

--- a/apps/code-agent/src/__tests__/domain/usecases/startAskAgent.test.ts
+++ b/apps/code-agent/src/__tests__/domain/usecases/startAskAgent.test.ts
@@ -11,6 +11,7 @@ import { createFirestoreCodeTaskRepository } from '../../../infra/firestore/fire
 import type { CodeTaskRepository } from '../../../domain/repositories/codeTaskRepository.js';
 import type { WorkerSettingsRepository } from '../../../domain/ports/workerSettingsRepository.js';
 import type { TaskEnqueueService } from '../../../domain/services/taskEnqueueService.js';
+import type { WhatsAppNotifier } from '../../../domain/services/whatsappNotifier.js';
 import { createWorkerSettingsRepository } from '../../../infra/firestore/workerSettingsRepository.js';
 import { startAskAgent } from '../../../domain/usecases/startAskAgent.js';
 
@@ -27,6 +28,7 @@ describe('startAskAgent', () => {
   let codeTaskRepo: CodeTaskRepository;
   let workerSettingsRepo: WorkerSettingsRepository;
   let taskEnqueueService: TaskEnqueueService;
+  let whatsappNotifier: WhatsAppNotifier;
 
   beforeEach(async () => {
     fakeFirestore = createFakeFirestore();
@@ -46,6 +48,9 @@ describe('startAskAgent', () => {
     taskEnqueueService = {
       enqueue: vi.fn().mockResolvedValue(ok({ taskId: 'test', queuePosition: 1 })),
     };
+    whatsappNotifier = {
+      notifyTaskDispatchBlocked: vi.fn().mockResolvedValue(ok(undefined)),
+    } as unknown as WhatsAppNotifier;
 
     // Seed a worker for the test user
     await workerSettingsRepo.addWorker('test-user-id', {
@@ -64,7 +69,7 @@ describe('startAskAgent', () => {
 
   it('submits task successfully on happy path', async () => {
     const result = await startAskAgent(
-      { logger, codeTaskRepo, workerSettingsRepo, taskEnqueueService },
+      { logger, codeTaskRepo, workerSettingsRepo, taskEnqueueService, whatsappNotifier },
       { userId: 'test-user-id', prompt: 'What is the architecture of this codebase?' },
     );
 
@@ -82,43 +87,87 @@ describe('startAskAgent', () => {
     );
   });
 
-  it('returns worker_not_configured when no workers are set up', async () => {
+  it('returns a failed task id when no workers are set up', async () => {
     // Use a user with no workers
     const result = await startAskAgent(
-      { logger, codeTaskRepo, workerSettingsRepo, taskEnqueueService },
+      { logger, codeTaskRepo, workerSettingsRepo, taskEnqueueService, whatsappNotifier },
+      { userId: 'user-with-no-workers', prompt: 'Ask something' },
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.status).toBe('failed');
+    const taskResult = await codeTaskRepo.findLatestAskAgentTask('user-with-no-workers');
+    expect(taskResult.ok).toBe(true);
+    if (!taskResult.ok) return;
+    expect(taskResult.value).not.toBeNull();
+    if (taskResult.value === null) return;
+    const task = taskResult.value;
+    expect(task).toEqual(expect.objectContaining({
+      status: 'failed',
+      error: expect.objectContaining({
+        code: 'dispatch_blocked_no_enabled_workers',
+      }),
+      dispatchStatus: expect.objectContaining({
+        state: 'terminal',
+        reason: 'no_enabled_workers',
+        nextAction: 'retry_after_fix',
+      }),
+    }));
+    expect(whatsappNotifier.notifyTaskDispatchBlocked).toHaveBeenCalledWith(
+      'user-with-no-workers',
+      expect.objectContaining({
+        reason: 'no_enabled_workers',
+        exampleTaskId: task.id,
+      }),
+    );
+  });
+
+  it('returns internal_error when no-worker ask-agent task failure cannot be persisted', async () => {
+    vi.spyOn(codeTaskRepo, 'update').mockResolvedValueOnce(
+      err({ code: 'FIRESTORE_ERROR', message: 'write failed' }),
+    );
+
+    const result = await startAskAgent(
+      { logger, codeTaskRepo, workerSettingsRepo, taskEnqueueService, whatsappNotifier },
       { userId: 'user-with-no-workers', prompt: 'Ask something' },
     );
 
     expect(result.ok).toBe(false);
     if (result.ok) return;
-    expect(result.error.code).toBe('worker_not_configured');
+    expect(result.error).toEqual({
+      code: 'internal_error',
+      message: 'Failed to persist dispatch failure status',
+    });
+    expect(whatsappNotifier.notifyTaskDispatchBlocked).not.toHaveBeenCalled();
   });
 
-  it('returns queue_full when queue is at capacity', async () => {
+  it('returns a failed task id when queue is at capacity', async () => {
     vi.mocked(taskEnqueueService.enqueue).mockResolvedValueOnce(
       err({ code: 'queue_full', message: 'Queue is full (50/50)' }),
     );
 
     const result = await startAskAgent(
-      { logger, codeTaskRepo, workerSettingsRepo, taskEnqueueService },
+      { logger, codeTaskRepo, workerSettingsRepo, taskEnqueueService, whatsappNotifier },
       { userId: 'test-user-id', prompt: 'Ask something' },
     );
 
-    expect(result.ok).toBe(false);
-    if (result.ok) return;
-    expect(result.error.code).toBe('queue_full');
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.status).toBe('failed');
+    expect(result.value.codeTaskId).toMatch(/^task_/);
   });
 
   it('returns duplicate_prompt when similar prompt was recently submitted', async () => {
     // Submit first task
     await startAskAgent(
-      { logger, codeTaskRepo, workerSettingsRepo, taskEnqueueService },
+      { logger, codeTaskRepo, workerSettingsRepo, taskEnqueueService, whatsappNotifier },
       { userId: 'test-user-id', prompt: 'Exact same prompt' },
     );
 
     // Submit second task with same prompt
     const result = await startAskAgent(
-      { logger, codeTaskRepo, workerSettingsRepo, taskEnqueueService },
+      { logger, codeTaskRepo, workerSettingsRepo, taskEnqueueService, whatsappNotifier },
       { userId: 'test-user-id', prompt: 'Exact same prompt' },
     );
 
@@ -133,7 +182,7 @@ describe('startAskAgent', () => {
     );
 
     const result = await startAskAgent(
-      { logger, codeTaskRepo, workerSettingsRepo, taskEnqueueService },
+      { logger, codeTaskRepo, workerSettingsRepo, taskEnqueueService, whatsappNotifier },
       { userId: 'test-user-id', prompt: 'Ask something new' },
     );
 
@@ -142,7 +191,7 @@ describe('startAskAgent', () => {
     expect(result.error.code).toBe('internal_error');
   });
 
-  it('returns internal_error when worker settings fetch fails', async () => {
+  it('returns a failed task id when worker settings fetch fails after task creation', async () => {
     // Create a mock workerSettingsRepo that fails
     const failingWorkerSettingsRepo: WorkerSettingsRepository = {
       ...workerSettingsRepo,
@@ -150,13 +199,56 @@ describe('startAskAgent', () => {
     };
 
     const result = await startAskAgent(
-      { logger, codeTaskRepo, workerSettingsRepo: failingWorkerSettingsRepo, taskEnqueueService },
+      { logger, codeTaskRepo, workerSettingsRepo: failingWorkerSettingsRepo, taskEnqueueService, whatsappNotifier },
       { userId: 'test-user-id', prompt: 'Ask something else' },
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.status).toBe('failed');
+    expect(result.value.codeTaskId).toMatch(/^task_/);
+
+    const taskResult = await codeTaskRepo.findById(result.value.codeTaskId);
+    expect(taskResult.ok).toBe(true);
+    if (!taskResult.ok) return;
+    expect(taskResult.value.status).toBe('failed');
+    expect(taskResult.value.error).toEqual(expect.objectContaining({
+      code: 'dispatch_blocked_dispatch_failed',
+    }));
+    expect(taskResult.value.dispatchStatus).toEqual(expect.objectContaining({
+      state: 'terminal',
+      reason: 'dispatch_failed',
+      nextAction: 'retry_after_fix',
+    }));
+    expect(whatsappNotifier.notifyTaskDispatchBlocked).toHaveBeenCalledWith(
+      'test-user-id',
+      expect.objectContaining({
+        reason: 'dispatch_failed',
+        exampleTaskId: result.value.codeTaskId,
+      }),
+    );
+  });
+
+  it('returns internal_error when settings-fetch failure status cannot be persisted', async () => {
+    const failingWorkerSettingsRepo: WorkerSettingsRepository = {
+      ...workerSettingsRepo,
+      getSettings: vi.fn().mockResolvedValue(err({ code: 'internal_error', message: 'Firestore error' })),
+    };
+    vi.spyOn(codeTaskRepo, 'update').mockResolvedValueOnce(
+      err({ code: 'FIRESTORE_ERROR', message: 'write failed' }),
+    );
+
+    const result = await startAskAgent(
+      { logger, codeTaskRepo, workerSettingsRepo: failingWorkerSettingsRepo, taskEnqueueService, whatsappNotifier },
+      { userId: 'test-user-id', prompt: 'Ask something with failing persistence' },
     );
 
     expect(result.ok).toBe(false);
     if (result.ok) return;
-    expect(result.error.code).toBe('internal_error');
-    expect(result.error.message).toBe('Failed to fetch worker settings');
+    expect(result.error).toEqual({
+      code: 'internal_error',
+      message: 'Failed to persist dispatch failure status',
+    });
+    expect(whatsappNotifier.notifyTaskDispatchBlocked).not.toHaveBeenCalled();
   });
 });

--- a/apps/code-agent/src/__tests__/domain/utils/retryableErrors.test.ts
+++ b/apps/code-agent/src/__tests__/domain/utils/retryableErrors.test.ts
@@ -15,12 +15,12 @@ describe('retryableErrors', () => {
       expect(isRetryableErrorCode('network_error')).toBe(true);
     });
 
-    it('returns false for at_capacity', () => {
-      expect(isRetryableErrorCode('at_capacity')).toBe(false);
+    it('returns true for at_capacity', () => {
+      expect(isRetryableErrorCode('at_capacity')).toBe(true);
     });
 
-    it('returns false for worker_busy', () => {
-      expect(isRetryableErrorCode('worker_busy')).toBe(false);
+    it('returns true for worker_busy', () => {
+      expect(isRetryableErrorCode('worker_busy')).toBe(true);
     });
 
     it('returns false for dispatch_failed', () => {

--- a/apps/code-agent/src/__tests__/helpers/mockServices.ts
+++ b/apps/code-agent/src/__tests__/helpers/mockServices.ts
@@ -163,6 +163,9 @@ export function setupTestServices({ actionsAgentUrl = 'http://actions-agent' }: 
     taskEnqueueService: createTaskEnqueueService({
       logger,
       codeTaskRepo: createFirestoreCodeTaskRepository({ firestore: fakeFirestore, logger }),
+      whatsappNotifier: createWhatsAppNotifier({
+        whatsappPublisher: { publishSendMessage: async () => ok(undefined) } as unknown as WhatsAppSendPublisher,
+      }),
     }),
     whatsappNotifier: createWhatsAppNotifier({
       whatsappPublisher: { publishSendMessage: async () => ok(undefined) } as unknown as WhatsAppSendPublisher,
@@ -196,11 +199,11 @@ export function setupTestServices({ actionsAgentUrl = 'http://actions-agent' }: 
   const taskEnqueueService = createTaskEnqueueService({
     logger,
     codeTaskRepo,
+    whatsappNotifier,
   });
   const codeTaskSystemStatusRepo = createFirestoreCodeTaskSystemStatusRepository({ firestore: fakeFirestore, logger });
   const codeTaskDispatchStatusService = createCodeTaskDispatchStatusService({
     statusRepo: codeTaskSystemStatusRepo,
-    whatsappNotifier,
     logger,
   });
 

--- a/apps/code-agent/src/__tests__/infra/firestore/dispatchRetryRepository.test.ts
+++ b/apps/code-agent/src/__tests__/infra/firestore/dispatchRetryRepository.test.ts
@@ -4,13 +4,14 @@
 
 import { describe, it, expect, beforeEach } from 'vitest';
 import { createFakeFirestore, setFirestore } from '@intexuraos/infra-firestore';
-import type { Firestore } from '@google-cloud/firestore';
+import { Timestamp, type Firestore } from '@google-cloud/firestore';
 import pino from 'pino';
 import { createFirestoreDispatchRetryRepository } from '../../../infra/firestore/dispatchRetryRepository.js';
 import type { CreateDispatchRetryInput } from '../../../domain/models/dispatchRetry.js';
 
 describe('FirestoreDispatchRetryRepository', () => {
   let repo: ReturnType<typeof createFirestoreDispatchRetryRepository>;
+  let fakeFirestore: Firestore;
 
   const sampleInput: CreateDispatchRetryInput = {
     type: 'new_task',
@@ -27,7 +28,7 @@ describe('FirestoreDispatchRetryRepository', () => {
   };
 
   beforeEach(() => {
-    const fakeFirestore = createFakeFirestore() as unknown as Firestore;
+    fakeFirestore = createFakeFirestore() as unknown as Firestore;
     setFirestore(fakeFirestore);
     const logger = pino({ level: 'silent' });
     repo = createFirestoreDispatchRetryRepository({ logger });
@@ -123,6 +124,171 @@ describe('FirestoreDispatchRetryRepository', () => {
       if (findResult.value === null) return;
       expect(findResult.value.attempts).toBe(1);
       expect(findResult.value.lastError).toBe('network_error: timeout');
+    });
+  });
+
+  describe('claimForProcessing', () => {
+    it('claims an unprocessed retry entry and exposes processingStartedAt', async () => {
+      const createResult = await repo.create(sampleInput);
+      expect(createResult.ok).toBe(true);
+      if (!createResult.ok) return;
+
+      const claimResult = await repo.claimForProcessing(
+        createResult.value.id,
+        new Date(Date.now() - 5 * 60 * 1000),
+      );
+
+      expect(claimResult.ok).toBe(true);
+      if (!claimResult.ok) return;
+      expect(claimResult.value).toBe(true);
+
+      const findResult = await repo.findOldest();
+      expect(findResult.ok).toBe(true);
+      if (!findResult.ok || findResult.value === null) return;
+      expect(findResult.value.processingStartedAt).toBeDefined();
+    });
+
+    it('does not claim an entry that was processed recently', async () => {
+      const createResult = await repo.create(sampleInput);
+      expect(createResult.ok).toBe(true);
+      if (!createResult.ok) return;
+
+      const firstClaim = await repo.claimForProcessing(
+        createResult.value.id,
+        new Date(Date.now() - 5 * 60 * 1000),
+      );
+      expect(firstClaim.ok).toBe(true);
+
+      const secondClaim = await repo.claimForProcessing(
+        createResult.value.id,
+        new Date(Date.now() - 5 * 60 * 1000),
+      );
+
+      expect(secondClaim.ok).toBe(true);
+      if (!secondClaim.ok) return;
+      expect(secondClaim.value).toBe(false);
+    });
+
+    it('reclaims an entry whose processing timestamp is stale', async () => {
+      const createResult = await repo.create(sampleInput);
+      expect(createResult.ok).toBe(true);
+      if (!createResult.ok) return;
+
+      const updateResult = await repo.update(createResult.value.id, {
+        attempts: 1,
+        lastAttemptAt: new Date('2025-01-01T00:00:00Z'),
+        lastError: 'previous attempt',
+        processingStartedAt: new Date('2025-01-01T00:00:00Z'),
+      });
+      expect(updateResult.ok).toBe(true);
+
+      const claimResult = await repo.claimForProcessing(
+        createResult.value.id,
+        new Date('2025-01-01T00:01:00Z'),
+      );
+
+      expect(claimResult.ok).toBe(true);
+      if (!claimResult.ok) return;
+      expect(claimResult.value).toBe(true);
+    });
+
+    it('handles Firestore Timestamp processing leases', async () => {
+      const createResult = await repo.create(sampleInput);
+      expect(createResult.ok).toBe(true);
+      if (!createResult.ok) return;
+
+      await fakeFirestore
+        .collection('dispatch_retries')
+        .doc(createResult.value.id)
+        .update({
+          processingStartedAt: Timestamp.fromDate(new Date('2025-01-01T00:00:00Z')),
+        });
+
+      const claimResult = await repo.claimForProcessing(
+        createResult.value.id,
+        new Date('2025-01-01T00:01:00Z'),
+      );
+
+      expect(claimResult.ok).toBe(true);
+      if (!claimResult.ok) return;
+      expect(claimResult.value).toBe(true);
+    });
+
+    it('claims entries with invalid processing timestamps', async () => {
+      const createResult = await repo.create(sampleInput);
+      expect(createResult.ok).toBe(true);
+      if (!createResult.ok) return;
+
+      await fakeFirestore
+        .collection('dispatch_retries')
+        .doc(createResult.value.id)
+        .update({
+          processingStartedAt: { toDate: 'not-a-function' },
+        });
+
+      const claimResult = await repo.claimForProcessing(
+        createResult.value.id,
+        new Date('2025-01-01T00:01:00Z'),
+      );
+
+      expect(claimResult.ok).toBe(true);
+      if (!claimResult.ok) return;
+      expect(claimResult.value).toBe(true);
+    });
+
+    it('claims entries when toDate does not return a Date', async () => {
+      const createResult = await repo.create(sampleInput);
+      expect(createResult.ok).toBe(true);
+      if (!createResult.ok) return;
+
+      await fakeFirestore
+        .collection('dispatch_retries')
+        .doc(createResult.value.id)
+        .update({
+          processingStartedAt: { toDate: () => 'not-a-date' },
+        });
+
+      const claimResult = await repo.claimForProcessing(
+        createResult.value.id,
+        new Date('2025-01-01T00:01:00Z'),
+      );
+
+      expect(claimResult.ok).toBe(true);
+      if (!claimResult.ok) return;
+      expect(claimResult.value).toBe(true);
+    });
+
+    it('claims entries with primitive invalid processing timestamps', async () => {
+      const createResult = await repo.create(sampleInput);
+      expect(createResult.ok).toBe(true);
+      if (!createResult.ok) return;
+
+      await fakeFirestore
+        .collection('dispatch_retries')
+        .doc(createResult.value.id)
+        .update({
+          processingStartedAt: 'not-a-timestamp',
+        });
+
+      const claimResult = await repo.claimForProcessing(
+        createResult.value.id,
+        new Date('2025-01-01T00:01:00Z'),
+      );
+
+      expect(claimResult.ok).toBe(true);
+      if (!claimResult.ok) return;
+      expect(claimResult.value).toBe(true);
+    });
+
+    it('returns false when the retry entry is missing', async () => {
+      const claimResult = await repo.claimForProcessing(
+        'dr_missing',
+        new Date(Date.now() - 5 * 60 * 1000),
+      );
+
+      expect(claimResult.ok).toBe(true);
+      if (!claimResult.ok) return;
+      expect(claimResult.value).toBe(false);
     });
   });
 
@@ -242,6 +408,7 @@ describe('FirestoreDispatchRetryRepository', () => {
       expect(findResult.value.userId).toBe('user_456');
       expect(findResult.value.message).toBe('a message');
       expect(findResult.value.lastAttemptAt).toBeDefined();
+      expect(findResult.value.processingStartedAt).toBeUndefined();
     });
 
     it('findOldest omits optional fields when not present in stored data', async () => {

--- a/apps/code-agent/src/__tests__/infra/firestore/task-serializer.test.ts
+++ b/apps/code-agent/src/__tests__/infra/firestore/task-serializer.test.ts
@@ -361,12 +361,14 @@ describe('buildUpdateData', () => {
       cancelNonceExpiresAt: null,
       implementationTaskId: null,
       fanOutChildTaskIds: null,
-    });
+      dispatchStatus: null,
+    } as UpdateTaskInput);
     expect(data['error']).toBeInstanceOf(FieldValue);
     expect(data['cancelNonce']).toBeInstanceOf(FieldValue);
     expect(data['cancelNonceExpiresAt']).toBeInstanceOf(FieldValue);
     expect(data['implementationTaskId']).toBeInstanceOf(FieldValue);
     expect(data['fanOutChildTaskIds']).toBeInstanceOf(FieldValue);
+    expect(data['dispatchStatus']).toBeInstanceOf(FieldValue);
   });
 
   it('passes non-null values through for nullable fields', () => {
@@ -376,12 +378,28 @@ describe('buildUpdateData', () => {
       cancelNonceExpiresAt: '2025-01-01',
       implementationTaskId: 'task_impl',
       fanOutChildTaskIds: ['task_a', 'task_b'],
-    });
+      dispatchStatus: {
+        state: 'waiting',
+        reason: 'workers_at_capacity',
+        terminal: false,
+        severity: 'warning',
+        message: 'All workers are busy.',
+        remediation: 'Wait for capacity.',
+        workerNames: ['home-dev'],
+        firstSeenAt: Timestamp.fromDate(new Date('2026-06-05T12:00:00.000Z')),
+        lastSeenAt: Timestamp.fromDate(new Date('2026-06-05T12:05:00.000Z')),
+        nextAction: 'will_retry_automatically',
+      },
+    } as UpdateTaskInput);
     expect(data['error']).toEqual({ code: 'X', message: 'oops' });
     expect(data['cancelNonce']).toBe('abcd');
     expect(data['cancelNonceExpiresAt']).toBe('2025-01-01');
     expect(data['implementationTaskId']).toBe('task_impl');
     expect(data['fanOutChildTaskIds']).toEqual(['task_a', 'task_b']);
+    expect(data['dispatchStatus']).toEqual(expect.objectContaining({
+      reason: 'workers_at_capacity',
+      nextAction: 'will_retry_automatically',
+    }));
   });
 
   it('sets every scalar field when provided', () => {

--- a/apps/code-agent/src/__tests__/infra/repositories/codeTaskRepositoryWithGroupUpdates.test.ts
+++ b/apps/code-agent/src/__tests__/infra/repositories/codeTaskRepositoryWithGroupUpdates.test.ts
@@ -10,6 +10,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Timestamp } from '@google-cloud/firestore';
+import type FirebaseFirestore from '@google-cloud/firestore';
 import type { Logger } from '@intexuraos/common-core';
 import { ok, err } from '@intexuraos/common-core';
 import type { CodeTaskRepository, CreateTaskInput } from '../../../domain/repositories/codeTaskRepository.js';
@@ -207,7 +208,7 @@ describe('withGroupUpdates decorator', () => {
 
       expect(result).toEqual(ok(newTask));
       expect(inner.findById).toHaveBeenCalledWith('task-1');
-      expect(inner.update).toHaveBeenCalledWith('task-1', { status: 'implemented' });
+      expect(inner.update).toHaveBeenCalledWith('task-1', { status: 'implemented' }, undefined);
       await Promise.resolve();
       expect(updateAfterStatusChangeSpy).toHaveBeenCalledWith(oldTask, newTask);
     });
@@ -264,6 +265,21 @@ describe('withGroupUpdates decorator', () => {
 
       await decorated.update('task-1', { status: 'reviewed' });
 
+      await Promise.resolve();
+      expect(updateAfterStatusChangeSpy).not.toHaveBeenCalled();
+    });
+
+    it('passes transaction options through and skips group summary side effects', async () => {
+      const newTask = makeTask({ status: 'failed' });
+      const transaction = {} as FirebaseFirestore.Transaction;
+      vi.mocked(inner.update).mockResolvedValue(ok(newTask));
+      const updateAfterStatusChangeSpy = vi.spyOn(groupSummaryRepo, 'updateAfterStatusChange');
+
+      const result = await decorated.update('task-1', { status: 'failed' }, { transaction });
+
+      expect(result).toEqual(ok(newTask));
+      expect(inner.findById).not.toHaveBeenCalled();
+      expect(inner.update).toHaveBeenCalledWith('task-1', { status: 'failed' }, { transaction });
       await Promise.resolve();
       expect(updateAfterStatusChangeSpy).not.toHaveBeenCalled();
     });

--- a/apps/code-agent/src/__tests__/infra/repositories/firestoreCodeTaskRepository.test.ts
+++ b/apps/code-agent/src/__tests__/infra/repositories/firestoreCodeTaskRepository.test.ts
@@ -4091,6 +4091,20 @@ describe('firestoreCodeTaskRepository', () => {
       const created = await repo.create(createTaskInput({ id: 'task-claim' }));
       expect(created.ok).toBe(true);
       if (!created.ok) return;
+      await repo.update('task-claim', {
+        dispatchStatus: {
+          state: 'waiting',
+          reason: 'workers_unreachable',
+          terminal: false,
+          severity: 'warning',
+          message: 'Workers are temporarily unreachable.',
+          remediation: 'The scheduler will retry automatically.',
+          workerNames: ['home-mac'],
+          firstSeenAt: Timestamp.now(),
+          lastSeenAt: Timestamp.now(),
+          nextAction: 'will_retry_automatically',
+        },
+      });
 
       const result = await repo.claimForDispatch('task-claim');
 
@@ -4103,6 +4117,7 @@ describe('firestoreCodeTaskRepository', () => {
       if (!after.ok) return;
       expect(after.value.status).toBe('dispatched');
       expect(after.value.dispatchedAt).toBeDefined();
+      expect(after.value.dispatchStatus).toBeUndefined();
     });
 
     it('returns false when task is already dispatched', async () => {

--- a/apps/code-agent/src/__tests__/infra/services/taskEnqueueServiceImpl.test.ts
+++ b/apps/code-agent/src/__tests__/infra/services/taskEnqueueServiceImpl.test.ts
@@ -18,6 +18,7 @@ import type { Logger } from '@intexuraos/common-core';
 import { Timestamp } from '@google-cloud/firestore';
 import type { CodeTask } from '../../../domain/models/codeTask.js';
 import type { RepositoryError } from '../../../domain/repositories/codeTaskRepository.js';
+import type { WhatsAppNotifier } from '../../../domain/services/whatsappNotifier.js';
 import { TaskEnqueueServiceImpl } from '../../../infra/services/taskEnqueueServiceImpl.js';
 
 // Mock config
@@ -37,6 +38,9 @@ describe('TaskEnqueueServiceImpl', () => {
     findById: ReturnType<typeof vi.fn>;
     countQueued: ReturnType<typeof vi.fn>;
     update: ReturnType<typeof vi.fn>;
+  };
+  let mockWhatsappNotifier: {
+    notifyTaskDispatchBlocked: ReturnType<typeof vi.fn>;
   };
 
   function createMockTask(overrides: Partial<CodeTask> = {}): CodeTask {
@@ -76,6 +80,9 @@ describe('TaskEnqueueServiceImpl', () => {
       countQueued: vi.fn(),
       update: vi.fn(),
     };
+    mockWhatsappNotifier = {
+      notifyTaskDispatchBlocked: vi.fn().mockResolvedValue(ok(undefined)),
+    };
   });
 
   afterEach(() => {
@@ -86,6 +93,7 @@ describe('TaskEnqueueServiceImpl', () => {
     return new TaskEnqueueServiceImpl({
       logger: mockLogger,
       codeTaskRepo: mockCodeTaskRepo as never,
+      whatsappNotifier: mockWhatsappNotifier as never as WhatsAppNotifier,
     });
   }
 
@@ -120,7 +128,7 @@ describe('TaskEnqueueServiceImpl', () => {
     }
   });
 
-  it('returns queue_full error and marks task as failed when queue reaches maxSize', async () => {
+  it('returns queue_full error, marks task failed with dispatch status, and notifies when queue reaches maxSize', async () => {
     const task = createMockTask();
     mockCodeTaskRepo.findById.mockResolvedValue(ok(task));
     mockCodeTaskRepo.countQueued.mockResolvedValue(ok(50)); // >= maxSize of 50
@@ -137,8 +145,48 @@ describe('TaskEnqueueServiceImpl', () => {
     // Verify task was marked as failed
     expect(mockCodeTaskRepo.update).toHaveBeenCalledWith('task-123', expect.objectContaining({
       status: 'failed',
-      error: expect.objectContaining({ code: 'queue_full' }),
+      error: expect.objectContaining({ code: 'dispatch_blocked_queue_full' }),
+      dispatchStatus: expect.objectContaining({
+        state: 'terminal',
+        reason: 'queue_full',
+        terminal: true,
+        nextAction: 'retry_after_fix',
+      }),
     }));
+    expect(mockWhatsappNotifier.notifyTaskDispatchBlocked).toHaveBeenCalledWith('user-456', expect.objectContaining({
+      workerType: 'opus',
+      reason: 'queue_full',
+      affectedTaskCount: 1,
+      exampleTaskId: 'task-123',
+    }));
+    expect(mockCodeTaskRepo.update).toHaveBeenCalledWith('task-123', {
+      dispatchStatus: expect.objectContaining({
+        notifiedReasons: expect.objectContaining({
+          queue_full: expect.any(Timestamp),
+        }),
+      }),
+    });
+    expect(mockCodeTaskRepo.update.mock.invocationCallOrder[0]).toBeLessThan(
+      mockWhatsappNotifier.notifyTaskDispatchBlocked.mock.invocationCallOrder[0] ?? 0,
+    );
+  });
+
+  it('returns internal_error and does not notify when queue-full task failure persistence fails', async () => {
+    const task = createMockTask();
+    mockCodeTaskRepo.findById.mockResolvedValue(ok(task));
+    mockCodeTaskRepo.countQueued.mockResolvedValue(ok(50));
+    mockCodeTaskRepo.update.mockResolvedValue(
+      err({ code: 'FIRESTORE_ERROR', message: 'write failed' } satisfies RepositoryError),
+    );
+
+    const service = createService();
+    const result = await service.enqueue({ taskId: 'task-123', userId: 'user-456' });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('internal_error');
+    }
+    expect(mockWhatsappNotifier.notifyTaskDispatchBlocked).not.toHaveBeenCalled();
   });
 
   it('sets queuedAt timestamp on the task', async () => {
@@ -285,7 +333,7 @@ describe('TaskEnqueueServiceImpl', () => {
       }
     });
 
-    it('marks all batch tasks failed when the queue is already full', async () => {
+    it('marks all batch tasks failed with dispatch status and notifies each task when the queue is already full', async () => {
       mockCodeTaskRepo.findById
         .mockResolvedValueOnce(ok(createMockTask({ id: 'task-1' })))
         .mockResolvedValueOnce(ok(createMockTask({ id: 'task-2' })));
@@ -299,14 +347,62 @@ describe('TaskEnqueueServiceImpl', () => {
       if (!result.ok) {
         expect(result.error.code).toBe('queue_full');
       }
-      expect(mockCodeTaskRepo.update).toHaveBeenCalledTimes(2);
+      expect(mockCodeTaskRepo.update).toHaveBeenCalledTimes(4);
       expect(mockCodeTaskRepo.update).toHaveBeenCalledWith(
         'task-1',
         expect.objectContaining({
           status: 'failed',
-          error: expect.objectContaining({ code: 'queue_full' }),
+          error: expect.objectContaining({ code: 'dispatch_blocked_queue_full' }),
+          dispatchStatus: expect.objectContaining({
+            reason: 'queue_full',
+          }),
         }),
       );
+      expect(mockCodeTaskRepo.update).toHaveBeenCalledWith('task-1', {
+        dispatchStatus: expect.objectContaining({
+          notifiedReasons: expect.objectContaining({
+            queue_full: expect.any(Timestamp),
+          }),
+        }),
+      });
+      expect(mockCodeTaskRepo.update).toHaveBeenCalledWith('task-2', {
+        dispatchStatus: expect.objectContaining({
+          notifiedReasons: expect.objectContaining({
+            queue_full: expect.any(Timestamp),
+          }),
+        }),
+      });
+      expect(mockWhatsappNotifier.notifyTaskDispatchBlocked).toHaveBeenCalledTimes(2);
+      expect(mockWhatsappNotifier.notifyTaskDispatchBlocked).toHaveBeenNthCalledWith(1, 'user-456', expect.objectContaining({
+        reason: 'queue_full',
+        affectedTaskCount: 2,
+        exampleTaskId: 'task-1',
+      }));
+      expect(mockWhatsappNotifier.notifyTaskDispatchBlocked).toHaveBeenNthCalledWith(2, 'user-456', expect.objectContaining({
+        reason: 'queue_full',
+        affectedTaskCount: 2,
+        exampleTaskId: 'task-2',
+      }));
+    });
+
+    it('returns internal_error and stops batch queue-full handling when task failure persistence fails', async () => {
+      mockCodeTaskRepo.findById
+        .mockResolvedValueOnce(ok(createMockTask({ id: 'task-1' })))
+        .mockResolvedValueOnce(ok(createMockTask({ id: 'task-2' })));
+      mockCodeTaskRepo.countQueued.mockResolvedValue(ok(50));
+      mockCodeTaskRepo.update.mockResolvedValueOnce(
+        err({ code: 'FIRESTORE_ERROR', message: 'write failed' } satisfies RepositoryError),
+      );
+
+      const service = createService();
+      const result = await service.enqueueMany({ taskIds: ['task-1', 'task-2'], userId: 'user-456' });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe('internal_error');
+      }
+      expect(mockCodeTaskRepo.update).toHaveBeenCalledTimes(1);
+      expect(mockWhatsappNotifier.notifyTaskDispatchBlocked).not.toHaveBeenCalled();
     });
 
     it('logs a warning and keeps original task when queuedAt update fails during batch enqueue', async () => {

--- a/apps/code-agent/src/__tests__/infra/services/whatsappNotifier.test.ts
+++ b/apps/code-agent/src/__tests__/infra/services/whatsappNotifier.test.ts
@@ -618,7 +618,7 @@ describe('WhatsAppNotifier', () => {
   });
 
   describe('notifyTaskDispatchBlocked', () => {
-    it('sends an actionable dispatch blocker notification with a queue link', async () => {
+    it('sends an actionable dispatch blocker notification with a task link when a task id is present', async () => {
       const notifier = createWhatsAppNotifier({
         ...createMockConfig(),
         webAppUrl: 'https://dev.intexuraos.cloud/',
@@ -641,8 +641,8 @@ describe('WhatsAppNotifier', () => {
         expect.objectContaining({
           userId: 'user-123',
           ctaUrl: {
-            displayText: 'View Dispatch Queue',
-            url: 'https://dev.intexuraos.cloud/#/code-tasks/dispatch-queue',
+            displayText: 'View Task',
+            url: 'https://dev.intexuraos.cloud/#/code-tasks/task-123',
           },
           important: true,
         })

--- a/apps/code-agent/src/__tests__/routes/askAgentStart.test.ts
+++ b/apps/code-agent/src/__tests__/routes/askAgentStart.test.ts
@@ -342,7 +342,7 @@ describe('POST /code/ask-agent/start', () => {
       expect(response.statusCode).toBe(400);
     });
 
-    it('returns WORKER_NOT_CONFIGURED when no workers are enabled', async () => {
+    it('returns a failed task id when no workers are enabled', async () => {
       // Use a different user that has no workers configured
       mockedJwtVerify.mockResolvedValueOnce({
         payload: { sub: 'user-with-no-workers', email: 'noworkers@example.com' },
@@ -361,8 +361,43 @@ describe('POST /code/ask-agent/start', () => {
       });
 
       const body = JSON.parse(response.body);
-      expect(body.success).toBe(false);
-      expect(body.error.code).toBe('WORKER_NOT_CONFIGURED');
+      expect(response.statusCode).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.data.status).toBe('failed');
+      expect(body.data.codeTaskId).toMatch(/^task_/);
+    });
+
+    it('returns a failed task id when worker settings fetch fails after task creation', async () => {
+      vi.spyOn(getServices().workerSettingsRepo, 'getSettings').mockResolvedValueOnce(
+        err({ code: 'internal_error', message: 'read failed' }),
+      );
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/ask-agent/start',
+        headers: {
+          authorization: 'Bearer test-token',
+        },
+        payload: {
+          prompt: 'Ask something while settings are unavailable',
+        },
+      });
+
+      const body = JSON.parse(response.body);
+      expect(response.statusCode).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.data.status).toBe('failed');
+      expect(body.data.codeTaskId).toMatch(/^task_/);
+
+      const taskResult = await codeTaskRepo.findById(body.data.codeTaskId);
+      expect(taskResult.ok).toBe(true);
+      if (taskResult.ok) {
+        expect(taskResult.value.status).toBe('failed');
+        expect(taskResult.value.dispatchStatus).toEqual(expect.objectContaining({
+          reason: 'dispatch_failed',
+          terminal: true,
+        }));
+      }
     });
 
     it('returns CONFLICT when duplicate prompt is detected', async () => {
@@ -394,7 +429,7 @@ describe('POST /code/ask-agent/start', () => {
       expect(body.error.code).toBe('CONFLICT');
     });
 
-    it('returns QUEUE_FULL when task queue is full', async () => {
+    it('returns a failed task id when task queue is full', async () => {
       vi.mocked(taskEnqueueService.enqueue).mockResolvedValueOnce(
         err({ code: 'queue_full', message: 'Task queue is full' }),
       );
@@ -411,8 +446,10 @@ describe('POST /code/ask-agent/start', () => {
       });
 
       const body = JSON.parse(response.body);
-      expect(body.success).toBe(false);
-      expect(body.error.code).toBe('QUEUE_FULL');
+      expect(response.statusCode).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.data.status).toBe('failed');
+      expect(body.data.codeTaskId).toMatch(/^task_/);
     });
 
     it('returns INTERNAL_ERROR when enqueue fails with unexpected error', async () => {

--- a/apps/code-agent/src/__tests__/routes/codeRoutes.archive.test.ts
+++ b/apps/code-agent/src/__tests__/routes/codeRoutes.archive.test.ts
@@ -189,6 +189,7 @@ describe('POST /code/tasks/:taskId/archive', () => {
       eventDecisionRepo: {} as never,
       dispatchRetryRepo: {
         async findOldest() { return ok(null); },
+        async claimForProcessing() { return ok(true); },
         async create() { return ok({} as never); },
         async delete() { return ok(undefined); },
         async update() { return ok(undefined); },

--- a/apps/code-agent/src/__tests__/routes/codeRoutes.branches.test.ts
+++ b/apps/code-agent/src/__tests__/routes/codeRoutes.branches.test.ts
@@ -55,7 +55,7 @@ const mockedJwtVerify = vi.mocked(jose.jwtVerify);
 import { buildServer } from '../../server.js';
 import { resetServices, setServices, getServices } from '../../services.js';
 import { createFakeFirestore, resetFirestore, setFirestore } from '@intexuraos/infra-firestore';
-import type { Firestore } from '@google-cloud/firestore';
+import { Timestamp, type Firestore } from '@google-cloud/firestore';
 import { createFirestoreCodeTaskRepository } from '../../infra/firestore/firestoreCodeTaskRepository.js';
 import type { Logger } from 'pino';
 import type { CodeTaskRepository } from '../../domain/repositories/codeTaskRepository.js';
@@ -227,6 +227,7 @@ describe('codeRoutes branch coverage', () => {
       eventDecisionRepo: {} as never,
       dispatchRetryRepo: {
         async findOldest() { return ok(null); },
+        async claimForProcessing() { return ok(true); },
         async create() { return ok({} as never); },
         async delete() { return ok(undefined); },
         async update() { return ok(undefined); },
@@ -348,7 +349,22 @@ describe('codeRoutes branch coverage', () => {
         implementationTaskId: 'impl-task-1',
         fanOutChildTaskIds: ['child-task-1', 'child-task-2'],
         error: { code: 'WORKER_ERROR', message: 'Worker crashed' },
-      });
+        dispatchStatus: {
+          state: 'terminal',
+          reason: 'dispatch_failed',
+          terminal: true,
+          severity: 'critical',
+          message: 'Worker rejected the dispatch request.',
+          remediation: 'Fix worker dispatch handling, then retry.',
+          workerNames: ['home-dev'],
+          firstSeenAt: Timestamp.fromDate(new Date('2026-06-05T12:00:00.000Z')),
+          lastSeenAt: Timestamp.fromDate(new Date('2026-06-05T12:01:00.000Z')),
+          nextAction: 'retry_after_fix',
+          notifiedReasons: {
+            dispatch_failed: Timestamp.fromDate(new Date('2026-06-05T12:02:00.000Z')),
+          },
+        },
+      } as Parameters<typeof repo.update>[1]);
 
       const response = await server.inject({
         method: 'GET',
@@ -368,6 +384,14 @@ describe('codeRoutes branch coverage', () => {
       expect(task.followUpReason).toBe('retry');
       expect(task.error).toBeDefined();
       expect(task.error.code).toBe('WORKER_ERROR');
+      expect(task.dispatchStatus).toEqual(expect.objectContaining({
+        state: 'terminal',
+        reason: 'dispatch_failed',
+        terminal: true,
+        firstSeenAt: '2026-06-05T12:00:00.000Z',
+        lastSeenAt: '2026-06-05T12:01:00.000Z',
+      }));
+      expect(task.dispatchStatus.notifiedReasons).toBeUndefined();
       expect(task.linearIssueId).toBe('INT-100');
       expect(task.prNumber).toBe(42);
       expect(task.agentType).toBe('planning');
@@ -470,6 +494,18 @@ describe('codeRoutes branch coverage', () => {
           status: 'running',
           dedupKey: 'dedup',
           callbackReceived: false,
+          dispatchStatus: {
+            state: 'waiting',
+            reason: 'worker_unavailable',
+            terminal: false,
+            severity: 'warning',
+            message: 'Worker unavailable.',
+            remediation: 'Wait for worker recovery.',
+            workerNames: [],
+            firstSeenAt: { seconds: 789 } as never,
+            lastSeenAt: { seconds: 790 } as never,
+            nextAction: 'will_retry_automatically',
+          },
           // Pass objects without toDate() to trigger timestampToIso returning undefined
           createdAt: { seconds: 123 } as never,
           updatedAt: { seconds: 456 } as never,
@@ -489,6 +525,8 @@ describe('codeRoutes branch coverage', () => {
       // Both should fall back to '' since timestampToIso returns undefined
       expect(body.data.createdAt).toBe('');
       expect(body.data.updatedAt).toBe('');
+      expect(body.data.dispatchStatus.firstSeenAt).toBe('');
+      expect(body.data.dispatchStatus.lastSeenAt).toBe('');
     });
   });
 
@@ -1818,7 +1856,7 @@ describe('codeRoutes branch coverage', () => {
   // POST /code/submit - settings null triggers ?? [] fallback (line 1292)
   // ============================================================
   describe('POST /code/submit no worker settings', () => {
-    it('returns WORKER_NOT_CONFIGURED when user has no worker settings', async () => {
+    it('returns a failed task id when user has no worker settings', async () => {
       // Override workerSettingsRepo to return null (no settings)
       const mockWorkerSettingsRepo = {
         ...getServices().workerSettingsRepo,
@@ -1834,11 +1872,11 @@ describe('codeRoutes branch coverage', () => {
         payload: { prompt: 'Fix the bug' },
       });
 
-      // With null settings, enabledWorkers = settings?.workers.filter() ?? [] = []
-      // Then enabledWorkers.length === 0 triggers WORKER_NOT_CONFIGURED (HTTP 424)
-      expect(response.statusCode).toBe(424);
+      expect(response.statusCode).toBe(200);
       const body = JSON.parse(response.body);
-      expect(body.error.code).toBe('WORKER_NOT_CONFIGURED');
+      expect(body.success).toBe(true);
+      expect(body.data.status).toBe('failed');
+      expect(body.data.codeTaskId).toBeDefined();
     });
   });
 
@@ -2553,7 +2591,7 @@ describe('codeRoutes branch coverage', () => {
   // POST /code/submit - enqueue queue_full error (line 1317)
   // ============================================================
   describe('POST /code/submit queue_full error', () => {
-    it('returns QUEUE_FULL when enqueue service returns queue_full', async () => {
+    it('returns a failed task id when enqueue service returns queue_full', async () => {
       setServices({
         ...getServices(),
         taskEnqueueService: {
@@ -2571,8 +2609,11 @@ describe('codeRoutes branch coverage', () => {
         payload: { prompt: 'Fix the bug' },
       });
 
+      expect(response.statusCode).toBe(200);
       const body = JSON.parse(response.body);
-      expect(body.error.code).toBe('QUEUE_FULL');
+      expect(body.success).toBe(true);
+      expect(body.data.status).toBe('failed');
+      expect(body.data.codeTaskId).toBeDefined();
     });
   });
 

--- a/apps/code-agent/src/__tests__/routes/codeRoutes.test.ts
+++ b/apps/code-agent/src/__tests__/routes/codeRoutes.test.ts
@@ -227,6 +227,7 @@ describe('codeRoutes', () => {
       eventDecisionRepo: {} as never,
       dispatchRetryRepo: {
         async findOldest() { return ok(null); },
+        async claimForProcessing() { return ok(true); },
         async create() { return ok({} as never); },
         async delete() { return ok(undefined); },
         async update() { return ok(undefined); },
@@ -1483,7 +1484,7 @@ describe('codeRoutes', () => {
       expect(body.error.code).toBe('CONFLICT');
     });
 
-    it('returns 503 when enqueue returns queue_full error', async () => {
+    it('returns a failed task id when enqueue returns queue_full error', async () => {
       setServices({
         ...getServices(),
         taskEnqueueService: {
@@ -1502,13 +1503,14 @@ describe('codeRoutes', () => {
         },
       });
 
-      expect(response.statusCode).toBe(503);
+      expect(response.statusCode).toBe(200);
       const body = JSON.parse(response.body);
-      expect(body.success).toBe(false);
-      expect(body.error.code).toBe('QUEUE_FULL');
+      expect(body.success).toBe(true);
+      expect(body.data.status).toBe('failed');
+      expect(body.data.codeTaskId).toBeDefined();
     });
 
-    it('returns 500 when getSettings fails with Firestore error', async () => {
+    it('returns a failed task id when getSettings fails after task creation', async () => {
       const services = getServices();
       const mockGetSettings = vi.spyOn(services.workerSettingsRepo, 'getSettings').mockResolvedValue(
         err({ code: 'internal_error', message: 'Firestore unavailable' })
@@ -1525,15 +1527,28 @@ describe('codeRoutes', () => {
         },
       });
 
-      expect(response.statusCode).toBe(500);
+      expect(response.statusCode).toBe(200);
       const body = JSON.parse(response.body);
-      expect(body.success).toBe(false);
-      expect(body.error.code).toBe('INTERNAL_ERROR');
+      expect(body.success).toBe(true);
+      expect(body.data).toEqual(expect.objectContaining({
+        status: 'failed',
+        codeTaskId: expect.stringMatching(/^task_/),
+      }));
+
+      const taskResult = await services.codeTaskRepo.findById(body.data.codeTaskId);
+      expect(taskResult.ok).toBe(true);
+      if (taskResult.ok) {
+        expect(taskResult.value.status).toBe('failed');
+        expect(taskResult.value.dispatchStatus).toEqual(expect.objectContaining({
+          reason: 'dispatch_failed',
+          terminal: true,
+        }));
+      }
 
       mockGetSettings.mockRestore();
     });
 
-    it('returns WORKER_NOT_CONFIGURED when user has no enabled workers', async () => {
+    it('returns a failed task id when user has no enabled workers', async () => {
       const services = getServices();
       const mockGetSettings = vi.spyOn(services.workerSettingsRepo, 'getSettings').mockResolvedValue(
         ok({
@@ -1564,10 +1579,11 @@ describe('codeRoutes', () => {
         },
       });
 
-      expect(response.statusCode).toBe(424);
+      expect(response.statusCode).toBe(200);
       const body = JSON.parse(response.body);
-      expect(body.success).toBe(false);
-      expect(body.error.code).toBe('WORKER_NOT_CONFIGURED');
+      expect(body.success).toBe(true);
+      expect(body.data.status).toBe('failed');
+      expect(body.data.codeTaskId).toBeDefined();
 
       mockGetSettings.mockRestore();
     });
@@ -4388,6 +4404,7 @@ describe('codeRoutes', () => {
       let deleted = false;
       const retryRepo: DispatchRetryRepository = {
         async findOldest() { return ok(expiredEntry); },
+        async claimForProcessing() { return ok(true); },
         async create() { return ok({} as never); },
         async delete() { deleted = true; return ok(undefined); },
         async update() { return ok(undefined); },
@@ -4411,6 +4428,135 @@ describe('codeRoutes', () => {
       expect(body.success).toBe(true);
       expect(body.data.action).toBe('expired');
       expect(deleted).toBe(true);
+    });
+
+    it('returns failed retry result when terminal retry failure has locks to clean up', async () => {
+      const services = getServices();
+      await services.workerSettingsRepo.updateWorker('test-user-id', 'home-mac', { enabled: false });
+      const created = await services.codeTaskRepo.create({
+        id: 'task-retry-terminal',
+        userId: 'test-user-id',
+        prompt: 'Retry terminal PR task',
+        sanitizedPrompt: 'Retry terminal PR task',
+        systemPromptHash: 'default',
+        workerType: 'auto',
+        workerLocation: 'pending',
+        repository: 'test/repo',
+        baseBranch: 'main',
+        traceId: 'trace-retry-terminal',
+        prNumber: 55,
+      });
+      expect(created.ok).toBe(true);
+
+      const retryEntry: DispatchRetry = {
+        id: 'dr_terminal-1',
+        type: 'new_task',
+        eventId: 'event-terminal-1',
+        repository: 'test/repo',
+        pullRequestNumber: 55,
+        senderLogin: 'tester',
+        taskId: 'task-retry-terminal',
+        userId: 'test-user-id',
+        attempts: 0,
+        maxAttempts: 3,
+        lastError: 'Worker unavailable',
+        createdAt: Timestamp.now(),
+        ttlMinutes: 60,
+      };
+      let deleted = false;
+      const retryRepo: DispatchRetryRepository = {
+        async findOldest() { return ok(retryEntry); },
+        async claimForProcessing() { return ok(true); },
+        async create() { return ok({} as never); },
+        async delete() { deleted = true; return ok(undefined); },
+        async update() { return ok(undefined); },
+      };
+      const listQueuedSpy = vi.spyOn(services.codeTaskRepo, 'listQueuedByAge');
+      setServices({
+        ...services,
+        dispatchRetryRepo: retryRepo,
+      });
+
+      const response = await server.inject({
+        method: 'POST',
+        url: '/internal/drain-queue',
+        headers: {
+          'x-internal-auth': 'test-internal-token',
+        },
+        payload: {},
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.success).toBe(true);
+      expect(body.data.action).toBe('failed');
+      expect(body.data.taskId).toBe('task-retry-terminal');
+      expect(deleted).toBe(true);
+      expect(listQueuedSpy).not.toHaveBeenCalled();
+    });
+
+    it('returns 500 when retry queue drain fails before regular queue drain', async () => {
+      const services = getServices();
+      await services.workerSettingsRepo.updateWorker('test-user-id', 'home-mac', { enabled: false });
+      const created = await services.codeTaskRepo.create({
+        id: 'task-retry-persist-failure',
+        userId: 'test-user-id',
+        prompt: 'Retry persistence failure task',
+        sanitizedPrompt: 'Retry persistence failure task',
+        systemPromptHash: 'default',
+        workerType: 'auto',
+        workerLocation: 'pending',
+        repository: 'test/repo',
+        baseBranch: 'main',
+        traceId: 'trace-retry-persist-failure',
+      });
+      expect(created.ok).toBe(true);
+      const retryEntry: DispatchRetry = {
+        id: 'dr_persist-failure-1',
+        type: 'new_task',
+        eventId: 'event-persist-failure-1',
+        repository: 'test/repo',
+        pullRequestNumber: 10,
+        senderLogin: 'tester',
+        taskId: 'task-retry-persist-failure',
+        userId: 'test-user-id',
+        attempts: 0,
+        maxAttempts: 3,
+        lastError: 'Worker unavailable',
+        createdAt: Timestamp.now(),
+        ttlMinutes: 60,
+      };
+      const retryRepo: DispatchRetryRepository = {
+        async findOldest() { return ok(retryEntry); },
+        async claimForProcessing() { return ok(true); },
+        async create() { return ok({} as never); },
+        async delete() { return ok(undefined); },
+        async update() { return ok(undefined); },
+      };
+      const listQueuedSpy = vi.spyOn(services.codeTaskRepo, 'listQueuedByAge');
+      vi.spyOn(services.codeTaskRepo, 'update').mockResolvedValueOnce(
+        err({ code: 'FIRESTORE_ERROR', message: 'task write failed' }),
+      );
+      setServices({
+        ...services,
+        dispatchRetryRepo: retryRepo,
+      });
+
+      const response = await server.inject({
+        method: 'POST',
+        url: '/internal/drain-queue',
+        headers: {
+          'x-internal-auth': 'test-internal-token',
+        },
+        payload: {},
+      });
+
+      expect(response.statusCode).toBe(500);
+      const body = JSON.parse(response.body);
+      expect(body.success).toBe(false);
+      expect(body.error.code).toBe('INTERNAL_ERROR');
+      expect(body.error.message).toBe('Failed to persist retry dispatch failure status');
+      expect(listQueuedSpy).not.toHaveBeenCalled();
     });
 
     it('returns 500 when drain use case fails', async () => {

--- a/apps/code-agent/src/__tests__/routes/codeSubmit.test.ts
+++ b/apps/code-agent/src/__tests__/routes/codeSubmit.test.ts
@@ -33,6 +33,7 @@ import type { CodeTaskRepository } from '../../domain/repositories/codeTaskRepos
 import type { TaskDispatcherService } from '../../domain/services/taskDispatcher.js';
 import type { ActionsAgentClient } from '../../infra/clients/actionsAgentClient.js';
 import type { WhatsAppNotifier } from '../../domain/services/whatsappNotifier.js';
+import type { CodeTaskDispatchStatusService } from '../../domain/services/codeTaskDispatchStatusService.js';
 import type { TaskEnqueueService } from '../../domain/services/taskEnqueueService.js';
 import { ok, err } from '@intexuraos/common-core';
 import type { WhatsAppSendPublisher } from '@intexuraos/whatsapp-pubsub-client';
@@ -51,6 +52,7 @@ import { createWorkerSettingsRepository } from '../../infra/firestore/workerSett
 import type { WorkerSettingsRepository } from '../../domain/ports/workerSettingsRepository.js';
 import type { WorkerHealthProbe } from '../../domain/ports/workerHealthProbe.js';
 import { mockWorkerHealthProbe, mockUserServiceClient } from '../helpers/mockServices.js';
+import { createTaskEnqueueService } from '../../infra/services/taskEnqueueServiceImpl.js';
 
 describe('POST /code/submit', () => {
   let app: Awaited<ReturnType<typeof buildServer>>;
@@ -59,6 +61,7 @@ describe('POST /code/submit', () => {
   let codeTaskRepo: CodeTaskRepository;
   let taskDispatcher: TaskDispatcherService;
   let taskEnqueueService: TaskEnqueueService;
+  let codeTaskDispatchStatusService: CodeTaskDispatchStatusService;
   let logChunkRepo: LogChunkRepository;
 
   beforeEach(async () => {
@@ -90,6 +93,10 @@ describe('POST /code/submit', () => {
 
     taskEnqueueService = {
       enqueue: vi.fn().mockResolvedValue(ok({ taskId: 'test', queuePosition: 1 })),
+    };
+    codeTaskDispatchStatusService = {
+      recordDispatchBlocked: vi.fn().mockResolvedValue(undefined),
+      resolveDispatchBlockers: vi.fn().mockResolvedValue(undefined),
     };
 
     const whatsappNotifier = createWhatsAppNotifier({
@@ -131,6 +138,7 @@ describe('POST /code/submit', () => {
       codeTaskRepo,
       taskDispatcher,
       whatsappNotifier,
+      codeTaskDispatchStatusService,
       logChunkRepo,
       logLineRepo,
       actionsAgentClient,
@@ -197,6 +205,7 @@ describe('POST /code/submit', () => {
       logLineRepo: LogLineRepository;
       actionsAgentClient: ActionsAgentClient;
       whatsappNotifier: WhatsAppNotifier;
+      codeTaskDispatchStatusService: CodeTaskDispatchStatusService;
       linearAgentClient: LinearAgentClient;
       linearIssueService: LinearIssueService;
       statusMirrorService: StatusMirrorService;
@@ -612,20 +621,24 @@ describe('POST /code/submit', () => {
   });
 
   describe('error handling', () => {
-    it('returns 503 when enqueue returns queue_full error', async () => {
-      const linearService = getServices().linearIssueService;
-      vi.spyOn(linearService, 'ensureIssueExists').mockResolvedValueOnce({
+    it('returns a failed task id when enqueue returns queue_full error', async () => {
+      const services = getServices();
+      vi.spyOn(services.linearIssueService, 'ensureIssueExists').mockResolvedValueOnce({
         linearIssueId: 'INT-123',
         linearIssueTitle: 'Fix the bug',
         linearIssueLabels: [],
         hasChildren: false,
         linearFallback: false,
       });
-
-      // Mock enqueue to return queue_full error
-      vi.mocked(taskEnqueueService.enqueue).mockResolvedValueOnce(
-        err({ code: 'queue_full', message: 'Queue is full (11/10). Please try again later.' })
-      );
+      vi.spyOn(codeTaskRepo, 'countQueued').mockResolvedValueOnce(ok(50));
+      setServices({
+        ...services,
+        taskEnqueueService: createTaskEnqueueService({
+          logger,
+          codeTaskRepo,
+          whatsappNotifier: services.whatsappNotifier,
+        }),
+      });
 
       const response = await app.inject({
         method: 'POST',
@@ -634,10 +647,209 @@ describe('POST /code/submit', () => {
         payload: { prompt: 'Fix the bug' },
       });
 
-      expect(response.statusCode).toBe(503);
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.success).toBe(true);
+      expect(body.data.status).toBe('failed');
+      expect(body.data.codeTaskId).toMatch(/^task_/);
+
+      const taskResult = await codeTaskRepo.findById(body.data.codeTaskId);
+      expect(taskResult.ok).toBe(true);
+      if (taskResult.ok) {
+        expect(taskResult.value.status).toBe('failed');
+        expect(taskResult.value.error).toEqual(expect.objectContaining({
+          code: 'dispatch_blocked_queue_full',
+          message: expect.stringContaining('queue is full'),
+        }));
+        const dispatchStatus = (taskResult.value as { dispatchStatus?: unknown }).dispatchStatus;
+        expect(dispatchStatus).toEqual(expect.objectContaining({
+          state: 'terminal',
+          reason: 'queue_full',
+          terminal: true,
+          nextAction: 'retry_after_fix',
+        }));
+      }
+    });
+
+    it('returns a failed task id when the user has no enabled workers', async () => {
+      const services = getServices();
+      await services.workerSettingsRepo.updateWorker('test-user-id', 'home-mac', { enabled: false });
+      vi.spyOn(services.linearIssueService, 'ensureIssueExists').mockResolvedValueOnce({
+        linearIssueId: 'INT-123',
+        linearIssueTitle: 'Fix the bug',
+        linearIssueLabels: [],
+        hasChildren: false,
+        linearFallback: false,
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/submit',
+        headers: { authorization: 'Bearer test-token' },
+        payload: { prompt: 'Fix the bug without workers' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.success).toBe(true);
+      expect(body.data.status).toBe('failed');
+      expect(body.data.codeTaskId).toMatch(/^task_/);
+
+      const taskResult = await codeTaskRepo.findById(body.data.codeTaskId);
+      expect(taskResult.ok).toBe(true);
+      if (taskResult.ok) {
+        expect(taskResult.value.status).toBe('failed');
+        expect(taskResult.value.error).toEqual(expect.objectContaining({
+          code: 'dispatch_blocked_no_enabled_workers',
+        }));
+        const dispatchStatus = (taskResult.value as { dispatchStatus?: unknown }).dispatchStatus;
+        expect(dispatchStatus).toEqual(expect.objectContaining({
+          state: 'terminal',
+          reason: 'no_enabled_workers',
+          terminal: true,
+          nextAction: 'retry_after_fix',
+        }));
+      }
+    });
+
+    it('returns a failed task id when worker settings fetch fails after task creation', async () => {
+      const services = getServices();
+      vi.spyOn(services.linearIssueService, 'ensureIssueExists').mockResolvedValueOnce({
+        linearIssueId: 'INT-123',
+        linearIssueTitle: 'Fix the bug',
+        linearIssueLabels: [],
+        hasChildren: false,
+        linearFallback: false,
+      });
+      vi.spyOn(services.workerSettingsRepo, 'getSettings').mockResolvedValueOnce(
+        err({ code: 'internal_error', message: 'read failed' }),
+      );
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/submit',
+        headers: { authorization: 'Bearer test-token' },
+        payload: { prompt: 'Fix the bug while settings read is down' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.success).toBe(true);
+      expect(body.data).toEqual(expect.objectContaining({
+        status: 'failed',
+        codeTaskId: expect.stringMatching(/^task_/),
+      }));
+
+      const taskResult = await codeTaskRepo.findById(body.data.codeTaskId);
+      expect(taskResult.ok).toBe(true);
+      if (taskResult.ok) {
+        expect(taskResult.value.status).toBe('failed');
+        expect(taskResult.value.error).toEqual(expect.objectContaining({
+          code: 'dispatch_blocked_dispatch_failed',
+        }));
+        expect(taskResult.value.dispatchStatus).toEqual(expect.objectContaining({
+          reason: 'dispatch_failed',
+          terminal: true,
+          nextAction: 'retry_after_fix',
+        }));
+      }
+    });
+
+    it('returns 500 when settings-fetch failure status cannot be persisted', async () => {
+      const services = getServices();
+      vi.spyOn(services.linearIssueService, 'ensureIssueExists').mockResolvedValueOnce({
+        linearIssueId: 'INT-123',
+        linearIssueTitle: 'Fix the bug',
+        linearIssueLabels: [],
+        hasChildren: false,
+        linearFallback: false,
+      });
+      vi.spyOn(services.workerSettingsRepo, 'getSettings').mockResolvedValueOnce(
+        err({ code: 'internal_error', message: 'read failed' }),
+      );
+      vi.spyOn(codeTaskRepo, 'update').mockResolvedValueOnce(
+        err({ code: 'FIRESTORE_ERROR', message: 'write failed' }),
+      );
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/submit',
+        headers: { authorization: 'Bearer test-token' },
+        payload: { prompt: 'Fix the bug while settings and writes are down' },
+      });
+
+      expect(response.statusCode).toBe(500);
       const body = JSON.parse(response.body);
       expect(body.success).toBe(false);
-      expect(body.error.code).toBe('QUEUE_FULL');
+      expect(body.error.code).toBe('INTERNAL_ERROR');
+      expect(body.error.message).toBe('write failed');
+    });
+
+    it('still fails the created task when dispatch status recording throws', async () => {
+      const services = getServices();
+      await services.workerSettingsRepo.updateWorker('test-user-id', 'home-mac', { enabled: false });
+      vi.mocked(codeTaskDispatchStatusService.recordDispatchBlocked).mockRejectedValueOnce(
+        new Error('status repo unavailable')
+      );
+      vi.spyOn(services.linearIssueService, 'ensureIssueExists').mockResolvedValueOnce({
+        linearIssueId: 'INT-123',
+        linearIssueTitle: 'Fix the bug',
+        linearIssueLabels: [],
+        hasChildren: false,
+        linearFallback: false,
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/submit',
+        headers: { authorization: 'Bearer test-token' },
+        payload: { prompt: 'Fix the bug while status recording is down' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.success).toBe(true);
+      expect(body.data).toEqual(expect.objectContaining({
+        status: 'failed',
+        codeTaskId: expect.stringMatching(/^task_/),
+      }));
+      const taskResult = await codeTaskRepo.findById(body.data.codeTaskId);
+      expect(taskResult.ok).toBe(true);
+      if (taskResult.ok) {
+        expect(taskResult.value.status).toBe('failed');
+        expect(taskResult.value.dispatchStatus).toEqual(expect.objectContaining({
+          reason: 'no_enabled_workers',
+          terminal: true,
+        }));
+      }
+    });
+
+    it('returns 500 when no-worker task failure persistence fails', async () => {
+      const services = getServices();
+      await services.workerSettingsRepo.updateWorker('test-user-id', 'home-mac', { enabled: false });
+      vi.spyOn(services.linearIssueService, 'ensureIssueExists').mockResolvedValueOnce({
+        linearIssueId: 'INT-123',
+        linearIssueTitle: 'Fix the bug',
+        linearIssueLabels: [],
+        hasChildren: false,
+        linearFallback: false,
+      });
+      vi.spyOn(codeTaskRepo, 'update').mockResolvedValueOnce(
+        err({ code: 'FIRESTORE_ERROR', message: 'write failed' }),
+      );
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/submit',
+        headers: { authorization: 'Bearer test-token' },
+        payload: { prompt: 'Fix the bug without workers while writes are down' },
+      });
+
+      expect(response.statusCode).toBe(500);
+      const body = JSON.parse(response.body);
+      expect(body.success).toBe(false);
+      expect(body.error.code).toBe('INTERNAL_ERROR');
+      expect(body.error.message).toBe('write failed');
     });
 
     it('returns 500 when enqueue returns internal_error', async () => {

--- a/apps/code-agent/src/domain/models/codeTask.ts
+++ b/apps/code-agent/src/domain/models/codeTask.ts
@@ -169,6 +169,44 @@ export interface TaskError {
   };
 }
 
+export type CodeTaskDispatchStatusReason =
+  | 'no_enabled_workers'
+  | 'workers_unreachable'
+  | 'workers_at_capacity'
+  | 'codex_auth_unavailable'
+  | 'claude_auth_unavailable'
+  | 'provider_auth_unavailable'
+  | 'docker_unavailable'
+  | 'disk_unavailable'
+  | 'unknown_worker_type'
+  | 'worker_unavailable'
+  | 'worker_busy'
+  | 'at_capacity'
+  | 'network_error'
+  | 'dispatch_failed'
+  | 'invalid_response'
+  | 'queue_full'
+  | 'queue_timeout'
+  | 'retry_expired'
+  | 'retry_exhausted'
+  | 'missing_pr_branch'
+  | 'scheduled_wait'
+  | 'active_task_blocked';
+
+export interface CodeTaskDispatchStatus {
+  state: 'waiting' | 'blocked' | 'terminal';
+  reason: CodeTaskDispatchStatusReason;
+  terminal: boolean;
+  severity: 'info' | 'warning' | 'critical';
+  message: string;
+  remediation: string;
+  workerNames: string[];
+  firstSeenAt: Timestamp;
+  lastSeenAt: Timestamp;
+  nextAction: 'will_retry_automatically' | 'retry_after_fix' | 'wait_until_scheduled' | 'wait_for_active_task';
+  notifiedReasons?: Partial<Record<CodeTaskDispatchStatusReason, Timestamp>>;
+}
+
 /**
  * Status summary for UI when logs unavailable.
  * Design reference: Lines 1017-1041
@@ -234,6 +272,7 @@ export interface CodeTask {
   // Results
   result?: TaskResult;
   error?: TaskError;
+  dispatchStatus?: CodeTaskDispatchStatus;
 
   // Timestamps
   createdAt: Timestamp;

--- a/apps/code-agent/src/domain/models/dispatchRetry.ts
+++ b/apps/code-agent/src/domain/models/dispatchRetry.ts
@@ -29,6 +29,7 @@ export interface DispatchRetry {
   lastError: string;
   createdAt: Timestamp;
   lastAttemptAt?: Timestamp;
+  processingStartedAt?: Timestamp | null;
   ttlMinutes: number;
 }
 

--- a/apps/code-agent/src/domain/repositories/codeTaskRepository.ts
+++ b/apps/code-agent/src/domain/repositories/codeTaskRepository.ts
@@ -9,6 +9,7 @@ import type { Timestamp } from '@google-cloud/firestore';
 import type {
   AgentType,
   CodeTask,
+  CodeTaskDispatchStatus,
   DispatchSchedule,
   ExecutionMemoryContext,
   ExecutionMemoryPostRun,
@@ -40,6 +41,8 @@ export type ExecutionMemoryPostRunCreateInput = Omit<
 export type DispatchScheduleCreateInput = Omit<DispatchSchedule, 'notBeforeAt'> & {
   notBeforeAt: Date | Timestamp;
 };
+
+export type CodeTaskDispatchStatusCreateInput = CodeTaskDispatchStatus;
 
 export interface CreateTaskInput {
   /** Pre-generated task ID. Auto-generated if not provided. */
@@ -99,6 +102,7 @@ export interface UpdateTaskInput {
   status?: TaskStatus;
   result?: CodeTask['result'];
   error?: CodeTask['error'] | null;
+  dispatchStatus?: CodeTaskDispatchStatusCreateInput | null;
   statusSummary?: CodeTask['statusSummary'];
   workerLocation?: string;
   callbackReceived?: boolean;
@@ -171,7 +175,10 @@ export interface CodeTaskRepository {
    */
   create(input: CreateTaskInput, options?: { transaction?: FirebaseFirestore.Transaction }): Promise<Result<CodeTask, RepositoryError>>;
 
-  findById(taskId: string): Promise<Result<CodeTask, RepositoryError>>;
+  findById(
+    taskId: string,
+    options?: { transaction?: FirebaseFirestore.Transaction }
+  ): Promise<Result<CodeTask, RepositoryError>>;
 
   findByIdForUser(
     taskId: string,

--- a/apps/code-agent/src/domain/repositories/dispatchRetryRepository.ts
+++ b/apps/code-agent/src/domain/repositories/dispatchRetryRepository.ts
@@ -30,6 +30,15 @@ export interface DispatchRetryRepository {
   >;
 
   /**
+   * Claim a retry entry for processing across scheduler replicas.
+   * Returns false when the entry is missing or already claimed recently.
+   */
+  claimForProcessing(
+    id: string,
+    staleBefore: Date,
+  ): Promise<Result<boolean, DispatchRetryRepositoryError>>;
+
+  /**
    * Delete a retry entry by ID.
    */
   delete(
@@ -45,6 +54,7 @@ export interface DispatchRetryRepository {
       attempts: number;
       lastAttemptAt: Date;
       lastError: string;
+      processingStartedAt?: Date | null;
     },
   ): Promise<Result<void, DispatchRetryRepositoryError>>;
 }

--- a/apps/code-agent/src/domain/services/codeTaskDispatchBlockers.ts
+++ b/apps/code-agent/src/domain/services/codeTaskDispatchBlockers.ts
@@ -99,7 +99,11 @@ function blocker(
 }
 
 function hasRequiredAuth(auth: CodeTaskAuthRequirement, health: HealthyWorker['health']): boolean {
-  if (auth.kind === 'codex') return health.workerAuths.codex.status === 'active';
+  if (auth.kind === 'codex') {
+    const codexAuth = health.workerAuths.codex;
+    return codexAuth.status === 'active'
+      || (codexAuth.status === 'expired' && codexAuth.refreshSupported === true);
+  }
   if (auth.kind === 'claude') return health.workerAuths.claude.status === 'active';
   return health.providerApiKeys[auth.envVar]?.configured === true;
 }

--- a/apps/code-agent/src/domain/services/codeTaskDispatchProblems.ts
+++ b/apps/code-agent/src/domain/services/codeTaskDispatchProblems.ts
@@ -1,0 +1,295 @@
+import { Timestamp } from '@google-cloud/firestore';
+import { ok } from '@intexuraos/common-core';
+import type { Logger } from '@intexuraos/common-core';
+import type {
+  CodeTask,
+  CodeTaskDispatchStatus,
+  CodeTaskDispatchStatusReason,
+  TaskError,
+} from '../models/codeTask.js';
+import type { CodeTaskRepository } from '../repositories/codeTaskRepository.js';
+import type { CodeTaskDispatchability } from './codeTaskDispatchBlockers.js';
+import type { DispatchError } from './taskDispatcher.js';
+import type { WhatsAppNotifier } from './whatsappNotifier.js';
+
+export type DispatchBlocker = Extract<CodeTaskDispatchability, { dispatchable: false }>;
+
+export interface DispatchProblem {
+  reason: CodeTaskDispatchStatusReason;
+  severity: 'info' | 'warning' | 'critical';
+  message: string;
+  remediation: string;
+  workerNames: string[];
+  terminal: boolean;
+}
+
+export interface BuildDispatchStatusInput {
+  task: CodeTask;
+  problem: DispatchProblem;
+  now?: Date;
+}
+
+export interface NotifyDispatchProblemForTaskInput {
+  task: CodeTask;
+  dispatchStatus: CodeTaskDispatchStatus;
+  problem: DispatchProblem;
+  whatsappNotifier: WhatsAppNotifier;
+  codeTaskRepo: CodeTaskRepository;
+  logger: Logger;
+  affectedTaskCount: number;
+  now?: Date;
+}
+
+const RECOVERABLE_BLOCKER_REASONS = new Set<CodeTaskDispatchStatusReason>([
+  'workers_at_capacity',
+  'workers_unreachable',
+]);
+
+const RECOVERABLE_ERROR_REASONS = new Set<CodeTaskDispatchStatusReason>([
+  'worker_unavailable',
+  'worker_busy',
+  'at_capacity',
+  'network_error',
+]);
+
+export function isTerminalDispatchBlockerReason(reason: CodeTaskDispatchStatusReason): boolean {
+  return !RECOVERABLE_BLOCKER_REASONS.has(reason);
+}
+
+export function dispatchProblemFromBlocker(blocker: DispatchBlocker): DispatchProblem {
+  return {
+    reason: blocker.reason,
+    severity: blocker.severity,
+    message: blocker.message,
+    remediation: blocker.remediation,
+    workerNames: blocker.workerNames,
+    terminal: isTerminalDispatchBlockerReason(blocker.reason),
+  };
+}
+
+export function dispatchProblemFromError(error: DispatchError): DispatchProblem {
+  if (error.blocker !== undefined) {
+    return dispatchProblemFromBlocker(error.blocker);
+  }
+
+  const reason = error.code;
+  const terminal = !RECOVERABLE_ERROR_REASONS.has(reason);
+  return {
+    reason,
+    severity: terminal ? 'critical' : 'warning',
+    message: terminal
+      ? `Dispatch failed before the worker could start: ${error.message}`
+      : `Dispatch is temporarily blocked: ${error.message}`,
+    remediation: terminal
+      ? 'Fix the worker dispatch/configuration issue, then retry this task.'
+      : 'The scheduler will retry this task automatically while workers recover.',
+    workerNames: [],
+    terminal,
+  };
+}
+
+export function queueFullDispatchProblem(message: string): DispatchProblem {
+  return {
+    reason: 'queue_full',
+    severity: 'critical',
+    message,
+    remediation: 'Wait for queued work to drain, then retry this task.',
+    workerNames: [],
+    terminal: true,
+  };
+}
+
+export function queueTimeoutDispatchProblem(input: {
+  message: string;
+  remediation: string;
+}): DispatchProblem {
+  return {
+    reason: 'queue_timeout',
+    severity: 'critical',
+    message: input.message,
+    remediation: input.remediation,
+    workerNames: [],
+    terminal: true,
+  };
+}
+
+export function dispatchFailureProblem(input: {
+  message: string;
+  remediation: string;
+}): DispatchProblem {
+  return {
+    reason: 'dispatch_failed',
+    severity: 'critical',
+    message: input.message,
+    remediation: input.remediation,
+    workerNames: [],
+    terminal: true,
+  };
+}
+
+export function missingPrBranchDispatchProblem(input: {
+  agentType: 'review' | 'remediation';
+  prNumber: number;
+}): DispatchProblem {
+  return {
+    reason: 'missing_pr_branch',
+    severity: 'critical',
+    message: `prBranch required for ${input.agentType} task (PR #${String(input.prNumber)})`,
+    remediation: 'Retry after the PR branch is available on the task payload.',
+    workerNames: [],
+    terminal: true,
+  };
+}
+
+export function retryExpiredDispatchProblem(ttlMinutes: number): DispatchProblem {
+  return {
+    reason: 'retry_expired',
+    severity: 'critical',
+    message: `Dispatch retry expired after ${String(ttlMinutes)} minutes`,
+    remediation: 'Fix the dispatch blocker, then retry this task.',
+    workerNames: [],
+    terminal: true,
+  };
+}
+
+export function retryExhaustedDispatchProblem(attempts: number, lastError: string): DispatchProblem {
+  return {
+    reason: 'retry_exhausted',
+    severity: 'critical',
+    message: `Dispatch retry exhausted after ${String(attempts)} attempts: ${lastError}`,
+    remediation: 'Fix the dispatch blocker, then retry this task.',
+    workerNames: [],
+    terminal: true,
+  };
+}
+
+export function nextActionForDispatchProblem(
+  problem: DispatchProblem
+): CodeTaskDispatchStatus['nextAction'] {
+  return problem.terminal ? 'retry_after_fix' : 'will_retry_automatically';
+}
+
+export function taskErrorFromDispatchStatus(dispatchStatus: CodeTaskDispatchStatus): TaskError {
+  return {
+    code: `dispatch_blocked_${dispatchStatus.reason}`,
+    message: dispatchStatus.message,
+    remediation: {
+      action: dispatchStatus.terminal ? 'retry' : 'wait',
+      manualSteps: dispatchStatus.remediation,
+    },
+  };
+}
+
+function existingNotifiedReasons(
+  task: CodeTask
+): Partial<Record<CodeTaskDispatchStatusReason, Timestamp>> {
+  return task.dispatchStatus?.notifiedReasons ?? {};
+}
+
+function firstSeenAtForReason(
+  task: CodeTask,
+  reason: CodeTaskDispatchStatusReason,
+  now: Timestamp
+): Timestamp {
+  return task.dispatchStatus?.reason === reason ? task.dispatchStatus.firstSeenAt : now;
+}
+
+export function buildDispatchStatusForProblem(
+  input: BuildDispatchStatusInput
+): CodeTaskDispatchStatus {
+  const now = Timestamp.fromDate(input.now ?? new Date());
+  const notifiedReasons = existingNotifiedReasons(input.task);
+
+  return {
+    state: input.problem.terminal ? 'terminal' : 'waiting',
+    reason: input.problem.reason,
+    terminal: input.problem.terminal,
+    severity: input.problem.severity,
+    message: input.problem.message,
+    remediation: input.problem.remediation,
+    workerNames: input.problem.workerNames,
+    firstSeenAt: firstSeenAtForReason(input.task, input.problem.reason, now),
+    lastSeenAt: now,
+    nextAction: nextActionForDispatchProblem(input.problem),
+    ...(Object.keys(notifiedReasons).length > 0 && { notifiedReasons }),
+  };
+}
+
+export async function notifyDispatchProblemForTask(
+  input: NotifyDispatchProblemForTaskInput
+): Promise<void> {
+  const notifiedReasons = input.dispatchStatus.notifiedReasons ?? {};
+  if (notifiedReasons[input.problem.reason] !== undefined) {
+    return;
+  }
+
+  const nextNotifiedReasons = {
+    ...notifiedReasons,
+    [input.problem.reason]: Timestamp.fromDate(input.now ?? new Date()),
+  };
+
+  const nextDispatchStatus: CodeTaskDispatchStatus = {
+    ...input.dispatchStatus,
+    notifiedReasons: nextNotifiedReasons,
+  };
+
+  const reserveResult = input.codeTaskRepo.runInTransaction !== undefined
+    ? await input.codeTaskRepo.runInTransaction(async (transaction) => {
+        const currentResult = await input.codeTaskRepo.findById(input.task.id, { transaction });
+        if (!currentResult.ok) {
+          return currentResult;
+        }
+        const currentStatus = currentResult.value.dispatchStatus;
+        if (currentStatus?.reason !== input.problem.reason) {
+          return ok({ shouldNotify: false });
+        }
+        if (currentStatus.notifiedReasons?.[input.problem.reason] !== undefined) {
+          return ok({ shouldNotify: false });
+        }
+        const updateResult = await input.codeTaskRepo.update(input.task.id, {
+          dispatchStatus: {
+            ...currentStatus,
+            notifiedReasons: {
+              ...(currentStatus.notifiedReasons ?? {}),
+              [input.problem.reason]: nextNotifiedReasons[input.problem.reason],
+            },
+          },
+        }, { transaction });
+        if (!updateResult.ok) {
+          return updateResult;
+        }
+        return ok({ shouldNotify: true });
+      })
+    : await input.codeTaskRepo.update(input.task.id, {
+        dispatchStatus: nextDispatchStatus,
+      }).then((updateResult) => updateResult.ok ? ok({ shouldNotify: true }) : updateResult);
+
+  if (!reserveResult.ok) {
+    input.logger.warn(
+      { taskId: input.task.id, reason: input.problem.reason, error: reserveResult.error },
+      'Failed to persist code task dispatch notification ledger'
+    );
+    return;
+  }
+
+  if (!reserveResult.value.shouldNotify) {
+    return;
+  }
+
+  const notifyResult = await input.whatsappNotifier.notifyTaskDispatchBlocked(input.task.userId, {
+    workerType: input.task.workerType,
+    reason: input.problem.reason,
+    affectedTaskCount: input.affectedTaskCount,
+    exampleTaskId: input.task.id,
+    message: input.problem.message,
+    remediation: input.problem.remediation,
+    workerNames: input.problem.workerNames,
+  });
+
+  if (!notifyResult.ok) {
+    input.logger.warn(
+      { taskId: input.task.id, reason: input.problem.reason, error: notifyResult.error },
+      'Failed to notify user about code task dispatch blocker'
+    );
+  }
+}

--- a/apps/code-agent/src/domain/services/codeTaskDispatchStatusService.ts
+++ b/apps/code-agent/src/domain/services/codeTaskDispatchStatusService.ts
@@ -1,9 +1,6 @@
 import type { Logger } from '@intexuraos/common-core';
 import type { CodeTaskSystemStatusRepository } from '../repositories/codeTaskSystemStatusRepository.js';
-import type { WhatsAppNotifier } from './whatsappNotifier.js';
 import type { CodeTaskDispatchability } from './codeTaskDispatchBlockers.js';
-
-const DEFAULT_RESEND_INTERVAL_MS = 6 * 60 * 60 * 1000;
 
 type DispatchBlocker = Extract<CodeTaskDispatchability, { dispatchable: false }>;
 
@@ -27,17 +24,7 @@ export interface CodeTaskDispatchStatusService {
 
 export interface CodeTaskDispatchStatusServiceDeps {
   readonly statusRepo: CodeTaskSystemStatusRepository;
-  readonly whatsappNotifier: WhatsAppNotifier;
   readonly logger: Logger;
-  readonly now?: () => Date;
-  readonly resendIntervalMs?: number;
-}
-
-function shouldNotify(lastNotifiedAt: Date | undefined, now: Date, resendIntervalMs: number): boolean {
-  if (lastNotifiedAt === undefined) {
-    return true;
-  }
-  return now.getTime() - lastNotifiedAt.getTime() >= resendIntervalMs;
 }
 
 export function createCodeTaskDispatchStatusService(
@@ -45,10 +32,7 @@ export function createCodeTaskDispatchStatusService(
 ): CodeTaskDispatchStatusService {
   const {
     statusRepo,
-    whatsappNotifier,
     logger,
-    now = (): Date => new Date(),
-    resendIntervalMs = DEFAULT_RESEND_INTERVAL_MS,
   } = deps;
 
   return {
@@ -70,32 +54,7 @@ export function createCodeTaskDispatchStatusService(
         return;
       }
 
-      const status = upsertResult.value;
-      const notificationTime = now();
-      if (!shouldNotify(status.lastNotifiedAt, notificationTime, resendIntervalMs)) {
-        return;
-      }
-
-      const exampleTaskId = input.exampleTaskIds[0];
-      const notifyResult = await whatsappNotifier.notifyTaskDispatchBlocked(input.userId, {
-        workerType: input.workerType,
-        reason: input.blocker.reason,
-        affectedTaskCount: input.affectedTaskCount,
-        ...(exampleTaskId !== undefined && { exampleTaskId }),
-        message: input.blocker.message,
-        remediation: input.blocker.remediation,
-        workerNames: input.blocker.workerNames,
-      });
-
-      if (!notifyResult.ok) {
-        logger.warn({ error: notifyResult.error, statusId: status.id }, 'Failed to notify user about code task dispatch blocker');
-        return;
-      }
-
-      const markResult = await statusRepo.markNotified(status.id, notificationTime);
-      if (!markResult.ok) {
-        logger.warn({ error: markResult.error, statusId: status.id }, 'Failed to mark code task dispatch blocker as notified');
-      }
+      return;
     },
 
     async resolveDispatchBlockers(input: ResolveCodeTaskDispatchBlockersInput): Promise<void> {

--- a/apps/code-agent/src/domain/services/whatsappNotifier.ts
+++ b/apps/code-agent/src/domain/services/whatsappNotifier.ts
@@ -6,8 +6,7 @@
  */
 
 import type { Result } from '@intexuraos/common-core';
-import type { CodeTask, TaskError } from '../models/codeTask.js';
-import type { CodeTaskDispatchBlockerReason } from './codeTaskDispatchBlockers.js';
+import type { CodeTask, CodeTaskDispatchStatusReason, TaskError } from '../models/codeTask.js';
 
 /**
  * Possible errors during notification sending.
@@ -19,7 +18,7 @@ export interface NotificationError {
 
 export interface TaskDispatchBlockedNotificationInfo {
   readonly workerType: string;
-  readonly reason: CodeTaskDispatchBlockerReason;
+  readonly reason: CodeTaskDispatchStatusReason;
   readonly affectedTaskCount: number;
   readonly exampleTaskId?: string;
   readonly message: string;

--- a/apps/code-agent/src/domain/usecases/drainRetryQueue.ts
+++ b/apps/code-agent/src/domain/usecases/drainRetryQueue.ts
@@ -6,7 +6,7 @@
  */
 
 import { Timestamp } from '@google-cloud/firestore';
-import { ok, type Result } from '@intexuraos/common-core';
+import { err, ok, type Result } from '@intexuraos/common-core';
 import type { Logger } from '@intexuraos/common-core';
 import type { UserServiceClient } from '@intexuraos/internal-clients';
 import type { LlmGenerateClient } from '@intexuraos/llm-factory';
@@ -23,8 +23,18 @@ import type { StatusMirrorService } from '../services/statusMirrorService.js';
 import type { CodeTaskDispatchStatusService } from '../services/codeTaskDispatchStatusService.js';
 import {
   classifyCodeTaskDispatchability,
-  type CodeTaskDispatchability,
 } from '../services/codeTaskDispatchBlockers.js';
+import {
+  buildDispatchStatusForProblem,
+  dispatchProblemFromBlocker,
+  dispatchProblemFromError,
+  notifyDispatchProblemForTask,
+  retryExhaustedDispatchProblem,
+  retryExpiredDispatchProblem,
+  taskErrorFromDispatchStatus,
+  type DispatchBlocker,
+  type DispatchProblem,
+} from '../services/codeTaskDispatchProblems.js';
 import { loadConfig } from '../../config.js';
 import { isRetryableErrorCode } from '../utils/retryableErrors.js';
 import { generateCancelNonce, CANCEL_NONCE_TTL_MS } from '../utils/secrets.js';
@@ -41,7 +51,7 @@ import { isStaleTaskError } from '../services/gitHubDispatchService.js';
 import { buildTaskCompleteWebhookUrl } from '../services/codeTaskCallbackUrls.js';
 import type { SendTaskMessageErrorCode } from './sendTaskMessage.js';
 
-type DispatchBlocker = Extract<CodeTaskDispatchability, { dispatchable: false }>;
+const RETRY_PROCESSING_LEASE_MS = 5 * 60 * 1000;
 
 async function recordDispatchBlockedForRetry(
   deps: Pick<DrainRetryQueueDeps, 'logger' | 'codeTaskDispatchStatusService'>,
@@ -68,6 +78,77 @@ async function recordDispatchBlockedForRetry(
   }
 }
 
+async function failRetryTaskForDispatchProblem(
+  deps: Pick<DrainRetryQueueDeps, 'logger' | 'codeTaskRepo' | 'whatsappNotifier'>,
+  task: CodeTask,
+  problem: DispatchProblem,
+): Promise<Result<void, DrainRetryQueueError>> {
+  const dispatchStatus = buildDispatchStatusForProblem({
+    task,
+    problem,
+  });
+  const updateResult = await deps.codeTaskRepo.update(task.id, {
+    status: 'failed',
+    error: taskErrorFromDispatchStatus(dispatchStatus),
+    dispatchStatus,
+  });
+  if (!updateResult.ok) {
+    deps.logger.error(
+      { taskId: task.id, reason: problem.reason, error: updateResult.error },
+      'Failed to persist failed status during retry dispatch blocker handling'
+    );
+    return err({
+      code: 'internal_error',
+      message: 'Failed to persist retry dispatch failure status',
+    });
+  }
+  await notifyDispatchProblemForTask({
+    task,
+    dispatchStatus,
+    problem,
+    whatsappNotifier: deps.whatsappNotifier,
+    codeTaskRepo: deps.codeTaskRepo,
+    logger: deps.logger,
+    affectedTaskCount: 1,
+  });
+  return ok(undefined);
+}
+
+async function recordRetryTaskDispatchProblem(
+  deps: Pick<DrainRetryQueueDeps, 'logger' | 'codeTaskRepo' | 'whatsappNotifier'>,
+  task: CodeTask,
+  problem: DispatchProblem,
+): Promise<Result<void, DrainRetryQueueError>> {
+  const dispatchStatus = buildDispatchStatusForProblem({
+    task,
+    problem,
+  });
+  const updateResult = await deps.codeTaskRepo.update(task.id, {
+    status: 'queued',
+    dispatchStatus,
+  });
+  if (!updateResult.ok) {
+    deps.logger.warn(
+      { taskId: task.id, reason: problem.reason, error: updateResult.error },
+      'Failed to persist task-level retry dispatch blocker status'
+    );
+    return err({
+      code: 'internal_error',
+      message: 'Failed to persist retry dispatch status',
+    });
+  }
+  await notifyDispatchProblemForTask({
+    task,
+    dispatchStatus,
+    problem,
+    whatsappNotifier: deps.whatsappNotifier,
+    codeTaskRepo: deps.codeTaskRepo,
+    logger: deps.logger,
+    affectedTaskCount: 1,
+  });
+  return ok(undefined);
+}
+
 async function resolveDispatchBlockersForRetry(
   deps: Pick<DrainRetryQueueDeps, 'logger' | 'codeTaskDispatchStatusService'>,
   task: CodeTask
@@ -87,6 +168,57 @@ async function resolveDispatchBlockersForRetry(
       'Failed to resolve code task retry dispatch blocker statuses'
     );
   }
+}
+
+function isTaskNotFoundError(error: { code: string }): boolean {
+  return error.code === 'NOT_FOUND' || error.code === 'not_found';
+}
+
+async function deleteRetryEntryOrError(
+  deps: Pick<DrainRetryQueueDeps, 'logger' | 'dispatchRetryRepo'>,
+  entry: DispatchRetry,
+  logMessage: string,
+  errorMessage: string,
+): Promise<Result<void, DrainRetryQueueError>> {
+  const deleteResult = await deps.dispatchRetryRepo.delete(entry.id);
+  if (!deleteResult.ok) {
+    deps.logger.error({ retryId: entry.id, error: deleteResult.error }, logMessage);
+    return err({ code: 'internal_error', message: errorMessage });
+  }
+  return ok(undefined);
+}
+
+async function claimRetryEntryForProcessing(
+  deps: Pick<DrainRetryQueueDeps, 'logger' | 'dispatchRetryRepo'>,
+  entry: DispatchRetry,
+): Promise<Result<boolean, DrainRetryQueueError>> {
+  const staleBefore = new Date(Date.now() - RETRY_PROCESSING_LEASE_MS);
+  const claimResult = await deps.dispatchRetryRepo.claimForProcessing(entry.id, staleBefore);
+  if (!claimResult.ok) {
+    deps.logger.error({ retryId: entry.id, error: claimResult.error }, 'Failed to claim retry entry for processing');
+    return err({ code: 'internal_error', message: 'Failed to claim retry entry for processing' });
+  }
+  return ok(claimResult.value);
+}
+
+async function updateRetryEntryOrError(
+  deps: Pick<DrainRetryQueueDeps, 'logger' | 'dispatchRetryRepo'>,
+  entry: DispatchRetry,
+  fields: {
+    attempts: number;
+    lastAttemptAt: Date;
+    lastError: string;
+  },
+): Promise<Result<void, DrainRetryQueueError>> {
+  const updateResult = await deps.dispatchRetryRepo.update(entry.id, {
+    ...fields,
+    processingStartedAt: null,
+  });
+  if (!updateResult.ok) {
+    deps.logger.error({ retryId: entry.id, error: updateResult.error }, 'Failed to update retry entry');
+    return err({ code: 'internal_error', message: 'Failed to update retry entry' });
+  }
+  return ok(undefined);
 }
 
 // In-memory guard for single-instance environments
@@ -161,6 +293,15 @@ export async function drainRetryQueue(
 
     logger.info({ retryId: entry.id, type: entry.type, attempts: entry.attempts }, 'Processing retry entry');
 
+    const claimResult = await claimRetryEntryForProcessing(deps, entry);
+    if (!claimResult.ok) {
+      return err(claimResult.error);
+    }
+    if (!claimResult.value) {
+      logger.info({ retryId: entry.id }, 'Retry entry is already claimed by another drain');
+      return ok({ action: 'skipped', ...(entry.taskId !== undefined && { taskId: entry.taskId }) });
+    }
+
     // Step 2: TTL check
     const createdAt = entry.createdAt.toDate();
     const ttlMs = entry.ttlMinutes * 60 * 1000;
@@ -168,34 +309,73 @@ export async function drainRetryQueue(
 
     if (now - createdAt.getTime() > ttlMs) {
       logger.warn({ retryId: entry.id, createdAt }, 'Retry entry expired');
-      await dispatchRetryRepo.delete(entry.id);
 
       if (entry.type === 'new_task' && entry.taskId !== undefined) {
-        await codeTaskRepo.update(entry.taskId, {
-          status: 'failed',
-          error: { code: 'retry_expired', message: `Dispatch retry expired after ${String(entry.ttlMinutes)} minutes` },
-        });
         const taskResult = await codeTaskRepo.findById(entry.taskId);
         if (taskResult.ok) {
-          const locksToCleanup = buildLockCleanups(taskResult.value);
-          // Notify user
-          const userId = taskResult.value.userId;
-          await whatsappNotifier.notifyDispatchRetryExhausted(userId, {
-            repository: entry.repository,
-            pullRequestNumber: entry.pullRequestNumber,
-            lastError: `Expired after ${String(entry.ttlMinutes)} minutes: ${entry.lastError}`,
+          const problem = retryExpiredDispatchProblem(entry.ttlMinutes);
+          const dispatchStatus = buildDispatchStatusForProblem({ task: taskResult.value, problem });
+          const updateResult = await codeTaskRepo.update(entry.taskId, {
+            status: 'failed',
+            error: { code: 'retry_expired', message: problem.message },
+            dispatchStatus,
           });
+          if (!updateResult.ok) {
+            logger.error(
+              { taskId: entry.taskId, error: updateResult.error },
+              'Failed to persist retry expiry task status'
+            );
+            return err({ code: 'internal_error', message: 'Failed to persist retry dispatch failure status' });
+          }
+          await notifyDispatchProblemForTask({
+            task: taskResult.value,
+            dispatchStatus,
+            problem,
+            whatsappNotifier,
+            codeTaskRepo,
+            logger,
+            affectedTaskCount: 1,
+          });
+          const deleteResult = await dispatchRetryRepo.delete(entry.id);
+          if (!deleteResult.ok) {
+            logger.error({ retryId: entry.id, error: deleteResult.error }, 'Failed to delete expired retry entry');
+            return err({ code: 'internal_error', message: 'Failed to delete expired retry entry' });
+          }
+          const locksToCleanup = buildLockCleanups(taskResult.value);
           return ok({ action: 'expired', taskId: entry.taskId, locksToCleanup });
+        }
+        if (!isTaskNotFoundError(taskResult.error)) {
+          logger.error({ taskId: entry.taskId, error: taskResult.error }, 'Failed to find expired retry task');
+          return err({ code: 'internal_error', message: 'Failed to find expired retry task' });
         }
       }
 
-      // task_message or task lookup failed: notify if we have userId
+      const deleteResult = await dispatchRetryRepo.delete(entry.id);
+      if (!deleteResult.ok) {
+        logger.error({ retryId: entry.id, error: deleteResult.error }, 'Failed to delete expired retry entry');
+        return err({ code: 'internal_error', message: 'Failed to delete expired retry entry' });
+      }
+
+      if (entry.type === 'new_task') {
+        logger.warn(
+          { retryId: entry.id, taskId: entry.taskId },
+          'Expired new-task retry target was not found; skipping task-level dispatch notification'
+        );
+        return ok({ action: 'expired', ...(entry.taskId !== undefined && { taskId: entry.taskId }) });
+      }
+
       if (entry.userId !== undefined) {
-        await whatsappNotifier.notifyDispatchRetryExhausted(entry.userId, {
+        const notifyResult = await whatsappNotifier.notifyDispatchRetryExhausted(entry.userId, {
           repository: entry.repository,
           pullRequestNumber: entry.pullRequestNumber,
           lastError: `Expired after ${String(entry.ttlMinutes)} minutes: ${entry.lastError}`,
         });
+        if (!notifyResult.ok) {
+          logger.warn(
+            { retryId: entry.id, userId: entry.userId, error: notifyResult.error },
+            'Failed to notify user about expired message retry'
+          );
+        }
       }
 
       return ok({ action: 'expired', ...(entry.taskId !== undefined && { taskId: entry.taskId }) });
@@ -204,31 +384,73 @@ export async function drainRetryQueue(
     // Step 3: Max attempts check
     if (entry.attempts >= entry.maxAttempts) {
       logger.warn({ retryId: entry.id, attempts: entry.attempts }, 'Retry entry exhausted max attempts');
-      await dispatchRetryRepo.delete(entry.id);
 
       if (entry.type === 'new_task' && entry.taskId !== undefined) {
-        await codeTaskRepo.update(entry.taskId, {
-          status: 'failed',
-          error: { code: 'retry_exhausted', message: `Dispatch retry exhausted after ${String(entry.attempts)} attempts: ${entry.lastError}` },
-        });
         const taskResult = await codeTaskRepo.findById(entry.taskId);
         if (taskResult.ok) {
-          const locksToCleanup = buildLockCleanups(taskResult.value);
-          await whatsappNotifier.notifyDispatchRetryExhausted(taskResult.value.userId, {
-            repository: entry.repository,
-            pullRequestNumber: entry.pullRequestNumber,
-            lastError: entry.lastError,
+          const problem = retryExhaustedDispatchProblem(entry.attempts, entry.lastError);
+          const dispatchStatus = buildDispatchStatusForProblem({ task: taskResult.value, problem });
+          const updateResult = await codeTaskRepo.update(entry.taskId, {
+            status: 'failed',
+            error: { code: 'retry_exhausted', message: problem.message },
+            dispatchStatus,
           });
+          if (!updateResult.ok) {
+            logger.error(
+              { taskId: entry.taskId, error: updateResult.error },
+              'Failed to persist retry exhaustion task status'
+            );
+            return err({ code: 'internal_error', message: 'Failed to persist retry dispatch failure status' });
+          }
+          await notifyDispatchProblemForTask({
+            task: taskResult.value,
+            dispatchStatus,
+            problem,
+            whatsappNotifier,
+            codeTaskRepo,
+            logger,
+            affectedTaskCount: 1,
+          });
+          const deleteResult = await dispatchRetryRepo.delete(entry.id);
+          if (!deleteResult.ok) {
+            logger.error({ retryId: entry.id, error: deleteResult.error }, 'Failed to delete exhausted retry entry');
+            return err({ code: 'internal_error', message: 'Failed to delete exhausted retry entry' });
+          }
+          const locksToCleanup = buildLockCleanups(taskResult.value);
           return ok({ action: 'exhausted', taskId: entry.taskId, locksToCleanup });
+        }
+        if (!isTaskNotFoundError(taskResult.error)) {
+          logger.error({ taskId: entry.taskId, error: taskResult.error }, 'Failed to find exhausted retry task');
+          return err({ code: 'internal_error', message: 'Failed to find exhausted retry task' });
         }
       }
 
+      const deleteResult = await dispatchRetryRepo.delete(entry.id);
+      if (!deleteResult.ok) {
+        logger.error({ retryId: entry.id, error: deleteResult.error }, 'Failed to delete exhausted retry entry');
+        return err({ code: 'internal_error', message: 'Failed to delete exhausted retry entry' });
+      }
+
+      if (entry.type === 'new_task') {
+        logger.warn(
+          { retryId: entry.id, taskId: entry.taskId },
+          'Exhausted new-task retry target was not found; skipping task-level dispatch notification'
+        );
+        return ok({ action: 'exhausted', ...(entry.taskId !== undefined && { taskId: entry.taskId }) });
+      }
+
       if (entry.userId !== undefined) {
-        await whatsappNotifier.notifyDispatchRetryExhausted(entry.userId, {
+        const notifyResult = await whatsappNotifier.notifyDispatchRetryExhausted(entry.userId, {
           repository: entry.repository,
           pullRequestNumber: entry.pullRequestNumber,
           lastError: entry.lastError,
         });
+        if (!notifyResult.ok) {
+          logger.warn(
+            { retryId: entry.id, userId: entry.userId, error: notifyResult.error },
+            'Failed to notify user about exhausted message retry'
+          );
+        }
       }
 
       return ok({ action: 'exhausted', ...(entry.taskId !== undefined && { taskId: entry.taskId }) });
@@ -251,11 +473,19 @@ async function handleNewTaskRetry(
   entry: DispatchRetry,
   config: ReturnType<typeof loadConfig>,
 ): Promise<Result<DrainRetryQueueResult, DrainRetryQueueError>> {
-  const { logger, dispatchRetryRepo, codeTaskRepo, taskDispatcher, linearAgentClient, whatsappNotifier, workerSettingsRepo } = deps;
+  const { logger, codeTaskRepo, taskDispatcher, linearAgentClient, whatsappNotifier, workerSettingsRepo } = deps;
 
   if (entry.taskId === undefined) {
     logger.error({ retryId: entry.id }, 'new_task retry missing taskId');
-    await dispatchRetryRepo.delete(entry.id);
+    const deleteResult = await deleteRetryEntryOrError(
+      deps,
+      entry,
+      'Failed to delete malformed new-task retry entry',
+      'Failed to delete malformed new-task retry entry',
+    );
+    if (!deleteResult.ok) {
+      return err(deleteResult.error);
+    }
     return ok({ action: 'failed' });
   }
 
@@ -263,26 +493,55 @@ async function handleNewTaskRetry(
   const taskResult = await codeTaskRepo.findById(entry.taskId);
   if (!taskResult.ok) {
     logger.error({ taskId: entry.taskId, error: taskResult.error }, 'Failed to find task for retry');
-    await dispatchRetryRepo.delete(entry.id);
+    if (!isTaskNotFoundError(taskResult.error)) {
+      return err({ code: 'internal_error', message: 'Failed to find task for retry' });
+    }
+    const deleteResult = await deleteRetryEntryOrError(
+      deps,
+      entry,
+      'Failed to delete retry entry after missing task lookup',
+      'Failed to delete retry entry after missing task lookup',
+    );
+    if (!deleteResult.ok) {
+      return err(deleteResult.error);
+    }
     return ok({ action: 'failed' });
   }
 
   const task = taskResult.value;
+  if (task.status !== 'queued') {
+    logger.warn(
+      { retryId: entry.id, taskId: task.id, status: task.status },
+      'Deleting stale new-task retry entry for task that is no longer queued'
+    );
+    const deleteResult = await deleteRetryEntryOrError(
+      deps,
+      entry,
+      'Failed to delete stale new-task retry entry',
+      'Failed to delete stale new-task retry entry',
+    );
+    if (!deleteResult.ok) {
+      return err(deleteResult.error);
+    }
+    return ok({ action: 'failed', taskId: entry.taskId });
+  }
 
   // Fetch worker credentials
   const settingsResult = await workerSettingsRepo.getSettings(task.userId);
-  if (!settingsResult.ok || settingsResult.value === null) {
+  if (!settingsResult.ok) {
     logger.error({ userId: task.userId }, 'Failed to fetch worker settings for retry');
-    await dispatchRetryRepo.update(entry.id, {
+    const updateResult = await updateRetryEntryOrError(deps, entry, {
       attempts: entry.attempts + 1,
       lastAttemptAt: new Date(),
       lastError: 'Failed to fetch worker settings',
     });
+    if (!updateResult.ok) {
+      return err(updateResult.error);
+    }
     return ok({ action: 'retry_failed', taskId: entry.taskId });
   }
 
-  const settings = settingsResult.value;
-  const enabledWorkers = settings.workers.filter((w) => w.enabled);
+  const enabledWorkers = settingsResult.value?.workers.filter((w) => w.enabled) ?? [];
 
   if (enabledWorkers.length === 0) {
     const dispatchability = classifyCodeTaskDispatchability({
@@ -292,12 +551,20 @@ async function handleNewTaskRetry(
     }) as DispatchBlocker;
     await recordDispatchBlockedForRetry(deps, task, dispatchability);
     logger.warn({ userId: task.userId }, 'No enabled workers during retry');
-    await dispatchRetryRepo.update(entry.id, {
-      attempts: entry.attempts + 1,
-      lastAttemptAt: new Date(),
-      lastError: 'No enabled workers',
-    });
-    return ok({ action: 'retry_failed', taskId: entry.taskId });
+    const failResult = await failRetryTaskForDispatchProblem(deps, task, dispatchProblemFromBlocker(dispatchability));
+    if (!failResult.ok) {
+      return err(failResult.error);
+    }
+    const deleteResult = await deleteRetryEntryOrError(
+      deps,
+      entry,
+      'Failed to delete retry entry after no enabled workers',
+      'Failed to delete retry entry after no enabled workers',
+    );
+    if (!deleteResult.ok) {
+      return err(deleteResult.error);
+    }
+    return ok({ action: 'failed', taskId: entry.taskId, locksToCleanup: buildLockCleanups(task) });
   }
 
   const workerCredentials: DispatchWorkerCredentials = {
@@ -381,6 +648,19 @@ async function handleNewTaskRetry(
 
   const dispatchExecutionMemoryContext = toDispatchExecutionMemoryContext(taskExecutionMemoryContext);
 
+  // Atomic queued->dispatched claim before the network call. The retry-row
+  // processing lease prevents duplicate retry processors, and this task claim
+  // prevents duplicate worker dispatch if another path races on the same task.
+  const taskClaimResult = await codeTaskRepo.claimForDispatch(task.id);
+  if (!taskClaimResult.ok) {
+    logger.error({ taskId: task.id, error: taskClaimResult.error }, 'Failed to claim retry task for dispatch');
+    return err({ code: 'internal_error', message: 'Failed to claim retry task for dispatch' });
+  }
+  if (!taskClaimResult.value) {
+    logger.info({ retryId: entry.id, taskId: task.id }, 'Retry task was claimed by another dispatcher or is no longer queued');
+    return ok({ action: 'skipped', taskId: entry.taskId });
+  }
+
   // Attempt dispatch
   const dispatchResult = await taskDispatcher.dispatch({
     taskId: task.id,
@@ -413,43 +693,58 @@ async function handleNewTaskRetry(
 
   if (!dispatchResult.ok) {
     const dispatchError = dispatchResult.error;
+    const dispatchProblem = dispatchProblemFromError(dispatchError);
 
     // Note: at_capacity is NOT retryable at entry *creation* (the regular task queue handles queuing),
     // but IS retryable during *drain* — if a retry entry already exists and the worker is at capacity,
     // we should increment and try again rather than permanently failing the task.
-    if (isRetryableErrorCode(dispatchError.code) || dispatchError.code === 'at_capacity') {
-      if (dispatchError.blocker !== undefined) {
-        await recordDispatchBlockedForRetry(deps, task, dispatchError.blocker);
+    if (dispatchError.blocker !== undefined) {
+      await recordDispatchBlockedForRetry(deps, task, dispatchError.blocker);
+    }
+
+    if (!dispatchProblem.terminal) {
+      const recordResult = await recordRetryTaskDispatchProblem(deps, task, dispatchProblem);
+      if (!recordResult.ok) {
+        return err(recordResult.error);
       }
-      await dispatchRetryRepo.update(entry.id, {
+      const updateResult = await updateRetryEntryOrError(deps, entry, {
         attempts: entry.attempts + 1,
         lastAttemptAt: new Date(),
         lastError: dispatchError.message,
       });
+      if (!updateResult.ok) {
+        return err(updateResult.error);
+      }
       logger.info({ retryId: entry.id, attempts: entry.attempts + 1 }, 'Retry dispatch failed, will retry again');
       return ok({ action: 'retry_failed', taskId: entry.taskId });
     }
 
     // Non-retryable — fail permanently
-    await dispatchRetryRepo.delete(entry.id);
-    await codeTaskRepo.update(entry.taskId, {
-      status: 'failed',
-      error: { code: dispatchError.code, message: `Retry dispatch failed: ${dispatchError.message}` },
-    });
+    const failResult = await failRetryTaskForDispatchProblem(deps, task, dispatchProblem);
+    if (!failResult.ok) {
+      return err(failResult.error);
+    }
+    const deleteResult = await deleteRetryEntryOrError(
+      deps,
+      entry,
+      'Failed to delete retry entry after terminal dispatch failure',
+      'Failed to delete retry entry after terminal dispatch failure',
+    );
+    if (!deleteResult.ok) {
+      return err(deleteResult.error);
+    }
     const locksToCleanup = buildLockCleanups(task);
     return ok({ action: 'failed', taskId: entry.taskId, locksToCleanup });
   }
 
-  // Success! Delete retry entry and update task
-  await dispatchRetryRepo.delete(entry.id);
+  // Success! The task claim already marked it dispatched before the network
+  // call; persist dispatch metadata before deleting the retry entry.
   await resolveDispatchBlockersForRetry(deps, task);
 
   const cancelNonce = generateCancelNonce();
   const cancelNonceExpiresAt = new Date(Date.now() + CANCEL_NONCE_TTL_MS).toISOString();
 
   const updateResult = await codeTaskRepo.update(entry.taskId, {
-    status: 'dispatched',
-    dispatchedAt: new Date(),
     // Seed lastHeartbeat at dispatch so findZombieTasks (which uses a Firestore
     // inequality filter on lastHeartbeat) can sweep tasks that crash/fail
     // before the worker ever sends its first real heartbeat. Without this,
@@ -458,17 +753,31 @@ async function handleNewTaskRetry(
     workerLocation: dispatchResult.value.workerLocation,
     cancelNonce,
     cancelNonceExpiresAt,
+    dispatchStatus: null,
   });
 
-  if (updateResult.ok) {
-    await archiveRetriedTaskAfterDispatch({
-      logger,
-      codeTaskRepo,
-      retryTaskId: task.id,
-      warningMessage: 'Failed to archive original task after retry drain dispatch',
-      ...(task.retriedFrom !== undefined && { retriedFrom: task.retriedFrom }),
-    });
-    await whatsappNotifier.notifyTaskStarted(task.userId, updateResult.value);
+  if (!updateResult.ok) {
+    logger.error({ taskId: entry.taskId, error: updateResult.error }, 'Failed to persist successful retry dispatch metadata');
+    return err({ code: 'internal_error', message: 'Failed to persist successful retry dispatch metadata' });
+  }
+
+  await archiveRetriedTaskAfterDispatch({
+    logger,
+    codeTaskRepo,
+    retryTaskId: task.id,
+    warningMessage: 'Failed to archive original task after retry drain dispatch',
+    ...(task.retriedFrom !== undefined && { retriedFrom: task.retriedFrom }),
+  });
+  await whatsappNotifier.notifyTaskStarted(task.userId, updateResult.value);
+
+  const deleteResult = await deleteRetryEntryOrError(
+    deps,
+    entry,
+    'Failed to delete retry entry after successful dispatch',
+    'Failed to delete retry entry after successful dispatch',
+  );
+  if (!deleteResult.ok) {
+    return err(deleteResult.error);
   }
 
   logger.info({ taskId: entry.taskId, workerLocation: dispatchResult.value.workerLocation }, 'Retry dispatch successful');
@@ -479,22 +788,33 @@ async function handleTaskMessageRetry(
   deps: DrainRetryQueueDeps,
   entry: DispatchRetry,
 ): Promise<Result<DrainRetryQueueResult, DrainRetryQueueError>> {
-  const { logger, dispatchRetryRepo, workerSettingsRepo, taskDispatcher, logLineRepo } = deps;
+  const { logger, workerSettingsRepo, taskDispatcher, logLineRepo } = deps;
 
   if (entry.userId === undefined || entry.taskId === undefined || entry.message === undefined) {
     logger.error({ retryId: entry.id }, 'task_message retry missing required fields');
-    await dispatchRetryRepo.delete(entry.id);
+    const deleteResult = await deleteRetryEntryOrError(
+      deps,
+      entry,
+      'Failed to delete malformed task-message retry entry',
+      'Failed to delete malformed task-message retry entry',
+    );
+    if (!deleteResult.ok) {
+      return err(deleteResult.error);
+    }
     return ok({ action: 'failed' });
   }
 
   // Fetch worker credentials
   const settingsResult = await workerSettingsRepo.getSettings(entry.userId);
   if (!settingsResult.ok || settingsResult.value === null) {
-    await dispatchRetryRepo.update(entry.id, {
+    const updateResult = await updateRetryEntryOrError(deps, entry, {
       attempts: entry.attempts + 1,
       lastAttemptAt: new Date(),
       lastError: 'Failed to fetch worker settings',
     });
+    if (!updateResult.ok) {
+      return err(updateResult.error);
+    }
     return ok({ action: 'retry_failed', taskId: entry.taskId });
   }
 
@@ -503,11 +823,14 @@ async function handleTaskMessageRetry(
   const worker = enabledWorkers[0];
 
   if (worker === undefined) {
-    await dispatchRetryRepo.update(entry.id, {
+    const updateResult = await updateRetryEntryOrError(deps, entry, {
       attempts: entry.attempts + 1,
       lastAttemptAt: new Date(),
       lastError: 'No enabled workers',
     });
+    if (!updateResult.ok) {
+      return err(updateResult.error);
+    }
     return ok({ action: 'retry_failed', taskId: entry.taskId });
   }
 
@@ -521,11 +844,14 @@ async function handleTaskMessageRetry(
 
   if (!sendResult.ok) {
     if (isRetryableErrorCode(sendResult.error.code)) {
-      await dispatchRetryRepo.update(entry.id, {
+      const updateResult = await updateRetryEntryOrError(deps, entry, {
         attempts: entry.attempts + 1,
         lastAttemptAt: new Date(),
         lastError: sendResult.error.message,
       });
+      if (!updateResult.ok) {
+        return err(updateResult.error);
+      }
       logger.info({ retryId: entry.id, attempts: entry.attempts + 1 }, 'Retry message send failed, will retry again');
       return ok({ action: 'retry_failed', taskId: entry.taskId });
     }
@@ -544,6 +870,16 @@ async function handleTaskMessageRetry(
         'Message retry detected stale task, falling back to new task creation'
       );
 
+      const deleteResult = await deleteRetryEntryOrError(
+        deps,
+        entry,
+        'Failed to delete retry entry before stale task fallback',
+        'Failed to delete retry entry before stale task fallback',
+      );
+      if (!deleteResult.ok) {
+        return err(deleteResult.error);
+      }
+
       const createResult = await deps.createTaskForPRFn({
         repository: entry.repository,
         prNumber: entry.pullRequestNumber,
@@ -553,8 +889,6 @@ async function handleTaskMessageRetry(
         ...(entry.prTitle !== undefined && { prTitle: entry.prTitle }),
         ...(entry.baseBranch !== undefined && { baseBranch: entry.baseBranch }),
       });
-
-      await dispatchRetryRepo.delete(entry.id);
 
       if (createResult.ok) {
         logger.info(
@@ -572,13 +906,29 @@ async function handleTaskMessageRetry(
     }
 
     // Non-retryable and not stale — drop permanently
-    await dispatchRetryRepo.delete(entry.id);
+    const deleteResult = await deleteRetryEntryOrError(
+      deps,
+      entry,
+      'Failed to delete retry entry after permanent message failure',
+      'Failed to delete retry entry after permanent message failure',
+    );
+    if (!deleteResult.ok) {
+      return err(deleteResult.error);
+    }
     logger.warn({ retryId: entry.id, error: sendResult.error }, 'Message retry failed permanently');
     return ok({ action: 'failed', taskId: entry.taskId });
   }
 
   // Success
-  await dispatchRetryRepo.delete(entry.id);
+  const deleteResult = await deleteRetryEntryOrError(
+    deps,
+    entry,
+    'Failed to delete retry entry after successful message delivery',
+    'Failed to delete retry entry after successful message delivery',
+  );
+  if (!deleteResult.ok) {
+    return err(deleteResult.error);
+  }
 
   // Write [resumed] log line
   const sequence = Date.now() * 1000;

--- a/apps/code-agent/src/domain/usecases/drainTaskQueue.ts
+++ b/apps/code-agent/src/domain/usecases/drainTaskQueue.ts
@@ -9,9 +9,10 @@
 
 import { err, ok, type Result } from '@intexuraos/common-core';
 import type { Logger } from '@intexuraos/common-core';
+import { Timestamp } from '@google-cloud/firestore';
 import type { UserServiceClient } from '@intexuraos/internal-clients';
 import type { LlmGenerateClient } from '@intexuraos/llm-factory';
-import type { CodeTask } from '../models/codeTask.js';
+import type { CodeTask, CodeTaskDispatchStatus } from '../models/codeTask.js';
 import type { CodeTaskRepository } from '../repositories/codeTaskRepository.js';
 import type { TaskDispatcherService, DispatchWorkerCredentials } from '../services/taskDispatcher.js';
 import type { LinearAgentClient } from '../ports/linearAgentClient.js';
@@ -20,15 +21,24 @@ import type { WorkerSettingsRepository } from '../ports/workerSettingsRepository
 import type { CodeTaskDispatchStatusService } from '../services/codeTaskDispatchStatusService.js';
 import {
   classifyCodeTaskDispatchability,
-  type CodeTaskDispatchability,
 } from '../services/codeTaskDispatchBlockers.js';
+import {
+  buildDispatchStatusForProblem,
+  dispatchProblemFromBlocker,
+  dispatchProblemFromError,
+  missingPrBranchDispatchProblem,
+  notifyDispatchProblemForTask,
+  queueTimeoutDispatchProblem,
+  taskErrorFromDispatchStatus,
+  type DispatchBlocker,
+  type DispatchProblem,
+} from '../services/codeTaskDispatchProblems.js';
 import { loadConfig } from '../../config.js';
 import { generateCancelNonce, CANCEL_NONCE_TTL_MS } from '../utils/secrets.js';
 import { buildLockCleanups, type LockCleanupInfo } from '../utils/prTaskLock.js';
 import { ensureDispatchLabelsForAgentType, resolveTaskAgentType } from '../utils/taskRouting.js';
 import { archiveRetriedTaskAfterDispatch } from '../utils/archiveRetriedTaskAfterDispatch.js';
 import { isMemoryEligibleAgent } from '../utils/memoryEligibility.js';
-import { isRetryableErrorCode } from '../utils/retryableErrors.js';
 import { shouldFanOut, fanOutChildTasks } from './fanOutChildTasks.js';
 import type { TaskEnqueueService } from '../services/taskEnqueueService.js';
 import { buildTaskCompleteWebhookUrl } from '../services/codeTaskCallbackUrls.js';
@@ -57,12 +67,160 @@ function groupTasksByPR(tasks: CodeTask[]): Map<string, CodeTask[]> {
   return groups;
 }
 
-type DispatchBlocker = Extract<CodeTaskDispatchability, { dispatchable: false }>;
-
 function findAffectedDispatchTasks(candidates: readonly CodeTask[], task: CodeTask): CodeTask[] {
   return candidates.filter(
     (candidate) => candidate.userId === task.userId && candidate.workerType === task.workerType
   );
+}
+
+function buildWaitingDispatchStatus(
+  task: CodeTask,
+  input: {
+    reason: 'scheduled_wait' | 'active_task_blocked';
+    message: string;
+    remediation: string;
+    nextAction: Extract<CodeTaskDispatchStatus['nextAction'], 'wait_until_scheduled' | 'wait_for_active_task'>;
+  }
+): CodeTaskDispatchStatus {
+  const now = Timestamp.fromDate(new Date());
+  return {
+    state: 'waiting',
+    reason: input.reason,
+    terminal: false,
+    severity: 'info',
+    message: input.message,
+    remediation: input.remediation,
+    workerNames: [],
+    firstSeenAt: task.dispatchStatus?.reason === input.reason ? task.dispatchStatus.firstSeenAt : now,
+    lastSeenAt: now,
+    nextAction: input.nextAction,
+    ...(task.dispatchStatus?.notifiedReasons !== undefined && {
+      notifiedReasons: task.dispatchStatus.notifiedReasons,
+    }),
+  };
+}
+
+async function recordScheduledWaitStatus(
+  deps: Pick<DrainTaskQueueDeps, 'logger' | 'codeTaskRepo'>,
+  task: CodeTask,
+  notBeforeAt: Date
+): Promise<void> {
+  const updateResult = await deps.codeTaskRepo.update(task.id, {
+    dispatchStatus: buildWaitingDispatchStatus(task, {
+      reason: 'scheduled_wait',
+      message: `Task is scheduled for dispatch at ${notBeforeAt.toISOString()}.`,
+      remediation: 'The scheduler will dispatch this task automatically once the scheduled time arrives.',
+      nextAction: 'wait_until_scheduled',
+    }),
+  });
+  if (!updateResult.ok) {
+    deps.logger.warn(
+      { taskId: task.id, notBeforeAt: notBeforeAt.toISOString(), error: updateResult.error },
+      'Failed to persist scheduled dispatch wait status'
+    );
+  }
+}
+
+async function recordActiveTaskWaitStatus(
+  deps: Pick<DrainTaskQueueDeps, 'logger' | 'codeTaskRepo'>,
+  task: CodeTask,
+  input:
+    | { activeTaskId?: string | undefined; queuedAt?: Date; scope: 'pr' }
+    | { activeTaskId?: string | undefined; queuedAt?: Date; scope: 'linear_issue'; linearIssueId: string }
+): Promise<void> {
+  const message = input.scope === 'pr'
+    ? `Another task is already dispatched or running for PR #${String(task.prNumber)}.`
+    : `Another task is already dispatched or running for Linear issue ${input.linearIssueId}.`;
+  const updateResult = await deps.codeTaskRepo.update(task.id, {
+    ...(input.queuedAt !== undefined && { queuedAt: input.queuedAt }),
+    dispatchStatus: buildWaitingDispatchStatus(task, {
+      reason: 'active_task_blocked',
+      message,
+      remediation: 'The scheduler will retry this task automatically after the active task finishes.',
+      nextAction: 'wait_for_active_task',
+    }),
+  });
+  if (!updateResult.ok) {
+    deps.logger.warn(
+      { taskId: task.id, activeTaskId: input.activeTaskId, error: updateResult.error },
+      input.scope === 'pr'
+        ? 'Failed to reset queuedAt for PR-locked task — TTL clock continues from original queuedAt'
+        : 'Failed to persist active-task dispatch wait status'
+    );
+  }
+}
+
+async function failTaskForDispatchProblem(
+  deps: Pick<DrainTaskQueueDeps, 'logger' | 'codeTaskRepo' | 'whatsappNotifier'>,
+  task: CodeTask,
+  problem: DispatchProblem,
+  affectedTaskCount: number,
+): Promise<Result<void, DrainTaskQueueError>> {
+  const dispatchStatus = buildDispatchStatusForProblem({
+    task,
+    problem,
+  });
+  const failUpdateResult = await deps.codeTaskRepo.update(task.id, {
+    status: 'failed',
+    error: taskErrorFromDispatchStatus(dispatchStatus),
+    dispatchStatus,
+  });
+  if (!failUpdateResult.ok) {
+    deps.logger.error(
+      { taskId: task.id, reason: problem.reason, error: failUpdateResult.error },
+      'Failed to persist failed status during dispatch blocker handling'
+    );
+    return err({
+      code: 'internal_error',
+      message: 'Failed to persist dispatch failure status',
+    });
+  }
+  await notifyDispatchProblemForTask({
+    task,
+    dispatchStatus,
+    problem,
+    whatsappNotifier: deps.whatsappNotifier,
+    codeTaskRepo: deps.codeTaskRepo,
+    logger: deps.logger,
+    affectedTaskCount,
+  });
+  return ok(undefined);
+}
+
+async function rollbackTaskForRecoverableDispatchProblem(
+  deps: Pick<DrainTaskQueueDeps, 'logger' | 'codeTaskRepo' | 'whatsappNotifier'>,
+  task: CodeTask,
+  problem: DispatchProblem,
+  affectedTaskCount: number,
+): Promise<Result<void, DrainTaskQueueError>> {
+  const dispatchStatus = buildDispatchStatusForProblem({
+    task,
+    problem,
+  });
+  const rollbackResult = await deps.codeTaskRepo.update(task.id, {
+    status: 'queued',
+    dispatchStatus,
+  });
+  if (!rollbackResult.ok) {
+    deps.logger.warn(
+      { taskId: task.id, error: rollbackResult.error },
+      'Failed to roll back claim after retryable dispatch error',
+    );
+    return err({
+      code: 'internal_error',
+      message: 'Failed to persist recoverable dispatch status',
+    });
+  }
+  await notifyDispatchProblemForTask({
+    task,
+    dispatchStatus,
+    problem,
+    whatsappNotifier: deps.whatsappNotifier,
+    codeTaskRepo: deps.codeTaskRepo,
+    logger: deps.logger,
+    affectedTaskCount,
+  });
+  return ok(undefined);
 }
 
 async function recordDispatchBlockedForTask(
@@ -269,6 +427,7 @@ export async function drainTaskQueue(
         if (nextEligibleAt === undefined || notBeforeDate.getTime() < nextEligibleAt.getTime()) {
           nextEligibleAt = notBeforeDate;
         }
+        await recordScheduledWaitStatus({ logger, codeTaskRepo }, candidate, notBeforeDate);
         logger.info(
           {
             taskId: candidate.id,
@@ -292,14 +451,12 @@ export async function drainTaskQueue(
             activeTaskId: prActiveResult.value.taskId,
           }, 'Skipping queued task — dispatched/running task exists for same PR');
 
-          // Reset TTL so PR-lock-blocked time does not count toward expiry
-          const resetResult = await codeTaskRepo.update(candidate.id, { queuedAt: new Date() });
-          if (!resetResult.ok) {
-            logger.warn(
-              { taskId: candidate.id, error: resetResult.error },
-              'Failed to reset queuedAt for PR-locked task — TTL clock continues from original queuedAt',
-            );
-          }
+          // Reset TTL so PR-lock-blocked time does not count toward expiry.
+          await recordActiveTaskWaitStatus(
+            { logger, codeTaskRepo },
+            candidate,
+            { queuedAt: new Date(), scope: 'pr', activeTaskId: prActiveResult.value.taskId }
+          );
 
           continue;
         }
@@ -323,6 +480,11 @@ export async function drainTaskQueue(
             },
             'Deferring review — another task on the same Linear issue is dispatched/running',
           );
+          await recordActiveTaskWaitStatus(
+            { logger, codeTaskRepo },
+            candidate,
+            { scope: 'linear_issue', linearIssueId: candidate.linearIssueId, activeTaskId: siblingResult.value.taskId }
+          );
           continue;
         }
       }
@@ -341,13 +503,30 @@ export async function drainTaskQueue(
 
       if (now - effectiveEligibleAt.getTime() > ttlMs) {
         logger.warn({ taskId: candidate.id, queuedAt }, 'Queued task expired');
-        await codeTaskRepo.update(candidate.id, {
+        const timeoutMessage = `Task expired in queue after ${String(config.queue.ttlMinutes)} minutes. Workers were still busy.`;
+        const timeoutProblem = queueTimeoutDispatchProblem({
+          message: timeoutMessage,
+          remediation: 'Retry this task after worker capacity is available.',
+        });
+        const dispatchStatus = buildDispatchStatusForProblem({
+          task: candidate,
+          problem: timeoutProblem,
+        });
+        const timeoutUpdateResult = await codeTaskRepo.update(candidate.id, {
           status: 'failed',
           error: {
             code: 'queue_timeout',
-            message: `Task expired in queue after ${String(config.queue.ttlMinutes)} minutes. Workers were still busy.`,
+            message: timeoutMessage,
           },
+          dispatchStatus,
         });
+        if (!timeoutUpdateResult.ok) {
+          logger.error(
+            { taskId: candidate.id, error: timeoutUpdateResult.error },
+            'Failed to mark task failed after queue timeout'
+          );
+          return err({ code: 'internal_error', message: 'Failed to persist queue timeout status' });
+        }
 
         const locksToCleanup = buildLockCleanups(candidate);
 
@@ -362,10 +541,15 @@ export async function drainTaskQueue(
           }
         }
 
-        const notifyResult = await whatsappNotifier.notifyTaskQueueExpired(candidate.userId, candidate);
-        if (!notifyResult.ok) {
-          logger.warn({ taskId: candidate.id, error: notifyResult.error }, 'Failed to send queue expired notification');
-        }
+        await notifyDispatchProblemForTask({
+          task: candidate,
+          dispatchStatus,
+          problem: timeoutProblem,
+          whatsappNotifier,
+          codeTaskRepo,
+          logger,
+          affectedTaskCount: 1,
+        });
 
         return ok({ action: 'expired', taskId: candidate.id, locksToCleanup });
       }
@@ -401,13 +585,12 @@ export async function drainTaskQueue(
 
     // Step 3: Fetch user's CURRENT worker settings
     const settingsResult = await workerSettingsRepo.getSettings(task.userId);
-    if (!settingsResult.ok || settingsResult.value === null) {
+    if (!settingsResult.ok) {
       logger.error({ userId: task.userId }, 'Failed to fetch worker settings for drain');
       return err({ code: 'internal_error', message: 'Failed to fetch worker settings' });
     }
 
-    const settings = settingsResult.value;
-    const enabledWorkers = settings.workers.filter((w) => w.enabled);
+    const enabledWorkers = settingsResult.value?.workers.filter((w) => w.enabled) ?? [];
 
     if (enabledWorkers.length === 0) {
       const dispatchability = classifyCodeTaskDispatchability({
@@ -415,12 +598,30 @@ export async function drainTaskQueue(
         workers: enabledWorkers,
         healthByWorkerName: {},
       }) as DispatchBlocker;
+      const claimResult = await codeTaskRepo.claimForDispatch(task.id);
+      if (!claimResult.ok) {
+        logger.error({ taskId: task.id, error: claimResult.error }, 'Failed to claim task for dispatch');
+        return ok({ action: 'still_busy', taskId: task.id });
+      }
+      if (!claimResult.value) {
+        logger.info({ taskId: task.id }, 'Skipped — claimed by another instance or no longer queued');
+        return ok({ action: 'still_busy', taskId: task.id });
+      }
       await recordDispatchBlockedForTask(deps, activeCandidates, task, dispatchability);
+      const failResult = await failTaskForDispatchProblem(
+        deps,
+        task,
+        dispatchProblemFromBlocker(dispatchability),
+        findAffectedDispatchTasks(activeCandidates, task).length,
+      );
+      if (!failResult.ok) {
+        return err(failResult.error);
+      }
       logger.warn(
         { userId: task.userId, taskId: task.id, reason: 'no_enabled_workers' },
-        'Drain blocked: user has no enabled workers — task stays queued until workers are configured or TTL expires',
+        'Drain blocked: user has no enabled workers — task failed immediately',
       );
-      return ok({ action: 'still_busy', taskId: task.id });
+      return ok({ action: 'failed', taskId: task.id, locksToCleanup: buildLockCleanups(task) });
     }
 
     const workerCredentials: DispatchWorkerCredentials = {
@@ -578,16 +779,32 @@ export async function drainTaskQueue(
     // these agents read code from the worktree and would silently check out the base branch
     // instead of the PR head, producing wrong review findings or fixing the wrong code.
     if (task.prNumber !== undefined && task.prBranch === undefined && (agentType === 'review' || agentType === 'remediation')) {
+      const problem = missingPrBranchDispatchProblem({
+        agentType,
+        prNumber: task.prNumber,
+      });
+      const dispatchStatus = buildDispatchStatusForProblem({ task, problem });
       logger.error(
         { taskId: task.id, prNumber: task.prNumber, agentType },
         'Review/remediation task has prNumber but no prBranch — refusing to dispatch on base branch'
       );
-      await codeTaskRepo.update(task.id, {
+      const updateResult = await codeTaskRepo.update(task.id, {
         status: 'failed',
-        error: {
-          code: 'MISSING_PR_BRANCH',
-          message: `prBranch required for ${agentType} task (PR #${String(task.prNumber)})`,
-        },
+        error: taskErrorFromDispatchStatus(dispatchStatus),
+        dispatchStatus,
+      });
+      if (!updateResult.ok) {
+        logger.error({ taskId: task.id, error: updateResult.error }, 'Failed to mark task failed after missing PR branch');
+        return err({ code: 'internal_error', message: 'Failed to persist dispatch failure status' });
+      }
+      await notifyDispatchProblemForTask({
+        task,
+        dispatchStatus,
+        problem,
+        whatsappNotifier,
+        codeTaskRepo,
+        logger,
+        affectedTaskCount: 1,
       });
       return ok({ action: 'failed', taskId: task.id, locksToCleanup: buildLockCleanups(task) });
     }
@@ -641,40 +858,36 @@ export async function drainTaskQueue(
 
     if (!dispatchResult.ok) {
       const dispatchError = dispatchResult.error;
+      const dispatchProblem = dispatchProblemFromError(dispatchError);
 
-      // Transient codes (at_capacity, worker_unavailable, network_error) keep
-      // the task queued. Do NOT reset queuedAt — TTL is measured from queuedAt
-      // and resetting would defeat the queue.ttlMinutes bound.
-      if (dispatchError.code === 'at_capacity' || isRetryableErrorCode(dispatchError.code)) {
-        if (dispatchError.blocker !== undefined) {
-          await recordDispatchBlockedForTask(deps, activeCandidates, task, dispatchError.blocker);
-        }
+      if (dispatchError.blocker !== undefined) {
+        await recordDispatchBlockedForTask(deps, activeCandidates, task, dispatchError.blocker);
+      }
+
+      // Recoverable dispatch problems keep the task queued. Do NOT reset
+      // queuedAt — TTL is measured from queuedAt and resetting would defeat
+      // the queue.ttlMinutes bound.
+      if (!dispatchProblem.terminal) {
         logger.info(
           { taskId: task.id, error: dispatchError, retryable: dispatchError.code !== 'at_capacity' },
           'Dispatch transient/retryable, task remains queued',
         );
-        // Roll the claim back so the next drain cycle can re-claim. dispatchedAt
-        // is intentionally left set as a "last attempted" marker.
-        const rollbackResult = await codeTaskRepo.update(task.id, { status: 'queued' });
+        const rollbackResult = await rollbackTaskForRecoverableDispatchProblem(
+          deps,
+          task,
+          dispatchProblem,
+          findAffectedDispatchTasks(activeCandidates, task).length,
+        );
         if (!rollbackResult.ok) {
-          logger.warn(
-            { taskId: task.id, error: rollbackResult.error },
-            'Failed to roll back claim after retryable dispatch error',
-          );
+          return err(rollbackResult.error);
         }
         return ok({ action: 'still_busy', taskId: task.id });
       }
 
       logger.error({ taskId: task.id, error: dispatchError }, 'Drain dispatch failed with permanent error');
-      const failUpdateResult = await codeTaskRepo.update(task.id, {
-        status: 'failed',
-        error: {
-          code: dispatchError.code,
-          message: `Drain dispatch failed: ${dispatchError.message}`,
-        },
-      });
-      if (!failUpdateResult.ok) {
-        logger.error({ taskId: task.id, error: failUpdateResult.error }, 'Failed to persist failed status during drain');
+      const failResult = await failTaskForDispatchProblem(deps, task, dispatchProblem, 1);
+      if (!failResult.ok) {
+        return err(failResult.error);
       }
 
       const locksToCleanup = buildLockCleanups(task);
@@ -696,6 +909,7 @@ export async function drainTaskQueue(
       workerLocation: dispatchResult.value.workerLocation,
       cancelNonce,
       cancelNonceExpiresAt,
+      dispatchStatus: null,
     });
 
     if (updateResult.ok) {

--- a/apps/code-agent/src/domain/usecases/startAskAgent.ts
+++ b/apps/code-agent/src/domain/usecases/startAskAgent.ts
@@ -11,6 +11,15 @@ import { randomUUID } from 'node:crypto';
 import type { CodeTaskRepository } from '../repositories/codeTaskRepository.js';
 import type { WorkerSettingsRepository } from '../ports/workerSettingsRepository.js';
 import type { TaskEnqueueService } from '../services/taskEnqueueService.js';
+import type { WhatsAppNotifier } from '../services/whatsappNotifier.js';
+import { classifyCodeTaskDispatchability } from '../services/codeTaskDispatchBlockers.js';
+import {
+  buildDispatchStatusForProblem,
+  dispatchFailureProblem,
+  dispatchProblemFromBlocker,
+  notifyDispatchProblemForTask,
+  taskErrorFromDispatchStatus,
+} from '../services/codeTaskDispatchProblems.js';
 import { sanitizePrompt } from '../utils/promptSanitization.js';
 import { generateWebhookSecret } from '../utils/secrets.js';
 import { loadConfig } from '../../config.js';
@@ -21,14 +30,12 @@ export interface StartAskAgentRequest {
 }
 
 export interface StartAskAgentResult {
-  status: 'submitted';
+  status: 'submitted' | 'failed';
   codeTaskId: string;
 }
 
 export type StartAskAgentErrorCode =
-  | 'worker_not_configured'
   | 'duplicate_prompt'
-  | 'queue_full'
   | 'internal_error';
 
 export interface StartAskAgentError {
@@ -41,13 +48,14 @@ export interface StartAskAgentDeps {
   codeTaskRepo: CodeTaskRepository;
   workerSettingsRepo: WorkerSettingsRepository;
   taskEnqueueService: TaskEnqueueService;
+  whatsappNotifier: WhatsAppNotifier;
 }
 
 export async function startAskAgent(
   deps: StartAskAgentDeps,
   request: StartAskAgentRequest,
 ): Promise<Result<StartAskAgentResult, StartAskAgentError>> {
-  const { logger, codeTaskRepo, workerSettingsRepo, taskEnqueueService } = deps;
+  const { logger, codeTaskRepo, workerSettingsRepo, taskEnqueueService, whatsappNotifier } = deps;
   const { userId, prompt } = request;
 
   // 1. Sanitize prompt
@@ -95,7 +103,33 @@ export async function startAskAgent(
   const settingsResult = await workerSettingsRepo.getSettings(userId);
   if (!settingsResult.ok) {
     logger.error({ userId, error: settingsResult.error }, 'Failed to fetch worker settings');
-    return err({ code: 'internal_error', message: 'Failed to fetch worker settings' });
+    const problem = dispatchFailureProblem({
+      message: 'Task could not be dispatched because worker settings could not be loaded.',
+      remediation: 'Retry this task after worker settings are available.',
+    });
+    const dispatchStatus = buildDispatchStatusForProblem({ task, problem });
+    const updateResult = await codeTaskRepo.update(task.id, {
+      status: 'failed',
+      error: taskErrorFromDispatchStatus(dispatchStatus),
+      dispatchStatus,
+    });
+    if (!updateResult.ok) {
+      logger.error({ taskId: task.id, error: updateResult.error }, 'Failed to fail ask-agent task after worker settings lookup failed');
+      return err({ code: 'internal_error', message: 'Failed to persist dispatch failure status' });
+    }
+    await notifyDispatchProblemForTask({
+      task,
+      dispatchStatus,
+      problem,
+      whatsappNotifier,
+      codeTaskRepo,
+      logger,
+      affectedTaskCount: 1,
+    });
+    return ok({
+      status: 'failed',
+      codeTaskId: task.id,
+    });
   }
 
   const settings = settingsResult.value;
@@ -103,9 +137,34 @@ export async function startAskAgent(
 
   if (enabledWorkers.length === 0) {
     logger.warn({ userId }, 'User has no workers configured for ask-agent');
-    return err({
-      code: 'worker_not_configured',
-      message: 'Please configure your workers in Settings before submitting tasks',
+    const dispatchability = classifyCodeTaskDispatchability({
+      workerType: task.workerType,
+      workers: enabledWorkers,
+      healthByWorkerName: {},
+    }) as Extract<ReturnType<typeof classifyCodeTaskDispatchability>, { dispatchable: false }>;
+    const problem = dispatchProblemFromBlocker(dispatchability);
+    const dispatchStatus = buildDispatchStatusForProblem({ task, problem });
+    const updateResult = await codeTaskRepo.update(task.id, {
+      status: 'failed',
+      error: taskErrorFromDispatchStatus(dispatchStatus),
+      dispatchStatus,
+    });
+    if (!updateResult.ok) {
+      logger.error({ taskId: task.id, error: updateResult.error }, 'Failed to fail ask-agent task after no enabled workers');
+      return err({ code: 'internal_error', message: 'Failed to persist dispatch failure status' });
+    }
+    await notifyDispatchProblemForTask({
+      task,
+      dispatchStatus,
+      problem,
+      whatsappNotifier,
+      codeTaskRepo,
+      logger,
+      affectedTaskCount: 1,
+    });
+    return ok({
+      status: 'failed',
+      codeTaskId: task.id,
     });
   }
 
@@ -117,7 +176,10 @@ export async function startAskAgent(
 
   if (!enqueueResult.ok) {
     if (enqueueResult.error.code === 'queue_full') {
-      return err({ code: 'queue_full', message: enqueueResult.error.message });
+      return ok({
+        status: 'failed',
+        codeTaskId: task.id,
+      });
     }
     return err({ code: 'internal_error', message: enqueueResult.error.message });
   }

--- a/apps/code-agent/src/domain/utils/retryableErrors.ts
+++ b/apps/code-agent/src/domain/utils/retryableErrors.ts
@@ -8,14 +8,16 @@
 /** Dispatch error codes that indicate transient infrastructure failures worth retrying. */
 const RETRYABLE_ERROR_CODES = new Set([
   'worker_unavailable',
+  'worker_busy',
+  'at_capacity',
   'network_error',
 ]);
 
 /**
  * Check if a dispatch error code represents a transient failure worth retrying.
  *
- * Retryable: worker_unavailable, network_error (transient infrastructure issues).
- * Not retryable: at_capacity (existing queue handles), worker_busy, dispatch_failed, invalid_response.
+ * Retryable: worker_unavailable, worker_busy, at_capacity, network_error.
+ * Not retryable: dispatch_failed, invalid_response.
  */
 export function isRetryableErrorCode(code: string): boolean {
   return RETRYABLE_ERROR_CODES.has(code);

--- a/apps/code-agent/src/infra/firestore/codeTaskRepositoryWithGroupUpdates.ts
+++ b/apps/code-agent/src/infra/firestore/codeTaskRepositoryWithGroupUpdates.ts
@@ -28,17 +28,18 @@ export function withGroupUpdates(
       return result;
     },
 
-    update: async (taskId, input): ReturnType<CodeTaskRepository['update']> => {
+    update: async (taskId, input, options): ReturnType<CodeTaskRepository['update']> => {
       // Only read old task if status is changing — saves the extra Firestore read
       // on heartbeat updates, workerLocation updates, etc.
+      const shouldUpdateGroupSummary = input.status !== undefined && options?.transaction === undefined;
       let oldTaskResult;
-      if (input.status !== undefined) {
+      if (shouldUpdateGroupSummary) {
         oldTaskResult = await inner.findById(taskId);
       }
 
-      const result = await inner.update(taskId, input);
+      const result = await inner.update(taskId, input, options);
 
-      if (result.ok && input.status !== undefined && oldTaskResult?.ok === true && result.value.agentType !== 'ask_agent') {
+      if (result.ok && shouldUpdateGroupSummary && oldTaskResult?.ok === true && result.value.agentType !== 'ask_agent') {
         void groupSummaryRepo.updateAfterStatusChange(oldTaskResult.value, result.value).catch((error: unknown) => {
           logger.warn({ error, taskId }, 'Group summary update failed after status change');
         });

--- a/apps/code-agent/src/infra/firestore/dispatchRetryRepository.ts
+++ b/apps/code-agent/src/infra/firestore/dispatchRetryRepository.ts
@@ -18,6 +18,18 @@ import { getFirestore } from '@intexuraos/infra-firestore';
 
 const COLLECTION_NAME = 'dispatch_retries';
 
+function timestampLikeToMillis(value: unknown): number | null {
+  if (value === null || value === undefined) return null;
+  if (value instanceof Date) return value.getTime();
+  if (typeof value === 'object' && 'toDate' in value) {
+    const maybeTimestamp = value as { toDate?: () => unknown };
+    if (typeof maybeTimestamp.toDate !== 'function') return null;
+    const date = maybeTimestamp.toDate();
+    return date instanceof Date ? date.getTime() : null;
+  }
+  return null;
+}
+
 export function createFirestoreDispatchRetryRepository(deps: {
   logger: Logger;
 }): DispatchRetryRepository {
@@ -107,9 +119,35 @@ export function createFirestoreDispatchRetryRepository(deps: {
         if (data['userId'] !== undefined) entry.userId = data['userId'] as string;
         if (data['message'] !== undefined) entry.message = data['message'] as string;
         if (data['lastAttemptAt'] !== undefined) entry.lastAttemptAt = data['lastAttemptAt'] as DispatchRetry['createdAt'];
+        if (data['processingStartedAt'] !== undefined) entry.processingStartedAt = data['processingStartedAt'] as DispatchRetry['createdAt'];
         return ok(entry);
       } catch (error) {
         logger.error({ error }, 'Failed to find oldest dispatch retry entry');
+        return err({
+          code: 'FIRESTORE_ERROR',
+          message: getErrorMessage(error, 'Unknown error'),
+        });
+      }
+    },
+
+    async claimForProcessing(
+      id: string,
+      staleBefore: Date,
+    ): Promise<Result<boolean, DispatchRetryRepositoryError>> {
+      try {
+        return ok(await firestore.runTransaction(async (txn) => {
+          const docRef = collection.doc(id);
+          const snap = await txn.get(docRef);
+          if (!snap.exists) return false;
+          const processingStartedAt = timestampLikeToMillis(snap.get('processingStartedAt'));
+          if (processingStartedAt !== null && processingStartedAt > staleBefore.getTime()) {
+            return false;
+          }
+          txn.update(docRef, { processingStartedAt: new Date() });
+          return true;
+        }));
+      } catch (error) {
+        logger.error({ error, id }, 'Failed to claim dispatch retry entry');
         return err({
           code: 'FIRESTORE_ERROR',
           message: getErrorMessage(error, 'Unknown error'),
@@ -132,13 +170,14 @@ export function createFirestoreDispatchRetryRepository(deps: {
 
     async update(
       id: string,
-      fields: { attempts: number; lastAttemptAt: Date; lastError: string }
+      fields: { attempts: number; lastAttemptAt: Date; lastError: string; processingStartedAt?: Date | null }
     ): Promise<Result<void, DispatchRetryRepositoryError>> {
       try {
         await collection.doc(id).update({
           attempts: fields.attempts,
           lastAttemptAt: fields.lastAttemptAt,
           lastError: fields.lastError,
+          ...(fields.processingStartedAt !== undefined && { processingStartedAt: fields.processingStartedAt }),
         });
         return ok(undefined);
       } catch (error) {

--- a/apps/code-agent/src/infra/firestore/firestoreCodeTaskRepository.ts
+++ b/apps/code-agent/src/infra/firestore/firestoreCodeTaskRepository.ts
@@ -5,7 +5,7 @@
 /* eslint-disable */
 
 import type { Firestore, Query, Transaction as FirestoreTransaction } from '@google-cloud/firestore';
-import { Timestamp } from '@google-cloud/firestore';
+import { FieldValue, Timestamp } from '@google-cloud/firestore';
 import { randomUUID } from 'node:crypto';
 import type { Logger, Result } from '@intexuraos/common-core';
 import { ok, err } from '@intexuraos/common-core';
@@ -88,8 +88,11 @@ export const createFirestoreCodeTaskRepository = (deps: {
         {}, 'Failed to create task', true,
       );
     },
-    findById: (taskId) => guarded<CodeTask>(async () => {
-      const doc = await collection.doc(taskId).get();
+    findById: (taskId, options) => guarded<CodeTask>(async () => {
+      const docRef = collection.doc(taskId);
+      const doc = options?.transaction !== undefined
+        ? await options.transaction.get(docRef)
+        : await docRef.get();
       if (!doc.exists) return err({ code: 'NOT_FOUND', message: `Task ${taskId} not found` });
       return ok(fromFirestoreDoc(doc));
     }, { taskId }, 'Failed to find task by id', true),
@@ -268,7 +271,11 @@ export const createFirestoreCodeTaskRepository = (deps: {
         const docRef = collection.doc(taskId);
         const snap = await txn.get(docRef);
         if (!snap.exists || snap.get('status') !== 'queued') return false;
-        txn.update(docRef, { status: 'dispatched', dispatchedAt: new Date() });
+        txn.update(docRef, {
+          status: 'dispatched',
+          dispatchedAt: new Date(),
+          dispatchStatus: FieldValue.delete(),
+        });
         return true;
       }),
       { taskId },

--- a/apps/code-agent/src/infra/firestore/task-serializer.ts
+++ b/apps/code-agent/src/infra/firestore/task-serializer.ts
@@ -271,6 +271,10 @@ export function buildUpdateData(input: UpdateTaskInput): Record<string, unknown>
   if (input.error !== undefined) {
     updateData['error'] = input.error === null ? FieldValue.delete() : input.error;
   }
+  if (input.dispatchStatus !== undefined) {
+    updateData['dispatchStatus'] =
+      input.dispatchStatus === null ? FieldValue.delete() : input.dispatchStatus;
+  }
   if (input.statusSummary !== undefined) {
     updateData['statusSummary'] = input.statusSummary;
   }

--- a/apps/code-agent/src/infra/services/taskEnqueueServiceImpl.ts
+++ b/apps/code-agent/src/infra/services/taskEnqueueServiceImpl.ts
@@ -7,7 +7,9 @@
 
 import { err, ok, type Result } from '@intexuraos/common-core';
 import type { Logger } from '@intexuraos/common-core';
+import type { CodeTask } from '../../domain/models/codeTask.js';
 import type { CodeTaskRepository } from '../../domain/repositories/codeTaskRepository.js';
+import type { WhatsAppNotifier } from '../../domain/services/whatsappNotifier.js';
 import type {
   TaskEnqueueService,
   EnqueueTaskInput,
@@ -15,11 +17,18 @@ import type {
   EnqueueResult,
   EnqueueError,
 } from '../../domain/services/taskEnqueueService.js';
+import {
+  buildDispatchStatusForProblem,
+  notifyDispatchProblemForTask,
+  queueFullDispatchProblem,
+  taskErrorFromDispatchStatus,
+} from '../../domain/services/codeTaskDispatchProblems.js';
 import { loadConfig } from '../../config.js';
 
 export interface TaskEnqueueServiceImplDeps {
   logger: Logger;
   codeTaskRepo: CodeTaskRepository;
+  whatsappNotifier: WhatsAppNotifier;
 }
 
 export function createTaskEnqueueService(deps: TaskEnqueueServiceImplDeps): TaskEnqueueService {
@@ -29,10 +38,50 @@ export function createTaskEnqueueService(deps: TaskEnqueueServiceImplDeps): Task
 export class TaskEnqueueServiceImpl implements TaskEnqueueService {
   private readonly logger: Logger;
   private readonly codeTaskRepo: CodeTaskRepository;
+  private readonly whatsappNotifier: WhatsAppNotifier;
 
   constructor(deps: TaskEnqueueServiceImplDeps) {
     this.logger = deps.logger;
     this.codeTaskRepo = deps.codeTaskRepo;
+    this.whatsappNotifier = deps.whatsappNotifier;
+  }
+
+  private async failTaskForQueueFull(
+    task: CodeTask,
+    message: string,
+    affectedTaskCount: number
+  ): Promise<Result<void, EnqueueError>> {
+    const problem = queueFullDispatchProblem(message);
+    const dispatchStatus = buildDispatchStatusForProblem({
+      task,
+      problem,
+    });
+
+    const updateResult = await this.codeTaskRepo.update(task.id, {
+      status: 'failed',
+      error: taskErrorFromDispatchStatus(dispatchStatus),
+      dispatchStatus,
+    });
+
+    if (!updateResult.ok) {
+      this.logger.error(
+        { taskId: task.id, error: updateResult.error },
+        'Failed to mark task failed when queue is full'
+      );
+      return err({ code: 'internal_error', message: 'Failed to fail task after queue capacity check' });
+    }
+
+    await notifyDispatchProblemForTask({
+      task,
+      dispatchStatus,
+      problem,
+      whatsappNotifier: this.whatsappNotifier,
+      codeTaskRepo: this.codeTaskRepo,
+      logger: this.logger,
+      affectedTaskCount,
+    });
+
+    return ok(undefined);
   }
 
   async enqueue(input: EnqueueTaskInput): Promise<Result<EnqueueResult, EnqueueError>> {
@@ -56,14 +105,11 @@ export class TaskEnqueueServiceImpl implements TaskEnqueueService {
     const queueCount = countResult.value;
 
     if (queueCount >= config.queue.maxSize) {
-      // Queue is full — mark task as failed
-      await this.codeTaskRepo.update(taskId, {
-        status: 'failed',
-        error: {
-          code: 'queue_full',
-          message: `All workers are busy and the queue is full (${String(queueCount)}/${String(config.queue.maxSize)}). Please try again in a few minutes.`,
-        },
-      });
+      const message = `All workers are busy and the queue is full (${String(queueCount)}/${String(config.queue.maxSize)}). Please try again in a few minutes.`;
+      const failResult = await this.failTaskForQueueFull(findResult.value, message, 1);
+      if (!failResult.ok) {
+        return failResult;
+      }
 
       this.logger.warn({ taskId, queueCount, maxSize: config.queue.maxSize }, 'Queue full, task failed');
       return err({
@@ -127,17 +173,13 @@ export class TaskEnqueueServiceImpl implements TaskEnqueueService {
     const baseQueueCount = Math.max(0, queueCount - taskIds.length);
 
     if (queueCount >= config.queue.maxSize) {
-      await Promise.all(
-        taskIds.map(async (taskId) => {
-          await this.codeTaskRepo.update(taskId, {
-            status: 'failed',
-            error: {
-              code: 'queue_full',
-              message: `All workers are busy and the queue is full (${String(queueCount)}/${String(config.queue.maxSize)}). Please try again in a few minutes.`,
-            },
-          });
-        }),
-      );
+      const message = `All workers are busy and the queue is full (${String(queueCount)}/${String(config.queue.maxSize)}). Please try again in a few minutes.`;
+      for (const task of tasks) {
+        const failResult = await this.failTaskForQueueFull(task, message, tasks.length);
+        if (!failResult.ok) {
+          return failResult;
+        }
+      }
 
       this.logger.warn(
         { taskIds, queueCount, maxSize: config.queue.maxSize },

--- a/apps/code-agent/src/infra/services/whatsappNotifierImpl.ts
+++ b/apps/code-agent/src/infra/services/whatsappNotifierImpl.ts
@@ -470,10 +470,13 @@ Please check worker availability and retry manually if needed.`;
       userId: string,
       info: TaskDispatchBlockedNotificationInfo
     ): Promise<Result<void, NotificationError>> {
+      const ctaUrl = info.exampleTaskId !== undefined
+        ? { displayText: 'View Task', url: buildTaskUrl(info.exampleTaskId, webAppUrl) }
+        : { displayText: 'View Dispatch Queue', url: buildDispatchQueueUrl(webAppUrl) };
       const result = await whatsappPublisher.publishSendMessage({
         userId,
         message: formatTaskDispatchBlockedMessage(info),
-        ctaUrl: { displayText: 'View Dispatch Queue', url: buildDispatchQueueUrl(webAppUrl) },
+        ctaUrl,
         important: true,
       });
 

--- a/apps/code-agent/src/routes/code/ask-agent-routes.ts
+++ b/apps/code-agent/src/routes/code/ask-agent-routes.ts
@@ -50,7 +50,7 @@ export const askAgentRoutes: FastifyPluginCallback<CodeRoutesOptions> = (fastify
                 data: {
                   type: 'object',
                   properties: {
-                    status: { type: 'string', enum: ['submitted'] },
+                    status: { type: 'string', enum: ['submitted', 'failed'] },
                     codeTaskId: { type: 'string' },
                   },
                   required: ['status', 'codeTaskId'],
@@ -103,7 +103,7 @@ export const askAgentRoutes: FastifyPluginCallback<CodeRoutesOptions> = (fastify
                   type: 'object',
                   required: ['code', 'message'],
                   properties: {
-                    code: { type: 'string', enum: ['MISCONFIGURED', 'QUEUE_FULL', 'WORKER_NOT_CONFIGURED'] },
+                    code: { type: 'string', enum: ['MISCONFIGURED'] },
                     message: { type: 'string' },
                   },
                 },
@@ -134,21 +134,19 @@ export const askAgentRoutes: FastifyPluginCallback<CodeRoutesOptions> = (fastify
           includeParams: true,
         });
 
-        const { codeTaskRepo, workerSettingsRepo, taskEnqueueService } = getServices();
+        const { codeTaskRepo, workerSettingsRepo, taskEnqueueService, whatsappNotifier } = getServices();
         /* v8 ignore start -- ts-type: FakeAuthPlugin always provides userId — ?? fallback unreachable @preserve */
         const userId = request.user?.userId ?? 'unknown-user';
         /* v8 ignore stop @preserve */
 
         const result = await startAskAgent(
-          { logger: request.log, codeTaskRepo, workerSettingsRepo, taskEnqueueService },
+          { logger: request.log, codeTaskRepo, workerSettingsRepo, taskEnqueueService, whatsappNotifier },
           { userId, prompt: request.body.prompt },
         );
 
         if (!result.ok) {
           const { error } = result;
-          if (error.code === 'worker_not_configured') return await reply.fail('WORKER_NOT_CONFIGURED', error.message);
           if (error.code === 'duplicate_prompt') return await reply.fail('CONFLICT', error.message);
-          if (error.code === 'queue_full') return await reply.fail('QUEUE_FULL', error.message);
           return await reply.fail('INTERNAL_ERROR', error.message);
         }
 

--- a/apps/code-agent/src/routes/code/queue-routes.ts
+++ b/apps/code-agent/src/routes/code/queue-routes.ts
@@ -187,7 +187,16 @@ export const queueRoutes: FastifyPluginCallback<CodeRoutesOptions> = (fastify, o
         /* v8 ignore stop @preserve */
       });
 
-      if (retryResult.ok && retryResult.value.action !== 'empty' && retryResult.value.action !== 'failed') {
+      if (!retryResult.ok) {
+        request.log.error({ error: retryResult.error }, 'Drain retry queue failed');
+        return await reply.fail('INTERNAL_ERROR', retryResult.error.message);
+      }
+
+      const retryHasLocksToCleanup = (retryResult.value.locksToCleanup?.length ?? 0) > 0;
+      if (
+        retryResult.value.action !== 'empty'
+        && (retryResult.value.action !== 'failed' || retryHasLocksToCleanup)
+      ) {
         for (const lock of retryResult.value.locksToCleanup ?? []) {
           await deletePRTaskLock(services.firestore, lock.repository, lock.prNumber, request.log);
         }

--- a/apps/code-agent/src/routes/code/responseFormatters.ts
+++ b/apps/code-agent/src/routes/code/responseFormatters.ts
@@ -4,7 +4,12 @@
  * Converts domain Firestore entities to JSON-serializable API responses.
  * Extracted from codeRoutes.ts as part of INT-1430 route split.
  */
-import type { AgentType, CodeTask, WorkerType } from '../../domain/models/codeTask.js';
+import type {
+  AgentType,
+  CodeTask,
+  CodeTaskDispatchStatus,
+  WorkerType,
+} from '../../domain/models/codeTask.js';
 import type { ExecutionMemoryType } from '../../domain/models/executionMemory.js';
 
 /**
@@ -82,11 +87,13 @@ function taskToApiResponse(task: {
     code: string;
     message: string;
     remediation?: {
+      action?: 'retry' | 'wait' | 'fix_code' | 'contact_support' | 'retry_smaller';
       retryAfter?: number;
       manualSteps?: string;
       supportLink?: string;
     };
   };
+  dispatchStatus?: CodeTaskDispatchStatus;
   executionMemoryContext?: CodeTask['executionMemoryContext'];
   executionMemoryPostRun?: CodeTask['executionMemoryPostRun'];
   completedAt?: unknown;
@@ -136,10 +143,15 @@ function taskToApiResponse(task: {
     code: string;
     message: string;
     remediation?: {
+      action?: 'retry' | 'wait' | 'fix_code' | 'contact_support' | 'retry_smaller';
       retryAfter?: number;
       manualSteps?: string;
       supportLink?: string;
     };
+  };
+  dispatchStatus?: Omit<CodeTaskDispatchStatus, 'firstSeenAt' | 'lastSeenAt' | 'notifiedReasons'> & {
+    firstSeenAt: string;
+    lastSeenAt: string;
   };
   executionMemoryContext?: {
     status: 'none' | 'matched' | 'error';
@@ -228,6 +240,9 @@ function taskToApiResponse(task: {
   const executionMemoryPostRun = task.executionMemoryPostRun !== undefined
     ? buildExecutionMemoryPostRun(task.executionMemoryPostRun)
     : undefined;
+  const dispatchStatus = task.dispatchStatus !== undefined
+    ? serializeDispatchStatus(task.dispatchStatus)
+    : undefined;
 
   return {
     id: task.id,
@@ -257,8 +272,29 @@ function taskToApiResponse(task: {
     ...(task.followUpReason !== undefined && { followUpReason: task.followUpReason }),
     ...(task.result !== undefined && { result: task.result }),
     ...(task.error !== undefined && { error: task.error }),
+    ...(dispatchStatus !== undefined && { dispatchStatus }),
     ...(executionMemoryContext !== undefined && { executionMemoryContext }),
     ...(executionMemoryPostRun !== undefined && { executionMemoryPostRun }),
+  };
+}
+
+function serializeDispatchStatus(
+  dispatchStatus: CodeTaskDispatchStatus,
+): Omit<CodeTaskDispatchStatus, 'firstSeenAt' | 'lastSeenAt' | 'notifiedReasons'> & {
+  firstSeenAt: string;
+  lastSeenAt: string;
+} {
+  return {
+    state: dispatchStatus.state,
+    reason: dispatchStatus.reason,
+    terminal: dispatchStatus.terminal,
+    severity: dispatchStatus.severity,
+    message: dispatchStatus.message,
+    remediation: dispatchStatus.remediation,
+    workerNames: dispatchStatus.workerNames,
+    firstSeenAt: timestampToIso(dispatchStatus.firstSeenAt) ?? '',
+    lastSeenAt: timestampToIso(dispatchStatus.lastSeenAt) ?? '',
+    nextAction: dispatchStatus.nextAction,
   };
 }
 

--- a/apps/code-agent/src/routes/code/schemas.ts
+++ b/apps/code-agent/src/routes/code/schemas.ts
@@ -120,6 +120,38 @@ const executionMemoryPostRunSchema = {
   required: ['status', 'attempts', 'generatedMemoryIds'],
 } as const;
 
+const dispatchStatusSchema = {
+  type: 'object',
+  nullable: true,
+  properties: {
+    state: { type: 'string', enum: ['waiting', 'blocked', 'terminal'] },
+    reason: { type: 'string' },
+    terminal: { type: 'boolean' },
+    severity: { type: 'string', enum: ['info', 'warning', 'critical'] },
+    message: { type: 'string' },
+    remediation: { type: 'string' },
+    workerNames: { type: 'array', items: { type: 'string' } },
+    firstSeenAt: { type: 'string', format: 'date-time' },
+    lastSeenAt: { type: 'string', format: 'date-time' },
+    nextAction: {
+      type: 'string',
+      enum: ['will_retry_automatically', 'retry_after_fix', 'wait_until_scheduled', 'wait_for_active_task'],
+    },
+  },
+  required: [
+    'state',
+    'reason',
+    'terminal',
+    'severity',
+    'message',
+    'remediation',
+    'workerNames',
+    'firstSeenAt',
+    'lastSeenAt',
+    'nextAction',
+  ],
+} as const;
+
 // Response schema for created task
 const codeTaskSchema = {
   type: 'object',
@@ -150,7 +182,7 @@ const codeTaskSchema = {
       ...linearIssueForDisplaySchema,
       nullable: true,
     },
-    agentType: { type: 'string', enum: ['planning', 'execution', 'pull_request', 'review'] },
+    agentType: { type: 'string', enum: ['planning', 'execution', 'pull_request', 'review', 'remediation', 'ask_agent'] },
     prNumber: { type: 'number', nullable: true },
     implementationTaskId: { type: 'string' },
     fanOutChildTaskIds: { type: 'array', items: { type: 'string' } },
@@ -177,19 +209,21 @@ const codeTaskSchema = {
       type: 'object',
       nullable: true,
       properties: {
-        code: { type: 'string' },
-        message: { type: 'string' },
-        remediation: {
-          type: 'object',
-          nullable: true,
-          properties: {
-            retryAfter: { type: 'number', nullable: true },
-            manualSteps: { type: 'string', nullable: true },
-            supportLink: { type: 'string', nullable: true },
+            code: { type: 'string' },
+            message: { type: 'string' },
+            remediation: {
+              type: 'object',
+              nullable: true,
+              properties: {
+                action: { type: 'string', enum: ['retry', 'wait', 'fix_code', 'contact_support', 'retry_smaller'], nullable: true },
+                retryAfter: { type: 'number', nullable: true },
+                manualSteps: { type: 'string', nullable: true },
+                supportLink: { type: 'string', nullable: true },
+              },
+            },
           },
         },
-      },
-    },
+    dispatchStatus: dispatchStatusSchema,
     executionMemoryContext: executionMemoryContextSchema,
     executionMemoryPostRun: executionMemoryPostRunSchema,
   },
@@ -217,5 +251,6 @@ export {
   workerTypeSchema,
   executionMemoryContextSchema,
   executionMemoryPostRunSchema,
+  dispatchStatusSchema,
   codeTaskSchema,
 };

--- a/apps/code-agent/src/routes/code/task-routes.ts
+++ b/apps/code-agent/src/routes/code/task-routes.ts
@@ -33,9 +33,18 @@ import { loadConfig } from '../../config.js';
 import type { TaskStatus, WorkerType } from '../../domain/models/codeTask.js';
 import type { WorkerConfig, WorkerHealthState, WorkerHealthStatus } from '../../domain/models/workerSettings.js';
 import type { DispatchScheduleCreateInput } from '../../domain/repositories/codeTaskRepository.js';
+import { classifyCodeTaskDispatchability } from '../../domain/services/codeTaskDispatchBlockers.js';
+import {
+  buildDispatchStatusForProblem,
+  dispatchFailureProblem,
+  dispatchProblemFromBlocker,
+  notifyDispatchProblemForTask,
+  taskErrorFromDispatchStatus,
+} from '../../domain/services/codeTaskDispatchProblems.js';
 import { taskToApiResponse, inFlightRequests } from './responseFormatters.js';
 import {
   codeTaskSchema,
+  dispatchStatusSchema,
   linearIssueForDisplaySchema,
   workerTypeSchema,
   executionMemoryContextSchema,
@@ -1457,7 +1466,7 @@ export const taskRoutes: FastifyPluginCallback<CodeRoutesOptions> = (fastify, op
                 data: {
                   type: 'object',
                   properties: {
-                    status: { type: 'string', enum: ['submitted'] },
+                    status: { type: 'string', enum: ['submitted', 'failed'] },
                     codeTaskId: { type: 'string' },
                   },
                   required: ['status', 'codeTaskId'],
@@ -1573,7 +1582,15 @@ export const taskRoutes: FastifyPluginCallback<CodeRoutesOptions> = (fastify, op
           includeParams: true,
         });
 
-        const { codeTaskRepo, linearIssueService, workerSettingsRepo, taskEnqueueService } = getServices();
+        const {
+          codeTaskRepo,
+          linearIssueService,
+          workerSettingsRepo,
+          taskEnqueueService,
+          whatsappNotifier,
+          codeTaskDispatchStatusService,
+          logger: serviceLogger,
+        } = getServices();
         const body = request.body as {
           prompt: string;
           workerType?: WorkerType;
@@ -1710,7 +1727,33 @@ export const taskRoutes: FastifyPluginCallback<CodeRoutesOptions> = (fastify, op
         const settingsResult = await workerSettingsRepo.getSettings(userId);
         if (!settingsResult.ok) {
           request.log.error({ userId, error: settingsResult.error }, 'Failed to fetch worker settings');
-          return await reply.fail('INTERNAL_ERROR', 'Failed to fetch worker settings');
+          const problem = dispatchFailureProblem({
+            message: 'Task could not be dispatched because worker settings could not be loaded.',
+            remediation: 'Retry this task after worker settings are available.',
+          });
+          const dispatchStatus = buildDispatchStatusForProblem({ task, problem });
+          const failUpdate = await codeTaskRepo.update(task.id, {
+            status: 'failed',
+            error: taskErrorFromDispatchStatus(dispatchStatus),
+            dispatchStatus,
+          });
+          if (!failUpdate.ok) {
+            request.log.error({ taskId: task.id, error: failUpdate.error }, 'Failed to mark task failed after worker settings lookup failed');
+            return await reply.fail('INTERNAL_ERROR', failUpdate.error.message);
+          }
+          await notifyDispatchProblemForTask({
+            task,
+            dispatchStatus,
+            problem,
+            whatsappNotifier,
+            codeTaskRepo,
+            logger: serviceLogger,
+            affectedTaskCount: 1,
+          });
+          return await reply.ok({
+            status: 'failed',
+            codeTaskId: task.id,
+          });
         }
 
         const settings = settingsResult.value;
@@ -1722,7 +1765,54 @@ export const taskRoutes: FastifyPluginCallback<CodeRoutesOptions> = (fastify, op
         // Fail if no workers configured
         if (enabledWorkers.length === 0) {
           request.log.warn({ userId }, 'User has no workers configured');
-          return await reply.fail('WORKER_NOT_CONFIGURED', 'Please configure your workers in Settings before submitting code tasks');
+          const dispatchability = classifyCodeTaskDispatchability({
+            workerType: task.workerType,
+            workers: enabledWorkers,
+            healthByWorkerName: {},
+          }) as Extract<ReturnType<typeof classifyCodeTaskDispatchability>, { dispatchable: false }>;
+          if (codeTaskDispatchStatusService !== undefined) {
+            try {
+              await codeTaskDispatchStatusService.recordDispatchBlocked({
+                userId,
+                workerType: task.workerType,
+                blocker: dispatchability,
+                affectedTaskCount: 1,
+                exampleTaskIds: [task.id],
+              });
+            } catch (error) {
+              request.log.warn(
+                { taskId: task.id, reason: dispatchability.reason, error },
+                'Failed to record code task dispatch blocker status during submit'
+              );
+            }
+          }
+          const problem = dispatchProblemFromBlocker(dispatchability);
+          const dispatchStatus = buildDispatchStatusForProblem({
+            task,
+            problem,
+          });
+          const failUpdate = await codeTaskRepo.update(task.id, {
+            status: 'failed',
+            error: taskErrorFromDispatchStatus(dispatchStatus),
+            dispatchStatus,
+          });
+          if (!failUpdate.ok) {
+            request.log.error({ taskId: task.id, error: failUpdate.error }, 'Failed to mark task failed after no enabled workers');
+            return await reply.fail('INTERNAL_ERROR', failUpdate.error.message);
+          }
+          await notifyDispatchProblemForTask({
+            task,
+            dispatchStatus,
+            problem,
+            whatsappNotifier,
+            codeTaskRepo,
+            logger: serviceLogger,
+            affectedTaskCount: 1,
+          });
+          return await reply.ok({
+            status: 'failed',
+            codeTaskId: task.id,
+          });
         }
 
         // Enqueue task for dispatch (INT-949)
@@ -1733,7 +1823,10 @@ export const taskRoutes: FastifyPluginCallback<CodeRoutesOptions> = (fastify, op
 
         if (!enqueueResult.ok) {
           if (enqueueResult.error.code === 'queue_full') {
-            return await reply.fail('QUEUE_FULL', enqueueResult.error.message);
+            return await reply.ok({
+              status: 'failed',
+              codeTaskId: task.id,
+            });
           }
           return await reply.fail('INTERNAL_ERROR', enqueueResult.error.message);
         }
@@ -1984,7 +2077,7 @@ export const taskRoutes: FastifyPluginCallback<CodeRoutesOptions> = (fastify, op
                       nullable: true,
                     },
                     prNumber: { type: 'number', nullable: true },
-                    agentType: { type: 'string', enum: ['planning', 'execution', 'pull_request', 'review'] },
+                    agentType: { type: 'string', enum: ['planning', 'execution', 'pull_request', 'review', 'remediation', 'ask_agent'] },
                     implementationTaskId: { type: 'string' },
                     parentTaskId: { type: 'string' },
                     followUpReason: { type: 'string' },
@@ -2022,10 +2115,12 @@ export const taskRoutes: FastifyPluginCallback<CodeRoutesOptions> = (fastify, op
                             retryAfter: { type: 'number', nullable: true },
                             manualSteps: { type: 'string', nullable: true },
                             supportLink: { type: 'string', nullable: true },
+                            action: { type: 'string', nullable: true },
                           },
                         },
                       },
                     },
+                    dispatchStatus: dispatchStatusSchema,
                     executionMemoryContext: executionMemoryContextSchema,
                     executionMemoryPostRun: executionMemoryPostRunSchema,
                     statusSummary: { type: 'object', nullable: true },

--- a/apps/code-agent/src/services.ts
+++ b/apps/code-agent/src/services.ts
@@ -75,7 +75,6 @@ export function initServices(config: ServiceConfig): void {
   });
   const codeTaskDispatchStatusService = createCodeTaskDispatchStatusService({
     statusRepo: repos.codeTaskSystemStatusRepo,
-    whatsappNotifier,
     logger,
   });
   const linearIssueService = createLinearIssueService({ linearAgentClient, logger });
@@ -113,7 +112,11 @@ export function initServices(config: ServiceConfig): void {
     // The original dispatched all edited bot comments without payload inspection.
   ]);
 
-  const taskEnqueueService = createTaskEnqueueService({ logger: logger.child({ service: 'task-enqueue' }), codeTaskRepo: repos.codeTaskRepo });
+  const taskEnqueueService = createTaskEnqueueService({
+    logger: logger.child({ service: 'task-enqueue' }),
+    codeTaskRepo: repos.codeTaskRepo,
+    whatsappNotifier,
+  });
 
   const mergeConflictDetector = createDetectMergeConflictsOnPush({
     logger, gitHubPRClient, gitHubPRSummaryRepo: repos.gitHubPRSummaryRepo, codeTaskRepo: repos.codeTaskRepo,

--- a/apps/web/src/__tests__/CodeTaskNewPage.test.tsx
+++ b/apps/web/src/__tests__/CodeTaskNewPage.test.tsx
@@ -613,3 +613,29 @@ describe('CodeTaskNewPage - per-task timeout (INT-1585)', () => {
     expect(payload['timeoutHours']).toBe(8);
   });
 });
+
+describe('CodeTaskNewPage - immediate failed task responses', () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('navigates to the task page when submit returns a failed task id', async () => {
+    vi.mocked(submitCodeTask).mockResolvedValueOnce({
+      status: 'failed',
+      codeTaskId: 'task-failed-123',
+    } as never);
+    render(<CodeTaskNewPage />);
+
+    const editor = screen.getAllByTestId('md-editor')[0] as HTMLTextAreaElement;
+    fireEvent.change(editor, { target: { value: 'task that cannot dispatch' } });
+
+    const submitButtons = screen.getAllByRole('button', { name: /submit task/i });
+    fireEvent.click(submitButtons[0] as HTMLElement);
+    fireEvent.click(screen.getByTestId('confirm-submit-btn'));
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/code-tasks/task-failed-123');
+    });
+  });
+});

--- a/apps/web/src/__tests__/CodeTaskViewPage.test.tsx
+++ b/apps/web/src/__tests__/CodeTaskViewPage.test.tsx
@@ -197,6 +197,67 @@ describe('CodeTaskViewPage', () => {
     });
   });
 
+  describe('dispatch status', () => {
+    it('shows retry prognosis and remediation for a queued dispatch blocker', () => {
+      const task = {
+        ...createTask({ status: 'queued' }),
+        dispatchStatus: {
+          state: 'waiting',
+          reason: 'workers_at_capacity',
+          terminal: false,
+          severity: 'warning',
+          message: 'All capable workers for codex are currently at capacity.',
+          remediation: 'Wait for a running task to finish or add worker capacity.',
+          workerNames: ['home-dev'],
+          firstSeenAt: '2026-06-05T12:00:00.000Z',
+          lastSeenAt: '2026-06-05T12:05:00.000Z',
+          nextAction: 'will_retry_automatically',
+        },
+      } as CodeTask;
+      mockUseTaskView.mockReturnValue(createTaskViewState(task));
+
+      render(<CodeTaskViewPage />);
+
+      expect(screen.getByText('Dispatch Waiting')).toBeInTheDocument();
+      expect(screen.getByText('All capable workers for codex are currently at capacity.')).toBeInTheDocument();
+      expect(screen.getByText(/This task will retry automatically/)).toBeInTheDocument();
+      expect(screen.getByText(/Wait for a running task to finish/)).toBeInTheDocument();
+      expect(screen.getByText(/home-dev/)).toBeInTheDocument();
+    });
+
+    it('shows terminal dispatch remediation on failed tasks', () => {
+      const task = {
+        ...createTask({
+          status: 'failed',
+          error: {
+            code: 'dispatch_blocked_no_enabled_workers',
+            message: 'No enabled code-task workers are configured for codex.',
+          },
+        }),
+        dispatchStatus: {
+          state: 'terminal',
+          reason: 'no_enabled_workers',
+          terminal: true,
+          severity: 'critical',
+          message: 'No enabled code-task workers are configured for codex.',
+          remediation: 'Enable or add a worker in worker settings, then retry dispatch.',
+          workerNames: [],
+          firstSeenAt: '2026-06-05T12:00:00.000Z',
+          lastSeenAt: '2026-06-05T12:00:00.000Z',
+          nextAction: 'retry_after_fix',
+        },
+      } as CodeTask;
+      mockUseTaskView.mockReturnValue(createTaskViewState(task));
+
+      render(<CodeTaskViewPage />);
+
+      expect(screen.getByText('Dispatch Failed')).toBeInTheDocument();
+      expect(screen.getAllByText('No enabled code-task workers are configured for codex.').length).toBeGreaterThan(0);
+      expect(screen.getByText(/Fix the blocker, then retry this task/)).toBeInTheDocument();
+      expect(screen.getByText(/Enable or add a worker/)).toBeInTheDocument();
+    });
+  });
+
   describe('Merge button (isMergeable)', () => {
     it('does NOT show Merge button for a planning-origin reviewed task without ready-to-merge label', () => {
       mockUseTaskView.mockReturnValue(createTaskViewState(

--- a/apps/web/src/pages/CodeTaskViewPage.tsx
+++ b/apps/web/src/pages/CodeTaskViewPage.tsx
@@ -1,6 +1,7 @@
 import { memo, useCallback, useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import {
+  AlertTriangle,
   CheckCircle2,
   Clock,
   Copy,
@@ -137,6 +138,7 @@ export function CodeTaskViewPage(): React.JSX.Element {
       <MemoTaskHeader task={task} workerStatusTag={workerStatusTag} />
 
       <MemoActiveProgressCard task={task} />
+      <MemoDispatchStatusCard task={task} />
 
       {task.parentTaskId !== undefined && task.followUpReason === 'execution_implement' ? (
         <DesignTaskBanner parentTaskId={task.parentTaskId} />
@@ -225,6 +227,54 @@ const MemoTaskHeader = memo(TaskHeader);
 const MemoLogStream = memo(LogStream);
 const MemoNextSteps = memo(NextSteps);
 const MemoTaskActions = memo(TaskActions);
+const MemoDispatchStatusCard = memo(function DispatchStatusCard({ task }: { task: CodeTask }): React.JSX.Element | null {
+  const dispatchStatus = task.dispatchStatus;
+  if (dispatchStatus === undefined) return null;
+
+  const isTerminal = dispatchStatus.terminal;
+  const title = isTerminal ? 'Dispatch Failed' : 'Dispatch Waiting';
+  const nextActionText =
+    dispatchStatus.nextAction === 'will_retry_automatically'
+      ? 'This task will retry automatically.'
+      : dispatchStatus.nextAction === 'retry_after_fix'
+        ? 'Fix the blocker, then retry this task.'
+        : dispatchStatus.nextAction === 'wait_until_scheduled'
+          ? 'This task is waiting for its scheduled dispatch time.'
+          : 'This task is waiting for another active task to finish.';
+  const workerText = dispatchStatus.workerNames.length > 0
+    ? `Workers: ${dispatchStatus.workerNames.join(', ')}`
+    : null;
+
+  return (
+    <Card className={`mb-6 ${isTerminal ? 'border-red-200 bg-red-50 dark:border-red-800 dark:bg-red-900/30' : 'border-amber-200 bg-amber-50 dark:border-amber-800 dark:bg-amber-900/30'}`}>
+      <div className="flex items-start gap-3">
+        <AlertTriangle className={`mt-0.5 h-5 w-5 flex-shrink-0 ${isTerminal ? 'text-red-600 dark:text-red-400' : 'text-amber-600 dark:text-amber-400'}`} />
+        <div className="min-w-0 flex-1">
+          <div className="mb-1 flex flex-wrap items-center gap-2">
+            <h3 className={`font-medium ${isTerminal ? 'text-red-900 dark:text-red-200' : 'text-amber-900 dark:text-amber-200'}`}>
+              {title}
+            </h3>
+            <span className={`rounded px-2 py-0.5 text-xs font-medium ${isTerminal ? 'bg-red-100 text-red-700 dark:bg-red-900/50 dark:text-red-300' : 'bg-amber-100 text-amber-700 dark:bg-amber-900/50 dark:text-amber-300'}`}>
+              {dispatchStatus.reason}
+            </span>
+          </div>
+          <p className={`text-sm ${isTerminal ? 'text-red-800 dark:text-red-300' : 'text-amber-800 dark:text-amber-300'}`}>
+            {dispatchStatus.message}
+          </p>
+          <p className={`mt-2 text-sm font-medium ${isTerminal ? 'text-red-900 dark:text-red-200' : 'text-amber-900 dark:text-amber-200'}`}>
+            {nextActionText}
+          </p>
+          <p className={`mt-1 text-sm ${isTerminal ? 'text-red-700 dark:text-red-300' : 'text-amber-700 dark:text-amber-300'}`}>
+            {dispatchStatus.remediation}
+          </p>
+          {workerText !== null ? (
+            <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">{workerText}</p>
+          ) : null}
+        </div>
+      </div>
+    </Card>
+  );
+}, (prev, next) => prev.task.dispatchStatus === next.task.dispatchStatus);
 const MemoExecutionMemoryCard = memo(function ExecutionMemoryCard({ task }: { task: CodeTask }): React.JSX.Element | null {
   const context = task.executionMemoryContext;
   const postRun = task.executionMemoryPostRun;

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -932,10 +932,48 @@ export interface CodeTaskError {
   code: string;
   message: string;
   remediation?: {
+    action?: 'retry' | 'wait' | 'fix_code' | 'contact_support' | 'retry_smaller';
     retryAfter?: number;
     manualSteps?: string;
     supportLink?: string;
   };
+}
+
+export type CodeTaskDispatchStatusReason =
+  | 'no_enabled_workers'
+  | 'workers_unreachable'
+  | 'workers_at_capacity'
+  | 'codex_auth_unavailable'
+  | 'claude_auth_unavailable'
+  | 'provider_auth_unavailable'
+  | 'docker_unavailable'
+  | 'disk_unavailable'
+  | 'unknown_worker_type'
+  | 'worker_unavailable'
+  | 'worker_busy'
+  | 'at_capacity'
+  | 'network_error'
+  | 'dispatch_failed'
+  | 'invalid_response'
+  | 'queue_full'
+  | 'queue_timeout'
+  | 'retry_expired'
+  | 'retry_exhausted'
+  | 'missing_pr_branch'
+  | 'scheduled_wait'
+  | 'active_task_blocked';
+
+export interface CodeTaskDispatchStatus {
+  state: 'waiting' | 'blocked' | 'terminal';
+  reason: CodeTaskDispatchStatusReason;
+  terminal: boolean;
+  severity: 'info' | 'warning' | 'critical';
+  message: string;
+  remediation: string;
+  workerNames: string[];
+  firstSeenAt: string;
+  lastSeenAt: string;
+  nextAction: 'will_retry_automatically' | 'retry_after_fix' | 'wait_until_scheduled' | 'wait_for_active_task';
 }
 
 export interface CodeTaskExecutionMemoryMatch {
@@ -1020,13 +1058,14 @@ export interface CodeTask {
     lastCommentAt: string | null;
   };
   prNumber?: number;
-  agentType?: 'planning' | 'execution' | 'pull_request' | 'review' | 'remediation';
+  agentType?: 'planning' | 'execution' | 'pull_request' | 'review' | 'remediation' | 'ask_agent';
   implementationTaskId?: string;
   fanOutChildTaskIds?: string[];
   parentTaskId?: string;
   followUpReason?: 'pr_comment' | 'user_feedback' | 'retry' | 'execution_implement' | 'merge_conflict';
   result?: CodeTaskResult;
   error?: CodeTaskError;
+  dispatchStatus?: CodeTaskDispatchStatus;
   executionMemoryContext?: CodeTaskExecutionMemoryContext;
   executionMemoryPostRun?: CodeTaskExecutionMemoryPostRun;
   /**
@@ -1066,7 +1105,7 @@ export interface SubmitCodeTaskRequest {
  * Response from submitting a code task
  */
 export interface SubmitCodeTaskResponse {
-  status: 'submitted';
+  status: 'submitted' | 'failed';
   codeTaskId: string;
 }
 
@@ -1074,7 +1113,7 @@ export interface SubmitCodeTaskResponse {
  * Response from POST /code/ask-agent/start
  */
 export interface AskAgentStartResponse {
-  status: 'submitted';
+  status: 'submitted' | 'failed';
   codeTaskId: string;
 }
 


### PR DESCRIPTION
## Summary
- Add task-level dispatch status so code task pages explain why dispatch is blocked and whether the task will retry.
- Fail terminal dispatch blockers immediately while keeping recoverable blockers queued/retrying with visible status.
- Send WhatsApp dispatch-blocked notifications per affected task, with notification ledgering and durable retry/task claims to avoid duplicate dispatch or lost retries.

## Verification
- pnpm run ci:tracked
- pnpm exec vitest run --coverage --coverage.include="apps/code-agent/src/**/*.ts" apps/code-agent
- pnpm run verify:v8-ignore
