### PR TITLE
[INT-1678] Support private WhatsApp conversations

### DIFF
--- a/apps/web/src/hooks/__tests__/usePrivateWhatsAppLog.test.tsx
+++ b/apps/web/src/hooks/__tests__/usePrivateWhatsAppLog.test.tsx
@@ -6,17 +6,12 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type {
-  PrivateWhatsAppMessage,
-  PrivateWhatsAppSender,
-  PrivateWhatsAppSenderDay,
-} from '@/types';
+import type { PrivateWhatsAppChat, PrivateWhatsAppMessage } from '@/types';
 
 const mocks = vi.hoisted(() => ({
   getAccessToken: vi.fn(),
-  listPrivateWhatsAppSenders: vi.fn(),
-  listPrivateWhatsAppMessages: vi.fn(),
-  listPrivateWhatsAppSenderDays: vi.fn(),
+  listPrivateWhatsAppChats: vi.fn(),
+  listPrivateWhatsAppChatMessages: vi.fn(),
 }));
 
 vi.mock('@/context', () => ({
@@ -26,47 +21,47 @@ vi.mock('@/context', () => ({
 }));
 
 vi.mock('@/services/whatsappApi', () => ({
-  listPrivateWhatsAppSenders: mocks.listPrivateWhatsAppSenders,
-  listPrivateWhatsAppMessages: mocks.listPrivateWhatsAppMessages,
-  listPrivateWhatsAppSenderDays: mocks.listPrivateWhatsAppSenderDays,
+  listPrivateWhatsAppChats: mocks.listPrivateWhatsAppChats,
+  listPrivateWhatsAppChatMessages: mocks.listPrivateWhatsAppChatMessages,
 }));
 
 import { usePrivateWhatsAppLog } from '../usePrivateWhatsAppLog.js';
 
-const senderA: PrivateWhatsAppSender = {
-  id: 'sender-a',
-  senderKey: 'phone:+48123456789',
-  senderDisplayName: 'Alice',
-  senderPhoneNumber: '+48123456789',
-  senderPhoneNumberNormalized: '48123456789',
+const groupChat: PrivateWhatsAppChat = {
+  id: 'chat-group',
+  displayName: 'Fishing Crew (WA)',
+  chatType: 'group',
   firstEventAt: '2026-06-22T08:00:00.000Z',
   lastEventAt: '2026-06-22T09:00:00.000Z',
-  messageCount: 2,
-  chatIds: ['chat-a'],
+  messageCount: 3,
+  participantCount: 2,
   updatedAt: '2026-06-22T09:01:00.000Z',
   schemaVersion: 2,
 };
 
-const senderB: PrivateWhatsAppSender = {
-  id: 'sender-b',
-  senderKey: 'matrix:@sender:home-dev',
+const directChat: PrivateWhatsAppChat = {
+  id: 'chat-direct',
+  displayName: 'Alice (WA)',
+  chatType: 'direct',
   firstEventAt: '2026-06-21T08:00:00.000Z',
   lastEventAt: '2026-06-21T09:00:00.000Z',
   messageCount: 1,
-  chatIds: ['chat-b'],
+  participantCount: 1,
   updatedAt: '2026-06-21T09:01:00.000Z',
   schemaVersion: 2,
 };
 
-const messageA: PrivateWhatsAppMessage = {
-  id: 'msg-a',
-  chatId: 'chat-a',
-  senderKey: senderA.senderKey,
-  senderDisplayName: 'Alice',
+const groupIncomingMessage: PrivateWhatsAppMessage = {
+  id: 'msg-group-incoming',
+  chatId: groupChat.id,
+  chatDisplayName: groupChat.displayName,
+  chatType: groupChat.chatType,
+  senderKey: 'phone:+48123456789',
+  senderDisplayName: 'Monika (WA)',
   senderPhoneNumber: '+48123456789',
   direction: 'incoming',
   messageType: 'text',
-  text: 'hello from Alice',
+  text: 'hello from the group',
   eventTimestamp: '2026-06-22T09:00:00.000Z',
   eventDayKey: '2026-06-22',
   eventTimeZone: 'Europe/Warsaw',
@@ -76,30 +71,34 @@ const messageA: PrivateWhatsAppMessage = {
   schemaVersion: 2,
 };
 
-const dayA: PrivateWhatsAppSenderDay = {
-  id: 'day-a',
-  senderKey: senderA.senderKey,
+const groupOutgoingMessage: PrivateWhatsAppMessage = {
+  id: 'msg-group-outgoing',
+  chatId: groupChat.id,
+  chatDisplayName: groupChat.displayName,
+  chatType: groupChat.chatType,
+  senderKey: 'matrix:@pbuchman:home-dev',
+  senderDisplayName: 'You',
+  direction: 'outgoing',
+  messageType: 'text',
+  text: 'sent by me',
+  eventTimestamp: '2026-06-22T09:01:00.000Z',
   eventDayKey: '2026-06-22',
   eventTimeZone: 'Europe/Warsaw',
-  senderDisplayName: 'Alice',
-  senderPhoneNumber: '+48123456789',
-  firstEventAt: '2026-06-22T08:00:00.000Z',
-  lastEventAt: '2026-06-22T09:00:00.000Z',
-  messageCount: 2,
-  messageTypeCounts: { text: 2 },
-  summaryStatus: 'not_started',
-  summarySourceMessageCount: 0,
-  updatedAt: '2026-06-22T09:01:00.000Z',
+  receivedAt: '2026-06-22T09:01:02.000Z',
+  ingestedAt: '2026-06-22T09:01:03.000Z',
+  deliveryMode: 'live',
   schemaVersion: 2,
 };
 
-const messageB: PrivateWhatsAppMessage = {
-  id: 'msg-b',
-  chatId: 'chat-b',
-  senderKey: senderB.senderKey,
+const directMessage: PrivateWhatsAppMessage = {
+  id: 'msg-direct',
+  chatId: directChat.id,
+  chatDisplayName: directChat.displayName,
+  chatType: directChat.chatType,
+  senderKey: 'matrix:@sender:home-dev',
   direction: 'incoming',
   messageType: 'text',
-  text: 'hello from sender B',
+  text: 'hello from direct chat',
   eventTimestamp: '2026-06-21T09:00:00.000Z',
   eventDayKey: '2026-06-21',
   eventTimeZone: 'Europe/Warsaw',
@@ -132,37 +131,30 @@ describe('usePrivateWhatsAppLog', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.getAccessToken.mockResolvedValue('tok');
-    mocks.listPrivateWhatsAppSenders.mockResolvedValue({
-      senders: [senderA, senderB],
-      nextCursor: 'senders-next',
+    mocks.listPrivateWhatsAppChats.mockResolvedValue({
+      chats: [groupChat, directChat],
+      nextCursor: 'chats-next',
     });
-    mocks.listPrivateWhatsAppMessages.mockResolvedValue({
-      messages: [messageA],
+    mocks.listPrivateWhatsAppChatMessages.mockResolvedValue({
+      messages: [groupIncomingMessage, groupOutgoingMessage],
       nextCursor: 'messages-next',
-    });
-    mocks.listPrivateWhatsAppSenderDays.mockResolvedValue({
-      senderDays: [dayA],
     });
   });
 
-  it('loads senders, auto-selects the first sender, and loads messages plus day aggregates', async () => {
+  it('loads chats, auto-selects the first chat, and loads the whole conversation', async () => {
     const { result } = renderHook(() => usePrivateWhatsAppLog(), { wrapper: createWrapper() });
 
     await waitFor(() => {
-      expect(result.current.selectedSender?.senderKey).toBe(senderA.senderKey);
+      expect(result.current.selectedChat?.id).toBe(groupChat.id);
     });
 
-    expect(result.current.senders).toEqual([senderA, senderB]);
-    expect(result.current.messages).toEqual([messageA]);
-    expect(result.current.senderDays).toEqual([dayA]);
-    expect(mocks.listPrivateWhatsAppSenders).toHaveBeenCalledWith('tok', { limit: 50 });
-    expect(mocks.listPrivateWhatsAppMessages).toHaveBeenCalledWith('tok', {
-      senderKey: senderA.senderKey,
+    expect(result.current.chats).toEqual([groupChat, directChat]);
+    expect(result.current.messages).toEqual([groupIncomingMessage, groupOutgoingMessage]);
+    expect(result.current.availableDays).toEqual(['2026-06-22']);
+    expect(mocks.listPrivateWhatsAppChats).toHaveBeenCalledWith('tok', { limit: 50 });
+    expect(mocks.listPrivateWhatsAppChatMessages).toHaveBeenCalledWith('tok', {
+      chatId: groupChat.id,
       limit: 50,
-    });
-    expect(mocks.listPrivateWhatsAppSenderDays).toHaveBeenCalledWith('tok', {
-      senderKey: senderA.senderKey,
-      limit: 60,
     });
   });
 
@@ -170,7 +162,7 @@ describe('usePrivateWhatsAppLog', () => {
     const { result } = renderHook(() => usePrivateWhatsAppLog(), { wrapper: createWrapper() });
 
     await waitFor(() => {
-      expect(result.current.selectedSender?.senderKey).toBe(senderA.senderKey);
+      expect(result.current.selectedChat?.id).toBe(groupChat.id);
     });
 
     await act(async () => {
@@ -178,8 +170,8 @@ describe('usePrivateWhatsAppLog', () => {
     });
 
     await waitFor(() => {
-      expect(mocks.listPrivateWhatsAppMessages).toHaveBeenLastCalledWith('tok', {
-        senderKey: senderA.senderKey,
+      expect(mocks.listPrivateWhatsAppChatMessages).toHaveBeenLastCalledWith('tok', {
+        chatId: groupChat.id,
         eventDayKey: '2026-06-22',
         limit: 50,
       });
@@ -187,40 +179,39 @@ describe('usePrivateWhatsAppLog', () => {
     expect(result.current.selectedDay).toBe('2026-06-22');
   });
 
-  it('ignores stale message responses after the selected sender changes', async () => {
-    const senderARequest = createDeferred<{ messages: PrivateWhatsAppMessage[] }>();
-    mocks.listPrivateWhatsAppMessages.mockImplementation(
-      (_token: string, options: { senderKey: string }) => {
-        if (options.senderKey === senderA.senderKey) {
-          return senderARequest.promise;
+  it('ignores stale message responses after the selected chat changes', async () => {
+    const groupRequest = createDeferred<{ messages: PrivateWhatsAppMessage[] }>();
+    mocks.listPrivateWhatsAppChatMessages.mockImplementation(
+      (_token: string, options: { chatId: string }) => {
+        if (options.chatId === groupChat.id) {
+          return groupRequest.promise;
         }
-        return Promise.resolve({ messages: [messageB] });
+        return Promise.resolve({ messages: [directMessage] });
       }
     );
-    mocks.listPrivateWhatsAppSenderDays.mockResolvedValue({ senderDays: [dayA] });
 
     const { result } = renderHook(() => usePrivateWhatsAppLog(), {
-      wrapper: createWrapper('/whatsapp/private?sender=phone:%2B48123456789'),
+      wrapper: createWrapper('/whatsapp/private?chat=chat-group'),
     });
 
     await waitFor(() => {
-      expect(result.current.selectedSender?.senderKey).toBe(senderA.senderKey);
+      expect(result.current.selectedChat?.id).toBe(groupChat.id);
     });
 
     await act(async () => {
-      result.current.selectSender(senderB.senderKey);
+      result.current.selectChat(directChat.id);
     });
 
     await waitFor(() => {
-      expect(result.current.messages).toEqual([messageB]);
+      expect(result.current.messages).toEqual([directMessage]);
     });
 
     await act(async () => {
-      senderARequest.resolve({ messages: [messageA] });
-      await senderARequest.promise;
+      groupRequest.resolve({ messages: [groupIncomingMessage] });
+      await groupRequest.promise;
     });
 
-    expect(result.current.selectedSenderKey).toBe(senderB.senderKey);
-    expect(result.current.messages).toEqual([messageB]);
+    expect(result.current.selectedChatId).toBe(directChat.id);
+    expect(result.current.messages).toEqual([directMessage]);
   });
 });

--- a/apps/web/src/hooks/usePrivateWhatsAppLog.ts
+++ b/apps/web/src/hooks/usePrivateWhatsAppLog.ts
@@ -3,83 +3,73 @@ import { useSearchParams } from 'react-router-dom';
 import { getErrorMessage } from '@intexuraos/common-core/errors';
 import { useAuth } from '@/context';
 import {
-  listPrivateWhatsAppMessages,
-  listPrivateWhatsAppSenderDays,
-  listPrivateWhatsAppSenders,
-  type ListPrivateWhatsAppMessagesOptions,
-  type ListPrivateWhatsAppSenderDaysOptions,
+  listPrivateWhatsAppChatMessages,
+  listPrivateWhatsAppChats,
+  type ListPrivateWhatsAppChatMessagesOptions,
 } from '@/services/whatsappApi';
-import type {
-  PrivateWhatsAppMessage,
-  PrivateWhatsAppSender,
-  PrivateWhatsAppSenderDay,
-} from '@/types';
+import type { PrivateWhatsAppChat, PrivateWhatsAppMessage } from '@/types';
 
-const SENDER_PAGE_SIZE = 50;
+const CHAT_PAGE_SIZE = 50;
 const MESSAGE_PAGE_SIZE = 50;
-const SENDER_DAY_PAGE_SIZE = 60;
 
 export interface UsePrivateWhatsAppLogResult {
-  senders: PrivateWhatsAppSender[];
-  filteredSenders: PrivateWhatsAppSender[];
-  selectedSender: PrivateWhatsAppSender | undefined;
-  selectedSenderKey: string | undefined;
+  chats: PrivateWhatsAppChat[];
+  filteredChats: PrivateWhatsAppChat[];
+  selectedChat: PrivateWhatsAppChat | undefined;
+  selectedChatId: string | undefined;
   selectedDay: string | undefined;
-  senderSearch: string;
+  chatSearch: string;
   messages: PrivateWhatsAppMessage[];
-  senderDays: PrivateWhatsAppSenderDay[];
-  senderCursor: string | undefined;
+  availableDays: string[];
+  chatCursor: string | undefined;
   messageCursor: string | undefined;
-  loadingSenders: boolean;
+  loadingChats: boolean;
   loadingMessages: boolean;
-  loadingSenderDays: boolean;
-  loadingMoreSenders: boolean;
+  loadingMoreChats: boolean;
   loadingMoreMessages: boolean;
   refreshing: boolean;
   error: string | null;
-  setSenderSearch: (value: string) => void;
-  selectSender: (senderKey: string) => void;
+  setChatSearch: (value: string) => void;
+  selectChat: (chatId: string) => void;
   selectDay: (dayKey: string) => void;
   clearDay: () => void;
   refresh: () => Promise<void>;
-  loadMoreSenders: () => Promise<void>;
+  loadMoreChats: () => Promise<void>;
   loadMoreMessages: () => Promise<void>;
 }
 
 export function usePrivateWhatsAppLog(): UsePrivateWhatsAppLogResult {
   const { getAccessToken } = useAuth();
   const [searchParams, setSearchParams] = useSearchParams();
-  const selectedSenderKey = searchParams.get('sender') ?? undefined;
+  const selectedChatId = searchParams.get('chat') ?? undefined;
   const selectedDay = searchParams.get('day') ?? undefined;
-  const selectedSenderKeyRef = useRef<string | undefined>(selectedSenderKey);
+  const selectedChatIdRef = useRef<string | undefined>(selectedChatId);
   const selectedDataRequestIdRef = useRef(0);
 
-  const [senders, setSenders] = useState<PrivateWhatsAppSender[]>([]);
-  const [senderSearch, setSenderSearch] = useState('');
+  const [chats, setChats] = useState<PrivateWhatsAppChat[]>([]);
+  const [chatSearch, setChatSearch] = useState('');
   const [messages, setMessages] = useState<PrivateWhatsAppMessage[]>([]);
-  const [senderDays, setSenderDays] = useState<PrivateWhatsAppSenderDay[]>([]);
-  const [senderCursor, setSenderCursor] = useState<string | undefined>(undefined);
+  const [chatCursor, setChatCursor] = useState<string | undefined>(undefined);
   const [messageCursor, setMessageCursor] = useState<string | undefined>(undefined);
-  const [loadingSenders, setLoadingSenders] = useState(true);
+  const [loadingChats, setLoadingChats] = useState(true);
   const [loadingMessages, setLoadingMessages] = useState(false);
-  const [loadingSenderDays, setLoadingSenderDays] = useState(false);
-  const [loadingMoreSenders, setLoadingMoreSenders] = useState(false);
+  const [loadingMoreChats, setLoadingMoreChats] = useState(false);
   const [loadingMoreMessages, setLoadingMoreMessages] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    selectedSenderKeyRef.current = selectedSenderKey;
-  }, [selectedSenderKey]);
+    selectedChatIdRef.current = selectedChatId;
+  }, [selectedChatId]);
 
   const setSelectionParams = useCallback(
-    (senderKey: string | undefined, dayKey?: string): void => {
+    (chatId: string | undefined, dayKey?: string): void => {
       setSearchParams((current) => {
         const next = new URLSearchParams(current);
-        if (senderKey === undefined || senderKey === '') {
-          next.delete('sender');
+        if (chatId === undefined || chatId === '') {
+          next.delete('chat');
         } else {
-          next.set('sender', senderKey);
+          next.set('chat', chatId);
         }
         if (dayKey === undefined || dayKey === '') {
           next.delete('day');
@@ -92,53 +82,48 @@ export function usePrivateWhatsAppLog(): UsePrivateWhatsAppLogResult {
     [setSearchParams]
   );
 
-  const loadSenders = useCallback(
+  const loadChats = useCallback(
     async (mode: 'replace' | 'append' = 'replace', cursor?: string): Promise<void> => {
       const append = mode === 'append';
       if (append && cursor === undefined) return;
 
       if (append) {
-        setLoadingMoreSenders(true);
+        setLoadingMoreChats(true);
       } else {
-        setLoadingSenders(true);
+        setLoadingChats(true);
       }
       setError(null);
 
       try {
         const token = await getAccessToken();
-        const response = await listPrivateWhatsAppSenders(token, {
-          limit: SENDER_PAGE_SIZE,
+        const response = await listPrivateWhatsAppChats(token, {
+          limit: CHAT_PAGE_SIZE,
           ...(append && cursor !== undefined ? { cursor } : {}),
         });
-        setSenders((prev) => (append ? [...prev, ...response.senders] : response.senders));
-        setSenderCursor(response.nextCursor);
+        setChats((prev) => (append ? [...prev, ...response.chats] : response.chats));
+        setChatCursor(response.nextCursor);
 
-        if (
-          !append &&
-          selectedSenderKeyRef.current === undefined &&
-          response.senders[0] !== undefined
-        ) {
-          setSelectionParams(response.senders[0].senderKey);
+        if (!append && selectedChatIdRef.current === undefined && response.chats[0] !== undefined) {
+          setSelectionParams(response.chats[0].id);
         }
       } catch (err) {
-        setError(getErrorMessage(err, 'Failed to load private WhatsApp senders'));
+        setError(getErrorMessage(err, 'Failed to load private WhatsApp chats'));
       } finally {
         if (append) {
-          setLoadingMoreSenders(false);
+          setLoadingMoreChats(false);
         } else {
-          setLoadingSenders(false);
+          setLoadingChats(false);
         }
       }
     },
     [getAccessToken, setSelectionParams]
   );
 
-  const loadSelectedSenderData = useCallback(
+  const loadSelectedChatData = useCallback(
     async (mode: 'replace' | 'append' = 'replace', cursor?: string): Promise<void> => {
-      if (selectedSenderKey === undefined) {
+      if (selectedChatId === undefined) {
         selectedDataRequestIdRef.current += 1;
         setMessages([]);
-        setSenderDays([]);
         setMessageCursor(undefined);
         return;
       }
@@ -153,16 +138,14 @@ export function usePrivateWhatsAppLog(): UsePrivateWhatsAppLogResult {
         setLoadingMoreMessages(true);
       } else {
         setLoadingMessages(true);
-        setLoadingSenderDays(true);
         setMessages([]);
-        setSenderDays([]);
       }
       setError(null);
 
       try {
         const token = await getAccessToken();
-        const messageOptions: ListPrivateWhatsAppMessagesOptions = {
-          senderKey: selectedSenderKey,
+        const messageOptions: ListPrivateWhatsAppChatMessagesOptions = {
+          chatId: selectedChatId,
           limit: MESSAGE_PAGE_SIZE,
         };
         if (selectedDay !== undefined) {
@@ -172,30 +155,14 @@ export function usePrivateWhatsAppLog(): UsePrivateWhatsAppLogResult {
           messageOptions.cursor = cursor;
         }
 
-        if (append) {
-          const messageResponse = await listPrivateWhatsAppMessages(token, messageOptions);
-          if (selectedDataRequestIdRef.current !== requestId) {
-            return;
-          }
-          setMessages((prev) => [...prev, ...messageResponse.messages]);
-          setMessageCursor(messageResponse.nextCursor);
-          return;
-        }
-
-        const senderDayOptions: ListPrivateWhatsAppSenderDaysOptions = {
-          senderKey: selectedSenderKey,
-          limit: SENDER_DAY_PAGE_SIZE,
-        };
-        const [messageResponse, senderDayResponse] = await Promise.all([
-          listPrivateWhatsAppMessages(token, messageOptions),
-          listPrivateWhatsAppSenderDays(token, senderDayOptions),
-        ]);
+        const messageResponse = await listPrivateWhatsAppChatMessages(token, messageOptions);
         if (selectedDataRequestIdRef.current !== requestId) {
           return;
         }
-        setMessages(messageResponse.messages);
+        setMessages((prev) =>
+          append ? [...prev, ...messageResponse.messages] : messageResponse.messages
+        );
         setMessageCursor(messageResponse.nextCursor);
-        setSenderDays(senderDayResponse.senderDays);
       } catch (err) {
         if (selectedDataRequestIdRef.current === requestId) {
           setError(getErrorMessage(err, 'Failed to load private WhatsApp messages'));
@@ -206,106 +173,107 @@ export function usePrivateWhatsAppLog(): UsePrivateWhatsAppLogResult {
             setLoadingMoreMessages(false);
           } else {
             setLoadingMessages(false);
-            setLoadingSenderDays(false);
           }
         }
       }
     },
-    [getAccessToken, selectedDay, selectedSenderKey]
+    [getAccessToken, selectedChatId, selectedDay]
   );
 
   useEffect(() => {
-    void loadSenders();
-  }, [loadSenders]);
+    void loadChats();
+  }, [loadChats]);
 
   useEffect(() => {
-    void loadSelectedSenderData();
-  }, [loadSelectedSenderData]);
+    void loadSelectedChatData();
+  }, [loadSelectedChatData]);
 
   const refresh = useCallback(async (): Promise<void> => {
     setRefreshing(true);
     try {
-      await Promise.all([loadSenders(), loadSelectedSenderData()]);
+      await Promise.all([loadChats(), loadSelectedChatData()]);
     } finally {
       setRefreshing(false);
     }
-  }, [loadSelectedSenderData, loadSenders]);
+  }, [loadChats, loadSelectedChatData]);
 
-  const loadMoreSenders = useCallback(async (): Promise<void> => {
-    await loadSenders('append', senderCursor);
-  }, [loadSenders, senderCursor]);
+  const loadMoreChats = useCallback(async (): Promise<void> => {
+    await loadChats('append', chatCursor);
+  }, [chatCursor, loadChats]);
 
   const loadMoreMessages = useCallback(async (): Promise<void> => {
-    await loadSelectedSenderData('append', messageCursor);
-  }, [loadSelectedSenderData, messageCursor]);
+    await loadSelectedChatData('append', messageCursor);
+  }, [loadSelectedChatData, messageCursor]);
 
-  const selectSender = useCallback(
-    (senderKey: string): void => {
-      setSelectionParams(senderKey);
+  const selectChat = useCallback(
+    (chatId: string): void => {
+      setSelectionParams(chatId);
     },
     [setSelectionParams]
   );
 
   const selectDay = useCallback(
     (dayKey: string): void => {
-      const senderKey = selectedSenderKeyRef.current;
-      if (senderKey !== undefined) {
-        setSelectionParams(senderKey, dayKey);
+      const chatId = selectedChatIdRef.current;
+      if (chatId !== undefined) {
+        setSelectionParams(chatId, dayKey);
       }
     },
     [setSelectionParams]
   );
 
   const clearDay = useCallback((): void => {
-    const senderKey = selectedSenderKeyRef.current;
-    if (senderKey !== undefined) {
-      setSelectionParams(senderKey);
+    const chatId = selectedChatIdRef.current;
+    if (chatId !== undefined) {
+      setSelectionParams(chatId);
     }
   }, [setSelectionParams]);
 
-  const selectedSender = useMemo(
-    () => senders.find((sender) => sender.senderKey === selectedSenderKey),
-    [selectedSenderKey, senders]
+  const selectedChat = useMemo(
+    () => chats.find((chat) => chat.id === selectedChatId),
+    [chats, selectedChatId]
   );
 
-  const filteredSenders = useMemo(() => {
-    const query = senderSearch.trim().toLowerCase();
-    if (query === '') return senders;
-    return senders.filter((sender) => {
-      const values = [
-        sender.senderDisplayName,
-        sender.senderPhoneNumber,
-        sender.senderPhoneNumberNormalized,
-        sender.senderKey,
-      ];
+  const filteredChats = useMemo(() => {
+    const query = chatSearch.trim().toLowerCase();
+    if (query === '') return chats;
+    return chats.filter((chat) => {
+      const values = [chat.displayName, chat.chatType, chat.id];
       return values.some((value) => value?.toLowerCase().includes(query) === true);
     });
-  }, [senderSearch, senders]);
+  }, [chatSearch, chats]);
+
+  const availableDays = useMemo(() => {
+    const days = new Set<string>();
+    for (const message of messages) {
+      days.add(message.eventDayKey ?? message.eventTimestamp.slice(0, 10));
+    }
+    return [...days].sort((a, b) => b.localeCompare(a));
+  }, [messages]);
 
   return {
-    senders,
-    filteredSenders,
-    selectedSender,
-    selectedSenderKey,
+    chats,
+    filteredChats,
+    selectedChat,
+    selectedChatId,
     selectedDay,
-    senderSearch,
+    chatSearch,
     messages,
-    senderDays,
-    senderCursor,
+    availableDays,
+    chatCursor,
     messageCursor,
-    loadingSenders,
+    loadingChats,
     loadingMessages,
-    loadingSenderDays,
-    loadingMoreSenders,
+    loadingMoreChats,
     loadingMoreMessages,
     refreshing,
     error,
-    setSenderSearch,
-    selectSender,
+    setChatSearch,
+    selectChat,
     selectDay,
     clearDay,
     refresh,
-    loadMoreSenders,
+    loadMoreChats,
     loadMoreMessages,
   };
 }

--- a/apps/web/src/pages/PrivateWhatsAppLogPage.tsx
+++ b/apps/web/src/pages/PrivateWhatsAppLogPage.tsx
@@ -7,34 +7,41 @@ import {
   RefreshCw,
   Search,
   UserRound,
+  UsersRound,
 } from 'lucide-react';
 import { Button, ErrorBanner, Layout } from '@/components';
 import { usePrivateWhatsAppLog } from '@/hooks/usePrivateWhatsAppLog';
 import { formatDateTimeCompact, formatRelative } from '@/utils/dateFormat';
 import type {
+  PrivateWhatsAppChat,
   PrivateWhatsAppMessage,
   PrivateWhatsAppMessageType,
-  PrivateWhatsAppSender,
 } from '@/types';
 
-function getSenderLabel(sender: PrivateWhatsAppSender | undefined, fallback?: string): string {
-  return (
-    sender?.senderDisplayName ??
-    sender?.senderPhoneNumber ??
-    fallback ??
-    sender?.senderKey ??
-    'Unknown sender'
-  );
+function getChatLabel(chat: PrivateWhatsAppChat | undefined, fallback?: string): string {
+  return chat?.displayName ?? fallback ?? chat?.id ?? 'Unknown chat';
 }
 
-function getSenderMeta(sender: PrivateWhatsAppSender): string {
-  if (sender.senderDisplayName !== undefined && sender.senderPhoneNumber !== undefined) {
-    return sender.senderPhoneNumber;
+function getChatMeta(chat: PrivateWhatsAppChat): string {
+  const messageCount = chat.messageCount;
+  if (chat.chatType === 'group') {
+    const participantCount = chat.participantCount;
+    return `${String(messageCount)} messages · ${String(participantCount)} participants`;
   }
-  if (sender.senderPhoneNumberNormalized !== undefined) {
-    return sender.senderPhoneNumberNormalized;
+  return `${String(messageCount)} messages`;
+}
+
+function getMessageSenderLabel(message: PrivateWhatsAppMessage): string {
+  if (message.direction === 'outgoing') {
+    return 'You';
   }
-  return sender.senderKey;
+  return (
+    message.senderDisplayName ??
+    message.senderPhoneNumber ??
+    message.senderPhoneNumberNormalized ??
+    message.senderKey ??
+    'Unknown sender'
+  );
 }
 
 function getDayKey(message: PrivateWhatsAppMessage): string {
@@ -96,7 +103,8 @@ function MessageBody({ message }: { message: PrivateWhatsAppMessage }): React.JS
     );
   }
 
-  const mediaName = message.media?.fileName ?? message.media?.mimeType ?? `${message.messageType} message`;
+  const mediaName =
+    message.media?.fileName ?? message.media?.mimeType ?? `${message.messageType} message`;
   const Icon = message.messageType === 'image' ? Image : FileText;
 
   return (
@@ -125,10 +133,19 @@ function groupMessagesByDay(
 
 export function PrivateWhatsAppLogPage(): React.JSX.Element {
   const log = usePrivateWhatsAppLog();
-  const selectedSenderLabel = getSenderLabel(log.selectedSender, log.selectedSenderKey);
+  const selectedChatLabel = getChatLabel(log.selectedChat, log.selectedChatId);
   const groupedMessages = useMemo(() => groupMessagesByDay(log.messages), [log.messages]);
-  const hasNoSenders = !log.loadingSenders && log.senders.length === 0;
-  const hasNoMessages = !log.loadingMessages && log.selectedSenderKey !== undefined && log.messages.length === 0;
+  const hasNoChats = !log.loadingChats && log.chats.length === 0;
+  const hasNoMessages =
+    !log.loadingMessages && log.selectedChatId !== undefined && log.messages.length === 0;
+  const dayCounts = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const message of log.messages) {
+      const dayKey = getDayKey(message);
+      counts.set(dayKey, (counts.get(dayKey) ?? 0) + 1);
+    }
+    return counts;
+  }, [log.messages]);
 
   return (
     <Layout>
@@ -139,7 +156,7 @@ export function PrivateWhatsAppLogPage(): React.JSX.Element {
               Private WhatsApp
             </h2>
             <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
-              Read-only incoming message log grouped by sender and day.
+              Read-only conversation log for direct and group chats.
             </p>
           </div>
           <Button
@@ -160,36 +177,36 @@ export function PrivateWhatsAppLogPage(): React.JSX.Element {
 
         <div className="grid min-h-[calc(100vh-12rem)] grid-cols-1 gap-4 xl:grid-cols-[minmax(18rem,22rem)_minmax(0,1fr)] 2xl:grid-cols-[minmax(20rem,24rem)_minmax(0,1fr)]">
           <aside
-            data-testid="private-whatsapp-sender-rail"
+            data-testid="private-whatsapp-chat-rail"
             className="flex max-h-[45vh] min-h-0 flex-col rounded-lg border border-slate-200 bg-white dark:border-slate-800 dark:bg-slate-900 sm:max-h-[28rem] xl:max-h-none"
           >
             <div className="border-b border-slate-200 p-3 dark:border-slate-800">
-              <label className="sr-only" htmlFor="private-whatsapp-sender-search">
-                Search senders
+              <label className="sr-only" htmlFor="private-whatsapp-chat-search">
+                Search chats
               </label>
               <div className="relative">
                 <Search className="pointer-events-none absolute left-3 top-2.5 h-4 w-4 text-slate-400" />
                 <input
-                  id="private-whatsapp-sender-search"
+                  id="private-whatsapp-chat-search"
                   type="search"
-                  value={log.senderSearch}
+                  value={log.chatSearch}
                   onChange={(event): void => {
-                    log.setSenderSearch(event.target.value);
+                    log.setChatSearch(event.target.value);
                   }}
-                  placeholder="Search senders"
+                  placeholder="Search chats"
                   className="w-full rounded-lg border border-slate-200 bg-slate-50 py-2 pl-9 pr-3 text-sm text-slate-900 outline-none transition-colors placeholder:text-slate-400 focus:border-blue-400 focus:bg-white focus:ring-2 focus:ring-blue-100 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100 dark:focus:border-blue-500 dark:focus:bg-slate-900 dark:focus:ring-blue-900/40"
                 />
               </div>
             </div>
 
             <div className="min-h-[14rem] flex-1 overflow-y-auto p-2">
-              {log.loadingSenders ? (
+              {log.loadingChats ? (
                 <div className="flex items-center justify-center py-10">
                   <div className="h-6 w-6 animate-spin rounded-full border-2 border-blue-600 border-t-transparent" />
                 </div>
               ) : null}
 
-              {hasNoSenders ? (
+              {hasNoChats ? (
                 <div className="flex flex-col items-center justify-center px-4 py-12 text-center">
                   <MessageSquare className="mb-3 h-10 w-10 text-slate-300 dark:text-slate-700" />
                   <p className="text-sm font-medium text-slate-700 dark:text-slate-200">
@@ -198,21 +215,22 @@ export function PrivateWhatsAppLogPage(): React.JSX.Element {
                 </div>
               ) : null}
 
-              {!log.loadingSenders && log.senders.length > 0 && log.filteredSenders.length === 0 ? (
+              {!log.loadingChats && log.chats.length > 0 && log.filteredChats.length === 0 ? (
                 <div className="px-4 py-8 text-center text-sm text-slate-500 dark:text-slate-400">
-                  No senders match this search.
+                  No chats match this search.
                 </div>
               ) : null}
 
               <div className="space-y-1">
-                {log.filteredSenders.map((sender) => {
-                  const selected = sender.senderKey === log.selectedSenderKey;
+                {log.filteredChats.map((chat) => {
+                  const selected = chat.id === log.selectedChatId;
+                  const Icon = chat.chatType === 'group' ? UsersRound : UserRound;
                   return (
                     <button
-                      key={sender.id}
+                      key={chat.id}
                       type="button"
                       onClick={(): void => {
-                        log.selectSender(sender.senderKey);
+                        log.selectChat(chat.id);
                       }}
                       className={`w-full rounded-lg border px-3 py-3 text-left transition-colors ${
                         selected
@@ -221,20 +239,23 @@ export function PrivateWhatsAppLogPage(): React.JSX.Element {
                       }`}
                     >
                       <div className="flex items-start justify-between gap-3">
-                        <div className="min-w-0">
-                          <p className="truncate text-sm font-semibold text-slate-950 dark:text-slate-50">
-                            {getSenderLabel(sender)}
-                          </p>
-                          <p className="mt-0.5 truncate text-xs text-slate-500 dark:text-slate-400">
-                            {getSenderMeta(sender)}
-                          </p>
+                        <div className="flex min-w-0 items-start gap-2">
+                          <Icon className="mt-0.5 h-4 w-4 shrink-0 text-slate-400" />
+                          <div className="min-w-0">
+                            <p className="truncate text-sm font-semibold text-slate-950 dark:text-slate-50">
+                              {getChatLabel(chat)}
+                            </p>
+                            <p className="mt-0.5 truncate text-xs text-slate-500 dark:text-slate-400">
+                              {getChatMeta(chat)}
+                            </p>
+                          </div>
                         </div>
                         <span className="rounded-full bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-600 dark:bg-slate-800 dark:text-slate-300">
-                          {String(sender.messageCount)}
+                          {String(chat.messageCount)}
                         </span>
                       </div>
                       <p className="mt-2 text-xs text-slate-500 dark:text-slate-400">
-                        {formatRelative(sender.lastEventAt)}
+                        {formatRelative(chat.lastEventAt)}
                       </p>
                     </button>
                   );
@@ -242,19 +263,19 @@ export function PrivateWhatsAppLogPage(): React.JSX.Element {
               </div>
             </div>
 
-            {log.senderCursor !== undefined ? (
+            {log.chatCursor !== undefined ? (
               <div className="border-t border-slate-200 p-3 dark:border-slate-800">
                 <Button
                   variant="ghost"
                   size="sm"
                   className="w-full"
                   onClick={(): void => {
-                    void log.loadMoreSenders();
+                    void log.loadMoreChats();
                   }}
-                  isLoading={log.loadingMoreSenders}
+                  isLoading={log.loadingMoreChats}
                   loadingText="Loading"
                 >
-                  Load more senders
+                  Load more chats
                 </Button>
               </div>
             ) : null}
@@ -268,21 +289,25 @@ export function PrivateWhatsAppLogPage(): React.JSX.Element {
               <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
                 <div className="min-w-0">
                   <div className="flex items-center gap-2">
-                    <UserRound className="h-5 w-5 text-slate-400" />
+                    {log.selectedChat?.chatType === 'group' ? (
+                      <UsersRound className="h-5 w-5 text-slate-400" />
+                    ) : (
+                      <UserRound className="h-5 w-5 text-slate-400" />
+                    )}
                     <h3 className="truncate text-lg font-semibold text-slate-950 dark:text-slate-50">
-                      {log.selectedSenderKey === undefined ? 'Select a sender' : selectedSenderLabel}
+                      {log.selectedChatId === undefined ? 'Select a chat' : selectedChatLabel}
                     </h3>
                   </div>
-                  {log.selectedSender !== undefined ? (
+                  {log.selectedChat !== undefined ? (
                     <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
-                      {String(log.selectedSender.messageCount)} total messages · Last seen{' '}
-                      {formatDateTimeCompact(log.selectedSender.lastEventAt)}
+                      {getChatMeta(log.selectedChat)} · Last seen{' '}
+                      {formatDateTimeCompact(log.selectedChat.lastEventAt)}
                     </p>
                   ) : null}
                 </div>
               </div>
 
-              {log.selectedSenderKey !== undefined ? (
+              {log.selectedChatId !== undefined ? (
                 <div className="mt-4 flex flex-wrap gap-2">
                   <button
                     type="button"
@@ -295,27 +320,26 @@ export function PrivateWhatsAppLogPage(): React.JSX.Element {
                   >
                     All days
                   </button>
-                  {log.senderDays.map((day) => (
+                  {log.availableDays.map((dayKey) => (
                     <button
-                      key={day.id}
+                      key={dayKey}
                       type="button"
                       onClick={(): void => {
-                        log.selectDay(day.eventDayKey);
+                        log.selectDay(dayKey);
                       }}
                       className={`inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-sm font-medium transition-colors ${
-                        log.selectedDay === day.eventDayKey
+                        log.selectedDay === dayKey
                           ? 'border-blue-300 bg-blue-50 text-blue-700 dark:border-blue-800 dark:bg-blue-950/40 dark:text-blue-300'
                           : 'border-slate-200 bg-white text-slate-600 hover:border-slate-300 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300'
                       }`}
                     >
                       <CalendarDays className="h-3.5 w-3.5" />
-                      <span>{day.eventDayKey}</span>
-                      <span className="text-xs text-slate-400">{String(day.messageCount)}</span>
+                      <span>{dayKey}</span>
+                      <span className="text-xs text-slate-400">
+                        {String(dayCounts.get(dayKey) ?? 0)}
+                      </span>
                     </button>
                   ))}
-                  {log.loadingSenderDays ? (
-                    <span className="px-2 py-1.5 text-sm text-slate-400">Loading days...</span>
-                  ) : null}
                 </div>
               ) : null}
             </div>
@@ -331,16 +355,16 @@ export function PrivateWhatsAppLogPage(): React.JSX.Element {
                 <div className="flex flex-col items-center justify-center py-20 text-center">
                   <MessageSquare className="mb-3 h-10 w-10 text-slate-300 dark:text-slate-700" />
                   <p className="text-sm font-medium text-slate-700 dark:text-slate-200">
-                    {log.selectedDay === undefined ? 'No messages for this sender.' : 'No messages for this day.'}
+                    {log.selectedDay === undefined ? 'No messages for this chat.' : 'No messages for this day.'}
                   </p>
                 </div>
               ) : null}
 
-              {!log.loadingMessages && log.selectedSenderKey === undefined ? (
+              {!log.loadingMessages && log.selectedChatId === undefined ? (
                 <div className="flex flex-col items-center justify-center py-20 text-center">
                   <UserRound className="mb-3 h-10 w-10 text-slate-300 dark:text-slate-700" />
                   <p className="text-sm font-medium text-slate-700 dark:text-slate-200">
-                    Select a sender to read messages.
+                    Select a chat to read messages.
                   </p>
                 </div>
               ) : null}
@@ -353,32 +377,49 @@ export function PrivateWhatsAppLogPage(): React.JSX.Element {
                         {formatDayLabel(group.dayKey)}
                       </span>
                     </div>
-                    <div className="divide-y divide-slate-100 rounded-lg border border-slate-100 dark:divide-slate-800 dark:border-slate-800">
-                      {group.messages.map((message) => (
-                        <article key={message.id} className="px-4 py-3">
-                          <div className="mb-2 flex flex-wrap items-center gap-2">
-                            <time
-                              dateTime={message.eventTimestamp}
-                              className="text-xs font-medium text-slate-500 dark:text-slate-400"
+                    <div className="space-y-3">
+                      {group.messages.map((message) => {
+                        const outgoing = message.direction === 'outgoing';
+                        return (
+                          <article
+                            key={message.id}
+                            className={`flex ${outgoing ? 'justify-end' : 'justify-start'}`}
+                          >
+                            <div
+                              className={`max-w-[min(42rem,100%)] rounded-lg border px-4 py-3 ${
+                                outgoing
+                                  ? 'border-blue-200 bg-blue-50 dark:border-blue-800 dark:bg-blue-950/30'
+                                  : 'border-slate-100 bg-white dark:border-slate-800 dark:bg-slate-900'
+                              }`}
                             >
-                              {formatMessageTime(message.eventTimestamp)}
-                            </time>
-                            <span
-                              className={`rounded-full border px-2 py-0.5 text-xs font-medium ${getMessageTypeClass(
-                                message.messageType
-                              )}`}
-                            >
-                              {message.messageType}
-                            </span>
-                            {message.deliveryMode === 'backfill' ? (
-                              <span className="rounded-full border border-amber-200 bg-amber-50 px-2 py-0.5 text-xs font-medium text-amber-700 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-300">
-                                backfill
-                              </span>
-                            ) : null}
-                          </div>
-                          <MessageBody message={message} />
-                        </article>
-                      ))}
+                              <div className="mb-2 flex flex-wrap items-center gap-2">
+                                <span className="text-xs font-semibold text-slate-700 dark:text-slate-200">
+                                  {getMessageSenderLabel(message)}
+                                </span>
+                                <time
+                                  dateTime={message.eventTimestamp}
+                                  className="text-xs font-medium text-slate-500 dark:text-slate-400"
+                                >
+                                  {formatMessageTime(message.eventTimestamp)}
+                                </time>
+                                <span
+                                  className={`rounded-full border px-2 py-0.5 text-xs font-medium ${getMessageTypeClass(
+                                    message.messageType
+                                  )}`}
+                                >
+                                  {message.messageType}
+                                </span>
+                                {message.deliveryMode === 'backfill' ? (
+                                  <span className="rounded-full border border-amber-200 bg-amber-50 px-2 py-0.5 text-xs font-medium text-amber-700 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-300">
+                                    backfill
+                                  </span>
+                                ) : null}
+                              </div>
+                              <MessageBody message={message} />
+                            </div>
+                          </article>
+                        );
+                      })}
                     </div>
                   </section>
                 ))}

--- a/apps/web/src/pages/__tests__/PrivateWhatsAppLogPage.test.tsx
+++ b/apps/web/src/pages/__tests__/PrivateWhatsAppLogPage.test.tsx
@@ -33,106 +33,112 @@ vi.mock('@/utils/dateFormat', () => ({
 
 import { PrivateWhatsAppLogPage } from '../PrivateWhatsAppLogPage.js';
 
-describe('PrivateWhatsAppLogPage', () => {
-  beforeEach(() => {
-    mockUsePrivateWhatsAppLog.mockReturnValue({
-      senders: [
-        {
-          id: 'sender-a',
-          senderKey: 'phone:+48123456789',
-          senderDisplayName: 'Alice',
-          senderPhoneNumber: '+48123456789',
-          firstEventAt: '2026-06-22T08:00:00.000Z',
-          lastEventAt: '2026-06-22T09:00:00.000Z',
-          messageCount: 2,
-          chatIds: ['chat-a'],
-          updatedAt: '2026-06-22T09:01:00.000Z',
-          schemaVersion: 2,
-        },
-      ],
-      filteredSenders: [
-        {
-          id: 'sender-a',
-          senderKey: 'phone:+48123456789',
-          senderDisplayName: 'Alice',
-          senderPhoneNumber: '+48123456789',
-          firstEventAt: '2026-06-22T08:00:00.000Z',
-          lastEventAt: '2026-06-22T09:00:00.000Z',
-          messageCount: 2,
-          chatIds: ['chat-a'],
-          updatedAt: '2026-06-22T09:01:00.000Z',
-          schemaVersion: 2,
-        },
-      ],
-      selectedSender: {
-        id: 'sender-a',
-        senderKey: 'phone:+48123456789',
-        senderDisplayName: 'Alice',
-        senderPhoneNumber: '+48123456789',
+function createHookResult(
+  overrides: Partial<UsePrivateWhatsAppLogResult> = {}
+): UsePrivateWhatsAppLogResult {
+  return {
+    chats: [
+      {
+        id: 'chat-group',
+        displayName: 'Fishing Crew (WA)',
+        chatType: 'group',
         firstEventAt: '2026-06-22T08:00:00.000Z',
         lastEventAt: '2026-06-22T09:00:00.000Z',
-        messageCount: 2,
-        chatIds: ['chat-a'],
+        messageCount: 3,
+        participantCount: 2,
         updatedAt: '2026-06-22T09:01:00.000Z',
         schemaVersion: 2,
       },
-      selectedSenderKey: 'phone:+48123456789',
-      selectedDay: undefined,
-      senderSearch: '',
-      messages: [
-        {
-          id: 'msg-a',
-          chatId: 'chat-a',
-          senderKey: 'phone:+48123456789',
-          senderDisplayName: 'Alice',
-          senderPhoneNumber: '+48123456789',
-          direction: 'incoming',
-          messageType: 'text',
-          text: 'hello from Alice',
-          eventTimestamp: '2026-06-22T09:00:00.000Z',
-          eventDayKey: '2026-06-22',
-          eventTimeZone: 'Europe/Warsaw',
-          receivedAt: '2026-06-22T09:00:02.000Z',
-          ingestedAt: '2026-06-22T09:00:03.000Z',
-          deliveryMode: 'live',
-          schemaVersion: 2,
-        },
-      ],
-      senderDays: [
-        {
-          id: 'day-a',
-          senderKey: 'phone:+48123456789',
-          eventDayKey: '2026-06-22',
-          eventTimeZone: 'Europe/Warsaw',
-          senderDisplayName: 'Alice',
-          senderPhoneNumber: '+48123456789',
-          firstEventAt: '2026-06-22T08:00:00.000Z',
-          lastEventAt: '2026-06-22T09:00:00.000Z',
-          messageCount: 2,
-          messageTypeCounts: { text: 2 },
-          summaryStatus: 'not_started',
-          summarySourceMessageCount: 0,
-          updatedAt: '2026-06-22T09:01:00.000Z',
-          schemaVersion: 2,
-        },
-      ],
-      senderCursor: undefined,
-      messageCursor: undefined,
-      loadingSenders: false,
-      loadingMessages: false,
-      loadingSenderDays: false,
-      loadingMoreSenders: false,
-      loadingMoreMessages: false,
-      refreshing: false,
-      error: null,
-      setSenderSearch: vi.fn(),
-      selectSender: vi.fn(),
-      selectDay: vi.fn(),
-      clearDay: vi.fn(),
-      refresh: vi.fn(),
-      loadMoreSenders: vi.fn(),
-      loadMoreMessages: vi.fn(),
-    });
+    ],
+    filteredChats: [
+      {
+        id: 'chat-group',
+        displayName: 'Fishing Crew (WA)',
+        chatType: 'group',
+        firstEventAt: '2026-06-22T08:00:00.000Z',
+        lastEventAt: '2026-06-22T09:00:00.000Z',
+        messageCount: 3,
+        participantCount: 2,
+        updatedAt: '2026-06-22T09:01:00.000Z',
+        schemaVersion: 2,
+      },
+    ],
+    selectedChat: {
+      id: 'chat-group',
+      displayName: 'Fishing Crew (WA)',
+      chatType: 'group',
+      firstEventAt: '2026-06-22T08:00:00.000Z',
+      lastEventAt: '2026-06-22T09:00:00.000Z',
+      messageCount: 3,
+      participantCount: 2,
+      updatedAt: '2026-06-22T09:01:00.000Z',
+      schemaVersion: 2,
+    },
+    selectedChatId: 'chat-group',
+    selectedDay: undefined,
+    chatSearch: '',
+    messages: [
+      {
+        id: 'msg-incoming',
+        chatId: 'chat-group',
+        chatDisplayName: 'Fishing Crew (WA)',
+        chatType: 'group',
+        senderKey: 'phone:+48123456789',
+        senderDisplayName: 'Monika (WA)',
+        senderPhoneNumber: '+48123456789',
+        direction: 'incoming',
+        messageType: 'text',
+        text: 'hello from the group',
+        eventTimestamp: '2026-06-22T09:00:00.000Z',
+        eventDayKey: '2026-06-22',
+        eventTimeZone: 'Europe/Warsaw',
+        receivedAt: '2026-06-22T09:00:02.000Z',
+        ingestedAt: '2026-06-22T09:00:03.000Z',
+        deliveryMode: 'live',
+        schemaVersion: 2,
+      },
+      {
+        id: 'msg-outgoing',
+        chatId: 'chat-group',
+        chatDisplayName: 'Fishing Crew (WA)',
+        chatType: 'group',
+        senderKey: 'matrix:@pbuchman:home-dev',
+        senderDisplayName: 'You',
+        direction: 'outgoing',
+        messageType: 'text',
+        text: 'sent by me',
+        eventTimestamp: '2026-06-22T09:01:00.000Z',
+        eventDayKey: '2026-06-22',
+        eventTimeZone: 'Europe/Warsaw',
+        receivedAt: '2026-06-22T09:01:02.000Z',
+        ingestedAt: '2026-06-22T09:01:03.000Z',
+        deliveryMode: 'live',
+        schemaVersion: 2,
+      },
+    ],
+    availableDays: ['2026-06-22'],
+    chatCursor: undefined,
+    messageCursor: undefined,
+    loadingChats: false,
+    loadingMessages: false,
+    loadingMoreChats: false,
+    loadingMoreMessages: false,
+    refreshing: false,
+    error: null,
+    setChatSearch: vi.fn(),
+    selectChat: vi.fn(),
+    selectDay: vi.fn(),
+    clearDay: vi.fn(),
+    refresh: vi.fn(),
+    loadMoreChats: vi.fn(),
+    loadMoreMessages: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('PrivateWhatsAppLogPage', () => {
+  beforeEach(() => {
+    mockUsePrivateWhatsAppLog.mockReturnValue(createHookResult());
   });
 
   afterEach(() => {
@@ -140,7 +146,7 @@ describe('PrivateWhatsAppLogPage', () => {
     vi.clearAllMocks();
   });
 
-  it('renders a read-only sender-first message log', () => {
+  it('renders a read-only conversation-first log with group participants and outgoing messages', () => {
     render(
       <MemoryRouter>
         <PrivateWhatsAppLogPage />
@@ -148,15 +154,18 @@ describe('PrivateWhatsAppLogPage', () => {
     );
 
     expect(screen.getByRole('heading', { name: /private whatsapp/i })).toBeInTheDocument();
-    expect(screen.getAllByText('Alice')).not.toHaveLength(0);
-    expect(screen.getByText('hello from Alice')).toBeInTheDocument();
+    expect(screen.getAllByText('Fishing Crew (WA)')).not.toHaveLength(0);
+    expect(screen.getByText('Monika (WA)')).toBeInTheDocument();
+    expect(screen.getByText('You')).toBeInTheDocument();
+    expect(screen.getByText('hello from the group')).toBeInTheDocument();
+    expect(screen.getByText('sent by me')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /2026-06-22/ })).toBeInTheDocument();
     expect(screen.queryByText(/^Reply$/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/^Delete$/i)).not.toBeInTheDocument();
     expect(screen.queryByPlaceholderText(/send a message/i)).not.toBeInTheDocument();
   });
 
-  it('uses the full work surface with a mobile-bounded sender rail', () => {
+  it('uses the full work surface with a mobile-bounded chat rail', () => {
     render(
       <MemoryRouter>
         <PrivateWhatsAppLogPage />
@@ -165,7 +174,7 @@ describe('PrivateWhatsAppLogPage', () => {
 
     expect(screen.getByTestId('private-whatsapp-log-shell')).toHaveClass('w-full', 'min-w-0');
     expect(screen.getByTestId('private-whatsapp-log-shell')).not.toHaveClass('max-w-7xl');
-    expect(screen.getByTestId('private-whatsapp-sender-rail')).toHaveClass(
+    expect(screen.getByTestId('private-whatsapp-chat-rail')).toHaveClass(
       'max-h-[45vh]',
       'xl:max-h-none'
     );
@@ -175,10 +184,7 @@ describe('PrivateWhatsAppLogPage', () => {
   it('uses day chips to filter messages by exact eventDayKey', async () => {
     const user = userEvent.setup();
     const selectDay = vi.fn();
-    mockUsePrivateWhatsAppLog.mockReturnValueOnce({
-      ...mockUsePrivateWhatsAppLog(),
-      selectDay,
-    });
+    mockUsePrivateWhatsAppLog.mockReturnValueOnce(createHookResult({ selectDay }));
 
     render(
       <MemoryRouter>

--- a/apps/web/src/services/__tests__/whatsappApi.private.test.ts
+++ b/apps/web/src/services/__tests__/whatsappApi.private.test.ts
@@ -6,6 +6,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   disablePrivateWhatsAppAccount,
   getPrivateWhatsAppAccount,
+  listPrivateWhatsAppChatMessages,
+  listPrivateWhatsAppChats,
   listPrivateWhatsAppMessages,
   listPrivateWhatsAppSenderDays,
   listPrivateWhatsAppSenders,
@@ -46,6 +48,23 @@ describe('whatsappApi private read helpers', () => {
     expect(call?.[2]).toBe(TOKEN);
   });
 
+  it('lists private chats without sourceAccountId in the browser path', async () => {
+    const { apiRequest } = await import('../apiClient.js');
+    vi.mocked(apiRequest).mockResolvedValue({ chats: [], nextCursor: 'next-chats' });
+
+    const result = await listPrivateWhatsAppChats(TOKEN, {
+      limit: 25,
+      cursor: 'chat-cursor',
+    });
+
+    expect(result.nextCursor).toBe('next-chats');
+    const call = vi.mocked(apiRequest).mock.calls[0];
+    expect(call?.[0]).toBe('https://wa.test');
+    expect(call?.[1]).toBe('/private/chats?limit=25&cursor=chat-cursor');
+    expect(call?.[1]).not.toContain('sourceAccountId');
+    expect(call?.[2]).toBe(TOKEN);
+  });
+
   it('lists private messages by sender and optional day without sourceAccountId', async () => {
     const { apiRequest } = await import('../apiClient.js');
     vi.mocked(apiRequest).mockResolvedValue({ messages: [] });
@@ -60,6 +79,24 @@ describe('whatsappApi private read helpers', () => {
     const call = vi.mocked(apiRequest).mock.calls[0];
     expect(call?.[1]).toBe(
       '/private/messages?senderKey=phone%3A%2B48123456789&eventDayKey=2026-06-22&limit=50&cursor=messages-cursor'
+    );
+    expect(call?.[1]).not.toContain('sourceAccountId');
+  });
+
+  it('lists private messages by chat and optional day without sourceAccountId', async () => {
+    const { apiRequest } = await import('../apiClient.js');
+    vi.mocked(apiRequest).mockResolvedValue({ messages: [] });
+
+    await listPrivateWhatsAppChatMessages(TOKEN, {
+      chatId: 'chat-a',
+      eventDayKey: '2026-06-22',
+      limit: 50,
+      cursor: 'messages-cursor',
+    });
+
+    const call = vi.mocked(apiRequest).mock.calls[0];
+    expect(call?.[1]).toBe(
+      '/private/chats/chat-a/messages?eventDayKey=2026-06-22&limit=50&cursor=messages-cursor'
     );
     expect(call?.[1]).not.toContain('sourceAccountId');
   });

--- a/apps/web/src/services/whatsappApi.ts
+++ b/apps/web/src/services/whatsappApi.ts
@@ -2,6 +2,7 @@ import { config } from '@/config';
 import { apiRequest } from './apiClient.js';
 import type {
   PrivateWhatsAppAccount,
+  PrivateWhatsAppChatsResponse,
   PrivateWhatsAppMessagesResponse,
   PrivateWhatsAppSenderDaysResponse,
   PrivateWhatsAppSendersResponse,
@@ -136,8 +137,20 @@ export interface ListPrivateWhatsAppSendersOptions {
   cursor?: string;
 }
 
+export interface ListPrivateWhatsAppChatsOptions {
+  limit?: number;
+  cursor?: string;
+}
+
 export interface ListPrivateWhatsAppMessagesOptions {
   senderKey: string;
+  eventDayKey?: string;
+  limit?: number;
+  cursor?: string;
+}
+
+export interface ListPrivateWhatsAppChatMessagesOptions {
+  chatId: string;
   eventDayKey?: string;
   limit?: number;
   cursor?: string;
@@ -184,6 +197,23 @@ export async function listPrivateWhatsAppSenders(
   );
 }
 
+export async function listPrivateWhatsAppChats(
+  accessToken: string,
+  options: ListPrivateWhatsAppChatsOptions = {}
+): Promise<PrivateWhatsAppChatsResponse> {
+  const params = new URLSearchParams();
+  appendOptionalNumber(params, 'limit', options.limit);
+  appendOptionalString(params, 'cursor', options.cursor);
+  const queryString = params.toString();
+  const path = queryString !== '' ? `/private/chats?${queryString}` : '/private/chats';
+
+  return await apiRequest<PrivateWhatsAppChatsResponse>(
+    config.whatsappServiceUrl,
+    path,
+    accessToken
+  );
+}
+
 export async function listPrivateWhatsAppMessages(
   accessToken: string,
   options: ListPrivateWhatsAppMessagesOptions
@@ -197,6 +227,28 @@ export async function listPrivateWhatsAppMessages(
   return await apiRequest<PrivateWhatsAppMessagesResponse>(
     config.whatsappServiceUrl,
     `/private/messages?${params.toString()}`,
+    accessToken
+  );
+}
+
+export async function listPrivateWhatsAppChatMessages(
+  accessToken: string,
+  options: ListPrivateWhatsAppChatMessagesOptions
+): Promise<PrivateWhatsAppMessagesResponse> {
+  const params = new URLSearchParams();
+  appendOptionalString(params, 'eventDayKey', options.eventDayKey);
+  appendOptionalNumber(params, 'limit', options.limit);
+  appendOptionalString(params, 'cursor', options.cursor);
+  const queryString = params.toString();
+  const encodedChatId = encodeURIComponent(options.chatId);
+  const path =
+    queryString !== ''
+      ? `/private/chats/${encodedChatId}/messages?${queryString}`
+      : `/private/chats/${encodedChatId}/messages`;
+
+  return await apiRequest<PrivateWhatsAppMessagesResponse>(
+    config.whatsappServiceUrl,
+    path,
     accessToken
   );
 }

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -194,6 +194,19 @@ export interface PrivateWhatsAppSender {
   schemaVersion: number;
 }
 
+export interface PrivateWhatsAppChat {
+  id: string;
+  chatType: 'direct' | 'group' | 'unknown';
+  displayName?: string;
+  avatarMxcUri?: string;
+  messageCount: number;
+  participantCount: number;
+  firstSeenAt: string;
+  lastEventAt: string;
+  updatedAt: string;
+  schemaVersion?: number;
+}
+
 export interface PrivateWhatsAppMessage {
   id: string;
   chatId: string;
@@ -253,6 +266,11 @@ export interface PrivateWhatsAppAccount {
 
 export interface PrivateWhatsAppSendersResponse {
   senders: PrivateWhatsAppSender[];
+  nextCursor?: string;
+}
+
+export interface PrivateWhatsAppChatsResponse {
+  chats: PrivateWhatsAppChat[];
   nextCursor?: string;
 }
 

--- a/apps/whatsapp-service/src/__tests__/fakes.ts
+++ b/apps/whatsapp-service/src/__tests__/fakes.ts
@@ -35,6 +35,9 @@ import type {
   PhoneVerificationStatus,
   PrivateWhatsAppAggregateRebuildInput,
   PrivateWhatsAppAggregateRebuildResult,
+  PrivateWhatsAppChat,
+  PrivateWhatsAppChatQueryInput,
+  PrivateWhatsAppChatQueryResult,
   PrivateWhatsAppIngestOutcome,
   PrivateWhatsAppMessage,
   PrivateWhatsAppMessageQueryInput,
@@ -770,6 +773,7 @@ export class FakePrivateWhatsAppRepository implements PrivateWhatsAppRepository 
     const messages = Array.from(this.stored.values())
       .filter((stored) => stored.sourceAccountId === input.sourceAccountId)
       .map((stored) => this.toMessage(stored))
+      .filter((message) => input.chatId === undefined || message.chatId === input.chatId)
       .filter((message) => input.senderKey === undefined || message.senderKey === input.senderKey)
       .filter(
         (message) => input.eventDayKey === undefined || message.eventDayKey === input.eventDayKey
@@ -794,6 +798,44 @@ export class FakePrivateWhatsAppRepository implements PrivateWhatsAppRepository 
       const lastMessage = page[page.length - 1];
       if (lastMessage !== undefined) {
         result.nextCursor = encodeFakePrivateWhatsAppCursor(lastMessage.eventTimestamp, lastMessage.id);
+      }
+    }
+    return Promise.resolve(ok(result));
+  }
+
+  findChats(
+    input: PrivateWhatsAppChatQueryInput
+  ): Promise<Result<PrivateWhatsAppChatQueryResult, WhatsAppError>> {
+    const dataFailure = this.consumeDataQueryFailure();
+    if (dataFailure !== null) {
+      return Promise.resolve(err(dataFailure));
+    }
+
+    const failure = this.consumeFailure();
+    if (failure !== null) {
+      return Promise.resolve(err(failure));
+    }
+
+    const chats = Array.from(this.buildChats().values())
+      .filter((chat) => chat.sourceAccountId === input.sourceAccountId)
+      .sort((a, b) => {
+        const timestampComparison = b.lastEventAt.localeCompare(a.lastEventAt);
+        return timestampComparison === 0 ? b.id.localeCompare(a.id) : timestampComparison;
+      });
+    const cursor = decodeFakePrivateWhatsAppCursor(input.cursor);
+    const startIndex =
+      cursor === undefined
+        ? 0
+        : chats.findIndex(
+            (chat) => chat.lastEventAt === cursor.sortValue && chat.id === cursor.id
+          ) + 1;
+    const safeStartIndex = startIndex < 0 ? 0 : startIndex;
+    const page = chats.slice(safeStartIndex, safeStartIndex + input.limit);
+    const result: PrivateWhatsAppChatQueryResult = { chats: page };
+    if (chats.length > safeStartIndex + input.limit) {
+      const lastChat = page[page.length - 1];
+      if (lastChat !== undefined) {
+        result.nextCursor = encodeFakePrivateWhatsAppCursor(lastChat.lastEventAt, lastChat.id);
       }
     }
     return Promise.resolve(ok(result));
@@ -1101,6 +1143,57 @@ export class FakePrivateWhatsAppRepository implements PrivateWhatsAppRepository 
       }
     }
     return senders;
+  }
+
+  private buildChats(): Map<string, PrivateWhatsAppChat> {
+    const chats = new Map<string, PrivateWhatsAppChat>();
+    for (const stored of this.stored.values()) {
+      const message = this.toMessage(stored);
+      const existing = chats.get(message.chatId);
+      const participantKeys = existing?.participantKeys ?? [];
+      const nextParticipantKeys =
+        message.senderKey === undefined || participantKeys.includes(message.senderKey)
+          ? participantKeys
+          : [...participantKeys, message.senderKey];
+
+      if (existing === undefined) {
+        const chat: PrivateWhatsAppChat = {
+          id: message.chatId,
+          userId: message.userId,
+          sourceAccountId: message.sourceAccountId,
+          matrixRoomId: message.matrixRoomId,
+          chatType: message.chatType ?? 'unknown',
+          firstSeenAt: message.eventTimestamp,
+          lastEventAt: message.eventTimestamp,
+          messageCount: 1,
+          participantCount: nextParticipantKeys.length,
+          participantKeys: nextParticipantKeys,
+          updatedAt: message.receivedAt,
+          schemaVersion: 2,
+        };
+        if (message.chatDisplayName !== undefined) {
+          chat.displayName = message.chatDisplayName;
+        }
+        chats.set(message.chatId, chat);
+        continue;
+      }
+
+      existing.messageCount = (existing.messageCount ?? 0) + 1;
+      existing.participantKeys = nextParticipantKeys;
+      existing.participantCount = nextParticipantKeys.length;
+      existing.firstSeenAt =
+        message.eventTimestamp < existing.firstSeenAt ? message.eventTimestamp : existing.firstSeenAt;
+      existing.lastEventAt =
+        message.eventTimestamp > existing.lastEventAt ? message.eventTimestamp : existing.lastEventAt;
+      existing.updatedAt = message.receivedAt;
+      if (message.chatDisplayName !== undefined && message.eventTimestamp >= existing.lastEventAt) {
+        existing.displayName = message.chatDisplayName;
+      }
+      if (message.chatType !== undefined && message.chatType !== 'unknown') {
+        existing.chatType = message.chatType;
+      }
+    }
+    return chats;
   }
 }
 

--- a/apps/whatsapp-service/src/__tests__/infra/privateWhatsAppRepository.test.ts
+++ b/apps/whatsapp-service/src/__tests__/infra/privateWhatsAppRepository.test.ts
@@ -355,8 +355,12 @@ describe('privateWhatsAppRepository', () => {
       matrixRoomId: '!room:matrix.example',
       chatType: 'direct',
       displayName: 'Alice',
+      messageCount: 1,
+      participantCount: 1,
+      participantKeys: ['phone:+48123456789'],
       firstSeenAt: '2026-06-22T10:00:00.000Z',
       lastEventAt: '2026-06-22T10:00:00.000Z',
+      schemaVersion: 2,
     });
     expect(message).toMatchObject({
       id: expectedMessageId,
@@ -823,9 +827,26 @@ describe('privateWhatsAppRepository', () => {
         },
       })
     );
+    const otherChatResult = await repository.storeIncomingMessage(
+      createStoreInput({
+        chat: {
+          matrixRoomId: '!other-room:matrix.example',
+          type: 'group',
+          displayName: 'Other Room',
+        },
+        message: {
+          ...createStoreInput().message,
+          matrixRoomId: '!other-room:matrix.example',
+          matrixEventId: '$event-other-chat',
+          text: 'different chat',
+          eventTimestamp: '2026-06-22T12:30:00.000Z',
+        },
+      })
+    );
     expect(firstResult.ok).toBe(true);
     expect(secondResult.ok).toBe(true);
     expect(otherSenderResult.ok).toBe(true);
+    expect(otherChatResult.ok).toBe(true);
 
     const malformedCursorResult = await repository.findMessages({
       sourceAccountId: 'pbuchman-private-whatsapp',
@@ -879,6 +900,110 @@ describe('privateWhatsAppRepository', () => {
     if (!zeroLimitResult.ok) throw new Error(zeroLimitResult.error.message);
     expect(zeroLimitResult.value.messages).toEqual([]);
     expect(zeroLimitResult.value.nextCursor).toBeUndefined();
+
+    const chatId = deterministicId('pbuchman-private-whatsapp', '!room:matrix.example');
+    const chatFilterResult = await repository.findMessages({
+      sourceAccountId: 'pbuchman-private-whatsapp',
+      chatId,
+      limit: 10,
+    });
+    expect(chatFilterResult.ok).toBe(true);
+    if (!chatFilterResult.ok) throw new Error(chatFilterResult.error.message);
+    expect(chatFilterResult.value.messages.map((message) => message.chatId)).toEqual([
+      chatId,
+      chatId,
+      chatId,
+    ]);
+  });
+
+  it('queries private WhatsApp chats newest-first and projects legacy chat documents safely', async () => {
+    const olderResult = await repository.storeIncomingMessage(createStoreInput());
+    const newerResult = await repository.storeIncomingMessage(
+      createStoreInput({
+        chat: {
+          matrixRoomId: '!group-room:matrix.example',
+          type: 'group',
+          displayName: 'Fishing Crew (WA)',
+        },
+        message: {
+          ...createStoreInput().message,
+          matrixRoomId: '!group-room:matrix.example',
+          matrixEventId: '$event-group',
+          matrixSenderId: '@whatsapp_48536911713:home-dev',
+          senderDisplayName: 'Piotrek (WA)',
+          senderPhoneNumber: '+48536911713',
+          senderPhoneNumberNormalized: '48536911713',
+          senderKey: 'phone:+48536911713',
+          text: 'group message',
+          eventTimestamp: '2026-06-23T09:00:00.000Z',
+        },
+      })
+    );
+    expect(olderResult.ok).toBe(true);
+    expect(newerResult.ok).toBe(true);
+
+    await fakeFirestore.collection(PRIVATE_WHATSAPP_CHATS_COLLECTION).doc('legacy-chat').set({
+      sourceAccountId: 'pbuchman-private-whatsapp',
+      displayName: 'Legacy Room',
+      avatarMxcUri: 'mxc://matrix.example/avatar',
+      lastEventAt: '2026-06-21T09:00:00.000Z',
+      messageCount: 7,
+      participantKeys: ['phone:+48111111111', 123],
+    });
+
+    const firstPage = await repository.findChats({
+      sourceAccountId: 'pbuchman-private-whatsapp',
+      limit: 1,
+    });
+    expect(firstPage.ok).toBe(true);
+    if (!firstPage.ok) throw new Error(firstPage.error.message);
+    expect(firstPage.value.chats).toMatchObject([
+      {
+        chatType: 'group',
+        displayName: 'Fishing Crew (WA)',
+        messageCount: 1,
+        participantCount: 1,
+      },
+    ]);
+    expect(firstPage.value.nextCursor).toEqual(expect.any(String));
+
+    const cursor = firstPage.value.nextCursor;
+    if (cursor === undefined) throw new Error('Expected chat cursor');
+    const secondPage = await repository.findChats({
+      sourceAccountId: 'pbuchman-private-whatsapp',
+      limit: 10,
+      cursor,
+    });
+    expect(secondPage.ok).toBe(true);
+    if (!secondPage.ok) throw new Error(secondPage.error.message);
+    expect(secondPage.value.chats.map((chat) => chat.id)).toContain('legacy-chat');
+
+    const legacy = secondPage.value.chats.find((chat) => chat.id === 'legacy-chat');
+    expect(legacy).toMatchObject({
+      id: 'legacy-chat',
+      userId: '',
+      sourceAccountId: 'pbuchman-private-whatsapp',
+      matrixRoomId: '',
+      chatType: 'unknown',
+      displayName: 'Legacy Room',
+      avatarMxcUri: 'mxc://matrix.example/avatar',
+      messageCount: 7,
+      participantCount: 1,
+      participantKeys: ['phone:+48111111111'],
+      firstSeenAt: '',
+      lastEventAt: '2026-06-21T09:00:00.000Z',
+      updatedAt: '',
+      schemaVersion: 2,
+    });
+
+    const zeroLimit = await repository.findChats({
+      sourceAccountId: 'pbuchman-private-whatsapp',
+      limit: 0,
+    });
+    expect(zeroLimit.ok).toBe(true);
+    if (!zeroLimit.ok) throw new Error(zeroLimit.error.message);
+    expect(zeroLimit.value.chats).toEqual([]);
+    expect(zeroLimit.value.nextCursor).toBeUndefined();
   });
 
   it('queries sender-day aggregates with and without sender cursors', async () => {

--- a/apps/whatsapp-service/src/__tests__/privateSyncRoutes.test.ts
+++ b/apps/whatsapp-service/src/__tests__/privateSyncRoutes.test.ts
@@ -363,6 +363,20 @@ describe('Private WhatsApp Sync Routes', () => {
     expect(body.error.code).toBe('UNAUTHORIZED');
   });
 
+  it('requires bearer auth for public private WhatsApp chat reads', async () => {
+    const chatsResponse = await ctx.app.inject({
+      method: 'GET',
+      url: '/private/chats',
+    });
+    const messagesResponse = await ctx.app.inject({
+      method: 'GET',
+      url: '/private/chats/chat-a/messages',
+    });
+
+    expect(chatsResponse.statusCode).toBe(401);
+    expect(messagesResponse.statusCode).toBe(401);
+  });
+
   it('requires bearer auth for public private WhatsApp sender-day reads', async () => {
     const response = await ctx.app.inject({
       method: 'GET',
@@ -388,6 +402,24 @@ describe('Private WhatsApp Sync Routes', () => {
     const body = JSON.parse(response.body) as { success: boolean; error: { code: string } };
     expect(body.success).toBe(false);
     expect(body.error.code).toBe('NOT_FOUND');
+  });
+
+  it('returns not found for private WhatsApp chat reads without a mirror', async () => {
+    const token = await createToken({ sub: 'user-other' });
+
+    const chatsResponse = await ctx.app.inject({
+      method: 'GET',
+      url: '/private/chats',
+      headers: { authorization: `Bearer ${token}` },
+    });
+    const messagesResponse = await ctx.app.inject({
+      method: 'GET',
+      url: '/private/chats/chat-a/messages',
+      headers: { authorization: `Bearer ${token}` },
+    });
+
+    expect(chatsResponse.statusCode).toBe(404);
+    expect(messagesResponse.statusCode).toBe(404);
   });
 
   it('returns the authenticated user private WhatsApp mirror account', async () => {
@@ -721,6 +753,299 @@ describe('Private WhatsApp Sync Routes', () => {
       headers: { authorization: `Bearer ${token}` },
     });
     expect(rejectedSourceAccount.statusCode).toBe(400);
+  });
+
+  it('returns private WhatsApp chats and reads a whole group conversation by chat id', async () => {
+    const groupEvents = [
+      {
+        ...(createPayload()['events'] as Record<string, unknown>[])[0],
+        matrixRoomId: '!group-room:matrix.example',
+        matrixEventId: '$group-piotrek',
+        matrixSenderId: '@whatsapp_48536911713:home-dev',
+        eventTimestamp: '2026-06-22T10:00:00.000Z',
+        chat: {
+          type: 'group',
+          displayName: 'Fishing Crew (WA)',
+        },
+        sender: {
+          displayName: 'Piotrek (WA)',
+          phoneNumber: '+48536911713',
+        },
+        message: {
+          direction: 'incoming',
+          type: 'text',
+          text: 'Kto jedzie?',
+        },
+      },
+      {
+        ...(createPayload()['events'] as Record<string, unknown>[])[0],
+        matrixRoomId: '!group-room:matrix.example',
+        matrixEventId: '$group-monika',
+        matrixSenderId: '@whatsapp_48517277952:home-dev',
+        eventTimestamp: '2026-06-22T10:02:00.000Z',
+        chat: {
+          type: 'group',
+          displayName: 'Fishing Crew (WA)',
+        },
+        sender: {
+          displayName: 'Monika (WA)',
+          phoneNumber: '+48517277952',
+        },
+        message: {
+          direction: 'incoming',
+          type: 'text',
+          text: 'Ja moge.',
+        },
+      },
+    ];
+    await ctx.app.inject({
+      method: 'POST',
+      url: '/internal/whatsapp/private/events',
+      headers: { 'x-internal-auth': 'test-internal-token' },
+      payload: createPayload({ events: groupEvents }),
+    });
+    const token = await createToken({ sub: 'user-123' });
+
+    const chatsResponse = await ctx.app.inject({
+      method: 'GET',
+      url: '/private/chats?limit=10',
+      headers: { authorization: `Bearer ${token}` },
+    });
+
+    expect(chatsResponse.statusCode).toBe(200);
+    const chatsBody = JSON.parse(chatsResponse.body) as {
+      success: boolean;
+      data: {
+        chats: {
+          id: string;
+          chatType: string;
+          displayName?: string;
+          messageCount: number;
+          participantCount: number;
+        }[];
+      };
+    };
+    expect(chatsBody.success).toBe(true);
+    expect(chatsBody.data.chats).toMatchObject([
+      {
+        chatType: 'group',
+        displayName: 'Fishing Crew (WA)',
+        messageCount: 2,
+        participantCount: 2,
+      },
+    ]);
+    const chatId = chatsBody.data.chats[0]?.id;
+    expect(chatId).toEqual(expect.any(String));
+
+    const messagesResponse = await ctx.app.inject({
+      method: 'GET',
+      url: `/private/chats/${encodeURIComponent(chatId ?? '')}/messages?limit=10`,
+      headers: { authorization: `Bearer ${token}` },
+    });
+
+    expect(messagesResponse.statusCode).toBe(200);
+    const messagesBody = JSON.parse(messagesResponse.body) as {
+      success: boolean;
+      data: {
+        messages: {
+          text?: string;
+          senderDisplayName?: string;
+          senderPhoneNumber?: string;
+          direction: string;
+          chatDisplayName?: string;
+          chatType?: string;
+        }[];
+      };
+    };
+    expect(messagesBody.success).toBe(true);
+    expect(messagesBody.data.messages).toMatchObject([
+      {
+        text: 'Ja moge.',
+        senderDisplayName: 'Monika (WA)',
+        senderPhoneNumber: '+48517277952',
+        direction: 'incoming',
+        chatDisplayName: 'Fishing Crew (WA)',
+        chatType: 'group',
+      },
+      {
+        text: 'Kto jedzie?',
+        senderDisplayName: 'Piotrek (WA)',
+        senderPhoneNumber: '+48536911713',
+        direction: 'incoming',
+        chatDisplayName: 'Fishing Crew (WA)',
+        chatType: 'group',
+      },
+    ]);
+    expect(JSON.stringify(messagesBody)).not.toContain('sourceAccountId');
+    expect(JSON.stringify(messagesBody)).not.toContain('rawMatrixEvent');
+  });
+
+  it('paginates private WhatsApp chats and rejects server-side public chat filters', async () => {
+    await ctx.app.inject({
+      method: 'POST',
+      url: '/internal/whatsapp/private/events',
+      headers: { 'x-internal-auth': 'test-internal-token' },
+      payload: createPayload(),
+    });
+    await ctx.app.inject({
+      method: 'POST',
+      url: '/internal/whatsapp/private/events',
+      headers: { 'x-internal-auth': 'test-internal-token' },
+      payload: createPayload({
+        events: [
+          {
+            ...(createPayload()['events'] as Record<string, unknown>[])[0],
+            matrixRoomId: '!second-room:matrix.example',
+            matrixEventId: '$event-second-chat',
+            eventTimestamp: '2026-06-22T12:00:00.000Z',
+            chat: {
+              type: 'direct',
+              displayName: 'Second Chat',
+            },
+          },
+        ],
+      }),
+    });
+    const token = await createToken({ sub: 'user-123' });
+
+    const firstPage = await ctx.app.inject({
+      method: 'GET',
+      url: '/private/chats?limit=1',
+      headers: { authorization: `Bearer ${token}` },
+    });
+
+    expect(firstPage.statusCode).toBe(200);
+    const firstBody = JSON.parse(firstPage.body) as {
+      data: { chats: { id: string }[]; nextCursor?: string };
+    };
+    expect(firstBody.data.chats).toHaveLength(1);
+    expect(firstBody.data.nextCursor).toEqual(expect.any(String));
+
+    const cursor = firstBody.data.nextCursor;
+    const secondPage = await ctx.app.inject({
+      method: 'GET',
+      url: `/private/chats?limit=10&cursor=${encodeURIComponent(cursor ?? '')}`,
+      headers: { authorization: `Bearer ${token}` },
+    });
+    const sourceFilter = await ctx.app.inject({
+      method: 'GET',
+      url: '/private/chats?sourceAccountId=wrong-source',
+      headers: { authorization: `Bearer ${token}` },
+    });
+    const invalidLimit = await ctx.app.inject({
+      method: 'GET',
+      url: '/private/chats?limit=0',
+      headers: { authorization: `Bearer ${token}` },
+    });
+
+    expect(secondPage.statusCode).toBe(200);
+    expect(sourceFilter.statusCode).toBe(400);
+    expect(invalidLimit.statusCode).toBe(400);
+  });
+
+  it('returns standard errors when private WhatsApp chat data queries fail', async () => {
+    const token = await createToken({ sub: 'user-123' });
+    ctx.privateWhatsAppRepository.failNextDataQuery({
+      code: 'PERSISTENCE_ERROR',
+      message: 'Simulated private chat query failure',
+    });
+    const chatsResponse = await ctx.app.inject({
+      method: 'GET',
+      url: '/private/chats',
+      headers: { authorization: `Bearer ${token}` },
+    });
+    ctx.privateWhatsAppRepository.failNextDataQuery({
+      code: 'PERSISTENCE_ERROR',
+      message: 'Simulated private chat message query failure',
+    });
+    const messagesResponse = await ctx.app.inject({
+      method: 'GET',
+      url: '/private/chats/chat-a/messages',
+      headers: { authorization: `Bearer ${token}` },
+    });
+
+    expect(chatsResponse.statusCode).toBe(500);
+    expect(messagesResponse.statusCode).toBe(500);
+  });
+
+  it('filters private WhatsApp chat messages by day and rejects server-side public message filters', async () => {
+    await ctx.app.inject({
+      method: 'POST',
+      url: '/internal/whatsapp/private/events',
+      headers: { 'x-internal-auth': 'test-internal-token' },
+      payload: createPayload({
+        events: [
+          {
+            ...(createPayload()['events'] as Record<string, unknown>[])[0],
+            matrixEventId: '$event-day-one',
+            eventTimestamp: '2026-06-22T10:00:00.000Z',
+          },
+          {
+            ...(createPayload()['events'] as Record<string, unknown>[])[0],
+            matrixEventId: '$event-day-two',
+            eventTimestamp: '2026-06-23T10:00:00.000Z',
+            message: {
+              direction: 'incoming',
+              type: 'text',
+              text: 'next day',
+            },
+          },
+        ],
+      }),
+    });
+    const token = await createToken({ sub: 'user-123' });
+    const chatsResponse = await ctx.app.inject({
+      method: 'GET',
+      url: '/private/chats?limit=1',
+      headers: { authorization: `Bearer ${token}` },
+    });
+    const chatsBody = JSON.parse(chatsResponse.body) as {
+      data: { chats: { id: string }[] };
+    };
+    const chatId = chatsBody.data.chats[0]?.id ?? '';
+
+    const dayResponse = await ctx.app.inject({
+      method: 'GET',
+      url: `/private/chats/${encodeURIComponent(chatId)}/messages?eventDayKey=2026-06-23&limit=1`,
+      headers: { authorization: `Bearer ${token}` },
+    });
+    const firstMessagePage = await ctx.app.inject({
+      method: 'GET',
+      url: `/private/chats/${encodeURIComponent(chatId)}/messages?limit=1`,
+      headers: { authorization: `Bearer ${token}` },
+    });
+    const firstMessagePageBody = JSON.parse(firstMessagePage.body) as {
+      data: { nextCursor?: string };
+    };
+    const secondMessagePage = await ctx.app.inject({
+      method: 'GET',
+      url: `/private/chats/${encodeURIComponent(chatId)}/messages?limit=10&cursor=${encodeURIComponent(
+        firstMessagePageBody.data.nextCursor ?? ''
+      )}`,
+      headers: { authorization: `Bearer ${token}` },
+    });
+    const sourceFilter = await ctx.app.inject({
+      method: 'GET',
+      url: `/private/chats/${encodeURIComponent(chatId)}/messages?sourceAccountId=wrong-source`,
+      headers: { authorization: `Bearer ${token}` },
+    });
+    const invalidLimit = await ctx.app.inject({
+      method: 'GET',
+      url: `/private/chats/${encodeURIComponent(chatId)}/messages?limit=0`,
+      headers: { authorization: `Bearer ${token}` },
+    });
+
+    expect(dayResponse.statusCode).toBe(200);
+    expect(firstMessagePage.statusCode).toBe(200);
+    expect(firstMessagePageBody.data.nextCursor).toEqual(expect.any(String));
+    expect(secondMessagePage.statusCode).toBe(200);
+    const dayBody = JSON.parse(dayResponse.body) as {
+      data: { messages: { text?: string }[]; nextCursor?: string };
+    };
+    expect(dayBody.data.messages).toMatchObject([{ text: 'next day' }]);
+    expect(dayBody.data.nextCursor).toBeUndefined();
+    expect(sourceFilter.statusCode).toBe(400);
+    expect(invalidLimit.statusCode).toBe(400);
   });
 
   it('returns a standard error envelope when public private sender query fails', async () => {

--- a/apps/whatsapp-service/src/__tests__/usecases/ingestPrivateWhatsAppEvents.test.ts
+++ b/apps/whatsapp-service/src/__tests__/usecases/ingestPrivateWhatsAppEvents.test.ts
@@ -8,6 +8,8 @@ import {
   type PrivateWhatsAppAccount,
   type PrivateWhatsAppAggregateRebuildInput,
   type PrivateWhatsAppAggregateRebuildResult,
+  type PrivateWhatsAppChatQueryInput,
+  type PrivateWhatsAppChatQueryResult,
   type PrivateWhatsAppIngestOutcome,
   type PrivateWhatsAppMessageQueryInput,
   type PrivateWhatsAppMessageQueryResult,
@@ -131,6 +133,12 @@ class TestPrivateWhatsAppRepository implements PrivateWhatsAppRepository {
     return Promise.resolve(ok({ messages: [] }));
   }
 
+  findChats(
+    _input: PrivateWhatsAppChatQueryInput
+  ): Promise<Result<PrivateWhatsAppChatQueryResult, WhatsAppError>> {
+    return Promise.resolve(ok({ chats: [] }));
+  }
+
   findSenders(
     _input: PrivateWhatsAppSenderQueryInput
   ): Promise<Result<PrivateWhatsAppSenderQueryResult, WhatsAppError>> {
@@ -185,6 +193,40 @@ describe('IngestPrivateWhatsAppEventsUseCase', () => {
     expect(repository.stored[0]?.deliveryMode).toBe('live');
     expect(repository.stored[0]?.message.text).toBe('hello from private whatsapp');
     expect(repository.stored[0]?.message.direction).toBe('incoming');
+  });
+
+  it('stores outgoing Matrix events from the private account owner', async () => {
+    const result = await useCase.execute(
+      createInput({
+        events: [
+          createEvent({
+            matrixEventId: '$outgoing-event-1',
+            matrixSenderId: '@pbuchman:home-dev',
+            sender: {
+              displayName: 'You',
+            },
+            message: {
+              direction: 'outgoing',
+              type: 'text',
+              text: 'sent by me',
+            },
+          }),
+        ],
+      }),
+      logger
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(result.error.message);
+    expect(result.value).toMatchObject({
+      accepted: 1,
+      duplicates: 0,
+      rejected: 0,
+    });
+    expect(repository.stored).toHaveLength(1);
+    expect(repository.stored[0]?.message.direction).toBe('outgoing');
+    expect(repository.stored[0]?.message.senderDisplayName).toBe('You');
+    expect(repository.stored[0]?.message.senderKey).toBe('matrix:@pbuchman:home-dev');
   });
 
   it('derives sender identity and Europe/Warsaw day metadata before persistence', async () => {
@@ -272,14 +314,14 @@ describe('IngestPrivateWhatsAppEventsUseCase', () => {
     expect(repository.stored).toHaveLength(1);
   });
 
-  it('rejects non-incoming events without writing them', async () => {
+  it('rejects unsupported directions without writing them', async () => {
     const result = await useCase.execute(
       createInput({
         events: [
           createEvent({
             matrixEventId: '$event-outgoing',
             message: {
-              direction: 'outgoing',
+              direction: 'sideways',
               type: 'text',
               text: 'sent from me',
             },

--- a/apps/whatsapp-service/src/domain/whatsapp/index.ts
+++ b/apps/whatsapp-service/src/domain/whatsapp/index.ts
@@ -44,6 +44,8 @@ export type {
   PrivateWhatsAppAccountStatus,
   PrivateWhatsAppChat,
   PrivateWhatsAppChatInput,
+  PrivateWhatsAppChatQueryInput,
+  PrivateWhatsAppChatQueryResult,
   PrivateWhatsAppChatType,
   PrivateWhatsAppDeliveryMode,
   PrivateWhatsAppAggregateRebuildInput,

--- a/apps/whatsapp-service/src/domain/whatsapp/models/PrivateWhatsApp.ts
+++ b/apps/whatsapp-service/src/domain/whatsapp/models/PrivateWhatsApp.ts
@@ -4,7 +4,7 @@
 
 export type PrivateWhatsAppDeliveryMode = 'live' | 'backfill';
 export type PrivateWhatsAppChatType = 'direct' | 'group' | 'unknown';
-export type PrivateWhatsAppMessageDirection = 'incoming';
+export type PrivateWhatsAppMessageDirection = 'incoming' | 'outgoing';
 export type PrivateWhatsAppSummaryStatus = 'not_started' | 'completed' | 'failed';
 export type PrivateWhatsAppAccountStatus = 'active' | 'disabled';
 export type PrivateWhatsAppMessageType =
@@ -96,9 +96,13 @@ export interface PrivateWhatsAppChat {
   chatType: PrivateWhatsAppChatType;
   displayName?: string;
   avatarMxcUri?: string;
+  messageCount?: number;
+  participantCount?: number;
+  participantKeys?: string[];
   firstSeenAt: string;
   lastEventAt: string;
   updatedAt: string;
+  schemaVersion?: number;
 }
 
 export interface PrivateWhatsAppMessage {
@@ -191,6 +195,7 @@ export interface PrivateWhatsAppIngestResult {
 
 export interface PrivateWhatsAppMessageQueryInput {
   sourceAccountId: string;
+  chatId?: string;
   senderKey?: string;
   from?: string;
   to?: string;
@@ -201,6 +206,17 @@ export interface PrivateWhatsAppMessageQueryInput {
 
 export interface PrivateWhatsAppMessageQueryResult {
   messages: PrivateWhatsAppMessage[];
+  nextCursor?: string;
+}
+
+export interface PrivateWhatsAppChatQueryInput {
+  sourceAccountId: string;
+  limit: number;
+  cursor?: string;
+}
+
+export interface PrivateWhatsAppChatQueryResult {
+  chats: PrivateWhatsAppChat[];
   nextCursor?: string;
 }
 

--- a/apps/whatsapp-service/src/domain/whatsapp/ports/privateWhatsAppRepository.ts
+++ b/apps/whatsapp-service/src/domain/whatsapp/ports/privateWhatsAppRepository.ts
@@ -5,6 +5,8 @@ import type {
   PrivateWhatsAppAccount,
   PrivateWhatsAppAggregateRebuildInput,
   PrivateWhatsAppAggregateRebuildResult,
+  PrivateWhatsAppChatQueryInput,
+  PrivateWhatsAppChatQueryResult,
   PrivateWhatsAppIngestOutcome,
   PrivateWhatsAppMessageQueryInput,
   PrivateWhatsAppMessageQueryResult,
@@ -35,6 +37,9 @@ export interface PrivateWhatsAppRepository {
   findMessages(
     input: PrivateWhatsAppMessageQueryInput
   ): Promise<Result<PrivateWhatsAppMessageQueryResult, WhatsAppError>>;
+  findChats(
+    input: PrivateWhatsAppChatQueryInput
+  ): Promise<Result<PrivateWhatsAppChatQueryResult, WhatsAppError>>;
   findSenders(
     input: PrivateWhatsAppSenderQueryInput
   ): Promise<Result<PrivateWhatsAppSenderQueryResult, WhatsAppError>>;

--- a/apps/whatsapp-service/src/domain/whatsapp/usecases/ingestPrivateWhatsAppEvents.ts
+++ b/apps/whatsapp-service/src/domain/whatsapp/usecases/ingestPrivateWhatsAppEvents.ts
@@ -5,6 +5,7 @@ import type {
   PrivateWhatsAppDeliveryMode,
   PrivateWhatsAppIngestEventResult,
   PrivateWhatsAppIngestResult,
+  PrivateWhatsAppMessageDirection,
   PrivateWhatsAppMessageType,
   StorePrivateWhatsAppMessageInput,
 } from '../models/PrivateWhatsApp.js';
@@ -81,6 +82,7 @@ const MESSAGE_TYPES = new Set<PrivateWhatsAppMessageType>([
 ]);
 
 const CHAT_TYPES = new Set<PrivateWhatsAppChatType>(['direct', 'group', 'unknown']);
+const MESSAGE_DIRECTIONS = new Set<PrivateWhatsAppMessageDirection>(['incoming', 'outgoing']);
 const PRIVATE_WHATSAPP_EVENT_TIME_ZONE = 'Europe/Warsaw';
 
 export class IngestPrivateWhatsAppEventsUseCase {
@@ -244,7 +246,10 @@ function parseMessage(
   }
 
   const direction = readRequiredString(rawMessage, 'direction');
-  if (direction !== 'incoming') {
+  if (
+    direction === null ||
+    !MESSAGE_DIRECTIONS.has(direction as PrivateWhatsAppMessageDirection)
+  ) {
     return rejectEvent(matrixEventId, 'unsupported_direction');
   }
 
@@ -355,7 +360,7 @@ function toStoreInput(
       matrixRoomId: event.matrixRoomId,
       matrixEventId: event.matrixEventId,
       matrixSenderId: event.matrixSenderId,
-      direction: 'incoming',
+      direction: event.message.direction as PrivateWhatsAppMessageDirection,
       type: normalizeMessageType(event.message.type),
       eventTimestamp: event.eventTimestamp,
       eventDayKey: toWarsawDayKey(event.eventTimestamp),

--- a/apps/whatsapp-service/src/infra/firestore/privateWhatsAppRepository.ts
+++ b/apps/whatsapp-service/src/infra/firestore/privateWhatsAppRepository.ts
@@ -5,9 +5,11 @@ import type { WhatsAppError } from '../../domain/whatsapp/index.js';
 import type {
   DisablePrivateWhatsAppAccountInput,
   PrivateWhatsAppAccount,
-  PrivateWhatsAppChat,
   PrivateWhatsAppAggregateRebuildInput,
   PrivateWhatsAppAggregateRebuildResult,
+  PrivateWhatsAppChat,
+  PrivateWhatsAppChatQueryInput,
+  PrivateWhatsAppChatQueryResult,
   PrivateWhatsAppIngestOutcome,
   PrivateWhatsAppMessage,
   PrivateWhatsAppMessageQueryInput,
@@ -86,6 +88,7 @@ export function createPrivateWhatsAppRepository(): PrivateWhatsAppRepository {
     disableAccount,
     storeIncomingMessage,
     findMessages,
+    findChats,
     findSenders,
     findSenderDays,
     rebuildAggregates,
@@ -378,6 +381,9 @@ async function findMessages(
       .collection(PRIVATE_WHATSAPP_MESSAGES_COLLECTION)
       .where('sourceAccountId', '==', input.sourceAccountId);
 
+    if (input.chatId !== undefined) {
+      query = query.where('chatId', '==', input.chatId);
+    }
     if (input.senderKey !== undefined) {
       query = query.where('senderKey', '==', input.senderKey);
     }
@@ -411,6 +417,41 @@ async function findMessages(
     return err({
       code: 'PERSISTENCE_ERROR',
       message: `Failed to query private WhatsApp messages: ${getErrorMessage(error, 'Unknown Firestore error')}`,
+    });
+  }
+}
+
+async function findChats(
+  input: PrivateWhatsAppChatQueryInput
+): Promise<Result<PrivateWhatsAppChatQueryResult, WhatsAppError>> {
+  try {
+    const db = getFirestore();
+    let query: Query = db
+      .collection(PRIVATE_WHATSAPP_CHATS_COLLECTION)
+      .where('sourceAccountId', '==', input.sourceAccountId)
+      .orderBy('lastEventAt', 'desc')
+      .orderBy(FieldPath.documentId(), 'desc');
+
+    const cursor = decodeCursor(input.cursor);
+    if (cursor !== undefined) {
+      query = query.startAfter(cursor.sortValue, cursor.id);
+    }
+
+    const snapshot = await query.limit(input.limit + 1).get();
+    const docs = snapshot.docs.slice(0, input.limit);
+    const chats = docs.map((doc) => normalizeChat(doc.id, doc.data()));
+    const result: PrivateWhatsAppChatQueryResult = { chats };
+    /* v8 ignore start -- schema: cursor generation is covered through public reads; zero-limit guard is defensive for malformed internal callers @preserve */
+    if (snapshot.docs.length > input.limit && input.limit > 0) {
+      const lastChat = chats[chats.length - 1] as PrivateWhatsAppChat;
+      result.nextCursor = encodeCursor(lastChat.lastEventAt, lastChat.id);
+    }
+    /* v8 ignore stop @preserve */
+    return ok(result);
+  } catch (error) {
+    return err({
+      code: 'PERSISTENCE_ERROR',
+      message: `Failed to query private WhatsApp chats: ${getErrorMessage(error, 'Unknown Firestore error')}`,
     });
   }
 }
@@ -618,10 +659,15 @@ function buildChat(
     sourceAccountId: input.sourceAccountId,
     matrixRoomId: input.chat.matrixRoomId,
     chatType: selectChatType(existingChat, input.chat.type, shouldApplyIncomingChatMetadata),
+    messageCount: (existingChat?.messageCount ?? 0) + 1,
     firstSeenAt: oldestTimestamp(existingChat?.firstSeenAt, input.message.eventTimestamp),
     lastEventAt: newestTimestamp(existingChat?.lastEventAt, input.message.eventTimestamp),
     updatedAt: now,
+    schemaVersion: PRIVATE_WHATSAPP_SCHEMA_VERSION,
   };
+  const participantKeys = appendUnique(existingChat?.participantKeys ?? [], getSenderKey(input));
+  chat.participantKeys = participantKeys;
+  chat.participantCount = participantKeys.length;
 
   if (
     input.chat.displayName !== undefined &&
@@ -772,7 +818,7 @@ function toStoreInputFromMessage(message: PrivateWhatsAppMessage): StorePrivateW
     matrixEventId: message.matrixEventId,
     matrixSenderId: message.matrixSenderId,
     senderKey,
-    direction: 'incoming',
+    direction: message.direction,
     type: isPrivateWhatsAppMessageType(message.messageType) ? message.messageType : 'unknown',
     eventTimestamp: message.eventTimestamp,
     eventDayKey,
@@ -839,6 +885,46 @@ function buildMessageUpgradeFields(
 
   return Object.keys(fields).length === 0 ? undefined : fields;
 }
+
+/* v8 ignore start -- schema: defensive Firestore chat projection fallbacks are only partially reachable through sourceAccountId-filtered queries @preserve */
+function normalizeChat(id: string, data: Record<string, unknown> | undefined): PrivateWhatsAppChat {
+  const chat = data as Partial<PrivateWhatsAppChat> | undefined;
+  const projected: PrivateWhatsAppChat = {
+    id,
+    userId: typeof chat?.userId === 'string' ? chat.userId : '',
+    sourceAccountId: typeof chat?.sourceAccountId === 'string' ? chat.sourceAccountId : '',
+    matrixRoomId: typeof chat?.matrixRoomId === 'string' ? chat.matrixRoomId : '',
+    chatType:
+      chat?.chatType === 'direct' || chat?.chatType === 'group' || chat?.chatType === 'unknown'
+        ? chat.chatType
+        : 'unknown',
+    firstSeenAt: typeof chat?.firstSeenAt === 'string' ? chat.firstSeenAt : '',
+    lastEventAt: typeof chat?.lastEventAt === 'string' ? chat.lastEventAt : '',
+    updatedAt: typeof chat?.updatedAt === 'string' ? chat.updatedAt : '',
+    schemaVersion:
+      typeof chat?.schemaVersion === 'number' ? chat.schemaVersion : PRIVATE_WHATSAPP_SCHEMA_VERSION,
+  };
+  if (typeof chat?.displayName === 'string') {
+    projected.displayName = chat.displayName;
+  }
+  if (typeof chat?.avatarMxcUri === 'string') {
+    projected.avatarMxcUri = chat.avatarMxcUri;
+  }
+  if (typeof chat?.messageCount === 'number') {
+    projected.messageCount = chat.messageCount;
+  }
+  if (typeof chat?.participantCount === 'number') {
+    projected.participantCount = chat.participantCount;
+  }
+  if (Array.isArray(chat?.participantKeys)) {
+    projected.participantKeys = chat.participantKeys.filter(
+      (participantKey): participantKey is string => typeof participantKey === 'string'
+    );
+    projected.participantCount = projected.participantCount ?? projected.participantKeys.length;
+  }
+  return projected;
+}
+/* v8 ignore stop @preserve */
 
 function getSenderKey(input: StorePrivateWhatsAppMessageInput): string {
   const senderPhoneNumberNormalized = getSenderPhoneNumberNormalized(input);

--- a/apps/whatsapp-service/src/routes/privateReadRoutes.ts
+++ b/apps/whatsapp-service/src/routes/privateReadRoutes.ts
@@ -2,6 +2,8 @@ import type { FastifyPluginCallback, FastifyReply, FastifyRequest } from 'fastif
 import { logIncomingRequest, requireAuth, type AuthUser } from '@intexuraos/common-http';
 import type {
   PrivateWhatsAppAccount,
+  PrivateWhatsAppChat,
+  PrivateWhatsAppChatQueryInput,
   PrivateWhatsAppMessage,
   PrivateWhatsAppMessageQueryInput,
   PrivateWhatsAppSender,
@@ -19,11 +21,26 @@ interface PrivateSendersQuerystring {
   cursor?: string;
 }
 
+interface PrivateChatsQuerystring {
+  limit?: number;
+  cursor?: string;
+}
+
 interface PrivateMessagesQuerystring {
   senderKey: string;
   eventDayKey?: string;
   limit?: number;
   cursor?: string;
+}
+
+interface PrivateChatMessagesQuerystring {
+  eventDayKey?: string;
+  limit?: number;
+  cursor?: string;
+}
+
+interface PrivateChatMessagesParams {
+  chatId: string;
 }
 
 interface PrivateSenderDaysQuerystring {
@@ -39,6 +56,10 @@ interface PrivateAccountBody {
 }
 
 type PublicPrivateWhatsAppAccount = Omit<PrivateWhatsAppAccount, 'id' | 'userId'>;
+type PublicPrivateWhatsAppChat = Omit<
+  PrivateWhatsAppChat,
+  'userId' | 'sourceAccountId' | 'matrixRoomId' | 'participantKeys'
+>;
 type PublicPrivateWhatsAppSender = Omit<PrivateWhatsAppSender, 'userId' | 'sourceAccountId'>;
 type PublicPrivateWhatsAppMessage = Omit<
   PrivateWhatsAppMessage,
@@ -92,6 +113,27 @@ function hasSourceAccountQuery(request: FastifyRequest): boolean {
 function getPublicSenderLogMetadata(query: Partial<PrivateSendersQuerystring>): Record<string, unknown> {
   return {
     route: 'whatsapp_private_senders_query',
+    hasCursor: typeof query.cursor === 'string',
+    limit: normalizeLimit(query.limit),
+  };
+}
+
+function getPublicChatsLogMetadata(query: Partial<PrivateChatsQuerystring>): Record<string, unknown> {
+  return {
+    route: 'whatsapp_private_chats_query',
+    hasCursor: typeof query.cursor === 'string',
+    limit: normalizeLimit(query.limit),
+  };
+}
+
+function getPublicChatMessagesLogMetadata(
+  query: Partial<PrivateChatMessagesQuerystring>,
+  params: Partial<PrivateChatMessagesParams>
+): Record<string, unknown> {
+  return {
+    route: 'whatsapp_private_chat_messages_query',
+    hasChatId: typeof params.chatId === 'string',
+    hasEventDayKey: typeof query.eventDayKey === 'string',
     hasCursor: typeof query.cursor === 'string',
     limit: normalizeLimit(query.limit),
   };
@@ -183,6 +225,21 @@ function toPublicSender(sender: PrivateWhatsAppSender): PublicPrivateWhatsAppSen
     updatedAt: sender.updatedAt,
     schemaVersion: sender.schemaVersion,
   }) as PublicPrivateWhatsAppSender;
+}
+
+function toPublicChat(chat: PrivateWhatsAppChat): PublicPrivateWhatsAppChat {
+  return omitUndefined({
+    id: chat.id,
+    chatType: chat.chatType,
+    displayName: chat.displayName,
+    avatarMxcUri: chat.avatarMxcUri,
+    messageCount: chat.messageCount,
+    participantCount: chat.participantCount,
+    firstSeenAt: chat.firstSeenAt,
+    lastEventAt: chat.lastEventAt,
+    updatedAt: chat.updatedAt,
+    schemaVersion: chat.schemaVersion,
+  }) as PublicPrivateWhatsAppChat;
 }
 
 function toPublicMessage(message: PrivateWhatsAppMessage): PublicPrivateWhatsAppMessage {
@@ -394,6 +451,201 @@ export function createPrivateReadRoutes(): FastifyPluginCallback {
           return await reply.fail('INTERNAL_ERROR', result.error.message);
         }
         return await reply.ok(toPublicAccount(result.value));
+      }
+    );
+
+    fastify.get<{ Querystring: PrivateChatsQuerystring }>(
+      '/private/chats',
+      {
+        attachValidation: true,
+        schema: {
+          operationId: 'listPrivateWhatsAppChats',
+          summary: 'List private WhatsApp chats',
+          tags: ['whatsapp'],
+          querystring: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+              limit: { type: 'integer', minimum: 1, maximum: 100, default: 50 },
+              cursor: { type: 'string', minLength: 1 },
+            },
+          },
+          response: {
+            200: {
+              description: 'Private WhatsApp chats retrieved successfully',
+              type: 'object',
+              properties: {
+                success: { type: 'boolean', const: true },
+                data: {
+                  type: 'object',
+                  properties: {
+                    chats: { type: 'array', items: { type: 'object', additionalProperties: true } },
+                    nextCursor: { type: 'string' },
+                  },
+                  required: ['chats'],
+                },
+              },
+              required: ['success', 'data'],
+            },
+            ...privateReadErrorResponses(),
+          },
+        },
+      },
+      async (request: FastifyRequest<{ Querystring: PrivateChatsQuerystring }>, reply: FastifyReply) => {
+        logIncomingRequest(request, {
+          message: 'Received request to GET /whatsapp/private/chats',
+          bodyPreviewLength: 0,
+          additionalFields: getPublicChatsLogMetadata(request.query),
+        });
+        const user = await requirePrivateWhatsAppOwner(request, reply);
+        if (user === null) {
+          return;
+        }
+        if (hasSourceAccountQuery(request)) {
+          return await reply.fail('INVALID_REQUEST', 'sourceAccountId is server-side only');
+        }
+        const validatedRequest = request as ValidatedRequest;
+        if (validatedRequest.validationError !== undefined) {
+          return await reply.fail('INVALID_REQUEST', 'Validation failed');
+        }
+        const account = await resolveActivePrivateAccount(user, reply);
+        if (account === null) {
+          return;
+        }
+
+        const input: PrivateWhatsAppChatQueryInput = {
+          sourceAccountId: account.sourceAccountId,
+          limit: normalizeLimit(request.query.limit),
+        };
+        if (request.query.cursor !== undefined) {
+          input.cursor = request.query.cursor;
+        }
+
+        const result = await getServices().privateWhatsAppRepository.findChats(input);
+        if (!result.ok) {
+          return await reply.fail('INTERNAL_ERROR', result.error.message);
+        }
+        request.log.info(
+          { route: 'whatsapp_private_chats_query', resultCount: result.value.chats.length },
+          'Private WhatsApp chats retrieved'
+        );
+        const response: { chats: PublicPrivateWhatsAppChat[]; nextCursor?: string } = {
+          chats: result.value.chats.map(toPublicChat),
+        };
+        if (result.value.nextCursor !== undefined) {
+          response.nextCursor = result.value.nextCursor;
+        }
+        return await reply.ok(response);
+      }
+    );
+
+    fastify.get<{
+      Params: PrivateChatMessagesParams;
+      Querystring: PrivateChatMessagesQuerystring;
+    }>(
+      '/private/chats/:chatId/messages',
+      {
+        attachValidation: true,
+        schema: {
+          operationId: 'listPrivateWhatsAppChatMessages',
+          summary: 'List private WhatsApp messages by chat',
+          tags: ['whatsapp'],
+          params: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+              chatId: { type: 'string', minLength: 1 },
+            },
+            required: ['chatId'],
+          },
+          querystring: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+              eventDayKey: { type: 'string', minLength: 10 },
+              limit: { type: 'integer', minimum: 1, maximum: 100, default: 50 },
+              cursor: { type: 'string', minLength: 1 },
+            },
+          },
+          response: {
+            200: {
+              description: 'Private WhatsApp chat messages retrieved successfully',
+              type: 'object',
+              properties: {
+                success: { type: 'boolean', const: true },
+                data: {
+                  type: 'object',
+                  properties: {
+                    messages: { type: 'array', items: { type: 'object', additionalProperties: true } },
+                    nextCursor: { type: 'string' },
+                  },
+                  required: ['messages'],
+                },
+              },
+              required: ['success', 'data'],
+            },
+            ...privateReadErrorResponses(),
+          },
+        },
+      },
+      async (
+        request: FastifyRequest<{
+          Params: PrivateChatMessagesParams;
+          Querystring: PrivateChatMessagesQuerystring;
+        }>,
+        reply: FastifyReply
+      ) => {
+        logIncomingRequest(request, {
+          message: 'Received request to GET /whatsapp/private/chats/:chatId/messages',
+          bodyPreviewLength: 0,
+          additionalFields: getPublicChatMessagesLogMetadata(request.query, request.params),
+        });
+        const user = await requirePrivateWhatsAppOwner(request, reply);
+        if (user === null) {
+          return;
+        }
+        if (hasSourceAccountQuery(request)) {
+          return await reply.fail('INVALID_REQUEST', 'sourceAccountId is server-side only');
+        }
+        const validatedRequest = request as ValidatedRequest;
+        if (validatedRequest.validationError !== undefined) {
+          return await reply.fail('INVALID_REQUEST', 'Validation failed');
+        }
+        const account = await resolveActivePrivateAccount(user, reply);
+        if (account === null) {
+          return;
+        }
+
+        const input: PrivateWhatsAppMessageQueryInput = {
+          sourceAccountId: account.sourceAccountId,
+          chatId: request.params.chatId,
+          limit: normalizeLimit(request.query.limit),
+        };
+        if (request.query.eventDayKey !== undefined) {
+          input.eventDayKey = request.query.eventDayKey;
+        }
+        if (request.query.cursor !== undefined) {
+          input.cursor = request.query.cursor;
+        }
+
+        const result = await getServices().privateWhatsAppRepository.findMessages(input);
+        if (!result.ok) {
+          return await reply.fail('INTERNAL_ERROR', result.error.message);
+        }
+        request.log.info(
+          {
+            route: 'whatsapp_private_chat_messages_query',
+            resultCount: result.value.messages.length,
+          },
+          'Private WhatsApp chat messages retrieved'
+        );
+        const response: { messages: PublicPrivateWhatsAppMessage[]; nextCursor?: string } = {
+          messages: result.value.messages.map(toPublicMessage),
+        };
+        if (result.value.nextCursor !== undefined) {
+          response.nextCursor = result.value.nextCursor;
+        }
+        return await reply.ok(response);
       }
     );
 

--- a/tools/whatsapp-private-matrix-sync/src/server.mjs
+++ b/tools/whatsapp-private-matrix-sync/src/server.mjs
@@ -214,7 +214,12 @@ export async function ensureRoomContextsForIncomingEvents(
 }
 
 export function matrixEventToPrivateWhatsAppEvent(roomId, event, roomContext, config) {
-  if (!isRecord(event) || !isIncomingWhatsAppMatrixEvent(event, config)) {
+  if (!isRecord(event)) {
+    return null;
+  }
+
+  const direction = getWhatsAppMatrixEventDirection(event, config);
+  if (direction === null) {
     return null;
   }
 
@@ -225,13 +230,14 @@ export function matrixEventToPrivateWhatsAppEvent(roomId, event, roomContext, co
     return null;
   }
 
-  const message = matrixEventToMessage(event);
+  const message = matrixEventToMessage(event, direction);
   if (message === null) {
     return null;
   }
 
   const senderPhoneNumber = phoneNumberFromWhatsAppMxid(sender);
-  const senderDisplayName = roomContext.memberDisplayNames?.[sender];
+  const senderDisplayName =
+    direction === 'outgoing' ? 'You' : roomContext.memberDisplayNames?.[sender];
   const chat = {
     type: roomContext.chatType ?? 'unknown',
   };
@@ -268,34 +274,43 @@ export function matrixEventToPrivateWhatsAppEvent(roomId, event, roomContext, co
 }
 
 export function isIncomingWhatsAppMatrixEvent(event, config) {
+  return getWhatsAppMatrixEventDirection(event, config) === 'incoming';
+}
+
+function getWhatsAppMatrixEventDirection(event, config) {
   const sender = readString(event, 'sender');
   if (sender === undefined) {
-    return false;
+    return null;
   }
   const bridgeBotUsers = config.bridgeBotUsers ?? defaultBridgeBotUsers;
-  if (sender === config.matrixUserId || bridgeBotUsers.has(sender)) {
-    return false;
+  if (bridgeBotUsers.has(sender)) {
+    return null;
   }
 
   const senderPhone = normalizePhoneNumber(phoneNumberFromWhatsAppMxid(sender) ?? '');
-  if (senderPhone === '') {
-    return false;
-  }
-  if (config.ownWhatsAppPhoneNumber !== '' && senderPhone === config.ownWhatsAppPhoneNumber) {
-    return false;
+  let direction = 'incoming';
+  if (sender === config.matrixUserId) {
+    direction = 'outgoing';
+  } else if (
+    config.ownWhatsAppPhoneNumber !== '' &&
+    senderPhone === config.ownWhatsAppPhoneNumber
+  ) {
+    direction = 'outgoing';
+  } else if (senderPhone === '') {
+    return null;
   }
 
   const type = readString(event, 'type');
   if (type === 'm.reaction' || type === 'm.sticker') {
-    return true;
+    return direction;
   }
   if (type !== 'm.room.message') {
-    return false;
+    return null;
   }
 
   const content = isRecord(event.content) ? event.content : {};
   const msgtype = readString(content, 'msgtype');
-  return msgtype !== 'm.notice';
+  return msgtype === 'm.notice' ? null : direction;
 }
 
 export function buildImpersonatedIdTokenRequest(config, sourceAccessToken) {
@@ -589,19 +604,19 @@ function mergeRoomContext(existing, next) {
   };
 }
 
-function matrixEventToMessage(event) {
+function matrixEventToMessage(event, direction) {
   const type = readString(event, 'type');
   const content = isRecord(event.content) ? event.content : {};
 
   if (type === 'm.reaction') {
     const relation = isRecord(content['m.relates_to']) ? content['m.relates_to'] : {};
     const reactionText = readString(relation, 'key');
-    return withOptionalText({ direction: 'incoming', type: 'reaction' }, reactionText);
+    return withOptionalText({ direction, type: 'reaction' }, reactionText);
   }
 
   if (type === 'm.sticker') {
     return withMediaFromContent(
-      withOptionalText({ direction: 'incoming', type: 'sticker' }, readString(content, 'body')),
+      withOptionalText({ direction, type: 'sticker' }, readString(content, 'body')),
       content
     );
   }
@@ -616,10 +631,7 @@ function matrixEventToMessage(event) {
     return null;
   }
 
-  const message = withOptionalText(
-    { direction: 'incoming', type: messageType },
-    readString(content, 'body')
-  );
+  const message = withOptionalText({ direction, type: messageType }, readString(content, 'body'));
 
   if (messageType === 'text') {
     return message;

--- a/tools/whatsapp-private-matrix-sync/src/server.test.mjs
+++ b/tools/whatsapp-private-matrix-sync/src/server.test.mjs
@@ -293,6 +293,171 @@ test('isIncomingWhatsAppMatrixEvent accepts incoming reactions and stickers', ()
   );
 });
 
+test('collectPrivateWhatsAppEvents maps messages authored by the Matrix user as outgoing', () => {
+  const events = collectPrivateWhatsAppEvents(
+    {
+      rooms: {
+        join: {
+          '!direct:home-dev': {
+            state: {
+              events: [
+                { type: 'm.room.name', content: { name: 'Tomek (WA)' } },
+                { type: 'm.room.topic', content: { topic: 'WhatsApp private chat' } },
+              ],
+            },
+            timeline: {
+              events: [
+                {
+                  type: 'm.room.message',
+                  event_id: '$outgoing-from-matrix-user',
+                  sender: '@pbuchman:home-dev',
+                  origin_server_ts: 1782205300000,
+                  content: { msgtype: 'm.text', body: 'sent from Element' },
+                },
+              ],
+            },
+          },
+        },
+      },
+    },
+    config
+  );
+
+  assert.equal(events.length, 1);
+  assert.deepEqual(events[0]?.message, {
+    direction: 'outgoing',
+    type: 'text',
+    text: 'sent from Element',
+  });
+  assert.equal(events[0]?.sender?.displayName, 'You');
+});
+
+test('collectPrivateWhatsAppEvents maps own WhatsApp number echoes as outgoing', () => {
+  const events = collectPrivateWhatsAppEvents(
+    {
+      rooms: {
+        join: {
+          '!direct:home-dev': {
+            state: {
+              events: [
+                { type: 'm.room.name', content: { name: 'Tomek (WA)' } },
+                { type: 'm.room.topic', content: { topic: 'WhatsApp private chat' } },
+              ],
+            },
+            timeline: {
+              events: [
+                matrixMessage({
+                  event_id: '$outgoing-from-own-phone',
+                  sender: '@whatsapp_48111222333:home-dev',
+                  content: { msgtype: 'm.text', body: 'sent from mobile' },
+                }),
+              ],
+            },
+          },
+        },
+      },
+    },
+    config
+  );
+
+  assert.equal(events.length, 1);
+  assert.deepEqual(events[0]?.message, {
+    direction: 'outgoing',
+    type: 'text',
+    text: 'sent from mobile',
+  });
+  assert.equal(events[0]?.sender?.phoneNumber, '+48111222333');
+});
+
+test('collectPrivateWhatsAppEvents maps group rooms as one conversation with participant senders', () => {
+  const events = collectPrivateWhatsAppEvents(
+    {
+      rooms: {
+        join: {
+          '!group:home-dev': {
+            state: {
+              events: [
+                { type: 'm.room.name', content: { name: 'Fishing Crew (WA)' } },
+                { type: 'm.room.topic', content: { topic: 'WhatsApp group' } },
+                {
+                  type: 'm.room.member',
+                  state_key: '@whatsapp_48536911713:home-dev',
+                  content: { displayname: 'Piotrek (WA)' },
+                },
+                {
+                  type: 'm.room.member',
+                  state_key: '@whatsapp_48517277952:home-dev',
+                  content: { displayname: 'Monika (WA)' },
+                },
+                {
+                  type: 'm.room.member',
+                  state_key: '@pbuchman:home-dev',
+                  content: { displayname: 'Piotr' },
+                },
+              ],
+            },
+            timeline: {
+              events: [
+                matrixMessage({
+                  event_id: '$group-piotrek',
+                  sender: '@whatsapp_48536911713:home-dev',
+                  content: { msgtype: 'm.text', body: 'Kto jedzie?' },
+                }),
+                matrixMessage({
+                  event_id: '$group-monika',
+                  sender: '@whatsapp_48517277952:home-dev',
+                  content: { msgtype: 'm.text', body: 'Ja moge.' },
+                }),
+                {
+                  type: 'm.room.message',
+                  event_id: '$group-me',
+                  sender: '@pbuchman:home-dev',
+                  origin_server_ts: 1782205305000,
+                  content: { msgtype: 'm.text', body: 'Tez bede.' },
+                },
+              ],
+            },
+          },
+        },
+      },
+    },
+    config
+  );
+
+  assert.deepEqual(
+    events.map((event) => ({
+      roomId: event.matrixRoomId,
+      chat: event.chat,
+      sender: event.sender,
+      direction: event.message.direction,
+      text: event.message.text,
+    })),
+    [
+      {
+        roomId: '!group:home-dev',
+        chat: { type: 'group', displayName: 'Fishing Crew (WA)' },
+        sender: { displayName: 'Piotrek (WA)', phoneNumber: '+48536911713' },
+        direction: 'incoming',
+        text: 'Kto jedzie?',
+      },
+      {
+        roomId: '!group:home-dev',
+        chat: { type: 'group', displayName: 'Fishing Crew (WA)' },
+        sender: { displayName: 'Monika (WA)', phoneNumber: '+48517277952' },
+        direction: 'incoming',
+        text: 'Ja moge.',
+      },
+      {
+        roomId: '!group:home-dev',
+        chat: { type: 'group', displayName: 'Fishing Crew (WA)' },
+        sender: { displayName: 'You' },
+        direction: 'outgoing',
+        text: 'Tez bede.',
+      },
+    ]
+  );
+});
+
 test('extractRoomContexts merges state from sync rooms with existing context', () => {
   const roomContexts = extractRoomContexts(
     {
@@ -395,28 +560,14 @@ test('ensureRoomContextsForIncomingEvents fetches Matrix state for new WhatsApp 
   assert.equal(events[0]?.sender?.displayName, 'Monika (WA)');
 });
 
-test('collectPrivateWhatsAppEvents ignores local user, bridge bot, own-number ghost, and non-message events', () => {
+test('collectPrivateWhatsAppEvents ignores bridge bot and non-message events', () => {
   const ignoredEvents = [
-    {
-      type: 'm.room.message',
-      event_id: '$from-user',
-      sender: '@pbuchman:home-dev',
-      origin_server_ts: 1782205200000,
-      content: { msgtype: 'm.text', body: 'outgoing from Element' },
-    },
     {
       type: 'm.room.message',
       event_id: '$from-bot',
       sender: '@whatsappbot:home-dev',
       origin_server_ts: 1782205200000,
       content: { msgtype: 'm.notice', body: 'bridge status' },
-    },
-    {
-      type: 'm.room.message',
-      event_id: '$from-own-phone',
-      sender: '@whatsapp_48111222333:home-dev',
-      origin_server_ts: 1782205200000,
-      content: { msgtype: 'm.text', body: 'sent from my mobile' },
     },
     {
       type: 'm.room.redaction',


### PR DESCRIPTION
Fixes INT-1678

## Summary
- sync private WhatsApp messages sent by the Matrix owner or own phone echo as outgoing
- add private WhatsApp chat summaries and chat-scoped message reads for direct and group conversations
- switch the private WhatsApp web view from sender-first to conversation-first with group participant labels and outgoing "You" messages

## Verification
- pnpm --filter whatsapp-private-matrix-sync test
- pnpm --filter @intexuraos/web typecheck
- pnpm --filter @intexuraos/web lint:local
- pnpm --filter @intexuraos/whatsapp-service typecheck
- pnpm --filter @intexuraos/whatsapp-service lint:local
- pnpm --filter web exec vitest run src/services/__tests__/whatsappApi.private.test.ts src/hooks/__tests__/usePrivateWhatsAppLog.test.tsx src/pages/__tests__/PrivateWhatsAppLogPage.test.tsx
- pnpm --filter whatsapp-service exec vitest run src/__tests__/usecases/ingestPrivateWhatsAppEvents.test.ts src/__tests__/privateSyncRoutes.test.ts src/__tests__/infra/privateWhatsAppRepository.test.ts
- pnpm run ci:tracked
