### PR TITLE
[INT-1694] Refresh README and homepage showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,304 +6,230 @@
   <p>
     <a href="https://github.com/pbuchman/intexuraos/actions"><img src="https://img.shields.io/github/actions/workflow/status/pbuchman/intexuraos/ci.yml?branch=main&label=Build&style=flat-square&logo=github" alt="Build Status"></a>
     <img src="https://img.shields.io/badge/Coverage-100%25-success?style=flat-square&logo=codecov" alt="Coverage">
-    <img src="https://img.shields.io/badge/TypeScript-5.7-blue?style=flat-square&logo=typescript&logoColor=white" alt="TypeScript">
-    <img src="https://img.shields.io/badge/AI_Models-15-purple?style=flat-square" alt="AI Models">
-    <img src="https://img.shields.io/badge/Components-58-orange?style=flat-square" alt="Components">
-    <img src="https://img.shields.io/badge/Hooks-26-green?style=flat-square" alt="Hooks">
-    <img src="https://img.shields.io/badge/CI_Scripts-27-green?style=flat-square" alt="CI Scripts">
+    <img src="https://img.shields.io/badge/TypeScript-Strict-blue?style=flat-square&logo=typescript&logoColor=white" alt="TypeScript Strict">
+    <img src="https://img.shields.io/badge/AI_Providers-5-purple?style=flat-square" alt="AI Providers">
     <img src="https://img.shields.io/badge/Infrastructure-Terraform-623CE4?style=flat-square&logo=terraform&logoColor=white" alt="Terraform">
   </p>
 </div>
 
-> TypeScript monorepo — app services, workers, and shared packages — built and maintained by a single developer under strict engineering discipline: 100% branch coverage as a CI gate, cross-LLM verification where no model evaluates its own output, 27 CI verification scripts, and 26 Claude Code hooks enforcing quality at every stage. The system takes a WhatsApp text message or web task and turns it into notes, calendar events, research drafts, bookmarks, or tested code changes.
+> **IntexuraOS is a personal agentic operating system for turning thoughts into executed work.**
 >
-> IntexuraOS does not use AI as a feature. It deploys AI agents that use software as a tool. The platform researches, schedules, manages tasks, and **writes and ships its own code**.
+> Send a WhatsApp message, dashboard task, GitHub comment, link, or research question. IntexuraOS routes it to a specialist agent, performs the work through typed service boundaries, verifies the result, and notifies you when there is something to review.
+>
+> A thought becomes a note. A date becomes a calendar event. A link becomes an enriched bookmark. A question becomes a multi-model research report. A bug report becomes a planned, tested code change running on your own machine.
 
-### Engineering Highlights
-
-|                                |                                                                                                             |
-| ------------------------------ | ----------------------------------------------------------------------------------------------------------- |
-| **Cross-LLM Verification**     | Writer and verifier are always different providers — Claude executes, Gemini verifies, TypeScript validates |
-| **Monorepo, One Developer**    | App services, workers, and packages in a strict TypeScript monorepo                                         |
-| **Autonomous Code Pipeline**   | WhatsApp text or web task → code planning → Docker-isolated execution → tested PR                           |
-| **Container Isolation**        | Non-root, all capabilities dropped, network-restricted, read-only secrets per task                          |
-| **26 Claude Code Hooks**       | 1 SessionStart, 15 PreToolUse, 7 PostToolUse, 3 Stop — enforcing patterns before code is written            |
-| **27 CI Verification Scripts** | Automated gates covering coverage, types, contracts, env vars, and cross-linking                            |
-| **Prompt Versioning**          | Semver-versioned prompts with SHA-256 audit trail and CI-enforced bump validation                           |
-| **Multi-Provider AI Council**  | 15 models across 5 core providers queried in parallel with attributed synthesis                             |
-| **Result Type Discipline**     | Every operation returns typed success or failure — no silent crashes, no unhandled exceptions               |
-| **Event-Driven Architecture**  | Pub/Sub topics decouple services with crash-safe state persistence                                          |
-
-**[The Self-Building System](#the-self-building-system)** · **[Cross-LLM Verification](#cross-llm-verification-pipeline)** · **[The Council of AI](#the-council-of-ai)** · **[Architecture](#architecture)** · **[Engineering Standards](#engineering-standards)** · **[Direct-Tool Intelligence](#direct-tool-intelligence)** · **[Getting Started](#getting-started)** · **[Documentation](#documentation)**
+**[Why It Is Different](#why-it-is-different)** · **[Agentic Patterns](#agentic-patterns-in-production)** · **[System Flow](#system-flow)** · **[Self-Building Code](#flagship-subsystem-self-building-code)** · **[Research Council](#multi-model-research-council)** · **[Engineering Proof](#engineering-proof)** · **[Getting Started](#getting-started)** · **[Documentation](#documentation)**
 
 ---
 
-## Ambient Task Submission
+## Why It Is Different
 
-You submit tasks while walking, while commuting, while thinking of something else. The primary interface is WhatsApp — an app already on your phone, already open, always available. This is not a convenience shortcut to a desktop workflow. It is a fundamentally different interaction model: ambient task submission that fits into the gaps of a working day.
+IntexuraOS is not one general assistant with a long tool list. It is a set of narrow agents, each with one domain, wrapped in deterministic software that controls what the model is allowed to do.
 
-Send a text message to WhatsApp. IntexuraOS routes it through Intex, which can create notes, calendar events, research drafts, bookmarks, and code tasks directly. A message about a bug becomes a code task. A question about solid-state batteries becomes a multi-model research draft. A mention of lunch Friday becomes a calendar event when the required details are clear.
+| What it is not                 | What IntexuraOS does instead                                                                                                                                   |
+| ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Not one generic chatbot**    | Specialist agents own notes, calendar, research, bookmarks, writing, RAG, notifications, Linear, GitHub, and code execution.                                   |
+| **Not just tool calling**      | Tool access is typed, gated, audited, and service-owned; unsupported requests fail clearly instead of being forced through a fallback workflow.                |
+| **Not just RAG**               | Retrieval is domain-specific, citation-validated, and connected to user knowledge plus recent WhatsApp/mobile context.                                         |
+| **Not just autonomous coding** | Code runs locally on your worker machine, inside isolated containers, with design review, independent verification, retry, and PR delivery.                    |
+| **Not prompt glue**            | Prompts are semver-versioned, LLM usage is attributed by prompt type, malformed model outputs are repaired or stored for review, and service state is durable. |
 
-## The Self-Building System
+The result is closer to a personal operating system than a productivity app: a single front door into many safe, inspectable workflows.
 
-Most AI coding tools wait for you to sit at a keyboard. IntexuraOS does not.
+## Agentic Patterns In Production
 
-You describe what needs to change — via WhatsApp text message or the web dashboard. The platform takes it from there: it designs the approach, writes the code inside an isolated container, runs automated tests, creates a code change for review, and updates the project issue. If the first attempt fails verification, it retries with preserved context. Code tasks default to planning mode so you can review the design before implementation.
+| Pattern                     | IntexuraOS implementation                                                                                              | What it proves                                                                                           |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| Direct-tool action agent    | [`intex-agent`](docs/services/intex-agent/features.md)                                                                 | WhatsApp text is classified through deterministic gates before one supported tool is exposed.            |
+| Multi-model council         | [`research-agent`](docs/services/research-agent/features.md)                                                           | Several providers answer independently, then synthesis preserves attribution and disagreements.          |
+| Citation-grounded RAG       | [`fishing-assistant-service`](docs/services/fishing-assistant-service/features.md)                                     | Knowledge, digest, and raw-message evidence are retrieved, ranked, cited, validated, and repaired.       |
+| Writing-state agent         | [`hellscript-agent`](docs/services/hellscript-agent/features.md)                                                       | User utterances become durable buffer events before drafts are generated from personal writing samples.  |
+| Extraction-to-action agents | [`calendar-agent`](docs/services/calendar-agent/features.md), [`linear-agent`](docs/services/linear-agent/features.md) | Natural language is parsed into structured data, validated, and either executed or stored for recovery.  |
+| Summarization memory        | [`mobile-notifications-service`](docs/services/mobile-notifications-service/features.md)                               | WhatsApp group messages become daily summaries plus persistent group state.                              |
+| Autonomous code agent       | [`code-agent`](docs/services/code-agent/features.md) + [`orchestrator`](docs/services/orchestrator/features.md)        | Design, execution, verification, PR creation, GitHub feedback, and retry form a full code delivery loop. |
+| Execution memory            | [`code-agent`](docs/services/code-agent/features.md)                                                                   | Prior code-task lessons are retrieved and injected into future execution tasks with post-run evaluation. |
 
-Your source code never leaves your network. The coding agent runs on your machine, under your AI subscription, inside containers you control. Any Unix machine becomes a worker station, connected through a single secure outbound connection — no firewall changes, no open ports. No third-party cloud touches your codebase.
+## System Flow
 
 ```mermaid
-graph LR
-    subgraph "You"
-        WA["WhatsApp: Fix the login redirect"]
-        WEB[Web UI task submission]
+flowchart LR
+    subgraph Inputs
+        WA[WhatsApp text]
+        WEB[Web dashboard]
+        GH[GitHub events]
+        LIN[Linear assignment]
     end
 
-    subgraph "Intelligence Layer"
-        INTEX[Intex Agent]
-        CA[Code Agent]
+    subgraph "Routing and Agents"
+        INTEX[Intex direct-tool gate]
+        RES[Research council]
+        RAG[Fishing RAG]
+        CAL[Calendar extraction]
+        BOOK[Bookmark enrichment]
+        NOTE[Notes]
+        CODE[Code agent]
+        WRITE[Hellscript writing]
     end
 
-    subgraph "Execution Layer"
-        ORCH[Orchestrator]
-        CW["Isolated Container<br>Claude Code + Git + Tests"]
+    subgraph "Execution and State"
+        PUBSUB[Pub/Sub workflows]
+        FS[Firestore-owned state]
+        ORCH[Local orchestrator]
+        WORKER[Isolated code worker]
     end
 
-    subgraph "Output"
-        PR[Code Change Ready]
-        LIN[Project Issue Updated]
-        NOTIFY[WhatsApp Notification]
+    subgraph Outputs
+        EVENT[Calendar event]
+        REPORT[Research report]
+        ANSWER[Cited answer]
+        PR[Pull request]
+        DIGEST[WhatsApp notification]
     end
 
-    WA --> INTEX --> CA
-    WEB --> CA
-    CA -->|"Secure handoff"| ORCH
-    ORCH -->|"Separate environment"| CW
-    CW -->|"Tests passed"| ORCH
-    ORCH -->|"Result delivered"| CA
-    CA --> PR
-    CA --> LIN
-    CA --> NOTIFY
+    WA --> INTEX
+    WEB --> INTEX
+    GH --> CODE
+    LIN --> CODE
+    INTEX --> RES
+    INTEX --> CAL
+    INTEX --> BOOK
+    INTEX --> NOTE
+    INTEX --> CODE
+    WEB --> RAG
+    WEB --> WRITE
+    RES --> PUBSUB
+    CAL --> FS
+    BOOK --> FS
+    NOTE --> FS
+    CODE --> ORCH --> WORKER
+    PUBSUB --> FS
+    FS --> EVENT
+    FS --> REPORT
+    RAG --> ANSWER
+    WORKER --> PR
+    PR --> DIGEST
+    REPORT --> DIGEST
 ```
-
-### End-to-End: From Message to Research Draft
-
-You send a WhatsApp text message: _"Research the latest developments in solid-state batteries."_ Intex recognizes that the request fits the research tool and creates a research draft for review. Five AI models can receive the same structured research plan simultaneously. Minutes later, a synthesis arrives with attributed claims, rated disagreements, and full source reports. A WhatsApp notification tells you the results are ready.
-
-The same direct-tool boundary covers the supported domains. A text message about a bug becomes a code task. A message about lunch Friday becomes a calendar event once the date and time are clear. A shared link becomes an enriched bookmark with an AI summary delivered to your phone. Unsupported requests get a clear response instead of being forced through a generic workflow.
-
-### The Code Pipeline
-
-**Step 1 — Planning.** A planning agent analyzes the task, enriches the project issue with technical context, creates subissues for complex work, and labels the issue when the plan is sound.
-
-**Step 2 — Execution.** A strict execution agent picks up the labeled issue, writes code in an isolated container with separate repository copies for each task, runs the full automated test suite, creates a code change for review, and moves the project issue to "In Review."
-
-**Verification.** After each attempt, a completion verifier checks the work against a checklist: Are the right files modified? Do tests pass? Is the code change created? If not, the system resumes with preserved context and tries again. Per-user limits on concurrency, hourly rate, and daily spend keep costs predictable — the estimated cost per task is about $1.17.
-
-### Isolation and Security
-
-Every task runs in its own world:
-
-- **Isolated containers** with all Linux capabilities dropped, non-root execution, no privilege escalation
-- **Separate repository copies** so concurrent tasks never interfere with each other
-- **Read-only secrets** mounted per task, never shared between tasks
-- **Network isolation** blocking cloud metadata endpoints, private IP ranges, and localhost
-- **Sensitive file guard** that automatically reverts commits touching credentials or secret keys
-- **Verified task requests** — every dispatch is cryptographically signed and checked before it runs
-
----
-
-## Cross-LLM Verification Pipeline
-
-The system that writes code must not be the system that approves it. IntexuraOS enforces this at the provider level.
-
-```mermaid
-sequenceDiagram
-    participant User as You
-    participant CA as Code Agent
-    participant CW as Claude (Anthropic)
-    participant GF as Gemini Flash (Google)
-    participant TS as TypeScript Schema
-    participant GH as GitHub PR
-
-    User->>CA: "Fix the login redirect"
-    CA->>CW: Execute in isolated container
-    CW->>CW: Write code, run tests
-    CW-->>GF: Last 50 lines of logs
-    GF->>TS: Structured completion data
-    TS->>TS: Validate against agent-type schema
-    GF->>GF: Deep semantic validation (200K chars)
-    GF->>GH: Post validation report to PR
-```
-
-**Stage 1 — Execution.** Claude (Anthropic) writes code inside an isolated Docker container, runs the full test suite, and creates a code change.
-
-**Stage 2 — Structured extraction.** Gemini 2.5 Flash (Google) independently extracts structured completion data from the last 50 lines of container logs and validates it against agent-type-specific schemas.
-
-**Stage 3 — Schema validation.** TypeScript validates the extracted data against strict schemas — no untyped pass-through.
-
-**Stage 4 — Deep semantic review.** A second Gemini pass reads up to 200,000 characters of the full session transcript, cross-references the project issue requirements, and posts a [detailed validation report](docs/architecture/webhook-verification-pipeline.md) directly to the GitHub PR.
-
-Neither model evaluates its own work. The writer never sees the verification criteria. The verifier never modifies the code.
-
----
-
-## The Council of AI
-
-When IntexuraOS needs to research a topic, it does not ask one model and hope for the best. It asks multiple models.
-
-**10 static research models plus OpenRouter across 5 core providers** — Google, OpenAI, Anthropic, Perplexity, and curated OpenRouter models — each queried in parallel, each reasoning independently, then synthesized into a single report with source attribution and confidence scoring.
-
-```mermaid
-graph TB
-    Q[Your Question] --> P[Parallel Dispatch]
-
-    P --> Gemini[Gemini 2.5 Pro]
-    P --> Claude[Claude Opus 4.6]
-    P --> GPT[GPT-5.4]
-    P --> Sonar[Perplexity Sonar Pro]
-
-    Gemini & Claude & GPT & Sonar --> S[Synthesis Engine]
-    S --> R[Research Report with Citations]
-    R --> Share[Public URL]
-    R --> WA2[WhatsApp Delivery]
-    R --> Notion[Notion Export]
-```
-
-Single-model assistants hallucinate. A council of models cross-checks. When three models agree and two disagree, that disagreement is surfaced — not hidden.
-
----
-
-## Architecture
-
-_This section is for developers and builders evaluating the system internals. As a user, this complexity exists so you do not have to think about it — you say what you need, and the platform routes your request to the right agent automatically._
-
-### From Message to Merged Code
-
-55 components — 20 app services, 6 workers, and 29 shared packages — all in a single repository with strict TypeScript. Many of these operate as autonomous agents and services. The architecture exists because one person needed leverage: each specialist handles one domain, so research output can feed a code task, a code task result can be pushed to project tracking and WhatsApp simultaneously, and the full loop closes without a human switching tools. No single-domain tool — coding assistant, research chatbot, or project tracker — can replicate this chain.
-
-```mermaid
-graph TD
-    subgraph "Entry Points"
-        WA3[WhatsApp]
-        WEB3[Web Dashboard]
-        GH[GitHub Events]
-    end
-
-    subgraph "Routing"
-        INTEX3["Intex Agent<br><small>Direct Tools</small>"]
-    end
-
-    subgraph "Specialist Agents"
-        RES[Research Agent]
-        CODE3[Code Agent]
-        CAL[Calendar Agent]
-        LIN3[Linear Agent]
-        BOOK[Bookmarks Agent]
-        NOTE[Notes Agent]
-        IMG[Image Service]
-        WEBAG[Web Agent]
-    end
-
-    subgraph "Code Execution"
-        ORCH3[Orchestrator]
-        CW3["Claude Worker<br><small>Isolated Container</small>"]
-    end
-
-    WA3 --> INTEX3
-    WEB3 --> INTEX3
-    GH --> CODE3
-    INTEX3 --> RES & CODE3 & CAL & BOOK & NOTE
-    CODE3 --> ORCH3 --> CW3
-```
-
-### Technology Stack
-
-| Layer              | Technologies                                                                 |
-| ------------------ | ---------------------------------------------------------------------------- |
-| **Runtime**        | Node.js 22, TypeScript 5.7 (strict mode)                                     |
-| **Framework**      | Fastify (web framework)                                                      |
-| **AI Providers**   | Anthropic, OpenAI, Google AI, Perplexity                                     |
-| **AI Tooling**     | Claude Code (autonomous worker), OpenAI (semantic document search)           |
-| **Data**           | Firestore, Google Cloud Storage                                              |
-| **Messaging**      | Cloud Pub/Sub (real-time message delivery)                                   |
-| **Auth**           | Auth0 (login), Google sign-in, Cloudflare Access, signed dispatch            |
-| **Infrastructure** | Terraform, Cloud Run, Cloud Functions, Docker, PM2                           |
-| **Observability**  | Dash0 (performance monitoring), Sentry (error tracking)                      |
-| **Integrations**   | WhatsApp Business API, Linear, GitHub, Google Calendar, Notion, Speechmatics |
-
-### AI Provider Matrix
-
-| Provider       | Models                                                   | Strengths                                                        |
-| -------------- | -------------------------------------------------------- | ---------------------------------------------------------------- |
-| **Google**     | Gemini 2.5 Pro, Flash, Flash-Image, 2.0 Flash            | Classification, fast operations, image generation                |
-| **OpenAI**     | GPT-5.4, O4 Mini Deep Research, GPT-4o Mini, GPT Image 1 | Deep research, synthesis, fast classification, document matching |
-| **Anthropic**  | Claude Opus 4.6, Sonnet 4.6/4.7, Haiku 3.5               | Analysis, validation, autonomous coding                          |
-| **Perplexity** | Sonar, Sonar Pro, Sonar Deep Research                    | Real-time web search with citations                              |
-
----
-
-## Engineering Standards
-
-The system writes and ships its own code. That only works if verification is rigorous enough to trust. Every guardrail below exists to make autonomy reliable — so an agent working at 3 AM produces the same quality as a human working at 10 AM.
-
-### 100% Branch Coverage
-
-Not a target. A gate. Every branch in every service is either tested or explicitly exempted with a documented reason. Automated tests fail on any unaccounted branch. No exceptions.
-
-### Strict TypeScript
-
-The compiler is configured to catch what tests might miss. Array access requires fallback handling. Optional properties must be declared precisely. Boolean checks must be explicit. Every operation returns a typed result — success or failure, never silent crashes. The system enforces these rules across all 55 components, so autonomous agents cannot introduce subtle type errors that pass tests but fail in production.
-
-### Automated Cross-Linking
-
-Project tracking issue numbers in a code change title connect to GitHub automatically. Error tracking prefixes on project issues connect to the monitoring system. Every artifact traces back to every other — so when the coding agent creates a change, the full chain from task to deployment is connected without human intervention.
-
-### Infrastructure as Code
-
-Everything in Terraform. No manual cloud console changes. Reproducible, auditable, version-controlled.
-
-### 26 Claude Code Hooks
-
-Every autonomous development session is governed by hooks that fire before and after tool use:
-
-- **1 SessionStart** hook loads project context and enforces development patterns
-- **15 PreToolUse** hooks validate inputs, prevent common mistakes, and enforce conventions before actions execute
-- **7 PostToolUse** hooks verify outputs, check formatting, and ensure consistency after actions complete
-- **3 Stop** hooks run final validations before a session ends
-
-Hooks encode the patterns that would otherwise live only in a developer's head — making autonomous work reproducible.
-
-### 27 CI Verification Scripts
-
-Automated gates that run on every commit, covering:
-
-- Branch coverage enforcement (100% or documented exemption)
-- TypeScript strict mode compliance across all 55 components
-- API contract validation and cross-service consistency
-- Environment variable verification (no missing vars in deployment)
-- Cross-linking between project tracking, error monitoring, and code changes
-- Prompt version bump enforcement with SHA-256 audit trail
-
-### Prompt Versioning
-
-Every AI prompt in the system is semver-versioned. CI enforces that prompt changes include a version bump. Each version is hashed (SHA-256) and stored, creating an audit trail that answers: what prompt produced this output, and when did it change?
-
----
 
 ## Direct-Tool Intelligence
 
-You submit tasks while walking, while commuting, while thinking of something else. The primary mobile interface is WhatsApp text — an app already on your phone, already open, always available. Cursor and Copilot accelerate a developer at the keyboard. IntexuraOS operates while you are away from one.
+You submit tasks while walking, commuting, or thinking of something else. WhatsApp is the mobile interface because it is already on your phone and already open. IntexuraOS turns that text into structured work.
 
-| You Say                                            | What Happens                                                   |
-| -------------------------------------------------- | -------------------------------------------------------------- |
-| _"Fix the login redirect on Safari"_               | Code task starts in planning mode for design review            |
-| _"Research quantum computing with Claude and GPT"_ | Research draft is created for review                           |
-| _"Schedule a sync with engineering Tuesday at 2"_  | Calendar event is created when title, date, and time are clear |
-| _"Save a note about the Q4 report"_                | Note is saved with a generated title                           |
-| _"Save this link about TypeScript 5.0"_            | Bookmark is saved with AI-generated context                    |
+| You say                                            | What happens                                                                  |
+| -------------------------------------------------- | ----------------------------------------------------------------------------- |
+| _"Fix the Safari login redirect"_                  | Code task starts in planning mode for design review.                          |
+| _"Research quantum computing with Claude and GPT"_ | Research draft is created with selected models and reviewable context.        |
+| _"Schedule a sync with engineering Tuesday at 2"_  | Calendar event is created when title, date, and time are clear.               |
+| _"Save a note about the Q4 report"_                | Note is saved with a generated title and searchable metadata.                 |
+| _"Save this link about TypeScript 5.0"_            | Bookmark is saved, enriched, summarized, and delivered back through WhatsApp. |
 
-**5 direct tools**: notes, calendar events, research drafts, bookmarks, and code tasks. Intex does not currently support voice messages, general approval workflows, task reminders, or project-tracker issue creation as standalone WhatsApp tools.
+The direct tools are intentionally limited: notes, calendar events, research drafts, bookmarks, and code tasks. Unsupported requests get a clear response instead of a guessed action.
+
+## Flagship Subsystem: Self-Building Code
+
+Most AI coding tools assume you are sitting at a keyboard. IntexuraOS does not.
+
+You describe the change through WhatsApp, the dashboard, Linear, or GitHub. The code agent designs the approach, pauses for review when needed, dispatches execution to a local worker, runs tests, creates a pull request, updates Linear, and reports progress back through the dashboard and WhatsApp.
+
+Your source code stays on infrastructure you control. The orchestrator runs on your worker machine and creates a separate isolated container for each task. Each task gets its own checkout, credentials, logs, and lifecycle state.
+
+```mermaid
+flowchart LR
+    START[Task submitted] --> PLAN[Planning agent writes design]
+    PLAN --> REVIEW{Design approved?}
+    REVIEW -->|yes| EXEC[Execution agent writes code]
+    REVIEW -->|changes requested| PLAN
+    EXEC --> TEST[Run tests and checks]
+    TEST --> VERIFY[Independent completion verifier]
+    VERIFY -->|passed| PR[Pull request ready]
+    VERIFY -->|failed| RETRY[Retry with preserved context]
+    RETRY --> EXEC
+    PR --> LINEAR[Linear updated]
+    PR --> WA[WhatsApp notification]
+```
+
+### Code Execution Guarantees
+
+- **Local worker execution**: the coding agent runs on your machine under your AI subscription.
+- **Container isolation**: each task has its own checkout, credentials, and restricted runtime.
+- **Design review**: code tasks default to planning before implementation.
+- **Independent verification**: the worker does not approve its own work.
+- **Retry and remediation**: failed completion checks preserve context and resume rather than dropping work.
+- **GitHub feedback loop**: PR comments can create follow-up tasks with full branch context.
+
+## Multi-Model Research Council
+
+Research-agent does not ask one model and trust the answer. It sends the same structured research plan to multiple providers, stores each result independently, then synthesizes the reports with attribution.
+
+```mermaid
+flowchart TB
+    Q[Research prompt and context] --> DRAFT[Reviewable research draft]
+    DRAFT --> FANOUT[Parallel model fan-out]
+    FANOUT --> GEM[Gemini]
+    FANOUT --> GPT[GPT]
+    FANOUT --> CLAUDE[Claude]
+    FANOUT --> SONAR[Perplexity Sonar]
+    GEM --> SYN[Synthesis]
+    GPT --> SYN
+    CLAUDE --> SYN
+    SONAR --> SYN
+    SYN --> ATTR[Attribution validation]
+    ATTR -->|valid| SHARE[Shareable report]
+    ATTR -->|invalid| REPAIR[Attribution repair]
+    REPAIR --> SHARE
+    SHARE --> NOTION[Notion export]
+    SHARE --> WA2[WhatsApp delivery]
+```
+
+The output is not a blended paragraph. It is a report that keeps source reports available, names which models supported which claims, and surfaces disagreements rather than hiding them.
+
+## Grounded RAG And Memory
+
+The fishing assistant and digest pipelines show the same philosophy in smaller domains: retrieve evidence, structure it, validate output, and keep state inspectable.
+
+```mermaid
+flowchart LR
+    KB[Knowledge pages] --> CHUNK[Chunk and embed]
+    DIGEST[WhatsApp digests] --> EVIDENCE[Evidence pool]
+    RAW[Recent raw messages] --> EVIDENCE
+    CHUNK --> RETRIEVE[Retrieve and rank]
+    EVIDENCE --> RETRIEVE
+    RETRIEVE --> PROMPT[Answer prompt with source aliases]
+    PROMPT --> JSON[Strict JSON answer]
+    JSON --> CITE[Citation validation]
+    CITE -->|valid| ANSWER[Stored answer]
+    CITE -->|invalid| REPAIR2[Repair prompt]
+    REPAIR2 --> CITE
+```
+
+## Engineering Proof
+
+The system can only delegate work safely because the engineering discipline is strict.
+
+| Discipline                 | How it is enforced                                                                                                 |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| **100% branch coverage**   | Every branch is tested or explicitly exempted with a documented blocker.                                           |
+| **Strict TypeScript**      | `noUncheckedIndexedAccess`, exact optional properties, explicit booleans, and typed results.                       |
+| **Prompt versioning**      | LLM prompts are `PromptBuilder` objects with semver versions and CI-enforced bump checks.                          |
+| **Cross-LLM verification** | The writer and verifier are different providers for high-stakes code workflows.                                    |
+| **Service ownership**      | Apps own their Firestore collections and communicate through typed internal HTTP clients.                          |
+| **Infrastructure as code** | Terraform owns persistent infrastructure; no manual cloud console changes.                                         |
+| **Usage visibility**       | LLM usage is tracked by model, provider, prompt type, call source, and correlation metadata.                       |
+| **CI gates**               | Verification scripts cover package exports, boundaries, env wiring, prompt versions, logging, contracts, and more. |
+
+### Architecture At A Glance
+
+| Layer              | Technologies                                                                 |
+| ------------------ | ---------------------------------------------------------------------------- |
+| **Runtime**        | Node.js, TypeScript strict mode                                              |
+| **Web**            | React, Vite, TailwindCSS                                                     |
+| **Services**       | Fastify apps on Cloud Run / Hetzner PM2                                      |
+| **Workers**        | Cloud Functions and VM-hosted orchestrator                                   |
+| **Data**           | Firestore, Google Cloud Storage                                              |
+| **Messaging**      | Cloud Pub/Sub                                                                |
+| **AI Providers**   | Google, OpenAI, Anthropic, Perplexity, OpenRouter                            |
+| **Integrations**   | WhatsApp Business API, Linear, GitHub, Google Calendar, Notion, Speechmatics |
+| **Infrastructure** | Terraform, Docker, PM2, nginx, GitHub Actions                                |
 
 ---
 
@@ -312,83 +238,12 @@ You submit tasks while walking, while commuting, while thinking of something els
 
 > See [CHANGELOG.md](CHANGELOG.md) for the complete history.
 
-#### v3.7.0
+| Improvement                        | Impact                                                                                               |
+| ---------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| **Fishing Assistant Chat and RAG** | Chat with grounded fishing knowledge, conversation history, mobile support, and validated citations. |
+| **Richer LLM Cost Visibility**     | Track LLM usage, research costs, image billing, and prompt-type reporting with more accurate detail. |
 
-| Improvement                        | Impact                                                                                              |
-| ---------------------------------- | --------------------------------------------------------------------------------------------------- |
-| **Fishing Assistant Chat and RAG** | Chat with grounded fishing knowledge, conversation history, mobile support, and validated citations |
-| **Richer LLM Cost Visibility**     | Track LLM usage, research costs, image billing, and prompt-type reporting with more accurate detail |
-
-#### v3.6.0
-
-| Improvement                         | Impact                                                                                        |
-| ----------------------------------- | --------------------------------------------------------------------------------------------- |
-| **WhatsApp Group Digests**          | End-to-end pipeline turns WhatsApp group messages into AI-generated daily digest summaries    |
-| **Centralized LLM Pricing**         | Single shared pricing package replaces duplicated definitions across 9 services               |
-| **Notification Importance Filter**  | Suppress low-priority WhatsApp notifications with an importance level filter                  |
-| **LLM Model Fallback**              | Primary and fallback default model selection with automatic retry when primary is unavailable |
-| **Prompt Type Tracking**            | End-to-end tracking through the LLM call stack shows which prompt drove each usage entry      |
-| **Task Mode Selector**              | Explicitly choose between planning and execution mode when starting a task                    |
-| **PWA Resilience**                  | Improved Progressive Web App stability on Android HyperOS                                     |
-| **Pub/Sub PR Triage**               | PR triage processing moved to Pub/Sub push so it no longer blocks the main request path       |
-| **Robust Task Finalization**        | Dedicated status endpoint ensures code tasks complete correctly instead of stalling           |
-| **Issue Group Importance**          | Mark issue groups as high-priority with an important flag                                     |
-| **Execution Memory Simplification** | Simplified pipeline reduces complexity and improves maintainability                           |
-| **Agent Model Inheritance**         | Code agent inherits user default LLM model settings instead of using hardcoded model          |
-
-#### v3.5.0
-
-| Improvement                  | Impact                                                                                         |
-| ---------------------------- | ---------------------------------------------------------------------------------------------- |
-| **Hellscript Agent**         | AI-powered writing following user style and preferences with categorized writing configuration |
-| **Codex Runtime**            | OpenAI Codex as a full execution backend with authentication, log processing, and worker types |
-| **Execution Memory**         | Data collection pipeline with vector retrieval and post-run distillation for smarter agents    |
-| **Remediation Agent**        | Autonomous auto-improvement loop with cross-LLM checks and event-sourcing                      |
-| **OpenRouter Integration**   | Route tasks through OpenRouter models with backend infrastructure and pricing display          |
-| **Ask Agent**                | Interactive back-and-forth Claude Code sessions directly from the UI                           |
-| **Code Task Groups**         | Backend grouping and pagination of code tasks by Linear issue representation                   |
-| **Cloudflare Web Research**  | Replaced Crawl4AI with Cloudflare Browser Rendering for JS-rendered pages                      |
-| **Auto-Archive**             | Merged code tasks archived automatically — batch archive and loading UX improvements           |
-| **Linear Issue Cleanup**     | AI-powered stale issue detection with review UI and scheduled pruning                          |
-| **CI Failure Auto-Handling** | Failed checks on agent PRs retried or escalated without user intervention                      |
-| **Worker Settings**          | Per-agent-type worker settings for independent performance and cost tuning                     |
-
-#### v3.4.0
-
-| Improvement                            | Impact                                                                                          |
-| -------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| **Hellscript Agent**                   | A new scripting service with backend, web UI, and infrastructure for authoring Hellscript tasks |
-| **Merge Queue**                        | Pull requests are queued and auto-merged in order without conflicts                             |
-| **Review Agent Plan Awareness**        | Code reviews check whether implementation matches the original plan                             |
-| **Merge Conflict Cron Reconciliation** | Conflict detection moved to a dedicated cron job for reliable, non-blocking operation           |
-
-#### v3.3.0
-
-| Improvement                      | Impact                                                                                                                       |
-| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| **GitHub Agent**                 | A new agent evaluates pull requests using tool calling, with a unified webhook evaluator routing GitHub events automatically |
-| **Alibaba Cloud Model Studio**   | Unified integration for Qwen and GLM-5 via Alibaba Cloud Model Studio, replacing the ZAI provider                            |
-| **Native Kimi Code API**         | Kimi code workers route through the native Kimi Code API using the stable `kimi-for-coding` model ID                         |
-| **Code Task Detail V2**          | Completely redesigned code task experience with a modern detail page and issue-centric grouped list view                     |
-| **Unified PR Automation Log**    | Every action taken on a pull request is now visible in a single, auditable automation log                                    |
-| **Structured Output Validation** | GitHub Agent triage produces reliable results with automatic repair prompts when structured output is malformed              |
-| **Gemini Tool-Call Mode**        | PR triage enforces Gemini tool-call mode with retry on failure and live pipeline progress display                            |
-| **Review Dispatch Overhaul**     | Fresh-start retry logic, notification deduplication, queue support, and per-user default worker type                         |
-| **PR Branch Inheritance**        | Code task retries inherit open PR branches so work-in-progress is never lost                                                 |
-| **Orchestrator Reliability**     | Deep validation plans from Linear issues, fatal exit code handling, and resume result preservation                           |
-| **Mandatory /simplify**          | Every orchestrator workflow now includes a mandatory code simplification step                                                |
-| **Planning-Task Gate**           | Autonomous planning only runs on issues explicitly tagged for planning                                                       |
-| **Agent-Based Routing**          | Requests automatically routed to the right specialist based on issue labels                                                  |
-| **One-Click Implement**          | Planned tasks go from design to pull request with a single button press                                                      |
-| **Task Queueing**                | New requests wait in line when workers are busy instead of being dropped                                                     |
-| **PR Comment Tasks**             | Leave a comment on a pull request and a code task is created automatically                                                   |
-| **More AI Models**               | Qwen, Sonnet, and MiniMax worker types join the coding agent lineup                                                          |
-| **WhatsApp Deep Links**          | Tap CTA buttons to navigate directly to tasks and dashboards                                                                 |
-| **Auto-Trigger Code Tasks**      | Assign a project issue and the coding agent starts designing immediately                                                     |
-| **Smarter Code Execution**       | The agent now plans before writing, reviews its own code twice, and summarizes progress                                      |
-| **Secret Stripping**             | API keys and tokens are automatically removed before reaching the coding agent                                               |
-| **Faster Verification**          | Full test and check pipeline runs in 3m43s, down from 5 minutes                                                              |
-| **Collapsible Log Output**       | Expand and collapse individual tool outputs when watching code tasks live                                                    |
+Earlier releases added WhatsApp group digests, centralized LLM pricing, Hellscript writing, Codex runtime support, execution memory, remediation workflows, GitHub PR triage, merge queue automation, and agent-based code task routing.
 
 </details>
 
@@ -402,13 +257,13 @@ You need three things: a WhatsApp account, a Google account, and a web browser.
 
 1. **Sign up** through the [web app](https://intexuraos.cloud/) and connect your WhatsApp number with a one-time verification code.
 2. **Link your Google account** for calendar access.
-3. **Send your first text message** and the system handles it immediately.
+3. **Send your first text message** and the system routes it immediately.
 
-The platform provides fallback AI model access, so you can run research and generate bookmarks before configuring your own API keys. For coding tasks, connect a worker machine — any Mac or Linux computer. For project tracking, connect Linear. For research exports, connect Notion. Each integration is optional and independent.
+The platform provides fallback AI model access, so you can run research and generate bookmarks before configuring your own API keys. For coding tasks, connect a worker machine. For project tracking, connect Linear. For research exports, connect Notion. Each integration is optional and independent.
 
 ### For Developers
 
-> **Note:** Full setup requires Google Cloud credentials and external service accounts (Auth0, WhatsApp Business, Linear, etc.). See the setup guide below for complete prerequisites.
+> **Note:** Full setup requires Google Cloud credentials and external service accounts such as Auth0, WhatsApp Business, Linear, and provider API keys.
 
 ```bash
 # Prerequisites: Node.js 22+, pnpm 9+, Docker
@@ -430,37 +285,35 @@ Full setup: **[Development Setup Guide](docs/setup/05-local-dev-with-gcp-deps.md
 
 ## Documentation
 
-| Document                                                    | Description                                                                                 |
-| ----------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| **[Platform Overview](docs/overview.md)**                   | What IntexuraOS does — specialized agents and services, from WhatsApp text to finished code |
-| **[Services Catalog](docs/services/index.md)**              | All 20 app services + 6 workers + 29 packages with technical details                        |
-| **[AI Architecture](docs/architecture/ai-architecture.md)** | Deep dive into 15 models across 5 core providers                                            |
-| **[Setup Guide](docs/setup/01-gcp-project.md)**             | Step-by-step cloud and local environment setup                                              |
+| Document                                                    | Description                                                           |
+| ----------------------------------------------------------- | --------------------------------------------------------------------- |
+| **[Platform Overview](docs/overview.md)**                   | What IntexuraOS does across agents, services, and workflows.          |
+| **[Services Catalog](docs/services/index.md)**              | App services, workers, and packages with technical details.           |
+| **[AI Architecture](docs/architecture/ai-architecture.md)** | Provider routing, model roles, prompt validation, and usage tracking. |
+| **[Setup Guide](docs/setup/01-gcp-project.md)**             | Step-by-step cloud and environment setup.                             |
 
 <details>
-<summary><strong>All Services</strong></summary>
+<summary><strong>Core Services</strong></summary>
 
-| Service                                                                                    | What It Does                                                                                           |
-| ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------ |
-| **[code-agent](docs/services/code-agent/features.md)**                                     | Autonomous code execution — design review, code-change lifecycle, cost controls                        |
-| **[orchestrator](docs/services/orchestrator/features.md)**                                 | Container-isolated coding sessions with completion verification                                        |
-| **[claude-worker](docs/services/claude-worker/features.md)**                               | Pre-configured coding environment inside each container                                                |
-| **[research-agent](docs/services/research-agent/features.md)**                             | Multi-model research with conflict analysis across 5 providers                                         |
-| **[web-agent](docs/services/web-agent/features.md)**                                       | Reads web pages for other agents, preserving source language                                           |
-| **[intex-agent](docs/services/intex-agent/features.md)**                                   | WhatsApp text conversations with direct tools for notes, calendar, research, bookmarks, and code tasks |
-| **[whatsapp-service](docs/services/whatsapp-service/features.md)**                         | Text ingestion, outbound notifications, verification, and message delivery                             |
-| **[calendar-agent](docs/services/calendar-agent/features.md)**                             | Calendar event creation, multilingual dates, failed event recovery                                     |
-| **[notes-agent](docs/services/notes-agent/features.md)**                                   | Tag-based notes from dashboard or Intex tool calls                                                     |
-| **[bookmarks-agent](docs/services/bookmarks-agent/features.md)**                           | Link saving with AI-generated summary and metadata extraction                                          |
-| **[linear-agent](docs/services/linear-agent/features.md)**                                 | Linear issue sync, assignment-triggered code tasks, and cleanup workflows                              |
-| **[mobile-notifications-service](docs/services/mobile-notifications-service/features.md)** | Android notification capture with filtering and pattern discovery                                      |
-| **[user-service](docs/services/user-service/features.md)**                                 | Encrypted API key vault, multi-method auth, provider key validation                                    |
-| **[app-settings-service](docs/services/app-settings-service/features.md)**                 | AI cost tracking per provider, model, and call type                                                    |
-| **[image-service](docs/services/image-service/features.md)**                               | AI-generated cover images for shared research reports                                                  |
-| **[notion-service](docs/services/notion-service/features.md)**                             | Research export to Notion with synthesis and per-model child pages                                     |
-| **[web](docs/services/web/features.md)**                                                   | Real-time dashboard with code streaming, integrations, and share menu                                  |
-| **[vm-lifecycle](docs/services/vm-lifecycle/features.md)**                                 | Weekday auto-start/stop for coding worker machines                                                     |
-| **[api-docs-hub](docs/services/api-docs-hub/features.md)**                                 | Unified interactive API reference for all backend services                                             |
+| Service                                                                                    | What it does                                                                                            |
+| ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------- |
+| **[intex-agent](docs/services/intex-agent/features.md)**                                   | WhatsApp text runtime with direct tools for notes, calendar, research, bookmarks, and code tasks.       |
+| **[code-agent](docs/services/code-agent/features.md)**                                     | Autonomous code planning, execution dispatch, GitHub feedback loops, cost controls, and task lifecycle. |
+| **[orchestrator](docs/services/orchestrator/features.md)**                                 | Local isolated coding sessions, worker supervision, completion verification, and status callbacks.      |
+| **[research-agent](docs/services/research-agent/features.md)**                             | Multi-model research with draft review, parallel provider calls, synthesis, and share/export flows.     |
+| **[fishing-assistant-service](docs/services/fishing-assistant-service/features.md)**       | User-scoped RAG with citations over fishing knowledge, digests, and recent message evidence.            |
+| **[hellscript-agent](docs/services/hellscript-agent/features.md)**                         | Writing assistant with stateful buffers, personal samples, style config, and versioned drafts.          |
+| **[calendar-agent](docs/services/calendar-agent/features.md)**                             | Calendar event extraction, Google Calendar creation, preview, and failed-event recovery.                |
+| **[linear-agent](docs/services/linear-agent/features.md)**                                 | Linear sync, issue extraction, assignment-triggered code tasks, and AI-assisted pruning.                |
+| **[bookmarks-agent](docs/services/bookmarks-agent/features.md)**                           | Bookmark CRUD, OpenGraph enrichment, AI summaries, duplicate handling, and WhatsApp delivery.           |
+| **[notes-agent](docs/services/notes-agent/features.md)**                                   | User-scoped notes with tags, source tracking, and direct-tool creation.                                 |
+| **[web-agent](docs/services/web-agent/features.md)**                                       | Link preview and page-summary extraction for research and bookmark workflows.                           |
+| **[mobile-notifications-service](docs/services/mobile-notifications-service/features.md)** | Android notification capture and WhatsApp group digest generation.                                      |
+| **[llm-usage-service](docs/services/llm-usage-service/features.md)**                       | Usage events, provider pricing, prompt-type attribution, and cost visibility.                           |
+| **[image-service](docs/services/image-service/features.md)**                               | Research cover image prompt generation, image creation, storage, and thumbnails.                        |
+| **[notion-service](docs/services/notion-service/features.md)**                             | Notion connection and research export support.                                                          |
+| **[whatsapp-service](docs/services/whatsapp-service/features.md)**                         | WhatsApp verification, inbound text ingestion, outbound notifications, and delivery events.             |
+| **[web](docs/services/web/features.md)**                                                   | Dashboard, PWA shell, live code logs, integrations, research, tasks, and settings.                      |
 
 </details>
 
@@ -471,16 +324,16 @@ Full setup: **[Development Setup Guide](docs/setup/05-local-dev-with-gcp-deps.md
 
 IntexuraOS is designed for individual power users who want depth in one workflow over breadth across many.
 
-- **WhatsApp-only mobile** — No SMS, email, or native push. WhatsApp's 24-hour messaging policy means you send the next message to reopen the window.
-- **Google Calendar only** — Primary, secondary, and shared calendars. Outlook and Apple Calendar are not connected.
-- **Linear for project tracking** — Jira, Asana, and other trackers are not connected.
-- **Android for notification capture** — iOS is not supported.
-- **English and Polish natively** — Other languages may work through pattern matching but are not explicitly tested.
-- **Designed for individual use** — No shared workspaces or team collaboration features.
-- **No recurring events or tasks** — Calendar events and todos are single instances. Recurring patterns are not yet built.
-- **Two worker machines** — You can configure a primary and a fallback coding worker, but not a larger pool.
-- **API keys configured manually** — Connecting AI providers requires generating and pasting keys yourself. The system validates every key before accepting it, but there is no one-click sign-in for most providers.
-- **Design review before code execution** — Code tasks pause between design and implementation for your approval. This is a deliberate quality gate, not an optimization to be removed.
+- **WhatsApp-only mobile**: no SMS, email, or native push channel.
+- **Google Calendar only**: Outlook and Apple Calendar are not connected.
+- **Linear for project tracking**: Jira, Asana, and other trackers are not connected.
+- **Android for notification capture**: iOS notification forwarding is not supported.
+- **English and Polish natively**: other languages may work, but are not explicitly tested.
+- **Designed for individual use**: no shared workspaces or team collaboration features.
+- **No recurring events or tasks**: calendar events and todos are single instances.
+- **Two worker machines**: one primary and one fallback coding worker.
+- **Manual API keys**: provider keys are generated by the user and validated before storage.
+- **Design review before code execution**: a deliberate quality gate, not an optimization to remove.
 
 </details>
 
@@ -488,12 +341,10 @@ IntexuraOS is designed for individual power users who want depth in one workflow
 
 ## About
 
-IntexuraOS is what happens when a single engineer builds agents that work for him — then builds agents that build agents. The system that verifies code was not written by the system that wrote it.
+IntexuraOS is both a working product and an engineering artifact: a distributed system, a personal automation layer, and a production showcase of how to place LLM agents inside typed, testable, inspectable software.
 
-**Built by [Piotr Buchman](https://www.linkedin.com/in/piotrbuchman/).**
-
----
+Built by [Piotr Buchman](https://www.linkedin.com/in/piotrbuchman/).
 
 <div align="center">
-  <sub>App services, workers, packages, AI models, hooks, CI scripts, 100% branch coverage. One developer.</sub>
+  <sub>Personal agentic OS. Specialist agents. Local code execution. Multi-model research. One developer.</sub>
 </div>

--- a/apps/web/src/components/home/AboutSection.tsx
+++ b/apps/web/src/components/home/AboutSection.tsx
@@ -14,10 +14,14 @@ export function AboutSection(): React.JSX.Element {
           </span>
         </h2>
         <p className="mx-auto mb-8 max-w-2xl text-lg leading-relaxed text-neutral-400">
-          IntexuraOS is what happens when a single engineer refuses to accept that one person can&apos;t
-          build and maintain a 24-service distributed system (plus 22 shared packages) with enterprise-grade reliability.
-          The answer isn&apos;t working harder. It&apos;s building agents that work for you — then building
-          agents that build agents.
+          IntexuraOS is what happens when one engineer treats agents as infrastructure, not demos.
+          It is a working personal product and an engineering artifact at the same time: distributed
+          system, agent platform, execution harness, and portfolio proof in one codebase.
+        </p>
+        <p className="mx-auto mb-8 max-w-2xl text-base leading-relaxed text-neutral-500">
+          The point is not that one person did everything manually. The point is that the system
+          captures intent, routes it to safe specialist agents, verifies the result, and leaves a trail
+          that another engineer can inspect.
         </p>
         <div className="flex flex-wrap items-center justify-center gap-4">
           <a

--- a/apps/web/src/components/home/AgentPatternsSection.tsx
+++ b/apps/web/src/components/home/AgentPatternsSection.tsx
@@ -1,0 +1,128 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import {
+  BookOpenCheck,
+  Brain,
+  CalendarCheck,
+  Code2,
+  FileText,
+  MessageSquare,
+  Network,
+  ShieldCheck,
+} from 'lucide-react';
+
+interface AgentPattern {
+  title: string;
+  service: string;
+  proof: string;
+  icon: React.ElementType;
+  accent: string;
+}
+
+const patterns: AgentPattern[] = [
+  {
+    title: 'Direct-tool action agent',
+    service: 'intex-agent',
+    proof: 'Tool-gated WhatsApp routing exposes one supported action at a time.',
+    icon: MessageSquare,
+    accent: 'bg-cyan-50 text-cyan-700',
+  },
+  {
+    title: 'Multi-model research council',
+    service: 'research-agent',
+    proof: 'Parallel providers synthesize with attribution and disagreement tracking.',
+    icon: Brain,
+    accent: 'bg-blue-50 text-blue-700',
+  },
+  {
+    title: 'Citation-validated RAG',
+    service: 'fishing-assistant-service',
+    proof: 'Knowledge, digests, and raw messages become cited answers with repair.',
+    icon: BookOpenCheck,
+    accent: 'bg-emerald-50 text-emerald-700',
+  },
+  {
+    title: 'Stateful writing agent',
+    service: 'hellscript-agent',
+    proof: 'Utterances become durable buffer events before drafts are generated.',
+    icon: FileText,
+    accent: 'bg-violet-50 text-violet-700',
+  },
+  {
+    title: 'Extraction-to-action agents',
+    service: 'calendar-agent / linear-agent',
+    proof: 'Natural language becomes validated external side effects or reviewable failures.',
+    icon: CalendarCheck,
+    accent: 'bg-amber-50 text-amber-700',
+  },
+  {
+    title: 'Autonomous code execution',
+    service: 'code-agent + orchestrator',
+    proof: 'Local isolated workers plan, execute, verify, retry, and deliver PRs.',
+    icon: Code2,
+    accent: 'bg-slate-100 text-slate-700',
+  },
+];
+
+export function AgentPatternsSection(): React.JSX.Element {
+  return (
+    <section className="bg-white px-6 py-24">
+      <div className="mx-auto max-w-7xl">
+        <div className="mb-16 max-w-3xl">
+          <p className="mb-4 text-sm font-semibold uppercase tracking-wider text-cyan-600">
+            Agentic Patterns In Production
+          </p>
+          <h2 className="mb-6 text-4xl font-bold tracking-tight text-neutral-900 md:text-5xl">
+            Not one assistant.{' '}
+            <span className="bg-gradient-to-r from-cyan-600 to-blue-600 bg-clip-text text-transparent">
+              A system of safe specialists.
+            </span>
+          </h2>
+          <p className="text-lg leading-relaxed text-neutral-600">
+            Each agent has a bounded job, typed interfaces, and explicit failure paths. The model
+            brings judgment; the software decides what it may touch.
+          </p>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {patterns.map((pattern) => {
+            const Icon = pattern.icon;
+            return (
+              <motion.div
+                key={pattern.title}
+                whileHover={{ y: -5 }}
+                initial={{ opacity: 0, y: 20 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                viewport={{ once: true }}
+                className="rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm transition-all hover:shadow-md"
+              >
+                <div className="mb-4 flex items-center justify-between gap-3">
+                  <div className={`inline-flex h-11 w-11 items-center justify-center rounded-xl ${pattern.accent}`}>
+                    <Icon className="h-5 w-5" />
+                  </div>
+                  <div className="inline-flex items-center gap-1 rounded-full border border-neutral-200 px-2 py-1 text-[11px] font-semibold text-neutral-500">
+                    <ShieldCheck className="h-3 w-3 text-emerald-500" />
+                    bounded
+                  </div>
+                </div>
+                <h3 className="mb-1 text-lg font-bold text-neutral-900">{pattern.title}</h3>
+                <p className="mb-3 font-mono text-xs font-semibold text-cyan-700">{pattern.service}</p>
+                <p className="text-sm leading-relaxed text-neutral-600">{pattern.proof}</p>
+              </motion.div>
+            );
+          })}
+        </div>
+
+        <div className="mt-10 flex items-start gap-4 rounded-2xl border border-neutral-200 bg-neutral-50 p-6">
+          <div className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-white text-cyan-700 shadow-sm">
+            <Network className="h-5 w-5" />
+          </div>
+          <p className="text-sm leading-relaxed text-neutral-600">
+            The value is the placement: LLMs operate inside service ownership, prompt versioning,
+            usage attribution, schema validation, and recoverable workflows.
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/home/CouncilSection.tsx
+++ b/apps/web/src/components/home/CouncilSection.tsx
@@ -4,7 +4,7 @@ import { Brain, Eye, Layers, Zap } from 'lucide-react';
 
 export function CouncilSection(): React.JSX.Element {
   const providers = [
-    { name: 'ANTHROPIC', models: '3 models: reasoning, coding, speed', role: 'Analysis, validation, autonomous coding', icon: Brain },
+    { name: 'ANTHROPIC', models: '4 models: reasoning, coding, speed', role: 'Analysis, validation, autonomous coding', icon: Brain },
     { name: 'OPENAI', models: '4 models: research, reasoning, images', role: 'Deep research, synthesis, embeddings', icon: Zap },
     { name: 'GOOGLE', models: '4 models: analysis, classification, images', role: 'Classification, routing, image gen', icon: Layers },
     { name: 'PERPLEXITY', models: '3 models: search, synthesis, deep dive', role: 'Real-time web search, citations', icon: Eye },
@@ -18,15 +18,15 @@ export function CouncilSection(): React.JSX.Element {
             The Council of AI
           </p>
           <h2 className="mb-6 max-w-3xl text-4xl font-bold tracking-tight md:text-5xl">
-            Four models debate.{' '}
+            A multi-model research council.{' '}
             <span className="bg-gradient-to-r from-cyan-400 to-blue-400 bg-clip-text text-transparent">
-              You get the truth.
+              With attribution.
             </span>
           </h2>
           <p className="max-w-2xl text-lg leading-relaxed text-neutral-400">
-            Single-model assistants hallucinate. Even Perplexity queries one model at a time. IntexuraOS
-            queries five and surfaces where they disagree. When three agree and two dissent, that
-            disagreement is surfaced — not hidden. Every claim traces back to which model said it and why.
+            The research-agent can run a multi-model research council across 15 configured models.
+            It surfaces agreement, disagreement, citations, and model attribution instead of flattening
+            every response into one opaque answer.
           </p>
         </div>
 
@@ -50,7 +50,8 @@ export function CouncilSection(): React.JSX.Element {
         <div className="mt-12 border-t border-neutral-800 pt-8">
           <p className="text-sm text-neutral-500">
             Specify models in natural language: &quot;Research AI trends with Claude and GPT&quot; — or let
-            the system choose. Every LLM call is tracked: model, tokens, cost. Full transparency.
+            the system choose. Every LLM call is tracked by model, tokens, and cost so the result can
+            be inspected after synthesis.
           </p>
         </div>
       </div>

--- a/apps/web/src/components/home/EngineeringSection.tsx
+++ b/apps/web/src/components/home/EngineeringSection.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Bot, GitBranch, Layers, Shield, Terminal } from 'lucide-react';
+import { Bot, FileCode, GitBranch, Layers, Shield, Terminal } from 'lucide-react';
 import { ModernCard } from './ModernCard.js';
 
 export function EngineeringSection(): React.JSX.Element {
@@ -55,7 +55,7 @@ export function EngineeringSection(): React.JSX.Element {
               details, and each service in control of its data instead of sharing hidden state.
             </p>
           </ModernCard>
-          <ModernCard title="Prompt Versioning" icon={Layers}>
+          <ModernCard title="Prompt Versioning" icon={FileCode}>
             <p className="text-neutral-600">
               Agent prompt versioning makes behavior reviewable. System prompts, repair prompts, and
               execution lessons evolve as code artifacts rather than invisible runtime folklore.

--- a/apps/web/src/components/home/EngineeringSection.tsx
+++ b/apps/web/src/components/home/EngineeringSection.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ArrowRight, Bot, Layers, Shield, Terminal } from 'lucide-react';
+import { Bot, GitBranch, Layers, Shield, Terminal } from 'lucide-react';
 import { ModernCard } from './ModernCard.js';
 
 export function EngineeringSection(): React.JSX.Element {
@@ -23,18 +23,19 @@ export function EngineeringSection(): React.JSX.Element {
             The compiler and the test suite are both gates that must pass before code ships.
           </p>
           <p className="text-sm leading-relaxed text-neutral-500">
-            This section is for developers evaluating the engineering standards behind the platform.
+            This section is for developers evaluating the engineering standards behind the platform:
+            prompt versioning, service ownership, Terraform, typed results, and cross-LLM verification.
           </p>
         </div>
 
         <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-          <ModernCard title="Every Path Tested" icon={Shield}>
+          <ModernCard title="Coverage Gate" icon={Shield}>
             <p className="text-neutral-600">
-              100% branch coverage. CI fails on any unaccounted branch. Every exemption requires a category
-              and justification. The test suite is the specification — if it passes, it works.
+              Branch coverage is enforced in CI. Every exemption requires a category and justification,
+              turning the test suite into executable documentation instead of a vanity metric.
             </p>
           </ModernCard>
-          <ModernCard title="The Compiler Is a Gate" icon={Layers}>
+          <ModernCard title="Strict TypeScript" icon={Layers}>
             <p className="text-neutral-600">
               Strict TypeScript catches what tests might miss:{' '}
               <code className="rounded bg-neutral-100 px-1 text-xs">noUncheckedIndexedAccess</code>,{' '}
@@ -42,36 +43,34 @@ export function EngineeringSection(): React.JSX.Element {
               <code className="rounded bg-neutral-100 px-1 text-xs">strictBooleanExpressions</code>.
             </p>
           </ModernCard>
-          <ModernCard title="Swap Any Part" icon={Layers}>
+          <ModernCard title="Typed Results" icon={Bot}>
             <p className="text-neutral-600">
-              Hexagonal architecture: domain logic is pure — no database imports, no HTTP frameworks.
-              Firestore, WhatsApp, GitHub are just adapters. Swap any without touching business rules.
+              Domain operations return explicit success or typed failure. Agents and adapters cannot hide
+              uncertainty behind exceptions, undefined values, or unstructured model text.
             </p>
           </ModernCard>
-          <ModernCard title="Extreme Ownership" icon={Shield}>
-            <p className="mb-3 text-neutral-600">
-              Based on Jocko Willink&apos;s principles. CI failure = your problem. No &quot;other services
-              failed&quot; rationalizations. Discovery creates ownership.
-            </p>
-            <a
-              href="https://github.com/pbuchman/intexuraos/blob/main/docs/philosophy/extreme-ownership.md"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex items-center gap-2 text-sm font-semibold text-cyan-600 transition-colors hover:text-cyan-700"
-            >
-              Read Philosophy <ArrowRight className="h-3.5 w-3.5" />
-            </a>
-          </ModernCard>
-          <ModernCard title="AI-Native Development" icon={Bot}>
+          <ModernCard title="Service Ownership" icon={GitBranch}>
             <p className="text-neutral-600">
-              AI isn&apos;t a feature — it&apos;s a team member. Custom skills for Linear issues, Sentry triage,
-              documentation generation. Cross-linking between all artifacts is automatic.
+              Explicit service ownership keeps domain logic pure, adapters responsible for integration
+              details, and each service in control of its data instead of sharing hidden state.
+            </p>
+          </ModernCard>
+          <ModernCard title="Prompt Versioning" icon={Layers}>
+            <p className="text-neutral-600">
+              Agent prompt versioning makes behavior reviewable. System prompts, repair prompts, and
+              execution lessons evolve as code artifacts rather than invisible runtime folklore.
             </p>
           </ModernCard>
           <ModernCard title="Infrastructure as Code" icon={Terminal}>
             <p className="text-neutral-600">
               Everything in Terraform. Cloud Run, Cloud Functions, Pub/Sub, IAM — reproducible, auditable,
               version-controlled. No manual console clicks.
+            </p>
+          </ModernCard>
+          <ModernCard title="Cross-LLM Verification" icon={Bot}>
+            <p className="text-neutral-600">
+              A cross-LLM verification pass is used where judgment matters: independent model checks review
+              plans, research synthesis, and code-task outcomes before work is presented as complete.
             </p>
           </ModernCard>
         </div>

--- a/apps/web/src/components/home/HeroSection.tsx
+++ b/apps/web/src/components/home/HeroSection.tsx
@@ -51,7 +51,7 @@ export function HeroSection(): React.JSX.Element {
 
           <p className="mx-auto mb-4 max-w-xl text-lg leading-relaxed text-neutral-600">
             You remember the bug while walking to lunch. You think of a research question on the commute home.
-            You are not at a keyboard.
+            You need a system that can safely act before the moment disappears.
           </p>
 
           <h1 className="mx-auto mb-8 max-w-4xl text-5xl font-extrabold tracking-tight text-neutral-900 md:text-7xl lg:text-[5.5rem] lg:leading-[1]">
@@ -64,14 +64,13 @@ export function HeroSection(): React.JSX.Element {
           </h1>
 
           <p className="mx-auto mb-4 max-w-2xl text-lg leading-relaxed text-neutral-600 md:text-xl">
-            Send a WhatsApp text message while walking. Come back to a calendar event created,
-            research synthesized from five AI models, code written and tested, project
-            task tracked. This is not a convenience shortcut to a desktop workflow.
-            It is a fundamentally different interaction model.
+            IntexuraOS is a personal agentic operating system made of specialist agents.
+            Send a WhatsApp text message or dashboard task and come back to a calendar event,
+            cited research report, summarized bookmark, writing draft, or tested pull request.
           </p>
 
           <p className="mx-auto mb-10 max-w-2xl text-lg font-semibold leading-relaxed text-neutral-500">
-            Chat gives you an answer. IntexuraOS gives you a calendar event, a pull request, or a research report.
+            The AI brings judgment; deterministic software boundaries decide what it may touch.
           </p>
 
           <div className="flex flex-col items-center justify-center gap-4 sm:flex-row">

--- a/apps/web/src/components/home/HeroShowcase.tsx
+++ b/apps/web/src/components/home/HeroShowcase.tsx
@@ -3,7 +3,6 @@ import {
   Bookmark,
   Calendar,
   Check,
-  CheckSquare,
   ChevronDown,
   ChevronUp,
   Code2,
@@ -154,7 +153,7 @@ export function HeroShowcase(): React.JSX.Element {
               <span className="text-[10px] font-black text-white">I</span>
             </div>
             <span className="text-[11px] font-bold text-slate-900">IntexuraOS</span>
-            <span className="text-[8px] text-slate-400">ver. 3.3.0</span>
+            <span className="text-[8px] text-slate-400">ver. 3.7.0</span>
           </div>
           <div className="flex items-center gap-1.5">
             <div className="flex items-center gap-1">
@@ -192,7 +191,7 @@ export function HeroShowcase(): React.JSX.Element {
             <div className="h-1" />
             <SbItem icon={BellRing} label="Mobile" chevron="down" />
             <SbItem icon={StickyNote} label="Notes" />
-            <SbItem icon={CheckSquare} label="Checklists" />
+            <SbItem icon={Sparkles} label="Fishing" />
             <div className="h-1" />
             <SbItem icon={Settings} label="Settings" chevron="down" />
           </div>
@@ -202,8 +201,8 @@ export function HeroShowcase(): React.JSX.Element {
             {/* Page header */}
             <div className="mb-2 flex items-center justify-between">
               <div>
-                <div className="text-sm font-bold text-slate-900">Code Tasks</div>
-                <div className="text-[8px] text-slate-400">4 issues · 1 needs attention · 0 failed</div>
+                <div className="text-sm font-bold text-slate-900">Agent Activity</div>
+                <div className="text-[8px] text-slate-400">4 workflows · 3 verified outputs · 0 failed</div>
               </div>
               <div className="flex items-center gap-1 rounded-md bg-blue-500 px-2 py-0.5 text-[9px] font-semibold text-white">
                 <Plus className="h-2.5 w-2.5" /> New Task
@@ -213,11 +212,10 @@ export function HeroShowcase(): React.JSX.Element {
             {/* Filter pills */}
             <div className="mb-2 flex gap-1">
               {[
-                { label: 'Active', count: '2', color: 'bg-blue-500', active: true },
-                { label: 'Needs Action', count: '1', color: 'bg-green-500' },
-                { label: 'Done', count: '47', color: 'bg-emerald-500' },
-                { label: 'Failed', count: '0', color: 'bg-red-500' },
-                { label: 'Archived', count: '12', color: 'bg-slate-400' },
+                { label: 'Tools', count: '5', color: 'bg-cyan-500', active: true },
+                { label: 'Research', count: '2', color: 'bg-blue-500' },
+                { label: 'Code', count: '1', color: 'bg-violet-500' },
+                { label: 'Digest', count: '1', color: 'bg-emerald-500' },
               ].map((p, idx) => (
                 <div key={idx} className={`flex items-center gap-1 rounded-full border px-1.5 py-0.5 text-[8px] font-semibold ${p.active === true ? 'border-blue-500 bg-blue-50 text-blue-700' : 'border-slate-200 text-slate-500'}`}>
                   <span className={`h-1.5 w-1.5 rounded-full ${p.color}`} />
@@ -228,7 +226,7 @@ export function HeroShowcase(): React.JSX.Element {
 
             {/* Column headers */}
             <div className="mb-1 grid grid-cols-[1fr_1fr_80px_70px_20px] gap-1 px-2 text-[7px] font-semibold uppercase tracking-wider text-slate-400">
-              <span>Issue</span><span>Pipeline</span><span>Time</span><span className="text-right">Output</span><span />
+              <span>Work item</span><span>Pipeline</span><span>Time</span><span className="text-right">Output</span><span />
             </div>
 
             {/* Task rows */}
@@ -242,26 +240,26 @@ export function HeroShowcase(): React.JSX.Element {
                 output={<span className="inline-flex rounded-full border border-blue-200 bg-blue-50 p-1"><Loader2 className="h-2.5 w-2.5 animate-spin text-blue-500" /></span>}
               />
               <TaskRow
-                issueId="INT-936"
-                title="Remove legacy CodeTaskViewPage"
-                pipeline={<><Dot state="done" /><PipeConn /><Dot state="done" /><PipeConn /><Dot state="done" /><span className="ml-0.5 text-slate-500">#1260</span></>}
-                time={<><span className="text-slate-500">Created</span> 2h ago<br /><span className="text-slate-500">Started</span> 2h ago</>}
-                output={<span className="inline-flex items-center gap-0.5 rounded-full border border-blue-200 bg-blue-50 px-1.5 py-0.5 text-[8px] font-semibold text-blue-600"><ExternalLink className="h-2 w-2" />#1260</span>}
+                issueId="RES-42"
+                title="Research draft ready: battery supply chain"
+                pipeline={<><Dot state="done" /><span className="ml-0.5 text-slate-500">Draft</span><PipeConn /><Dot state="done" /><span className="ml-0.5 text-slate-500">Council</span><PipeConn /><Dot state="done" /></>}
+                time={<><span className="text-slate-500">Created</span> 18m ago<br /><span className="text-slate-500">Models</span> 5 providers</>}
+                output={<span className="inline-flex items-center gap-0.5 rounded-full border border-cyan-200 bg-cyan-50 px-1.5 py-0.5 text-[8px] font-semibold text-cyan-700"><ExternalLink className="h-2 w-2" />Report</span>}
               />
               <TaskRow
-                issueId="INT-935"
-                title="Streamline mobile chat bottom sheet"
+                issueId="CAL"
+                title="Calendar event created: dentist Friday 9:00"
                 accent="green"
-                pipeline={<><Dot state="done" /><span className="ml-0.5 text-slate-500">Plan</span><PipeConn /><Dot state="action" /><span className="ml-0.5 text-green-600">Implement</span></>}
-                time={<><span className="text-slate-500">Created</span> 5h ago<br /><span className="text-slate-500">Started</span> Pending</>}
-                output={<span className="inline-flex items-center gap-0.5 rounded bg-green-600 px-1.5 py-0.5 text-[8px] font-semibold text-white"><Play className="h-2 w-2 fill-white" />Implement</span>}
+                pipeline={<><Dot state="done" /><span className="ml-0.5 text-slate-500">Extract</span><PipeConn /><Dot state="done" /><span className="ml-0.5 text-slate-500">Create</span></>}
+                time={<><span className="text-slate-500">Created</span> 31m ago<br /><span className="text-slate-500">Calendar</span> Primary</>}
+                output={<span className="inline-flex items-center gap-0.5 rounded bg-green-600 px-1.5 py-0.5 text-[8px] font-semibold text-white"><Check className="h-2 w-2" />Done</span>}
               />
               <TaskRow
-                issueId="INT-934"
-                title="Add horizontal scrolling for mobile logs"
-                pipeline={<><Dot state="done" /><PipeConn /><Dot state="done" /><PipeConn /><Dot state="done" /><span className="ml-0.5 text-slate-500">#1258</span></>}
-                time={<><span className="text-slate-500">Created</span> 1d ago<br /><span className="text-slate-500">Started</span> 1d ago</>}
-                output={<span className="inline-flex items-center gap-0.5 rounded-full border border-blue-200 bg-blue-50 px-1.5 py-0.5 text-[8px] font-semibold text-blue-600"><ExternalLink className="h-2 w-2" />#1258</span>}
+                issueId="LINK"
+                title="Bookmark summarized: TypeScript 5 migration"
+                pipeline={<><Dot state="done" /><span className="ml-0.5 text-slate-500">Fetch</span><PipeConn /><Dot state="done" /><span className="ml-0.5 text-slate-500">Summarize</span></>}
+                time={<><span className="text-slate-500">Created</span> 1h ago<br /><span className="text-slate-500">Source</span> Web</>}
+                output={<span className="inline-flex items-center gap-0.5 rounded-full border border-blue-200 bg-blue-50 px-1.5 py-0.5 text-[8px] font-semibold text-blue-600"><Bookmark className="h-2 w-2" />Saved</span>}
               />
             </div>
           </div>
@@ -300,29 +298,29 @@ export function HeroShowcase(): React.JSX.Element {
         <div className="flex min-h-[300px] flex-col gap-1 bg-[#ece5dd] p-1.5">
           {/* Text request */}
           <WaUser>
-            Resolve merge conflicts on PR 1237
+            Research battery supply chain and save this link
             <WaTime>9:41 AM ✓✓</WaTime>
           </WaUser>
 
-          {/* Code task created */}
+          {/* Research created */}
           <WaBot>
-            <span className="text-[8px]"><strong>INT-937</strong> | Code task created</span><br />
-            <span className="text-[8px] text-neutral-500">Planning complete. Execution started on the selected worker.</span>
+            <span className="text-[8px]"><strong>RES-42</strong> | Research draft ready</span><br />
+            <span className="text-[8px] text-neutral-500">5 providers selected. Synthesis will preserve attribution.</span>
             <WaTime align="left">9:41 AM</WaTime>
           </WaBot>
 
-          {/* Progress */}
+          {/* Bookmark */}
           <WaBot>
-            <span className="text-[8px]"><strong>INT-937</strong> | Running tests</span><br />
-            <span className="text-[8px] text-neutral-500">3 conflicted files fixed in auth and routing modules.</span>
+            <span className="text-[8px]"><strong>LINK</strong> | Bookmark summarized</span><br />
+            <span className="text-[8px] text-neutral-500">Metadata extracted and AI summary saved.</span>
             <WaTime align="left">9:43 AM</WaTime>
           </WaBot>
 
           {/* Completion */}
           <WaBot>
-            <div className="text-[9px] font-bold text-emerald-800">INT-937 | Merge conflicts resolved</div>
-            <div className="text-[8px] text-neutral-500">2 commits · fix/conflicts-pr-1237</div>
-            <WaBtn>View Pull Request</WaBtn>
+            <div className="text-[9px] font-bold text-emerald-800">RES-42 | Research report ready</div>
+            <div className="text-[8px] text-neutral-500">Agreement map · source reports · citations</div>
+            <WaBtn>View Research</WaBtn>
             <WaTime align="left">9:47 AM</WaTime>
           </WaBot>
         </div>

--- a/apps/web/src/components/home/SelfBuildingSection.tsx
+++ b/apps/web/src/components/home/SelfBuildingSection.tsx
@@ -31,9 +31,9 @@ export function SelfBuildingSection(): React.JSX.Element {
           <p className="mb-6 text-lg leading-relaxed text-neutral-600">
             Most AI coding tools wait for you to sit at a keyboard. IntexuraOS doesn&apos;t. You describe
             what needs to change — while walking, while commuting, wherever the idea hits.
-            The platform designs the approach, writes the code in a sealed container on your
-            machine, runs the full test suite, creates a code change for review, and updates the
-            project issue. If verification fails, it retries with preserved context.
+            The platform designs the approach, writes the code in an isolated container on your
+            worker machine, runs the full test suite, creates a code change for review, and updates the
+            project issue. A separate independent verification pass decides whether the attempt is complete.
           </p>
           <p className="text-sm leading-relaxed text-neutral-500">
             24 services communicate over authenticated HTTP. No shared databases. Each service owns its data.
@@ -53,8 +53,8 @@ export function SelfBuildingSection(): React.JSX.Element {
             </div>
             <h3 className="mb-2 text-lg font-bold text-neutral-900">Your Code Never Leaves Your Network</h3>
             <p className="text-neutral-600">
-              Cursor and Copilot send your code to the cloud. IntexuraOS runs on your machine, inside
-              isolated containers, powered by your own AI subscription. Your source code stays where it belongs.
+              The orchestrator runs on a worker you control. Each task receives its own checkout,
+              credentials, and container, powered by your configured coding runtime.
             </p>
           </motion.div>
           <motion.div
@@ -93,7 +93,7 @@ export function SelfBuildingSection(): React.JSX.Element {
           <PipelineStep
             number="Verify"
             title="Check"
-            description="An independent verifier checks the work against completion criteria: correct files modified, tests passing, code change created. If not, the system resumes automatically."
+            description="A separate independent verification step checks the work against completion criteria: correct files modified, tests passing, code change created. If not, the system resumes automatically."
             icon={CheckCircle2}
             accent="bg-green-100 text-green-700"
           />

--- a/apps/web/src/components/home/StatsSection.tsx
+++ b/apps/web/src/components/home/StatsSection.tsx
@@ -12,7 +12,7 @@ export function StatsSection(): React.JSX.Element {
           <StatBlock value="24" label="Services" />
           <StatBlock value="5" label="Direct Tools" />
           <StatBlock value="5" label="AI Providers" />
-          <StatBlock value="16" label="AI Models" />
+          <StatBlock value="15" label="AI Models" />
           <StatBlock value="1" label="Developer" />
         </div>
       </div>

--- a/apps/web/src/components/home/VoiceSection.tsx
+++ b/apps/web/src/components/home/VoiceSection.tsx
@@ -9,9 +9,9 @@ import {
 
 export function VoiceSection(): React.JSX.Element {
   const actions = [
-    { input: 'Fix the Safari login redirect', output: 'Code change created, tests passing, project tracker updated', icon: Code2, tag: 'CODE' },
-    { input: 'Research quantum computing breakthroughs', output: '5-model synthesis with citations and disagreement analysis', icon: Brain, tag: 'RESEARCH' },
-    { input: 'Schedule sync with engineering Tuesday 2pm', output: 'Calendar event drafted with the right title, time, and guests', icon: Layers, tag: 'CALENDAR' },
+    { input: 'Fix the Safari login redirect', output: 'Code task starts in planning mode for design review', icon: Code2, tag: 'CODE' },
+    { input: 'Research quantum computing breakthroughs', output: 'Multi-model synthesis with citations and disagreement analysis', icon: Brain, tag: 'RESEARCH' },
+    { input: 'Schedule sync with engineering Tuesday 2pm', output: 'Calendar event created when title, date, and time are clear', icon: Layers, tag: 'CALENDAR' },
     { input: 'Save this link about TypeScript 5.0', output: 'AI summary generated, metadata extracted, bookmarked', icon: MessageSquare, tag: 'LINK' },
     { input: 'Interesting thought about microservice boundaries', output: 'Note created with tags, searchable later', icon: MessageSquare, tag: 'NOTE' },
   ];
@@ -21,21 +21,21 @@ export function VoiceSection(): React.JSX.Element {
       <div className="mx-auto max-w-7xl">
         <div className="mb-16 max-w-2xl">
           <p className="mb-4 text-sm font-semibold uppercase tracking-wider text-cyan-600">
-            Text-First Intelligence
+            Direct-Tool Intelligence
           </p>
           <h2 className="mb-6 text-4xl font-bold tracking-tight text-neutral-900 md:text-5xl">
-            Type.{' '}
+            Text in.{' '}
             <span className="bg-gradient-to-r from-cyan-600 to-blue-600 bg-clip-text text-transparent">
-              It understands.
+              Safe action out.
             </span>
           </h2>
           <p className="mb-6 text-lg leading-relaxed text-neutral-600">
-            Five tool types. One interface. Send a WhatsApp text message.
-            The system figures out what you meant — even when the wording is imprecise — and
-            routes it to the right specialist. Polish and English supported.
+            Five tool types. One mobile interface. Send a WhatsApp text message and Intex
+            exposes only the supported action that fits: note, event, research draft, bookmark,
+            or code task. Polish and English are first-class paths.
           </p>
           <p className="text-sm leading-relaxed text-neutral-500">
-            This is not one AI that tries to do everything. It is 24 services, each built for a single domain.
+            Unsupported requests get a clear response instead of being forced through a generic workflow.
           </p>
         </div>
 
@@ -78,7 +78,8 @@ export function VoiceSection(): React.JSX.Element {
             <div>
               <p className="text-sm font-semibold text-cyan-700">Fishing Assistant</p>
               <p className="mt-1 text-sm text-neutral-600">
-                Plan sessions, inspect digests, and keep chat history grounded in the fishing knowledge base with source citations.
+                Ask questions against saved knowledge, digest summaries, and recent message context.
+                Answers are grounded in retrieved evidence and validated citations.
               </p>
             </div>
           </div>

--- a/apps/web/src/components/home/__tests__/HomeMessaging.test.ts
+++ b/apps/web/src/components/home/__tests__/HomeMessaging.test.ts
@@ -1,0 +1,56 @@
+/**
+ * @vitest-environment node
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+function readHomeFile(relativePath: string): string {
+  return readFileSync(resolve(__dirname, '..', relativePath), 'utf-8');
+}
+
+describe('homepage showcase messaging', () => {
+  it('positions IntexuraOS as a personal agentic operating system', () => {
+    const hero = readHomeFile('HeroSection.tsx');
+
+    expect(hero).toContain('personal agentic operating system');
+    expect(hero).toContain('specialist agents');
+    expect(hero).toContain('deterministic software boundaries');
+  });
+
+  it('keeps the hero product mock current and representative', () => {
+    const showcase = readHomeFile('HeroShowcase.tsx');
+
+    expect(showcase).toContain('ver. 3.7.0');
+    expect(showcase).toContain('Research draft ready');
+    expect(showcase).toContain('Calendar event created');
+    expect(showcase).toContain('Bookmark summarized');
+    expect(showcase).not.toContain('ver. 3.3.0');
+    expect(showcase).not.toContain('Checklists');
+  });
+
+  it('adds an agentic patterns section to the homepage flow', () => {
+    const sectionPath = resolve(__dirname, '..', 'AgentPatternsSection.tsx');
+    const homePage = readFileSync(resolve(__dirname, '../../../pages/HomePage.tsx'), 'utf-8');
+
+    expect(existsSync(sectionPath)).toBe(true);
+    expect(homePage).toContain('AgentPatternsSection');
+  });
+
+  it('uses precise claims for code execution, research, and engineering proof', () => {
+    const selfBuilding = readHomeFile('SelfBuildingSection.tsx');
+    const council = readHomeFile('CouncilSection.tsx');
+    const engineering = readHomeFile('EngineeringSection.tsx');
+
+    expect(selfBuilding).toContain('independent verification');
+    expect(selfBuilding).not.toContain('Cursor and Copilot send your code to the cloud');
+
+    expect(council).toContain('multi-model research council');
+    expect(council).not.toContain('You get the truth');
+
+    expect(engineering).toContain('prompt versioning');
+    expect(engineering).toContain('service ownership');
+    expect(engineering).toContain('cross-LLM verification');
+  });
+});

--- a/apps/web/src/components/home/__tests__/HomeMessaging.test.ts
+++ b/apps/web/src/components/home/__tests__/HomeMessaging.test.ts
@@ -32,16 +32,29 @@ describe('homepage showcase messaging', () => {
 
   it('adds an agentic patterns section to the homepage flow', () => {
     const sectionPath = resolve(__dirname, '..', 'AgentPatternsSection.tsx');
+    const section = readFileSync(sectionPath, 'utf-8');
     const homePage = readFileSync(resolve(__dirname, '../../../pages/HomePage.tsx'), 'utf-8');
 
     expect(existsSync(sectionPath)).toBe(true);
     expect(homePage).toContain('AgentPatternsSection');
+    expect(section).toContain('Direct-tool action agent');
+    expect(section).toContain('Citation-validated RAG');
+    expect(section).toContain('Autonomous code execution');
+    expect(section).toContain('safe specialists');
+    expect(section).toContain('Agentic Patterns In Production');
   });
 
   it('uses precise claims for code execution, research, and engineering proof', () => {
+    const voice = readHomeFile('VoiceSection.tsx');
     const selfBuilding = readHomeFile('SelfBuildingSection.tsx');
     const council = readHomeFile('CouncilSection.tsx');
     const engineering = readHomeFile('EngineeringSection.tsx');
+    const about = readHomeFile('AboutSection.tsx');
+
+    expect(voice).toContain('Direct-Tool Intelligence');
+    expect(voice).toContain('Safe action out');
+    expect(voice).toContain('Unsupported requests get a clear response');
+    expect(voice).not.toContain('Text-First Intelligence');
 
     expect(selfBuilding).toContain('independent verification');
     expect(selfBuilding).not.toContain('Cursor and Copilot send your code to the cloud');
@@ -52,5 +65,9 @@ describe('homepage showcase messaging', () => {
     expect(engineering).toContain('prompt versioning');
     expect(engineering).toContain('service ownership');
     expect(engineering).toContain('cross-LLM verification');
+
+    expect(about).toContain('agents as infrastructure, not demos');
+    expect(about).toContain('safe specialist agents');
+    expect(about).not.toContain('refuses to accept');
   });
 });

--- a/apps/web/src/pages/HomePage.tsx
+++ b/apps/web/src/pages/HomePage.tsx
@@ -3,6 +3,7 @@ import { Navbar } from '@/components/home/Navbar.js';
 import { HeroSection } from '@/components/home/HeroSection.js';
 import { StatsSection } from '@/components/home/StatsSection.js';
 import { VoiceSection } from '@/components/home/VoiceSection.js';
+import { AgentPatternsSection } from '@/components/home/AgentPatternsSection.js';
 import { SelfBuildingSection } from '@/components/home/SelfBuildingSection.js';
 import { CouncilSection } from '@/components/home/CouncilSection.js';
 import { IntegrationsSection } from '@/components/home/IntegrationsSection.js';
@@ -20,6 +21,7 @@ export function HomePage(): React.JSX.Element {
       <HeroSection />
       <StatsSection />
       <VoiceSection />
+      <AgentPatternsSection />
       <SelfBuildingSection />
       <CouncilSection />
       <IntegrationsSection />


### PR DESCRIPTION
## Summary

- Reframe README around IntexuraOS as a personal agentic operating system with safe specialist agents
- Refresh homepage hero, showcase, direct-tool section, self-building, council, engineering, and about copy
- Add an agentic-patterns homepage section and source-level messaging guards

## Verification

- `pnpm run ci:tracked`

## Linear

Linear: omitted by `$commit-push`; GitHub automation will create or link the Linear issue after PR creation.
