### PR TITLE
[INT-1676] Fix private WhatsApp log layout and Matrix invite sync

### DIFF
--- a/apps/web/src/pages/PrivateWhatsAppLogPage.tsx
+++ b/apps/web/src/pages/PrivateWhatsAppLogPage.tsx
@@ -132,7 +132,7 @@ export function PrivateWhatsAppLogPage(): React.JSX.Element {
 
   return (
     <Layout>
-      <div className="mx-auto flex max-w-7xl flex-col gap-4">
+      <div data-testid="private-whatsapp-log-shell" className="flex w-full min-w-0 flex-col gap-4">
         <header className="flex flex-col gap-3 border-b border-slate-200 pb-4 dark:border-slate-800 md:flex-row md:items-end md:justify-between">
           <div>
             <h2 className="text-2xl font-bold text-slate-950 dark:text-slate-50">
@@ -158,8 +158,11 @@ export function PrivateWhatsAppLogPage(): React.JSX.Element {
 
         <ErrorBanner message={log.error} />
 
-        <div className="grid min-h-[calc(100vh-12rem)] grid-cols-1 gap-4 lg:grid-cols-[22rem_minmax(0,1fr)]">
-          <aside className="flex min-h-0 flex-col rounded-lg border border-slate-200 bg-white dark:border-slate-800 dark:bg-slate-900">
+        <div className="grid min-h-[calc(100vh-12rem)] grid-cols-1 gap-4 xl:grid-cols-[minmax(18rem,22rem)_minmax(0,1fr)] 2xl:grid-cols-[minmax(20rem,24rem)_minmax(0,1fr)]">
+          <aside
+            data-testid="private-whatsapp-sender-rail"
+            className="flex max-h-[45vh] min-h-0 flex-col rounded-lg border border-slate-200 bg-white dark:border-slate-800 dark:bg-slate-900 sm:max-h-[28rem] xl:max-h-none"
+          >
             <div className="border-b border-slate-200 p-3 dark:border-slate-800">
               <label className="sr-only" htmlFor="private-whatsapp-sender-search">
                 Search senders
@@ -257,7 +260,10 @@ export function PrivateWhatsAppLogPage(): React.JSX.Element {
             ) : null}
           </aside>
 
-          <section className="min-w-0 rounded-lg border border-slate-200 bg-white dark:border-slate-800 dark:bg-slate-900">
+          <section
+            data-testid="private-whatsapp-message-timeline"
+            className="min-w-0 rounded-lg border border-slate-200 bg-white dark:border-slate-800 dark:bg-slate-900"
+          >
             <div className="sticky top-16 z-10 border-b border-slate-200 bg-white/95 p-4 backdrop-blur dark:border-slate-800 dark:bg-slate-900/95">
               <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
                 <div className="min-w-0">

--- a/apps/web/src/pages/__tests__/PrivateWhatsAppLogPage.test.tsx
+++ b/apps/web/src/pages/__tests__/PrivateWhatsAppLogPage.test.tsx
@@ -156,6 +156,22 @@ describe('PrivateWhatsAppLogPage', () => {
     expect(screen.queryByPlaceholderText(/send a message/i)).not.toBeInTheDocument();
   });
 
+  it('uses the full work surface with a mobile-bounded sender rail', () => {
+    render(
+      <MemoryRouter>
+        <PrivateWhatsAppLogPage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByTestId('private-whatsapp-log-shell')).toHaveClass('w-full', 'min-w-0');
+    expect(screen.getByTestId('private-whatsapp-log-shell')).not.toHaveClass('max-w-7xl');
+    expect(screen.getByTestId('private-whatsapp-sender-rail')).toHaveClass(
+      'max-h-[45vh]',
+      'xl:max-h-none'
+    );
+    expect(screen.getByTestId('private-whatsapp-message-timeline')).toHaveClass('min-w-0');
+  });
+
   it('uses day chips to filter messages by exact eventDayKey', async () => {
     const user = userEvent.setup();
     const selectDay = vi.fn();

--- a/scripts/__tests__/verify-required-endpoints.test.ts
+++ b/scripts/__tests__/verify-required-endpoints.test.ts
@@ -1,0 +1,17 @@
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const SCRIPT = path.resolve(import.meta.dirname, '..', 'verify-required-endpoints.mjs');
+
+describe('verify-required-endpoints', () => {
+  it('accepts dist-only service bundles that expose the required endpoints', () => {
+    const result = spawnSync('node', [SCRIPT], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toMatch(/All \d+ services have required endpoints/);
+  });
+});

--- a/scripts/verify-required-endpoints.mjs
+++ b/scripts/verify-required-endpoints.mjs
@@ -11,7 +11,7 @@
  * 4. Report missing endpoints with remediation steps
  */
 
-import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 
 const repoRoot = resolve(import.meta.dirname, '..');
@@ -53,10 +53,10 @@ function checkServerFile(appName) {
     let content = '';
     let exists = false;
 
-    if (statSync(serverPath).isFile()) {
+    if (existsSync(serverPath) && statSync(serverPath).isFile()) {
       content = readFileSync(serverPath, 'utf8');
       exists = true;
-    } else if (statSync(distPath).isFile()) {
+    } else if (existsSync(distPath) && statSync(distPath).isFile()) {
       content = readFileSync(distPath, 'utf8');
       exists = true;
     }

--- a/tools/whatsapp-private-matrix-sync/src/server.mjs
+++ b/tools/whatsapp-private-matrix-sync/src/server.mjs
@@ -136,6 +136,22 @@ export function extractRoomContexts(syncResponse, existingRoomContexts = {}) {
   return roomContexts;
 }
 
+export function collectWhatsAppInviteRoomIds(syncResponse, config) {
+  const invitedRooms = syncResponse?.rooms?.invite;
+  if (!isRecord(invitedRooms)) {
+    return [];
+  }
+
+  const roomIds = [];
+  for (const [roomId, room] of Object.entries(invitedRooms)) {
+    if (isWhatsAppInviteRoom(room, config)) {
+      roomIds.push(roomId);
+    }
+  }
+
+  return roomIds;
+}
+
 export async function ensureRoomContextsForIncomingEvents(
   syncResponse,
   existingRoomContexts,
@@ -326,6 +342,7 @@ export async function runSyncIteration(config, runtime, deps = {}) {
   const readSyncStateFn = deps.readSyncState ?? readSyncState;
   const fetchMatrixSyncFn = deps.fetchMatrixSync ?? fetchMatrixSync;
   const fetchMatrixRoomStateFn = deps.fetchMatrixRoomState ?? fetchMatrixRoomState;
+  const joinMatrixRoomFn = deps.joinMatrixRoom ?? joinMatrixRoom;
   const postEventsInBatchesFn = deps.postEventsInBatches ?? postEventsInBatches;
   const writeSyncStateFn = deps.writeSyncState ?? writeSyncState;
   const nowISOString = deps.nowISOString ?? (() => new Date().toISOString());
@@ -345,12 +362,24 @@ export async function runSyncIteration(config, runtime, deps = {}) {
   const hasStoredBatch = typeof state.nextBatch === 'string' && state.nextBatch.length > 0;
   runtime.state = hasStoredBatch ? 'running' : 'initializing';
 
-  const syncResponse = await fetchMatrixSyncFn(
+  let syncResponse = await fetchMatrixSyncFn(
     config,
     matrixAccessToken,
     state.nextBatch,
     hasStoredBatch ? config.pollTimeoutMs : config.initialSyncTimeoutMs
   );
+  let syncResponseCount = 1;
+
+  const inviteRoomIds = collectWhatsAppInviteRoomIds(syncResponse, config);
+  if (inviteRoomIds.length > 0) {
+    for (const roomId of inviteRoomIds) {
+      await joinMatrixRoomFn(config, matrixAccessToken, roomId);
+    }
+    runtime.counters.joinedRooms = (runtime.counters.joinedRooms ?? 0) + inviteRoomIds.length;
+
+    syncResponse = await fetchMatrixSyncFn(config, matrixAccessToken, state.nextBatch, 0);
+    syncResponseCount += 1;
+  }
 
   let roomContexts = extractRoomContexts(syncResponse, state.roomContexts ?? {});
   if (hasStoredBatch) {
@@ -366,7 +395,7 @@ export async function runSyncIteration(config, runtime, deps = {}) {
     hasStoredBatch,
     roomContexts,
   });
-  runtime.counters.syncResponses = (runtime.counters.syncResponses ?? 0) + 1;
+  runtime.counters.syncResponses = (runtime.counters.syncResponses ?? 0) + syncResponseCount;
 
   if (plan.events.length > 0) {
     await postEventsInBatchesFn(config, plan.events);
@@ -527,6 +556,28 @@ function incomingWhatsAppSendersFromRoom(room, config) {
   return senders;
 }
 
+function isWhatsAppInviteRoom(room, config) {
+  if (!isRecord(room)) {
+    return false;
+  }
+
+  const inviteStateEvents = Array.isArray(room.invite_state?.events)
+    ? room.invite_state.events
+    : [];
+  const bridgeBotUsers = config.bridgeBotUsers ?? defaultBridgeBotUsers;
+  return inviteStateEvents.some((event) => {
+    if (!isRecord(event)) {
+      return false;
+    }
+    const sender = readString(event, 'sender');
+    if (sender !== undefined && bridgeBotUsers.has(sender)) {
+      return true;
+    }
+
+    return readString(event, 'type') === 'm.bridge';
+  });
+}
+
 function mergeRoomContext(existing, next) {
   return {
     ...(existing ?? {}),
@@ -684,6 +735,27 @@ async function fetchMatrixRoomState(config, accessToken, roomId, stateType, stat
   if (!response.ok) {
     throw new Error(`matrix_room_state_failed_${response.status}`);
   }
+  return await response.json();
+}
+
+async function joinMatrixRoom(config, accessToken, roomId) {
+  const url = new URL(
+    `/_matrix/client/v3/join/${encodeURIComponent(roomId)}`,
+    config.homeserverUrl
+  );
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${accessToken}`,
+      'content-type': 'application/json',
+    },
+    body: '{}',
+  });
+
+  if (!response.ok) {
+    throw new Error(`matrix_join_failed_${response.status}`);
+  }
+
   return await response.json();
 }
 

--- a/tools/whatsapp-private-matrix-sync/src/server.test.mjs
+++ b/tools/whatsapp-private-matrix-sync/src/server.test.mjs
@@ -5,6 +5,7 @@ import {
   buildHealthPayload,
   buildImpersonatedIdTokenRequest,
   buildIngestPayload,
+  collectWhatsAppInviteRoomIds,
   collectPrivateWhatsAppEvents,
   createConfig,
   createProcessingPlan,
@@ -469,6 +470,136 @@ test('createConfig supports missing env defaults and configurable bridge bot use
     isIncomingWhatsAppMatrixEvent(matrixMessage({ sender: '@bridgebot:matrix.example' }), custom),
     false
   );
+});
+
+test('collectWhatsAppInviteRoomIds returns only WhatsApp bridge invites', () => {
+  assert.deepEqual(
+    collectWhatsAppInviteRoomIds(
+      {
+        rooms: {
+          invite: {
+            '!whatsapp:home-dev': {
+              invite_state: {
+                events: [
+                  {
+                    type: 'm.room.member',
+                    sender: '@whatsappbot:home-dev',
+                    state_key: '@pbuchman:home-dev',
+                    content: { membership: 'invite' },
+                  },
+                ],
+              },
+            },
+            '!bridge-event:home-dev': {
+              invite_state: {
+                events: [{ type: 'm.bridge', sender: '@someone:home-dev', content: {} }],
+              },
+            },
+            '!ordinary:home-dev': {
+              invite_state: {
+                events: [
+                  {
+                    type: 'm.room.member',
+                    sender: '@friend:home-dev',
+                    state_key: '@pbuchman:home-dev',
+                    content: { membership: 'invite' },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+      config
+    ),
+    ['!whatsapp:home-dev', '!bridge-event:home-dev']
+  );
+});
+
+test('runSyncIteration joins WhatsApp invite rooms before processing joined timelines', async () => {
+  const runtime = { state: 'starting', counters: {} };
+  const joinedRoomIds = [];
+  const postedBatches = [];
+  const writtenStates = [];
+  const syncResponses = [
+    {
+      next_batch: 's-invite',
+      rooms: {
+        invite: {
+          '!business:home-dev': {
+            invite_state: {
+              events: [
+                {
+                  type: 'm.room.member',
+                  sender: '@whatsappbot:home-dev',
+                  state_key: '@pbuchman:home-dev',
+                  content: { membership: 'invite' },
+                },
+              ],
+            },
+          },
+          '!ordinary:home-dev': {
+            invite_state: {
+              events: [{ type: 'm.room.member', sender: '@friend:home-dev' }],
+            },
+          },
+        },
+      },
+    },
+    {
+      next_batch: 's-joined',
+      rooms: {
+        join: {
+          '!business:home-dev': {
+            state: {
+              events: [
+                { type: 'm.room.name', content: { name: 'Test Number (WA)' } },
+                { type: 'm.room.topic', content: { topic: 'WhatsApp private chat' } },
+              ],
+            },
+            timeline: {
+              events: [
+                matrixMessage({
+                  event_id: '$business-message',
+                  sender: '@whatsapp_15551381846:home-dev',
+                  content: { msgtype: 'm.text', body: 'prod marker' },
+                }),
+              ],
+            },
+          },
+        },
+      },
+    },
+  ];
+
+  await runSyncIteration(config, runtime, {
+    readAccessToken: () => 'matrix-token',
+    hasNonEmptyFile: () => true,
+    readSyncState: async () => ({ nextBatch: 's0' }),
+    fetchMatrixSync: async () => syncResponses.shift(),
+    fetchMatrixRoomState: async () => ({}),
+    joinMatrixRoom: async (_config, _accessToken, roomId) => {
+      joinedRoomIds.push(roomId);
+      return { room_id: roomId };
+    },
+    postEventsInBatches: async (_config, events) => {
+      postedBatches.push(events);
+    },
+    writeSyncState: async (_stateFile, state) => {
+      writtenStates.push(state);
+    },
+    nowISOString: () => '2026-06-24T07:20:00.000Z',
+  });
+
+  assert.deepEqual(joinedRoomIds, ['!business:home-dev']);
+  assert.equal(postedBatches.length, 1);
+  assert.equal(postedBatches[0]?.length, 1);
+  assert.equal(postedBatches[0]?.[0]?.matrixEventId, '$business-message');
+  assert.equal(postedBatches[0]?.[0]?.chat.displayName, 'Test Number (WA)');
+  assert.equal(writtenStates[0]?.nextBatch, 's-joined');
+  assert.equal(runtime.counters.joinedRooms, 1);
+  assert.equal(runtime.counters.syncResponses, 2);
+  assert.equal(runtime.counters.postedEvents, 1);
 });
 
 test('runSyncIteration surfaces Matrix sync, ingest API, and corrupted state errors', async () => {


### PR DESCRIPTION
## Summary
- Let the private WhatsApp log use the full app work surface and keep the sender rail bounded on mobile.
- Teach the private Matrix sync adapter to auto-join WhatsApp bridge invite rooms before processing joined timelines.
- Fix the endpoint verifier dist fallback and add a regression test for dist-only service bundles.

## Verification
- pnpm vitest run scripts/__tests__/verify-required-endpoints.test.ts
- pnpm run verify:endpoints
- pnpm run ci:tracked

Fixes INT-1676