### PR TITLE
[INT-1678] Add private WhatsApp chat indexes

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1966,6 +1966,72 @@
           "order": "DESCENDING"
         }
       ]
+    },
+    {
+      "collectionGroup": "whatsapp_private_chats",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "sourceAccountId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "lastEventAt",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "__name__",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "whatsapp_private_messages",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "sourceAccountId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "chatId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "eventTimestamp",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "__name__",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "whatsapp_private_messages",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "sourceAccountId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "chatId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "eventDayKey",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "eventTimestamp",
+          "order": "DESCENDING"
+        },
+        {
+          "fieldPath": "__name__",
+          "order": "DESCENDING"
+        }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/migrations/115_private-whatsapp-chat-pagination-indexes.mjs
+++ b/migrations/115_private-whatsapp-chat-pagination-indexes.mjs
@@ -1,0 +1,52 @@
+/**
+ * Migration 115: Private WhatsApp chat pagination indexes.
+ *
+ * Required by:
+ * - whatsapp-service public private chat list queries
+ * - whatsapp-service public private chat message reads
+ */
+
+export const metadata = {
+  id: '115',
+  name: 'private-whatsapp-chat-pagination-indexes',
+  description: 'Stable pagination indexes for private WhatsApp chat lists and chat message reads',
+  createdAt: '2026-06-24',
+};
+
+export const indexes = [
+  {
+    collectionGroup: 'whatsapp_private_chats',
+    queryScope: 'COLLECTION',
+    fields: [
+      { fieldPath: 'sourceAccountId', order: 'ASCENDING' },
+      { fieldPath: 'lastEventAt', order: 'DESCENDING' },
+      { fieldPath: '__name__', order: 'DESCENDING' },
+    ],
+  },
+  {
+    collectionGroup: 'whatsapp_private_messages',
+    queryScope: 'COLLECTION',
+    fields: [
+      { fieldPath: 'sourceAccountId', order: 'ASCENDING' },
+      { fieldPath: 'chatId', order: 'ASCENDING' },
+      { fieldPath: 'eventTimestamp', order: 'DESCENDING' },
+      { fieldPath: '__name__', order: 'DESCENDING' },
+    ],
+  },
+  {
+    collectionGroup: 'whatsapp_private_messages',
+    queryScope: 'COLLECTION',
+    fields: [
+      { fieldPath: 'sourceAccountId', order: 'ASCENDING' },
+      { fieldPath: 'chatId', order: 'ASCENDING' },
+      { fieldPath: 'eventDayKey', order: 'ASCENDING' },
+      { fieldPath: 'eventTimestamp', order: 'DESCENDING' },
+      { fieldPath: '__name__', order: 'DESCENDING' },
+    ],
+  },
+];
+
+export async function up(context) {
+  console.log('  Deploying private WhatsApp chat pagination indexes...');
+  await context.deployIndexes();
+}

--- a/migrations/__tests__/115-private-whatsapp-chat-pagination-indexes.test.ts
+++ b/migrations/__tests__/115-private-whatsapp-chat-pagination-indexes.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { indexes, metadata, up } from '../115_private-whatsapp-chat-pagination-indexes.mjs'; // @allow-missing-js -- .mjs import
+
+describe('migration 115 - private whatsapp chat pagination indexes', () => {
+  it('exports the expected metadata', () => {
+    expect(metadata).toMatchObject({
+      id: '115',
+      name: 'private-whatsapp-chat-pagination-indexes',
+      description:
+        'Stable pagination indexes for private WhatsApp chat lists and chat message reads',
+      createdAt: '2026-06-24',
+    });
+  });
+
+  it('defines the stable chat and chat-message pagination indexes', () => {
+    expect(indexes).toEqual([
+      {
+        collectionGroup: 'whatsapp_private_chats',
+        queryScope: 'COLLECTION',
+        fields: [
+          { fieldPath: 'sourceAccountId', order: 'ASCENDING' },
+          { fieldPath: 'lastEventAt', order: 'DESCENDING' },
+          { fieldPath: '__name__', order: 'DESCENDING' },
+        ],
+      },
+      {
+        collectionGroup: 'whatsapp_private_messages',
+        queryScope: 'COLLECTION',
+        fields: [
+          { fieldPath: 'sourceAccountId', order: 'ASCENDING' },
+          { fieldPath: 'chatId', order: 'ASCENDING' },
+          { fieldPath: 'eventTimestamp', order: 'DESCENDING' },
+          { fieldPath: '__name__', order: 'DESCENDING' },
+        ],
+      },
+      {
+        collectionGroup: 'whatsapp_private_messages',
+        queryScope: 'COLLECTION',
+        fields: [
+          { fieldPath: 'sourceAccountId', order: 'ASCENDING' },
+          { fieldPath: 'chatId', order: 'ASCENDING' },
+          { fieldPath: 'eventDayKey', order: 'ASCENDING' },
+          { fieldPath: 'eventTimestamp', order: 'DESCENDING' },
+          { fieldPath: '__name__', order: 'DESCENDING' },
+        ],
+      },
+    ]);
+  });
+
+  it('deploys indexes in up()', async () => {
+    const deployIndexes = vi.fn().mockResolvedValue(undefined);
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    await up({ deployIndexes });
+
+    expect(deployIndexes).toHaveBeenCalledOnce();
+    consoleSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
Fixes INT-1678

## Summary
- add migration 115 for private WhatsApp chat-list pagination
- add chat-scoped private message indexes for the current conversation-first UI
- regenerate firestore.indexes.json from migrations

## Dev deployment
- Deployed firestore.indexes.json to intexuraos-dev-pbuchman with Firebase CLI
- Deployed regenerated firestore.rules to intexuraos-dev-pbuchman because current migration 112 includes rule cleanup
- Repaired Dev _migrations records for IDs 112-115 after discovering Dev had applied the pre-renumbered 112/113 private WhatsApp migrations; records now match current source checksums and `node scripts/migrate.mjs --dry-run --project intexuraos-dev-pbuchman` reports no pending migrations
- Verified the exact chat-list, chat-message, and day-filtered chat-message Firestore queries succeed on Dev

## Verification
- node scripts/verify-migrations.mjs
- pnpm --filter migrations test -- migrations/__tests__/115-private-whatsapp-chat-pagination-indexes.test.ts
- pnpm run ci:tracked
