### PR TITLE
[INT-1658] [codex] fix code-agent callback routing

### DIFF
--- a/scripts/__tests__/hetzner-runtime.test.ts
+++ b/scripts/__tests__/hetzner-runtime.test.ts
@@ -93,7 +93,11 @@ describe('Hetzner nginx runtime config', () => {
 
     for (const service of manifest.services) {
       const upstream = upstreamName(service.name);
-      expect(config, service.apiPath).toContain(`location ${service.apiPath}/`);
+      if (service.name === 'code-agent') {
+        expect(config, service.apiPath).toContain(`location ^~ ${service.apiPath}/`);
+      } else {
+        expect(config, service.apiPath).toContain(`location ${service.apiPath}/`);
+      }
       expect(config, service.apiPath).toContain(`proxy_pass http://${upstream}/;`);
     }
 
@@ -116,6 +120,15 @@ describe('Hetzner nginx runtime config', () => {
     expect(config).not.toContain('/api/cron/');
     expect(config).not.toContain('/api/hellscript/');
     expect(config).not.toContain('data_insights_agent');
+  });
+
+  it('routes canonical code-agent internal callbacks before the public internal deny rule', () => {
+    const config = readRequired(nginxConfigPath);
+
+    expect(config).toContain('location ^~ /api/code/ { proxy_pass http://code_agent/; }');
+    expect(config.indexOf('location ^~ /api/code/')).toBeLessThan(
+      config.indexOf('location ~ ^/api/[a-z0-9-]+/internal(?:/|$)')
+    );
   });
 
   it('does not forward browser credentials to retained public GCS buckets', () => {
@@ -279,6 +292,9 @@ describe('Hetzner web asset deployment', () => {
     expect(script).toContain(
       'sudo -n INTEXURAOS_ENVIRONMENT=prod bash scripts/hetzner/deploy-nginx.sh'
     );
+    expect(script).toContain('verify_non_404_route');
+    expect(script).toContain('"/api/code/internal/logs"');
+    expect(script).toContain('Code-agent callback route returned 404');
     expect(script.indexOf('scripts/observability/install-grafana-alloy.sh')).toBeGreaterThan(
       script.indexOf('scripts/hetzner/load-secrets.sh')
     );

--- a/scripts/hetzner/github-actions-deploy.sh
+++ b/scripts/hetzner/github-actions-deploy.sh
@@ -142,6 +142,20 @@ deploy_runtime() {
   fi
 }
 
+verify_non_404_route() {
+  local route_path="$1"
+  local status=""
+
+  status="$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' --max-time 15 \
+    --request POST \
+    --resolve "${PUBLIC_DOMAIN}:443:${HETZNER_PROD_HOST}" \
+    "https://${PUBLIC_DOMAIN}${route_path}")"
+
+  if [[ "${status}" == "404" ]]; then
+    fail "Code-agent callback route returned 404: ${route_path}"
+  fi
+}
+
 verify_deployment() {
   run_remote 'curl --fail --silent --show-error --max-time 10 http://127.0.0.1/healthz >/dev/null'
   curl --fail --silent --show-error --max-time 15 \
@@ -153,6 +167,7 @@ verify_deployment() {
   curl --fail --silent --show-error --max-time 15 \
     --resolve "${PUBLIC_DOMAIN}:443:${HETZNER_PROD_HOST}" \
     "https://${PUBLIC_DOMAIN}/api/settings/health" >/dev/null
+  verify_non_404_route "/api/code/internal/logs"
 }
 
 main() {

--- a/scripts/hetzner/nginx/intexuraos.conf
+++ b/scripts/hetzner/nginx/intexuraos.conf
@@ -91,6 +91,9 @@ server {
         return 200 "ok\n";
     }
 
+    location = /api/code { proxy_pass http://code_agent/; }
+    location ^~ /api/code/ { proxy_pass http://code_agent/; }
+
     location ~ ^/api/[a-z0-9-]+/internal(?:/|$) {
         return 404;
     }
@@ -123,8 +126,6 @@ server {
     location /api/chat/ { proxy_pass http://chat_agent/; }
     location = /api/linear { proxy_pass http://linear_agent/; }
     location /api/linear/ { proxy_pass http://linear_agent/; }
-    location = /api/code { proxy_pass http://code_agent/; }
-    location /api/code/ { proxy_pass http://code_agent/; }
     location = /api/images { proxy_pass http://image_service/; }
     location /api/images/ { proxy_pass http://image_service/; }
     location = /api/web { proxy_pass http://web_agent/; }


### PR DESCRIPTION
## Summary
- route `/api/code/*` through code-agent before the generic public internal deny rule
- add a Hetzner runtime regression test for canonical callback routing
- add a deploy smoke check that fails if the callback logs route returns `404`

## Root Cause
Production Nginx denied `/api/code/internal/*` with the generic `/api/*/internal` 404 rule before the code-agent proxy route could handle callback traffic.

## Validation
- `pnpm vitest run scripts/__tests__/hetzner-runtime.test.ts`
- deployed to Hetzner prod and verified callback routes return code-agent validation `400`, not routing `404`
