### PR TITLE
[INT-1665] Fix code task documentation review dispatch

### DIFF
--- a/apps/code-agent/src/domain/constants/reviewTypes.ts
+++ b/apps/code-agent/src/domain/constants/reviewTypes.ts
@@ -1,23 +1,10 @@
-/**
- * Review type constants — single source of truth.
- *
- * ALL_REVIEW_TYPES: the complete set used by validation and event storage.
- * LLM_TOOL_REVIEW_TYPES: the subset exposed to the LLM tool enum.
- *
- * plan_review is excluded from the LLM tool enum because plan-only PRs
- * are handled separately from LLM triage.
- */
+import {
+  CODE_TASK_REVIEW_TYPES,
+  LLM_TRIAGE_REVIEW_TYPES,
+  type CodeTaskReviewType,
+} from '@intexuraos/code-task-domain';
 
-export const ALL_REVIEW_TYPES = [
-  'code_quality',
-  'security',
-  'architecture',
-  'plan_review',
-  'test_quality',
-  'documentation',
-] as const;
-export type ReviewType = (typeof ALL_REVIEW_TYPES)[number];
+export const ALL_REVIEW_TYPES = CODE_TASK_REVIEW_TYPES;
+export type ReviewType = CodeTaskReviewType;
 
-export const LLM_TOOL_REVIEW_TYPES = ALL_REVIEW_TYPES.filter(
-  (t): t is Exclude<ReviewType, 'plan_review'> => t !== 'plan_review',
-);
+export const LLM_TOOL_REVIEW_TYPES = LLM_TRIAGE_REVIEW_TYPES;

--- a/packages/code-task-domain/package.json
+++ b/packages/code-task-domain/package.json
@@ -9,6 +9,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./worker-types": "./src/codeTaskWorkerTypes.ts",
+    "./review-types": "./src/codeTaskReviewTypes.ts",
     "./timeout": "./src/codeTaskTimeout.ts"
   },
   "scripts": {

--- a/packages/code-task-domain/src/__tests__/codeTaskReviewTypes.test.ts
+++ b/packages/code-task-domain/src/__tests__/codeTaskReviewTypes.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+const EXPECTED_CODE_TASK_REVIEW_TYPES = [
+  'code_quality',
+  'security',
+  'architecture',
+  'plan_review',
+  'test_quality',
+  'documentation',
+];
+
+describe('code task review types', () => {
+  it('exports the canonical review type list from the package root', async () => {
+    const codeTaskDomain = (await import('../index.js')) as Record<string, unknown>;
+
+    expect(codeTaskDomain['CODE_TASK_REVIEW_TYPES']).toEqual(EXPECTED_CODE_TASK_REVIEW_TYPES);
+  });
+
+  it('exports LLM triage review types without plan_review', async () => {
+    const codeTaskDomain = (await import('../index.js')) as Record<string, unknown>;
+
+    expect(codeTaskDomain['LLM_TRIAGE_REVIEW_TYPES']).toEqual([
+      'code_quality',
+      'security',
+      'architecture',
+      'test_quality',
+      'documentation',
+    ]);
+  });
+
+  it('exports a runtime review type guard that recognizes documentation', async () => {
+    const codeTaskDomain = (await import('../index.js')) as Record<string, unknown>;
+    const guard = codeTaskDomain['isCodeTaskReviewType'];
+
+    expect(typeof guard).toBe('function');
+
+    if (typeof guard !== 'function') {
+      return;
+    }
+
+    for (const reviewType of EXPECTED_CODE_TASK_REVIEW_TYPES) {
+      expect(guard(reviewType)).toBe(true);
+    }
+
+    expect(guard('requirements')).toBe(false);
+  });
+});

--- a/packages/code-task-domain/src/codeTaskReviewTypes.ts
+++ b/packages/code-task-domain/src/codeTaskReviewTypes.ts
@@ -1,0 +1,21 @@
+export const CODE_TASK_REVIEW_TYPES = [
+  'code_quality',
+  'security',
+  'architecture',
+  'plan_review',
+  'test_quality',
+  'documentation',
+] as const;
+
+export type CodeTaskReviewType = (typeof CODE_TASK_REVIEW_TYPES)[number];
+export type LlmTriageReviewType = Exclude<CodeTaskReviewType, 'plan_review'>;
+
+const CODE_TASK_REVIEW_TYPE_SET = new Set<string>(CODE_TASK_REVIEW_TYPES);
+
+export function isCodeTaskReviewType(value: string): value is CodeTaskReviewType {
+  return CODE_TASK_REVIEW_TYPE_SET.has(value);
+}
+
+export const LLM_TRIAGE_REVIEW_TYPES = CODE_TASK_REVIEW_TYPES.filter(
+  (reviewType): reviewType is LlmTriageReviewType => reviewType !== 'plan_review'
+);

--- a/packages/code-task-domain/src/index.ts
+++ b/packages/code-task-domain/src/index.ts
@@ -8,6 +8,13 @@ export {
   type CodeTaskWorkerType,
 } from './codeTaskWorkerTypes.js';
 export {
+  CODE_TASK_REVIEW_TYPES,
+  LLM_TRIAGE_REVIEW_TYPES,
+  isCodeTaskReviewType,
+  type CodeTaskReviewType,
+  type LlmTriageReviewType,
+} from './codeTaskReviewTypes.js';
+export {
   resolvePlanDocumentPathFromLinearContext,
   type PlanResolutionContext,
 } from './planPathResolver.js';

--- a/workers/orchestrator/src/__tests__/create-task-request-schema.test.ts
+++ b/workers/orchestrator/src/__tests__/create-task-request-schema.test.ts
@@ -97,6 +97,31 @@ describe('CreateTaskRequestSchema — retriedFrom', () => {
   });
 });
 
+describe('CreateTaskRequestSchema — reviewTypes', () => {
+  const baseRequest = {
+    taskId: 'task_00000000-0000-0000-0000-0000000000c1',
+    workerType: 'mimo-pro',
+    prompt: 'Review PR documentation and code quality',
+    webhookUrl: 'https://intexuraos.cloud/api/code/internal/task-hook',
+    webhookSecret: 'sec',
+    linearIssueLabels: [],
+    hasChildren: false,
+    agentType: 'review',
+  } as const;
+
+  it('accepts documentation review type from code-agent review dispatch', () => {
+    const result = CreateTaskRequestSchema.safeParse({
+      ...baseRequest,
+      reviewTypes: ['documentation', 'architecture', 'code_quality'],
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.reviewTypes).toEqual(['documentation', 'architecture', 'code_quality']);
+    }
+  });
+});
+
 describe('CreateTaskRequestSchema — timeoutHours (INT-1585)', () => {
   const baseRequest = {
     taskId: 'task_00000000-0000-0000-0000-0000000000b1',

--- a/workers/orchestrator/src/__tests__/routes.test.ts
+++ b/workers/orchestrator/src/__tests__/routes.test.ts
@@ -545,6 +545,26 @@ describe('Routes', () => {
       );
     });
 
+    it('forwards documentation reviewTypes to dispatcher.submitTask', async () => {
+      const payload = {
+        taskId: 'task_00000000-0000-0000-0000-00000000d0c5',
+        workerType: 'mimo-pro',
+        prompt: 'Review documentation changes',
+        webhookUrl: 'https://intexuraos.cloud/api/code/internal/task-hook',
+        webhookSecret: 'sec',
+        linearIssueLabels: [],
+        hasChildren: false,
+        agentType: 'review',
+        reviewTypes: ['documentation'],
+      };
+      const { headers, body } = createSignedRequest(payload);
+      const response = await app.inject({ method: 'POST', url: '/tasks', headers, body });
+      expect(response.statusCode).toBe(202);
+      expect(dispatcher.submitTask).toHaveBeenCalledWith(
+        expect.objectContaining({ reviewTypes: ['documentation'] })
+      );
+    });
+
     it('forwards retriedFrom to dispatcher.submitTask', async () => {
       const payload = {
         taskId: 'task_00000000-0000-0000-0000-0000000000f1',

--- a/workers/orchestrator/src/types/schemas.ts
+++ b/workers/orchestrator/src/types/schemas.ts
@@ -1,4 +1,5 @@
 import {
+  CODE_TASK_REVIEW_TYPES,
   CODE_TASK_WORKER_TYPES,
   MIN_TIMEOUT_HOURS,
   MAX_TIMEOUT_HOURS,
@@ -81,9 +82,7 @@ export const CreateTaskRequestSchema = z.object({
   prNumber: z.number().int().positive().optional(),
   continuationPrNumber: z.number().int().positive().optional(),
   continuationPrBranch: z.string().min(1).optional(),
-  reviewTypes: z
-    .array(z.enum(['code_quality', 'security', 'architecture', 'plan_review', 'test_quality']))
-    .optional(),
+  reviewTypes: z.array(z.enum(CODE_TASK_REVIEW_TYPES)).optional(),
   /**
    * Optional per-task timeout in hours (1–12). When omitted, the orchestrator
    * applies its 5h default. INT-1585.


### PR DESCRIPTION
## Summary

- Share code-task review types from @intexuraos/code-task-domain
- Allow orchestrator /tasks requests to accept documentation review dispatches
- Add regression coverage for shared review types, schema validation, and route forwarding

## Verification

- `pnpm run ci:tracked`

## Linear

Linear: omitted by `$commit-push`; GitHub automation will create or link the Linear issue after PR creation.