### PR TITLE
[INT-1663] Add commit-push and subagent release workflows

### DIFF
--- a/.codex/skills/commit-push/SKILL.md
+++ b/.codex/skills/commit-push/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: commit-push
+description: Use when the user says "commit push", "commit and push", "push a PR", or asks Codex to finalize IntexuraOS changes by committing, pushing, and opening a pull request against development.
+---
+
+# Commit Push
+
+## Overview
+
+Finalize IntexuraOS work by committing the current intended changes, pushing a feature branch, and opening a pull request against `development`.
+
+This skill is an IntexuraOS-specific exception to the normal Linear issue ID requirement. Do not ask for a Linear issue ID when this skill is invoked. GitHub automation will create or link the Linear issue after the PR is opened.
+
+When invoked as direct finalization, do not ask for confirmation before commit, push, or PR creation unless a blocker requires user input.
+
+## Scope Guard
+
+Use this skill only in the IntexuraOS repo.
+
+Before any mutation:
+
+1. Confirm the repo root has `.claude/CLAUDE.md`, `pnpm-workspace.yaml`, and `package.json`.
+2. Confirm `package.json` has `"name": "intexuraos"`.
+3. Confirm `git remote get-url origin` points to `pbuchman/intexuraos`.
+4. If any check fails, stop and report that `$commit-push` is repo-specific.
+
+After the scope check:
+
+1. Read `.claude/CLAUDE.md` and every concrete file it requires, as usual.
+2. Preserve the `.claude/CLAUDE.md` Git CLI rule: use `gh` for PR and GitHub operations it supports; use `git` only for local worktree, branch, staging, commit, and push operations where `gh` has no equivalent.
+
+## Linear ID Exception
+
+Only this rule is overridden:
+
+- Do not stop to ask for an `INT-XXX` issue ID.
+- Do not fabricate an `INT-XXX` issue ID.
+- Do not create or update a Linear issue manually.
+- Use a descriptive branch, commit message, PR title, and PR body without `INT-XXX`.
+- Include this PR body note:
+
+```markdown
+Linear: omitted by `$commit-push`; GitHub automation will create or link the Linear issue after PR creation.
+```
+
+This exception does not apply to release finalization, ordinary GitHub workflows, or any other skill.
+
+All other project rules still apply, especially:
+
+- `pnpm run ci:tracked` must pass before commit.
+- Never commit directly to `main` or `development`.
+- Open the PR against `development`.
+- Do not use forbidden ownership language around CI failures.
+- Do not revert user changes unless explicitly requested.
+
+## Workflow
+
+### 1. Inspect Worktree
+
+Run:
+
+```bash
+git status --short
+git diff --stat
+git diff
+```
+
+Identify the intended change set. If there are unrelated or risky changes, stage only the intended files and mention exclusions in the final response.
+
+If there are no changes to commit, stop and report that the worktree has nothing to finalize.
+
+### 2. Ensure Feature Branch
+
+Check the current branch:
+
+```bash
+git branch --show-current
+```
+
+If on `main` or `development`, create a feature branch before committing:
+
+```bash
+BRANCH="codex/<short-change-slug>-$(date +%Y%m%d-%H%M)"
+git switch -c "$BRANCH"
+```
+
+If already on a non-protected branch, keep using it unless the branch name is clearly wrong for the work.
+
+### 3. Run Commit Gate
+
+Run from repo root:
+
+```bash
+pnpm run ci:tracked
+```
+
+If CI fails:
+
+- Capture and inspect the failure.
+- Fix failures that block the accepted work, then rerun `pnpm run ci:tracked`.
+- Do not commit until CI passes.
+- If the failure cannot be resolved without user input or a risky scope change, stop and report the exact blocker.
+
+### 4. Stage And Commit
+
+Stage only intended files:
+
+```bash
+git add <files>
+git status --short
+```
+
+Commit with a concise message and no fake issue ID:
+
+```bash
+git commit -m "<type>: <clear summary>"
+```
+
+Use conventional prefixes when they fit: `feat`, `fix`, `docs`, `chore`, `refactor`.
+
+### 5. Update With Latest Development
+
+Before pushing or opening a PR, update the feature branch with the latest base branch:
+
+```bash
+git fetch origin development
+git rebase origin/development
+```
+
+If the branch is already shared remotely and rebasing would require a force push, merge instead:
+
+```bash
+git merge --no-edit origin/development
+```
+
+Resolve conflicts if needed. After the branch includes the latest `origin/development`, rerun the final commit gate:
+
+```bash
+pnpm run ci:tracked
+```
+
+Do not push or create a PR until this final CI run passes.
+
+### 6. Push And Open PR
+
+Push the feature branch:
+
+```bash
+git push -u origin HEAD
+```
+
+Open the pull request against `development`:
+
+```bash
+cat > /tmp/commit-push-pr-body.md <<'PR_BODY'
+## Summary
+
+- <what changed>
+
+## Verification
+
+- `pnpm run ci:tracked`
+
+## Linear
+
+Linear: omitted by `$commit-push`; GitHub automation will create or link the Linear issue after PR creation.
+PR_BODY
+
+gh pr create --base development --head "$(git branch --show-current)" \
+  --title "<clear PR title without INT-XXX>" \
+  --body-file /tmp/commit-push-pr-body.md
+```
+
+If an open PR already exists for the branch, do not create a duplicate. Use the existing PR and report its URL.
+
+PR body format:
+
+```markdown
+## Summary
+
+- <what changed>
+
+## Verification
+
+- `pnpm run ci:tracked`
+
+## Linear
+
+Linear: omitted by `$commit-push`; GitHub automation will create or link the Linear issue after PR creation.
+```
+
+## Final Response
+
+Report:
+
+- branch name
+- commit SHA
+- PR URL
+- `pnpm run ci:tracked` result
+- any files intentionally left unstaged
+
+Do not commit, push, or open a PR if the user only asked for a plan, review, or explanation.

--- a/.codex/skills/commit-push/agents/openai.yaml
+++ b/.codex/skills/commit-push/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: 'Commit Push'
+  short_description: 'Finalize IntexuraOS changes'
+  default_prompt: 'Use $commit-push to commit changes, push a branch, and open a PR against development without asking for a Linear issue ID.'

--- a/.codex/skills/release/SKILL.md
+++ b/.codex/skills/release/SKILL.md
@@ -18,9 +18,11 @@ $release --collect          # Only collect and triage release data
 
 ## Codex Execution Model
 
-- Run the workflow in the current Codex session with the default model.
-- Do not require slash commands or legacy agent definitions.
-- Former release-agent instructions live in `reference/agent-prompts.md`; execute those prompts in the current session unless the user explicitly asks for Codex subagents.
+- Use subagent-driven execution first whenever Codex subagent tools are available.
+- Before Phase 1, create a short release execution plan and use the `superpowers:subagent-driven-development` pattern: bounded subagent tasks, controller integration, spec/quality review loops for mutating work, and final controller verification.
+- Fall back to current-session execution only when subagent tools are unavailable; report that fallback before continuing.
+- Do not create git worktrees for this repo. `.claude/CLAUDE.md` forbids worktrees, so all release work stays in the active checkout while subagents use their normal forked workspaces.
+- Former release-agent instructions live in `reference/agent-prompts.md`; use them as subagent task prompts by default.
 - Use the existing `$share` skill or the explicit GCS upload commands in the workflow when publishing the prioritizer page.
 - Follow project rules from `.claude/CLAUDE.md` for branch, commit, CI, and PR behavior.
 
@@ -39,7 +41,7 @@ $release --collect          # Only collect and triage release data
 
 1. Feature prioritization happens once in Phase 1 using the interactive prioritizer page.
 2. Notable changes and minor fixes bypass the prioritizer and are automatically included in the changelog unless netted out.
-3. Service documentation runs silently in the current Codex session by default.
+3. Service documentation runs silently through bounded subagent tasks by default.
 4. `pnpm run ci:tracked` must pass before any release commit.
 5. All package versions must stay synchronized across root, apps, packages, and workers.
 6. Finalization must use a feature branch and a PR targeting `development`; do not commit directly to `development` or `main`.
@@ -51,8 +53,9 @@ $release --collect          # Only collect and triage release data
 
 | Phase | Name            | Interaction | Key Actions                                                                                      |
 | ----- | --------------- | ----------- | ------------------------------------------------------------------------------------------------ |
+| 0     | Subagent Plan   | Automatic   | Build the subagent-driven execution plan and choose fallback only if tools are unavailable       |
 | 1     | Kickoff         | User Input  | Analyze semver, create prioritizer page, parse user priorities                                   |
-| 2     | Service Docs    | Silent      | Update service docs for modified services and validate factual accuracy                          |
+| 2     | Service Docs    | Silent      | Update service docs through bounded workers and validate factual accuracy                        |
 | 3     | High-Level Docs | Automatic   | Update `docs/overview.md`, README badges, and `docs/services/index.md`                           |
 | 4     | README          | Automatic   | Generate or update README "What's New" from highlighted release features                         |
 | 5     | Website         | Automatic   | Update homepage version strings and `WhatsNewSection`                                            |
@@ -78,6 +81,7 @@ If any required tool is unavailable, stop and report the failing tool, purpose, 
 - Collection workflow: `workflows/collect-release-data.md`
 - Website audit workflow: `workflows/website-audit.md`
 - Former agent prompts: `reference/agent-prompts.md`
+- Subagent execution: `reference/subagent-execution.md`
 - Semver analysis: `reference/semver-analysis.md`
 - Phase checklist: `reference/phase-checklist.md`
 - Templates: `templates/`

--- a/.codex/skills/release/agents/openai.yaml
+++ b/.codex/skills/release/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: 'Release'
-  short_description: 'Prepare IntexuraOS releases'
-  default_prompt: 'Use $release to prepare an IntexuraOS release with release data triage, docs, changelog, version updates, and GitHub release notes.'
+  short_description: 'Subagent-driven IntexuraOS releases'
+  default_prompt: 'Use $release to prepare an IntexuraOS release with subagent-driven triage, docs, changelog, version updates, and GitHub release notes.'

--- a/.codex/skills/release/reference/agent-prompts.md
+++ b/.codex/skills/release/reference/agent-prompts.md
@@ -1,6 +1,8 @@
 # Agent Prompt Reference
 
-These prompts replace the old release-specific external agent definitions. Execute them in the current Codex session with the default model unless the user explicitly requests delegated or parallel agent work.
+These prompts replace the old release-specific external agent definitions. Use them as Codex subagent task prompts by default, following `reference/subagent-execution.md`.
+
+When subagent tools are unavailable, execute the same prompts in the current session with the default model.
 
 ---
 

--- a/.codex/skills/release/reference/phase-checklist.md
+++ b/.codex/skills/release/reference/phase-checklist.md
@@ -4,6 +4,15 @@ Use this as the quick release checklist for `$release`.
 
 ---
 
+## Phase 0: Subagent Plan
+
+- [ ] Verify whether Codex subagent tools are available
+- [ ] Read `reference/subagent-execution.md`
+- [ ] Create a short subagent-driven release execution plan or report current-session fallback
+- [ ] Confirm no git worktree will be created
+
+---
+
 ## Phase 1: Kickoff
 
 - [ ] Verify tools: `git`, `gh`, `node`, `jq`, `gsutil`
@@ -30,15 +39,15 @@ gh pr list --state merged --base development --json number,title,body,mergedAt,a
 
 - [ ] Skip if `--skip-docs`
 - [ ] Build a release context block for each modified service
-- [ ] Execute `Service Scribe` from `reference/agent-prompts.md` in the current Codex session
-- [ ] Execute `Doc Validator` from `reference/agent-prompts.md` for each updated service
+- [ ] Dispatch one `Service Scribe` worker per modified service with bounded `docs/services/<service>/` write scope
+- [ ] Dispatch `Doc Validator` explorer for each updated service
 - [ ] Log coverage and contradiction findings
 
 ---
 
 ## Phase 3: High-Level Docs
 
-- [ ] Execute `Docs Updater` from `reference/agent-prompts.md`
+- [ ] Dispatch `Docs Updater` worker from `reference/agent-prompts.md`
 - [ ] Update `docs/overview.md` only for grounded high-priority capabilities
 - [ ] Verify README badges
 - [ ] Verify `docs/services/index.md` lists real services only
@@ -74,6 +83,7 @@ gh pr list --state merged --base development --json number,title,body,mergedAt,a
 - [ ] Run `pnpm run ci:tracked` and fix all failures
 - [ ] Refresh RAG embeddings unless `--skip-docs`
 - [ ] Run pre-commit release validation
+- [ ] Dispatch final `xhigh` release auditor and fix critical findings
 - [ ] Confirm a real `INT-XXX` exists, or get explicit user permission to proceed without one before branch or PR creation
 - [ ] Commit on feature branch
 - [ ] Push feature branch

--- a/.codex/skills/release/reference/subagent-execution.md
+++ b/.codex/skills/release/reference/subagent-execution.md
@@ -1,0 +1,66 @@
+# Subagent Execution Reference
+
+Use this reference when running `$release` with Codex subagent tools available.
+
+## Default Routing
+
+1. The controller reads the release workflow, builds a short execution plan, and keeps ownership of release state.
+2. The controller dispatches bounded subagent tasks for collection triage, service docs, validation, high-level docs, README, website, CI fixes, and final audit.
+3. The controller integrates subagent results, performs irreversible operations, and verifies the release.
+4. If subagent tools are unavailable, execute the same workflow in the current session and report the fallback.
+
+Do not create git worktrees. This repo forbids worktrees in `.claude/CLAUDE.md`.
+
+## Controller-Owned Work
+
+The controller must not delegate:
+
+- user prioritizer generation, publishing, and export parsing
+- final semver decision and changelog synthesis
+- package version sync and lockfile refresh
+- `pnpm run ci:tracked` gate ownership
+- commit, push, PR creation, tag creation, GitHub Release creation
+- post-release validation and release summary
+
+Subagents may investigate, edit bounded files, validate, or fix bounded failures, but the controller remains accountable for final release correctness.
+
+## Reasoning Effort
+
+Use the inherited model by default. Set only `reasoning_effort`.
+
+| Release Role          | Codex Agent Type | Effort                                           |
+| --------------------- | ---------------- | ------------------------------------------------ |
+| Commit Grouper        | `explorer`       | `medium`                                         |
+| Change Classifier     | `explorer`       | `high`                                           |
+| Netting Detector      | `explorer`       | `xhigh`                                          |
+| Summary Writer        | `explorer`       | `high`                                           |
+| Service Scribe        | `worker`         | `medium`, or `high` for broad/new services       |
+| Doc Validator         | `explorer`       | `high`                                           |
+| Docs Updater          | `worker`         | `high`                                           |
+| README Writer         | `worker`         | `high`                                           |
+| Website Worker        | `worker`         | `high`                                           |
+| CI Failure Fixer      | `worker`         | `high`, escalate to `xhigh` after repeat failure |
+| Final Release Auditor | `explorer`       | `xhigh`                                          |
+
+`xhigh` is the Codex tool value for extra-high reasoning effort.
+
+## Delegation Rules
+
+- Give every subagent the exact prompt section from `reference/agent-prompts.md` or a complete release-specific task.
+- Include release context, required input sections, allowed write scope, required output format, and files it may not touch.
+- Tell workers they are not alone in the codebase, must not revert other edits, and must list changed files.
+- Run mutating workers sequentially unless their write scopes are disjoint.
+- Read-only explorer audits may run in parallel when they answer independent questions.
+- Do not ask subagents to commit, push, create PRs, tag, create GitHub Releases, or change versions across the monorepo.
+
+## Review Pattern
+
+For mutating subagent work:
+
+1. Worker completes the bounded task and reports changed files.
+2. Controller reviews the diff and runs the relevant local check.
+3. Dispatch a spec-compliance review for non-trivial edits.
+4. Dispatch a quality/factual review when the edit changes docs, README, website, or release artifacts.
+5. Send fixes back to the same worker until the review passes or the controller takes ownership of the blocker.
+
+For release triage prompts, the controller appends approved generated markdown to `.prerelease-data.md`. Triage subagents return markdown only.

--- a/.codex/skills/release/templates/release-summary.md
+++ b/.codex/skills/release/templates/release-summary.md
@@ -30,6 +30,14 @@ Use this template to display the final summary after Phase 6 completes.
 | bookmarks-agent | Updated |
 | research-agent  | Skipped |
 
+## Subagent Execution
+
+| Area                | Mode              | Effort            |
+| ------------------- | ----------------- | ----------------- |
+| Release triage      | Sequential agents | medium/high/xhigh |
+| Service docs        | Service workers   | medium/high       |
+| Final release audit | Explorer          | xhigh             |
+
 ## Files Changed
 
 ### Documentation
@@ -110,7 +118,7 @@ Release complete.
 
 | Status    | Meaning                                      |
 | --------- | -------------------------------------------- |
-| Updated   | Service docs updated successfully            |
+| Updated   | Service docs worker completed successfully   |
 | Skipped   | Service not modified in this release         |
 | Failed    | Service docs update encountered an error     |
 

--- a/.codex/skills/release/templates/website-suggestions.md
+++ b/.codex/skills/release/templates/website-suggestions.md
@@ -96,4 +96,4 @@ Phase 5 auto-implements website improvements from High-priority features without
 2. **Update hero statistics** if service/model counts changed
 3. **For major releases:** Create VersionHistorySection using marketing slogan from Phase 1
 
-All improvements are implemented directly in the current Codex session using the existing React, Tailwind, motion, and icon patterns in `apps/web/src/pages/HomePage.tsx`.
+All improvements are implemented by the Phase 5 website worker using the existing React, Tailwind, motion, and icon patterns in `apps/web/src/pages/HomePage.tsx`.

--- a/.codex/skills/release/workflows/collect-release-data.md
+++ b/.codex/skills/release/workflows/collect-release-data.md
@@ -2,7 +2,7 @@
 
 **Trigger:** User calls `$release --collect`.
 
-Run deterministic data collection, then enrich `.prerelease-data.md` by executing the four triage prompts from `reference/agent-prompts.md` in the current Codex session.
+Run deterministic data collection, then enrich `.prerelease-data.md` through four sequential subagent triage steps. Use current-session execution only when Codex subagent tools are unavailable.
 
 ---
 
@@ -38,16 +38,17 @@ After the script completes, read `.prerelease-data.md` and count commits. If few
 
 ---
 
-## Current-Session Triage Pattern
+## Subagent Triage Pattern
 
 Each triage step follows the same pattern:
 
 1. Read the required sections from `.prerelease-data.md`.
 2. Read the named prompt in `reference/agent-prompts.md`.
-3. Execute the prompt in the current Codex session using the default model.
-4. Append exactly the generated markdown section to `.prerelease-data.md`.
+3. Dispatch an `explorer` subagent with the required input, exact prompt section, required output heading, and `reasoning_effort` from the step below.
+4. Review the returned markdown for shape and obvious omissions.
+5. Append exactly the approved generated markdown section to `.prerelease-data.md`.
 
-Do not use external agent names by default. Use Codex subagents only if the user explicitly asks for delegated or parallel agent work.
+These steps are sequential because each step consumes prior generated output. If subagent tools are unavailable, report the fallback and execute the same prompts in the current session with the default model.
 
 ---
 
@@ -59,6 +60,8 @@ Input: `## Commits` from `.prerelease-data.md`.
 
 Output to append: `## Commit Analysis`.
 
+Agent: `explorer`, `reasoning_effort: medium`.
+
 ---
 
 ## Step 2: Change Classifier
@@ -68,6 +71,8 @@ Prompt section: `## Change Classifier` in `reference/agent-prompts.md`.
 Input: `## Pull Requests` and `## Commit Analysis` from `.prerelease-data.md`.
 
 Output to append: `## Change Groups`.
+
+Agent: `explorer`, `reasoning_effort: high`.
 
 ---
 
@@ -79,6 +84,8 @@ Input: `## Change Groups` and `## Pull Requests` from `.prerelease-data.md`.
 
 Output to append: `## Netting Analysis`.
 
+Agent: `explorer`, `reasoning_effort: xhigh`.
+
 ---
 
 ## Step 4: Summary Writer
@@ -88,6 +95,8 @@ Prompt section: `## Summary Writer` in `reference/agent-prompts.md`.
 Input: `## Change Groups` and `## Netting Analysis` from `.prerelease-data.md`.
 
 Output to append: `## Triage Summary`.
+
+Agent: `explorer`, `reasoning_effort: high`.
 
 ---
 

--- a/.codex/skills/release/workflows/full-release.md
+++ b/.codex/skills/release/workflows/full-release.md
@@ -2,7 +2,29 @@
 
 **Trigger:** User calls `$release`, `$release --skip-docs`, or `$release --phase N`.
 
-Run this workflow in the current Codex session using the default model. Use Codex subagents only if the user explicitly asks for delegated or parallel agent work.
+Run this workflow with subagent-driven execution first. Use `reference/subagent-execution.md` before Phase 1. Fall back to current-session execution only when Codex subagent tools are unavailable.
+
+---
+
+## Phase 0: Subagent-Driven Release Plan
+
+Before release operations:
+
+1. Verify whether Codex subagent tools are available.
+2. Read `reference/subagent-execution.md`.
+3. Create a short release execution plan using the `superpowers:subagent-driven-development` pattern.
+4. Keep controller-owned work in the controller session.
+5. Identify bounded subagent tasks and reasoning efforts for this release.
+
+Do not create git worktrees. This repo forbids worktrees in `.claude/CLAUDE.md`.
+
+If subagent tools are unavailable, report:
+
+```text
+Subagent tools are unavailable; falling back to current-session release execution.
+```
+
+Then execute all referenced prompts in the current session with the default model.
 
 ---
 
@@ -86,6 +108,15 @@ Use `reference/semver-analysis.md`:
 
 Do not build the changelog until prioritization is parsed.
 
+For larger releases or fresh `.prerelease-data.md` generation, delegate triage using `reference/subagent-execution.md`:
+
+- `Commit Grouper`: explorer, `reasoning_effort: medium`
+- `Change Classifier`: explorer, `reasoning_effort: high`
+- `Netting Detector`: explorer, `reasoning_effort: xhigh`
+- `Summary Writer`: explorer, `reasoning_effort: high`
+
+These triage tasks are sequential because each step consumes the prior output. The controller appends approved generated sections to `.prerelease-data.md`.
+
 ### 1.7 Single Prioritization Touchpoint
 
 Only features are shown in the prioritizer. Notable changes and minor fixes are automatically included in the changelog.
@@ -157,7 +188,7 @@ For each service in `MODIFIED_SERVICES`, build a release context from Phase 1:
 
 Omit skip-priority features and minor fixes.
 
-For each service, execute `reference/agent-prompts.md` section `## Service Scribe` in the current Codex session with:
+For each service, dispatch a `worker` subagent using `reference/agent-prompts.md` section `## Service Scribe` with `reasoning_effort: medium`; use `high` for broad changes or newly added services:
 
 ```text
 Generate documentation for <service-name>.
@@ -165,13 +196,15 @@ Generate documentation for <service-name>.
 <release-context-block>
 ```
 
-After each service update, execute `## Doc Validator` from `reference/agent-prompts.md` against that service. Log validation summaries. Do not block the release solely on missing coverage unless the validator finds critical hallucinations or active contradictions.
+Give each service-doc worker a disjoint write scope under `docs/services/<service>/`. Tell the worker not to edit changelog, package versions, release notes, README, website, or git state.
+
+After each service update, dispatch an `explorer` subagent using `## Doc Validator` from `reference/agent-prompts.md` with `reasoning_effort: high`. Log validation summaries. Do not block the release solely on missing coverage unless the validator finds critical hallucinations or active contradictions.
 
 ---
 
 ## Phase 3: High-Level Docs
 
-Execute `reference/agent-prompts.md` section `## Docs Updater` in the current Codex session with:
+Dispatch a `worker` subagent using `reference/agent-prompts.md` section `## Docs Updater` with `reasoning_effort: high`:
 
 ```text
 Version: vX.Y.Z
@@ -187,13 +220,15 @@ The prompt updates `docs/overview.md`, verifies README badges, and checks `docs/
 
 Skip edits if no high-priority features affect high-level docs.
 
+Write scope: `docs/overview.md`, README badges only, and `docs/services/index.md`. Do not edit changelog, package versions, release notes, website, or git state.
+
 ---
 
 ## Phase 4: README Update
 
 Read `README.md` and `templates/readme-whats-new.md`.
 
-Generate the README "What's New" section from highlighted or high-priority feature items:
+Dispatch a `worker` subagent with `reasoning_effort: high` to generate the README "What's New" section from highlighted or high-priority feature items:
 
 - use user comments first
 - fall back to triage summaries
@@ -202,6 +237,8 @@ Generate the README "What's New" section from highlighted or high-priority featu
 
 For patch and minor releases, append new tiles to the current major-version section and update its version header. For major releases, create a new section and move prior major-version highlights into history.
 
+Write scope: `README.md` only. The controller reviews the diff before Phase 5.
+
 ---
 
 ## Phase 5: Website Improvements
@@ -209,6 +246,8 @@ For patch and minor releases, append new tiles to the current major-version sect
 Target file: `apps/web/src/pages/HomePage.tsx`.
 
 Skip only when there are zero high-priority features.
+
+Dispatch a `worker` subagent with `reasoning_effort: high`. Write scope: `apps/web/src/pages/HomePage.tsx` only.
 
 Required changes:
 
@@ -220,6 +259,8 @@ Required changes:
 - for major releases, add version history using the marketing slogan when provided
 
 Use existing React, Tailwind, motion, and `lucide-react` patterns in the file.
+
+After the website worker returns, the controller reviews the diff and verifies that website and README content do not present migrations, refactors, or moved functionality as new features.
 
 ---
 
@@ -280,6 +321,8 @@ pnpm run ci:tracked
 
 This must pass completely before committing. If it fails, fix every failure and rerun.
 
+The controller owns the CI gate. For bounded CI failures, dispatch a `worker` subagent with `reasoning_effort: high`; escalate to `xhigh` after repeated failure. Give the worker the failing output and a narrow write scope. The controller reruns `pnpm run ci:tracked`.
+
 ### 6.5 Refresh RAG Embeddings
 
 Skip when `--skip-docs` is used.
@@ -306,6 +349,8 @@ Verify before staging:
 - modified service docs contain recent changes when Phase 2 ran
 - website and README do not present migrations or refactors as new features
 - documented endpoints and version numbers are grounded in code or tags
+
+Before committing, dispatch a final `explorer` subagent with `reasoning_effort: xhigh` as Final Release Auditor. It must check the planned release artifacts against `reference/subagent-execution.md`, this workflow, and `.claude/CLAUDE.md`. Fix all critical findings before staging.
 
 ### 6.7 Commit and PR to Development
 


### PR DESCRIPTION
## Summary

- Add the IntexuraOS `$commit-push` skill for committing, pushing, and opening PRs without requiring a manual Linear ID.
- Update the `$release` skill to prefer bounded Codex subagent execution, with fallback guidance and release audit routing.

## Verification

- `pnpm run ci:tracked`
- `pnpm verify:migrations`

## Linear

Linear: omitted by `$commit-push`; GitHub automation will create or link the Linear issue after PR creation.