### PR TITLE
[INT-1660] ci: speed up local and GitHub CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
   # Type Check & Lint - split across parallel runners for faster feedback
   # =============================================================================
   type-lint:
-    name: ${{ matrix.check.name }}
+    name: ${{ matrix.check.name }}${{ matrix.check.shard && format(' ({0})', matrix.check.shard) || '' }}
     runs-on: ubuntu-latest
     if: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) }}
     strategy:
@@ -28,7 +28,14 @@ jobs:
           - name: Type Check
             run: pnpm run typecheck && pnpm run typecheck:tests
           - name: Lint
-            run: pnpm run lint
+            shard: 1/3
+            run: pnpm run lint -- --shard=1/3
+          - name: Lint
+            shard: 2/3
+            run: pnpm run lint -- --shard=2/3
+          - name: Lint
+            shard: 3/3
+            run: pnpm run lint -- --shard=3/3
     env:
       NODE_OPTIONS: '--max-old-space-size=6144'
 
@@ -55,17 +62,17 @@ jobs:
         run: ${{ matrix.check.run }}
 
   # =============================================================================
-  # Tests - sharded across 3 runners for ~3x speedup
+  # Tests - sharded across 5 runners for faster feedback
   # Each shard runs a subset of test files with blob reporter + coverage
   # =============================================================================
   tests:
-    name: Tests (${{ matrix.shard }}/3)
+    name: Tests (${{ matrix.shard }}/5)
     runs-on: ubuntu-latest
     if: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) }}
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3]
+        shard: [1, 2, 3, 4, 5]
     env:
       NODE_OPTIONS: '--max-old-space-size=6144'
 
@@ -88,16 +95,17 @@ jobs:
       - name: Build packages
         run: pnpm build
 
-      - name: Run Tests (shard ${{ matrix.shard }}/3)
+      - name: Run Tests (shard ${{ matrix.shard }}/5)
         run: >-
           pnpm vitest run
+          --reporter=default
           --reporter=blob
           --coverage
           --coverage.thresholds.lines=0
           --coverage.thresholds.branches=0
           --coverage.thresholds.functions=0
           --coverage.thresholds.statements=0
-          --shard=${{ matrix.shard }}/3
+          --shard=${{ matrix.shard }}/5
 
       - name: Upload blob report
         if: always()

--- a/scripts/__tests__/ci-sharding.test.ts
+++ b/scripts/__tests__/ci-sharding.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { parseShardArg, selectShardItems } from '../lib/sharding.mjs'; // @allow-missing-js -- .mjs import
+
+describe('CI sharding helpers', () => {
+  it('parses shard arguments in index/count format', () => {
+    expect(parseShardArg('2/5')).toEqual({ index: 2, count: 5 });
+  });
+
+  it('rejects invalid shard arguments', () => {
+    expect(() => parseShardArg('0/3')).toThrow(/Shard index must be between 1 and 3/);
+    expect(() => parseShardArg('4/3')).toThrow(/Shard index must be between 1 and 3/);
+    expect(() => parseShardArg('two/3')).toThrow(/Invalid shard/);
+  });
+
+  it('selects deterministic non-overlapping shard subsets', () => {
+    const workspaces = ['a', 'b', 'c', 'd', 'e', 'f', 'g'];
+
+    expect(selectShardItems(workspaces, { index: 1, count: 3 })).toEqual(['a', 'd', 'g']);
+    expect(selectShardItems(workspaces, { index: 2, count: 3 })).toEqual(['b', 'e']);
+    expect(selectShardItems(workspaces, { index: 3, count: 3 })).toEqual(['c', 'f']);
+  });
+});

--- a/scripts/__tests__/run-sharded-coverage.test.ts
+++ b/scripts/__tests__/run-sharded-coverage.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { buildCoverageShardCommand, mergeShardOutputs } from '../lib/coverage-sharding.mjs'; // @allow-missing-js -- .mjs import
+
+describe('coverage sharding helpers', () => {
+  it('builds a Vitest shard command that writes isolated shard artifacts', () => {
+    expect(buildCoverageShardCommand(2, 3)).toEqual([
+      'vitest',
+      'run',
+      '--reporter=default',
+      '--reporter=blob',
+      '--coverage',
+      '--coverage.thresholds.lines=0',
+      '--coverage.thresholds.branches=0',
+      '--coverage.thresholds.functions=0',
+      '--coverage.thresholds.statements=0',
+      '--coverage.reportsDirectory=coverage/shard-2',
+      '--shard=2/3',
+    ]);
+  });
+
+  it('merges shard stdout in shard order for verify-test-stdout', () => {
+    const output = mergeShardOutputs([
+      { shard: 2, output: 'second\n' },
+      { shard: 1, output: 'first\n' },
+    ]);
+
+    expect(output).toBe('first\nsecond\n');
+  });
+});

--- a/scripts/__tests__/verify-test-stdout.test.ts
+++ b/scripts/__tests__/verify-test-stdout.test.ts
@@ -1,0 +1,43 @@
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const OUTPUT_FILE = 'scripts/test-results/test-output.txt';
+const SCRIPT = 'scripts/verify-test-stdout.mjs';
+
+describe('verify-test-stdout', () => {
+  let originalOutput: string | null;
+
+  beforeEach(() => {
+    originalOutput = existsSync(OUTPUT_FILE) ? readFileSync(OUTPUT_FILE, 'utf-8') : null;
+  });
+
+  afterEach(() => {
+    if (originalOutput === null) {
+      rmSync(OUTPUT_FILE, { force: true });
+    } else {
+      writeFileSync(OUTPUT_FILE, originalOutput);
+    }
+  });
+
+  it('allows Vitest blob reporter artifact lines', () => {
+    mkdirSync('scripts/test-results', { recursive: true });
+    writeFileSync(
+      OUTPUT_FILE,
+      [
+        ' RUN  v4.0.17 /repo',
+        ' ✓ apps/web/src/pages/__tests__/LinearIssuesPage.size.test.ts (1 test) 1ms',
+        'blob report written to /repo/.vitest-reports/blob-1-3.json',
+        ' Tests  1 passed',
+      ].join('\n')
+    );
+
+    const result = spawnSync('node', [SCRIPT], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('No unexpected test stdout output detected');
+  });
+});

--- a/scripts/__tests__/verify-v8-ignore-skip-coverage.test.ts
+++ b/scripts/__tests__/verify-v8-ignore-skip-coverage.test.ts
@@ -1,0 +1,16 @@
+import { spawnSync } from 'node:child_process';
+import { describe, expect, it } from 'vitest';
+
+const SCRIPT = 'scripts/verify-v8-ignore.mjs';
+
+describe('verify-v8-ignore coverage data mode', () => {
+  it('can skip coverage-data cross-checks for pre-test static validation', () => {
+    const result = spawnSync('node', [SCRIPT, '--skip-coverage-data'], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Coverage data checks skipped');
+  });
+});

--- a/scripts/ci.mjs
+++ b/scripts/ci.mjs
@@ -26,18 +26,6 @@ const phases = [
     ],
   },
   {
-    name: 'Tests',
-    parallel: false,
-    commands: [
-      {
-        name: 'test:coverage',
-        run: 'pnpm run test:coverage',
-        saveTo: 'scripts/test-results/test-output.txt',
-      },
-      { name: 'test-stdout', script: 'verify-test-stdout.mjs' },
-    ],
-  },
-  {
     name: 'Static Validation',
     parallel: true,
     failFast: true,
@@ -66,7 +54,7 @@ const phases = [
       { name: 'envelope', script: 'verify-envelope.mjs' },
       { name: 'reply-send', script: 'verify-reply-send.mjs' },
       { name: 'sentry-logging', script: 'verify-sentry-logging.mjs' },
-      { name: 'v8-ignore', script: 'verify-v8-ignore.mjs' },
+      { name: 'v8-ignore', run: 'node scripts/verify-v8-ignore.mjs --skip-coverage-data' },
       { name: 'web-service-manifest', script: 'verify-web-service-manifest.mjs' },
       { name: 'service-wiring', script: 'verify-service-wiring.mjs' },
       { name: 'route-resource-names', script: 'verify-route-resource-names.mjs' },
@@ -75,6 +63,22 @@ const phases = [
       { name: 'llm-architecture', run: 'npx tsx scripts/verify-llm-architecture.ts' },
       { name: 'web-env-lockstep', run: 'node scripts/ci/check-web-env-lockstep.cjs' },
     ],
+  },
+  {
+    name: 'Tests',
+    parallel: false,
+    commands: [
+      {
+        name: 'test:coverage',
+        run: 'node scripts/run-sharded-coverage.mjs --shards=3',
+      },
+      { name: 'test-stdout', script: 'verify-test-stdout.mjs' },
+    ],
+  },
+  {
+    name: 'Coverage Validation',
+    parallel: false,
+    commands: [{ name: 'v8-ignore:coverage', script: 'verify-v8-ignore.mjs' }],
   },
   {
     name: 'Build & Format',

--- a/scripts/lib/coverage-sharding.mjs
+++ b/scripts/lib/coverage-sharding.mjs
@@ -1,0 +1,22 @@
+export function buildCoverageShardCommand(shard, shardCount) {
+  return [
+    'vitest',
+    'run',
+    '--reporter=default',
+    '--reporter=blob',
+    '--coverage',
+    '--coverage.thresholds.lines=0',
+    '--coverage.thresholds.branches=0',
+    '--coverage.thresholds.functions=0',
+    '--coverage.thresholds.statements=0',
+    `--coverage.reportsDirectory=coverage/shard-${shard}`,
+    `--shard=${shard}/${shardCount}`,
+  ];
+}
+
+export function mergeShardOutputs(outputs) {
+  return outputs
+    .toSorted((a, b) => a.shard - b.shard)
+    .map((entry) => entry.output)
+    .join('');
+}

--- a/scripts/lib/sharding.mjs
+++ b/scripts/lib/sharding.mjs
@@ -1,0 +1,23 @@
+export function parseShardArg(value) {
+  const match = /^(\d+)\/(\d+)$/.exec(value);
+  if (!match) {
+    throw new Error(`Invalid shard "${value}". Expected format: index/count`);
+  }
+
+  const index = Number.parseInt(match[1], 10);
+  const count = Number.parseInt(match[2], 10);
+
+  if (count < 1) {
+    throw new Error('Shard count must be at least 1');
+  }
+
+  if (index < 1 || index > count) {
+    throw new Error(`Shard index must be between 1 and ${count}`);
+  }
+
+  return { index, count };
+}
+
+export function selectShardItems(items, shard) {
+  return items.filter((_, index) => index % shard.count === shard.index - 1);
+}

--- a/scripts/lint-parallel.mjs
+++ b/scripts/lint-parallel.mjs
@@ -12,6 +12,7 @@
 import { spawn } from 'node:child_process';
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { parseShardArg, selectShardItems } from './lib/sharding.mjs';
 
 const rootDir = resolve(import.meta.dirname, '..');
 
@@ -22,6 +23,8 @@ const CONCURRENT_LIMIT = 4;
 // Check for --sequential flag
 const args = process.argv.slice(2);
 const SEQUENTIAL_MODE = args.includes('--sequential');
+const shardArg = args.find((arg) => arg.startsWith('--shard='));
+const shard = shardArg ? parseShardArg(shardArg.slice('--shard='.length)) : null;
 const concurrency = SEQUENTIAL_MODE ? 1 : CONCURRENT_LIMIT;
 
 // Workspace patterns from pnpm-workspace.yaml
@@ -98,11 +101,13 @@ async function runInBatches(workspaces, batchSize) {
 // Main execution
 (async () => {
   try {
-    const workspaces = getWorkspaces();
+    const allWorkspaces = getWorkspaces();
+    const workspaces = shard ? selectShardItems(allWorkspaces, shard) : allWorkspaces;
     const activeProcesses = [];
 
     const modeText = SEQUENTIAL_MODE ? 'sequentially' : `in batches of ${concurrency}`;
-    console.log(`Running lint for ${workspaces.length} workspaces ${modeText}...\n`);
+    const shardText = shard ? ` (shard ${shard.index}/${shard.count})` : '';
+    console.log(`Running lint for ${workspaces.length} workspaces${shardText} ${modeText}...\n`);
 
     if (workspaces.length === 0) {
       console.log('⚠️  No workspaces with lint:local script found\n');

--- a/scripts/run-sharded-coverage.mjs
+++ b/scripts/run-sharded-coverage.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+
+import { spawn } from 'node:child_process';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { buildCoverageShardCommand, mergeShardOutputs } from './lib/coverage-sharding.mjs';
+
+const repoRoot = resolve(import.meta.dirname, '..');
+const outputPath = join(repoRoot, 'scripts/test-results/test-output.txt');
+
+function parseArgs(argv) {
+  const shardsArg = argv.find((arg) => arg.startsWith('--shards='));
+  const shards = shardsArg ? Number.parseInt(shardsArg.split('=')[1] ?? '', 10) : 3;
+
+  if (!Number.isInteger(shards) || shards < 1) {
+    throw new Error('--shards must be a positive integer');
+  }
+
+  return { shards };
+}
+
+function runShard(shard, shardCount) {
+  return new Promise((resolveShard) => {
+    const [command, ...args] = buildCoverageShardCommand(shard, shardCount);
+    const proc = spawn('pnpm', ['exec', command, ...args], {
+      cwd: repoRoot,
+      env: { ...process.env },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let output = '';
+    proc.stdout.on('data', (data) => {
+      const text = data.toString();
+      output += text;
+      process.stdout.write(text);
+    });
+    proc.stderr.on('data', (data) => {
+      const text = data.toString();
+      output += text;
+      process.stderr.write(text);
+    });
+    proc.on('close', (code) => {
+      resolveShard({ shard, code: code ?? 1, output });
+    });
+  });
+}
+
+async function runMerge() {
+  return await new Promise((resolveMerge) => {
+    const proc = spawn('pnpm', ['vitest', '--merge-reports', '--coverage'], {
+      cwd: repoRoot,
+      env: { ...process.env },
+      stdio: 'inherit',
+    });
+    proc.on('close', (code) => {
+      resolveMerge(code ?? 1);
+    });
+  });
+}
+
+async function main() {
+  const { shards } = parseArgs(process.argv.slice(2));
+
+  rmSync(join(repoRoot, '.vitest-reports'), { recursive: true, force: true });
+  rmSync(join(repoRoot, 'coverage'), { recursive: true, force: true });
+
+  const results = await Promise.all(
+    Array.from({ length: shards }, (_, index) => runShard(index + 1, shards))
+  );
+
+  mkdirSync(dirname(outputPath), { recursive: true });
+  writeFileSync(outputPath, mergeShardOutputs(results));
+
+  const failed = results.filter((result) => result.code !== 0);
+  if (failed.length > 0) {
+    console.error(
+      `\n❌ ${failed.length} coverage shard(s) failed: ${failed.map((r) => r.shard).join(', ')}\n`
+    );
+    process.exit(1);
+  }
+
+  const mergeCode = await runMerge();
+  if (mergeCode !== 0) {
+    process.exit(mergeCode);
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/scripts/verify-test-stdout.mjs
+++ b/scripts/verify-test-stdout.mjs
@@ -36,6 +36,7 @@ const VITEST_PATTERNS = [
   /^\(Use `node --trace-deprecation \.\.\.` to show where the warning was created\)$/,
   /^\d+:\d+:\d+\s*(AM|PM)\s*\[vite\]/,
   /^\s*Plugin: vite:/,
+  /^blob report written to .*\.vitest-reports\/blob-\d+-\d+\.json$/,
 ];
 
 function isVitestLine(line) {

--- a/scripts/verify-v8-ignore.mjs
+++ b/scripts/verify-v8-ignore.mjs
@@ -1062,6 +1062,8 @@ function verifyOneToOneMapping(coverageData, comments) {
 // ============================================================================
 
 async function main() {
+  const skipCoverageData = process.argv.includes('--skip-coverage-data');
+
   // Check for --help flag
   if (process.argv.includes('--help') || process.argv.includes('-h')) {
     console.log('v8 Ignore Comment Validator');
@@ -1080,6 +1082,8 @@ async function main() {
     console.log('');
     console.log('Flags:');
     console.log('  --all           Show all uncovered branches (not just first 50)');
+    console.log('  --skip-coverage-data');
+    console.log('                  Skip coverage/coverage-final.json cross-checks');
     console.log('');
     console.log('Rules:');
     console.log('  - Every start must have a matching stop in the same file');
@@ -1134,7 +1138,7 @@ async function main() {
   const coveragePath = resolve(ROOT_DIR, 'coverage/coverage-final.json');
   let coverageErrors = [];
 
-  if (existsSync(coveragePath)) {
+  if (!skipCoverageData && existsSync(coveragePath)) {
     const coverageData = JSON.parse(readFileSync(coveragePath, 'utf8'));
     coverageErrors = validateCoverage(Array.from(validComments), coverageData);
   }
@@ -1142,7 +1146,7 @@ async function main() {
   // Phase E: Report missing comments
   let missingReport = [];
 
-  if (existsSync(coveragePath)) {
+  if (!skipCoverageData && existsSync(coveragePath)) {
     const coverageData = JSON.parse(readFileSync(coveragePath, 'utf8'));
     missingReport = reportMissingComments(coverageData, comments);
   }
@@ -1150,7 +1154,7 @@ async function main() {
   // Phase E-1: Report exempted branches (for visibility)
   let exemptedReport = [];
 
-  if (existsSync(coveragePath)) {
+  if (!skipCoverageData && existsSync(coveragePath)) {
     const coverageData = JSON.parse(readFileSync(coveragePath, 'utf8'));
     exemptedReport = reportExemptedBranches(coverageData, comments);
   }
@@ -1161,7 +1165,7 @@ async function main() {
     stats: { totalBlocks: 0, totalUncoveredBranches: 0, totalExemptedBranches: 0 },
   };
 
-  if (existsSync(coveragePath)) {
+  if (!skipCoverageData && existsSync(coveragePath)) {
     const coverageData = JSON.parse(readFileSync(coveragePath, 'utf8'));
     mappingResult = verifyOneToOneMapping(coverageData, comments);
   }
@@ -1185,6 +1189,9 @@ async function main() {
   console.log(
     `  ${blockCount} exclusion blocks (lines within blocks are not tracked by v8 coverage)`
   );
+  if (skipCoverageData) {
+    console.log('  Coverage data checks skipped');
+  }
 
   if (allErrors.length > 0) {
     console.log(`\n❌ ${allErrors.length} error(s) found:\n`);


### PR DESCRIPTION
## Summary

No Linear issue provided.

Speeds up local and GitHub CI by removing the two measured bottlenecks:

- GitHub lint: split the previous single lint job into 3 deterministic workspace shards.
- GitHub tests: increase Vitest coverage shards from 3 to 5 and keep default reporter output visible while still uploading blob reports for coverage merge.
- Local CI tests: run coverage shards in parallel locally, then merge reports once.
- Static validation: allow the pre-test V8 ignore check to skip coverage-data reads, then run the coverage-backed check after tests.

## Measured Timing

| Environment | Before | After | Saved |
| --- | ---: | ---: | ---: |
| Local `pnpm run ci:tracked` | 443.2s | 275.6s | 167.6s (37.8%) |
| GitHub Actions CI | 344s | 283s | 61s (17.7%) |

Baseline GH run: https://github.com/pbuchman/intexuraos/actions/runs/27214228759
After-change GH run: https://github.com/pbuchman/intexuraos/actions/runs/27216346474

## Bottleneck Shift

Before:
- Local: Tests, 335.0s.
- GitHub: Lint, 311s; slowest test shard, 295s.

After:
- Local: Tests, 143.7s.
- GitHub: Tests (4/5), 204s; E2E Isolation, 195s; next test shards around 186-192s.

Confidence: high. Timings are from local baseline/after `ci:tracked` runs plus successful GitHub baseline/after workflow runs on the branch.

## Validation

- `pnpm vitest run scripts/__tests__/github-actions-pnpm.test.ts scripts/__tests__/ci-sharding.test.ts scripts/__tests__/run-sharded-coverage.test.ts scripts/__tests__/verify-test-stdout.test.ts scripts/__tests__/verify-v8-ignore-skip-coverage.test.ts`
- `pnpm run ci:tracked`
- GitHub Actions CI run 27216346474 passed
