### PR TITLE
[INT-1678] Accept WhatsApp LID group senders

### DIFF
--- a/tools/whatsapp-private-matrix-sync/src/server.mjs
+++ b/tools/whatsapp-private-matrix-sync/src/server.mjs
@@ -296,7 +296,7 @@ function getWhatsAppMatrixEventDirection(event, config) {
     senderPhone === config.ownWhatsAppPhoneNumber
   ) {
     direction = 'outgoing';
-  } else if (senderPhone === '') {
+  } else if (!isWhatsAppMatrixUserId(sender)) {
     return null;
   }
 
@@ -752,7 +752,7 @@ function isActiveWhatsAppMember(event) {
 }
 
 function isWhatsAppMatrixUserId(value) {
-  return typeof value === 'string' && /^@whatsapp_[0-9]+:/.test(value);
+  return typeof value === 'string' && /^@whatsapp_(?:[0-9]+|lid-[A-Za-z0-9_-]+):/.test(value);
 }
 
 function readMatrixTimestamp(event) {

--- a/tools/whatsapp-private-matrix-sync/src/server.test.mjs
+++ b/tools/whatsapp-private-matrix-sync/src/server.test.mjs
@@ -510,6 +510,59 @@ test('collectPrivateWhatsAppEvents infers group rooms from WhatsApp member state
   assert.equal(events[0]?.sender?.displayName, 'One (WA)');
 });
 
+test('collectPrivateWhatsAppEvents maps WhatsApp LID group sender events', () => {
+  const events = collectPrivateWhatsAppEvents(
+    {
+      rooms: {
+        join: {
+          '!lid-group:home-dev': {
+            state: {
+              events: [
+                { type: 'm.room.name', content: { name: 'LID Crew (WA)' } },
+                {
+                  type: 'm.room.member',
+                  state_key: '@whatsapp_lid-111111111111111:home-dev',
+                  content: { membership: 'join', displayname: 'LID One (WA)' },
+                },
+                {
+                  type: 'm.room.member',
+                  state_key: '@whatsapp_lid-222222222222222:home-dev',
+                  content: { membership: 'join', displayname: 'LID Two (WA)' },
+                },
+                {
+                  type: 'm.room.member',
+                  state_key: '@whatsapp_lid-333333333333333:home-dev',
+                  content: { membership: 'join', displayname: 'LID Three (WA)' },
+                },
+              ],
+            },
+            timeline: {
+              events: [
+                matrixMessage({
+                  event_id: '$lid-group-message',
+                  sender: '@whatsapp_lid-111111111111111:home-dev',
+                  content: { msgtype: 'm.text', body: 'lid sender message' },
+                }),
+              ],
+            },
+          },
+        },
+      },
+    },
+    config
+  );
+
+  assert.equal(events.length, 1);
+  assert.equal(events[0]?.chat.type, 'group');
+  assert.equal(events[0]?.sender?.displayName, 'LID One (WA)');
+  assert.equal(events[0]?.sender?.phoneNumber, undefined);
+  assert.deepEqual(events[0]?.message, {
+    direction: 'incoming',
+    type: 'text',
+    text: 'lid sender message',
+  });
+});
+
 test('extractRoomContexts merges state from sync rooms with existing context', () => {
   const roomContexts = extractRoomContexts(
     {


### PR DESCRIPTION
Fixes INT-1678

## Summary
- accept Matrix WhatsApp sender IDs in the `@whatsapp_lid-*` format used by group rooms
- keep rejecting non-WhatsApp Matrix senders instead of relying on numeric phone extraction
- add regression coverage for LID-authored group timeline events

## Verification
- pnpm --filter whatsapp-private-matrix-sync test
- pnpm run ci:tracked
- rebuilt/restarted Home Dev `whatsapp-sync` container and verified `/health`
- verified target Matrix room `!FDEIpXlTDUhBHZTDRX:home-dev` maps to group events
- replayed a 20-event `backfill` for that target room: 20 accepted, 0 duplicates, 0 rejected
- verified Firestore target chat exists as `group` with 20 messages
- verified Dev UI and Prod UI show the target chat with 20 visible messages and group metadata
