### PR TITLE
[INT-1681] Fix Intex session timeline display

### DIFF
--- a/apps/intex-agent/src/__tests__/domain/handleIncomingMessage.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/handleIncomingMessage.test.ts
@@ -186,6 +186,7 @@ describe('handleIncomingMessage', () => {
 
     expect(repo.sessions[0]?.status).toBe('unsupported');
     expect(repo.sessions[0]?.endReason).toBe('unsupported_request');
+    expect(repo.sessions[0]?.summary).toBe('book me a flight to Lisbon');
     expect(eventTypes(repo)).toEqual([
       'session_started',
       'user_message',
@@ -196,6 +197,57 @@ describe('handleIncomingMessage', () => {
     expect(replies.messages[0]?.message).toBe(
       'New session started.\n\nI do not support that yet. I can create notes and calendar events.'
     );
+  });
+
+  it('truncates unsupported session summaries from long user messages', async () => {
+    const repo = new FakeSessionRepository();
+    const runner = new FakeRunner([
+      {
+        outcome: 'unsupported',
+        reply: 'I can only create notes and calendar events.',
+      },
+    ]);
+    const replies = new FakeReplyPublisher();
+    const longText = 'What are events in my calendar tomorrow and which ones conflict with preparation time';
+    const repeatedText = `${longText} ${longText}`;
+
+    await handleIncomingMessage(
+      message({ text: repeatedText }),
+      deps(repo, runner, replies)
+    );
+
+    expect(repo.sessions[0]?.summary).toBe(`${repeatedText.slice(0, 117)}...`);
+  });
+
+  it('normalizes WhatsApp epoch-second timestamps and records fresh event timestamps', async () => {
+    const repo = new FakeSessionRepository();
+    const runner = new FakeRunner([
+      {
+        outcome: 'unsupported',
+        reply: 'I can only create notes and calendar events.',
+      },
+    ]);
+    const replies = new FakeReplyPublisher();
+    const clock = new SequenceClock([
+      '2026-06-24T16:10:19.000Z',
+      '2026-06-24T16:10:19.001Z',
+      '2026-06-24T16:10:19.002Z',
+      '2026-06-24T16:10:20.000Z',
+      '2026-06-24T16:10:20.001Z',
+      '2026-06-24T16:10:20.002Z',
+      '2026-06-24T16:10:20.003Z',
+    ]);
+
+    await handleIncomingMessage(
+      message({
+        timestamp: '1782317416',
+        text: 'What are events in my calendar tomorrow?',
+      }),
+      deps(repo, runner, replies, clock)
+    );
+
+    expect(repo.sessions[0]?.lastUserMessageAt).toBe('2026-06-24T16:10:16.000Z');
+    expect(new Set(repo.events.map((event) => event.createdAt)).size).toBe(repo.events.length);
   });
 
   it('supersedes an open session and starts an idle one for an explicit new-session command', async () => {
@@ -289,19 +341,35 @@ describe('handleIncomingMessage', () => {
 function deps(
   sessionRepository: FakeSessionRepository,
   runner: FakeRunner,
-  replies: FakeReplyPublisher
+  replies: FakeReplyPublisher,
+  clock: { now: () => string } = { now: () => NOW }
 ): Parameters<typeof handleIncomingMessage>[1] {
   return {
     sessionRepository,
     runner,
     replyPublisher: replies,
-    clock: { now: () => NOW },
+    clock,
     ids: {
       sessionId: () => `session-${String(sessionRepository.createdSessions.length + 1)}`,
       eventId: () => `event-${String(sessionRepository.events.length + 1)}`,
     },
     sessionTimeoutMs: 30 * 60 * 1000,
   };
+}
+
+class SequenceClock {
+  private index = 0;
+
+  constructor(private readonly values: string[]) {}
+
+  now(): string {
+    const value = this.values[this.index];
+    if (value === undefined) {
+      throw new Error('No fake clock value configured');
+    }
+    this.index += 1;
+    return value;
+  }
 }
 
 function eventTypes(repo: FakeSessionRepository): IntexAgentSessionEventType[] {

--- a/apps/intex-agent/src/__tests__/domain/sessionTimestamps.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/sessionTimestamps.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getSessionTimestampMs,
+  normalizeSessionTimestamp,
+} from '../../domain/sessions/sessionTimestamps.js';
+
+describe('session timestamp helpers', () => {
+  it('keeps ISO timestamps normalized as ISO strings', () => {
+    const timestamp = '2026-06-24T16:10:16.000Z';
+
+    expect(normalizeSessionTimestamp(timestamp)).toBe(timestamp);
+    expect(getSessionTimestampMs(timestamp)).toBe(Date.parse(timestamp));
+  });
+
+  it('normalizes epoch-second timestamps from WhatsApp', () => {
+    expect(normalizeSessionTimestamp('1782317416')).toBe('2026-06-24T16:10:16.000Z');
+    expect(getSessionTimestampMs('1782317416')).toBe(Date.parse('2026-06-24T16:10:16.000Z'));
+  });
+
+  it('normalizes epoch-millisecond timestamps', () => {
+    expect(normalizeSessionTimestamp('1782317416000')).toBe('2026-06-24T16:10:16.000Z');
+    expect(getSessionTimestampMs('1782317416000')).toBe(Date.parse('2026-06-24T16:10:16.000Z'));
+  });
+
+  it('preserves invalid timestamp strings and reports NaN milliseconds', () => {
+    expect(normalizeSessionTimestamp('')).toBe('');
+    expect(getSessionTimestampMs('')).toBeNaN();
+    expect(normalizeSessionTimestamp('not-a-date')).toBe('not-a-date');
+    expect(getSessionTimestampMs('not-a-date')).toBeNaN();
+  });
+
+  it('does not treat unsafe numeric strings as valid epoch values', () => {
+    const unsafeEpoch = '9007199254740992';
+
+    expect(normalizeSessionTimestamp(unsafeEpoch)).toBe(unsafeEpoch);
+    expect(getSessionTimestampMs(unsafeEpoch)).toBeNaN();
+  });
+
+  it('rejects numeric timestamps outside the JavaScript date range', () => {
+    const outOfRangeEpoch = '9007199254740991';
+
+    expect(normalizeSessionTimestamp(outOfRangeEpoch)).toBe(outOfRangeEpoch);
+    expect(getSessionTimestampMs(outOfRangeEpoch)).toBeNaN();
+  });
+});

--- a/apps/intex-agent/src/__tests__/infra/firestore/sessionRepository.test.ts
+++ b/apps/intex-agent/src/__tests__/infra/firestore/sessionRepository.test.ts
@@ -97,6 +97,42 @@ describe('FirestoreSessionRepository', () => {
       { id: 'event-2' },
     ]);
   });
+
+  it('uses session event order as a tie-breaker when events share the same timestamp', async () => {
+    const firestore = createFakeFirestore() as unknown as Firestore;
+    const repo = new FirestoreSessionRepository({ firestore });
+    const createdAt = '2026-06-24T10:00:00.000Z';
+
+    await repo.createSession(session({ id: 'session-1' }));
+    await repo.appendEvent(event({ id: 'assistant', type: 'assistant_message', createdAt }));
+    await repo.appendEvent(event({ id: 'unsupported', type: 'unsupported_request', createdAt }));
+    await repo.appendEvent(event({ id: 'user', type: 'user_message', createdAt }));
+    await repo.appendEvent(event({ id: 'closed', type: 'session_closed', createdAt }));
+    await repo.appendEvent(event({ id: 'started', type: 'session_started', createdAt }));
+
+    await expect(repo.listEvents('session-1', 'user-1')).resolves.toMatchObject([
+      { id: 'started' },
+      { id: 'user' },
+      { id: 'unsupported' },
+      { id: 'assistant' },
+      { id: 'closed' },
+    ]);
+  });
+
+  it('uses event id as the final tie-breaker for matching event type and timestamp', async () => {
+    const firestore = createFakeFirestore() as unknown as Firestore;
+    const repo = new FirestoreSessionRepository({ firestore });
+    const createdAt = '2026-06-24T10:00:00.000Z';
+
+    await repo.createSession(session({ id: 'session-1' }));
+    await repo.appendEvent(event({ id: 'user-z', type: 'user_message', createdAt }));
+    await repo.appendEvent(event({ id: 'user-a', type: 'user_message', createdAt }));
+
+    await expect(repo.listEvents('session-1', 'user-1')).resolves.toMatchObject([
+      { id: 'user-a' },
+      { id: 'user-z' },
+    ]);
+  });
 });
 
 function session(overrides: Partial<IntexAgentSession> = {}): IntexAgentSession {

--- a/apps/intex-agent/src/__tests__/routes/sessionRoutes.test.ts
+++ b/apps/intex-agent/src/__tests__/routes/sessionRoutes.test.ts
@@ -154,6 +154,135 @@ describe('intex-agent routes', () => {
     expect(sessionRepository.listSessionsCalls).toEqual(['user-1']);
   });
 
+  it('derives a missing session summary from the first user message', async () => {
+    const { activeTool: _activeTool, summary: _summary, ...sessionWithoutTitle } = session;
+    sessionRepository.sessions = [
+      {
+        ...sessionWithoutTitle,
+        id: 'session-without-summary',
+        status: 'unsupported',
+        endReason: 'unsupported_request',
+      },
+    ];
+    sessionRepository.events = [
+      {
+        ...event,
+        id: 'user-event',
+        sessionId: 'session-without-summary',
+        type: 'user_message',
+        payload: { text: 'What are events in my calendar tomorrow?' },
+      },
+    ];
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/sessions',
+      headers: { authorization: 'Bearer test-token' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.body)).toMatchObject({
+      success: true,
+      data: [
+        {
+          id: 'session-without-summary',
+          summary: 'What are events in my calendar tomorrow?',
+        },
+      ],
+    });
+    expect(sessionRepository.listEventsCalls).toEqual([
+      { sessionId: 'session-without-summary', userId: 'user-1' },
+    ]);
+  });
+
+  it('truncates derived session summaries from long user messages', async () => {
+    const { activeTool: _activeTool, summary: _summary, ...sessionWithoutTitle } = session;
+    const longText = 'Review every calendar event tomorrow and explain which ones need preparation';
+    const repeatedText = `${longText} ${longText} ${longText}`;
+    sessionRepository.sessions = [
+      {
+        ...sessionWithoutTitle,
+        id: 'session-long-summary',
+        status: 'unsupported',
+        endReason: 'unsupported_request',
+      },
+    ];
+    sessionRepository.events = [
+      {
+        ...event,
+        id: 'user-event-long',
+        sessionId: 'session-long-summary',
+        type: 'user_message',
+        payload: { text: repeatedText },
+      },
+    ];
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/sessions',
+      headers: { authorization: 'Bearer test-token' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.body)).toMatchObject({
+      success: true,
+      data: [
+        {
+          id: 'session-long-summary',
+          summary: `${repeatedText.slice(0, 117)}...`,
+        },
+      ],
+    });
+  });
+
+  it('leaves titleless sessions unchanged when user message text is unusable', async () => {
+    const { activeTool: _activeTool, summary: _summary, ...sessionWithoutTitle } = session;
+    sessionRepository.sessions = [
+      {
+        ...sessionWithoutTitle,
+        id: 'session-non-string-title',
+        status: 'unsupported',
+        endReason: 'unsupported_request',
+      },
+      {
+        ...sessionWithoutTitle,
+        id: 'session-blank-title',
+        status: 'unsupported',
+        endReason: 'unsupported_request',
+      },
+    ];
+    sessionRepository.events = [
+      {
+        ...event,
+        id: 'user-event-non-string',
+        sessionId: 'session-non-string-title',
+        type: 'user_message',
+        payload: { text: 42 },
+      },
+      {
+        ...event,
+        id: 'user-event-blank',
+        sessionId: 'session-blank-title',
+        type: 'user_message',
+        payload: { text: '  \n  ' },
+      },
+    ];
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/sessions',
+      headers: { authorization: 'Bearer test-token' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body) as { data: Record<string, unknown>[] };
+    expect(body.data).toHaveLength(2);
+    expect(body.data[0]).toMatchObject({ id: 'session-non-string-title' });
+    expect(body.data[0]).not.toHaveProperty('summary');
+    expect(body.data[1]).toMatchObject({ id: 'session-blank-title' });
+    expect(body.data[1]).not.toHaveProperty('summary');
+  });
+
   it('does not list sessions when authentication fails', async () => {
     vi.mocked(requireAuth).mockResolvedValueOnce(null);
 

--- a/apps/intex-agent/src/domain/messages/handleIncomingMessage.ts
+++ b/apps/intex-agent/src/domain/messages/handleIncomingMessage.ts
@@ -12,6 +12,7 @@ import type {
   IntexAgentSessionStatus,
   IntexAgentToolName,
 } from '../sessions/types.js';
+import { normalizeSessionTimestamp } from '../sessions/sessionTimestamps.js';
 
 export type IntexAgentRunnerResult =
   | {
@@ -70,6 +71,7 @@ export async function handleIncomingMessage(
   deps: HandleIncomingMessageDeps
 ): Promise<IncomingMessageHandlerResult> {
   const now = deps.clock.now();
+  const normalizedUserTimestamp = normalizeSessionTimestamp(input.timestamp);
   const currentSession = await deps.sessionRepository.findOpenSession(input.userId);
   const decision = decideSessionTransition({
     currentSession,
@@ -80,28 +82,28 @@ export async function handleIncomingMessage(
 
   await closePreviousSessionIfNeeded(decision, deps);
 
-  const session = await resolveSession(decision, input, deps, now);
+  const session = await resolveSession(decision, input, deps, normalizedUserTimestamp);
   const effectiveMessage = decision.effectiveUserMessageText;
 
   if (effectiveMessage === null) {
     const reply = prefixForDecision(decision) + newSessionReadyText();
-    await appendAssistantMessage(session, deps, now, reply);
+    const assistantAt = await appendAssistantMessage(session, deps, reply);
     await deps.sessionRepository.updateSession(session.id, {
       status: 'waiting_for_user',
-      lastAssistantMessageAt: now,
+      lastAssistantMessageAt: assistantAt,
     });
     await publishReply(input, deps, session.id, reply);
     return { sessionId: session.id };
   }
 
-  await appendEvent(deps, session, now, 'user_message', {
+  await appendEvent(deps, session, 'user_message', {
     messageId: input.messageId,
     text: effectiveMessage,
     sourceType: input.sourceType,
   });
   await deps.sessionRepository.updateSession(session.id, {
     status: 'active',
-    lastUserMessageAt: input.timestamp,
+    lastUserMessageAt: normalizedUserTimestamp,
   });
 
   const events = await deps.sessionRepository.listEvents(session.id, input.userId);
@@ -111,7 +113,7 @@ export async function handleIncomingMessage(
     message: effectiveMessage,
     messageId: input.messageId,
   });
-  await applyRunnerResult(input, deps, session, runnerResult, now, prefixForDecision(decision));
+  await applyRunnerResult(input, deps, session, runnerResult, prefixForDecision(decision));
 
   return { sessionId: session.id };
 }
@@ -130,35 +132,36 @@ async function closePreviousSessionIfNeeded(
     endedAt: close.endedAt,
     endReason: close.endReason,
   });
-  await appendEvent(deps, session, close.endedAt, 'session_closed', {
+  await appendEvent(deps, session, 'session_closed', {
     status: close.status,
     reason: close.endReason,
-  });
+  }, close.endedAt);
 }
 
 async function resolveSession(
   decision: SessionTransitionDecision,
   input: IntexIncomingMessage,
   deps: HandleIncomingMessageDeps,
-  now: string
+  normalizedUserTimestamp: string
 ): Promise<IntexAgentSession> {
   if (decision.action === 'continue') {
     return decision.session;
   }
 
+  const startedAt = deps.clock.now();
   const session: IntexAgentSession = await deps.sessionRepository.createSession({
     id: deps.ids.sessionId(),
     userId: input.userId,
     channel: 'whatsapp',
     status: 'active',
-    startedAt: now,
-    lastUserMessageAt: input.timestamp,
+    startedAt,
+    lastUserMessageAt: normalizedUserTimestamp,
     startReason: decision.startReason,
   });
-  await appendEvent(deps, session, now, 'session_started', {
+  await appendEvent(deps, session, 'session_started', {
     reason: decision.startReason,
     explicit: decision.isExplicitNewSession,
-  });
+  }, startedAt);
   return session;
 }
 
@@ -167,16 +170,15 @@ async function applyRunnerResult(
   deps: HandleIncomingMessageDeps,
   session: IntexAgentSession,
   runnerResult: IntexAgentRunnerResult,
-  now: string,
   replyPrefix: string
 ): Promise<void> {
   if (runnerResult.outcome === 'needs_clarification') {
     const reply = replyPrefix + stripDuplicateSessionPrefix(runnerResult.reply);
-    await appendEvent(deps, session, now, 'clarification_requested', { message: reply });
-    await appendAssistantMessage(session, deps, now, reply);
+    await appendEvent(deps, session, 'clarification_requested', { message: reply });
+    const assistantAt = await appendAssistantMessage(session, deps, reply);
     await deps.sessionRepository.updateSession(session.id, {
       status: 'waiting_for_user',
-      lastAssistantMessageAt: now,
+      lastAssistantMessageAt: assistantAt,
     });
     await publishReply(input, deps, session.id, reply);
     return;
@@ -184,76 +186,82 @@ async function applyRunnerResult(
 
   if (runnerResult.outcome === 'unsupported') {
     const reply = replyPrefix + runnerResult.reply;
-    await appendEvent(deps, session, now, 'unsupported_request', { message: runnerResult.reply });
-    await appendAssistantMessage(session, deps, now, reply);
-    await closeSession(session, deps, now, 'unsupported', 'unsupported_request');
+    await appendEvent(deps, session, 'unsupported_request', { message: runnerResult.reply });
+    const assistantAt = await appendAssistantMessage(session, deps, reply);
+    await closeSession(session, deps, 'unsupported', 'unsupported_request', {
+      lastAssistantMessageAt: assistantAt,
+      summary: summarizeUserMessage(input.text),
+    });
     await publishReply(input, deps, session.id, reply);
     return;
   }
 
   const reply = replyPrefix + runnerResult.reply;
-  await appendEvent(deps, session, now, 'tool_call_completed', {
+  await appendEvent(deps, session, 'tool_call_completed', {
     ...(runnerResult.toolName !== undefined ? { toolName: runnerResult.toolName } : {}),
   });
-  await appendAssistantMessage(session, deps, now, reply);
+  const assistantAt = await appendAssistantMessage(session, deps, reply);
+  const endedAt = deps.clock.now();
   await deps.sessionRepository.updateSession(session.id, {
     status: 'completed',
-    endedAt: now,
-    lastAssistantMessageAt: now,
+    endedAt,
+    lastAssistantMessageAt: assistantAt,
     endReason: 'tool_completed',
     ...(runnerResult.toolName !== undefined ? { activeTool: runnerResult.toolName } : {}),
     ...(runnerResult.summary !== undefined ? { summary: runnerResult.summary } : {}),
   });
-  await appendEvent(deps, session, now, 'session_closed', {
+  await appendEvent(deps, session, 'session_closed', {
     status: 'completed',
     reason: 'tool_completed',
-  });
+  }, endedAt);
   await publishReply(input, deps, session.id, reply);
 }
 
 async function closeSession(
   session: IntexAgentSession,
   deps: HandleIncomingMessageDeps,
-  now: string,
   status: IntexAgentSessionStatus,
-  endReason: IntexAgentSessionEndReason
+  endReason: IntexAgentSessionEndReason,
+  metadata: { lastAssistantMessageAt: string; summary: string }
 ): Promise<void> {
+  const endedAt = deps.clock.now();
   await deps.sessionRepository.updateSession(session.id, {
     status,
-    endedAt: now,
-    lastAssistantMessageAt: now,
+    endedAt,
+    lastAssistantMessageAt: metadata.lastAssistantMessageAt,
     endReason,
+    summary: metadata.summary,
   });
-  await appendEvent(deps, session, now, 'session_closed', {
+  await appendEvent(deps, session, 'session_closed', {
     status,
     reason: endReason,
-  });
+  }, endedAt);
 }
 
 async function appendAssistantMessage(
   session: IntexAgentSession,
   deps: HandleIncomingMessageDeps,
-  now: string,
   text: string
-): Promise<void> {
-  await appendEvent(deps, session, now, 'assistant_message', { text });
+): Promise<string> {
+  return await appendEvent(deps, session, 'assistant_message', { text });
 }
 
 async function appendEvent(
   deps: HandleIncomingMessageDeps,
   session: IntexAgentSession,
-  now: string,
   type: IntexAgentSessionEventType,
-  payload: Record<string, unknown>
-): Promise<void> {
+  payload: Record<string, unknown>,
+  createdAt = deps.clock.now()
+): Promise<string> {
   await deps.sessionRepository.appendEvent({
     id: deps.ids.eventId(),
     sessionId: session.id,
     userId: session.userId,
     type,
     payload,
-    createdAt: now,
+    createdAt,
   });
+  return createdAt;
 }
 
 async function publishReply(
@@ -292,4 +300,12 @@ function newSessionReadyText(): string {
 
 function stripDuplicateSessionPrefix(text: string): string {
   return text.replace(/^New session started\.\s*/i, '').trimStart();
+}
+
+function summarizeUserMessage(message: string): string {
+  const normalized = message.trim().replace(/\s+/g, ' ');
+  if (normalized.length <= 120) {
+    return normalized;
+  }
+  return `${normalized.slice(0, 117)}...`;
 }

--- a/apps/intex-agent/src/domain/sessions/sessionController.ts
+++ b/apps/intex-agent/src/domain/sessions/sessionController.ts
@@ -5,6 +5,7 @@ import type {
   IntexAgentSessionStartReason,
   IntexAgentSessionStatus,
 } from './types.js';
+import { getSessionTimestampMs } from './sessionTimestamps.js';
 
 export interface SessionTransitionInput {
   currentSession: IntexAgentSession | null;
@@ -108,8 +109,8 @@ function isTerminal(session: IntexAgentSession): boolean {
 }
 
 function isExpired(session: IntexAgentSession, now: string, timeoutMs: number): boolean {
-  const lastUserMessageAt = new Date(session.lastUserMessageAt).getTime();
-  const nowMs = new Date(now).getTime();
+  const lastUserMessageAt = getSessionTimestampMs(session.lastUserMessageAt);
+  const nowMs = getSessionTimestampMs(now);
   return nowMs - lastUserMessageAt > timeoutMs;
 }
 

--- a/apps/intex-agent/src/domain/sessions/sessionTimestamps.ts
+++ b/apps/intex-agent/src/domain/sessions/sessionTimestamps.ts
@@ -1,0 +1,29 @@
+export function normalizeSessionTimestamp(value: string): string {
+  const parsed = parseSessionTimestamp(value);
+  return parsed?.toISOString() ?? value;
+}
+
+export function getSessionTimestampMs(value: string): number {
+  return parseSessionTimestamp(value)?.getTime() ?? Number.NaN;
+}
+
+function parseSessionTimestamp(value: string): Date | null {
+  const trimmed = value.trim();
+  if (trimmed === '') {
+    return null;
+  }
+
+  if (/^\d+$/.test(trimmed)) {
+    const epoch = Number(trimmed);
+    if (Number.isSafeInteger(epoch)) {
+      const millis = trimmed.length <= 10 ? epoch * 1000 : epoch;
+      const date = new Date(millis);
+      if (!Number.isNaN(date.getTime())) {
+        return date;
+      }
+    }
+  }
+
+  const date = new Date(trimmed);
+  return Number.isNaN(date.getTime()) ? null : date;
+}

--- a/apps/intex-agent/src/infra/firestore/sessionRepository.ts
+++ b/apps/intex-agent/src/infra/firestore/sessionRepository.ts
@@ -4,7 +4,12 @@ import type {
   SessionRepositorySessionDraft,
   SessionRepositorySessionUpdate,
 } from '../../domain/ports/sessionRepository.js';
-import type { IntexAgentSession, IntexAgentSessionEvent } from '../../domain/sessions/types.js';
+import type {
+  IntexAgentSession,
+  IntexAgentSessionEvent,
+  IntexAgentSessionEventType,
+} from '../../domain/sessions/types.js';
+import { getSessionTimestampMs } from '../../domain/sessions/sessionTimestamps.js';
 
 export const INTEX_AGENT_SESSIONS_COLLECTION = 'intex_agent_sessions';
 export const INTEX_AGENT_SESSION_EVENTS_COLLECTION = 'intex_agent_session_events';
@@ -17,6 +22,17 @@ type SessionDocument = IntexAgentSession;
 type SessionEventDocument = IntexAgentSessionEvent;
 
 const OPEN_STATUSES = new Set(['active', 'waiting_for_user', 'executing_tool']);
+const EVENT_TYPE_ORDER: Record<IntexAgentSessionEventType, number> = {
+  session_started: 0,
+  user_message: 10,
+  tool_call_started: 20,
+  tool_call_completed: 30,
+  tool_call_failed: 30,
+  unsupported_request: 40,
+  clarification_requested: 40,
+  assistant_message: 50,
+  session_closed: 90,
+};
 
 export class FirestoreSessionRepository implements SessionRepository {
   private readonly firestore: Firestore;
@@ -59,7 +75,7 @@ export class FirestoreSessionRepository implements SessionRepository {
     return snapshot.docs
       .map((doc) => toEvent(doc.id, doc.data() as SessionEventDocument))
       .filter((event) => event.userId === userId)
-      .sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+      .sort(compareSessionEvents);
   }
 
   async findOpenSession(userId: string): Promise<IntexAgentSession | null> {
@@ -71,7 +87,7 @@ export class FirestoreSessionRepository implements SessionRepository {
     const sessions = snapshot.docs
       .map((doc) => toSession(doc.id, doc.data() as SessionDocument))
       .filter((session) => OPEN_STATUSES.has(session.status))
-      .sort((a, b) => b.lastUserMessageAt.localeCompare(a.lastUserMessageAt));
+      .sort((a, b) => getSessionTimestampMs(b.lastUserMessageAt) - getSessionTimestampMs(a.lastUserMessageAt));
 
     return sessions[0] ?? null;
   }
@@ -113,4 +129,18 @@ function toSessionDocument(session: IntexAgentSession): SessionDocument {
 
 function toEventDocument(event: IntexAgentSessionEvent): SessionEventDocument {
   return { ...event };
+}
+
+function compareSessionEvents(a: IntexAgentSessionEvent, b: IntexAgentSessionEvent): number {
+  const timeDiff = getSessionTimestampMs(a.createdAt) - getSessionTimestampMs(b.createdAt);
+  if (timeDiff !== 0) {
+    return timeDiff;
+  }
+
+  const typeDiff = EVENT_TYPE_ORDER[a.type] - EVENT_TYPE_ORDER[b.type];
+  if (typeDiff !== 0) {
+    return typeDiff;
+  }
+
+  return a.id.localeCompare(b.id);
 }

--- a/apps/intex-agent/src/routes/sessionRoutes.ts
+++ b/apps/intex-agent/src/routes/sessionRoutes.ts
@@ -1,6 +1,7 @@
 import { logIncomingRequest, requireAuth } from '@intexuraos/common-http';
 import type { FastifyPluginCallback, FastifyReply, FastifyRequest } from 'fastify';
 import { getServices } from '../services.js';
+import type { IntexAgentSession, IntexAgentSessionEvent } from '../domain/sessions/types.js';
 
 interface SessionParams {
   sessionId: string;
@@ -33,8 +34,10 @@ export const sessionRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
         return;
       }
 
-      const sessions = await getServices().sessionRepository.listSessions(user.userId);
-      return await reply.ok(sessions);
+      const { sessionRepository } = getServices();
+      const sessions = await sessionRepository.listSessions(user.userId);
+      const enrichedSessions = await enrichSessionsWithSummary(sessions, user.userId);
+      return await reply.ok(enrichedSessions);
     }
   );
 
@@ -84,7 +87,8 @@ export const sessionRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
         return;
       }
 
-      const session = await getServices().sessionRepository.getSession(
+      const { sessionRepository } = getServices();
+      const session = await sessionRepository.getSession(
         request.params.sessionId,
         user.userId
       );
@@ -92,9 +96,54 @@ export const sessionRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
         return await reply.fail('NOT_FOUND', 'Session not found');
       }
 
-      return await reply.ok(session);
+      return await reply.ok(await enrichSessionWithSummary(session, user.userId));
     }
   );
 
   done();
 };
+
+async function enrichSessionsWithSummary(
+  sessions: IntexAgentSession[],
+  userId: string
+): Promise<IntexAgentSession[]> {
+  return await Promise.all(sessions.map((session) => enrichSessionWithSummary(session, userId)));
+}
+
+async function enrichSessionWithSummary(
+  session: IntexAgentSession,
+  userId: string
+): Promise<IntexAgentSession> {
+  if (hasTitleMetadata(session)) {
+    return session;
+  }
+
+  const events = await getServices().sessionRepository.listEvents(session.id, userId);
+  const title = getFirstUserMessageTitle(events);
+  return title === undefined ? session : { ...session, summary: title };
+}
+
+function hasTitleMetadata(session: IntexAgentSession): boolean {
+  return (
+    (session.summary !== undefined && session.summary.trim() !== '') ||
+    session.activeTool !== undefined
+  );
+}
+
+function getFirstUserMessageTitle(events: IntexAgentSessionEvent[]): string | undefined {
+  const event = events.find((candidate) => candidate.type === 'user_message');
+  const text = event?.payload['text'];
+  if (typeof text !== 'string') {
+    return undefined;
+  }
+
+  const normalized = text.trim().replace(/\s+/g, ' ');
+  if (normalized === '') {
+    return undefined;
+  }
+
+  if (normalized.length <= 120) {
+    return normalized;
+  }
+  return `${normalized.slice(0, 117)}...`;
+}

--- a/apps/web/src/components/intex-agent/IntexSessionRail.tsx
+++ b/apps/web/src/components/intex-agent/IntexSessionRail.tsx
@@ -1,7 +1,12 @@
 import { MessageSquare } from 'lucide-react';
-import { formatDateTimeCompact, formatRelative } from '@/utils/dateFormat';
 import type { IntexAgentSession } from '@/types';
-import { formatSessionValue, getSessionStatusClass } from './sessionPresentation.js';
+import {
+  formatSessionDateTimeCompact,
+  formatSessionRelative,
+  formatSessionValue,
+  getSessionStatusClass,
+  getSessionTitle,
+} from './sessionPresentation.js';
 
 interface IntexSessionRailProps {
   sessions: IntexAgentSession[];
@@ -49,7 +54,7 @@ export function IntexSessionRail({
         <div className="space-y-1">
           {sessions.map((session) => {
             const selected = session.id === selectedSessionId;
-            const label = session.summary ?? formatSessionValue(session.activeTool);
+            const label = getSessionTitle(session);
             return (
               <button
                 key={session.id}
@@ -69,7 +74,7 @@ export function IntexSessionRail({
                       {label}
                     </p>
                     <p className="mt-0.5 truncate text-xs text-slate-500 dark:text-slate-400">
-                      {formatDateTimeCompact(session.startedAt)}
+                      {formatSessionDateTimeCompact(session.startedAt)}
                     </p>
                   </div>
                   <span
@@ -81,7 +86,7 @@ export function IntexSessionRail({
                   </span>
                 </div>
                 <p className="mt-2 text-xs text-slate-500 dark:text-slate-400">
-                  Last user message {formatRelative(session.lastUserMessageAt)}
+                  Last user message {formatSessionRelative(session.lastUserMessageAt)}
                 </p>
               </button>
             );

--- a/apps/web/src/components/intex-agent/IntexSessionTimeline.tsx
+++ b/apps/web/src/components/intex-agent/IntexSessionTimeline.tsx
@@ -1,10 +1,11 @@
 import { Bot, CheckCircle2, MessageCircle, PlayCircle, Wrench } from 'lucide-react';
-import { formatDateTime, formatDateTimeCompact } from '@/utils/dateFormat';
 import type { IntexAgentSession, IntexAgentSessionEvent } from '@/types';
 import {
+  formatSessionDateTimeCompact,
   formatSessionValue,
-  getSessionEventClass,
   getSessionStatusClass,
+  getSessionEventClass,
+  getSessionTitle,
 } from './sessionPresentation.js';
 
 interface IntexSessionTimelineProps {
@@ -94,13 +95,15 @@ export function IntexSessionTimeline({
             <div className="flex items-center gap-2">
               <Bot className="h-5 w-5 text-slate-400" />
               <h3 className="truncate text-lg font-semibold text-slate-950 dark:text-slate-50">
-                {session === undefined ? 'Select a session' : session.summary ?? session.id}
+                {session === undefined ? 'Select a session' : getSessionTitle(session)}
               </h3>
             </div>
             {session !== undefined ? (
               <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
-                Started {formatDateTime(session.startedAt)}
-                {session.endedAt !== undefined ? ` · Ended ${formatDateTime(session.endedAt)}` : ''}
+                Started {formatSessionDateTimeCompact(session.startedAt)}
+                {session.endedAt !== undefined
+                  ? ` · Ended ${formatSessionDateTimeCompact(session.endedAt)}`
+                  : ''}
               </p>
             ) : null}
           </div>
@@ -167,7 +170,7 @@ export function IntexSessionTimeline({
                   dateTime={event.createdAt}
                   className="text-xs font-medium text-slate-500 dark:text-slate-400"
                 >
-                  {formatDateTimeCompact(event.createdAt)}
+                  {formatSessionDateTimeCompact(event.createdAt)}
                 </time>
               </div>
               <p className="whitespace-pre-wrap break-words text-sm leading-6 text-slate-800 dark:text-slate-100">

--- a/apps/web/src/components/intex-agent/__tests__/sessionPresentation.test.ts
+++ b/apps/web/src/components/intex-agent/__tests__/sessionPresentation.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { IntexAgentSession, IntexAgentSessionEvent } from '@/types';
+import {
+  formatSessionDateTimeCompact,
+  formatSessionRelative,
+  getSessionTitle,
+  parseSessionTimestamp,
+  sortSessionEventsForTimeline,
+} from '../sessionPresentation.js';
+
+function session(overrides: Partial<IntexAgentSession> = {}): IntexAgentSession {
+  return {
+    id: 'session-1',
+    userId: 'user-1',
+    channel: 'whatsapp',
+    status: 'unsupported',
+    startedAt: '2026-06-24T16:10:19.341Z',
+    lastUserMessageAt: '1782317416',
+    startReason: 'no_active_session',
+    endReason: 'unsupported_request',
+    ...overrides,
+  };
+}
+
+function event(
+  id: string,
+  type: IntexAgentSessionEvent['type'],
+  overrides: Partial<IntexAgentSessionEvent> = {}
+): IntexAgentSessionEvent {
+  return {
+    id,
+    sessionId: 'session-1',
+    userId: 'user-1',
+    type,
+    payload: {},
+    createdAt: '2026-06-24T16:10:19.341Z',
+    ...overrides,
+  };
+}
+
+describe('Intex session presentation', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-24T16:15:16.000Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('parses WhatsApp epoch-second timestamps before formatting them', () => {
+    expect(parseSessionTimestamp('1782317416')?.toISOString()).toBe(
+      '2026-06-24T16:10:16.000Z'
+    );
+    expect(formatSessionRelative('1782317416')).toBe('5m ago');
+    expect(formatSessionDateTimeCompact('1782317416')).not.toContain('Invalid');
+  });
+
+  it('uses stable meaningful titles instead of Unknown for sessions without summaries', () => {
+    expect(getSessionTitle(session({ summary: 'What are events in my calendar tomorrow?' }))).toBe(
+      'What are events in my calendar tomorrow?'
+    );
+    expect(getSessionTitle(session())).toBe('Unsupported Request');
+  });
+
+  it('sorts equal-timestamp events in chronological conversation order', () => {
+    const sorted = sortSessionEventsForTimeline([
+      event('assistant', 'assistant_message'),
+      event('unsupported', 'unsupported_request'),
+      event('user', 'user_message'),
+      event('closed', 'session_closed'),
+      event('started', 'session_started'),
+    ]);
+
+    expect(sorted.map((item) => item.id)).toEqual([
+      'started',
+      'user',
+      'unsupported',
+      'assistant',
+      'closed',
+    ]);
+  });
+});

--- a/apps/web/src/components/intex-agent/sessionPresentation.ts
+++ b/apps/web/src/components/intex-agent/sessionPresentation.ts
@@ -1,4 +1,22 @@
-import type { IntexAgentSessionEventType, IntexAgentSessionStatus } from '@/types';
+import type {
+  IntexAgentSession,
+  IntexAgentSessionEvent,
+  IntexAgentSessionEventType,
+  IntexAgentSessionStatus,
+} from '@/types';
+import { formatDateTimeCompact, formatRelative } from '@/utils/dateFormat';
+
+const EVENT_TYPE_ORDER: Record<IntexAgentSessionEventType, number> = {
+  session_started: 0,
+  user_message: 10,
+  tool_call_started: 20,
+  tool_call_completed: 30,
+  tool_call_failed: 30,
+  unsupported_request: 40,
+  clarification_requested: 40,
+  assistant_message: 50,
+  session_closed: 90,
+};
 
 export function formatSessionValue(value: string | undefined): string {
   if (value === undefined || value.trim() === '') {
@@ -9,6 +27,56 @@ export function formatSessionValue(value: string | undefined): string {
     .filter((part) => part !== '')
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
     .join(' ');
+}
+
+export function parseSessionTimestamp(value: string): Date | undefined {
+  const trimmed = value.trim();
+  if (trimmed === '') {
+    return undefined;
+  }
+
+  if (/^\d+$/.test(trimmed)) {
+    const epoch = Number(trimmed);
+    if (Number.isSafeInteger(epoch)) {
+      const millis = trimmed.length <= 10 ? epoch * 1000 : epoch;
+      const date = new Date(millis);
+      if (!Number.isNaN(date.getTime())) {
+        return date;
+      }
+    }
+  }
+
+  const date = new Date(trimmed);
+  return Number.isNaN(date.getTime()) ? undefined : date;
+}
+
+export function formatSessionDateTimeCompact(value: string): string {
+  const date = parseSessionTimestamp(value);
+  return date === undefined ? 'Unknown' : formatDateTimeCompact(date.toISOString());
+}
+
+export function formatSessionRelative(value: string): string {
+  const date = parseSessionTimestamp(value);
+  return date === undefined ? 'Unknown' : formatRelative(date.toISOString());
+}
+
+export function getSessionTitle(session: IntexAgentSession): string {
+  if (session.summary !== undefined && session.summary.trim() !== '') {
+    return session.summary;
+  }
+  if (session.activeTool !== undefined) {
+    return formatSessionValue(session.activeTool);
+  }
+  if (session.endReason !== undefined) {
+    return formatSessionValue(session.endReason);
+  }
+  return formatSessionValue(session.status);
+}
+
+export function sortSessionEventsForTimeline(
+  events: IntexAgentSessionEvent[]
+): IntexAgentSessionEvent[] {
+  return [...events].sort(compareSessionEvents);
 }
 
 export function getSessionStatusClass(status: IntexAgentSessionStatus): string {
@@ -46,4 +114,20 @@ export function getSessionEventClass(type: IntexAgentSessionEventType): string {
     case 'session_closed':
       return 'border-slate-200 bg-slate-50 dark:border-slate-800 dark:bg-slate-900';
   }
+}
+
+function compareSessionEvents(a: IntexAgentSessionEvent, b: IntexAgentSessionEvent): number {
+  const aTime = parseSessionTimestamp(a.createdAt)?.getTime() ?? 0;
+  const bTime = parseSessionTimestamp(b.createdAt)?.getTime() ?? 0;
+  const timeDiff = aTime - bTime;
+  if (timeDiff !== 0) {
+    return timeDiff;
+  }
+
+  const typeDiff = EVENT_TYPE_ORDER[a.type] - EVENT_TYPE_ORDER[b.type];
+  if (typeDiff !== 0) {
+    return typeDiff;
+  }
+
+  return a.id.localeCompare(b.id);
 }

--- a/apps/web/src/pages/IntexAgentSessionsPage.tsx
+++ b/apps/web/src/pages/IntexAgentSessionsPage.tsx
@@ -4,7 +4,10 @@ import { useSearchParams } from 'react-router-dom';
 import { Button, ErrorBanner, Layout } from '@/components';
 import { IntexSessionRail } from '@/components/intex-agent/IntexSessionRail.js';
 import { IntexSessionTimeline } from '@/components/intex-agent/IntexSessionTimeline.js';
-import { formatSessionValue } from '@/components/intex-agent/sessionPresentation.js';
+import {
+  formatSessionValue,
+  sortSessionEventsForTimeline,
+} from '@/components/intex-agent/sessionPresentation.js';
 import { useAuth } from '@/context';
 import { ApiError, listIntexAgentSessionEvents, listIntexAgentSessions } from '@/services';
 import type { IntexAgentSession, IntexAgentSessionEvent } from '@/types';
@@ -105,6 +108,7 @@ export function IntexAgentSessionsPage(): React.JSX.Element {
     () => sessions.filter((session) => sessionMatchesSearch(session, search)),
     [sessions, search]
   );
+  const timelineEvents = useMemo(() => sortSessionEventsForTimeline(events), [events]);
   const selectedSession = sessions.find((session) => session.id === selectedSessionId);
 
   const selectSession = (sessionId: string): void => {
@@ -183,7 +187,7 @@ export function IntexAgentSessionsPage(): React.JSX.Element {
 
           <IntexSessionTimeline
             session={selectedSession}
-            events={events}
+            events={timelineEvents}
             loading={loadingEvents}
           />
         </div>


### PR DESCRIPTION
## Summary

- Normalize WhatsApp epoch timestamps for Intex sessions so dates no longer render as invalid.
- Derive titles for unsupported/titleless sessions from user messages and fall back to meaningful status/end reason labels.
- Sort session events chronologically with deterministic tie-breakers in backend and frontend timeline rendering.

## Verification

- `pnpm run ci:tracked`

## Linear

Linear: omitted by `$commit-push`; GitHub automation will create or link the Linear issue after PR creation.