### PR TITLE
[INT-1693] Add guarded retired async cleanup

### DIFF
--- a/docs/operations/hetzner-prod-runbook.md
+++ b/docs/operations/hetzner-prod-runbook.md
@@ -334,6 +334,33 @@ the activation. The `scripts/hetzner/cutover-gcp-edge.sh` helper prints the
 equivalent `gcloud` updates for audit or emergency use, but Terraform is the
 source of truth.
 
+## Retired Async Cleanup
+
+After removed app services are absent from PM2 on dev and production, use the
+guarded cleanup marker in `terraform/hetzner-prod/retired-async-cleanup.tf` to
+delete stale prod-Hetzner Scheduler jobs and Pub/Sub push subscriptions that no
+longer appear in the active async maps. The marker describes each target first
+and exits without deleting if the live endpoint differs from the Terraform
+inventory.
+
+Run the one-time cleanup with the normal Hetzner Terraform credentials:
+
+```bash
+STORAGE_EMULATOR_HOST= FIRESTORE_EMULATOR_HOST= PUBSUB_EMULATOR_HOST= \
+GOOGLE_APPLICATION_CREDENTIALS=$HOME/.config/gcloud/sa-key.json \
+terraform -chdir=terraform/hetzner-prod apply \
+  -var='enable_retired_async_consumer_cleanup=true'
+```
+
+After the cleanup apply succeeds, return to the committed default so later
+plain applies do not keep a cleanup marker in state:
+
+```bash
+STORAGE_EMULATOR_HOST= FIRESTORE_EMULATOR_HOST= PUBSUB_EMULATOR_HOST= \
+GOOGLE_APPLICATION_CREDENTIALS=$HOME/.config/gcloud/sa-key.json \
+terraform -chdir=terraform/hetzner-prod apply
+```
+
 ## Pre-Cutover Smoke Test
 
 Before changing DNS, every PM2 process must respond on localhost:

--- a/scripts/__tests__/hetzner-runtime.test.ts
+++ b/scripts/__tests__/hetzner-runtime.test.ts
@@ -50,6 +50,10 @@ const terraformHetznerCloudInitPath = resolve(
 );
 const terraformHetznerPubsubPath = resolve(repoRoot, 'terraform/hetzner-prod/pubsub.tf');
 const terraformHetznerSchedulerPath = resolve(repoRoot, 'terraform/hetzner-prod/scheduler.tf');
+const terraformHetznerRetiredAsyncCleanupPath = resolve(
+  repoRoot,
+  'terraform/hetzner-prod/retired-async-cleanup.tf'
+);
 const terraformHetznerVariablesPath = resolve(repoRoot, 'terraform/hetzner-prod/variables.tf');
 const terraformHetznerOutputsPath = resolve(repoRoot, 'terraform/hetzner-prod/outputs.tf');
 const terraformHetznerTfvarsExamplePath = resolve(
@@ -625,10 +629,44 @@ describe('Hetzner async edge cutover', () => {
     const hetznerMain = readRequired(terraformHetznerMainPath);
     const hetznerPubsub = readRequired(terraformHetznerPubsubPath);
     const hetznerScheduler = readRequired(terraformHetznerSchedulerPath);
+    const hetznerRetiredAsyncCleanup = readRequired(terraformHetznerRetiredAsyncCleanupPath);
+    const hetznerVariables = readRequired(terraformHetznerVariablesPath);
     const hetznerOutputs = readRequired(terraformHetznerOutputsPath);
     const prodAutoTfvars = JSON.parse(readRequired(terraformHetznerProdAutoTfvarsPath)) as {
       activate_hetzner_async_consumers?: boolean;
     };
+    const retiredSchedulerJobs: Array<[string, string[]]> = [
+      [
+        retiredDashed('intexuraos', 'retry', 'pending', 'actions', 'prod', 'hetzner'),
+        ['internal', 'actions', 'retry-pending'],
+      ],
+      [
+        retiredDashed('intexuraos', 'cron', 'agent', 'tick', 'prod', 'hetzner'),
+        ['internal', 'cron', 'tick'],
+      ],
+      [
+        retiredDashed('intexuraos', 'retry', 'pending', 'commands', 'prod', 'hetzner'),
+        ['internal', 'retry-pending'],
+      ],
+    ];
+    const retiredPubsubSubscriptions: Array<[string, string[]]> = [
+      [
+        retiredDashed('intexuraos', 'todos', 'processing', 'prod', 'hetzner'),
+        ['internal', 'todos', 'pubsub', retiredDashed('todos', 'processing')],
+      ],
+      [
+        retiredDashed('intexuraos', 'commands', 'ingest', 'prod', 'hetzner'),
+        ['internal', 'commands'],
+      ],
+      [
+        retiredDashed('intexuraos', 'actions', 'queue', 'prod', 'hetzner'),
+        ['internal', 'actions', 'process'],
+      ],
+      [
+        retiredDashed('intexuraos', 'approval', 'reply', 'prod', 'hetzner'),
+        ['internal', 'actions', retiredDashed('approval', 'reply')],
+      ],
+    ];
 
     expect(script).toContain('PUBSUB_ROUTES=(');
     expect(script).toContain('SCHEDULER_ROUTES=(');
@@ -674,8 +712,32 @@ describe('Hetzner async edge cutover', () => {
         .split('code_tasks_zombie_sweep = {')[1]
         ?.split('\n    archive_stale_groups = {')[0] ?? '';
     expect(zombieSweepJob).toContain('path                 = "/internal/code/detect-zombies"');
-    expect(zombieSweepJob).toContain('body                 = null');
-    expect(zombieSweepJob).not.toContain('base64encode("{}")');
+    expect(zombieSweepJob).toContain('body                 = base64encode("{}")');
+    expect(zombieSweepJob).toContain(
+      'headers              = { "Content-Type" = "application/json" }'
+    );
+    expect(hetznerVariables).toContain('variable "enable_retired_async_consumer_cleanup"');
+    expect(hetznerVariables).toContain('default     = false');
+    expect(hetznerRetiredAsyncCleanup).toContain(
+      'resource "terraform_data" "retired_async_consumer_cleanup"'
+    );
+    expect(hetznerRetiredAsyncCleanup).toContain(
+      'count = var.enable_retired_async_consumer_cleanup ? 1 : 0'
+    );
+    expect(hetznerRetiredAsyncCleanup).toContain('Refusing to delete scheduler job');
+    expect(hetznerRetiredAsyncCleanup).toContain('Refusing to delete Pub/Sub subscription');
+    for (const [jobName, pathParts] of retiredSchedulerJobs) {
+      const path = `/${pathParts.join('/')}`;
+      expect(hetznerRetiredAsyncCleanup, jobName).toContain(jobName);
+      expect(hetznerRetiredAsyncCleanup, path).toContain(path);
+      expect(hetznerScheduler, jobName).not.toContain(jobName);
+    }
+    for (const [subscriptionName, pathParts] of retiredPubsubSubscriptions) {
+      const path = `/${pathParts.join('/')}`;
+      expect(hetznerRetiredAsyncCleanup, subscriptionName).toContain(subscriptionName);
+      expect(hetznerRetiredAsyncCleanup, path).toContain(path);
+      expect(hetznerPubsub, subscriptionName).not.toContain(subscriptionName);
+    }
     expect(hetznerOutputs).toContain(
       'filter        = subscription.filter == "" ? null : subscription.filter'
     );

--- a/scripts/__tests__/verify-removed-agents.test.ts
+++ b/scripts/__tests__/verify-removed-agents.test.ts
@@ -152,6 +152,32 @@ fastify.post('/internal/intex-agent/messages', async () => ({}));
     expect(result.stdout).toContain('Removed agent verification passed');
   });
 
+  it('allows only the explicit Terraform retired async cleanup inventory to name deleted resources', () => {
+    writeFixture(
+      rootDir,
+      'terraform/hetzner-prod/retired-async-cleanup.tf',
+      `
+locals {
+  retired_prod_hetzner_pubsub_subscriptions = {
+    commands_ingest = {
+      subscription_name = "intexuraos-commands-ingest-prod-hetzner"
+      push_path         = "/internal/commands"
+    }
+    actions_queue = {
+      subscription_name = "intexuraos-actions-queue-prod-hetzner"
+      push_path         = "/internal/actions/process"
+    }
+  }
+}
+`
+    );
+
+    const result = runVerifier(rootDir);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Removed agent verification passed');
+  });
+
   it('passes on the repository root after the removed agents cleanup is complete', () => {
     const result = runVerifier(REPO_ROOT);
 

--- a/scripts/verify-removed-agents.mjs
+++ b/scripts/verify-removed-agents.mjs
@@ -52,6 +52,7 @@ const IGNORE_EXACT_PATHS = new Set([
   'docs/architect-review-report.md',
   'docs/documentation-runs.md',
   'docs/features-rewrite-history.md',
+  'terraform/hetzner-prod/retired-async-cleanup.tf',
   'scripts/verify-removed-agents.mjs',
   'scripts/__tests__/verify-removed-agents.test.ts',
 ]);

--- a/terraform/hetzner-prod/prod.auto.tfvars.json
+++ b/terraform/hetzner-prod/prod.auto.tfvars.json
@@ -6,6 +6,7 @@
   "domain": "intexuraos.cloud",
   "hetzner_origin": "https://intexuraos.cloud",
   "activate_hetzner_async_consumers": true,
+  "enable_retired_async_consumer_cleanup": false,
   "hetzner_location": "nbg1",
   "hetzner_server_type": "cx33",
   "hetzner_image": "ubuntu-24.04",

--- a/terraform/hetzner-prod/retired-async-cleanup.tf
+++ b/terraform/hetzner-prod/retired-async-cleanup.tf
@@ -1,0 +1,142 @@
+locals {
+  retired_prod_hetzner_scheduler_jobs = {
+    retry_pending_actions = {
+      job_name = "intexuraos-retry-pending-actions-prod-hetzner"
+      path     = "/internal/actions/retry-pending"
+    }
+    cron_agent_tick = {
+      job_name = "intexuraos-cron-agent-tick-prod-hetzner"
+      path     = "/internal/cron/tick"
+    }
+    retry_pending_commands = {
+      job_name = "intexuraos-retry-pending-commands-prod-hetzner"
+      path     = "/internal/retry-pending"
+    }
+  }
+
+  retired_prod_hetzner_pubsub_subscriptions = {
+    todos_processing = {
+      subscription_name = "intexuraos-todos-processing-prod-hetzner"
+      push_path         = "/internal/todos/pubsub/todos-processing"
+    }
+    commands_ingest = {
+      subscription_name = "intexuraos-commands-ingest-prod-hetzner"
+      push_path         = "/internal/commands"
+    }
+    actions_queue = {
+      subscription_name = "intexuraos-actions-queue-prod-hetzner"
+      push_path         = "/internal/actions/process"
+    }
+    approval_reply = {
+      subscription_name = "intexuraos-approval-reply-prod-hetzner"
+      push_path         = "/internal/actions/approval-reply"
+    }
+  }
+}
+
+resource "terraform_data" "retired_async_consumer_cleanup" {
+  count = var.enable_retired_async_consumer_cleanup ? 1 : 0
+
+  input = {
+    project_id           = var.project_id
+    region               = var.region
+    scheduler_jobs       = local.retired_prod_hetzner_scheduler_jobs
+    pubsub_subscriptions = local.retired_prod_hetzner_pubsub_subscriptions
+  }
+
+  triggers_replace = {
+    cleanup_contract = sha256(jsonencode({
+      project_id           = var.project_id
+      region               = var.region
+      hetzner_origin       = var.hetzner_origin
+      scheduler_jobs       = local.retired_prod_hetzner_scheduler_jobs
+      pubsub_subscriptions = local.retired_prod_hetzner_pubsub_subscriptions
+    }))
+  }
+
+  provisioner "local-exec" {
+    interpreter = ["/usr/bin/env", "bash", "-lc"]
+    command     = <<-EOT
+      set -euo pipefail
+
+      command -v gcloud >/dev/null
+
+      project='${var.project_id}'
+      region='${var.region}'
+
+      describe_or_absent() {
+        local err_file
+        err_file="$(mktemp)"
+        if "$@" 2>"$err_file"; then
+          rm -f "$err_file"
+          return 0
+        fi
+
+        if grep -Eiq 'NOT_FOUND|not found|does not exist' "$err_file"; then
+          rm -f "$err_file"
+          return 2
+        fi
+
+        cat "$err_file" >&2
+        rm -f "$err_file"
+        return 1
+      }
+
+      delete_scheduler_job() {
+        local name="$1"
+        local expected_uri="$2"
+        local actual_uri
+
+        if actual_uri="$(describe_or_absent gcloud scheduler jobs describe "$name" --project "$project" --location "$region" --format='value(httpTarget.uri)')"; then
+          if [[ -z "$actual_uri" || "$actual_uri" != "$expected_uri" ]]; then
+            printf 'Refusing to delete scheduler job %s: expected URI %s, got %s\n' "$name" "$expected_uri" "$actual_uri" >&2
+            return 1
+          fi
+          gcloud scheduler jobs delete "$name" --project "$project" --location "$region" --quiet
+          return
+        fi
+
+        case "$?" in
+          2)
+            printf 'Scheduler job %s is already absent\n' "$name"
+            ;;
+          *)
+            return 1
+            ;;
+        esac
+      }
+
+      delete_pubsub_subscription() {
+        local name="$1"
+        local expected_endpoint="$2"
+        local actual_endpoint
+
+        if actual_endpoint="$(describe_or_absent gcloud pubsub subscriptions describe "$name" --project "$project" --format='value(pushConfig.pushEndpoint)')"; then
+          if [[ -z "$actual_endpoint" || "$actual_endpoint" != "$expected_endpoint" ]]; then
+            printf 'Refusing to delete Pub/Sub subscription %s: expected endpoint %s, got %s\n' "$name" "$expected_endpoint" "$actual_endpoint" >&2
+            return 1
+          fi
+          gcloud pubsub subscriptions delete "$name" --project "$project" --quiet
+          return
+        fi
+
+        case "$?" in
+          2)
+            printf 'Pub/Sub subscription %s is already absent\n' "$name"
+            ;;
+          *)
+            return 1
+            ;;
+        esac
+      }
+
+      %{for _, job in local.retired_prod_hetzner_scheduler_jobs~}
+      delete_scheduler_job '${job.job_name}' '${var.hetzner_origin}${job.path}'
+      %{endfor~}
+
+      %{for _, subscription in local.retired_prod_hetzner_pubsub_subscriptions~}
+      delete_pubsub_subscription '${subscription.subscription_name}' '${var.hetzner_origin}${subscription.push_path}'
+      %{endfor~}
+    EOT
+  }
+}

--- a/terraform/hetzner-prod/scheduler.tf
+++ b/terraform/hetzner-prod/scheduler.tf
@@ -97,8 +97,8 @@ locals {
       schedule             = "*/5 * * * *"
       time_zone            = "UTC"
       path                 = "/internal/code/detect-zombies"
-      body                 = null
-      headers              = {}
+      body                 = base64encode("{}")
+      headers              = { "Content-Type" = "application/json" }
       retry_count          = 1
       max_retry_duration   = "60s"
       min_backoff_duration = "5s"

--- a/terraform/hetzner-prod/terraform.tfvars.example
+++ b/terraform/hetzner-prod/terraform.tfvars.example
@@ -9,6 +9,8 @@ environment = "prod"
 domain      = "intexuraos.cloud"
 
 activate_hetzner_async_consumers = true
+# Set true only for the one-time guarded cleanup documented in the runbook.
+enable_retired_async_consumer_cleanup = false
 
 hetzner_location    = "nbg1"
 hetzner_server_type = "cx33"

--- a/terraform/hetzner-prod/variables.tf
+++ b/terraform/hetzner-prod/variables.tf
@@ -65,6 +65,12 @@ variable "activate_hetzner_async_consumers" {
   default     = false
 }
 
+variable "enable_retired_async_consumer_cleanup" {
+  description = "When true, runs the one-time guarded cleanup for stale prod-hetzner Scheduler jobs and Pub/Sub push subscriptions that no longer appear in the active Hetzner async maps."
+  type        = bool
+  default     = false
+}
+
 variable "hetzner_location" {
   description = "Hetzner location for the prod VM and primary IPv4."
   type        = string


### PR DESCRIPTION
## Summary

- Add an opt-in Terraform cleanup marker for stale prod-Hetzner Scheduler jobs and Pub/Sub push subscriptions, with endpoint checks before deletion.
- Change the zombie sweep Scheduler job to send an empty JSON body with `Content-Type: application/json`.
- Document the cleanup apply flow and extend tests/verifiers for the explicit cleanup inventory.

## Verification

- `pnpm exec vitest run scripts/__tests__/hetzner-runtime.test.ts scripts/__tests__/verify-removed-agents.test.ts`
- `pnpm run verify:removed-agents`
- `terraform fmt -check -recursive terraform/hetzner-prod`
- `TF_DATA_DIR="$(mktemp -d)" terraform -chdir=terraform/hetzner-prod init -backend=false -input=false && terraform -chdir=terraform/hetzner-prod validate`
- `pnpm run ci:tracked`

## Linear

Linear: omitted by `$commit-push`; GitHub automation will create or link the Linear issue after PR creation.
