### PR TITLE
[INT-1678] Sync private WhatsApp outgoing and group events

### DIFF
--- a/tools/whatsapp-private-matrix-sync/src/server.mjs
+++ b/tools/whatsapp-private-matrix-sync/src/server.mjs
@@ -239,7 +239,7 @@ export function matrixEventToPrivateWhatsAppEvent(roomId, event, roomContext, co
   const senderDisplayName =
     direction === 'outgoing' ? 'You' : roomContext.memberDisplayNames?.[sender];
   const chat = {
-    type: roomContext.chatType ?? 'unknown',
+    type: inferChatType(roomContext),
   };
 
   if (roomContext.displayName !== undefined) {
@@ -483,6 +483,7 @@ function extractRoomContext(room) {
   const context = {
     memberDisplayNames: {},
   };
+  const whatsappMemberIds = new Set();
 
   const stateEvents = [
     ...(Array.isArray(room.state?.events) ? room.state.events : []),
@@ -514,11 +515,18 @@ function extractRoomContext(room) {
     }
 
     if (event.type === 'm.room.member' && isRecord(event.content)) {
+      if (isActiveWhatsAppMember(event)) {
+        whatsappMemberIds.add(event.state_key);
+      }
       const displayName = readString(event.content, 'displayname');
       if (displayName !== undefined) {
         context.memberDisplayNames[event.state_key] = displayName;
       }
     }
+  }
+
+  if (whatsappMemberIds.size > 0) {
+    context.whatsappMemberCount = whatsappMemberIds.size;
   }
 
   return context;
@@ -549,9 +557,14 @@ function roomContextFromStateEvent(type, content, stateKey) {
   }
   if (type === 'm.room.member' && stateKey !== undefined) {
     const displayName = readString(content, 'displayname');
-    return displayName === undefined
-      ? { memberDisplayNames: {} }
-      : { memberDisplayNames: { [stateKey]: displayName } };
+    const context =
+      displayName === undefined
+        ? { memberDisplayNames: {} }
+        : { memberDisplayNames: { [stateKey]: displayName } };
+    if (isWhatsAppMatrixUserId(stateKey) && readString(content, 'membership') !== 'leave') {
+      context.whatsappMemberCount = 1;
+    }
+    return context;
   }
 
   return { memberDisplayNames: {} };
@@ -594,7 +607,7 @@ function isWhatsAppInviteRoom(room, config) {
 }
 
 function mergeRoomContext(existing, next) {
-  return {
+  const merged = {
     ...(existing ?? {}),
     ...next,
     memberDisplayNames: {
@@ -602,6 +615,12 @@ function mergeRoomContext(existing, next) {
       ...(next.memberDisplayNames ?? {}),
     },
   };
+  const existingCount = (existing ?? {}).whatsappMemberCount;
+  const nextCount = next.whatsappMemberCount;
+  if (typeof existingCount === 'number' || typeof nextCount === 'number') {
+    merged.whatsappMemberCount = Math.max(existingCount ?? 0, nextCount ?? 0);
+  }
+  return merged;
 }
 
 function matrixEventToMessage(event, direction) {
@@ -698,6 +717,42 @@ function chatTypeFromTopic(topic) {
     return 'group';
   }
   return 'unknown';
+}
+
+function inferChatType(roomContext) {
+  if (roomContext.chatType !== undefined && roomContext.chatType !== 'unknown') {
+    return roomContext.chatType;
+  }
+  const whatsappMemberCount =
+    typeof roomContext.whatsappMemberCount === 'number'
+      ? roomContext.whatsappMemberCount
+      : countWhatsAppMembers(roomContext.memberDisplayNames);
+  if (whatsappMemberCount > 2) {
+    return 'group';
+  }
+  if (whatsappMemberCount > 0) {
+    return 'direct';
+  }
+  return roomContext.chatType ?? 'unknown';
+}
+
+function countWhatsAppMembers(memberDisplayNames) {
+  if (!isRecord(memberDisplayNames)) {
+    return 0;
+  }
+  return Object.keys(memberDisplayNames).filter(isWhatsAppMatrixUserId).length;
+}
+
+function isActiveWhatsAppMember(event) {
+  if (!isRecord(event) || !isRecord(event.content) || typeof event.state_key !== 'string') {
+    return false;
+  }
+  const membership = readString(event.content, 'membership');
+  return isWhatsAppMatrixUserId(event.state_key) && membership !== 'leave' && membership !== 'ban';
+}
+
+function isWhatsAppMatrixUserId(value) {
+  return typeof value === 'string' && /^@whatsapp_[0-9]+:/.test(value);
 }
 
 function readMatrixTimestamp(event) {

--- a/tools/whatsapp-private-matrix-sync/src/server.test.mjs
+++ b/tools/whatsapp-private-matrix-sync/src/server.test.mjs
@@ -458,6 +458,58 @@ test('collectPrivateWhatsAppEvents maps group rooms as one conversation with par
   );
 });
 
+test('collectPrivateWhatsAppEvents infers group rooms from WhatsApp member state when topic is missing', () => {
+  const events = collectPrivateWhatsAppEvents(
+    {
+      rooms: {
+        join: {
+          '!group-without-topic:home-dev': {
+            state: {
+              events: [
+                { type: 'm.room.name', content: { name: 'Weekend Crew (WA)' } },
+                {
+                  type: 'm.room.member',
+                  state_key: '@whatsapp_48111111111:home-dev',
+                  content: { membership: 'join', displayname: 'One (WA)' },
+                },
+                {
+                  type: 'm.room.member',
+                  state_key: '@whatsapp_48222222222:home-dev',
+                  content: { membership: 'join', displayname: 'Two (WA)' },
+                },
+                {
+                  type: 'm.room.member',
+                  state_key: '@whatsapp_48333333333:home-dev',
+                  content: { membership: 'join', displayname: 'Three (WA)' },
+                },
+                {
+                  type: 'm.room.member',
+                  state_key: '@pbuchman:home-dev',
+                  content: { membership: 'join', displayname: 'Piotr' },
+                },
+              ],
+            },
+            timeline: {
+              events: [
+                matrixMessage({
+                  event_id: '$group-without-topic-message',
+                  sender: '@whatsapp_48111111111:home-dev',
+                  content: { msgtype: 'm.text', body: 'topic metadata is absent' },
+                }),
+              ],
+            },
+          },
+        },
+      },
+    },
+    config
+  );
+
+  assert.equal(events.length, 1);
+  assert.equal(events[0]?.chat.type, 'group');
+  assert.equal(events[0]?.sender?.displayName, 'One (WA)');
+});
+
 test('extractRoomContexts merges state from sync rooms with existing context', () => {
   const roomContexts = extractRoomContexts(
     {
@@ -501,6 +553,7 @@ test('extractRoomContexts merges state from sync rooms with existing context', (
         '@whatsapp_48517277952:home-dev': 'Monika (WA)',
         '@whatsapp_48536911713:home-dev': 'Piotrek (WA)',
       },
+      whatsappMemberCount: 1,
     },
   });
 });


### PR DESCRIPTION
Fixes INT-1678

## Summary
- keep private Matrix sync events authored by the Matrix user or own WhatsApp phone and map them as outgoing
- infer WhatsApp group rooms from Matrix member state when bridge topic metadata is missing
- add regression coverage for outgoing events and topic-less group rooms

## Verification
- pnpm --filter whatsapp-private-matrix-sync test
- pnpm run ci:tracked
- deployed rebuilt whatsapp-sync container on Home Dev and verified /health is running