### PR TITLE
[INT-1666] Tighten Artifact Registry retention

### DIFF
--- a/docs/operations/artifact-registry-cleanup.md
+++ b/docs/operations/artifact-registry-cleanup.md
@@ -57,7 +57,7 @@ node scripts/artifact-registry/generate-prune-plan.mjs \
   --project=intexuraos-dev-pbuchman \
   --location=europe-central2 \
   --repository=intexuraos-dev \
-  --keep-count=3 \
+  --keep-count=1 \
   --protected=/tmp/artifact-registry/live-$(date +%F)/protected-digests.json \
   --retired-packages=claude-worker,commands-router,data-insights-service,llm-orchestrator,llm-orchestrator-service \
   --out-dir=/tmp/artifact-registry/plan-$(date +%F)
@@ -141,12 +141,12 @@ terraform plan
 
 The intended steady state is:
 
-- active cleanup policy after live digests are verified inside the newest-3 window
-- global keep count of `3`
-- general delete policy for images older than `86400s` (1 day)
+- active cleanup policy after live digests are verified inside the newest-1 window
+- global keep count of `1`
+- general delete policy for images older than `259200s` (3 days)
 - `code-worker` delete policy for images older than `86400s` (1 day)
 
-If the exported prune plan shows no package with more than `3` retained digests, the live runtimes are already inside the retained window and the policy can be applied immediately.
+If the exported prune plan shows no package with more than `1` retained digest, the live runtimes are already inside the retained window and the policy can be applied immediately.
 
 ## Verification
 

--- a/scripts/__tests__/artifact-registry-config.test.ts
+++ b/scripts/__tests__/artifact-registry-config.test.ts
@@ -45,8 +45,8 @@ describe('artifact registry prevention config', () => {
     expect(moduleVariables).toContain('variable "code_worker_cleanup_delete_older_than"');
 
     expect(environmentMain).toMatch(/cleanup_policy_dry_run\s*=\s*false/);
-    expect(environmentMain).toMatch(/cleanup_keep_count\s*=\s*3/);
-    expect(environmentMain).toMatch(/cleanup_delete_older_than\s*=\s*"86400s"/);
+    expect(environmentMain).toMatch(/cleanup_keep_count\s*=\s*1/);
+    expect(environmentMain).toMatch(/cleanup_delete_older_than\s*=\s*"259200s"/);
     expect(environmentMain).toMatch(/code_worker_cleanup_delete_older_than\s*=\s*"86400s"/);
   });
 });

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -386,8 +386,8 @@ module "artifact_registry" {
   environment                           = var.environment
   labels                                = local.common_labels
   cleanup_policy_dry_run                = false
-  cleanup_keep_count                    = 3
-  cleanup_delete_older_than             = "86400s"
+  cleanup_keep_count                    = 1
+  cleanup_delete_older_than             = "259200s"
   code_worker_cleanup_delete_older_than = "86400s"
 
   depends_on = [google_project_service.apis]


### PR DESCRIPTION
## Summary

- Tighten Artifact Registry retention to keep one version per package.
- Extend general image cleanup to three days while preserving one-day code-worker cleanup.
- Update the cleanup runbook and regression test for the new policy.

## Verification

- `pnpm run ci:tracked`

## Linear

Linear: omitted by `$commit-push`; GitHub automation will create or link the Linear issue after PR creation.
