### PR TITLE
[INT-1673] Add private WhatsApp ingest endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,10 @@ apps/*/.env
 .claude/settings.local.json
 .claude/settings.local.*.json
 
+# Codex local hooks
+.codex/hooks.json
+.codex/hooks/
+
 # GCP Service Account Keys
 *service-account*.json
 gcp-*.json

--- a/apps/whatsapp-service/src/__tests__/fakes.ts
+++ b/apps/whatsapp-service/src/__tests__/fakes.ts
@@ -33,7 +33,10 @@ import type {
   PhoneVerification,
   PhoneVerificationRepository,
   PhoneVerificationStatus,
+  PrivateWhatsAppIngestOutcome,
+  PrivateWhatsAppRepository,
   SendMessageResult,
+  StorePrivateWhatsAppMessageInput,
   TextMessageSendResult,
   ThumbnailGeneratorPort,
   ThumbnailResult,
@@ -568,6 +571,62 @@ export class FakeWhatsAppMessageRepository implements WhatsAppMessageRepository 
     this.shouldFailFindById = false;
     this.shouldFailFindByWaMessageId = false;
     this.nextCursorToReturn = undefined;
+  }
+}
+
+/**
+ * Fake private WhatsApp repository for sync route and use case tests.
+ */
+export class FakePrivateWhatsAppRepository implements PrivateWhatsAppRepository {
+  private readonly stored = new Map<string, StorePrivateWhatsAppMessageInput>();
+  private failNextError: WhatsAppError | null = null;
+
+  failNext(error: WhatsAppError): void {
+    this.failNextError = error;
+  }
+
+  storeIncomingMessage(
+    input: StorePrivateWhatsAppMessageInput
+  ): Promise<Result<PrivateWhatsAppIngestOutcome, WhatsAppError>> {
+    if (this.failNextError !== null) {
+      const error = this.failNextError;
+      this.failNextError = null;
+      return Promise.resolve(err(error));
+    }
+
+    const existing = this.stored.get(input.message.matrixEventId);
+    const chatId = `chat:${input.sourceAccountId}:${input.chat.matrixRoomId}`;
+    const messageId = `message:${input.sourceAccountId}:${input.message.matrixEventId}`;
+
+    if (existing !== undefined) {
+      return Promise.resolve(
+        ok({
+          outcome: 'duplicate',
+          chatId,
+          messageId,
+          matrixEventId: input.message.matrixEventId,
+        })
+      );
+    }
+
+    this.stored.set(input.message.matrixEventId, input);
+    return Promise.resolve(
+      ok({
+        outcome: 'created',
+        chatId,
+        messageId,
+        matrixEventId: input.message.matrixEventId,
+      })
+    );
+  }
+
+  getAll(): StorePrivateWhatsAppMessageInput[] {
+    return Array.from(this.stored.values());
+  }
+
+  clear(): void {
+    this.stored.clear();
+    this.failNextError = null;
   }
 }
 

--- a/apps/whatsapp-service/src/__tests__/infra/privateWhatsAppRepository.test.ts
+++ b/apps/whatsapp-service/src/__tests__/infra/privateWhatsAppRepository.test.ts
@@ -1,0 +1,373 @@
+import { createHash } from 'node:crypto';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createFakeFirestore, resetFirestore, setFirestore } from '@intexuraos/infra-firestore';
+import {
+  createPrivateWhatsAppRepository,
+  PRIVATE_WHATSAPP_CHATS_COLLECTION,
+  PRIVATE_WHATSAPP_MESSAGES_COLLECTION,
+} from '../../infra/firestore/privateWhatsAppRepository.js';
+import type { StorePrivateWhatsAppMessageInput } from '../../domain/whatsapp/index.js';
+
+function deterministicId(sourceAccountId: string, matrixId: string): string {
+  return createHash('sha256').update(`${sourceAccountId}\0${matrixId}`).digest('hex');
+}
+
+function createStoreInput(
+  overrides: Partial<StorePrivateWhatsAppMessageInput> = {}
+): StorePrivateWhatsAppMessageInput {
+  return {
+    sourceAccountId: 'pbuchman-private-whatsapp',
+    userId: 'user-123',
+    deliveryMode: 'live',
+    receivedAt: '2026-06-22T10:00:02.000Z',
+    chat: {
+      matrixRoomId: '!room:matrix.example',
+      type: 'direct',
+      displayName: 'Alice',
+    },
+    message: {
+      matrixRoomId: '!room:matrix.example',
+      matrixEventId: '$event-1',
+      matrixSenderId: '@alice:matrix.example',
+      senderDisplayName: 'Alice',
+      senderPhoneNumber: '+48123456789',
+      direction: 'incoming',
+      type: 'text',
+      text: 'hello',
+      eventTimestamp: '2026-06-22T10:00:00.000Z',
+      rawMatrixEvent: {
+        type: 'm.room.message',
+        event_id: '$event-1',
+      },
+    },
+    ...overrides,
+  };
+}
+
+describe('privateWhatsAppRepository', () => {
+  let fakeFirestore: ReturnType<typeof createFakeFirestore>;
+  let repository: ReturnType<typeof createPrivateWhatsAppRepository>;
+
+  beforeEach(() => {
+    fakeFirestore = createFakeFirestore();
+    setFirestore(fakeFirestore as unknown as Parameters<typeof setFirestore>[0]);
+    repository = createPrivateWhatsAppRepository();
+  });
+
+  afterEach(() => {
+    resetFirestore();
+  });
+
+  it('stores a chat and message with deterministic ids', async () => {
+    const input = createStoreInput();
+
+    const result = await repository.storeIncomingMessage(input);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(result.error.message);
+    const expectedChatId = deterministicId(input.sourceAccountId, input.chat.matrixRoomId);
+    const expectedMessageId = deterministicId(
+      input.sourceAccountId,
+      input.message.matrixEventId
+    );
+    expect(result.value).toEqual({
+      outcome: 'created',
+      chatId: expectedChatId,
+      messageId: expectedMessageId,
+      matrixEventId: input.message.matrixEventId,
+    });
+
+    const data = fakeFirestore.getAllData();
+    const chat = data.get(PRIVATE_WHATSAPP_CHATS_COLLECTION)?.get(expectedChatId);
+    const message = data.get(PRIVATE_WHATSAPP_MESSAGES_COLLECTION)?.get(expectedMessageId);
+    expect(chat).toMatchObject({
+      id: expectedChatId,
+      userId: 'user-123',
+      sourceAccountId: 'pbuchman-private-whatsapp',
+      matrixRoomId: '!room:matrix.example',
+      chatType: 'direct',
+      displayName: 'Alice',
+      firstSeenAt: '2026-06-22T10:00:00.000Z',
+      lastEventAt: '2026-06-22T10:00:00.000Z',
+    });
+    expect(message).toMatchObject({
+      id: expectedMessageId,
+      chatId: expectedChatId,
+      userId: 'user-123',
+      sourceAccountId: 'pbuchman-private-whatsapp',
+      matrixEventId: '$event-1',
+      direction: 'incoming',
+      messageType: 'text',
+      text: 'hello',
+      deliveryMode: 'live',
+    });
+  });
+
+  it('returns duplicate without overwriting an existing message', async () => {
+    const input = createStoreInput();
+    const firstResult = await repository.storeIncomingMessage(input);
+    expect(firstResult.ok).toBe(true);
+
+    const duplicateResult = await repository.storeIncomingMessage(
+      createStoreInput({
+        message: {
+          ...input.message,
+          text: 'changed text from retry',
+        },
+      })
+    );
+
+    expect(duplicateResult.ok).toBe(true);
+    if (!duplicateResult.ok) throw new Error(duplicateResult.error.message);
+    expect(duplicateResult.value.outcome).toBe('duplicate');
+
+    const messageId = deterministicId(input.sourceAccountId, input.message.matrixEventId);
+    const message = fakeFirestore
+      .getAllData()
+      .get(PRIVATE_WHATSAPP_MESSAGES_COLLECTION)
+      ?.get(messageId);
+    expect(message?.['text']).toBe('hello');
+  });
+
+  it('updates chat metadata when a later event arrives in the same room', async () => {
+    const firstResult = await repository.storeIncomingMessage(createStoreInput());
+    expect(firstResult.ok).toBe(true);
+
+    const secondResult = await repository.storeIncomingMessage(
+      createStoreInput({
+        chat: {
+          matrixRoomId: '!room:matrix.example',
+          type: 'direct',
+          displayName: 'Alice Cooper',
+        },
+        message: {
+          ...createStoreInput().message,
+          matrixEventId: '$event-2',
+          text: 'newer message',
+          eventTimestamp: '2026-06-22T10:05:00.000Z',
+        },
+      })
+    );
+
+    expect(secondResult.ok).toBe(true);
+    const chatId = deterministicId('pbuchman-private-whatsapp', '!room:matrix.example');
+    const chat = fakeFirestore.getAllData().get(PRIVATE_WHATSAPP_CHATS_COLLECTION)?.get(chatId);
+    expect(chat?.['displayName']).toBe('Alice Cooper');
+    expect(chat?.['lastEventAt']).toBe('2026-06-22T10:05:00.000Z');
+  });
+
+  it('keeps the newer chat timestamp and lowers firstSeenAt when an older backfill event arrives later', async () => {
+    const liveResult = await repository.storeIncomingMessage(
+      createStoreInput({
+        message: {
+          ...createStoreInput().message,
+          matrixEventId: '$event-live',
+          eventTimestamp: '2026-06-22T10:05:00.000Z',
+        },
+      })
+    );
+    expect(liveResult.ok).toBe(true);
+
+    const backfillResult = await repository.storeIncomingMessage(
+      createStoreInput({
+        deliveryMode: 'backfill',
+        message: {
+          ...createStoreInput().message,
+          matrixEventId: '$event-backfill',
+          eventTimestamp: '2026-06-22T09:55:00.000Z',
+        },
+      })
+    );
+
+    expect(backfillResult.ok).toBe(true);
+    const chatId = deterministicId('pbuchman-private-whatsapp', '!room:matrix.example');
+    const chat = fakeFirestore.getAllData().get(PRIVATE_WHATSAPP_CHATS_COLLECTION)?.get(chatId);
+    expect(chat?.['firstSeenAt']).toBe('2026-06-22T09:55:00.000Z');
+    expect(chat?.['lastEventAt']).toBe('2026-06-22T10:05:00.000Z');
+  });
+
+  it('keeps newer chat metadata when an older sparse backfill event arrives later', async () => {
+    const liveResult = await repository.storeIncomingMessage(
+      createStoreInput({
+        chat: {
+          matrixRoomId: '!room:matrix.example',
+          type: 'direct',
+          displayName: 'Current Alice',
+          avatarMxcUri: 'mxc://matrix.example/current-avatar',
+        },
+        message: {
+          ...createStoreInput().message,
+          matrixEventId: '$event-live',
+          eventTimestamp: '2026-06-22T10:05:00.000Z',
+        },
+      })
+    );
+    expect(liveResult.ok).toBe(true);
+
+    const backfillResult = await repository.storeIncomingMessage(
+      createStoreInput({
+        deliveryMode: 'backfill',
+        chat: {
+          matrixRoomId: '!room:matrix.example',
+          type: 'unknown',
+          displayName: 'Old Alice',
+          avatarMxcUri: 'mxc://matrix.example/old-avatar',
+        },
+        message: {
+          ...createStoreInput().message,
+          matrixEventId: '$event-backfill',
+          eventTimestamp: '2026-06-22T09:55:00.000Z',
+        },
+      })
+    );
+
+    expect(backfillResult.ok).toBe(true);
+    const chatId = deterministicId('pbuchman-private-whatsapp', '!room:matrix.example');
+    const chat = fakeFirestore.getAllData().get(PRIVATE_WHATSAPP_CHATS_COLLECTION)?.get(chatId);
+    expect(chat?.['chatType']).toBe('direct');
+    expect(chat?.['displayName']).toBe('Current Alice');
+    expect(chat?.['avatarMxcUri']).toBe('mxc://matrix.example/current-avatar');
+    expect(chat?.['lastEventAt']).toBe('2026-06-22T10:05:00.000Z');
+  });
+
+  it('stores media messages without adding absent optional message fields', async () => {
+    const input = createStoreInput({
+      chat: {
+        matrixRoomId: '!media-room:matrix.example',
+        type: 'group',
+      },
+      message: {
+        matrixRoomId: '!media-room:matrix.example',
+        matrixEventId: '$event-media',
+        matrixSenderId: '@alice:matrix.example',
+        direction: 'incoming',
+        type: 'image',
+        media: {
+          mxcUri: 'mxc://matrix.example/media',
+          mimeType: 'image/jpeg',
+          fileName: 'photo.jpg',
+          sizeBytes: 12345,
+          sha256: 'hash123',
+        },
+        eventTimestamp: '2026-06-22T10:10:00.000Z',
+        rawMatrixEvent: {
+          type: 'm.room.message',
+          event_id: '$event-media',
+        },
+      },
+    });
+
+    const result = await repository.storeIncomingMessage(input);
+
+    expect(result.ok).toBe(true);
+    const chatId = deterministicId(input.sourceAccountId, input.chat.matrixRoomId);
+    const messageId = deterministicId(input.sourceAccountId, input.message.matrixEventId);
+    const data = fakeFirestore.getAllData();
+    const chat = data.get(PRIVATE_WHATSAPP_CHATS_COLLECTION)?.get(chatId);
+    const message = data.get(PRIVATE_WHATSAPP_MESSAGES_COLLECTION)?.get(messageId);
+    expect(chat).not.toHaveProperty('displayName');
+    expect(message).not.toHaveProperty('senderDisplayName');
+    expect(message).not.toHaveProperty('senderPhoneNumber');
+    expect(message).not.toHaveProperty('text');
+    expect(message?.['media']).toEqual({
+      mxcUri: 'mxc://matrix.example/media',
+      mimeType: 'image/jpeg',
+      fileName: 'photo.jpg',
+      sizeBytes: 12345,
+      sha256: 'hash123',
+    });
+  });
+
+  it('keeps a known chat type when a newer event reports unknown type', async () => {
+    const firstResult = await repository.storeIncomingMessage(createStoreInput());
+    expect(firstResult.ok).toBe(true);
+
+    const secondResult = await repository.storeIncomingMessage(
+      createStoreInput({
+        chat: {
+          matrixRoomId: '!room:matrix.example',
+          type: 'unknown',
+        },
+        message: {
+          ...createStoreInput().message,
+          matrixEventId: '$event-unknown-type',
+          eventTimestamp: '2026-06-22T10:06:00.000Z',
+        },
+      })
+    );
+
+    expect(secondResult.ok).toBe(true);
+    const chatId = deterministicId('pbuchman-private-whatsapp', '!room:matrix.example');
+    const chat = fakeFirestore.getAllData().get(PRIVATE_WHATSAPP_CHATS_COLLECTION)?.get(chatId);
+    expect(chat?.['chatType']).toBe('direct');
+    expect(chat?.['lastEventAt']).toBe('2026-06-22T10:06:00.000Z');
+  });
+
+  it('repairs invalid existing chat timestamps when a valid later event arrives', async () => {
+    const invalidResult = await repository.storeIncomingMessage(
+      createStoreInput({
+        message: {
+          ...createStoreInput().message,
+          matrixEventId: '$event-invalid-existing',
+          eventTimestamp: 'not-a-date',
+        },
+      })
+    );
+    expect(invalidResult.ok).toBe(true);
+
+    const validResult = await repository.storeIncomingMessage(
+      createStoreInput({
+        message: {
+          ...createStoreInput().message,
+          matrixEventId: '$event-valid-after-invalid',
+          eventTimestamp: '2026-06-22T10:15:00.000Z',
+        },
+      })
+    );
+
+    expect(validResult.ok).toBe(true);
+    const chatId = deterministicId('pbuchman-private-whatsapp', '!room:matrix.example');
+    const chat = fakeFirestore.getAllData().get(PRIVATE_WHATSAPP_CHATS_COLLECTION)?.get(chatId);
+    expect(chat?.['firstSeenAt']).toBe('2026-06-22T10:15:00.000Z');
+    expect(chat?.['lastEventAt']).toBe('2026-06-22T10:15:00.000Z');
+  });
+
+  it('ignores invalid next timestamps when preserving existing chat bounds', async () => {
+    const validResult = await repository.storeIncomingMessage(createStoreInput());
+    expect(validResult.ok).toBe(true);
+
+    const invalidResult = await repository.storeIncomingMessage(
+      createStoreInput({
+        chat: {
+          matrixRoomId: '!room:matrix.example',
+          type: 'group',
+          displayName: 'Invalid Timestamp Name',
+        },
+        message: {
+          ...createStoreInput().message,
+          matrixEventId: '$event-invalid-next',
+          eventTimestamp: 'not-a-date',
+        },
+      })
+    );
+
+    expect(invalidResult.ok).toBe(true);
+    const chatId = deterministicId('pbuchman-private-whatsapp', '!room:matrix.example');
+    const chat = fakeFirestore.getAllData().get(PRIVATE_WHATSAPP_CHATS_COLLECTION)?.get(chatId);
+    expect(chat?.['chatType']).toBe('direct');
+    expect(chat?.['displayName']).toBe('Alice');
+    expect(chat?.['firstSeenAt']).toBe('2026-06-22T10:00:00.000Z');
+    expect(chat?.['lastEventAt']).toBe('2026-06-22T10:00:00.000Z');
+  });
+
+  it('returns a persistence error when Firestore fails', async () => {
+    fakeFirestore.configure({ errorToThrow: new Error('DB unavailable') });
+
+    const result = await repository.storeIncomingMessage(createStoreInput());
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('Expected persistence failure');
+    expect(result.error.code).toBe('PERSISTENCE_ERROR');
+    expect(result.error.message).toContain('Failed to store private WhatsApp message');
+  });
+});

--- a/apps/whatsapp-service/src/__tests__/privateSyncRoutes.test.ts
+++ b/apps/whatsapp-service/src/__tests__/privateSyncRoutes.test.ts
@@ -1,0 +1,336 @@
+import { vi } from 'vitest';
+
+const commonHttpState = vi.hoisted(() => ({
+  logIncomingRequest: vi.fn(),
+}));
+
+vi.mock('@intexuraos/common-http', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@intexuraos/common-http')>();
+
+  return {
+    ...actual,
+    logIncomingRequest: commonHttpState.logIncomingRequest,
+  };
+});
+
+import { beforeEach, describe, expect, it, setupTestContext } from './testUtils.js';
+
+describe('Private WhatsApp Sync Routes', () => {
+  const ctx = setupTestContext();
+
+  beforeEach(() => {
+    commonHttpState.logIncomingRequest.mockClear();
+  });
+
+  function createPayload(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+    return {
+      sourceAccountId: 'pbuchman-private-whatsapp',
+      userId: 'user-123',
+      deliveryMode: 'live',
+      events: [
+        {
+          matrixRoomId: '!room:matrix.example',
+          matrixEventId: '$event-1',
+          matrixSenderId: '@alice:matrix.example',
+          eventTimestamp: '2026-06-22T10:00:00.000Z',
+          chat: {
+            type: 'direct',
+            displayName: 'Alice',
+          },
+          sender: {
+            displayName: 'Alice',
+            phoneNumber: '+48123456789',
+          },
+          message: {
+            direction: 'incoming',
+            type: 'text',
+            text: 'hello from private whatsapp',
+          },
+          rawMatrixEvent: {
+            type: 'm.room.message',
+            event_id: '$event-1',
+          },
+        },
+      ],
+      ...overrides,
+    };
+  }
+
+  it('requires internal auth on the production internal path', async () => {
+    const response = await ctx.app.inject({
+      method: 'POST',
+      url: '/internal/whatsapp/private/events',
+      payload: createPayload(),
+    });
+
+    expect(response.statusCode).toBe(401);
+    const body = JSON.parse(response.body) as { success: boolean; error: { code: string } };
+    expect(body.success).toBe(false);
+    expect(body.error.code).toBe('UNAUTHORIZED');
+  });
+
+  it('rejects bearer-only auth because nginx must inject internal auth', async () => {
+    const response = await ctx.app.inject({
+      method: 'POST',
+      url: '/internal/whatsapp/private/events',
+      headers: { authorization: 'Bearer arbitrary-unverified-token' },
+      payload: createPayload(),
+    });
+
+    expect(response.statusCode).toBe(401);
+    const body = JSON.parse(response.body) as { success: boolean; error: { code: string } };
+    expect(body.success).toBe(false);
+    expect(body.error.code).toBe('UNAUTHORIZED');
+  });
+
+  it('validates the batch envelope before ingestion', async () => {
+    const response = await ctx.app.inject({
+      method: 'POST',
+      url: '/internal/whatsapp/private/events',
+      headers: { 'x-internal-auth': 'test-internal-token' },
+      payload: {
+        sourceAccountId: 'pbuchman-private-whatsapp',
+        userId: 'user-123',
+        deliveryMode: 'live',
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    const body = JSON.parse(response.body) as { success: boolean; error: { code: string } };
+    expect(body.success).toBe(false);
+    expect(body.error.code).toBe('INVALID_REQUEST');
+  });
+
+  it('ingests live incoming private WhatsApp events', async () => {
+    const response = await ctx.app.inject({
+      method: 'POST',
+      url: '/internal/whatsapp/private/events',
+      headers: { 'x-internal-auth': 'test-internal-token' },
+      payload: createPayload(),
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body) as {
+      success: boolean;
+      data: {
+        accepted: number;
+        duplicates: number;
+        rejected: number;
+        messages: { matrixEventId: string; outcome: string }[];
+      };
+    };
+    expect(body.success).toBe(true);
+    expect(body.data).toMatchObject({
+      accepted: 1,
+      duplicates: 0,
+      rejected: 0,
+      messages: [{ matrixEventId: '$event-1', outcome: 'created' }],
+    });
+  });
+
+  it('logs private sync requests without raw body previews', async () => {
+    const payload = createPayload();
+    await ctx.app.inject({
+      method: 'POST',
+      url: '/internal/whatsapp/private/events',
+      headers: { 'x-internal-auth': 'test-internal-token' },
+      payload,
+    });
+
+    expect(commonHttpState.logIncomingRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        message: 'Received request to /internal/whatsapp/private/events',
+        bodyPreviewLength: 0,
+        additionalFields: {
+          route: 'internal_whatsapp_private_events',
+          deliveryMode: 'live',
+          eventCount: 1,
+          hasSourceAccountId: true,
+          hasUserId: true,
+        },
+      })
+    );
+    const logOptions = commonHttpState.logIncomingRequest.mock.calls[0]?.[1];
+    expect(JSON.stringify(logOptions)).not.toContain('hello from private whatsapp');
+    expect(JSON.stringify(logOptions)).not.toContain('+48123456789');
+    expect(JSON.stringify(logOptions)).not.toContain('Alice');
+    expect(JSON.stringify(logOptions)).not.toContain('$event-1');
+  });
+
+  it('logs non-object private sync bodies without inspecting payload contents', async () => {
+    const response = await ctx.app.inject({
+      method: 'POST',
+      url: '/internal/whatsapp/private/events',
+      headers: { 'x-internal-auth': 'test-internal-token' },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(commonHttpState.logIncomingRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        bodyPreviewLength: 0,
+        additionalFields: {
+          route: 'internal_whatsapp_private_events',
+          bodyType: 'undefined',
+        },
+      })
+    );
+  });
+
+  it('logs invalid private sync envelopes with coarse metadata only', async () => {
+    const response = await ctx.app.inject({
+      method: 'POST',
+      url: '/internal/whatsapp/private/events',
+      headers: { 'x-internal-auth': 'test-internal-token' },
+      payload: {
+        sourceAccountId: 123,
+        deliveryMode: 42,
+        events: 'not-an-event-array',
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(commonHttpState.logIncomingRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        bodyPreviewLength: 0,
+        additionalFields: {
+          route: 'internal_whatsapp_private_events',
+          deliveryMode: 'unknown',
+          eventCount: 0,
+          hasSourceAccountId: false,
+          hasUserId: false,
+        },
+      })
+    );
+  });
+
+  it('returns a standard error envelope when private message persistence fails', async () => {
+    ctx.privateWhatsAppRepository.failNext({
+      code: 'PERSISTENCE_ERROR',
+      message: 'Simulated private WhatsApp persistence failure',
+    });
+
+    const response = await ctx.app.inject({
+      method: 'POST',
+      url: '/internal/whatsapp/private/events',
+      headers: { 'x-internal-auth': 'test-internal-token' },
+      payload: createPayload(),
+    });
+
+    expect(response.statusCode).toBe(500);
+    const body = JSON.parse(response.body) as { success: boolean; error: { code: string } };
+    expect(body.success).toBe(false);
+    expect(body.error.code).toBe('INTERNAL_ERROR');
+  });
+
+  it('rejects malformed event objects without failing the whole batch', async () => {
+    const validEvent = (createPayload()['events'] as Record<string, unknown>[])[0];
+    const response = await ctx.app.inject({
+      method: 'POST',
+      url: '/internal/whatsapp/private/events',
+      headers: { 'x-internal-auth': 'test-internal-token' },
+      payload: createPayload({
+        events: [
+          {
+            ...validEvent,
+            matrixEventId: '$event-valid',
+          },
+          {
+            matrixEventId: '$event-missing-message',
+            matrixRoomId: '!room:matrix.example',
+            matrixSenderId: '@alice:matrix.example',
+            eventTimestamp: '2026-06-22T10:01:00.000Z',
+            chat: {
+              type: 'direct',
+              displayName: 'Alice',
+            },
+          },
+        ],
+      }),
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body) as {
+      success: boolean;
+      data: {
+        accepted: number;
+        rejected: number;
+        messages: { matrixEventId: string; outcome: string; reason?: string }[];
+      };
+    };
+    expect(body.success).toBe(true);
+    expect(body.data).toMatchObject({
+      accepted: 1,
+      rejected: 1,
+      messages: [
+        { matrixEventId: '$event-valid', outcome: 'created' },
+        {
+          matrixEventId: '$event-missing-message',
+          outcome: 'rejected',
+          reason: 'missing_message',
+        },
+      ],
+    });
+  });
+
+  it('rejects non-object event entries without failing the whole batch', async () => {
+    const validEvent = (createPayload()['events'] as Record<string, unknown>[])[0];
+    const response = await ctx.app.inject({
+      method: 'POST',
+      url: '/internal/whatsapp/private/events',
+      headers: { 'x-internal-auth': 'test-internal-token' },
+      payload: createPayload({
+        events: [
+          {
+            ...validEvent,
+            matrixEventId: '$event-valid',
+          },
+          'not-an-event-object',
+        ],
+      }),
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body) as {
+      success: boolean;
+      data: {
+        accepted: number;
+        rejected: number;
+        messages: { matrixEventId: string; outcome: string; reason?: string }[];
+      };
+    };
+    expect(body.success).toBe(true);
+    expect(body.data).toMatchObject({
+      accepted: 1,
+      rejected: 1,
+      messages: [
+        { matrixEventId: '$event-valid', outcome: 'created' },
+        {
+          matrixEventId: '<unknown>',
+          outcome: 'rejected',
+          reason: 'invalid_event',
+        },
+      ],
+    });
+  });
+
+  it('supports backfill batches through the same ingest contract', async () => {
+    const response = await ctx.app.inject({
+      method: 'POST',
+      url: '/internal/whatsapp/private/events',
+      headers: { 'x-internal-auth': 'test-internal-token' },
+      payload: createPayload({ deliveryMode: 'backfill' }),
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body) as {
+      success: boolean;
+      data: { accepted: number; messages: { outcome: string }[] };
+    };
+    expect(body.success).toBe(true);
+    expect(body.data.accepted).toBe(1);
+    expect(body.data.messages[0]?.outcome).toBe('created');
+  });
+});

--- a/apps/whatsapp-service/src/__tests__/pubsubRoutes.test.ts
+++ b/apps/whatsapp-service/src/__tests__/pubsubRoutes.test.ts
@@ -8,6 +8,7 @@ import { buildServer } from '../server.js';
 import { resetServices, setServices } from '../services.js';
 import {
   FakeEventPublisher,
+  FakePrivateWhatsAppRepository,
   FakeLinkPreviewFetcherPort,
   FakeMediaStorage,
   FakeMessageSender,
@@ -98,6 +99,7 @@ describe('Pub/Sub Routes', () => {
       outboundMessageRepository,
       phoneVerificationRepository: new FakePhoneVerificationRepository(),
       notificationPreferencesRepository: prefs,
+      privateWhatsAppRepository: new FakePrivateWhatsAppRepository(),
     });
 
     process.env['INTEXURAOS_INTERNAL_AUTH_TOKEN'] = INTERNAL_AUTH_TOKEN;

--- a/apps/whatsapp-service/src/__tests__/testUtils.ts
+++ b/apps/whatsapp-service/src/__tests__/testUtils.ts
@@ -10,6 +10,7 @@ import { resetServices, setServices } from '../services.js';
 import { clearJwksCache } from '@intexuraos/common-http';
 import {
   FakeEventPublisher,
+  FakePrivateWhatsAppRepository,
   FakeLinkPreviewFetcherPort,
   FakeMediaStorage,
   FakeMessageSender,
@@ -471,6 +472,7 @@ export interface TestContext {
   outboundMessageRepository: FakeOutboundMessageRepository;
   phoneVerificationRepository: FakePhoneVerificationRepository;
   notificationPreferencesRepository: FakeNotificationPreferencesRepository;
+  privateWhatsAppRepository: FakePrivateWhatsAppRepository;
   messageSender: FakeMessageSender;
   linkPreviewFetcher: FakeLinkPreviewFetcherPort;
 }
@@ -491,6 +493,7 @@ export function setupTestContext(): TestContext {
     phoneVerificationRepository: null as unknown as FakePhoneVerificationRepository,
     notificationPreferencesRepository:
       null as unknown as FakeNotificationPreferencesRepository,
+    privateWhatsAppRepository: null as unknown as FakePrivateWhatsAppRepository,
     messageSender: null as unknown as FakeMessageSender,
     linkPreviewFetcher: null as unknown as FakeLinkPreviewFetcherPort,
   };
@@ -513,6 +516,7 @@ export function setupTestContext(): TestContext {
     context.outboundMessageRepository = new FakeOutboundMessageRepository();
     context.phoneVerificationRepository = new FakePhoneVerificationRepository();
     context.notificationPreferencesRepository = new FakeNotificationPreferencesRepository();
+    context.privateWhatsAppRepository = new FakePrivateWhatsAppRepository();
     context.messageSender = new FakeMessageSender();
     context.linkPreviewFetcher = new FakeLinkPreviewFetcherPort();
 
@@ -529,6 +533,7 @@ export function setupTestContext(): TestContext {
       outboundMessageRepository: context.outboundMessageRepository,
       phoneVerificationRepository: context.phoneVerificationRepository,
       notificationPreferencesRepository: context.notificationPreferencesRepository,
+      privateWhatsAppRepository: context.privateWhatsAppRepository,
     });
 
     clearJwksCache();

--- a/apps/whatsapp-service/src/__tests__/usecases/ingestPrivateWhatsAppEvents.test.ts
+++ b/apps/whatsapp-service/src/__tests__/usecases/ingestPrivateWhatsAppEvents.test.ts
@@ -1,0 +1,395 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { err, ok, type Result } from '@intexuraos/common-core';
+import {
+  IngestPrivateWhatsAppEventsUseCase,
+  type IngestPrivateWhatsAppEventInput,
+  type IngestPrivateWhatsAppEventsInput,
+  type PrivateWhatsAppIngestOutcome,
+  type PrivateWhatsAppRepository,
+  type StorePrivateWhatsAppMessageInput,
+  type WhatsAppError,
+} from '../../domain/whatsapp/index.js';
+import type { Logger } from '../../domain/whatsapp/utils/logger.js';
+
+const logger: Logger = {
+  info: (): void => undefined,
+  error: (): void => undefined,
+};
+
+function createEvent(overrides: Partial<IngestPrivateWhatsAppEventInput> = {}): IngestPrivateWhatsAppEventInput {
+  return {
+    matrixRoomId: '!room:matrix.example',
+    matrixEventId: '$event-1',
+    matrixSenderId: '@sender:matrix.example',
+    eventTimestamp: '2026-06-22T10:00:00.000Z',
+    chat: {
+      type: 'direct',
+      displayName: 'Alice',
+    },
+    sender: {
+      displayName: 'Alice',
+      phoneNumber: '+48123456789',
+    },
+    message: {
+      direction: 'incoming',
+      type: 'text',
+      text: 'hello from private whatsapp',
+    },
+    rawMatrixEvent: {
+      type: 'm.room.message',
+      event_id: '$event-1',
+    },
+    ...overrides,
+  };
+}
+
+function createInput(
+  overrides: Partial<IngestPrivateWhatsAppEventsInput> = {}
+): IngestPrivateWhatsAppEventsInput {
+  return {
+    sourceAccountId: 'pbuchman-private-whatsapp',
+    userId: 'user-123',
+    deliveryMode: 'live',
+    events: [createEvent()],
+    ...overrides,
+  };
+}
+
+class TestPrivateWhatsAppRepository implements PrivateWhatsAppRepository {
+  readonly stored: StorePrivateWhatsAppMessageInput[] = [];
+  private readonly seenEventIds = new Map<string, PrivateWhatsAppIngestOutcome>();
+  failNextStore = false;
+
+  storeIncomingMessage(
+    input: StorePrivateWhatsAppMessageInput
+  ): Promise<Result<PrivateWhatsAppIngestOutcome, WhatsAppError>> {
+    if (this.failNextStore) {
+      this.failNextStore = false;
+      return Promise.resolve(
+        err({ code: 'PERSISTENCE_ERROR', message: 'Failed to persist private WhatsApp message' })
+      );
+    }
+
+    const existing = this.seenEventIds.get(input.message.matrixEventId);
+    if (existing !== undefined) {
+      return Promise.resolve(ok({ ...existing, outcome: 'duplicate' }));
+    }
+
+    const outcome: PrivateWhatsAppIngestOutcome = {
+      outcome: 'created',
+      chatId: `chat-${String(this.stored.length + 1)}`,
+      messageId: `message-${String(this.stored.length + 1)}`,
+      matrixEventId: input.message.matrixEventId,
+    };
+    this.stored.push(input);
+    this.seenEventIds.set(input.message.matrixEventId, outcome);
+    return Promise.resolve(ok(outcome));
+  }
+}
+
+describe('IngestPrivateWhatsAppEventsUseCase', () => {
+  let repository: TestPrivateWhatsAppRepository;
+  let useCase: IngestPrivateWhatsAppEventsUseCase;
+
+  beforeEach(() => {
+    repository = new TestPrivateWhatsAppRepository();
+    useCase = new IngestPrivateWhatsAppEventsUseCase({
+      privateWhatsAppRepository: repository,
+    });
+  });
+
+  it('stores incoming live Matrix events as private WhatsApp messages', async () => {
+    const result = await useCase.execute(createInput(), logger);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(result.error.message);
+    expect(result.value).toMatchObject({
+      accepted: 1,
+      duplicates: 0,
+      rejected: 0,
+      messages: [
+        {
+          matrixEventId: '$event-1',
+          messageId: 'message-1',
+          chatId: 'chat-1',
+          outcome: 'created',
+        },
+      ],
+    });
+    expect(repository.stored).toHaveLength(1);
+    expect(repository.stored[0]?.deliveryMode).toBe('live');
+    expect(repository.stored[0]?.message.text).toBe('hello from private whatsapp');
+    expect(repository.stored[0]?.message.direction).toBe('incoming');
+  });
+
+  it('marks repeated Matrix event ids as duplicates', async () => {
+    const firstResult = await useCase.execute(createInput(), logger);
+    expect(firstResult.ok).toBe(true);
+
+    const duplicateResult = await useCase.execute(createInput(), logger);
+
+    expect(duplicateResult.ok).toBe(true);
+    if (!duplicateResult.ok) throw new Error(duplicateResult.error.message);
+    expect(duplicateResult.value).toMatchObject({
+      accepted: 0,
+      duplicates: 1,
+      rejected: 0,
+      messages: [{ matrixEventId: '$event-1', outcome: 'duplicate' }],
+    });
+    expect(repository.stored).toHaveLength(1);
+  });
+
+  it('rejects non-incoming events without writing them', async () => {
+    const result = await useCase.execute(
+      createInput({
+        events: [
+          createEvent({
+            matrixEventId: '$event-outgoing',
+            message: {
+              direction: 'outgoing',
+              type: 'text',
+              text: 'sent from me',
+            },
+          }),
+        ],
+      }),
+      logger
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(result.error.message);
+    expect(result.value).toMatchObject({
+      accepted: 0,
+      duplicates: 0,
+      rejected: 1,
+      messages: [
+        {
+          matrixEventId: '$event-outgoing',
+          outcome: 'rejected',
+          reason: 'unsupported_direction',
+        },
+      ],
+    });
+    expect(repository.stored).toHaveLength(0);
+  });
+
+  it('keeps valid events when the same batch contains an invalid event', async () => {
+    const result = await useCase.execute(
+      createInput({
+        events: [
+          createEvent({ matrixEventId: '$event-valid' }),
+          createEvent({
+            matrixEventId: '$event-invalid',
+            matrixRoomId: '',
+          }),
+        ],
+      }),
+      logger
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(result.error.message);
+    expect(result.value.accepted).toBe(1);
+    expect(result.value.rejected).toBe(1);
+    expect(result.value.messages.map((message) => message.outcome)).toEqual([
+      'created',
+      'rejected',
+    ]);
+    expect(repository.stored).toHaveLength(1);
+  });
+
+  it('reports parser rejection reasons for malformed Matrix events', async () => {
+    const validEvent = createEvent();
+    const malformedEvents: unknown[] = [
+      'not-an-event',
+      { ...validEvent, matrixEventId: '' },
+      { ...validEvent, matrixEventId: '$missing-room', matrixRoomId: '' },
+      { ...validEvent, matrixEventId: '$missing-sender', matrixSenderId: '' },
+      { ...validEvent, matrixEventId: '$missing-timestamp', eventTimestamp: '' },
+      { ...validEvent, matrixEventId: '$invalid-timestamp', eventTimestamp: 'not-a-date' },
+      { ...validEvent, matrixEventId: '$invalid-received-type', receivedAt: 42 },
+      {
+        ...validEvent,
+        matrixEventId: '$invalid-received-date',
+        receivedAt: 'not-a-date',
+      },
+      { ...validEvent, matrixEventId: '$missing-message', message: undefined },
+      {
+        ...validEvent,
+        matrixEventId: '$media-not-object',
+        message: { ...validEvent.message, media: 'mxc://matrix.example/media' },
+      },
+      {
+        ...validEvent,
+        matrixEventId: '$missing-media-uri',
+        message: { ...validEvent.message, media: { mimeType: 'image/jpeg' } },
+      },
+    ];
+
+    const result = await useCase.execute(createInput({ events: malformedEvents }), logger);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(result.error.message);
+    expect(result.value.accepted).toBe(0);
+    expect(result.value.rejected).toBe(malformedEvents.length);
+    expect(result.value.messages).toEqual([
+      { matrixEventId: '<unknown>', outcome: 'rejected', reason: 'invalid_event' },
+      {
+        matrixEventId: '<unknown>',
+        outcome: 'rejected',
+        reason: 'missing_matrix_event_id',
+      },
+      {
+        matrixEventId: '$missing-room',
+        outcome: 'rejected',
+        reason: 'missing_matrix_room_id',
+      },
+      {
+        matrixEventId: '$missing-sender',
+        outcome: 'rejected',
+        reason: 'missing_matrix_sender_id',
+      },
+      {
+        matrixEventId: '$missing-timestamp',
+        outcome: 'rejected',
+        reason: 'missing_event_timestamp',
+      },
+      {
+        matrixEventId: '$invalid-timestamp',
+        outcome: 'rejected',
+        reason: 'invalid_event_timestamp',
+      },
+      {
+        matrixEventId: '$invalid-received-type',
+        outcome: 'rejected',
+        reason: 'invalid_received_at',
+      },
+      {
+        matrixEventId: '$invalid-received-date',
+        outcome: 'rejected',
+        reason: 'invalid_received_at',
+      },
+      { matrixEventId: '$missing-message', outcome: 'rejected', reason: 'missing_message' },
+      {
+        matrixEventId: '$media-not-object',
+        outcome: 'rejected',
+        reason: 'missing_media_mxc_uri',
+      },
+      {
+        matrixEventId: '$missing-media-uri',
+        outcome: 'rejected',
+        reason: 'missing_media_mxc_uri',
+      },
+    ]);
+    expect(repository.stored).toHaveLength(0);
+  });
+
+  it('normalizes sparse Matrix payloads and preserves media metadata', async () => {
+    const noChatEvent = {
+      matrixRoomId: '!room-no-chat:matrix.example',
+      matrixEventId: '$event-no-chat',
+      matrixSenderId: '@sender:matrix.example',
+      eventTimestamp: '2026-06-22T10:01:00.000Z',
+      message: {
+        direction: 'incoming',
+        type: 'text',
+        text: 'message without chat metadata',
+      },
+    };
+    const sparseChatEvent = {
+      matrixRoomId: '!room-sparse:matrix.example',
+      matrixEventId: '$event-sparse',
+      matrixSenderId: '@sender:matrix.example',
+      eventTimestamp: '2026-06-22T10:02:00.000Z',
+      chat: {},
+      message: {
+        direction: 'incoming',
+      },
+    };
+    const mediaEvent = {
+      matrixRoomId: '!room-media:matrix.example',
+      matrixEventId: '$event-media',
+      matrixSenderId: '@sender:matrix.example',
+      eventTimestamp: '2026-06-22T10:03:00.000Z',
+      receivedAt: '2026-06-22T10:03:05.000Z',
+      chat: {
+        type: 'broadcast',
+        avatarMxcUri: 'mxc://matrix.example/avatar',
+      },
+      sender: {},
+      message: {
+        direction: 'incoming',
+        type: 'location',
+        media: {
+          mxcUri: 'mxc://matrix.example/media',
+          mimeType: 'image/jpeg',
+          fileName: 'photo.jpg',
+          sizeBytes: 12345,
+          sha256: 'hash123',
+        },
+      },
+    };
+    const minimalMediaEvent = {
+      matrixRoomId: '!room-minimal-media:matrix.example',
+      matrixEventId: '$event-minimal-media',
+      matrixSenderId: '@sender:matrix.example',
+      eventTimestamp: '2026-06-22T10:04:00.000Z',
+      chat: {
+        type: 'direct',
+      },
+      message: {
+        direction: 'incoming',
+        type: 'image',
+        media: {
+          mxcUri: 'mxc://matrix.example/minimal-media',
+        },
+      },
+    };
+
+    const result = await useCase.execute(
+      createInput({ events: [noChatEvent, sparseChatEvent, mediaEvent, minimalMediaEvent] }),
+      logger
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(result.error.message);
+    expect(result.value.accepted).toBe(4);
+    expect(repository.stored).toHaveLength(4);
+
+    expect(repository.stored[0]?.chat.type).toBe('unknown');
+    expect(repository.stored[0]?.message.type).toBe('text');
+    expect(repository.stored[0]?.message.rawMatrixEvent).toBe(noChatEvent);
+
+    expect(repository.stored[1]?.chat.type).toBe('unknown');
+    expect(repository.stored[1]?.message.type).toBe('unknown');
+    expect(repository.stored[1]?.message.text).toBeUndefined();
+
+    expect(repository.stored[2]?.receivedAt).toBe('2026-06-22T10:03:05.000Z');
+    expect(repository.stored[2]?.chat.type).toBe('unknown');
+    expect(repository.stored[2]?.chat.avatarMxcUri).toBe('mxc://matrix.example/avatar');
+    expect(repository.stored[2]?.message.type).toBe('unknown');
+    expect(repository.stored[2]?.message.senderDisplayName).toBeUndefined();
+    expect(repository.stored[2]?.message.senderPhoneNumber).toBeUndefined();
+    expect(repository.stored[2]?.message.media).toEqual({
+      mxcUri: 'mxc://matrix.example/media',
+      mimeType: 'image/jpeg',
+      fileName: 'photo.jpg',
+      sizeBytes: 12345,
+      sha256: 'hash123',
+    });
+
+    expect(repository.stored[3]?.message.media).toEqual({
+      mxcUri: 'mxc://matrix.example/minimal-media',
+    });
+  });
+
+  it('returns a persistence error so callers can retry the batch', async () => {
+    repository.failNextStore = true;
+
+    const result = await useCase.execute(createInput(), logger);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('Expected persistence failure');
+    expect(result.error.code).toBe('PERSISTENCE_ERROR');
+  });
+});

--- a/apps/whatsapp-service/src/domain/whatsapp/index.ts
+++ b/apps/whatsapp-service/src/domain/whatsapp/index.ts
@@ -38,6 +38,22 @@ export type {
   PhoneVerificationStatus,
 } from './models/PhoneVerification.js';
 
+export type {
+  PrivateWhatsAppChat,
+  PrivateWhatsAppChatInput,
+  PrivateWhatsAppChatType,
+  PrivateWhatsAppDeliveryMode,
+  PrivateWhatsAppIngestEventResult,
+  PrivateWhatsAppIngestOutcome,
+  PrivateWhatsAppIngestResult,
+  PrivateWhatsAppMediaInfo,
+  PrivateWhatsAppMessage,
+  PrivateWhatsAppMessageDirection,
+  PrivateWhatsAppMessageInput,
+  PrivateWhatsAppMessageType,
+  StorePrivateWhatsAppMessageInput,
+} from './models/PrivateWhatsApp.js';
+
 // Ports
 export type {
   WhatsAppUserMapping,
@@ -75,6 +91,8 @@ export type {
 } from './ports/outboundMessageRepository.js';
 
 export type { NotificationPreferencesRepository } from './ports/notificationPreferencesRepository.js';
+
+export type { PrivateWhatsAppRepository } from './ports/privateWhatsAppRepository.js';
 
 // Events
 export type {
@@ -132,6 +150,13 @@ export {
   type RetryPendingWebhookEventsInput,
   type RetryPendingWebhookEventsResult,
 } from './usecases/retryPendingWebhookEvents.js';
+
+export {
+  IngestPrivateWhatsAppEventsUseCase,
+  type IngestPrivateWhatsAppEventInput,
+  type IngestPrivateWhatsAppEventsDeps,
+  type IngestPrivateWhatsAppEventsInput,
+} from './usecases/ingestPrivateWhatsAppEvents.js';
 
 export {
   shouldDeliverMessage,

--- a/apps/whatsapp-service/src/domain/whatsapp/models/PrivateWhatsApp.ts
+++ b/apps/whatsapp-service/src/domain/whatsapp/models/PrivateWhatsApp.ts
@@ -1,0 +1,111 @@
+/**
+ * Domain model for private WhatsApp messages synchronized through Matrix.
+ */
+
+export type PrivateWhatsAppDeliveryMode = 'live' | 'backfill';
+export type PrivateWhatsAppChatType = 'direct' | 'group' | 'unknown';
+export type PrivateWhatsAppMessageDirection = 'incoming';
+export type PrivateWhatsAppMessageType =
+  | 'text'
+  | 'image'
+  | 'audio'
+  | 'video'
+  | 'file'
+  | 'sticker'
+  | 'reaction'
+  | 'redaction'
+  | 'unknown';
+
+export interface PrivateWhatsAppMediaInfo {
+  mxcUri: string;
+  mimeType?: string;
+  fileName?: string;
+  sizeBytes?: number;
+  sha256?: string;
+}
+
+export interface PrivateWhatsAppChatInput {
+  matrixRoomId: string;
+  type: PrivateWhatsAppChatType;
+  displayName?: string;
+  avatarMxcUri?: string;
+}
+
+export interface PrivateWhatsAppMessageInput {
+  matrixRoomId: string;
+  matrixEventId: string;
+  matrixSenderId: string;
+  senderDisplayName?: string;
+  senderPhoneNumber?: string;
+  direction: PrivateWhatsAppMessageDirection;
+  type: PrivateWhatsAppMessageType;
+  text?: string;
+  media?: PrivateWhatsAppMediaInfo;
+  eventTimestamp: string;
+  rawMatrixEvent: unknown;
+}
+
+export interface StorePrivateWhatsAppMessageInput {
+  sourceAccountId: string;
+  userId: string;
+  deliveryMode: PrivateWhatsAppDeliveryMode;
+  receivedAt: string;
+  chat: PrivateWhatsAppChatInput;
+  message: PrivateWhatsAppMessageInput;
+}
+
+export interface PrivateWhatsAppChat {
+  id: string;
+  userId: string;
+  sourceAccountId: string;
+  matrixRoomId: string;
+  chatType: PrivateWhatsAppChatType;
+  displayName?: string;
+  avatarMxcUri?: string;
+  firstSeenAt: string;
+  lastEventAt: string;
+  updatedAt: string;
+}
+
+export interface PrivateWhatsAppMessage {
+  id: string;
+  chatId: string;
+  userId: string;
+  sourceAccountId: string;
+  matrixRoomId: string;
+  matrixEventId: string;
+  matrixSenderId: string;
+  senderDisplayName?: string;
+  senderPhoneNumber?: string;
+  direction: PrivateWhatsAppMessageDirection;
+  messageType: PrivateWhatsAppMessageType;
+  text?: string;
+  media?: PrivateWhatsAppMediaInfo;
+  eventTimestamp: string;
+  receivedAt: string;
+  ingestedAt: string;
+  deliveryMode: PrivateWhatsAppDeliveryMode;
+  rawMatrixEvent: unknown;
+}
+
+export interface PrivateWhatsAppIngestOutcome {
+  outcome: 'created' | 'duplicate';
+  chatId: string;
+  messageId: string;
+  matrixEventId: string;
+}
+
+export interface PrivateWhatsAppIngestEventResult {
+  matrixEventId: string;
+  outcome: 'created' | 'duplicate' | 'rejected';
+  chatId?: string;
+  messageId?: string;
+  reason?: string;
+}
+
+export interface PrivateWhatsAppIngestResult {
+  accepted: number;
+  duplicates: number;
+  rejected: number;
+  messages: PrivateWhatsAppIngestEventResult[];
+}

--- a/apps/whatsapp-service/src/domain/whatsapp/ports/privateWhatsAppRepository.ts
+++ b/apps/whatsapp-service/src/domain/whatsapp/ports/privateWhatsAppRepository.ts
@@ -1,0 +1,12 @@
+import type { Result } from '@intexuraos/common-core';
+import type { WhatsAppError } from '../models/error.js';
+import type {
+  PrivateWhatsAppIngestOutcome,
+  StorePrivateWhatsAppMessageInput,
+} from '../models/PrivateWhatsApp.js';
+
+export interface PrivateWhatsAppRepository {
+  storeIncomingMessage(
+    input: StorePrivateWhatsAppMessageInput
+  ): Promise<Result<PrivateWhatsAppIngestOutcome, WhatsAppError>>;
+}

--- a/apps/whatsapp-service/src/domain/whatsapp/usecases/ingestPrivateWhatsAppEvents.ts
+++ b/apps/whatsapp-service/src/domain/whatsapp/usecases/ingestPrivateWhatsAppEvents.ts
@@ -1,0 +1,402 @@
+import { err, ok, type Result } from '@intexuraos/common-core';
+import type { WhatsAppError } from '../models/error.js';
+import type {
+  PrivateWhatsAppChatType,
+  PrivateWhatsAppDeliveryMode,
+  PrivateWhatsAppIngestEventResult,
+  PrivateWhatsAppIngestResult,
+  PrivateWhatsAppMessageType,
+  StorePrivateWhatsAppMessageInput,
+} from '../models/PrivateWhatsApp.js';
+import type { PrivateWhatsAppRepository } from '../ports/privateWhatsAppRepository.js';
+import type { Logger } from '../utils/logger.js';
+
+export interface IngestPrivateWhatsAppEventsInput {
+  sourceAccountId: string;
+  userId: string;
+  deliveryMode: PrivateWhatsAppDeliveryMode;
+  events: unknown[];
+}
+
+export interface IngestPrivateWhatsAppEventInput {
+  matrixRoomId: string;
+  matrixEventId: string;
+  matrixSenderId: string;
+  eventTimestamp: string;
+  receivedAt?: string;
+  chat: {
+    type: string;
+    displayName?: string;
+    avatarMxcUri?: string;
+  };
+  sender?: {
+    displayName?: string;
+    phoneNumber?: string;
+  };
+  message: {
+    direction: string;
+    type: string;
+    text?: string;
+    media?: {
+      mxcUri: string;
+      mimeType?: string;
+      fileName?: string;
+      sizeBytes?: number;
+      sha256?: string;
+    };
+  };
+  rawMatrixEvent: unknown;
+}
+
+export interface IngestPrivateWhatsAppEventsDeps {
+  privateWhatsAppRepository: PrivateWhatsAppRepository;
+}
+
+type ParseEventResult =
+  | { ok: true; event: IngestPrivateWhatsAppEventInput }
+  | RejectedEvent;
+type ParseMessageResult =
+  | { ok: true; message: IngestPrivateWhatsAppEventInput['message'] }
+  | RejectedEvent;
+type ParseMediaResult =
+  | { ok: true; media?: IngestPrivateWhatsAppEventInput['message']['media'] }
+  | RejectedEvent;
+
+interface RejectedEvent {
+  ok: false;
+  matrixEventId: string;
+  reason: string;
+}
+
+const MESSAGE_TYPES = new Set<PrivateWhatsAppMessageType>([
+  'text',
+  'image',
+  'audio',
+  'video',
+  'file',
+  'sticker',
+  'reaction',
+  'redaction',
+  'unknown',
+]);
+
+const CHAT_TYPES = new Set<PrivateWhatsAppChatType>(['direct', 'group', 'unknown']);
+
+export class IngestPrivateWhatsAppEventsUseCase {
+  constructor(private readonly deps: IngestPrivateWhatsAppEventsDeps) {}
+
+  async execute(
+    input: IngestPrivateWhatsAppEventsInput,
+    logger: Logger
+  ): Promise<Result<PrivateWhatsAppIngestResult, WhatsAppError>> {
+    const messages: PrivateWhatsAppIngestEventResult[] = [];
+
+    for (const rawEvent of input.events) {
+      const parsedEvent = parseEvent(rawEvent);
+      if (!parsedEvent.ok) {
+        messages.push({
+          matrixEventId: parsedEvent.matrixEventId,
+          outcome: 'rejected',
+          reason: parsedEvent.reason,
+        });
+        continue;
+      }
+
+      const event = parsedEvent.event;
+      const storeInput = toStoreInput(input, event);
+      const storeResult = await this.deps.privateWhatsAppRepository.storeIncomingMessage(storeInput);
+      if (!storeResult.ok) {
+        logger.error(
+          {
+            matrixEventId: event.matrixEventId,
+            sourceAccountId: input.sourceAccountId,
+            error: storeResult.error,
+          },
+          'Failed to store private WhatsApp event'
+        );
+        return err(storeResult.error);
+      }
+
+      const outcome = storeResult.value;
+      const result: PrivateWhatsAppIngestEventResult = {
+        matrixEventId: outcome.matrixEventId,
+        outcome: outcome.outcome,
+        chatId: outcome.chatId,
+        messageId: outcome.messageId,
+      };
+      messages.push(result);
+    }
+
+    const summary = summarize(messages);
+    logger.info(
+      {
+        sourceAccountId: input.sourceAccountId,
+        deliveryMode: input.deliveryMode,
+        accepted: summary.accepted,
+        duplicates: summary.duplicates,
+        rejected: summary.rejected,
+      },
+      'Private WhatsApp ingest completed'
+    );
+    return ok(summary);
+  }
+}
+
+function parseEvent(rawEvent: unknown): ParseEventResult {
+  if (!isRecord(rawEvent)) {
+    return rejectEvent('<unknown>', 'invalid_event');
+  }
+
+  const matrixEventId = readRequiredString(rawEvent, 'matrixEventId');
+  if (matrixEventId === null) return rejectEvent('<unknown>', 'missing_matrix_event_id');
+
+  const matrixRoomId = readRequiredString(rawEvent, 'matrixRoomId');
+  if (matrixRoomId === null) return rejectEvent(matrixEventId, 'missing_matrix_room_id');
+
+  const matrixSenderId = readRequiredString(rawEvent, 'matrixSenderId');
+  if (matrixSenderId === null) return rejectEvent(matrixEventId, 'missing_matrix_sender_id');
+
+  const eventTimestamp = readRequiredString(rawEvent, 'eventTimestamp');
+  if (eventTimestamp === null) return rejectEvent(matrixEventId, 'missing_event_timestamp');
+  if (Number.isNaN(Date.parse(eventTimestamp))) {
+    return rejectEvent(matrixEventId, 'invalid_event_timestamp');
+  }
+
+  const receivedAt = readOptionalString(rawEvent, 'receivedAt');
+  if (receivedAt === null || (receivedAt !== undefined && Number.isNaN(Date.parse(receivedAt)))) {
+    return rejectEvent(matrixEventId, 'invalid_received_at');
+  }
+
+  const message = parseMessage(rawEvent, matrixEventId);
+  if (!message.ok) return message;
+
+  const chat = parseChat(rawEvent);
+  const event: IngestPrivateWhatsAppEventInput = {
+    matrixRoomId,
+    matrixEventId,
+    matrixSenderId,
+    eventTimestamp,
+    chat,
+    message: message.message,
+    rawMatrixEvent: rawEvent['rawMatrixEvent'] ?? rawEvent,
+  };
+
+  if (receivedAt !== undefined) {
+    event.receivedAt = receivedAt;
+  }
+
+  const sender = parseSender(rawEvent);
+  if (sender !== undefined) {
+    event.sender = sender;
+  }
+
+  return { ok: true, event };
+}
+
+function parseChat(rawEvent: Record<string, unknown>): IngestPrivateWhatsAppEventInput['chat'] {
+  const rawChat = rawEvent['chat'];
+  if (!isRecord(rawChat)) {
+    return { type: 'unknown' };
+  }
+
+  const chat: IngestPrivateWhatsAppEventInput['chat'] = {
+    type: readOptionalString(rawChat, 'type') ?? 'unknown',
+  };
+  const displayName = readOptionalString(rawChat, 'displayName');
+  if (typeof displayName === 'string') {
+    chat.displayName = displayName;
+  }
+  const avatarMxcUri = readOptionalString(rawChat, 'avatarMxcUri');
+  if (typeof avatarMxcUri === 'string') {
+    chat.avatarMxcUri = avatarMxcUri;
+  }
+  return chat;
+}
+
+function parseSender(
+  rawEvent: Record<string, unknown>
+): IngestPrivateWhatsAppEventInput['sender'] | undefined {
+  const rawSender = rawEvent['sender'];
+  if (!isRecord(rawSender)) {
+    return undefined;
+  }
+
+  const sender: NonNullable<IngestPrivateWhatsAppEventInput['sender']> = {};
+  const displayName = readOptionalString(rawSender, 'displayName');
+  if (typeof displayName === 'string') {
+    sender.displayName = displayName;
+  }
+  const phoneNumber = readOptionalString(rawSender, 'phoneNumber');
+  if (typeof phoneNumber === 'string') {
+    sender.phoneNumber = phoneNumber;
+  }
+  return sender;
+}
+
+function parseMessage(
+  rawEvent: Record<string, unknown>,
+  matrixEventId: string
+): ParseMessageResult {
+  const rawMessage = rawEvent['message'];
+  if (!isRecord(rawMessage)) {
+    return rejectEvent(matrixEventId, 'missing_message');
+  }
+
+  const direction = readRequiredString(rawMessage, 'direction');
+  if (direction !== 'incoming') {
+    return rejectEvent(matrixEventId, 'unsupported_direction');
+  }
+
+  const message: IngestPrivateWhatsAppEventInput['message'] = {
+    direction,
+    type: readOptionalString(rawMessage, 'type') ?? 'unknown',
+  };
+  const text = readOptionalString(rawMessage, 'text');
+  if (typeof text === 'string') {
+    message.text = text;
+  }
+
+  const media = parseMedia(rawMessage, matrixEventId);
+  if (!media.ok) return media;
+  if (media.media !== undefined) {
+    message.media = media.media;
+  }
+
+  return { ok: true, message };
+}
+
+function parseMedia(
+  rawMessage: Record<string, unknown>,
+  matrixEventId: string
+): ParseMediaResult {
+  const rawMedia = rawMessage['media'];
+  if (rawMedia === undefined) {
+    return { ok: true };
+  }
+  if (!isRecord(rawMedia)) {
+    return rejectEvent(matrixEventId, 'missing_media_mxc_uri');
+  }
+
+  const mxcUri = readRequiredString(rawMedia, 'mxcUri');
+  if (mxcUri === null) {
+    return rejectEvent(matrixEventId, 'missing_media_mxc_uri');
+  }
+
+  const media: NonNullable<IngestPrivateWhatsAppEventInput['message']['media']> = { mxcUri };
+  const mimeType = readOptionalString(rawMedia, 'mimeType');
+  if (typeof mimeType === 'string') {
+    media.mimeType = mimeType;
+  }
+  const fileName = readOptionalString(rawMedia, 'fileName');
+  if (typeof fileName === 'string') {
+    media.fileName = fileName;
+  }
+  const sizeBytes = rawMedia['sizeBytes'];
+  if (typeof sizeBytes === 'number' && Number.isFinite(sizeBytes)) {
+    media.sizeBytes = sizeBytes;
+  }
+  const sha256 = readOptionalString(rawMedia, 'sha256');
+  if (typeof sha256 === 'string') {
+    media.sha256 = sha256;
+  }
+  return { ok: true, media };
+}
+
+function rejectEvent(matrixEventId: string, reason: string): RejectedEvent {
+  return { ok: false, matrixEventId, reason };
+}
+
+function readRequiredString(record: Record<string, unknown>, key: string): string | null {
+  const value = record[key];
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    return null;
+  }
+  return value;
+}
+
+function readOptionalString(
+  record: Record<string, unknown>,
+  key: string
+): string | undefined | null {
+  const value = record[key];
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== 'string') {
+    return null;
+  }
+  return value;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function toStoreInput(
+  input: IngestPrivateWhatsAppEventsInput,
+  event: IngestPrivateWhatsAppEventInput
+): StorePrivateWhatsAppMessageInput {
+  const storeInput: StorePrivateWhatsAppMessageInput = {
+    sourceAccountId: input.sourceAccountId,
+    userId: input.userId,
+    deliveryMode: input.deliveryMode,
+    receivedAt: event.receivedAt ?? new Date().toISOString(),
+    chat: {
+      matrixRoomId: event.matrixRoomId,
+      type: normalizeChatType(event.chat.type),
+    },
+    message: {
+      matrixRoomId: event.matrixRoomId,
+      matrixEventId: event.matrixEventId,
+      matrixSenderId: event.matrixSenderId,
+      direction: 'incoming',
+      type: normalizeMessageType(event.message.type),
+      eventTimestamp: event.eventTimestamp,
+      rawMatrixEvent: event.rawMatrixEvent,
+    },
+  };
+
+  if (event.chat.displayName !== undefined) {
+    storeInput.chat.displayName = event.chat.displayName;
+  }
+  if (event.chat.avatarMxcUri !== undefined) {
+    storeInput.chat.avatarMxcUri = event.chat.avatarMxcUri;
+  }
+  if (event.sender?.displayName !== undefined) {
+    storeInput.message.senderDisplayName = event.sender.displayName;
+  }
+  if (event.sender?.phoneNumber !== undefined) {
+    storeInput.message.senderPhoneNumber = event.sender.phoneNumber;
+  }
+  if (event.message.text !== undefined) {
+    storeInput.message.text = event.message.text;
+  }
+  if (event.message.media !== undefined) {
+    storeInput.message.media = event.message.media;
+  }
+
+  return storeInput;
+}
+
+function normalizeChatType(type: string): PrivateWhatsAppChatType {
+  if (CHAT_TYPES.has(type as PrivateWhatsAppChatType)) {
+    return type as PrivateWhatsAppChatType;
+  }
+  return 'unknown';
+}
+
+function normalizeMessageType(type: string): PrivateWhatsAppMessageType {
+  if (MESSAGE_TYPES.has(type as PrivateWhatsAppMessageType)) {
+    return type as PrivateWhatsAppMessageType;
+  }
+  return 'unknown';
+}
+
+function summarize(messages: PrivateWhatsAppIngestEventResult[]): PrivateWhatsAppIngestResult {
+  return {
+    accepted: messages.filter((message) => message.outcome === 'created').length,
+    duplicates: messages.filter((message) => message.outcome === 'duplicate').length,
+    rejected: messages.filter((message) => message.outcome === 'rejected').length,
+    messages,
+  };
+}

--- a/apps/whatsapp-service/src/infra/firestore/index.ts
+++ b/apps/whatsapp-service/src/infra/firestore/index.ts
@@ -48,3 +48,11 @@ export {
   getPreferences,
   savePreferences,
 } from './notificationPreferencesRepository.js';
+
+export {
+  PRIVATE_WHATSAPP_CHATS_COLLECTION,
+  PRIVATE_WHATSAPP_MESSAGES_COLLECTION,
+  createPrivateWhatsAppChatId,
+  createPrivateWhatsAppMessageId,
+  createPrivateWhatsAppRepository,
+} from './privateWhatsAppRepository.js';

--- a/apps/whatsapp-service/src/infra/firestore/privateWhatsAppRepository.ts
+++ b/apps/whatsapp-service/src/infra/firestore/privateWhatsAppRepository.ts
@@ -1,0 +1,230 @@
+import { createHash } from 'node:crypto';
+import { err, getErrorMessage, ok, type Result } from '@intexuraos/common-core';
+import { getFirestore } from '@intexuraos/infra-firestore';
+import type { WhatsAppError } from '../../domain/whatsapp/index.js';
+import type {
+  PrivateWhatsAppChat,
+  PrivateWhatsAppIngestOutcome,
+  PrivateWhatsAppMessage,
+  StorePrivateWhatsAppMessageInput,
+} from '../../domain/whatsapp/index.js';
+import type { PrivateWhatsAppRepository } from '../../domain/whatsapp/index.js';
+
+export const PRIVATE_WHATSAPP_CHATS_COLLECTION = 'whatsapp_private_chats';
+export const PRIVATE_WHATSAPP_MESSAGES_COLLECTION = 'whatsapp_private_messages';
+
+export function createPrivateWhatsAppChatId(
+  sourceAccountId: string,
+  matrixRoomId: string
+): string {
+  return createPrivateWhatsAppId(sourceAccountId, matrixRoomId);
+}
+
+export function createPrivateWhatsAppMessageId(
+  sourceAccountId: string,
+  matrixEventId: string
+): string {
+  return createPrivateWhatsAppId(sourceAccountId, matrixEventId);
+}
+
+function createPrivateWhatsAppId(sourceAccountId: string, matrixId: string): string {
+  return createHash('sha256').update(`${sourceAccountId}\0${matrixId}`).digest('hex');
+}
+
+export function createPrivateWhatsAppRepository(): PrivateWhatsAppRepository {
+  return {
+    storeIncomingMessage,
+  };
+}
+
+async function storeIncomingMessage(
+  input: StorePrivateWhatsAppMessageInput
+): Promise<Result<PrivateWhatsAppIngestOutcome, WhatsAppError>> {
+  try {
+    const db = getFirestore();
+    const chatId = createPrivateWhatsAppChatId(input.sourceAccountId, input.chat.matrixRoomId);
+    const messageId = createPrivateWhatsAppMessageId(
+      input.sourceAccountId,
+      input.message.matrixEventId
+    );
+    const chatRef = db.collection(PRIVATE_WHATSAPP_CHATS_COLLECTION).doc(chatId);
+    const messageRef = db.collection(PRIVATE_WHATSAPP_MESSAGES_COLLECTION).doc(messageId);
+
+    const outcome = await db.runTransaction(async (transaction) => {
+      const existingMessage = await transaction.get(messageRef);
+      if (existingMessage.exists) {
+        return {
+          outcome: 'duplicate' as const,
+          chatId,
+          messageId,
+          matrixEventId: input.message.matrixEventId,
+        };
+      }
+
+      const existingChat = await transaction.get(chatRef);
+      const chat = buildChat(input, chatId, existingChat.data() as PrivateWhatsAppChat | undefined);
+      const message = buildMessage(input, chatId, messageId);
+
+      transaction.set(chatRef, chat, { merge: true });
+      transaction.set(messageRef, message);
+
+      return {
+        outcome: 'created' as const,
+        chatId,
+        messageId,
+        matrixEventId: input.message.matrixEventId,
+      };
+    });
+
+    return ok(outcome);
+  } catch (error) {
+    return err({
+      code: 'PERSISTENCE_ERROR',
+      message: `Failed to store private WhatsApp message: ${getErrorMessage(error, 'Unknown Firestore error')}`,
+    });
+  }
+}
+
+function buildChat(
+  input: StorePrivateWhatsAppMessageInput,
+  chatId: string,
+  existingChat: PrivateWhatsAppChat | undefined
+): PrivateWhatsAppChat {
+  const now = new Date().toISOString();
+  const shouldApplyIncomingChatMetadata = isSameOrNewerChatEvent(
+    existingChat,
+    input.message.eventTimestamp
+  );
+  const chat: PrivateWhatsAppChat = {
+    id: chatId,
+    userId: input.userId,
+    sourceAccountId: input.sourceAccountId,
+    matrixRoomId: input.chat.matrixRoomId,
+    chatType: selectChatType(existingChat, input.chat.type, shouldApplyIncomingChatMetadata),
+    firstSeenAt: oldestTimestamp(existingChat?.firstSeenAt, input.message.eventTimestamp),
+    lastEventAt: newestTimestamp(existingChat?.lastEventAt, input.message.eventTimestamp),
+    updatedAt: now,
+  };
+
+  if (
+    input.chat.displayName !== undefined &&
+    (shouldApplyIncomingChatMetadata || existingChat?.displayName === undefined)
+  ) {
+    chat.displayName = input.chat.displayName;
+  } else if (existingChat?.displayName !== undefined) {
+    chat.displayName = existingChat.displayName;
+  }
+  if (
+    input.chat.avatarMxcUri !== undefined &&
+    (shouldApplyIncomingChatMetadata || existingChat?.avatarMxcUri === undefined)
+  ) {
+    chat.avatarMxcUri = input.chat.avatarMxcUri;
+  } else if (existingChat?.avatarMxcUri !== undefined) {
+    chat.avatarMxcUri = existingChat.avatarMxcUri;
+  }
+
+  return chat;
+}
+
+function selectChatType(
+  existingChat: PrivateWhatsAppChat | undefined,
+  nextChatType: StorePrivateWhatsAppMessageInput['chat']['type'],
+  shouldApplyIncomingChatMetadata: boolean
+): PrivateWhatsAppChat['chatType'] {
+  if (existingChat === undefined) {
+    return nextChatType;
+  }
+  if (!shouldApplyIncomingChatMetadata) {
+    return existingChat.chatType;
+  }
+  if (nextChatType === 'unknown' && existingChat.chatType !== 'unknown') {
+    return existingChat.chatType;
+  }
+  return nextChatType;
+}
+
+function oldestTimestamp(existingTimestamp: string | undefined, nextTimestamp: string): string {
+  if (existingTimestamp === undefined) {
+    return nextTimestamp;
+  }
+  const existingMs = Date.parse(existingTimestamp);
+  const nextMs = Date.parse(nextTimestamp);
+  if (Number.isNaN(existingMs)) {
+    return nextTimestamp;
+  }
+  if (Number.isNaN(nextMs)) {
+    return existingTimestamp;
+  }
+  return nextMs < existingMs ? nextTimestamp : existingTimestamp;
+}
+
+function newestTimestamp(existingTimestamp: string | undefined, nextTimestamp: string): string {
+  if (existingTimestamp === undefined) {
+    return nextTimestamp;
+  }
+  const existingMs = Date.parse(existingTimestamp);
+  const nextMs = Date.parse(nextTimestamp);
+  if (Number.isNaN(existingMs)) {
+    return nextTimestamp;
+  }
+  if (Number.isNaN(nextMs)) {
+    return existingTimestamp;
+  }
+  return nextMs > existingMs ? nextTimestamp : existingTimestamp;
+}
+
+function isSameOrNewerChatEvent(
+  existingChat: PrivateWhatsAppChat | undefined,
+  nextTimestamp: string
+): boolean {
+  if (existingChat === undefined) {
+    return true;
+  }
+  const existingMs = Date.parse(existingChat.lastEventAt);
+  const nextMs = Date.parse(nextTimestamp);
+  if (Number.isNaN(existingMs)) {
+    return true;
+  }
+  if (Number.isNaN(nextMs)) {
+    return false;
+  }
+  return nextMs >= existingMs;
+}
+
+function buildMessage(
+  input: StorePrivateWhatsAppMessageInput,
+  chatId: string,
+  messageId: string
+): PrivateWhatsAppMessage {
+  const message: PrivateWhatsAppMessage = {
+    id: messageId,
+    chatId,
+    userId: input.userId,
+    sourceAccountId: input.sourceAccountId,
+    matrixRoomId: input.message.matrixRoomId,
+    matrixEventId: input.message.matrixEventId,
+    matrixSenderId: input.message.matrixSenderId,
+    direction: input.message.direction,
+    messageType: input.message.type,
+    eventTimestamp: input.message.eventTimestamp,
+    receivedAt: input.receivedAt,
+    ingestedAt: new Date().toISOString(),
+    deliveryMode: input.deliveryMode,
+    rawMatrixEvent: input.message.rawMatrixEvent,
+  };
+
+  if (input.message.senderDisplayName !== undefined) {
+    message.senderDisplayName = input.message.senderDisplayName;
+  }
+  if (input.message.senderPhoneNumber !== undefined) {
+    message.senderPhoneNumber = input.message.senderPhoneNumber;
+  }
+  if (input.message.text !== undefined) {
+    message.text = input.message.text;
+  }
+  if (input.message.media !== undefined) {
+    message.media = input.message.media;
+  }
+
+  return message;
+}

--- a/apps/whatsapp-service/src/routes/index.ts
+++ b/apps/whatsapp-service/src/routes/index.ts
@@ -13,6 +13,7 @@ import { preferencesRoutes } from './preferencesRoutes.js';
 import { createPubsubRoutes } from './pubsubRoutes.js';
 import { verificationRoutes } from './verificationRoutes.js';
 import { internalRoutes } from './internalRoutes.js';
+import { privateSyncRoutes } from './privateSyncRoutes.js';
 
 /**
  * Creates routes plugin with config.
@@ -29,6 +30,7 @@ export function createWhatsappRoutes(config: Config): FastifyPluginCallback {
     fastify.register(verificationRoutes);
     fastify.register(createPubsubRoutes());
     fastify.register(internalRoutes);
+    fastify.register(privateSyncRoutes);
     done();
   };
 }

--- a/apps/whatsapp-service/src/routes/privateSyncRoutes.ts
+++ b/apps/whatsapp-service/src/routes/privateSyncRoutes.ts
@@ -1,0 +1,160 @@
+import type { FastifyPluginCallback, FastifyReply, FastifyRequest } from 'fastify';
+import { logIncomingRequest, validateInternalAuth } from '@intexuraos/common-http';
+import {
+  IngestPrivateWhatsAppEventsUseCase,
+  type IngestPrivateWhatsAppEventsInput,
+} from '../domain/whatsapp/index.js';
+import { getServices } from '../services.js';
+
+type ValidatedRequest = FastifyRequest & { validationError?: unknown };
+
+function getPrivateSyncLogMetadata(body: unknown): Record<string, unknown> {
+  if (body === null || typeof body !== 'object') {
+    return {
+      route: 'internal_whatsapp_private_events',
+      bodyType: typeof body,
+    };
+  }
+
+  const payload = body as Record<string, unknown>;
+  return {
+    route: 'internal_whatsapp_private_events',
+    deliveryMode: typeof payload['deliveryMode'] === 'string' ? payload['deliveryMode'] : 'unknown',
+    eventCount: Array.isArray(payload['events']) ? payload['events'].length : 0,
+    hasSourceAccountId: typeof payload['sourceAccountId'] === 'string',
+    hasUserId: typeof payload['userId'] === 'string',
+  };
+}
+
+export const privateSyncRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
+  fastify.post(
+    '/internal/whatsapp/private/events',
+    {
+      attachValidation: true,
+      schema: {
+        operationId: 'ingestPrivateWhatsAppEvents',
+        summary: 'Ingest private WhatsApp events',
+        description:
+          'Internal endpoint for an external Matrix/mautrix bridge to synchronize private WhatsApp messages into Firestore.',
+        tags: ['internal'],
+        body: {
+          type: 'object',
+          additionalProperties: false,
+          properties: {
+            sourceAccountId: { type: 'string', minLength: 1 },
+            userId: { type: 'string', minLength: 1 },
+            deliveryMode: { type: 'string', enum: ['live', 'backfill'] },
+            events: {
+              type: 'array',
+              minItems: 1,
+              maxItems: 100,
+              items: {},
+            },
+          },
+          required: ['sourceAccountId', 'userId', 'deliveryMode', 'events'],
+        },
+        response: {
+          200: {
+            description: 'Private WhatsApp events ingested',
+            type: 'object',
+            properties: {
+              success: { type: 'boolean', const: true },
+              data: {
+                type: 'object',
+                properties: {
+                  accepted: { type: 'number' },
+                  duplicates: { type: 'number' },
+                  rejected: { type: 'number' },
+                  messages: {
+                    type: 'array',
+                    items: {
+                      type: 'object',
+                      properties: {
+                        matrixEventId: { type: 'string' },
+                        outcome: {
+                          type: 'string',
+                          enum: ['created', 'duplicate', 'rejected'],
+                        },
+                        chatId: { type: 'string' },
+                        messageId: { type: 'string' },
+                        reason: { type: 'string' },
+                      },
+                      required: ['matrixEventId', 'outcome'],
+                    },
+                  },
+                },
+                required: ['accepted', 'duplicates', 'rejected', 'messages'],
+              },
+            },
+            required: ['success', 'data'],
+          },
+          400: {
+            description: 'Invalid request',
+            type: 'object',
+            properties: {
+              success: { type: 'boolean', const: false },
+              error: { $ref: 'ErrorBody#' },
+            },
+            required: ['success', 'error'],
+          },
+          401: {
+            description: 'Unauthorized',
+            type: 'object',
+            properties: {
+              success: { type: 'boolean', const: false },
+              error: { $ref: 'ErrorBody#' },
+            },
+            required: ['success', 'error'],
+          },
+          500: {
+            description: 'Persistence failure',
+            type: 'object',
+            properties: {
+              success: { type: 'boolean', const: false },
+              error: { $ref: 'ErrorBody#' },
+            },
+            required: ['success', 'error'],
+          },
+        },
+      },
+    },
+    async (request: FastifyRequest, reply: FastifyReply) => {
+      logIncomingRequest(request, {
+        message: 'Received request to /internal/whatsapp/private/events',
+        bodyPreviewLength: 0,
+        additionalFields: getPrivateSyncLogMetadata(request.body),
+      });
+
+      const authResult = validateInternalAuth(request);
+      if (!authResult.valid) {
+        request.log.warn(
+          { reason: authResult.reason },
+          'Internal auth failed for private WhatsApp ingest'
+        );
+        return await reply.fail('UNAUTHORIZED', 'Internal auth failed for private WhatsApp ingest');
+      }
+
+      const validatedRequest = request as ValidatedRequest;
+      if (validatedRequest.validationError !== undefined) {
+        return await reply.fail('INVALID_REQUEST', 'Validation failed');
+      }
+
+      const services = getServices();
+      const useCase = new IngestPrivateWhatsAppEventsUseCase({
+        privateWhatsAppRepository: services.privateWhatsAppRepository,
+      });
+      const result = await useCase.execute(
+        request.body as IngestPrivateWhatsAppEventsInput,
+        request.log
+      );
+
+      if (!result.ok) {
+        return await reply.fail('INTERNAL_ERROR', result.error.message);
+      }
+
+      return await reply.ok(result.value);
+    }
+  );
+
+  done();
+};

--- a/apps/whatsapp-service/src/routes/routes.ts
+++ b/apps/whatsapp-service/src/routes/routes.ts
@@ -16,6 +16,7 @@
  * PUT    /whatsapp/preferences        → ./preferencesRoutes.ts
  * POST   /internal/whatsapp/pubsub/send-message   → ./pubsubRoutes.ts
  * POST   /internal/whatsapp/webhooks/retry-pending → ./internalRoutes.ts
+ * POST   /internal/whatsapp/private/events        → ./privateSyncRoutes.ts
  * ─────────────────────────────────────────────────────────────
  */
 

--- a/apps/whatsapp-service/src/services.ts
+++ b/apps/whatsapp-service/src/services.ts
@@ -22,6 +22,7 @@ import type {
   NotificationPreferencesRepository,
   OutboundMessageRepository,
   PhoneVerificationRepository,
+  PrivateWhatsAppRepository,
   ThumbnailGeneratorPort,
   WhatsAppCloudApiPort,
   WhatsAppMessageRepository,
@@ -30,6 +31,7 @@ import type {
   WhatsAppWebhookEventRepository,
 } from './domain/whatsapp/index.js';
 import { createOutboundMessageRepository } from './infra/firestore/outboundMessageRepository.js';
+import { createPrivateWhatsAppRepository } from './infra/firestore/privateWhatsAppRepository.js';
 
 /**
  * Configuration for service initialization.
@@ -74,6 +76,7 @@ export interface ServiceContainer {
   outboundMessageRepository: OutboundMessageRepository;
   phoneVerificationRepository: PhoneVerificationRepository;
   notificationPreferencesRepository: NotificationPreferencesRepository;
+  privateWhatsAppRepository: PrivateWhatsAppRepository;
   mediaStorage: MediaStoragePort;
   eventPublisher: EventPublisherPort;
   messageSender: WhatsAppMessageSender;
@@ -113,6 +116,7 @@ export function getServices(): ServiceContainer {
     outboundMessageRepository: createOutboundMessageRepository(),
     phoneVerificationRepository: new PhoneVerificationRepositoryAdapter(),
     notificationPreferencesRepository: new NotificationPreferencesRepositoryAdapter(),
+    privateWhatsAppRepository: createPrivateWhatsAppRepository(),
     mediaStorage: new GcsMediaStorageAdapter(serviceConfig.mediaBucket),
     eventPublisher: new GcpPubSubPublisher(buildPubSubConfig(serviceConfig)),
     messageSender: new WhatsAppCloudApiSender(

--- a/docs/operations/hetzner-prod-runbook.md
+++ b/docs/operations/hetzner-prod-runbook.md
@@ -370,6 +370,13 @@ The verifier only accepts tokens whose signed `email` claim is one of the
 expected retained-GCP Pub/Sub push service accounts or the Cloud Scheduler
 service account.
 
+Private WhatsApp sync uses the same edge-auth path. The external bridge machine
+must call `POST https://intexuraos.cloud/internal/whatsapp/private/events` with
+a Google OIDC bearer token whose audience is `https://intexuraos.cloud` and
+whose email claim is
+`intexuraos-wa-private-sync-dev@intexuraos-dev-pbuchman.iam.gserviceaccount.com`.
+The public `/api/whatsapp/internal/*` prefix is blocked and must not be used.
+
 ## Route Ownership Notes
 
 Public `/api/*` routes mirror `apps/web/service-manifest.json`.

--- a/firestore-collections.json
+++ b/firestore-collections.json
@@ -38,6 +38,14 @@
       "owner": "whatsapp-service",
       "description": "Phone number verification codes with TTL-based expiry for WhatsApp connection"
     },
+    "whatsapp_private_chats": {
+      "owner": "whatsapp-service",
+      "description": "Private WhatsApp chat metadata synchronized from Matrix/mautrix bridge events. Separate from WhatsApp Business API collections."
+    },
+    "whatsapp_private_messages": {
+      "owner": "whatsapp-service",
+      "description": "Read-only private WhatsApp messages synchronized from Matrix/mautrix bridge events. Separate from WhatsApp Business API messages and mobile notifications."
+    },
     "mobile_notifications": {
       "owner": "mobile-notifications-service",
       "description": "Mobile push notifications received from user devices"

--- a/scripts/__tests__/hetzner-runtime.test.ts
+++ b/scripts/__tests__/hetzner-runtime.test.ts
@@ -216,7 +216,9 @@ describe('Hetzner nginx runtime config', () => {
 
     expect(config).toContain('access_by_lua_file /etc/nginx/lua/jwt-verify.lua;');
     expect(verifier).toContain('EXPECTED_AUD = "https://intexuraos.cloud"');
-    expect(verifier).toContain('ALLOWED_SERVICE_ACCOUNTS');
+    expect(verifier).toContain('GLOBAL_ALLOWED_SERVICE_ACCOUNTS');
+    expect(verifier).toContain('ROUTE_ALLOWED_SERVICE_ACCOUNTS');
+    expect(verifier).toContain('ngx.var.uri');
     expect(verifier).toContain(
       'intexuraos-scheduler-dev@intexuraos-dev-pbuchman.iam.gserviceaccount.com'
     );
@@ -241,6 +243,28 @@ describe('Hetzner nginx runtime config', () => {
     expect(verifier).toContain('ngx.var.edge_internal_auth_token = internal_auth_token');
     expect(verifier).not.toContain('ngx.req.set_header("X-Internal-Auth"');
     expect(verifier).toContain('/etc/intexuraos/internal-auth-token');
+
+    const globalAllowlist = verifier.slice(
+      verifier.indexOf('GLOBAL_ALLOWED_SERVICE_ACCOUNTS'),
+      verifier.indexOf('ROUTE_ALLOWED_SERVICE_ACCOUNTS')
+    );
+    const routeAllowlist = verifier.slice(verifier.indexOf('ROUTE_ALLOWED_SERVICE_ACCOUNTS'));
+    expect(globalAllowlist).not.toContain(
+      'intexuraos-wa-private-sync-dev@intexuraos-dev-pbuchman.iam.gserviceaccount.com'
+    );
+    expect(routeAllowlist).toContain('["/internal/whatsapp/private/events"]');
+    expect(routeAllowlist).toContain(
+      'intexuraos-wa-private-sync-dev@intexuraos-dev-pbuchman.iam.gserviceaccount.com'
+    );
+
+    const allowFunction = verifier.slice(
+      verifier.indexOf('local function is_service_account_allowed'),
+      verifier.indexOf('local auth_header')
+    );
+    const routeLookupIndex = allowFunction.indexOf('ROUTE_ALLOWED_SERVICE_ACCOUNTS[ngx.var.uri]');
+    const globalLookupIndex = allowFunction.indexOf('GLOBAL_ALLOWED_SERVICE_ACCOUNTS[email]');
+    expect(routeLookupIndex).toBeGreaterThanOrEqual(0);
+    expect(globalLookupIndex).toBeGreaterThan(routeLookupIndex);
   });
 });
 
@@ -565,6 +589,7 @@ describe('Hetzner async edge cutover', () => {
     expect(devTerraform).not.toContain('local.async_edge_audience');
     expect(prTriageTerraform).not.toContain('local.hetzner_edge_origin');
     expect(hetznerMain).toContain('activate_hetzner_async_consumers');
+    expect(hetznerMain).toContain('"/internal/whatsapp/private/events"');
     expect(hetznerPubsub).toContain('google_pubsub_subscription" "hetzner_push"');
     expect(hetznerPubsub).toContain(
       'filter  = var.activate_hetzner_async_consumers ? null : local.pubsub_staging_filter'

--- a/scripts/hetzner/nginx/jwt-verify.lua
+++ b/scripts/hetzner/nginx/jwt-verify.lua
@@ -4,7 +4,7 @@ local openidc = require("resty.openidc")
 local EXPECTED_ISS = "https://accounts.google.com"
 local EXPECTED_AUD = "https://intexuraos.cloud"
 local INTERNAL_AUTH_TOKEN_FILE = "/etc/intexuraos/internal-auth-token"
-local ALLOWED_SERVICE_ACCOUNTS = {
+local GLOBAL_ALLOWED_SERVICE_ACCOUNTS = {
   ["intexuraos-scheduler-dev@intexuraos-dev-pbuchman.iam.gserviceaccount.com"] = true,
   ["intexuraos-whatsapp-svc-dev@intexuraos-dev-pbuchman.iam.gserviceaccount.com"] = true,
   ["intexuraos-commands-agents-dev@intexuraos-dev-pbuchman.iam.gserviceaccount.com"] = true,
@@ -14,6 +14,12 @@ local ALLOWED_SERVICE_ACCOUNTS = {
   ["intexuraos-bookmarks-dev@intexuraos-dev-pbuchman.iam.gserviceaccount.com"] = true,
   ["intexuraos-todos-dev@intexuraos-dev-pbuchman.iam.gserviceaccount.com"] = true,
   ["intexuraos-code-dev@intexuraos-dev-pbuchman.iam.gserviceaccount.com"] = true,
+}
+
+local ROUTE_ALLOWED_SERVICE_ACCOUNTS = {
+  ["/internal/whatsapp/private/events"] = {
+    ["intexuraos-wa-private-sync-dev@intexuraos-dev-pbuchman.iam.gserviceaccount.com"] = true,
+  },
 }
 
 local opts = {
@@ -58,6 +64,15 @@ local function read_internal_auth_token()
   return token
 end
 
+local function is_service_account_allowed(email)
+  local route_allowed_service_accounts = ROUTE_ALLOWED_SERVICE_ACCOUNTS[ngx.var.uri]
+  if route_allowed_service_accounts ~= nil then
+    return route_allowed_service_accounts[email] == true
+  end
+
+  return GLOBAL_ALLOWED_SERVICE_ACCOUNTS[email] == true
+end
+
 local auth_header = ngx.var.http_authorization
 if auth_header == nil then
   return deny(ngx.HTTP_UNAUTHORIZED, "missing_authorization_header")
@@ -96,7 +111,7 @@ if not aud_ok then
   return deny(ngx.HTTP_UNAUTHORIZED, "invalid_audience")
 end
 
-if type(claims.email) ~= "string" or not ALLOWED_SERVICE_ACCOUNTS[claims.email] then
+if type(claims.email) ~= "string" or not is_service_account_allowed(claims.email) then
   ngx.log(ngx.WARN, "Google OIDC service account is not allowed")
   return deny(ngx.HTTP_FORBIDDEN, "forbidden_service_account")
 end

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -589,6 +589,12 @@ resource "google_service_account" "hetzner_runtime" {
   description  = "Union runtime service account for PM2 services on the Hetzner VM"
 }
 
+resource "google_service_account" "whatsapp_private_sync" {
+  account_id   = "intexuraos-wa-private-sync-${var.environment}"
+  display_name = "IntexuraOS Private WhatsApp Sync (${var.environment})"
+  description  = "External bridge caller identity for private WhatsApp sync ingestion"
+}
+
 resource "google_secret_manager_secret_iam_member" "hetzner_provisioner_runtime_secrets" {
   for_each = local.hetzner_runtime_secret_names
 
@@ -634,6 +640,12 @@ resource "google_service_account_iam_member" "hetzner_runtime_token_creator" {
   service_account_id = google_service_account.hetzner_runtime.name
   role               = "roles/iam.serviceAccountTokenCreator"
   member             = "serviceAccount:${google_service_account.hetzner_runtime.email}"
+}
+
+resource "google_service_account_iam_member" "whatsapp_private_sync_token_creator" {
+  service_account_id = google_service_account.whatsapp_private_sync.name
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "serviceAccount:${google_service_account.whatsapp_private_sync.email}"
 }
 
 resource "google_storage_bucket_iam_member" "hetzner_runtime_bucket_object_admin" {
@@ -1667,6 +1679,11 @@ output "firestore_database" {
 output "service_accounts" {
   description = "Service account emails"
   value       = module.iam.service_accounts
+}
+
+output "whatsapp_private_sync_service_account" {
+  description = "Service account email allowed to call production private WhatsApp sync ingest"
+  value       = google_service_account.whatsapp_private_sync.email
 }
 
 output "static_assets_bucket_name" {

--- a/terraform/hetzner-prod/main.tf
+++ b/terraform/hetzner-prod/main.tf
@@ -84,6 +84,7 @@ locals {
     "/internal/notifications/digest/run-yesterday"      = "mobile-notifications-service"
     "/internal/retry-pending"                           = "commands-agent"
     "/internal/todos/pubsub/todos-processing"           = "todos-agent"
+    "/internal/whatsapp/private/events"                 = "whatsapp-service"
     "/internal/whatsapp/pubsub/media-cleanup"           = "whatsapp-service"
     "/internal/whatsapp/pubsub/process-webhook"         = "whatsapp-service"
     "/internal/whatsapp/pubsub/send-message"            = "whatsapp-service"


### PR DESCRIPTION
## Summary

- Add read-only private WhatsApp ingest at `/internal/whatsapp/private/events`, with live/backfill batches and per-event rejection.
- Store private chats/messages in dedicated Firestore collections owned by whatsapp-service.
- Wire Hetzner edge auth/routing so the external bridge calls `https://intexuraos.cloud/internal/whatsapp/private/events` through route-scoped Google OIDC.

## Verification

- `pnpm run ci:tracked`
- `pnpm vitest run apps/whatsapp-service/src/__tests__/privateSyncRoutes.test.ts apps/whatsapp-service/src/__tests__/usecases/ingestPrivateWhatsAppEvents.test.ts apps/whatsapp-service/src/__tests__/infra/privateWhatsAppRepository.test.ts scripts/__tests__/hetzner-runtime.test.ts`
- `codex review --base origin/development`

## Linear

Linear: omitted by `$commit-push`; GitHub automation will create or link the Linear issue after PR creation.