### PR TITLE
[INT-1691] fix: tighten Intex agent session routing

### DIFF
--- a/apps/actions-agent/src/__tests__/executeResearchAction.test.ts
+++ b/apps/actions-agent/src/__tests__/executeResearchAction.test.ts
@@ -234,6 +234,33 @@ describe('executeResearchAction usecase', () => {
     expect(messages[0]?.message).toContain('https://app.test.com/#/research/notified-research-123');
   });
 
+  it('does not prepend webAppUrl when research-agent returns an absolute resource URL', async () => {
+    const action = createAction({ status: 'awaiting_approval' });
+    await fakeActionRepo.save(action);
+    fakeResearchClient.setNextResponse({
+      status: 'completed',
+      message: 'Research draft created successfully',
+      resourceUrl: 'https://intexuraos.cloud/#/research/notified-research-123',
+    });
+
+    const usecase = createExecuteResearchActionUseCase({
+      actionRepository: fakeActionRepo,
+      researchServiceClient: fakeResearchClient,
+      whatsappPublisher: fakeWhatsappPublisher,
+      webAppUrl: 'https://app.test.com',
+      logger: createMockLogger(),
+    });
+
+    await usecase('action-123');
+
+    const messages = fakeWhatsappPublisher.getSentMessages();
+    expect(messages).toHaveLength(1);
+    expect(messages[0]?.message).toContain(
+      'View it here: https://intexuraos.cloud/#/research/notified-research-123'
+    );
+    expect(messages[0]?.message).not.toContain('https://app.test.comhttps://intexuraos.cloud');
+  });
+
   it('succeeds even when WhatsApp notification fails (best-effort)', async () => {
     const action = createAction({ status: 'awaiting_approval' });
     await fakeActionRepo.save(action);

--- a/apps/actions-agent/src/domain/usecases/executeResearchAction.ts
+++ b/apps/actions-agent/src/domain/usecases/executeResearchAction.ts
@@ -59,9 +59,11 @@ export function createExecuteResearchActionUseCase(
         sourceActionId: prepared['sourceActionId'] as string,
       }),
     buildCompletionMessage: (_action: Action, response) =>
-      /* v8 ignore start -- ts-type: nullish coalescing fallback guard for undefined resourceUrl @preserve */
-      `📚 ${response.message} View it here: ${webAppUrl}${response.resourceUrl ?? ''}`,
-    /* v8 ignore stop @preserve */
+      `📚 ${response.message} View it here: ${resolveResourceUrl(webAppUrl, response.resourceUrl as string)}`,
     correlationPrefix: 'research-complete',
   });
+}
+
+function resolveResourceUrl(webAppUrl: string, resourceUrl: string): string {
+  return /^https?:\/\//i.test(resourceUrl) ? resourceUrl : `${webAppUrl}${resourceUrl}`;
 }

--- a/apps/intex-agent/src/__tests__/domain/handleIncomingMessage.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/handleIncomingMessage.test.ts
@@ -76,7 +76,7 @@ describe('handleIncomingMessage', () => {
       {
         outcome: 'no_action',
         reply: 'Cześć! U mnie wszystko w porządku. W czym mogę pomóc?',
-      } as unknown as IntexAgentRunnerResult,
+      },
     ]);
     const replies = new FakeReplyPublisher();
 

--- a/apps/intex-agent/src/__tests__/domain/handleIncomingMessage.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/handleIncomingMessage.test.ts
@@ -63,7 +63,45 @@ describe('handleIncomingMessage', () => {
     expect(replies.messages).toEqual([
       {
         userId: 'user-1',
-        message: 'New session started.\n\nSaved that note.',
+        message: 'Saved that note.',
+        replyToMessageId: 'wamid-1',
+        correlationId: 'session-1',
+      },
+    ]);
+  });
+
+  it('keeps greeting sessions open without publishing lifecycle text', async () => {
+    const repo = new FakeSessionRepository();
+    const runner = new FakeRunner([
+      {
+        outcome: 'no_action',
+        reply: 'Cześć! U mnie wszystko w porządku. W czym mogę pomóc?',
+      } as unknown as IntexAgentRunnerResult,
+    ]);
+    const replies = new FakeReplyPublisher();
+
+    const result = await handleIncomingMessage(
+      message({ text: 'Cześć! Co u Ciebie?' }),
+      deps(repo, runner, replies)
+    );
+
+    expect(result).toEqual({ sessionId: 'session-1' });
+    expect(repo.sessions[0]).toMatchObject({
+      id: 'session-1',
+      status: 'waiting_for_user',
+      startReason: 'no_active_session',
+    });
+    expect(repo.sessions[0]?.endedAt).toBeUndefined();
+    expect(repo.sessions[0]?.endReason).toBeUndefined();
+    expect(eventTypes(repo)).toEqual([
+      'session_started',
+      'user_message',
+      'assistant_message',
+    ]);
+    expect(replies.messages).toEqual([
+      {
+        userId: 'user-1',
+        message: 'Cześć! U mnie wszystko w porządku. W czym mogę pomóc?',
         replyToMessageId: 'wamid-1',
         correlationId: 'session-1',
       },
@@ -76,7 +114,6 @@ describe('handleIncomingMessage', () => {
       {
         outcome: 'completed',
         reply: 'Created the calendar event.',
-        summary: 'Created dentist appointment.',
         toolName: 'create_calendar_event',
       },
     ]);
@@ -89,10 +126,11 @@ describe('handleIncomingMessage', () => {
 
     expect(repo.sessions[0]?.status).toBe('completed');
     expect(repo.sessions[0]?.activeTool).toBe('create_calendar_event');
+    expect(repo.sessions[0]?.summary).toBeUndefined();
     expect(eventPayloads(repo, 'tool_call_completed')[0]).toMatchObject({
       toolName: 'create_calendar_event',
     });
-    expect(replies.messages[0]?.message).toBe('New session started.\n\nCreated the calendar event.');
+    expect(replies.messages[0]?.message).toBe('Created the calendar event.');
   });
 
   it('asks for clarification and keeps the session waiting when a calendar date is missing', async () => {
@@ -117,9 +155,7 @@ describe('handleIncomingMessage', () => {
       'clarification_requested',
       'assistant_message',
     ]);
-    expect(replies.messages[0]?.message).toBe(
-      'New session started.\n\nWhich day should I schedule it for?'
-    );
+    expect(replies.messages[0]?.message).toBe('Which day should I schedule it for?');
   });
 
   it('continues a waiting session when the user answers a clarification', async () => {
@@ -195,7 +231,7 @@ describe('handleIncomingMessage', () => {
       'session_closed',
     ]);
     expect(replies.messages[0]?.message).toBe(
-      'New session started.\n\nI do not support that yet. I can create notes and calendar events.'
+      'I do not support that yet. I can create notes and calendar events.'
     );
   });
 
@@ -289,11 +325,11 @@ describe('handleIncomingMessage', () => {
     ]);
     expect(runner.calls).toEqual([]);
     expect(replies.messages[0]?.message).toBe(
-      'Previous session superseded. New session started.\n\nWhat would you like me to help with? I can create notes and calendar events.'
+      'What would you like me to help with? I can create notes, calendar events, research drafts, bookmarks, and code tasks.'
     );
   });
 
-  it('expires a stale session, starts a new one, and completes without optional summary metadata', async () => {
+  it('expires a stale session and rejects completed runner results without a tool name', async () => {
     const repo = new FakeSessionRepository();
     repo.seedSession({
       id: 'session-stale',
@@ -325,15 +361,15 @@ describe('handleIncomingMessage', () => {
       },
       {
         id: 'session-1',
-        status: 'completed',
-        endReason: 'tool_completed',
+        status: 'unsupported',
+        endReason: 'unsupported_request',
       },
     ]);
-    expect(repo.sessions[1]?.activeTool).toBeUndefined();
-    expect(repo.sessions[1]?.summary).toBeUndefined();
-    expect(eventPayloads(repo, 'tool_call_completed')).toEqual([{}]);
+    expect(repo.sessions[1]?.status).toBe('unsupported');
+    expect(repo.sessions[1]?.endReason).toBe('unsupported_request');
+    expect(eventPayloads(repo, 'tool_call_completed')).toEqual([]);
     expect(replies.messages[0]?.message).toBe(
-      'Previous session expired. New session started.\n\nSaved it.'
+      'I could not safely understand that request. I can create notes, calendar events, research drafts, bookmarks, and code tasks.'
     );
   });
 });

--- a/apps/intex-agent/src/__tests__/domain/intexAgentRunner.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/intexAgentRunner.test.ts
@@ -37,11 +37,14 @@ describe('createIntexAgentRunner', () => {
       toolName: 'create_note',
     });
     expect(client.calls[0]?.systemPrompt).toBe(INTEX_AGENT_SYSTEM_PROMPT.text);
-    expect(INTEX_AGENT_SYSTEM_PROMPT.version).toBe('2.0.0');
+    expect(INTEX_AGENT_SYSTEM_PROMPT.version).toBe('2.1.0');
     expect(client.calls[0]?.systemPrompt).toContain('You are Intex in WhatsApp Assistant conversations.');
     expect(client.calls[0]?.systemPrompt).not.toContain('You are IntexuraOS');
     expect(client.calls[0]?.systemPrompt).toContain('Code tasks default to planning mode');
     expect(client.calls[0]?.systemPrompt).toContain('execution');
+    expect(client.calls[0]?.systemPrompt).toContain('Return no_action');
+    expect(client.calls[0]?.systemPrompt).toContain('Do not use create_research to inspect personal IntexuraOS data');
+    expect(client.calls[0]?.systemPrompt).toContain('what is in my calendar');
     expect(client.calls[0]?.messages).toEqual([
       { role: 'user', content: 'create event tomorrow' },
       { role: 'assistant', content: 'What time?' },
@@ -89,6 +92,25 @@ describe('createIntexAgentRunner', () => {
     });
   });
 
+  it('normalizes no-action responses for greetings without closing the session', async () => {
+    const client = new FakeToolCallingClient([
+      ok(
+        toolResult({
+          outcome: 'no_action',
+          reply: 'Cześć! W czym mogę pomóc?',
+        })
+      ),
+    ]);
+    const runner = createIntexAgentRunner({ client, toolExecutor: fakeToolExecutor() });
+
+    await expect(
+      runner.run({ session: session(), events: [], message: 'Cześć! Co u Ciebie?' })
+    ).resolves.toEqual({
+      outcome: 'no_action',
+      reply: 'Cześć! W czym mogę pomóc?',
+    });
+  });
+
   it('returns unsupported when the model result is malformed instead of executing a hidden action', async () => {
     const client = new FakeToolCallingClient([
       ok({
@@ -111,7 +133,14 @@ describe('createIntexAgentRunner', () => {
 
   it('ignores malformed historical events when building the transcript', async () => {
     const client = new FakeToolCallingClient([
-      ok(toolResult({ outcome: 'completed', reply: 'Done.', summary: 'Saved note' })),
+      ok(
+        toolResult({
+          outcome: 'completed',
+          reply: 'Done.',
+          summary: 'Saved note',
+          toolName: 'create_note',
+        })
+      ),
     ]);
     const runner = createIntexAgentRunner({ client, toolExecutor: fakeToolExecutor() });
 
@@ -128,6 +157,7 @@ describe('createIntexAgentRunner', () => {
       outcome: 'completed',
       reply: 'Done.',
       summary: 'Saved note',
+      toolName: 'create_note',
     });
     expect(client.calls[0]?.messages).toEqual([
       { role: 'user', content: 'remember the parking spot' },
@@ -208,7 +238,90 @@ describe('createIntexAgentRunner', () => {
     }
   );
 
-  it('drops unsupported completed tool names from normalized responses', async () => {
+  it('uses the executed tool name when the final model JSON omits toolName', async () => {
+    const client = new ToolExecutingFakeToolCallingClient({
+      toolName: 'create_research',
+      args: {
+        title: 'Calendar events tomorrow',
+        prompt: 'Prepare a research draft about tomorrow calendar events.',
+      },
+    }, [
+      ok(
+        toolResult({
+          outcome: 'completed',
+          reply: 'Created a research draft.',
+          summary: 'Calendar events tomorrow',
+        })
+      ),
+    ]);
+    const runner = createIntexAgentRunner({ client, toolExecutor: fakeToolExecutor() });
+
+    await expect(
+      runner.run({
+        session: session(),
+        events: [],
+        message: 'Chciałbym zobaczyć, jakie mam wydarzenia w kalendarzu na jutro',
+      })
+    ).resolves.toEqual({
+      outcome: 'completed',
+      reply: 'Created a research draft.',
+      summary: 'Calendar events tomorrow',
+      toolName: 'create_research',
+    });
+  });
+
+  it('rejects completed responses when no tool actually ran and no supported toolName is present', async () => {
+    const client = new FakeToolCallingClient([
+      ok(
+        toolResult({
+          outcome: 'completed',
+          reply: 'Done.',
+          summary: 'Handled request.',
+        })
+      ),
+    ]);
+    const runner = createIntexAgentRunner({ client, toolExecutor: fakeToolExecutor() });
+
+    await expect(
+      runner.run({ session: session(), events: [], message: 'Cześć! Co u Ciebie?' })
+    ).resolves.toEqual({
+      outcome: 'unsupported',
+      reply:
+        'I could not safely understand that request. I can create notes, calendar events, research drafts, bookmarks, and code tasks.',
+    });
+  });
+
+  it('rejects completed responses when multiple tools ran in one turn', async () => {
+    const client = new ToolExecutingFakeToolCallingClient([
+      {
+        toolName: 'create_note',
+        args: { title: 'Trip idea', content: 'Visit Lisbon' },
+      },
+      {
+        toolName: 'create_link',
+        args: { url: 'https://example.com', title: 'Example' },
+      },
+    ], [
+      ok(
+        toolResult({
+          outcome: 'completed',
+          reply: 'Done.',
+          summary: 'Handled multiple requests.',
+        })
+      ),
+    ]);
+    const runner = createIntexAgentRunner({ client, toolExecutor: fakeToolExecutor() });
+
+    await expect(
+      runner.run({ session: session(), events: [], message: 'remember Lisbon and save example.com' })
+    ).resolves.toEqual({
+      outcome: 'unsupported',
+      reply:
+        'I could not safely understand that request. I can create notes, calendar events, research drafts, bookmarks, and code tasks.',
+    });
+  });
+
+  it('rejects unsupported completed tool names from normalized responses', async () => {
     const client = new FakeToolCallingClient([
       ok(
         toolResult({
@@ -224,9 +337,9 @@ describe('createIntexAgentRunner', () => {
     await expect(
       runner.run({ session: session(), events: [], message: 'remember this' })
     ).resolves.toEqual({
-      outcome: 'completed',
-      reply: 'Done.',
-      summary: 'Handled request.',
+      outcome: 'unsupported',
+      reply:
+        'I could not safely understand that request. I can create notes, calendar events, research drafts, bookmarks, and code tasks.',
     });
   });
 
@@ -298,5 +411,28 @@ class FakeToolCallingClient implements ToolCallingClient {
       throw new Error('No fake tool result configured');
     }
     return Promise.resolve(next);
+  }
+}
+
+class ToolExecutingFakeToolCallingClient extends FakeToolCallingClient {
+  constructor(
+    private readonly toolCalls: { toolName: string; args: Record<string, unknown> } | { toolName: string; args: Record<string, unknown> }[],
+    results: Result<ToolCallingResult, LLMError>[]
+  ) {
+    super(results);
+  }
+
+  override async run(
+    params: Parameters<ToolCallingClient['run']>[0]
+  ): Promise<Result<ToolCallingResult, LLMError>> {
+    const toolCalls = Array.isArray(this.toolCalls) ? this.toolCalls : [this.toolCalls];
+    for (const toolCall of toolCalls) {
+      const tool = params.tools.find((candidate) => candidate.name === toolCall.toolName);
+      if (tool === undefined) {
+        throw new Error(`Missing fake tool ${toolCall.toolName}`);
+      }
+      await tool.run(toolCall.args);
+    }
+    return await super.run(params);
   }
 }

--- a/apps/intex-agent/src/__tests__/domain/intexAgentRunner.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/intexAgentRunner.test.ts
@@ -12,7 +12,10 @@ import type { IntexAgentSession, IntexAgentSessionEvent } from '../../domain/ses
 
 describe('createIntexAgentRunner', () => {
   it('uses the versioned prompt, transcript messages, and supported tools', async () => {
-    const client = new FakeToolCallingClient([
+    const client = new ToolExecutingFakeToolCallingClient({
+      toolName: 'create_note',
+      args: { content: 'The door code is 1234.', title: 'Door code' },
+    }, [
       ok(toolResult({ outcome: 'completed', reply: 'Saved.', toolName: 'create_note' })),
     ]);
 
@@ -132,7 +135,10 @@ describe('createIntexAgentRunner', () => {
   });
 
   it('ignores malformed historical events when building the transcript', async () => {
-    const client = new FakeToolCallingClient([
+    const client = new ToolExecutingFakeToolCallingClient({
+      toolName: 'create_note',
+      args: { content: 'Parking spot is B12.' },
+    }, [
       ok(
         toolResult({
           outcome: 'completed',
@@ -215,7 +221,10 @@ describe('createIntexAgentRunner', () => {
   it.each(['create_research', 'create_link', 'create_code_task'] as const)(
     'keeps supported completed tool names: %s',
     async (toolName) => {
-      const client = new FakeToolCallingClient([
+      const client = new ToolExecutingFakeToolCallingClient({
+        toolName,
+        args: toolArgsFor(toolName),
+      }, [
         ok(
           toolResult({
             outcome: 'completed',
@@ -284,6 +293,28 @@ describe('createIntexAgentRunner', () => {
 
     await expect(
       runner.run({ session: session(), events: [], message: 'Cześć! Co u Ciebie?' })
+    ).resolves.toEqual({
+      outcome: 'unsupported',
+      reply:
+        'I could not safely understand that request. I can create notes, calendar events, research drafts, bookmarks, and code tasks.',
+    });
+  });
+
+  it('rejects completed responses when the model claims a supported toolName but no tool ran', async () => {
+    const client = new FakeToolCallingClient([
+      ok(
+        toolResult({
+          outcome: 'completed',
+          reply: 'Done.',
+          summary: 'Handled request.',
+          toolName: 'create_note',
+        })
+      ),
+    ]);
+    const runner = createIntexAgentRunner({ client, toolExecutor: fakeToolExecutor() });
+
+    await expect(
+      runner.run({ session: session(), events: [], message: 'remember this' })
     ).resolves.toEqual({
       outcome: 'unsupported',
       reply:
@@ -397,6 +428,16 @@ function fakeToolExecutor(): IntexAgentToolExecutor {
     createLink: async () => 'bookmark-1',
     createCodeTask: async () => 'code-task-1',
   };
+}
+
+function toolArgsFor(toolName: 'create_research' | 'create_link' | 'create_code_task'): Record<string, unknown> {
+  if (toolName === 'create_research') {
+    return { title: 'Research topic', prompt: 'Research this topic.' };
+  }
+  if (toolName === 'create_link') {
+    return { url: 'https://example.com', title: 'Example' };
+  }
+  return { prompt: 'Investigate this code issue.' };
 }
 
 class FakeToolCallingClient implements ToolCallingClient {

--- a/apps/intex-agent/src/domain/agent/intexAgentRunner.ts
+++ b/apps/intex-agent/src/domain/agent/intexAgentRunner.ts
@@ -106,8 +106,7 @@ function parseRunnerContent(
 
   if (outcome === 'completed') {
     const summary = parsed['summary'];
-    const toolName = parsed['toolName'];
-    const completedToolName = getCompletedToolName(toolName, executedToolNames);
+    const completedToolName = getCompletedToolName(executedToolNames);
     if (completedToolName === undefined) {
       return malformedResult();
     }
@@ -151,10 +150,7 @@ function createTrackingToolExecutor(
   };
 }
 
-function getCompletedToolName(
-  parsedToolName: unknown,
-  executedToolNames: IntexAgentToolName[]
-): IntexAgentToolName | undefined {
+function getCompletedToolName(executedToolNames: IntexAgentToolName[]): IntexAgentToolName | undefined {
   const uniqueExecutedToolNames = [...new Set(executedToolNames)];
   if (uniqueExecutedToolNames.length === 1) {
     const [executedToolName] = uniqueExecutedToolNames as [IntexAgentToolName];
@@ -165,7 +161,7 @@ function getCompletedToolName(
     return undefined;
   }
 
-  return isSupportedToolName(parsedToolName) ? parsedToolName : undefined;
+  return undefined;
 }
 
 function parseJsonObject(content: string): Record<string, unknown> | null {
@@ -185,14 +181,4 @@ function malformedResult(): IntexAgentRunnerResult {
     outcome: 'unsupported',
     reply: `I could not safely understand that request. I can create ${SUPPORTED_CAPABILITIES}.`,
   };
-}
-
-function isSupportedToolName(toolName: unknown): toolName is IntexAgentToolName {
-  return (
-    toolName === 'create_note' ||
-    toolName === 'create_calendar_event' ||
-    toolName === 'create_research' ||
-    toolName === 'create_link' ||
-    toolName === 'create_code_task'
-  );
 }

--- a/apps/intex-agent/src/domain/agent/intexAgentRunner.ts
+++ b/apps/intex-agent/src/domain/agent/intexAgentRunner.ts
@@ -4,7 +4,15 @@ import type {
   IntexAgentRunnerResult,
 } from '../messages/handleIncomingMessage.js';
 import type { IntexAgentSessionEvent, IntexAgentToolName } from '../sessions/types.js';
-import { createIntexAgentToolDefinitions, type IntexAgentToolExecutor } from './toolDefinitions.js';
+import {
+  createIntexAgentToolDefinitions,
+  type CreateCalendarEventToolArgs,
+  type CreateCodeTaskToolArgs,
+  type CreateLinkToolArgs,
+  type CreateNoteToolArgs,
+  type CreateResearchToolArgs,
+  type IntexAgentToolExecutor,
+} from './toolDefinitions.js';
 import { INTEX_AGENT_SYSTEM_PROMPT } from './systemPrompt.js';
 
 const SUPPORTED_CAPABILITIES =
@@ -18,10 +26,13 @@ export interface IntexAgentRunnerConfig {
 export function createIntexAgentRunner(config: IntexAgentRunnerConfig): IntexAgentRunner {
   return {
     async run(input): Promise<IntexAgentRunnerResult> {
+      const executedToolNames: IntexAgentToolName[] = [];
       const result = await config.client.run({
         systemPrompt: INTEX_AGENT_SYSTEM_PROMPT.text,
         messages: buildMessages(input.events, input.message),
-        tools: createIntexAgentToolDefinitions(config.toolExecutor),
+        tools: createIntexAgentToolDefinitions(
+          createTrackingToolExecutor(config.toolExecutor, executedToolNames)
+        ),
         promptType: 'intex-agent-whatsapp-session',
         maxIterations: 5,
       });
@@ -33,7 +44,7 @@ export function createIntexAgentRunner(config: IntexAgentRunnerConfig): IntexAge
         };
       }
 
-      return parseRunnerContent(result.value.content);
+      return parseRunnerContent(result.value.content, executedToolNames);
     },
   };
 }
@@ -66,7 +77,10 @@ function messageFromEvent(event: IntexAgentSessionEvent): ToolCallingMessage | n
   return null;
 }
 
-function parseRunnerContent(content: string): IntexAgentRunnerResult {
+function parseRunnerContent(
+  content: string,
+  executedToolNames: IntexAgentToolName[]
+): IntexAgentRunnerResult {
   const parsed = parseJsonObject(content);
   if (parsed === null) {
     return malformedResult();
@@ -82,6 +96,10 @@ function parseRunnerContent(content: string): IntexAgentRunnerResult {
     return { outcome, reply };
   }
 
+  if (outcome === 'no_action') {
+    return { outcome, reply };
+  }
+
   if (outcome === 'unsupported') {
     return { outcome, reply };
   }
@@ -89,15 +107,65 @@ function parseRunnerContent(content: string): IntexAgentRunnerResult {
   if (outcome === 'completed') {
     const summary = parsed['summary'];
     const toolName = parsed['toolName'];
+    const completedToolName = getCompletedToolName(toolName, executedToolNames);
+    if (completedToolName === undefined) {
+      return malformedResult();
+    }
+
     return {
       outcome,
       reply,
       ...(typeof summary === 'string' ? { summary } : {}),
-      ...(isSupportedToolName(toolName) ? { toolName } : {}),
+      toolName: completedToolName,
     };
   }
 
   return malformedResult();
+}
+
+function createTrackingToolExecutor(
+  executor: IntexAgentToolExecutor,
+  executedToolNames: IntexAgentToolName[]
+): IntexAgentToolExecutor {
+  return {
+    async createNote(args: CreateNoteToolArgs): Promise<string> {
+      executedToolNames.push('create_note');
+      return await executor.createNote(args);
+    },
+    async createCalendarEvent(args: CreateCalendarEventToolArgs): Promise<string> {
+      executedToolNames.push('create_calendar_event');
+      return await executor.createCalendarEvent(args);
+    },
+    async createResearch(args: CreateResearchToolArgs): Promise<string> {
+      executedToolNames.push('create_research');
+      return await executor.createResearch(args);
+    },
+    async createLink(args: CreateLinkToolArgs): Promise<string> {
+      executedToolNames.push('create_link');
+      return await executor.createLink(args);
+    },
+    async createCodeTask(args: CreateCodeTaskToolArgs): Promise<string> {
+      executedToolNames.push('create_code_task');
+      return await executor.createCodeTask(args);
+    },
+  };
+}
+
+function getCompletedToolName(
+  parsedToolName: unknown,
+  executedToolNames: IntexAgentToolName[]
+): IntexAgentToolName | undefined {
+  const uniqueExecutedToolNames = [...new Set(executedToolNames)];
+  if (uniqueExecutedToolNames.length === 1) {
+    const [executedToolName] = uniqueExecutedToolNames as [IntexAgentToolName];
+    return executedToolName;
+  }
+
+  if (uniqueExecutedToolNames.length > 1) {
+    return undefined;
+  }
+
+  return isSupportedToolName(parsedToolName) ? parsedToolName : undefined;
 }
 
 function parseJsonObject(content: string): Record<string, unknown> | null {

--- a/apps/intex-agent/src/domain/agent/systemPrompt.ts
+++ b/apps/intex-agent/src/domain/agent/systemPrompt.ts
@@ -3,19 +3,26 @@ import { OpenRouterToolCallingModels } from '@intexuraos/llm-contract';
 export const INTEX_AGENT_MODEL = OpenRouterToolCallingModels.Gemini3FlashPreview;
 
 export const INTEX_AGENT_SYSTEM_PROMPT = {
-  version: '2.0.0',
+  version: '2.1.0',
   text: [
     'You are Intex in WhatsApp Assistant conversations.',
+    'Supported tools create or save resources only. Do not use tools to answer read-only questions unless a matching read tool exists.',
     'You can currently help with these user jobs: create notes, create calendar events, create research drafts, save links as bookmarks, and create code tasks.',
+    'For greetings, thanks, smalltalk, or questions about what you can do, do not call a tool. Return no_action with a concise helpful reply.',
     'Use create_note when the user asks to remember, save, note, write down, keep, or store information.',
-    'Use create_calendar_event when the user asks to create a meeting, appointment, scheduled block, or calendar item.',
+    'Use create_calendar_event only when the user asks to create, add, schedule, or plan a meeting, appointment, scheduled block, or calendar item.',
     'For calendar events, ask a clarification before using the tool if title, date, time, start, or end is missing or ambiguous.',
-    'Use create_research when the user asks to research, investigate, compare, look up, or gather information.',
+    'Do not use create_calendar_event to list, inspect, search, summarize, or answer questions about existing calendar events.',
+    'If the user asks "what is in my calendar", "show tomorrow\'s events", or similar, return unsupported unless a read-calendar tool exists.',
+    'Use create_research only when the user explicitly wants a research draft, report, investigation, or comparison about an external topic.',
+    'Do not use create_research to inspect personal IntexuraOS data such as calendar, notes, bookmarks, code tasks, or WhatsApp history.',
     'Use create_link when the user asks to save, bookmark, keep, or remember a link or URL.',
     'Use create_code_task when the user asks to create a code task or asks for code work to be planned or executed.',
     'Code tasks default to planning mode. Only set taskMode to execution when the user explicitly asks for execution mode, says create code task execution, or says the task is in execution stage.',
     'If the request is not one of the supported jobs, do not call a tool. Say it is not supported yet and mention notes, calendar events, research drafts, bookmarks, and code tasks.',
     'Return only JSON with outcome, reply, optional summary, and optional toolName.',
-    'Allowed outcomes are completed, needs_clarification, and unsupported.',
+    'Allowed outcomes are completed, needs_clarification, no_action, and unsupported.',
+    'Return completed only after exactly one tool succeeds, and include that exact toolName.',
+    'Never include session lifecycle text such as "New session started" in replies.',
   ].join('\n'),
 } as const;

--- a/apps/intex-agent/src/domain/agent/toolDefinitions.ts
+++ b/apps/intex-agent/src/domain/agent/toolDefinitions.ts
@@ -83,7 +83,7 @@ export function createIntexAgentToolDefinitions(executor: IntexAgentToolExecutor
     {
       name: 'create_calendar_event',
       description:
-        'Use when the user wants a calendar event, appointment, meeting, scheduled block, or calendar item created. Ask a clarification before calling this tool if the title, date, time, start, or end is missing or ambiguous.',
+        'Use only when the user wants a calendar event, appointment, meeting, scheduled block, or calendar item created. Do not use to list, inspect, summarize, or answer questions about existing calendar events. Ask a clarification before calling this tool if the title, date, time, start, or end is missing or ambiguous.',
       parameters: {
         type: 'object',
         additionalProperties: false,
@@ -126,7 +126,7 @@ export function createIntexAgentToolDefinitions(executor: IntexAgentToolExecutor
     {
       name: 'create_research',
       description:
-        'Use when the user asks to research, investigate, compare, look up, or gather information. Creates a research draft for the user to review.',
+        'Use only when the user explicitly asks for a research draft, report, investigation, or comparison about an external topic. Do not use to inspect personal IntexuraOS data such as calendar, notes, bookmarks, code tasks, or WhatsApp history. Creates a research draft for the user to review.',
       parameters: {
         type: 'object',
         additionalProperties: false,

--- a/apps/intex-agent/src/domain/messages/handleIncomingMessage.ts
+++ b/apps/intex-agent/src/domain/messages/handleIncomingMessage.ts
@@ -26,6 +26,10 @@ export type IntexAgentRunnerResult =
       reply: string;
     }
   | {
+      outcome: 'no_action';
+      reply: string;
+    }
+  | {
       outcome: 'unsupported';
       reply: string;
     };
@@ -86,7 +90,7 @@ export async function handleIncomingMessage(
   const effectiveMessage = decision.effectiveUserMessageText;
 
   if (effectiveMessage === null) {
-    const reply = prefixForDecision(decision) + newSessionReadyText();
+    const reply = newSessionReadyText();
     const assistantAt = await appendAssistantMessage(session, deps, reply);
     await deps.sessionRepository.updateSession(session.id, {
       status: 'waiting_for_user',
@@ -113,7 +117,7 @@ export async function handleIncomingMessage(
     message: effectiveMessage,
     messageId: input.messageId,
   });
-  await applyRunnerResult(input, deps, session, runnerResult, prefixForDecision(decision));
+  await applyRunnerResult(input, deps, session, runnerResult);
 
   return { sessionId: session.id };
 }
@@ -169,11 +173,21 @@ async function applyRunnerResult(
   input: IntexIncomingMessage,
   deps: HandleIncomingMessageDeps,
   session: IntexAgentSession,
-  runnerResult: IntexAgentRunnerResult,
-  replyPrefix: string
+  runnerResult: IntexAgentRunnerResult
 ): Promise<void> {
+  if (runnerResult.outcome === 'no_action') {
+    const reply = stripDuplicateSessionPrefix(runnerResult.reply);
+    const assistantAt = await appendAssistantMessage(session, deps, reply);
+    await deps.sessionRepository.updateSession(session.id, {
+      status: 'waiting_for_user',
+      lastAssistantMessageAt: assistantAt,
+    });
+    await publishReply(input, deps, session.id, reply);
+    return;
+  }
+
   if (runnerResult.outcome === 'needs_clarification') {
-    const reply = replyPrefix + stripDuplicateSessionPrefix(runnerResult.reply);
+    const reply = stripDuplicateSessionPrefix(runnerResult.reply);
     await appendEvent(deps, session, 'clarification_requested', { message: reply });
     const assistantAt = await appendAssistantMessage(session, deps, reply);
     await deps.sessionRepository.updateSession(session.id, {
@@ -185,7 +199,7 @@ async function applyRunnerResult(
   }
 
   if (runnerResult.outcome === 'unsupported') {
-    const reply = replyPrefix + runnerResult.reply;
+    const reply = stripDuplicateSessionPrefix(runnerResult.reply);
     await appendEvent(deps, session, 'unsupported_request', { message: runnerResult.reply });
     const assistantAt = await appendAssistantMessage(session, deps, reply);
     await closeSession(session, deps, 'unsupported', 'unsupported_request', {
@@ -196,9 +210,14 @@ async function applyRunnerResult(
     return;
   }
 
-  const reply = replyPrefix + runnerResult.reply;
+  if (runnerResult.toolName === undefined) {
+    await applyUnsupportedRunnerResult(input, deps, session, malformedRunnerResult());
+    return;
+  }
+
+  const reply = stripDuplicateSessionPrefix(runnerResult.reply);
   await appendEvent(deps, session, 'tool_call_completed', {
-    ...(runnerResult.toolName !== undefined ? { toolName: runnerResult.toolName } : {}),
+    toolName: runnerResult.toolName,
   });
   const assistantAt = await appendAssistantMessage(session, deps, reply);
   const endedAt = deps.clock.now();
@@ -207,7 +226,7 @@ async function applyRunnerResult(
     endedAt,
     lastAssistantMessageAt: assistantAt,
     endReason: 'tool_completed',
-    ...(runnerResult.toolName !== undefined ? { activeTool: runnerResult.toolName } : {}),
+    activeTool: runnerResult.toolName,
     ...(runnerResult.summary !== undefined ? { summary: runnerResult.summary } : {}),
   });
   await appendEvent(deps, session, 'session_closed', {
@@ -278,28 +297,30 @@ async function publishReply(
   });
 }
 
-function prefixForDecision(decision: SessionTransitionDecision): string {
-  if (decision.action === 'continue') {
-    return '';
-  }
-
-  if (decision.closeCurrentSession?.status === 'superseded') {
-    return 'Previous session superseded. New session started.\n\n';
-  }
-
-  if (decision.closeCurrentSession?.status === 'expired') {
-    return 'Previous session expired. New session started.\n\n';
-  }
-
-  return 'New session started.\n\n';
-}
-
 function newSessionReadyText(): string {
-  return 'What would you like me to help with? I can create notes and calendar events.';
+  return 'What would you like me to help with? I can create notes, calendar events, research drafts, bookmarks, and code tasks.';
 }
 
 function stripDuplicateSessionPrefix(text: string): string {
-  return text.replace(/^New session started\.\s*/i, '').trimStart();
+  return text
+    .replace(/^(Previous session (?:superseded|expired)\. )?New session started\.\s*/i, '')
+    .trimStart();
+}
+
+async function applyUnsupportedRunnerResult(
+  input: IntexIncomingMessage,
+  deps: HandleIncomingMessageDeps,
+  session: IntexAgentSession,
+  runnerResult: Extract<IntexAgentRunnerResult, { outcome: 'unsupported' }>
+): Promise<void> {
+  const reply = stripDuplicateSessionPrefix(runnerResult.reply);
+  await appendEvent(deps, session, 'unsupported_request', { message: runnerResult.reply });
+  const assistantAt = await appendAssistantMessage(session, deps, reply);
+  await closeSession(session, deps, 'unsupported', 'unsupported_request', {
+    lastAssistantMessageAt: assistantAt,
+    summary: summarizeUserMessage(input.text),
+  });
+  await publishReply(input, deps, session.id, reply);
 }
 
 function summarizeUserMessage(message: string): string {
@@ -308,4 +329,12 @@ function summarizeUserMessage(message: string): string {
     return normalized;
   }
   return `${normalized.slice(0, 117)}...`;
+}
+
+function malformedRunnerResult(): Extract<IntexAgentRunnerResult, { outcome: 'unsupported' }> {
+  return {
+    outcome: 'unsupported',
+    reply:
+      'I could not safely understand that request. I can create notes, calendar events, research drafts, bookmarks, and code tasks.',
+  };
 }

--- a/apps/research-agent/src/__tests__/routes.test.ts
+++ b/apps/research-agent/src/__tests__/routes.test.ts
@@ -3488,6 +3488,30 @@ describe('Internal Routes', () => {
       expect(body.success).toBe(true);
       expect(body.data.status).toBe('completed');
       expect(body.data.message).toBe('Research "Test Draft Research" created successfully');
+      expect(body.data.resourceUrl).toBe('https://app.example.com/#/research/generated-id-123');
+    });
+
+    it('keeps draft research resource URLs relative when webAppUrl is empty', async () => {
+      getServices().webAppUrl = '';
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/internal/research/draft',
+        headers: { 'x-internal-auth': TEST_INTERNAL_TOKEN },
+        payload: {
+          userId: TEST_USER_ID,
+          title: 'Test Draft Research',
+          prompt: 'Test prompt content',
+          originalMessage: 'Research AI using gemini and o4',
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body) as {
+        success: boolean;
+        data: { status: string; message: string; resourceUrl?: string };
+      };
+      expect(body.success).toBe(true);
       expect(body.data.resourceUrl).toBe('/#/research/generated-id-123');
     });
 

--- a/apps/research-agent/src/routes/internalRoutes.ts
+++ b/apps/research-agent/src/routes/internalRoutes.ts
@@ -176,7 +176,7 @@ export const internalRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
       }
 
       const body = request.body as CreateDraftResearchBody;
-      const { researchRepo, generateId, userServiceClient } = getServices();
+      const { researchRepo, generateId, userServiceClient, webAppUrl } = getServices();
       const researchId = generateId();
 
       // Extract model preferences from original message using LLM
@@ -260,7 +260,7 @@ export const internalRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
         return await reply.ok(feedback);
       }
 
-      const resourceUrl = `/#/research/${researchId}`;
+      const resourceUrl = buildWebAppResourceUrl(webAppUrl, `/#/research/${researchId}`);
       const feedback: ServiceFeedback = {
         status: 'completed',
         message: `Research "${body.title}" created successfully`,
@@ -1045,3 +1045,8 @@ export const internalRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
 
   done();
 };
+
+function buildWebAppResourceUrl(webAppUrl: string, path: string): string {
+  const normalizedBase = webAppUrl.replace(/\/+$/, '');
+  return normalizedBase === '' ? path : `${normalizedBase}${path}`;
+}

--- a/apps/web/src/components/intex-agent/IntexSessionTimeline.tsx
+++ b/apps/web/src/components/intex-agent/IntexSessionTimeline.tsx
@@ -123,7 +123,12 @@ export function IntexSessionTimeline({
             <span>Start: {formatSessionValue(session.startReason)}</span>
             <span>End: {formatSessionValue(session.endReason)}</span>
             <span>Tool: {formatSessionValue(session.activeTool)}</span>
-            <span>Assistant: {session.lastAssistantMessageAt ?? 'No reply yet'}</span>
+            <span>
+              Assistant:{' '}
+              {session.lastAssistantMessageAt !== undefined
+                ? formatSessionDateTimeCompact(session.lastAssistantMessageAt)
+                : 'No reply yet'}
+            </span>
           </div>
         ) : null}
       </div>

--- a/apps/web/src/components/intex-agent/__tests__/IntexSessionTimeline.test.tsx
+++ b/apps/web/src/components/intex-agent/__tests__/IntexSessionTimeline.test.tsx
@@ -1,0 +1,39 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { IntexAgentSession } from '@/types';
+import { formatDateTimeCompact } from '@/utils/dateFormat';
+import { IntexSessionTimeline } from '../IntexSessionTimeline.js';
+
+function session(overrides: Partial<IntexAgentSession> = {}): IntexAgentSession {
+  return {
+    id: 'session-1',
+    userId: 'user-1',
+    channel: 'whatsapp',
+    status: 'completed',
+    startedAt: '2026-06-24T22:15:00.000Z',
+    endedAt: '2026-06-24T22:15:06.903Z',
+    lastUserMessageAt: '2026-06-24T22:15:00.000Z',
+    lastAssistantMessageAt: '2026-06-24T22:15:06.903Z',
+    startReason: 'no_active_session',
+    endReason: 'tool_completed',
+    activeTool: 'create_research',
+    summary: 'Created research draft',
+    ...overrides,
+  };
+}
+
+describe('IntexSessionTimeline', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('formats assistant timestamps and renders current tool names in metadata', () => {
+    render(<IntexSessionTimeline session={session()} events={[]} loading={false} />);
+
+    expect(screen.getByText('Tool: Create Research')).toBeInTheDocument();
+    expect(
+      screen.getByText(`Assistant: ${formatDateTimeCompact('2026-06-24T22:15:06.903Z')}`)
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/2026-06-24T22:15:06.903Z/)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -309,7 +309,12 @@ export type IntexAgentSessionEndReason =
   | 'cancelled_by_user'
   | 'superseded_by_user';
 
-export type IntexAgentToolName = 'create_note' | 'create_calendar_event';
+export type IntexAgentToolName =
+  | 'create_note'
+  | 'create_calendar_event'
+  | 'create_research'
+  | 'create_link'
+  | 'create_code_task';
 
 export interface IntexAgentSession {
   id: string;


### PR DESCRIPTION
## Summary
- Keep greeting/no-action Intex sessions open and remove lifecycle text from WhatsApp replies.
- Tighten Intex tool routing so calendar reads are not misrouted to research, and require concrete tool identity for completions.
- Return absolute research draft URLs and format Intex session assistant timestamps in the dashboard.

## Verification
- `pnpm run ci:tracked`

## Linear
Linear: omitted by `$commit-push`; GitHub automation will create or link the Linear issue after PR creation.