### PR TITLE
[INT-1662] Fix WhatsApp bookmark recovery and mobile bookmark rows

### DIFF
--- a/apps/web/src/components/bookmarks/BookmarkRow.tsx
+++ b/apps/web/src/components/bookmarks/BookmarkRow.tsx
@@ -44,7 +44,10 @@ export function BookmarkRow({
 
   return (
     <div className="group relative cursor-pointer rounded-lg border border-slate-200 bg-white px-4 py-3 text-sm transition-shadow hover:shadow-md dark:border-slate-700 dark:bg-slate-800">
-      <div className="grid grid-cols-[40px_1fr_auto_140px_80px] items-center gap-2">
+      <div
+        data-testid="bookmark-row-layout"
+        className="grid grid-cols-[40px_minmax(0,1fr)] items-start gap-2 sm:grid-cols-[40px_minmax(0,1fr)_auto_140px_80px] sm:items-center"
+      >
         {/* Thumbnail */}
         <div className="shrink-0">
           {ogImage !== null && !ogImageError ? (
@@ -73,10 +76,13 @@ export function BookmarkRow({
         </div>
 
         {/* Title + hostname */}
-        <div className="min-w-0">
+        <div data-testid="bookmark-row-main" className="min-w-0">
           <button onClick={onOpen} className="w-full cursor-pointer text-left" type="button">
-            <div className="flex items-center gap-2">
-              <p className="truncate font-medium text-slate-900 dark:text-slate-100">
+            <div data-testid="bookmark-row-title-line" className="flex min-w-0 items-center gap-2">
+              <p
+                data-testid="bookmark-row-title"
+                className="min-w-0 flex-1 truncate font-medium text-slate-900 dark:text-slate-100"
+              >
                 {hasAiSummary ? (
                   <span className="mr-1 inline-flex items-center text-purple-600 dark:text-purple-400">
                     <Sparkles className="mr-0.5 h-3 w-3" />
@@ -91,15 +97,25 @@ export function BookmarkRow({
                 </span>
               ) : null}
             </div>
-            <p className="truncate text-xs text-slate-500 dark:text-slate-400">
+            <p
+              data-testid="bookmark-row-url"
+              className="truncate text-xs text-slate-500 dark:text-slate-400"
+            >
               {getHostname(bookmark.url)}
               {displayDescription !== null ? ` · ${truncateText(displayDescription, 60)}` : null}
+              <span data-testid="bookmark-row-mobile-date" className="sm:hidden">
+                {' · '}
+                {formatDate(bookmark.updatedAt)}
+              </span>
             </p>
           </button>
         </div>
 
         {/* Tags */}
-        <div className="flex shrink-0 items-center gap-1">
+        <div
+          data-testid="bookmark-row-tags"
+          className="col-start-2 flex min-w-0 flex-wrap items-center gap-1 sm:col-start-auto sm:flex-nowrap sm:shrink-0"
+        >
           {bookmark.tags.slice(0, 2).map((tag) => (
             <button
               key={tag}
@@ -120,12 +136,15 @@ export function BookmarkRow({
         </div>
 
         {/* Time */}
-        <div className="text-xs text-slate-400 dark:text-slate-500">
+        <div
+          data-testid="bookmark-row-desktop-date"
+          className="hidden text-xs text-slate-400 dark:text-slate-500 sm:block"
+        >
           {formatDate(bookmark.updatedAt)}
         </div>
 
         {/* Actions */}
-        <div className="flex items-center justify-end gap-1">
+        <div className="hidden items-center justify-end gap-1 sm:flex">
           <a
             href={bookmark.url}
             target="_blank"

--- a/apps/web/src/components/bookmarks/__tests__/BookmarkRow.test.tsx
+++ b/apps/web/src/components/bookmarks/__tests__/BookmarkRow.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { BookmarkRow } from '../BookmarkRow.js';
+import type { Bookmark } from '@/types';
+
+function createBookmark(overrides?: Partial<Bookmark>): Bookmark {
+  return {
+    id: 'bookmark-1',
+    userId: 'user-1',
+    url: 'https://example.com/a/very/long/path/that/should/not/crowd/the/title',
+    title: 'A very long bookmark title that needs most of the mobile viewport',
+    description: 'A useful description for the saved page',
+    tags: ['payments', 'infra', 'apis'],
+    ogPreview: null,
+    ogFetchedAt: null,
+    ogFetchStatus: 'processed',
+    aiSummary: null,
+    aiSummarizedAt: null,
+    source: 'whatsapp_text',
+    sourceId: 'action-1',
+    archived: false,
+    createdAt: '2026-06-10T07:18:52.951Z',
+    updatedAt: '2026-06-10T07:18:52.951Z',
+    ...overrides,
+  };
+}
+
+describe('BookmarkRow', () => {
+  it('uses a mobile-first layout that gives title and URL the main row width', () => {
+    render(
+      <BookmarkRow
+        bookmark={createBookmark()}
+        onOpen={vi.fn()}
+        onDelete={vi.fn().mockResolvedValue(undefined)}
+        onTagClick={vi.fn()}
+      />
+    );
+
+    expect(screen.getByTestId('bookmark-row-layout')).toHaveClass(
+      'grid-cols-[40px_minmax(0,1fr)]',
+      'sm:grid-cols-[40px_minmax(0,1fr)_auto_140px_80px]'
+    );
+    expect(screen.getByTestId('bookmark-row-main')).toHaveClass('min-w-0');
+    expect(screen.getByTestId('bookmark-row-title-line')).toHaveClass('min-w-0');
+    expect(screen.getByTestId('bookmark-row-title')).toHaveClass('min-w-0', 'flex-1', 'truncate');
+    expect(screen.getByTestId('bookmark-row-url')).toHaveClass('truncate');
+    expect(screen.getByTestId('bookmark-row-tags')).toHaveClass('col-start-2', 'sm:col-start-auto');
+    expect(screen.getByTestId('bookmark-row-mobile-date')).toHaveClass('sm:hidden');
+    expect(screen.getByTestId('bookmark-row-desktop-date')).toHaveClass('hidden', 'sm:block');
+  });
+});

--- a/apps/whatsapp-service/src/__tests__/config.test.ts
+++ b/apps/whatsapp-service/src/__tests__/config.test.ts
@@ -9,6 +9,7 @@ describe('config validation', () => {
   let savedAccess: string | undefined;
   let savedWaba: string | undefined;
   let savedPhone: string | undefined;
+  let savedCommandsIngestTopic: string | undefined;
 
   beforeEach(() => {
     savedVerify = process.env['INTEXURAOS_WHATSAPP_VERIFY_TOKEN'];
@@ -16,6 +17,7 @@ describe('config validation', () => {
     savedAccess = process.env['INTEXURAOS_WHATSAPP_ACCESS_TOKEN'];
     savedWaba = process.env['INTEXURAOS_WHATSAPP_WABA_ID'];
     savedPhone = process.env['INTEXURAOS_WHATSAPP_PHONE_NUMBER_ID'];
+    savedCommandsIngestTopic = process.env['INTEXURAOS_PUBSUB_COMMANDS_INGEST_TOPIC'];
   });
 
   afterEach(() => {
@@ -45,6 +47,11 @@ describe('config validation', () => {
     } else {
       delete process.env['INTEXURAOS_WHATSAPP_PHONE_NUMBER_ID'];
     }
+    if (savedCommandsIngestTopic !== undefined) {
+      process.env['INTEXURAOS_PUBSUB_COMMANDS_INGEST_TOPIC'] = savedCommandsIngestTopic;
+    } else {
+      delete process.env['INTEXURAOS_PUBSUB_COMMANDS_INGEST_TOPIC'];
+    }
   });
 
   it('validates required env vars', async () => {
@@ -73,6 +80,7 @@ describe('config validation', () => {
     process.env['INTEXURAOS_PUBSUB_MEDIA_CLEANUP_SUBSCRIPTION'] = 'test';
     process.env['INTEXURAOS_PUBSUB_AUDIO_STORED_TOPIC'] = 'test';
     process.env['INTEXURAOS_PUBSUB_APPROVAL_REPLY_TOPIC'] = 'test';
+    process.env['INTEXURAOS_PUBSUB_COMMANDS_INGEST_TOPIC'] = 'test';
     process.env['INTEXURAOS_GCP_PROJECT_ID'] = 'test';
     process.env['INTEXURAOS_WEB_AGENT_URL'] = 'https://web-agent.example.com';
     process.env['INTEXURAOS_INTERNAL_AUTH_TOKEN'] = 'test-auth-token';
@@ -92,6 +100,7 @@ describe('config validation', () => {
     process.env['INTEXURAOS_WHATSAPP_MEDIA_BUCKET'] = 'test';
     process.env['INTEXURAOS_PUBSUB_MEDIA_CLEANUP_TOPIC'] = 'test';
     process.env['INTEXURAOS_PUBSUB_MEDIA_CLEANUP_SUBSCRIPTION'] = 'test';
+    process.env['INTEXURAOS_PUBSUB_COMMANDS_INGEST_TOPIC'] = 'test';
     process.env['INTEXURAOS_GCP_PROJECT_ID'] = 'test';
     process.env['INTEXURAOS_WEB_AGENT_URL'] = 'https://web-agent.example.com';
     process.env['INTEXURAOS_INTERNAL_AUTH_TOKEN'] = 'test-auth-token';
@@ -127,6 +136,7 @@ describe('config validation', () => {
     process.env['INTEXURAOS_WHATSAPP_MEDIA_BUCKET'] = 'test-bucket';
     process.env['INTEXURAOS_PUBSUB_MEDIA_CLEANUP_TOPIC'] = 'test-cleanup';
     process.env['INTEXURAOS_PUBSUB_MEDIA_CLEANUP_SUBSCRIPTION'] = 'test-cleanup-sub';
+    process.env['INTEXURAOS_PUBSUB_COMMANDS_INGEST_TOPIC'] = 'test-commands-ingest';
     process.env['INTEXURAOS_PUBSUB_AUDIO_STORED_TOPIC'] = 'test-audio-stored';
     process.env['INTEXURAOS_PUBSUB_APPROVAL_REPLY_TOPIC'] = 'test-approval-reply';
     process.env['INTEXURAOS_GCP_PROJECT_ID'] = 'test-project';

--- a/apps/whatsapp-service/src/__tests__/fakes.ts
+++ b/apps/whatsapp-service/src/__tests__/fakes.ts
@@ -86,6 +86,7 @@ export class FakeWhatsAppWebhookEventRepository implements WhatsAppWebhookEventR
     metadata: {
       ignoredReason?: IgnoredReason;
       failureDetails?: string;
+      retryable?: boolean;
       inboxNoteId?: string;
     }
   ): Promise<Result<WhatsAppWebhookEvent, WhatsAppError>> {
@@ -98,6 +99,7 @@ export class FakeWhatsAppWebhookEventRepository implements WhatsAppWebhookEventR
       status,
       processedAt: new Date().toISOString(),
       ...metadata,
+      retryable: status === 'failed' ? (metadata.retryable ?? false) : false,
     };
     this.events.set(eventId, updated);
     return Promise.resolve(ok(updated));
@@ -105,6 +107,21 @@ export class FakeWhatsAppWebhookEventRepository implements WhatsAppWebhookEventR
 
   getEvent(eventId: string): Promise<Result<WhatsAppWebhookEvent | null, WhatsAppError>> {
     return Promise.resolve(ok(this.events.get(eventId) ?? null));
+  }
+
+  findRetryableEvents(options: {
+    olderThan: string;
+    limit: number;
+  }): Promise<Result<WhatsAppWebhookEvent[], WhatsAppError>> {
+    const events = Array.from(this.events.values())
+      .filter(
+        (event) =>
+          (event.status === 'pending' || (event.status === 'failed' && event.retryable === true)) &&
+          event.receivedAt < options.olderThan
+      )
+      .sort((a, b) => a.receivedAt.localeCompare(b.receivedAt))
+      .slice(0, options.limit);
+    return Promise.resolve(ok(events));
   }
 
   getAll(): WhatsAppWebhookEvent[] {
@@ -345,6 +362,7 @@ export class FakeWhatsAppMessageRepository implements WhatsAppMessageRepository 
   private shouldThrowOnUpdateTranscription = false;
   private shouldFailUpdateTranscription = false;
   private shouldFailFindById = false;
+  private shouldFailFindByWaMessageId = false;
   private nextCursorToReturn: string | undefined = undefined;
 
   setFailSave(fail: boolean): void {
@@ -377,6 +395,10 @@ export class FakeWhatsAppMessageRepository implements WhatsAppMessageRepository 
 
   setFailFindById(fail: boolean): void {
     this.shouldFailFindById = fail;
+  }
+
+  setFailFindByWaMessageId(fail: boolean): void {
+    this.shouldFailFindByWaMessageId = fail;
   }
 
   /**
@@ -472,6 +494,22 @@ export class FakeWhatsAppMessageRepository implements WhatsAppMessageRepository 
     return Promise.resolve(ok(message));
   }
 
+  findByWaMessageId(
+    userId: string,
+    waMessageId: string
+  ): Promise<Result<WhatsAppMessage | null, WhatsAppError>> {
+    if (this.shouldFailFindByWaMessageId) {
+      return Promise.resolve(
+        err({ code: 'INTERNAL_ERROR', message: 'Simulated findByWaMessageId failure' })
+      );
+    }
+    const message =
+      Array.from(this.messages.values()).find(
+        (candidate) => candidate.userId === userId && candidate.waMessageId === waMessageId
+      ) ?? null;
+    return Promise.resolve(ok(message));
+  }
+
   updateTranscription(
     userId: string,
     messageId: string,
@@ -528,6 +566,7 @@ export class FakeWhatsAppMessageRepository implements WhatsAppMessageRepository 
     this.shouldThrowOnUpdateTranscription = false;
     this.shouldFailUpdateTranscription = false;
     this.shouldFailFindById = false;
+    this.shouldFailFindByWaMessageId = false;
     this.nextCursorToReturn = undefined;
   }
 }

--- a/apps/whatsapp-service/src/__tests__/infra/messageRepository.test.ts
+++ b/apps/whatsapp-service/src/__tests__/infra/messageRepository.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { createFakeFirestore, resetFirestore, setFirestore } from '@intexuraos/infra-firestore';
 import {
   deleteMessage,
+  findByWaMessageId,
   findById,
   getMessage,
   getMessagesByUser,
@@ -275,6 +276,41 @@ describe('messageRepository', () => {
     });
   });
 
+  describe('findByWaMessageId', () => {
+    it('returns null for non-existent WhatsApp message id', async () => {
+      const result = await findByWaMessageId('user-123', 'wamid.missing');
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value).toBeNull();
+      }
+    });
+
+    it('returns the matching message for the same user and WhatsApp message id', async () => {
+      const saved = await saveMessage(createTestMessage({ waMessageId: 'wamid.existing' }));
+      if (!saved.ok) throw new Error('Setup failed');
+
+      const result = await findByWaMessageId('user-123', 'wamid.existing');
+
+      expect(result.ok).toBe(true);
+      if (result.ok && result.value !== null) {
+        expect(result.value.id).toBe(saved.value.id);
+        expect(result.value.waMessageId).toBe('wamid.existing');
+      }
+    });
+
+    it('returns null when the WhatsApp message id belongs to another user', async () => {
+      await saveMessage(createTestMessage({ userId: 'other-user', waMessageId: 'wamid.other' }));
+
+      const result = await findByWaMessageId('user-123', 'wamid.other');
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value).toBeNull();
+      }
+    });
+  });
+
   describe('updateTranscription', () => {
     it('updates transcription state', async () => {
       const saved = await saveMessage(
@@ -430,6 +466,18 @@ describe('messageRepository', () => {
       if (!result.ok) {
         expect(result.error.code).toBe('PERSISTENCE_ERROR');
         expect(result.error.message).toContain('Failed to find message');
+      }
+    });
+
+    it('returns error when Firestore fails on findByWaMessageId', async () => {
+      fakeFirestore.configure({ errorToThrow: new Error('Query error') });
+
+      const result = await findByWaMessageId('user-123', 'wamid.test');
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe('PERSISTENCE_ERROR');
+        expect(result.error.message).toContain('Failed to find message by WhatsApp id');
       }
     });
 

--- a/apps/whatsapp-service/src/__tests__/infra/messageRepository.test.ts
+++ b/apps/whatsapp-service/src/__tests__/infra/messageRepository.test.ts
@@ -293,10 +293,10 @@ describe('messageRepository', () => {
       const result = await findByWaMessageId('user-123', 'wamid.existing');
 
       expect(result.ok).toBe(true);
-      if (result.ok && result.value !== null) {
-        expect(result.value.id).toBe(saved.value.id);
-        expect(result.value.waMessageId).toBe('wamid.existing');
-      }
+      if (!result.ok) throw new Error('Expected ok result');
+      expect(result.value).not.toBeNull();
+      expect(result.value?.id).toBe(saved.value.id);
+      expect(result.value?.waMessageId).toBe('wamid.existing');
     });
 
     it('returns null when the WhatsApp message id belongs to another user', async () => {

--- a/apps/whatsapp-service/src/__tests__/infra/pubsubPublisher.test.ts
+++ b/apps/whatsapp-service/src/__tests__/infra/pubsubPublisher.test.ts
@@ -54,6 +54,7 @@ describe('GcpPubSubPublisher', () => {
       mediaCleanupTopic: 'media-cleanup-topic',
       audioStoredTopic: 'audio-stored-topic',
       approvalReplyTopic: 'approval-reply-topic',
+      commandsIngestTopic: 'commands-ingest-topic',
       logger: pino({ name: 'test', level: 'silent' }),
     });
   });
@@ -87,6 +88,20 @@ describe('GcpPubSubPublisher', () => {
             // Cast: testing the runtime guard for callers that bypass the type system
           } as unknown as ConstructorParameters<typeof GcpPubSubPublisher>[0])
       ).toThrow('approvalReplyTopic is required');
+    });
+
+    it('throws when commandsIngestTopic is missing', () => {
+      expect(
+        () =>
+          new GcpPubSubPublisher({
+            projectId: 'test-project',
+            mediaCleanupTopic: 'media-cleanup-topic',
+            audioStoredTopic: 'audio-stored-topic',
+            approvalReplyTopic: 'approval-reply-topic',
+            logger: pino({ name: 'test', level: 'silent' }),
+            // Cast: testing the runtime guard for callers that bypass the type system
+          } as unknown as ConstructorParameters<typeof GcpPubSubPublisher>[0])
+      ).toThrow('commandsIngestTopic is required');
     });
   });
 
@@ -131,7 +146,7 @@ describe('GcpPubSubPublisher', () => {
   });
 
   describe('publishCommandIngest', () => {
-    it('skips publish when topic is not configured', async () => {
+    it('publishes to the required command ingest topic', async () => {
       const event = {
         type: 'command.ingest' as const,
         userId: 'user-123',
@@ -144,9 +159,10 @@ describe('GcpPubSubPublisher', () => {
       const result = await publisher.publishCommandIngest(event);
 
       expect(result.ok).toBe(true);
-      expect(mockPublishToOptionalTopic).toHaveBeenCalledWith(null, event, {
+      expect(mockPublishToTopic).toHaveBeenCalledWith('commands-ingest-topic', event, {
         externalId: 'wamid.abc',
       });
+      expect(mockPublishToOptionalTopic).not.toHaveBeenCalled();
     });
 
     it('publishes event when topic is configured', async () => {
@@ -171,7 +187,7 @@ describe('GcpPubSubPublisher', () => {
       const result = await publisherWithTopic.publishCommandIngest(event);
 
       expect(result.ok).toBe(true);
-      expect(mockPublishToOptionalTopic).toHaveBeenCalledWith('commands-ingest-topic', event, {
+      expect(mockPublishToTopic).toHaveBeenCalledWith('commands-ingest-topic', event, {
         externalId: 'wamid.voice123',
       });
     });
@@ -185,7 +201,7 @@ describe('GcpPubSubPublisher', () => {
         commandsIngestTopic: 'commands-ingest-topic',
         logger: pino({ name: 'test', level: 'silent' }),
       });
-      mockPublishToOptionalTopic.mockResolvedValue({
+      mockPublishToTopic.mockResolvedValue({
         ok: false,
         error: { code: 'PUBLISH_FAILED', message: 'Topic unavailable' },
       });
@@ -231,6 +247,7 @@ describe('GcpPubSubPublisher', () => {
         mediaCleanupTopic: 'media-cleanup-topic',
         audioStoredTopic: 'audio-stored-topic',
         approvalReplyTopic: 'approval-reply-topic',
+        commandsIngestTopic: 'commands-ingest-topic',
         webhookProcessTopic: 'webhook-process-topic',
         logger: pino({ name: 'test', level: 'silent' }),
       });
@@ -257,6 +274,7 @@ describe('GcpPubSubPublisher', () => {
         mediaCleanupTopic: 'media-cleanup-topic',
         audioStoredTopic: 'audio-stored-topic',
         approvalReplyTopic: 'approval-reply-topic',
+        commandsIngestTopic: 'commands-ingest-topic',
         webhookProcessTopic: 'webhook-process-topic',
         logger: pino({ name: 'test', level: 'silent' }),
       });
@@ -367,6 +385,7 @@ describe('GcpPubSubPublisher', () => {
         mediaCleanupTopic: 'media-cleanup-topic',
         audioStoredTopic: 'audio-stored-topic',
         approvalReplyTopic: 'approval-reply-topic',
+        commandsIngestTopic: 'commands-ingest-topic',
         webhookProcessTopic: 'webhook-process-topic',
         logger: pino({ name: 'test', level: 'silent' }),
       });
@@ -392,6 +411,7 @@ describe('GcpPubSubPublisher', () => {
         mediaCleanupTopic: 'media-cleanup-topic',
         audioStoredTopic: 'audio-stored-topic',
         approvalReplyTopic: 'approval-reply-topic',
+        commandsIngestTopic: 'commands-ingest-topic',
         webhookProcessTopic: 'webhook-process-topic',
         logger: pino({ name: 'test', level: 'silent' }),
       });

--- a/apps/whatsapp-service/src/__tests__/openapi-contract.test.ts
+++ b/apps/whatsapp-service/src/__tests__/openapi-contract.test.ts
@@ -32,6 +32,7 @@ describe('whatsapp-service OpenAPI contract', () => {
     mediaBucket: 'test-media-bucket',
     mediaCleanupTopic: 'test-media-cleanup',
     mediaCleanupSubscription: 'test-media-cleanup-sub',
+    commandsIngestTopic: 'test-commands-ingest',
     audioStoredTopic: 'test-audio-stored',
     approvalReplyTopic: 'test-approval-reply',
     gcpProjectId: 'test-project',

--- a/apps/whatsapp-service/src/__tests__/pubsubRoutes.test.ts
+++ b/apps/whatsapp-service/src/__tests__/pubsubRoutes.test.ts
@@ -33,6 +33,7 @@ const testConfig: Config = {
   mediaBucket: 'test-media-bucket',
   mediaCleanupTopic: 'test-media-cleanup',
   mediaCleanupSubscription: 'test-media-cleanup-sub',
+  commandsIngestTopic: 'test-commands-ingest',
   audioStoredTopic: 'test-audio-stored',
   approvalReplyTopic: 'test-approval-reply',
   gcpProjectId: 'test-project',

--- a/apps/whatsapp-service/src/__tests__/testUtils.ts
+++ b/apps/whatsapp-service/src/__tests__/testUtils.ts
@@ -101,6 +101,7 @@ export const testConfig: Config = {
   mediaBucket: 'test-media-bucket',
   mediaCleanupTopic: 'test-media-cleanup',
   mediaCleanupSubscription: 'test-media-cleanup-sub',
+  commandsIngestTopic: 'test-commands-ingest',
   audioStoredTopic: 'test-audio-stored',
   approvalReplyTopic: 'test-approval-reply',
   gcpProjectId: 'test-project',

--- a/apps/whatsapp-service/src/__tests__/usecases/retryPendingWebhookEvents.test.ts
+++ b/apps/whatsapp-service/src/__tests__/usecases/retryPendingWebhookEvents.test.ts
@@ -1,0 +1,402 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { err, ok, type Result } from '@intexuraos/common-core';
+import {
+  RetryPendingWebhookEventsUseCase,
+  type ProcessWebhookEventResult,
+  type ProcessWebhookEventUseCase,
+  type WebhookProcessingStatus,
+  type WhatsAppError,
+  type WhatsAppWebhookEvent,
+  type WhatsAppWebhookEventRepository,
+} from '../../domain/whatsapp/index.js';
+import type { Logger } from '../../domain/whatsapp/utils/logger.js';
+
+const logger: Logger = {
+  info: (): void => {
+    // No-op: test logger
+  },
+  error: (): void => {
+    // No-op: test logger
+  },
+};
+
+function createEvent(overrides: Partial<WhatsAppWebhookEvent> = {}): WhatsAppWebhookEvent {
+  return {
+    id: 'event-1',
+    payload: {},
+    signatureValid: true,
+    receivedAt: '2020-01-01T00:00:00.000Z',
+    phoneNumberId: '123456789012345',
+    status: 'pending',
+    ...overrides,
+  };
+}
+
+class TestWebhookEventRepository implements WhatsAppWebhookEventRepository {
+  readonly events = new Map<string, WhatsAppWebhookEvent>();
+  readonly failedGetEventIds = new Set<string>();
+  failFindRetryable = false;
+  lastFindRetryableOptions: { olderThan: string; limit: number } | undefined;
+
+  saveEvent(
+    event: Omit<WhatsAppWebhookEvent, 'id'>
+  ): Promise<Result<WhatsAppWebhookEvent, WhatsAppError>> {
+    const saved = { id: `event-${String(this.events.size + 1)}`, ...event };
+    this.events.set(saved.id, saved);
+    return Promise.resolve(ok(saved));
+  }
+
+  updateEventStatus(
+    eventId: string,
+    status: WebhookProcessingStatus,
+    metadata: {
+      failureDetails?: string;
+      retryable?: boolean;
+    }
+  ): Promise<Result<WhatsAppWebhookEvent, WhatsAppError>> {
+    const existing = this.events.get(eventId);
+    if (existing === undefined) {
+      return Promise.resolve(err({ code: 'NOT_FOUND', message: 'Event not found' }));
+    }
+    const updated: WhatsAppWebhookEvent = {
+      ...existing,
+      status,
+      failureDetails: metadata.failureDetails,
+      retryable: status === 'failed' ? (metadata.retryable ?? false) : false,
+      processedAt: new Date().toISOString(),
+    };
+    this.events.set(eventId, updated);
+    return Promise.resolve(ok(updated));
+  }
+
+  getEvent(eventId: string): Promise<Result<WhatsAppWebhookEvent | null, WhatsAppError>> {
+    if (this.failedGetEventIds.has(eventId)) {
+      return Promise.resolve(err({ code: 'INTERNAL_ERROR', message: `Failed to get ${eventId}` }));
+    }
+    return Promise.resolve(ok(this.events.get(eventId) ?? null));
+  }
+
+  findRetryableEvents(options: {
+    olderThan: string;
+    limit: number;
+  }): Promise<Result<WhatsAppWebhookEvent[], WhatsAppError>> {
+    this.lastFindRetryableOptions = options;
+    if (this.failFindRetryable) {
+      return Promise.resolve(
+        err({ code: 'INTERNAL_ERROR', message: 'Failed to query retryable events' })
+      );
+    }
+    const events = Array.from(this.events.values())
+      .filter(
+        (event) =>
+          (event.status === 'pending' || (event.status === 'failed' && event.retryable === true)) &&
+          event.receivedAt < options.olderThan
+      )
+      .sort((a, b) => a.receivedAt.localeCompare(b.receivedAt))
+      .slice(0, options.limit);
+    return Promise.resolve(ok(events));
+  }
+
+  setEvent(event: WhatsAppWebhookEvent): void {
+    this.events.set(event.id, event);
+  }
+
+  deleteEvent(eventId: string): void {
+    this.events.delete(eventId);
+  }
+}
+
+type ProcessHandler = (
+  event: WhatsAppWebhookEvent,
+  repository: TestWebhookEventRepository
+) => Promise<ProcessWebhookEventResult>;
+
+function createProcessWebhookEventUseCase(
+  repository: TestWebhookEventRepository,
+  handler: ProcessHandler
+): ProcessWebhookEventUseCase {
+  return {
+    execute: async (_payload, savedEvent): Promise<ProcessWebhookEventResult> => {
+      const event = repository.events.get(savedEvent.id);
+      if (event === undefined) {
+        throw new Error(`Event ${savedEvent.id} missing from test repository`);
+      }
+      return await handler(event, repository);
+    },
+  } as ProcessWebhookEventUseCase;
+}
+
+describe('RetryPendingWebhookEventsUseCase', () => {
+  let repository: TestWebhookEventRepository;
+
+  beforeEach(() => {
+    repository = new TestWebhookEventRepository();
+  });
+
+  function createUseCase(handler: ProcessHandler): RetryPendingWebhookEventsUseCase {
+    return new RetryPendingWebhookEventsUseCase({
+      webhookEventRepository: repository,
+      processWebhookEventUseCase: createProcessWebhookEventUseCase(repository, handler),
+    });
+  }
+
+  it('returns a failed query result when automatic retry lookup fails', async () => {
+    repository.failFindRetryable = true;
+    const before = Date.now();
+
+    const result = await createUseCase(async () => undefined).execute({}, logger);
+
+    expect(result).toMatchObject({
+      processed: 0,
+      skipped: 0,
+      failed: 1,
+      total: 0,
+      events: [
+        {
+          eventId: 'query',
+          outcome: 'failed',
+          reason: 'Failed to query retryable events',
+        },
+      ],
+    });
+    expect(repository.lastFindRetryableOptions?.limit).toBe(50);
+    const olderThan = Date.parse(repository.lastFindRetryableOptions?.olderThan ?? '');
+    expect(olderThan).toBeGreaterThanOrEqual(before - 121_000);
+    expect(olderThan).toBeLessThanOrEqual(Date.now() - 119_000);
+  });
+
+  it('clamps automatic retry limits and supports dry runs', async () => {
+    repository.setEvent(createEvent({ id: 'event-dry-run' }));
+
+    const result = await createUseCase(async () => {
+      throw new Error('dry run should not process events');
+    }).execute({ limit: 999, olderThanSeconds: 0, dryRun: true }, logger);
+
+    expect(repository.lastFindRetryableOptions?.limit).toBe(100);
+    expect(result).toMatchObject({
+      processed: 0,
+      skipped: 1,
+      failed: 0,
+      total: 1,
+      events: [{ eventId: 'event-dry-run', outcome: 'skipped', reason: 'dry_run' }],
+    });
+  });
+
+  it('returns a failed query result when exact event lookup fails', async () => {
+    repository.failedGetEventIds.add('event-get-fails');
+
+    const result = await createUseCase(async () => undefined).execute(
+      { eventIds: ['event-get-fails'] },
+      logger
+    );
+
+    expect(result).toMatchObject({
+      failed: 1,
+      total: 0,
+      events: [{ eventId: 'query', outcome: 'failed', reason: 'Failed to get event-get-fails' }],
+    });
+  });
+
+  it('ignores missing exact event ids', async () => {
+    const result = await createUseCase(async () => undefined).execute(
+      { eventIds: ['event-missing'] },
+      logger
+    );
+
+    expect(result).toMatchObject({
+      processed: 0,
+      skipped: 0,
+      failed: 0,
+      total: 0,
+      events: [],
+    });
+  });
+
+  it('skips terminal events before dry-run retryable events', async () => {
+    repository.setEvent(createEvent({ id: 'event-completed', status: 'completed' }));
+    repository.setEvent(createEvent({ id: 'event-pending' }));
+
+    const result = await createUseCase(async () => {
+      throw new Error('skipped events should not be processed');
+    }).execute({ eventIds: ['event-completed', 'event-pending'], dryRun: true }, logger);
+
+    expect(result).toMatchObject({
+      processed: 0,
+      skipped: 2,
+      failed: 0,
+      total: 2,
+      events: [
+        {
+          eventId: 'event-completed',
+          outcome: 'skipped',
+          status: 'completed',
+          reason: 'terminal_status',
+        },
+        {
+          eventId: 'event-pending',
+          outcome: 'skipped',
+          status: 'pending',
+          reason: 'dry_run',
+        },
+      ],
+    });
+  });
+
+  it('records failures returned by the webhook processor', async () => {
+    repository.setEvent(createEvent({ id: 'event-process-fails' }));
+
+    const result = await createUseCase(async () => ({
+      ok: false,
+      retryable: true,
+      failureDetails: 'processor failed',
+    })).execute({ eventIds: ['event-process-fails'] }, logger);
+
+    expect(result).toMatchObject({
+      processed: 0,
+      skipped: 0,
+      failed: 1,
+      total: 1,
+      events: [
+        {
+          eventId: 'event-process-fails',
+          outcome: 'failed',
+          status: 'failed',
+          reason: 'processor failed',
+        },
+      ],
+    });
+  });
+
+  it('records failures when the updated event cannot be loaded', async () => {
+    repository.setEvent(createEvent({ id: 'event-updated-read-fails' }));
+    repository.failedGetEventIds.add('event-updated-read-fails');
+
+    const result = await createUseCase(async () => undefined).execute({}, logger);
+
+    expect(result).toMatchObject({
+      failed: 1,
+      total: 1,
+      events: [
+        {
+          eventId: 'event-updated-read-fails',
+          outcome: 'failed',
+          reason: 'Failed to get event-updated-read-fails',
+        },
+      ],
+    });
+  });
+
+  it('records failures when the updated event disappears after retry', async () => {
+    repository.setEvent(createEvent({ id: 'event-deleted' }));
+
+    const result = await createUseCase(async (event, repo) => {
+      repo.deleteEvent(event.id);
+      return undefined;
+    }).execute({}, logger);
+
+    expect(result).toMatchObject({
+      failed: 1,
+      total: 1,
+      events: [
+        {
+          eventId: 'event-deleted',
+          outcome: 'failed',
+          reason: 'event_missing_after_retry',
+        },
+      ],
+    });
+  });
+
+  it('records failed outcomes for events still pending or failed after retry', async () => {
+    repository.setEvent(createEvent({ id: 'event-still-pending' }));
+    repository.setEvent(createEvent({ id: 'event-still-failed', status: 'failed', retryable: true }));
+
+    const result = await createUseCase(async (event, repo) => {
+      if (event.id === 'event-still-failed') {
+        repo.setEvent({
+          ...event,
+          status: 'failed',
+          failureDetails: 'still failing',
+          retryable: true,
+        });
+        return undefined;
+      }
+      repo.setEvent({ ...event, status: 'pending' });
+      return undefined;
+    }).execute({}, logger);
+
+    expect(result).toMatchObject({
+      processed: 0,
+      skipped: 0,
+      failed: 2,
+      total: 2,
+      events: [
+        {
+          eventId: 'event-still-pending',
+          outcome: 'failed',
+          status: 'pending',
+          reason: 'retry_did_not_complete',
+        },
+        {
+          eventId: 'event-still-failed',
+          outcome: 'failed',
+          status: 'failed',
+          reason: 'still failing',
+        },
+      ],
+    });
+  });
+
+  it('classifies completed events as processed and terminal non-bookmark events as skipped', async () => {
+    repository.setEvent(createEvent({ id: 'event-completes' }));
+    repository.setEvent(createEvent({ id: 'event-ignored' }));
+
+    const result = await createUseCase(async (event, repo) => {
+      repo.setEvent({
+        ...event,
+        status: event.id === 'event-completes' ? 'completed' : 'ignored',
+      });
+      return undefined;
+    }).execute({}, logger);
+
+    expect(result).toMatchObject({
+      processed: 1,
+      skipped: 1,
+      failed: 0,
+      total: 2,
+      events: [
+        {
+          eventId: 'event-completes',
+          outcome: 'processed',
+          status: 'completed',
+        },
+        {
+          eventId: 'event-ignored',
+          outcome: 'skipped',
+          status: 'ignored',
+          reason: 'non_bookmark_terminal_status',
+        },
+      ],
+    });
+  });
+
+  it('records thrown processor errors', async () => {
+    repository.setEvent(createEvent({ id: 'event-throws' }));
+
+    const result = await createUseCase(async () => {
+      throw new Error('processor threw');
+    }).execute({}, logger);
+
+    expect(result).toMatchObject({
+      failed: 1,
+      total: 1,
+      events: [
+        {
+          eventId: 'event-throws',
+          outcome: 'failed',
+          reason: 'processor threw',
+        },
+      ],
+    });
+  });
+});

--- a/apps/whatsapp-service/src/__tests__/usecases/retryPendingWebhookEvents.test.ts
+++ b/apps/whatsapp-service/src/__tests__/usecases/retryPendingWebhookEvents.test.ts
@@ -61,10 +61,14 @@ class TestWebhookEventRepository implements WhatsAppWebhookEventRepository {
     const updated: WhatsAppWebhookEvent = {
       ...existing,
       status,
-      failureDetails: metadata.failureDetails,
       retryable: status === 'failed' ? (metadata.retryable ?? false) : false,
       processedAt: new Date().toISOString(),
     };
+    if (metadata.failureDetails !== undefined) {
+      updated.failureDetails = metadata.failureDetails;
+    } else {
+      delete updated.failureDetails;
+    }
     this.events.set(eventId, updated);
     return Promise.resolve(ok(updated));
   }
@@ -116,14 +120,14 @@ function createProcessWebhookEventUseCase(
   handler: ProcessHandler
 ): ProcessWebhookEventUseCase {
   return {
-    execute: async (_payload, savedEvent): Promise<ProcessWebhookEventResult> => {
+    execute: async (_payload: unknown, savedEvent: { id: string }): Promise<ProcessWebhookEventResult> => {
       const event = repository.events.get(savedEvent.id);
       if (event === undefined) {
         throw new Error(`Event ${savedEvent.id} missing from test repository`);
       }
       return await handler(event, repository);
     },
-  } as ProcessWebhookEventUseCase;
+  } as unknown as ProcessWebhookEventUseCase;
 }
 
 describe('RetryPendingWebhookEventsUseCase', () => {

--- a/apps/whatsapp-service/src/__tests__/webhookAsyncProcessing.test.ts
+++ b/apps/whatsapp-service/src/__tests__/webhookAsyncProcessing.test.ts
@@ -2043,6 +2043,74 @@ describe('Webhook async processing', () => {
       expect(commandEvents.length).toBe(0);
     });
 
+    it('rejects retry-pending requests without internal scheduler auth', async () => {
+      const response = await ctx.app.inject({
+        method: 'POST',
+        url: '/internal/whatsapp/webhooks/retry-pending',
+        payload: {
+          eventIds: ['event-retry-link'],
+        },
+      });
+
+      expect(response.statusCode).toBe(401);
+      const body = JSON.parse(response.body) as {
+        success: boolean;
+        error: { code: string; message: string };
+      };
+      expect(body.success).toBe(false);
+      expect(body.error.code).toBe('UNAUTHORIZED');
+    });
+
+    it('rejects invalid retry-pending request bodies after internal scheduler auth', async () => {
+      const response = await ctx.app.inject({
+        method: 'POST',
+        url: '/internal/whatsapp/webhooks/retry-pending',
+        headers: {
+          'content-type': 'application/json',
+          'x-internal-auth': process.env['INTEXURAOS_INTERNAL_AUTH_TOKEN'] ?? 'test-internal-token',
+        },
+        payload: [],
+      });
+
+      expect(response.statusCode).toBe(400);
+      const body = JSON.parse(response.body) as {
+        success: boolean;
+        error: { code: string; message: string };
+      };
+      expect(body.success).toBe(false);
+      expect(body.error.code).toBe('INVALID_REQUEST');
+    });
+
+    it('accepts a null scheduler body for retry-pending requests', async () => {
+      const response = await ctx.app.inject({
+        method: 'POST',
+        url: '/internal/whatsapp/webhooks/retry-pending',
+        headers: {
+          'content-type': 'application/json',
+          'x-internal-auth': process.env['INTEXURAOS_INTERNAL_AUTH_TOKEN'] ?? 'test-internal-token',
+        },
+        payload: 'null',
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body) as {
+        success: boolean;
+        data: {
+          processed: number;
+          skipped: number;
+          failed: number;
+          total: number;
+        };
+      };
+      expect(body.success).toBe(true);
+      expect(body.data).toMatchObject({
+        processed: 0,
+        skipped: 0,
+        failed: 0,
+        total: 0,
+      });
+    });
+
     it('retries a pending webhook event by exact id and publishes command.ingest', async () => {
       await ctx.userMappingRepository.saveMapping(testUserId, [senderPhone]);
 

--- a/apps/whatsapp-service/src/__tests__/webhookAsyncProcessing.test.ts
+++ b/apps/whatsapp-service/src/__tests__/webhookAsyncProcessing.test.ts
@@ -53,14 +53,14 @@ describe('Webhook async processing', () => {
    * Helper to trigger webhook processing via Pub/Sub endpoint.
    * The webhook handler publishes to Pub/Sub, so we simulate the push by calling the endpoint.
    */
-  async function triggerWebhookProcessing(): Promise<void> {
+  async function triggerWebhookProcessing(): Promise<number | null> {
     const events = ctx.eventPublisher.getWebhookProcessEvents();
     if (events.length === 0) {
-      return;
+      return null;
     }
     const event = events[events.length - 1];
     if (event === undefined) {
-      return;
+      return null;
     }
 
     const pubsubPayload = {
@@ -72,7 +72,7 @@ describe('Webhook async processing', () => {
       subscription: 'test-subscription',
     };
 
-    await ctx.app.inject({
+    const response = await ctx.app.inject({
       method: 'POST',
       url: '/internal/whatsapp/pubsub/process-webhook',
       headers: {
@@ -81,6 +81,8 @@ describe('Webhook async processing', () => {
       },
       payload: JSON.stringify(pubsubPayload),
     });
+
+    return response.statusCode;
   }
 
   describe('processWebhookAsync', () => {
@@ -822,15 +824,54 @@ describe('Webhook async processing', () => {
       expect(response.statusCode).toBe(200);
 
       // Wait for async processing
-      await triggerWebhookProcessing();
+      const processingStatus = await triggerWebhookProcessing();
+      expect(processingStatus).toBe(500);
 
       // Event should be marked as FAILED
       const events = ctx.webhookEventRepository.getAll();
       expect(events.length).toBe(1);
       expect(events[0]?.status).toBe('failed');
       expect(events[0]?.failureDetails).toContain('Failed to save message');
+      expect(events[0]?.retryable).toBe(true);
 
       // No message should be stored
+      const messages = ctx.messageRepository.getAll();
+      expect(messages.length).toBe(0);
+    });
+
+    it('marks event as retryable when existing message lookup fails', async () => {
+      const senderPhone = '15551234567';
+      const userId = 'test-user-id';
+
+      await ctx.userMappingRepository.saveMapping(userId, [senderPhone]);
+
+      ctx.messageRepository.setFailFindByWaMessageId(true);
+
+      const payload = createWebhookPayload();
+      const payloadString = JSON.stringify(payload);
+      const signature = createSignature(payloadString, testConfig.appSecret);
+
+      const response = await ctx.app.inject({
+        method: 'POST',
+        url: '/webhooks',
+        headers: {
+          'content-type': 'application/json',
+          'x-hub-signature-256': signature,
+        },
+        payload: payloadString,
+      });
+
+      expect(response.statusCode).toBe(200);
+
+      const processingStatus = await triggerWebhookProcessing();
+      expect(processingStatus).toBe(500);
+
+      const events = ctx.webhookEventRepository.getAll();
+      expect(events.length).toBe(1);
+      expect(events[0]?.status).toBe('failed');
+      expect(events[0]?.failureDetails).toContain('Failed to look up existing message');
+      expect(events[0]?.retryable).toBe(true);
+
       const messages = ctx.messageRepository.getAll();
       expect(messages.length).toBe(0);
     });
@@ -864,13 +905,15 @@ describe('Webhook async processing', () => {
       expect(response.statusCode).toBe(200);
 
       // Wait for async processing
-      await triggerWebhookProcessing();
+      const processingStatus = await triggerWebhookProcessing();
+      expect(processingStatus).toBe(200);
 
       // Event should be persisted (save happens before the error)
       const events = ctx.webhookEventRepository.getAll();
       expect(events.length).toBe(1);
       // Status is now FAILED - the catch block updates status to prevent stuck events
       expect(events[0]?.status).toBe('failed');
+      expect(events[0]?.retryable).toBe(false);
     });
   });
 
@@ -1959,7 +2002,7 @@ describe('Webhook async processing', () => {
       expect(commandEvents.length).toBe(0);
     });
 
-    it('handles command.ingest publish failure gracefully', async () => {
+    it('marks webhook failed and returns retryable status when command.ingest publish fails', async () => {
       // Set up user mapping so the webhook processing reaches handleTextMessage
       await ctx.userMappingRepository.saveMapping(testUserId, [senderPhone]);
 
@@ -1984,16 +2027,244 @@ describe('Webhook async processing', () => {
       expect(response.statusCode).toBe(200);
 
       // Trigger async processing
-      await triggerWebhookProcessing();
+      const processingStatus = await triggerWebhookProcessing();
 
-      // command.ingest failure is non-fatal — event still completes
+      expect(processingStatus).toBe(500);
+
+      // command.ingest failure is fatal for bookmark creation, so the webhook remains retryable
       const events = ctx.webhookEventRepository.getAll();
       expect(events.length).toBe(1);
-      expect(events[0]?.status).toBe('completed');
+      expect(events[0]?.status).toBe('failed');
+      expect(events[0]?.failureDetails).toContain('Failed to publish command ingest');
+      expect(events[0]?.retryable).toBe(true);
 
       // No command ingest events were published (publisher failed)
       const commandEvents = ctx.eventPublisher.getCommandIngestEvents();
       expect(commandEvents.length).toBe(0);
+    });
+
+    it('retries a pending webhook event by exact id and publishes command.ingest', async () => {
+      await ctx.userMappingRepository.saveMapping(testUserId, [senderPhone]);
+
+      const payload = createWebhookPayload();
+      ctx.webhookEventRepository.setEvent({
+        id: 'event-retry-link',
+        payload,
+        signatureValid: true,
+        receivedAt: '2020-01-01T00:00:00.000Z',
+        phoneNumberId: '123456789012345',
+        status: 'pending',
+      });
+
+      const response = await ctx.app.inject({
+        method: 'POST',
+        url: '/internal/whatsapp/webhooks/retry-pending',
+        headers: {
+          'x-internal-auth': process.env['INTEXURAOS_INTERNAL_AUTH_TOKEN'] ?? 'test-internal-token',
+        },
+        payload: {
+          eventIds: ['event-retry-link'],
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body) as {
+        success: boolean;
+        data: {
+          processed: number;
+          skipped: number;
+          failed: number;
+          total: number;
+        };
+      };
+      expect(body.success).toBe(true);
+      expect(body.data).toMatchObject({
+        processed: 1,
+        skipped: 0,
+        failed: 0,
+        total: 1,
+      });
+
+      const events = ctx.webhookEventRepository.getAll();
+      expect(events[0]?.status).toBe('completed');
+      expect(ctx.messageRepository.getMessagesByUserSync(testUserId)).toHaveLength(1);
+      expect(ctx.eventPublisher.getCommandIngestEvents()).toHaveLength(1);
+    });
+
+    it('drains old pending webhook events when the scheduler posts an empty body', async () => {
+      await ctx.userMappingRepository.saveMapping(testUserId, [senderPhone]);
+
+      const payload = createWebhookPayload();
+      ctx.webhookEventRepository.setEvent({
+        id: 'event-scheduler-empty-body',
+        payload,
+        signatureValid: true,
+        receivedAt: '2020-01-01T00:00:00.000Z',
+        phoneNumberId: '123456789012345',
+        status: 'pending',
+      });
+
+      const response = await ctx.app.inject({
+        method: 'POST',
+        url: '/internal/whatsapp/webhooks/retry-pending',
+        headers: {
+          'x-internal-auth': process.env['INTEXURAOS_INTERNAL_AUTH_TOKEN'] ?? 'test-internal-token',
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body) as {
+        success: boolean;
+        data: {
+          processed: number;
+          skipped: number;
+          failed: number;
+          total: number;
+        };
+      };
+      expect(body.success).toBe(true);
+      expect(body.data).toMatchObject({
+        processed: 1,
+        skipped: 0,
+        failed: 0,
+        total: 1,
+      });
+
+      const events = ctx.webhookEventRepository.getAll();
+      expect(events[0]?.status).toBe('completed');
+      expect(ctx.messageRepository.getMessagesByUserSync(testUserId)).toHaveLength(1);
+      expect(ctx.eventPublisher.getCommandIngestEvents()).toHaveLength(1);
+    });
+
+    it('reuses an existing WhatsApp message row when replaying a webhook', async () => {
+      await ctx.userMappingRepository.saveMapping(testUserId, [senderPhone]);
+
+      const payload = createWebhookPayload();
+      ctx.messageRepository.setMessage({
+        id: 'existing-message',
+        userId: testUserId,
+        waMessageId: 'wamid.HBgNMTU1NTEyMzQ1Njc4FQIAEhgUM0VCMDRBNzYwREQ0RjMwMjYzMDcA',
+        fromNumber: senderPhone,
+        toNumber: '15551234567',
+        text: 'Hello, World!',
+        mediaType: 'text',
+        timestamp: '1234567890',
+        receivedAt: '2026-06-10T07:18:52.951Z',
+        webhookEventId: 'event-previous-attempt',
+      });
+
+      const payloadString = JSON.stringify(payload);
+      const signature = createSignature(payloadString, testConfig.appSecret);
+
+      const response = await ctx.app.inject({
+        method: 'POST',
+        url: '/webhooks',
+        headers: {
+          'content-type': 'application/json',
+          'x-hub-signature-256': signature,
+        },
+        payload: payloadString,
+      });
+
+      expect(response.statusCode).toBe(200);
+
+      await triggerWebhookProcessing();
+
+      expect(ctx.messageRepository.getMessagesByUserSync(testUserId)).toHaveLength(1);
+      expect(ctx.eventPublisher.getCommandIngestEvents()).toHaveLength(1);
+    });
+
+    it('drains old failed webhook events when the scheduler posts an empty body', async () => {
+      await ctx.userMappingRepository.saveMapping(testUserId, [senderPhone]);
+
+      const payload = createWebhookPayload();
+      ctx.webhookEventRepository.setEvent({
+        id: 'event-scheduler-failed-empty-body',
+        payload,
+        signatureValid: true,
+        receivedAt: '2020-01-01T00:00:00.000Z',
+        phoneNumberId: '123456789012345',
+        status: 'failed',
+        failureDetails: 'Failed to publish command ingest: transient Pub/Sub error',
+        retryable: true,
+      });
+
+      const response = await ctx.app.inject({
+        method: 'POST',
+        url: '/internal/whatsapp/webhooks/retry-pending',
+        headers: {
+          'x-internal-auth': process.env['INTEXURAOS_INTERNAL_AUTH_TOKEN'] ?? 'test-internal-token',
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body) as {
+        success: boolean;
+        data: {
+          processed: number;
+          skipped: number;
+          failed: number;
+          total: number;
+        };
+      };
+      expect(body.success).toBe(true);
+      expect(body.data).toMatchObject({
+        processed: 1,
+        skipped: 0,
+        failed: 0,
+        total: 1,
+      });
+
+      const events = ctx.webhookEventRepository.getAll();
+      expect(events[0]?.status).toBe('completed');
+      expect(ctx.messageRepository.getMessagesByUserSync(testUserId)).toHaveLength(1);
+      expect(ctx.eventPublisher.getCommandIngestEvents()).toHaveLength(1);
+    });
+
+    it('does not automatically retry old failed non-bookmark webhook events', async () => {
+      await ctx.userMappingRepository.saveMapping(testUserId, [senderPhone]);
+
+      const payload = createAudioWebhookPayload();
+      ctx.webhookEventRepository.setEvent({
+        id: 'event-scheduler-audio-failed-empty-body',
+        payload,
+        signatureValid: true,
+        receivedAt: '2020-01-01T00:00:00.000Z',
+        phoneNumberId: '123456789012345',
+        status: 'failed',
+        failureDetails: 'Failed to publish audio stored event: transient Pub/Sub error',
+      });
+
+      const response = await ctx.app.inject({
+        method: 'POST',
+        url: '/internal/whatsapp/webhooks/retry-pending',
+        headers: {
+          'x-internal-auth': process.env['INTEXURAOS_INTERNAL_AUTH_TOKEN'] ?? 'test-internal-token',
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body) as {
+        success: boolean;
+        data: {
+          processed: number;
+          skipped: number;
+          failed: number;
+          total: number;
+        };
+      };
+      expect(body.success).toBe(true);
+      expect(body.data).toMatchObject({
+        processed: 0,
+        skipped: 0,
+        failed: 0,
+        total: 0,
+      });
+
+      const events = ctx.webhookEventRepository.getAll();
+      expect(events[0]?.status).toBe('failed');
+      expect(ctx.messageRepository.getMessagesByUserSync(testUserId)).toHaveLength(0);
+      expect(ctx.eventPublisher.getAudioStoredEvents()).toHaveLength(0);
     });
   });
 
@@ -3182,10 +3453,12 @@ describe('Webhook async processing', () => {
 
       await triggerWebhookProcessing();
 
-      // Event should still be completed (command ingest failure is logged, not thrown)
+      // Event should fail so Pub/Sub can retry bookmark-producing command ingestion
       const events = ctx.webhookEventRepository.getAll();
       expect(events.length).toBe(1);
-      expect(events[0]?.status).toBe('completed');
+      expect(events[0]?.status).toBe('failed');
+      expect(events[0]?.failureDetails).toContain('Failed to publish command ingest');
+      expect(events[0]?.retryable).toBe(true);
 
       // No command ingest events should be published (publish failed)
       const commandEvents = ctx.eventPublisher.getCommandIngestEvents();

--- a/apps/whatsapp-service/src/adapters.ts
+++ b/apps/whatsapp-service/src/adapters.ts
@@ -29,7 +29,9 @@ import {
   deleteMessage,
   disconnectUserMapping,
   findById,
+  findByWaMessageId,
   findPendingByUserAndPhone,
+  findRetryableWebhookEvents,
   findPhoneByUserId,
   findUserByPhoneNumber,
   findVerificationById,
@@ -67,6 +69,7 @@ export class WebhookEventRepositoryAdapter implements WhatsAppWebhookEventReposi
     metadata: {
       ignoredReason?: IgnoredReason;
       failureDetails?: string;
+      retryable?: boolean;
       inboxNoteId?: string;
     }
   ): Promise<Result<WhatsAppWebhookEvent, WhatsAppError>> {
@@ -75,6 +78,13 @@ export class WebhookEventRepositoryAdapter implements WhatsAppWebhookEventReposi
 
   async getEvent(eventId: string): Promise<Result<WhatsAppWebhookEvent | null, WhatsAppError>> {
     return await getWebhookEvent(eventId);
+  }
+
+  async findRetryableEvents(options: {
+    olderThan: string;
+    limit: number;
+  }): Promise<Result<WhatsAppWebhookEvent[], WhatsAppError>> {
+    return await findRetryableWebhookEvents(options);
   }
 }
 
@@ -140,6 +150,13 @@ export class MessageRepositoryAdapter implements WhatsAppMessageRepository {
     messageId: string
   ): Promise<Result<WhatsAppMessage | null, WhatsAppError>> {
     return await findById(userId, messageId);
+  }
+
+  async findByWaMessageId(
+    userId: string,
+    waMessageId: string
+  ): Promise<Result<WhatsAppMessage | null, WhatsAppError>> {
+    return await findByWaMessageId(userId, waMessageId);
   }
 
   async updateTranscription(

--- a/apps/whatsapp-service/src/config.ts
+++ b/apps/whatsapp-service/src/config.ts
@@ -70,9 +70,11 @@ const configSchema = z.object({
 
   /**
    * Pub/Sub topic for commands ingest events.
-   * Optional - commands-agent integration.
+   * Required: WhatsApp text messages must reach commands-agent to become bookmarks.
    */
-  commandsIngestTopic: z.string().optional(),
+  commandsIngestTopic: z
+    .string()
+    .min(1, 'INTEXURAOS_PUBSUB_COMMANDS_INGEST_TOPIC is required'),
 
   /**
    * Pub/Sub topic for send message events.
@@ -171,6 +173,7 @@ export function validateConfigEnv(): string[] {
     'INTEXURAOS_PUBSUB_MEDIA_CLEANUP_SUBSCRIPTION',
     'INTEXURAOS_PUBSUB_AUDIO_STORED_TOPIC',
     'INTEXURAOS_PUBSUB_APPROVAL_REPLY_TOPIC',
+    'INTEXURAOS_PUBSUB_COMMANDS_INGEST_TOPIC',
     'INTEXURAOS_GCP_PROJECT_ID',
     'INTEXURAOS_WEB_AGENT_URL',
     'INTEXURAOS_INTERNAL_AUTH_TOKEN',

--- a/apps/whatsapp-service/src/domain/whatsapp/index.ts
+++ b/apps/whatsapp-service/src/domain/whatsapp/index.ts
@@ -124,7 +124,14 @@ export {
 export {
   ProcessWebhookEventUseCase,
   type ProcessWebhookEventDeps,
+  type ProcessWebhookEventResult,
 } from './usecases/processWebhookEventUseCase.js';
+
+export {
+  RetryPendingWebhookEventsUseCase,
+  type RetryPendingWebhookEventsInput,
+  type RetryPendingWebhookEventsResult,
+} from './usecases/retryPendingWebhookEvents.js';
 
 export {
   shouldDeliverMessage,

--- a/apps/whatsapp-service/src/domain/whatsapp/ports/repositories.ts
+++ b/apps/whatsapp-service/src/domain/whatsapp/ports/repositories.ts
@@ -45,6 +45,7 @@ export interface WhatsAppWebhookEvent {
   status: WebhookProcessingStatus;
   ignoredReason?: IgnoredReason;
   failureDetails?: string;
+  retryable?: boolean;
   processedAt?: string;
 }
 
@@ -97,9 +98,14 @@ export interface WhatsAppWebhookEventRepository {
     metadata: {
       ignoredReason?: IgnoredReason;
       failureDetails?: string;
+      retryable?: boolean;
     }
   ): Promise<Result<WhatsAppWebhookEvent, WhatsAppError>>;
   getEvent(eventId: string): Promise<Result<WhatsAppWebhookEvent | null, WhatsAppError>>;
+  findRetryableEvents(options: {
+    olderThan: string;
+    limit: number;
+  }): Promise<Result<WhatsAppWebhookEvent[], WhatsAppError>>;
 }
 
 /**
@@ -135,6 +141,14 @@ export interface WhatsAppMessageRepository {
   findById(
     userId: string,
     messageId: string
+  ): Promise<Result<WhatsAppMessage | null, WhatsAppError>>;
+
+  /**
+   * Find a message by user ID and WhatsApp message ID.
+   */
+  findByWaMessageId(
+    userId: string,
+    waMessageId: string
   ): Promise<Result<WhatsAppMessage | null, WhatsAppError>>;
 
   /**

--- a/apps/whatsapp-service/src/domain/whatsapp/usecases/processWebhookEventUseCase.ts
+++ b/apps/whatsapp-service/src/domain/whatsapp/usecases/processWebhookEventUseCase.ts
@@ -52,6 +52,21 @@ export interface ProcessWebhookEventDeps {
   eventPublisher: EventPublisherPort;
 }
 
+export interface ProcessWebhookEventFailure {
+  ok: false;
+  retryable: boolean;
+  failureDetails: string;
+}
+
+export type ProcessWebhookEventResult = ProcessWebhookEventFailure | undefined;
+
+class RetryableWebhookProcessingError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'RetryableWebhookProcessingError';
+  }
+}
+
 /**
  * Use case for processing WhatsApp webhook events asynchronously.
  */
@@ -62,7 +77,11 @@ export class ProcessWebhookEventUseCase {
    * Process webhook event synchronously.
    * Validates user mapping and routes to appropriate usecase.
    */
-  async execute(payload: WebhookPayload, savedEvent: { id: string }, logger: Logger): Promise<void> {
+  async execute(
+    payload: WebhookPayload,
+    savedEvent: { id: string },
+    logger: Logger
+  ): Promise<ProcessWebhookEventResult> {
     const { webhookEventRepository, userMappingRepository } = this.deps;
 
     logger.info({ eventId: savedEvent.id }, 'Starting asynchronous webhook processing');
@@ -329,6 +348,17 @@ export class ProcessWebhookEventUseCase {
         logger
       );
     } catch (error) {
+      if (error instanceof RetryableWebhookProcessingError) {
+        logger.error(
+          {
+            eventId: savedEvent.id,
+            error: error.message,
+          },
+          'Retryable webhook processing failure'
+        );
+        return { ok: false, retryable: true, failureDetails: error.message };
+      }
+
       logger.error(
         {
           eventId: savedEvent.id,
@@ -339,8 +369,15 @@ export class ProcessWebhookEventUseCase {
       // Update event status so it's not stuck in 'pending' forever
       await this.deps.webhookEventRepository.updateEventStatus(savedEvent.id, 'failed', {
         failureDetails: `Unexpected error: ${getErrorMessage(error)}`,
+        retryable: false,
       });
+      return {
+        ok: false,
+        retryable: false,
+        failureDetails: `Unexpected error: ${getErrorMessage(error)}`,
+      };
     }
+    return undefined;
   }
 
   /**
@@ -644,28 +681,52 @@ export class ProcessWebhookEventUseCase {
     }
     /* v8 ignore stop @preserve */
 
-    // Save message to Firestore
-    const saveResult = await messageRepository.saveMessage(messageToSave);
-
-    if (!saveResult.ok) {
+    const existingMessageResult = await messageRepository.findByWaMessageId(userId, waMessageId);
+    if (!existingMessageResult.ok) {
       logger.error(
-        { error: saveResult.error, eventId: savedEvent.id },
-        'Failed to save message'
+        { error: existingMessageResult.error, eventId: savedEvent.id, waMessageId },
+        'Failed to look up existing message by WhatsApp message ID'
       );
       await webhookEventRepository.updateEventStatus(savedEvent.id, 'failed', {
-        failureDetails: `Failed to save message: ${saveResult.error.message}`,
+        failureDetails: `Failed to look up existing message: ${existingMessageResult.error.message}`,
+        retryable: true,
       });
-      return;
+      throw new RetryableWebhookProcessingError(
+        `Failed to look up existing message: ${existingMessageResult.error.message}`
+      );
     }
 
-    const savedMessage = saveResult.value;
+    let savedMessage = existingMessageResult.value;
+
+    if (savedMessage === null) {
+      const saveResult = await messageRepository.saveMessage(messageToSave);
+
+      if (!saveResult.ok) {
+        logger.error(
+          { error: saveResult.error, eventId: savedEvent.id },
+          'Failed to save message'
+        );
+        await webhookEventRepository.updateEventStatus(savedEvent.id, 'failed', {
+          failureDetails: `Failed to save message: ${saveResult.error.message}`,
+          retryable: true,
+        });
+        throw new RetryableWebhookProcessingError(
+          `Failed to save message: ${saveResult.error.message}`
+        );
+      }
+
+      savedMessage = saveResult.value;
+    } else {
+      logger.info(
+        { eventId: savedEvent.id, userId, messageId: savedMessage.id, waMessageId },
+        'Reusing existing text message for webhook replay'
+      );
+    }
 
     logger.info(
       { eventId: savedEvent.id, userId, messageId: savedMessage.id },
       'Text message saved to database'
     );
-
-    await webhookEventRepository.updateEventStatus(savedEvent.id, 'completed', {});
 
     // Check if this is a reply to another message (potential approval response)
     const replyContext = extractReplyContext(payload);
@@ -776,10 +837,16 @@ export class ProcessWebhookEventUseCase {
       });
 
       if (!commandPublishResult.ok) {
+        const failureDetails = `Failed to publish command ingest: ${commandPublishResult.error.message}`;
         logger.error(
           { eventId: savedEvent.id, error: commandPublishResult.error },
           'Failed to publish command ingest event'
         );
+        await webhookEventRepository.updateEventStatus(savedEvent.id, 'failed', {
+          failureDetails,
+          retryable: true,
+        });
+        throw new RetryableWebhookProcessingError(failureDetails);
       }
     }
 
@@ -803,6 +870,7 @@ export class ProcessWebhookEventUseCase {
       'Text message processing completed successfully'
     );
 
+    await webhookEventRepository.updateEventStatus(savedEvent.id, 'completed', {});
     await this.markMessageAsRead(payload, savedEvent, logger);
   }
 

--- a/apps/whatsapp-service/src/domain/whatsapp/usecases/retryPendingWebhookEvents.ts
+++ b/apps/whatsapp-service/src/domain/whatsapp/usecases/retryPendingWebhookEvents.ts
@@ -1,0 +1,209 @@
+import { getErrorMessage } from '@intexuraos/common-core';
+import type { Logger } from '../utils/logger.js';
+import type {
+  WhatsAppWebhookEvent,
+  WhatsAppWebhookEventRepository,
+} from '../ports/repositories.js';
+import type { ProcessWebhookEventUseCase } from './processWebhookEventUseCase.js';
+import type { WebhookPayload } from '../../../routes/schemas.js';
+
+export interface RetryPendingWebhookEventsInput {
+  eventIds?: string[];
+  limit?: number;
+  olderThanSeconds?: number;
+  dryRun?: boolean;
+}
+
+export interface RetryPendingWebhookEventResult {
+  eventId: string;
+  outcome: 'processed' | 'skipped' | 'failed';
+  status?: string;
+  reason?: string;
+}
+
+export interface RetryPendingWebhookEventsResult {
+  processed: number;
+  skipped: number;
+  failed: number;
+  total: number;
+  events: RetryPendingWebhookEventResult[];
+}
+
+export interface RetryPendingWebhookEventsDeps {
+  webhookEventRepository: WhatsAppWebhookEventRepository;
+  processWebhookEventUseCase: ProcessWebhookEventUseCase;
+}
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 100;
+const DEFAULT_OLDER_THAN_SECONDS = 120;
+const RETRYABLE_STATUSES = new Set(['pending', 'failed']);
+
+export class RetryPendingWebhookEventsUseCase {
+  constructor(private readonly deps: RetryPendingWebhookEventsDeps) {}
+
+  async execute(
+    input: RetryPendingWebhookEventsInput,
+    logger: Logger
+  ): Promise<RetryPendingWebhookEventsResult> {
+    const limit = Math.min(Math.max(input.limit ?? DEFAULT_LIMIT, 1), MAX_LIMIT);
+    const dryRun = input.dryRun ?? false;
+    const eventsResult =
+      input.eventIds !== undefined && input.eventIds.length > 0
+        ? await this.findEventsById(input.eventIds)
+        : await this.findRetryableEvents(
+            input.olderThanSeconds ?? DEFAULT_OLDER_THAN_SECONDS,
+            limit
+          );
+
+    if (!eventsResult.ok) {
+      return {
+        processed: 0,
+        skipped: 0,
+        failed: 1,
+        total: 0,
+        events: [
+          {
+            eventId: 'query',
+            outcome: 'failed',
+            reason: eventsResult.error,
+          },
+        ],
+      };
+    }
+
+    const results: RetryPendingWebhookEventResult[] = [];
+    for (const event of eventsResult.value) {
+      if (!RETRYABLE_STATUSES.has(event.status)) {
+        results.push({
+          eventId: event.id,
+          outcome: 'skipped',
+          status: event.status,
+          reason: 'terminal_status',
+        });
+        continue;
+      }
+
+      if (dryRun) {
+        results.push({
+          eventId: event.id,
+          outcome: 'skipped',
+          status: event.status,
+          reason: 'dry_run',
+        });
+        continue;
+      }
+
+      logger.info({ eventId: event.id, status: event.status }, 'Retrying WhatsApp webhook event');
+
+      try {
+        const processResult = await this.deps.processWebhookEventUseCase.execute(
+          event.payload as WebhookPayload,
+          { id: event.id },
+          logger
+        );
+
+        if (processResult?.ok === false) {
+          results.push({
+            eventId: event.id,
+            outcome: 'failed',
+            status: 'failed',
+            reason: processResult.failureDetails,
+          });
+          continue;
+        }
+
+        const updatedResult = await this.deps.webhookEventRepository.getEvent(event.id);
+        if (!updatedResult.ok) {
+          results.push({
+            eventId: event.id,
+            outcome: 'failed',
+            reason: updatedResult.error.message,
+          });
+          continue;
+        }
+
+        const updated = updatedResult.value;
+        if (updated === null) {
+          results.push({
+            eventId: event.id,
+            outcome: 'failed',
+            reason: 'event_missing_after_retry',
+          });
+          continue;
+        }
+
+        if (updated.status === 'failed' || updated.status === 'pending') {
+          results.push({
+            eventId: event.id,
+            outcome: 'failed',
+            status: updated.status,
+            reason: updated.failureDetails ?? 'retry_did_not_complete',
+          });
+          continue;
+        }
+
+        const outcome: RetryPendingWebhookEventResult = {
+          eventId: event.id,
+          outcome: updated.status === 'completed' ? 'processed' : 'skipped',
+          status: updated.status,
+        };
+        if (updated.status !== 'completed') {
+          outcome.reason = 'non_bookmark_terminal_status';
+        }
+        results.push(outcome);
+      } catch (error) {
+        results.push({
+          eventId: event.id,
+          outcome: 'failed',
+          reason: getErrorMessage(error, 'Unknown retry error'),
+        });
+      }
+    }
+
+    return summarizeResults(results);
+  }
+
+  private async findEventsById(
+    eventIds: string[]
+  ): Promise<{ ok: true; value: WhatsAppWebhookEvent[] } | { ok: false; error: string }> {
+    const events: WhatsAppWebhookEvent[] = [];
+    for (const eventId of eventIds) {
+      const result = await this.deps.webhookEventRepository.getEvent(eventId);
+      if (!result.ok) {
+        return { ok: false, error: result.error.message };
+      }
+      if (result.value !== null) {
+        events.push(result.value);
+      }
+    }
+    return { ok: true, value: events };
+  }
+
+  private async findRetryableEvents(
+    olderThanSeconds: number,
+    limit: number
+  ): Promise<{ ok: true; value: WhatsAppWebhookEvent[] } | { ok: false; error: string }> {
+    const olderThan = new Date(Date.now() - olderThanSeconds * 1000).toISOString();
+    const result = await this.deps.webhookEventRepository.findRetryableEvents({
+      olderThan,
+      limit,
+    });
+    if (!result.ok) {
+      return { ok: false, error: result.error.message };
+    }
+    return { ok: true, value: result.value };
+  }
+}
+
+function summarizeResults(
+  events: RetryPendingWebhookEventResult[]
+): RetryPendingWebhookEventsResult {
+  return {
+    processed: events.filter((event) => event.outcome === 'processed').length,
+    skipped: events.filter((event) => event.outcome === 'skipped').length,
+    failed: events.filter((event) => event.outcome === 'failed').length,
+    total: events.length,
+    events,
+  };
+}

--- a/apps/whatsapp-service/src/infra/firestore/index.ts
+++ b/apps/whatsapp-service/src/infra/firestore/index.ts
@@ -9,6 +9,7 @@ export {
   saveWebhookEvent,
   updateWebhookEventStatus,
   getWebhookEvent,
+  findRetryableWebhookEvents,
 } from './webhookEventRepository.js';
 
 export {
@@ -26,6 +27,7 @@ export {
   getMessagesByUser,
   getMessage,
   findById,
+  findByWaMessageId,
   updateTranscription,
   updateLinkPreview,
   deleteMessage,

--- a/apps/whatsapp-service/src/infra/firestore/messageRepository.ts
+++ b/apps/whatsapp-service/src/infra/firestore/messageRepository.ts
@@ -180,6 +180,33 @@ export async function findById(
   }
 }
 
+export async function findByWaMessageId(
+  userId: string,
+  waMessageId: string
+): Promise<Result<WhatsAppMessage | null, WhatsAppError>> {
+  try {
+    const db = getFirestore();
+    const snapshot = await db
+      .collection(COLLECTION_NAME)
+      .where('userId', '==', userId)
+      .where('waMessageId', '==', waMessageId)
+      .limit(1)
+      .get();
+
+    const doc = snapshot.docs[0];
+    if (doc === undefined) {
+      return ok(null);
+    }
+
+    return ok(doc.data() as WhatsAppMessage);
+  } catch (error) {
+    return err({
+      code: 'PERSISTENCE_ERROR',
+      message: `Failed to find message by WhatsApp id: ${getErrorMessage(error, 'Unknown Firestore error')}`,
+    });
+  }
+}
+
 /**
  * Update message transcription state.
  */

--- a/apps/whatsapp-service/src/infra/firestore/webhookEventRepository.ts
+++ b/apps/whatsapp-service/src/infra/firestore/webhookEventRepository.ts
@@ -27,6 +27,7 @@ export interface WhatsAppWebhookEvent {
   status: WebhookProcessingStatus;
   ignoredReason?: IgnoredReason;
   failureDetails?: string;
+  retryable?: boolean;
   inboxNoteId?: string;
   processedAt?: string;
 }
@@ -67,6 +68,7 @@ export async function updateWebhookEventStatus(
   metadata: {
     ignoredReason?: IgnoredReason;
     failureDetails?: string;
+    retryable?: boolean;
     inboxNoteId?: string;
   }
 ): Promise<Result<WhatsAppWebhookEvent, WhatsAppError>> {
@@ -77,6 +79,7 @@ export async function updateWebhookEventStatus(
     const update: Partial<WhatsAppWebhookEvent> = {
       status,
       processedAt: new Date().toISOString(),
+      retryable: status === 'failed' ? (metadata.retryable ?? false) : false,
     };
 
     if (metadata.ignoredReason !== undefined) update.ignoredReason = metadata.ignoredReason;
@@ -108,6 +111,43 @@ export async function getWebhookEvent(
     return err({
       code: 'PERSISTENCE_ERROR',
       message: `Failed to get webhook event: ${getErrorMessage(error, 'Unknown Firestore error')}`,
+    });
+  }
+}
+
+export async function findRetryableWebhookEvents(options: {
+  olderThan: string;
+  limit: number;
+}): Promise<Result<WhatsAppWebhookEvent[], WhatsAppError>> {
+  try {
+    const db = getFirestore();
+    const pendingSnapshot = await db
+      .collection(WHATSAPP_EVENTS_COLLECTION)
+      .where('status', '==', 'pending')
+      .where('receivedAt', '<', options.olderThan)
+      .orderBy('receivedAt', 'asc')
+      .limit(options.limit)
+      .get();
+
+    const failedSnapshot = await db
+      .collection(WHATSAPP_EVENTS_COLLECTION)
+      .where('status', '==', 'failed')
+      .where('retryable', '==', true)
+      .where('receivedAt', '<', options.olderThan)
+      .orderBy('receivedAt', 'asc')
+      .limit(options.limit)
+      .get();
+
+    const events = [...pendingSnapshot.docs, ...failedSnapshot.docs]
+      .map((doc) => doc.data() as WhatsAppWebhookEvent)
+      .sort((a, b) => a.receivedAt.localeCompare(b.receivedAt))
+      .slice(0, options.limit);
+
+    return ok(events);
+  } catch (error) {
+    return err({
+      code: 'PERSISTENCE_ERROR',
+      message: `Failed to find retryable webhook events: ${getErrorMessage(error, 'Unknown Firestore error')}`,
     });
   }
 }

--- a/apps/whatsapp-service/src/infra/pubsub/publisher.ts
+++ b/apps/whatsapp-service/src/infra/pubsub/publisher.ts
@@ -28,8 +28,10 @@ export interface GcpPubSubPublisherConfig {
    * Required: triggers actions-agent to process approval/rejection of pending actions.
    */
   approvalReplyTopic: string;
-  /** Optional: commands-agent integration; safe to leave unset in dev. */
-  commandsIngestTopic?: string;
+  /**
+   * Required: commands-agent turns WhatsApp text commands into bookmark records.
+   */
+  commandsIngestTopic: string;
   /** Optional: webhook async-processing fanout; safe to leave unset in dev. */
   webhookProcessTopic?: string;
   logger: Logger;
@@ -42,7 +44,7 @@ export class GcpPubSubPublisher extends BasePubSubPublisher implements EventPubl
   private readonly mediaCleanupTopic: string;
   private readonly audioStoredTopic: string;
   private readonly approvalReplyTopic: string;
-  private readonly commandsIngestTopic: string | null;
+  private readonly commandsIngestTopic: string;
   private readonly webhookProcessTopic: string | null;
 
   constructor(config: GcpPubSubPublisherConfig) {
@@ -60,10 +62,14 @@ export class GcpPubSubPublisher extends BasePubSubPublisher implements EventPubl
     if (config.approvalReplyTopic === undefined || config.approvalReplyTopic === '') {
       throw new Error('approvalReplyTopic is required');
     }
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- belt-and-suspenders runtime guard for callers that bypass the type system
+    if (config.commandsIngestTopic === undefined || config.commandsIngestTopic === '') {
+      throw new Error('commandsIngestTopic is required');
+    }
     this.mediaCleanupTopic = config.mediaCleanupTopic;
     this.audioStoredTopic = config.audioStoredTopic;
     this.approvalReplyTopic = config.approvalReplyTopic;
-    this.commandsIngestTopic = config.commandsIngestTopic ?? null;
+    this.commandsIngestTopic = config.commandsIngestTopic;
     this.webhookProcessTopic = config.webhookProcessTopic ?? null;
   }
 
@@ -78,7 +84,7 @@ export class GcpPubSubPublisher extends BasePubSubPublisher implements EventPubl
   }
 
   async publishCommandIngest(event: CommandIngestEvent): Promise<Result<void, WhatsAppError>> {
-    const result = await this.publishToOptionalTopic(
+    const result = await this.publishToTopic(
       this.commandsIngestTopic,
       event,
       { externalId: event.externalId },

--- a/apps/whatsapp-service/src/routes/index.ts
+++ b/apps/whatsapp-service/src/routes/index.ts
@@ -12,6 +12,7 @@ import { messageMediaRoutes } from './messageMediaRoutes.js';
 import { preferencesRoutes } from './preferencesRoutes.js';
 import { createPubsubRoutes } from './pubsubRoutes.js';
 import { verificationRoutes } from './verificationRoutes.js';
+import { internalRoutes } from './internalRoutes.js';
 
 /**
  * Creates routes plugin with config.
@@ -27,6 +28,7 @@ export function createWhatsappRoutes(config: Config): FastifyPluginCallback {
     fastify.register(preferencesRoutes);
     fastify.register(verificationRoutes);
     fastify.register(createPubsubRoutes());
+    fastify.register(internalRoutes);
     done();
   };
 }

--- a/apps/whatsapp-service/src/routes/internalRoutes.ts
+++ b/apps/whatsapp-service/src/routes/internalRoutes.ts
@@ -1,0 +1,124 @@
+import type { FastifyPluginCallback, FastifyReply, FastifyRequest } from 'fastify';
+import { authenticateInternalScheduler, logIncomingRequest } from '@intexuraos/common-http';
+import {
+  ProcessWebhookEventUseCase,
+  RetryPendingWebhookEventsUseCase,
+  type RetryPendingWebhookEventsInput,
+} from '../domain/whatsapp/index.js';
+import { getServices } from '../services.js';
+
+export const internalRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
+  fastify.post(
+    '/internal/whatsapp/webhooks/retry-pending',
+    {
+      attachValidation: true,
+      schema: {
+        operationId: 'retryPendingWhatsAppWebhooks',
+        summary: 'Retry pending WhatsApp webhook events',
+        description:
+          'Internal endpoint called by Cloud Scheduler or an operator to drain persisted WhatsApp webhook events that did not complete async processing.',
+        tags: ['internal'],
+        body: {
+          type: 'object',
+          properties: {
+            eventIds: {
+              type: 'array',
+              items: { type: 'string', minLength: 1 },
+            },
+            limit: { type: 'number', minimum: 1, maximum: 100 },
+            olderThanSeconds: { type: 'number', minimum: 0 },
+            dryRun: { type: 'boolean' },
+          },
+        },
+        response: {
+          200: {
+            description: 'Retry completed',
+            type: 'object',
+            properties: {
+              success: { type: 'boolean', const: true },
+              data: {
+                type: 'object',
+                properties: {
+                  processed: { type: 'number' },
+                  skipped: { type: 'number' },
+                  failed: { type: 'number' },
+                  total: { type: 'number' },
+                  events: {
+                    type: 'array',
+                    items: {
+                      type: 'object',
+                      properties: {
+                        eventId: { type: 'string' },
+                        outcome: { type: 'string' },
+                        status: { type: 'string' },
+                        reason: { type: 'string' },
+                      },
+                      required: ['eventId', 'outcome'],
+                    },
+                  },
+                },
+                required: ['processed', 'skipped', 'failed', 'total', 'events'],
+              },
+            },
+            required: ['success', 'data'],
+          },
+          401: {
+            description: 'Unauthorized',
+            type: 'object',
+            properties: {
+              success: { type: 'boolean', const: false },
+              error: { $ref: 'ErrorBody#' },
+            },
+            required: ['success', 'error'],
+          },
+        },
+      },
+    },
+    async (request: FastifyRequest, reply: FastifyReply) => {
+      logIncomingRequest(request, {
+        message: 'Received request to /internal/whatsapp/webhooks/retry-pending',
+        bodyPreviewLength: 300,
+      });
+
+      const authResult = authenticateInternalScheduler(request);
+      if (!authResult.authenticated) {
+        request.log.warn({ reason: 'auth_failed' }, 'Internal auth failed for webhook retry');
+        return await reply.fail('UNAUTHORIZED', 'Internal auth failed for webhook retry');
+      }
+
+      if (
+        (request as FastifyRequest & { validationError?: Error }).validationError !== undefined &&
+        request.body !== undefined &&
+        request.body !== null
+      ) {
+        return await reply.fail('INVALID_REQUEST', 'Validation failed');
+      }
+
+      const services = getServices();
+      const processWebhookEventUseCase = new ProcessWebhookEventUseCase({
+        webhookEventRepository: services.webhookEventRepository,
+        userMappingRepository: services.userMappingRepository,
+        messageRepository: services.messageRepository,
+        outboundMessageRepository: services.outboundMessageRepository,
+        mediaStorage: services.mediaStorage,
+        whatsappCloudApi: services.whatsappCloudApi,
+        thumbnailGenerator: services.thumbnailGenerator,
+        eventPublisher: services.eventPublisher,
+      });
+      const retryPendingWebhookEventsUseCase = new RetryPendingWebhookEventsUseCase({
+        webhookEventRepository: services.webhookEventRepository,
+        processWebhookEventUseCase,
+      });
+
+      const result = await retryPendingWebhookEventsUseCase.execute(
+        (request.body ?? {}) as RetryPendingWebhookEventsInput,
+        request.log
+      );
+
+      request.log.info(result, 'Pending WhatsApp webhook retry completed');
+      return await reply.ok(result);
+    }
+  );
+
+  done();
+};

--- a/apps/whatsapp-service/src/routes/pubsubRoutes.ts
+++ b/apps/whatsapp-service/src/routes/pubsubRoutes.ts
@@ -729,35 +729,45 @@ export function createPubsubRoutes(): FastifyPluginCallback {
             'Processing webhook event'
           );
 
+          let payload: WebhookPayload;
           try {
-            const payload = JSON.parse(eventData.payload) as WebhookPayload;
-            const services = getServices();
-
-            const processWebhookEventUseCase = new ProcessWebhookEventUseCase({
-              webhookEventRepository: services.webhookEventRepository,
-              userMappingRepository: services.userMappingRepository,
-              messageRepository: services.messageRepository,
-              outboundMessageRepository: services.outboundMessageRepository,
-              mediaStorage: services.mediaStorage,
-              whatsappCloudApi: services.whatsappCloudApi,
-              thumbnailGenerator: services.thumbnailGenerator,
-              eventPublisher: services.eventPublisher,
-            });
-
-            await processWebhookEventUseCase.execute(
-              payload,
-              { id: eventData.eventId },
-              request.log
-            );
-
-            request.log.info({ eventId: eventData.eventId }, 'Webhook processing completed');
+            payload = JSON.parse(eventData.payload) as WebhookPayload;
           } catch (error) {
             request.log.error(
               { eventId: eventData.eventId, error: getErrorMessage(error) },
-              'Failed to process webhook event'
+              'Failed to parse webhook event payload'
             );
+            return await reply.ok({});
           }
 
+          const services = getServices();
+
+          const processWebhookEventUseCase = new ProcessWebhookEventUseCase({
+            webhookEventRepository: services.webhookEventRepository,
+            userMappingRepository: services.userMappingRepository,
+            messageRepository: services.messageRepository,
+            outboundMessageRepository: services.outboundMessageRepository,
+            mediaStorage: services.mediaStorage,
+            whatsappCloudApi: services.whatsappCloudApi,
+            thumbnailGenerator: services.thumbnailGenerator,
+            eventPublisher: services.eventPublisher,
+          });
+
+          const result = await processWebhookEventUseCase.execute(
+            payload,
+            { id: eventData.eventId },
+            request.log
+          );
+
+          if (result?.ok === false && result.retryable) {
+            request.log.error(
+              { eventId: eventData.eventId, failureDetails: result.failureDetails },
+              'Webhook processing failed with retryable error'
+            );
+            return await reply.fail('INTERNAL_ERROR', result.failureDetails);
+          }
+
+          request.log.info({ eventId: eventData.eventId }, 'Webhook processing completed');
           return await reply.ok({});
         }
 

--- a/apps/whatsapp-service/src/routes/routes.ts
+++ b/apps/whatsapp-service/src/routes/routes.ts
@@ -15,6 +15,7 @@
  * GET    /whatsapp/preferences        → ./preferencesRoutes.ts
  * PUT    /whatsapp/preferences        → ./preferencesRoutes.ts
  * POST   /internal/whatsapp/pubsub/send-message   → ./pubsubRoutes.ts
+ * POST   /internal/whatsapp/webhooks/retry-pending → ./internalRoutes.ts
  * ─────────────────────────────────────────────────────────────
  */
 

--- a/apps/whatsapp-service/src/server.ts
+++ b/apps/whatsapp-service/src/server.ts
@@ -111,15 +111,12 @@ export async function buildServer(config: Config): Promise<FastifyInstance> {
     mediaCleanupTopic: config.mediaCleanupTopic,
     audioStoredTopic: config.audioStoredTopic,
     approvalReplyTopic: config.approvalReplyTopic,
+    commandsIngestTopic: config.commandsIngestTopic,
     whatsappAccessToken: config.accessToken,
     whatsappPhoneNumberId: config.allowedPhoneNumberIds[0] ?? '',
     webAgentUrl: config.webAgentUrl,
     internalAuthToken: config.internalAuthToken,
   };
-  if (config.commandsIngestTopic !== undefined) {
-    (serviceConfig as { commandsIngestTopic?: string }).commandsIngestTopic =
-      config.commandsIngestTopic;
-  }
   if (config.webhookProcessTopic !== undefined) {
     (serviceConfig as { webhookProcessTopic?: string }).webhookProcessTopic =
       config.webhookProcessTopic;

--- a/apps/whatsapp-service/src/services.ts
+++ b/apps/whatsapp-service/src/services.ts
@@ -40,7 +40,7 @@ export interface ServiceConfig {
   mediaCleanupTopic: string;
   audioStoredTopic: string;
   approvalReplyTopic: string;
-  commandsIngestTopic?: string;
+  commandsIngestTopic: string;
   webhookProcessTopic?: string;
   whatsappAccessToken: string;
   whatsappPhoneNumberId: string;
@@ -54,11 +54,9 @@ function buildPubSubConfig(config: ServiceConfig): GcpPubSubPublisherConfig {
     mediaCleanupTopic: config.mediaCleanupTopic,
     audioStoredTopic: config.audioStoredTopic,
     approvalReplyTopic: config.approvalReplyTopic,
+    commandsIngestTopic: config.commandsIngestTopic,
     logger: createAppLogger({ name: 'whatsapp-pubsub-publisher' }),
   };
-  if (config.commandsIngestTopic !== undefined) {
-    pubsubConfig.commandsIngestTopic = config.commandsIngestTopic;
-  }
   if (config.webhookProcessTopic !== undefined) {
     pubsubConfig.webhookProcessTopic = config.webhookProcessTopic;
   }

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1901,6 +1901,52 @@
           "order": "ASCENDING"
         }
       ]
+    },
+    {
+      "collectionGroup": "whatsapp_webhook_events",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "receivedAt",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "whatsapp_webhook_events",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "retryable",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "receivedAt",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "whatsapp_messages",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "userId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "waMessageId",
+          "order": "ASCENDING"
+        }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/migrations/110_whatsapp-webhook-retry-indexes.mjs
+++ b/migrations/110_whatsapp-webhook-retry-indexes.mjs
@@ -1,0 +1,48 @@
+/**
+ * Migration 110: WhatsApp webhook retry indexes.
+ *
+ * Required by:
+ * - whatsapp-service pending webhook drain: status == pending, receivedAt asc
+ * - whatsapp-service retryable failed webhook drain: status == failed, retryable == true, receivedAt asc
+ * - whatsapp-service webhook replay idempotency: userId + waMessageId lookup
+ */
+
+export const metadata = {
+  id: '110',
+  name: 'whatsapp-webhook-retry-indexes',
+  description: 'Composite indexes for retrying pending and retryable WhatsApp webhook events safely',
+  createdAt: '2026-06-10',
+};
+
+export const indexes = [
+  {
+    collectionGroup: 'whatsapp_webhook_events',
+    queryScope: 'COLLECTION',
+    fields: [
+      { fieldPath: 'status', order: 'ASCENDING' },
+      { fieldPath: 'receivedAt', order: 'ASCENDING' },
+    ],
+  },
+  {
+    collectionGroup: 'whatsapp_webhook_events',
+    queryScope: 'COLLECTION',
+    fields: [
+      { fieldPath: 'status', order: 'ASCENDING' },
+      { fieldPath: 'retryable', order: 'ASCENDING' },
+      { fieldPath: 'receivedAt', order: 'ASCENDING' },
+    ],
+  },
+  {
+    collectionGroup: 'whatsapp_messages',
+    queryScope: 'COLLECTION',
+    fields: [
+      { fieldPath: 'userId', order: 'ASCENDING' },
+      { fieldPath: 'waMessageId', order: 'ASCENDING' },
+    ],
+  },
+];
+
+export async function up(context) {
+  console.log('  Deploying WhatsApp webhook retry indexes...');
+  await context.deployIndexes();
+}

--- a/migrations/__tests__/110-whatsapp-webhook-retry-indexes.test.ts
+++ b/migrations/__tests__/110-whatsapp-webhook-retry-indexes.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { indexes, metadata, up } from '../110_whatsapp-webhook-retry-indexes.mjs'; // @allow-missing-js -- .mjs import
+
+describe('migration 110 - whatsapp webhook retry indexes', () => {
+  it('exports the expected metadata', () => {
+    expect(metadata).toMatchObject({
+      id: '110',
+      name: 'whatsapp-webhook-retry-indexes',
+      description: 'Composite indexes for retrying pending and retryable WhatsApp webhook events safely',
+      createdAt: '2026-06-10',
+    });
+  });
+
+  it('defines indexes for webhook draining and message replay idempotency', () => {
+    expect(indexes).toEqual([
+      {
+        collectionGroup: 'whatsapp_webhook_events',
+        queryScope: 'COLLECTION',
+        fields: [
+          { fieldPath: 'status', order: 'ASCENDING' },
+          { fieldPath: 'receivedAt', order: 'ASCENDING' },
+        ],
+      },
+      {
+        collectionGroup: 'whatsapp_webhook_events',
+        queryScope: 'COLLECTION',
+        fields: [
+          { fieldPath: 'status', order: 'ASCENDING' },
+          { fieldPath: 'retryable', order: 'ASCENDING' },
+          { fieldPath: 'receivedAt', order: 'ASCENDING' },
+        ],
+      },
+      {
+        collectionGroup: 'whatsapp_messages',
+        queryScope: 'COLLECTION',
+        fields: [
+          { fieldPath: 'userId', order: 'ASCENDING' },
+          { fieldPath: 'waMessageId', order: 'ASCENDING' },
+        ],
+      },
+    ]);
+  });
+
+  it('deploys indexes in up()', async () => {
+    const deployIndexes = vi.fn().mockResolvedValue(undefined);
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    await up({ deployIndexes });
+
+    expect(deployIndexes).toHaveBeenCalledOnce();
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/migrations/manifest.json
+++ b/migrations/manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastReservedId": "108",
+  "lastReservedId": "110",
   "entries": [
     {
       "id": "001",
@@ -540,6 +540,16 @@
       "id": "108",
       "name": "code-task-system-statuses-active-listener-index",
       "checksum": "sha256:56a6ccef03564b5d9adaaa47a96fbae5bdb9c0384cf4ec8b52f93ef6f859d0c7"
+    },
+    {
+      "id": "109",
+      "name": "mimo-v25-pro-model-migration",
+      "checksum": "sha256:b581ad9d577aa9dfe1b880a6abc70909d61d0766d90f1ce9c1509795feb8b28d"
+    },
+    {
+      "id": "110",
+      "name": "whatsapp-webhook-retry-indexes",
+      "checksum": "sha256:71172362d85eb9b83bb165aa398d23f19c3f8b9629864fa87d6ef631fd3de632"
     }
   ]
 }

--- a/terraform/hetzner-prod/main.tf
+++ b/terraform/hetzner-prod/main.tf
@@ -88,6 +88,7 @@ locals {
     "/internal/whatsapp/pubsub/process-webhook"         = "whatsapp-service"
     "/internal/whatsapp/pubsub/send-message"            = "whatsapp-service"
     "/internal/whatsapp/pubsub/transcription-completed" = "whatsapp-service"
+    "/internal/whatsapp/webhooks/retry-pending"         = "whatsapp-service"
   }
 }
 

--- a/terraform/hetzner-prod/scheduler.tf
+++ b/terraform/hetzner-prod/scheduler.tf
@@ -78,6 +78,19 @@ locals {
       min_backoff_duration = "5s"
       max_backoff_duration = "30s"
     }
+    retry_pending_whatsapp_webhooks = {
+      job_name             = "intexuraos-retry-pending-whatsapp-webhooks-prod-hetzner"
+      description          = "Retry persisted WhatsApp webhook events stuck before async processing via Hetzner edge"
+      schedule             = "*/5 * * * *"
+      time_zone            = "UTC"
+      path                 = "/internal/whatsapp/webhooks/retry-pending"
+      body                 = null
+      headers              = {}
+      retry_count          = 1
+      max_retry_duration   = "60s"
+      min_backoff_duration = "5s"
+      max_backoff_duration = "30s"
+    }
     drain_task_queue = {
       job_name             = "intexuraos-drain-task-queue-prod-hetzner"
       description          = "Drain queued code tasks when workers become available via Hetzner edge"

--- a/tools/pubsub-ui/server.mjs
+++ b/tools/pubsub-ui/server.mjs
@@ -69,7 +69,7 @@ async function forwardToServiceEndpoint(topicName, message) {
   const endpoint = TOPIC_ENDPOINTS[topicName];
   if (!endpoint) {
     console.log(`[PubSub UI] No endpoint configured for topic: ${topicName}`);
-    return;
+    return true;
   }
 
   try {
@@ -86,7 +86,13 @@ async function forwardToServiceEndpoint(topicName, message) {
     console.log(`[PubSub UI] │  Endpoint: ${endpoint}`);
     console.log(`[PubSub UI] │  Message ID: ${message.id}`);
     console.log(`[PubSub UI] │  Data size: ${message.data.length} bytes`);
-    console.log(`[PubSub UI] │  Auth token (full): ${INTEXURAOS_INTERNAL_AUTH_TOKEN}`);
+    console.log(
+      `[PubSub UI] │  Auth token: ${
+        INTEXURAOS_INTERNAL_AUTH_TOKEN
+          ? '***' + INTEXURAOS_INTERNAL_AUTH_TOKEN.slice(-4)
+          : 'NOT SET'
+      }`
+    );
 
     const response = await fetch(endpoint, {
       method: 'POST',
@@ -103,16 +109,19 @@ async function forwardToServiceEndpoint(topicName, message) {
       if (responseBody) {
         console.log(`[PubSub UI]    Body:`, responseBody);
       }
+      return true;
     } else {
       const errorBody = await response.text();
       console.error(`[PubSub UI] └─ ERROR: ${response.status} ${response.statusText}`);
       if (errorBody) {
         console.error(`[PubSub UI]    Body:`, errorBody);
       }
+      return false;
     }
   } catch (error) {
     console.error(`[PubSub UI] └─ EXCEPTION: ${error.message}`);
     console.error(`[PubSub UI]    Stack:`, error.stack);
+    return false;
   }
 }
 
@@ -170,9 +179,13 @@ async function setupTopicsAndSubscriptions() {
           event,
         });
 
-        await forwardToServiceEndpoint(topicName, message);
+        const forwarded = await forwardToServiceEndpoint(topicName, message);
 
-        message.ack();
+        if (forwarded) {
+          message.ack();
+        } else {
+          message.nack();
+        }
       });
 
       subscription.on('error', (error) => {


### PR DESCRIPTION
## Summary
- Make WhatsApp text webhooks recoverable when Pub/Sub delivery or command ingestion stalls: required command.ingest topic config, idempotent message replay by WhatsApp message ID, explicit retryability on recoverable text failures, and non-retryable handling for generic failures.
- Add an internal scheduler endpoint/use case for retrying old pending webhook events and explicitly retryable failed webhook events, with Firestore indexes and Terraform scheduler wiring.
- Fix mobile bookmark row layout so title/URL take the primary width and the date no longer consumes most of the row.

## Root Cause
WhatsApp webhook processing could acknowledge the incoming Meta webhook but fail later in the async Pub/Sub path, leaving events pending or inconsistently failed. Text bookmark ingestion also depended on optional command ingest publishing, so a missing or failed topic could silently prevent bookmarks from being created.

## Validation
- `pnpm run verify:workspace:tracked whatsapp-service` (1,036 files, 18,381 tests)
- `pnpm --filter @intexuraos/web test -- src/components/bookmarks/__tests__/BookmarkRow.test.tsx` (129 files, 902 tests)
- `pnpm --filter @intexuraos/whatsapp-service build`
- `pnpm --filter @intexuraos/web build`
- `pnpm run verify:migrations`
- `pnpm run verify:firestore-artifacts`
- `terraform fmt -check -recursive terraform/hetzner-prod`
- `git diff --cached --check`

## Review
Requested code review via the superpowers reviewer. Final pass returned no findings after retryability consistency fixes.

---
- Linear: [INT-1662](https://linear.app/pbuchman/issue/INT-1662)
- IntexuraOS Code Task: [View task](https://intexuraos.cloud/#/code-tasks/task_61bd0561-a846-4912-9313-a4173ef24312)
- Worker Type: `mimo-pro`
- Model: `mimo-v2.5-pro`