### PR TITLE
[INT-1680] Fix Intex WhatsApp replies

### DIFF
--- a/apps/intex-agent/src/__tests__/domain/intexAgentRunner.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/intexAgentRunner.test.ts
@@ -37,7 +37,9 @@ describe('createIntexAgentRunner', () => {
       toolName: 'create_note',
     });
     expect(client.calls[0]?.systemPrompt).toBe(INTEX_AGENT_SYSTEM_PROMPT.text);
-    expect(INTEX_AGENT_SYSTEM_PROMPT.version).toBe('0.1.0');
+    expect(INTEX_AGENT_SYSTEM_PROMPT.version).toBe('1.0.0');
+    expect(client.calls[0]?.systemPrompt).toContain('You are Intex in WhatsApp Assistant conversations.');
+    expect(client.calls[0]?.systemPrompt).not.toContain('You are IntexuraOS');
     expect(client.calls[0]?.messages).toEqual([
       { role: 'user', content: 'create event tomorrow' },
       { role: 'assistant', content: 'What time?' },

--- a/apps/intex-agent/src/__tests__/infra/pubsub/whatsappReplyPublisher.test.ts
+++ b/apps/intex-agent/src/__tests__/infra/pubsub/whatsappReplyPublisher.test.ts
@@ -22,6 +22,7 @@ describe('createWhatsAppReplyPublisher', () => {
         message: 'New session started.',
         replyToMessageId: 'wamid-1',
         correlationId: 'session-1',
+        important: true,
       },
     ]);
   });

--- a/apps/intex-agent/src/domain/agent/systemPrompt.ts
+++ b/apps/intex-agent/src/domain/agent/systemPrompt.ts
@@ -3,9 +3,9 @@ import { OpenRouterToolCallingModels } from '@intexuraos/llm-contract';
 export const INTEX_AGENT_MODEL = OpenRouterToolCallingModels.Gemini3FlashPreview;
 
 export const INTEX_AGENT_SYSTEM_PROMPT = {
-  version: '0.1.0',
+  version: '1.0.0',
   text: [
-    'You are IntexuraOS in WhatsApp Assistant conversations.',
+    'You are Intex in WhatsApp Assistant conversations.',
     'You can currently help with exactly two user jobs: create notes and create calendar events.',
     'Use create_note when the user asks to remember, save, note, write down, keep, or store information.',
     'Use create_calendar_event when the user asks to create a meeting, appointment, scheduled block, or calendar item.',

--- a/apps/intex-agent/src/infra/pubsub/whatsappReplyPublisher.ts
+++ b/apps/intex-agent/src/infra/pubsub/whatsappReplyPublisher.ts
@@ -15,6 +15,7 @@ export function createWhatsAppReplyPublisher(
         message: input.message,
         replyToMessageId: input.replyToMessageId,
         correlationId: input.correlationId,
+        important: true,
       });
 
       if (!result.ok) {

--- a/scripts/hetzner/nginx/jwt-verify.lua
+++ b/scripts/hetzner/nginx/jwt-verify.lua
@@ -13,6 +13,7 @@ local GLOBAL_ALLOWED_SERVICE_ACCOUNTS = {
   ["intexuraos-calendar-dev@intexuraos-dev-pbuchman.iam.gserviceaccount.com"] = true,
   ["intexuraos-bookmarks-dev@intexuraos-dev-pbuchman.iam.gserviceaccount.com"] = true,
   ["intexuraos-code-dev@intexuraos-dev-pbuchman.iam.gserviceaccount.com"] = true,
+  ["intexuraos-intex-agent-dev@intexuraos-dev-pbuchman.iam.gserviceaccount.com"] = true,
 }
 
 local ROUTE_ALLOWED_SERVICE_ACCOUNTS = {

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -998,6 +998,7 @@ module "pubsub_whatsapp_send" {
     research_agent  = module.iam.service_accounts["research_agent"]
     bookmarks_agent = module.iam.service_accounts["bookmarks_agent"]
     code_agent      = module.iam.service_accounts["code_agent"]
+    intex_agent     = module.iam.service_accounts["intex_agent"]
   }
 
   depends_on = [


### PR DESCRIPTION
## Summary
- Update the Intex agent prompt so it identifies as Intex in WhatsApp conversations.
- Mark Intex WhatsApp replies as important so they are delivered for important-only notification preferences.
- Persist the Intex Pub/Sub publisher and Hetzner JWT allowlist wiring needed for WhatsApp delivery.

## Verification
- `pnpm --filter @intexuraos/intex-agent test -- src/__tests__/domain/intexAgentRunner.test.ts src/__tests__/infra/pubsub/whatsappReplyPublisher.test.ts`
- `pnpm run ci:tracked`
- `pnpm run ci:tracked` after rebasing on `origin/development`

## Linear
Linear: omitted by `$commit-push`; GitHub automation will create or link the Linear issue after PR creation.
