### PR TITLE
INT-1668 Fix orchestrator completion when Docker hangs

### DIFF
--- a/workers/orchestrator/src/__tests__/task-dispatcher.test.ts
+++ b/workers/orchestrator/src/__tests__/task-dispatcher.test.ts
@@ -9666,6 +9666,7 @@ describe('TaskDispatcher', () => {
       const task = state.tasks['msg-completed-task'];
       if (!task) throw new Error('Task not found');
       task.status = 'completed';
+      task.runtimeSessionId = 'aaaaaaaa-0000-4000-a000-000000000000';
       await statePersistence.save(state);
 
       const result = await dispatcher.sendMessage('msg-completed-task', 'Follow-up');
@@ -9698,6 +9699,7 @@ describe('TaskDispatcher', () => {
       const task = state.tasks['msg-failed-task'];
       if (!task) throw new Error('Task not found');
       task.status = 'failed';
+      task.runtimeSessionId = 'aaaaaaaa-0000-4000-a000-000000000001';
       await statePersistence.save(state);
 
       const result = await dispatcher.sendMessage('msg-failed-task', 'Retry please');
@@ -10887,7 +10889,7 @@ describe('TaskDispatcher', () => {
       vi.mocked(mockIsolationProvider.isWorkerRunning).mockResolvedValue(false);
     });
 
-    it('proceeds with inactivity restart when destroyWorker hangs indefinitely', async () => {
+    it('finalizes failure instead of restarting when destroyWorker hangs indefinitely', async () => {
       vi.useFakeTimers();
       vi.mocked(mockIsolationProvider.isWorkerRunning).mockResolvedValue(true);
       vi.mocked(mockIsolationProvider.destroyWorker).mockImplementationOnce(
@@ -10904,9 +10906,17 @@ describe('TaskDispatcher', () => {
         'Failed to destroy worker for inactivity restart'
       );
       const task = await dispatcher.getTask('destroy-hang-test');
-      expect(task?.inactivityRestartCount).toBe(1);
+      expect(task?.status).toBe('failed');
+      expect(mockStatusUpdateClient.commit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          taskId: 'destroy-hang-test',
+          status: 'failed',
+          error: expect.objectContaining({ code: 'TASK_INACTIVITY_RESTART_FAILED' }),
+        })
+      );
 
       warnSpy.mockRestore();
+      vi.mocked(mockIsolationProvider.destroyWorker).mockImplementation(async () => undefined);
       vi.useRealTimers();
       vi.mocked(mockIsolationProvider.isWorkerRunning).mockResolvedValue(false);
     });

--- a/workers/orchestrator/src/services/task-dispatcher/__tests__/attempt-lifecycle.test.ts
+++ b/workers/orchestrator/src/services/task-dispatcher/__tests__/attempt-lifecycle.test.ts
@@ -53,6 +53,29 @@ describe('AttemptLifecycle', () => {
       // After it resolves the flag must be cleared.
       expect(harness.ctx.inactivityRestartInProgress.has('task-1')).toBe(false);
     });
+
+    it('finalizes failure instead of resuming when destroyWorker fails', async () => {
+      const task = makeTask({ runtimeSessionId: 'session-1' });
+      harness.tasks.set(task.taskId, task);
+      harness.destroyWorker.mockRejectedValueOnce(new Error('docker stuck'));
+
+      await al.doHandleInactivityRestart(task.taskId);
+
+      expect(harness.ctx.startWorkerAttempt).not.toHaveBeenCalled();
+      expect(harness.ctx.finalizeTask).toHaveBeenCalledWith(
+        task,
+        'failed',
+        expect.objectContaining({
+          error: expect.objectContaining({
+            code: 'TASK_INACTIVITY_RESTART_FAILED',
+          }),
+        })
+      );
+      expect(harness.appendOrchestratorTaskLog).not.toHaveBeenCalledWith(
+        task.taskId,
+        'Worker destroyed for inactivity restart'
+      );
+    });
   });
 
   describe('executeTaskSetup', () => {

--- a/workers/orchestrator/src/services/task-dispatcher/__tests__/completion-pipeline.test.ts
+++ b/workers/orchestrator/src/services/task-dispatcher/__tests__/completion-pipeline.test.ts
@@ -173,5 +173,35 @@ describe('CompletionPipeline', () => {
       expect(harness.runningCount.value).toBe(0);
       expect(harness.webhookSend).toHaveBeenCalled();
     });
+
+    it('persists and sends terminal status even when Docker cleanup hangs', async () => {
+      vi.useFakeTimers();
+      harness.runningCount.value = 1;
+      const task = makeTask({ taskId: 'final-cleanup-hangs' });
+      harness.tasks.set(task.taskId, task);
+      const commit = vi.fn().mockResolvedValue({ ok: true, value: undefined });
+      (harness.ctx.statusUpdateClient as unknown as { commit: typeof commit }).commit = commit;
+      harness.destroyWorker.mockImplementationOnce(() => new Promise<void>(() => undefined));
+
+      const finalizePromise = cp.finalizeTask(task, 'completed', {
+        result: { branch: 'b', commits: 1, summary: 'done' },
+      });
+      void finalizePromise.catch(() => undefined);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(task.status).toBe('completed');
+      expect(harness.saveTask).toHaveBeenCalledWith(task);
+      expect(commit).toHaveBeenCalledWith(expect.objectContaining({ taskId: task.taskId }));
+      await Promise.resolve();
+      await Promise.resolve();
+      const terminalWebhookCall = harness.webhookSend.mock.calls.find((call) => {
+        const input = call[0] as { payload?: { status?: string; taskId?: string } } | undefined;
+        return input?.payload?.taskId === task.taskId && input.payload.status === 'completed';
+      });
+      expect(terminalWebhookCall).toBeDefined();
+      await vi.advanceTimersByTimeAsync(31_000);
+      vi.useRealTimers();
+    });
   });
 });

--- a/workers/orchestrator/src/services/task-dispatcher/__tests__/task-runner.test.ts
+++ b/workers/orchestrator/src/services/task-dispatcher/__tests__/task-runner.test.ts
@@ -31,6 +31,27 @@ describe('TaskRunner', () => {
       expect(harness.ctx.lastOutputAt.has('task-1')).toBe(true);
     });
 
+    it('stops activity timeout when worker attempt completes', async () => {
+      const task = makeTask();
+
+      await runner.startWorkerAttempt(task, {
+        prompt: 'do thing',
+        continueSession: false,
+      });
+      const workerConfig = harness.createWorker.mock.calls[0]?.[0] as
+        | { onComplete?: (exitCode: number) => void }
+        | undefined;
+      if (workerConfig?.onComplete === undefined) {
+        throw new Error('createWorker did not receive onComplete');
+      }
+
+      workerConfig.onComplete(0);
+
+      expect(harness.ctx.taskExitCodes.get('task-1')).toBe(0);
+      expect(harness.ctx.attemptCompletionSignals.has('task-1')).toBe(true);
+      expect(harness.activityTimeoutManager.stop).toHaveBeenCalledWith('task-1');
+    });
+
     it('error path: returns ok:false on createWorker failure and logs the failure', async () => {
       const task = makeTask();
       harness.createWorker.mockRejectedValueOnce(new Error('docker exploded'));

--- a/workers/orchestrator/src/services/task-dispatcher/__tests__/task-timers.test.ts
+++ b/workers/orchestrator/src/services/task-dispatcher/__tests__/task-timers.test.ts
@@ -166,6 +166,38 @@ describe('TaskTimers', () => {
       expect(harness.handleTaskCompletion).toHaveBeenCalledTimes(1);
     });
 
+    it('finalizes from attempt completion signal without waiting for Docker liveness', async () => {
+      harness.ctx.attemptCompletionSignals.add('task-1');
+      harness.isWorkerRunning.mockImplementationOnce(() => new Promise<boolean>(() => undefined));
+
+      timers.startCompletionMonitoring('task-1');
+
+      await vi.advanceTimersByTimeAsync(COMPLETION_CHECK_INTERVAL_MS);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(harness.isWorkerRunning).not.toHaveBeenCalled();
+      expect(harness.handleTaskCompletion).toHaveBeenCalledTimes(1);
+    });
+
+    it('bounds Docker liveness checks when no attempt completion signal exists', async () => {
+      harness.isWorkerRunning.mockImplementationOnce(() => new Promise<boolean>(() => undefined));
+
+      timers.startCompletionMonitoring('task-1');
+
+      await vi.advanceTimersByTimeAsync(COMPLETION_CHECK_INTERVAL_MS);
+      await vi.advanceTimersByTimeAsync(31_000);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(harness.handleTaskCompletion).not.toHaveBeenCalled();
+      expect(harness.ctx.completionInProgress.has('task-1')).toBe(false);
+      expect(harness.logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ taskId: 'task-1' }),
+        'Docker liveness check timed out; treating worker as still running'
+      );
+    });
+
     it('clears its own timer when the task is no longer running', async () => {
       const completedTask = makeTask({ status: 'completed' });
       harness.tasks.set(completedTask.taskId, completedTask);

--- a/workers/orchestrator/src/services/task-dispatcher/attempt-lifecycle.ts
+++ b/workers/orchestrator/src/services/task-dispatcher/attempt-lifecycle.ts
@@ -552,10 +552,28 @@ export class AttemptLifecycle {
         `destroyWorker timed out after ${String(WORKER_DESTROY_TIMEOUT_MS / 1000)}s`
       );
     } catch (destroyError) {
+      const message = getErrorMessage(destroyError);
       ctx.logger.warn(
         { taskId, error: destroyError },
         'Failed to destroy worker for inactivity restart'
       );
+      ctx.appendOrchestratorTaskLog(
+        taskId,
+        `Failed to destroy worker for inactivity restart: ${message}`
+      );
+      const result = await ctx.checkForResult(task);
+      const error: TaskError = {
+        code: 'TASK_INACTIVITY_RESTART_FAILED',
+        message: `Failed to destroy worker before inactivity restart: ${message}`,
+        remediation: { action: 'retry' },
+      };
+      /* v8 ignore start -- ts-type: exactOptionalPropertyTypes spread for result on failed inactivity restart finalization @preserve */
+      await ctx.finalizeTask(task, 'failed', {
+        ...(result !== undefined && { result }),
+        error,
+      });
+      /* v8 ignore stop @preserve */
+      return;
     }
     ctx.appendOrchestratorTaskLog(taskId, 'Worker destroyed for inactivity restart');
 

--- a/workers/orchestrator/src/services/task-dispatcher/completion-pipeline.ts
+++ b/workers/orchestrator/src/services/task-dispatcher/completion-pipeline.ts
@@ -30,6 +30,8 @@ import type { DispatcherContext } from './dispatcher-context.js';
 import { verifyCompletion } from '../completion-verifier.js';
 import type { WorkerRuntime } from '../runtime/index.js';
 import type { ResumeSummaryExtractor } from '../completion-verifier.js';
+import { withTimeout } from '../../with-timeout.js';
+import { WORKER_DESTROY_TIMEOUT_MS } from './retry-logic.js';
 
 /**
  * Legacy test-only verdict shape. Production code never emits this; only
@@ -1223,47 +1225,6 @@ export class CompletionPipeline {
       ctx.logForwarder.close(task.taskId);
     }
 
-    if (shouldPreserve && task.agentType === 'pull_request' && task.prNumber !== undefined) {
-      /* v8 ignore start -- source-map: optional chaining on listPreservedWorkers not tracked by v8 even though test covers both undefined and array paths @preserve */
-      const preserved = (await ctx.isolation.provider.listPreservedWorkers?.()) ?? [];
-      /* v8 ignore stop @preserve */
-      if (preserved.length > 0) {
-        const savedState = await ctx.statePersistence.load();
-        for (const p of preserved) {
-          const preservedTask = savedState.tasks[p.taskId];
-          if (
-            preservedTask?.agentType === 'pull_request' &&
-            preservedTask.prNumber === task.prNumber &&
-            preservedTask.taskId !== task.taskId
-          ) {
-            ctx.logger.info(
-              { oldTaskId: p.taskId, newTaskId: task.taskId, prNumber: task.prNumber },
-              'Destroying previous preserved pull_request container for same PR'
-            );
-            await ctx.isolation.provider.destroyWorker(p.taskId);
-          }
-        }
-      }
-    }
-    if (shouldPreserve) {
-      /* v8 ignore start -- ts-type: optional chaining + nullish coalescing on preserveWorker; IsolationProvider.preserveWorker is structurally optional but always defined by both DockerProvider and the FakeIsolationProvider, so the undefined branch is unreachable from any test entry point @preserve */
-      const preserved = (await ctx.isolation.provider.preserveWorker?.(task.taskId)) ?? false;
-      /* v8 ignore stop @preserve */
-      if (preserved) {
-        ctx.appendOrchestratorTaskLog(
-          task.taskId,
-          `Preserved worker container for debugging: taskId=${task.taskId} status=${finalStatus}`
-        );
-      } else {
-        ctx.appendOrchestratorTaskLog(
-          task.taskId,
-          `Failed to preserve worker container (no tracked worker): taskId=${task.taskId} status=${finalStatus}`
-        );
-        await ctx.teardownAttempt(task.taskId, false);
-      }
-    } else {
-      await ctx.teardownAttempt(task.taskId, false);
-    }
     ctx.isolation.tokenRefresher.unregisterTask(task.taskId);
     ctx.claudeErrors.delete(task.taskId);
     ctx.taskExitCodes.delete(task.taskId);
@@ -1411,6 +1372,78 @@ export class CompletionPipeline {
     ctx.logger.info(
       {},
       `Task finalized: id=${task.taskId} status=${finalStatus} durationMs=${String(new Date(task.completedAt).getTime() - new Date(task.startedAt).getTime())}`
+    );
+    await this.cleanupFinalizedWorker(task, finalStatus, shouldPreserve);
+  }
+
+  private async cleanupFinalizedWorker(
+    task: Task,
+    finalStatus: 'completed' | 'failed' | 'interrupted' | 'cancelled',
+    shouldPreserve: boolean
+  ): Promise<void> {
+    const ctx = this.ctx;
+    try {
+      if (shouldPreserve && task.agentType === 'pull_request' && task.prNumber !== undefined) {
+        /* v8 ignore start -- source-map: optional chaining on listPreservedWorkers not tracked by v8 even though test covers both undefined and array paths @preserve */
+        const preserved = (await ctx.isolation.provider.listPreservedWorkers?.()) ?? [];
+        /* v8 ignore stop @preserve */
+        if (preserved.length > 0) {
+          const savedState = await ctx.statePersistence.load();
+          for (const p of preserved) {
+            const preservedTask = savedState.tasks[p.taskId];
+            if (
+              preservedTask?.agentType === 'pull_request' &&
+              preservedTask.prNumber === task.prNumber &&
+              preservedTask.taskId !== task.taskId
+            ) {
+              ctx.logger.info(
+                { oldTaskId: p.taskId, newTaskId: task.taskId, prNumber: task.prNumber },
+                'Destroying previous preserved pull_request container for same PR'
+              );
+              await this.withWorkerCleanupTimeout(
+                p.taskId,
+                ctx.isolation.provider.destroyWorker(p.taskId)
+              );
+            }
+          }
+        }
+      }
+      if (shouldPreserve) {
+        /* v8 ignore start -- ts-type: optional chaining + nullish coalescing on preserveWorker; IsolationProvider.preserveWorker is structurally optional but always defined by both DockerProvider and the FakeIsolationProvider, so the undefined branch is unreachable from any test entry point @preserve */
+        const preserved = (await ctx.isolation.provider.preserveWorker?.(task.taskId)) ?? false;
+        /* v8 ignore stop @preserve */
+        if (preserved) {
+          ctx.appendOrchestratorTaskLog(
+            task.taskId,
+            `Preserved worker container for debugging: taskId=${task.taskId} status=${finalStatus}`
+          );
+        } else {
+          ctx.appendOrchestratorTaskLog(
+            task.taskId,
+            `Failed to preserve worker container (no tracked worker): taskId=${task.taskId} status=${finalStatus}`
+          );
+          await this.withWorkerCleanupTimeout(task.taskId, ctx.teardownAttempt(task.taskId, false));
+        }
+      } else {
+        await this.withWorkerCleanupTimeout(task.taskId, ctx.teardownAttempt(task.taskId, false));
+      }
+    } catch (cleanupError) {
+      ctx.logger.warn(
+        { taskId: task.taskId, error: cleanupError, _skipSentry: true },
+        'Worker cleanup after task finalization failed'
+      );
+      ctx.appendOrchestratorTaskLog(
+        task.taskId,
+        `Worker cleanup after finalization failed: ${String(cleanupError)}`
+      );
+    }
+  }
+
+  private async withWorkerCleanupTimeout<T>(taskId: string, cleanup: Promise<T>): Promise<T> {
+    return await withTimeout(
+      cleanup,
+      WORKER_DESTROY_TIMEOUT_MS,
+      `worker cleanup timed out after ${String(WORKER_DESTROY_TIMEOUT_MS / 1000)}s for ${taskId}`
     );
   }
 }

--- a/workers/orchestrator/src/services/task-dispatcher/retry-logic.ts
+++ b/workers/orchestrator/src/services/task-dispatcher/retry-logic.ts
@@ -16,6 +16,7 @@ export const CONTAINER_CREATE_TIMEOUT_MS = 120_000; // 2 minutes
 export const ZOMBIE_CLEANUP_TIMEOUT_MS = 30_000; // 30s — generous limit for best-effort destroy
 export const EVIDENCE_CAPTURE_TIMEOUT_MS = 30_000; // 30s — copyOut/statsSnapshot are best-effort pre-kill telemetry
 export const WORKER_DESTROY_TIMEOUT_MS = 30_000; // 30s — bound destroyWorker so docker unresponsiveness cannot wedge the task in 'running'
+export const DOCKER_LIVENESS_CHECK_TIMEOUT_MS = 30_000; // 30s — bound Docker inspect so completion signals can still finalize tasks
 export const INACTIVITY_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes — no output triggers kill+restart
 export const MAX_INACTIVITY_RESTARTS = 3; // max consecutive restarts before task is failed
 

--- a/workers/orchestrator/src/services/task-dispatcher/task-runner.ts
+++ b/workers/orchestrator/src/services/task-dispatcher/task-runner.ts
@@ -135,6 +135,7 @@ export class TaskRunner {
         void this.handleRuntimeEvents(task, runtime.flushAttemptState(runtimeAttemptState));
         ctx.taskExitCodes.set(task.taskId, exitCode);
         ctx.attemptCompletionSignals.add(task.taskId);
+        ctx.activityTimeoutManager.stop(task.taskId);
         ctx.appendOrchestratorTaskLog(
           task.taskId,
           `Worker attempt completed: exitCode=${String(exitCode)}`
@@ -296,6 +297,7 @@ export class TaskRunner {
         if (!ctx.attemptCompletionSignals.has(taskId)) {
           ctx.taskExitCodes.set(taskId, event.exitCode);
           ctx.attemptCompletionSignals.add(taskId);
+          ctx.activityTimeoutManager.stop(taskId);
           ctx.logger.info(
             { taskId, exitCode: event.exitCode },
             'Detected runtime stream result; signaling attempt completion'
@@ -307,6 +309,7 @@ export class TaskRunner {
       if (!ctx.attemptCompletionSignals.has(taskId)) {
         ctx.taskExitCodes.set(taskId, event.exitCode);
         ctx.attemptCompletionSignals.add(taskId);
+        ctx.activityTimeoutManager.stop(taskId);
         ctx.logger.info(
           { taskId, exitCode: event.exitCode },
           'Detected runtime stream result; signaling attempt completion'

--- a/workers/orchestrator/src/services/task-dispatcher/task-timers.ts
+++ b/workers/orchestrator/src/services/task-dispatcher/task-timers.ts
@@ -7,6 +7,7 @@ import {
   COMPLETION_CHECK_INTERVAL_MS,
   ACTIVITY_HEARTBEAT_THRESHOLD_MS,
   WORKER_DESTROY_TIMEOUT_MS,
+  DOCKER_LIVENESS_CHECK_TIMEOUT_MS,
 } from './retry-logic.js';
 import type { DispatcherContext } from './dispatcher-context.js';
 
@@ -196,9 +197,8 @@ export class TaskTimers {
               return;
             }
 
-            // Check if Docker container is still running
-            const isRunning = await ctx.isolation.provider.isWorkerRunning(taskId);
             const attemptCompleted = ctx.attemptCompletionSignals.has(taskId);
+            const isRunning = attemptCompleted ? false : await this.isWorkerRunningBounded(taskId);
 
             // Emit activity heartbeat when no Docker output for threshold duration
             const lastActivity = ctx.lastOutputAt.get(taskId);
@@ -245,6 +245,22 @@ export class TaskTimers {
     ctx.activeTasks.set(`${taskId}-monitor`, checkInterval);
     // INT-1551 §E.7: cancel completion poll if shutdown signal fires.
     this.attachShutdownAbort(checkInterval, true);
+  }
+
+  private async isWorkerRunningBounded(taskId: string): Promise<boolean> {
+    try {
+      return await withTimeout(
+        this.ctx.isolation.provider.isWorkerRunning(taskId),
+        DOCKER_LIVENESS_CHECK_TIMEOUT_MS,
+        `Docker liveness check timed out after ${String(DOCKER_LIVENESS_CHECK_TIMEOUT_MS / 1000)}s`
+      );
+    } catch (error) {
+      this.ctx.logger.warn(
+        { taskId, error, _skipSentry: true },
+        'Docker liveness check timed out; treating worker as still running'
+      );
+      return true;
+    }
   }
 
   /**


### PR DESCRIPTION
Fixes INT-1668

## Summary
- Finalize completed attempts from orchestrator completion signals before Docker liveness checks.
- Persist terminal task status, commit status updates, and send terminal webhooks before best-effort Docker cleanup.
- Stop activity timeouts on attempt completion and fail inactivity restarts when worker destroy cannot be trusted.

## Verification
- pnpm --filter @intexuraos/orchestrator exec vitest run src/services/task-dispatcher/__tests__/task-timers.test.ts src/services/task-dispatcher/__tests__/task-runner.test.ts src/services/task-dispatcher/__tests__/completion-pipeline.test.ts src/services/task-dispatcher/__tests__/attempt-lifecycle.test.ts src/__tests__/task-dispatcher.test.ts
- pnpm run verify:workspace:tracked orchestrator
- pnpm run ci:tracked