### PR TITLE
[INT-1678] Preserve private WhatsApp group classification

### DIFF
--- a/apps/whatsapp-service/src/__tests__/infra/privateWhatsAppRepository.test.ts
+++ b/apps/whatsapp-service/src/__tests__/infra/privateWhatsAppRepository.test.ts
@@ -743,6 +743,61 @@ describe('privateWhatsAppRepository', () => {
     expect(chat?.['lastEventAt']).toBe('2026-06-22T10:06:00.000Z');
   });
 
+  it('keeps group chat type when a newer event is misclassified as direct', async () => {
+    const groupResult = await repository.storeIncomingMessage(
+      createStoreInput({
+        chat: {
+          matrixRoomId: '!group-room:matrix.example',
+          type: 'group',
+          displayName: 'Fishing Crew (WA)',
+        },
+        message: {
+          ...createStoreInput().message,
+          matrixRoomId: '!group-room:matrix.example',
+          matrixEventId: '$event-group',
+          matrixSenderId: '@whatsapp_lid-111111111111111:home-dev',
+          senderDisplayName: 'LID One (WA)',
+          senderKey: 'matrix:@whatsapp_lid-111111111111111:home-dev',
+          text: 'group message',
+          eventTimestamp: '2026-06-22T10:00:00.000Z',
+        },
+      })
+    );
+    expect(groupResult.ok).toBe(true);
+
+    const directResult = await repository.storeIncomingMessage(
+      createStoreInput({
+        chat: {
+          matrixRoomId: '!group-room:matrix.example',
+          type: 'direct',
+          displayName: 'Fishing Crew (WA)',
+        },
+        message: {
+          ...createStoreInput().message,
+          matrixRoomId: '!group-room:matrix.example',
+          matrixEventId: '$event-misclassified-reaction',
+          matrixSenderId: '@whatsapp_lid-222222222222222:home-dev',
+          senderDisplayName: 'LID Two (WA)',
+          senderKey: 'matrix:@whatsapp_lid-222222222222222:home-dev',
+          direction: 'incoming',
+          type: 'reaction',
+          text: 'ok',
+          eventTimestamp: '2026-06-22T10:06:00.000Z',
+          rawMatrixEvent: {
+            type: 'm.reaction',
+            event_id: '$event-misclassified-reaction',
+          },
+        },
+      })
+    );
+
+    expect(directResult.ok).toBe(true);
+    const chatId = deterministicId('pbuchman-private-whatsapp', '!group-room:matrix.example');
+    const chat = fakeFirestore.getAllData().get(PRIVATE_WHATSAPP_CHATS_COLLECTION)?.get(chatId);
+    expect(chat?.['chatType']).toBe('group');
+    expect(chat?.['lastEventAt']).toBe('2026-06-22T10:06:00.000Z');
+  });
+
   it('repairs invalid existing chat timestamps when a valid later event arrives', async () => {
     const invalidResult = await repository.storeIncomingMessage(
       createStoreInput({

--- a/apps/whatsapp-service/src/infra/firestore/privateWhatsAppRepository.ts
+++ b/apps/whatsapp-service/src/infra/firestore/privateWhatsAppRepository.ts
@@ -703,6 +703,9 @@ function selectChatType(
   if (nextChatType === 'unknown' && existingChat.chatType !== 'unknown') {
     return existingChat.chatType;
   }
+  if (existingChat.chatType === 'group' && nextChatType === 'direct') {
+    return existingChat.chatType;
+  }
   return nextChatType;
 }
 

--- a/tools/whatsapp-private-matrix-sync/src/server.mjs
+++ b/tools/whatsapp-private-matrix-sync/src/server.mjs
@@ -723,10 +723,12 @@ function inferChatType(roomContext) {
   if (roomContext.chatType !== undefined && roomContext.chatType !== 'unknown') {
     return roomContext.chatType;
   }
-  const whatsappMemberCount =
-    typeof roomContext.whatsappMemberCount === 'number'
-      ? roomContext.whatsappMemberCount
-      : countWhatsAppMembers(roomContext.memberDisplayNames);
+  const cachedWhatsAppMemberCount =
+    typeof roomContext.whatsappMemberCount === 'number' ? roomContext.whatsappMemberCount : 0;
+  const whatsappMemberCount = Math.max(
+    cachedWhatsAppMemberCount,
+    countWhatsAppMembers(roomContext.memberDisplayNames)
+  );
   if (whatsappMemberCount > 2) {
     return 'group';
   }

--- a/tools/whatsapp-private-matrix-sync/src/server.test.mjs
+++ b/tools/whatsapp-private-matrix-sync/src/server.test.mjs
@@ -563,6 +563,57 @@ test('collectPrivateWhatsAppEvents maps WhatsApp LID group sender events', () =>
   });
 });
 
+test('collectPrivateWhatsAppEvents keeps stale cached LID member counts from downgrading groups', () => {
+  const events = collectPrivateWhatsAppEvents(
+    {
+      rooms: {
+        join: {
+          '!stale-lid-group:home-dev': {
+            timeline: {
+              events: [
+                {
+                  type: 'm.reaction',
+                  event_id: '$stale-lid-group-reaction',
+                  sender: '@whatsapp_lid-111111111111111:home-dev',
+                  origin_server_ts: 1782205200123,
+                  content: {
+                    'm.relates_to': {
+                      rel_type: 'm.annotation',
+                      event_id: '$message-being-reacted-to',
+                      key: 'ok',
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
+    },
+    config,
+    {
+      '!stale-lid-group:home-dev': {
+        chatType: 'unknown',
+        whatsappMemberCount: 1,
+        memberDisplayNames: {
+          '@whatsapp_lid-111111111111111:home-dev': 'LID One (WA)',
+          '@whatsapp_lid-222222222222222:home-dev': 'LID Two (WA)',
+          '@whatsapp_lid-333333333333333:home-dev': 'LID Three (WA)',
+        },
+      },
+    }
+  );
+
+  assert.equal(events.length, 1);
+  assert.equal(events[0]?.chat.type, 'group');
+  assert.equal(events[0]?.sender?.displayName, 'LID One (WA)');
+  assert.deepEqual(events[0]?.message, {
+    direction: 'incoming',
+    type: 'reaction',
+    text: 'ok',
+  });
+});
+
 test('extractRoomContexts merges state from sync rooms with existing context', () => {
   const roomContexts = extractRoomContexts(
     {


### PR DESCRIPTION
Fixes INT-1678

## Summary
- infer private WhatsApp group rooms from the richer Matrix member map when cached member counts are stale
- keep existing group chat aggregates from being downgraded by a newer misclassified direct event
- add regression coverage for stale LID group member context and repository downgrade protection

## Verification
- pnpm --filter whatsapp-private-matrix-sync test
- pnpm vitest run apps/whatsapp-service/src/__tests__/infra/privateWhatsAppRepository.test.ts
- pnpm run ci:tracked

## Dev hotfix verification
- rebuilt whatsapp-matrix sync container on home-dev
- restarted whatsapp-service on home-dev
- verified adapter health and whatsapp-service health
- repaired one previously misclassified live reaction metadata row to group