### PR TITLE
[INT-1713] fix: stop request-shape errors from becoming Sentry issues

### DIFF
--- a/packages/infra-sentry/src/__tests__/fastify.test.ts
+++ b/packages/infra-sentry/src/__tests__/fastify.test.ts
@@ -161,7 +161,7 @@ describe('setupSentryErrorHandler', () => {
     });
 
     expect(response.statusCode).toBe(400);
-    expect(Sentry.captureException).toHaveBeenCalled();
+    expect(Sentry.captureException).not.toHaveBeenCalled();
   });
 
   it('handles FST_ERR_CTP_EMPTY_JSON_BODY error', async () => {
@@ -181,7 +181,36 @@ describe('setupSentryErrorHandler', () => {
     });
 
     expect(response.statusCode).toBe(400);
-    expect(Sentry.captureException).toHaveBeenCalled();
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+  });
+
+  it('handles unsupported media type errors without capturing to Sentry', async () => {
+    setupSentryErrorHandler(app);
+
+    app.post(
+      '/test',
+      {
+        schema: {
+          body: {
+            type: 'object',
+            properties: {
+              value: { type: 'string' },
+            },
+          },
+        },
+      },
+      async () => ({ ok: true })
+    );
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/test',
+      headers: { 'content-type': 'application/octet-stream' },
+      payload: '{}',
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(Sentry.captureException).not.toHaveBeenCalled();
   });
 
   it('handles validation error with non-array validation property', async () => {
@@ -238,7 +267,7 @@ describe('setupSentryErrorHandler', () => {
     });
 
     expect(response.statusCode).toBe(400);
-    expect(Sentry.captureException).toHaveBeenCalled();
+    expect(Sentry.captureException).not.toHaveBeenCalled();
   });
 
   it('handles validation error with undefined message', async () => {
@@ -258,7 +287,7 @@ describe('setupSentryErrorHandler', () => {
     });
 
     expect(response.statusCode).toBe(400);
-    expect(Sentry.captureException).toHaveBeenCalled();
+    expect(Sentry.captureException).not.toHaveBeenCalled();
   });
 
   it('handles validation error with empty instancePath triggering required property regex', async () => {
@@ -278,7 +307,7 @@ describe('setupSentryErrorHandler', () => {
     });
 
     expect(response.statusCode).toBe(400);
-    expect(Sentry.captureException).toHaveBeenCalled();
+    expect(Sentry.captureException).not.toHaveBeenCalled();
   });
 
   it('handles validation error with empty instancePath and undefined message', async () => {
@@ -298,7 +327,7 @@ describe('setupSentryErrorHandler', () => {
     });
 
     expect(response.statusCode).toBe(400);
-    expect(Sentry.captureException).toHaveBeenCalled();
+    expect(Sentry.captureException).not.toHaveBeenCalled();
   });
 
   it('handles validation error with both instancePath and message undefined', async () => {
@@ -318,7 +347,7 @@ describe('setupSentryErrorHandler', () => {
     });
 
     expect(response.statusCode).toBe(400);
-    expect(Sentry.captureException).toHaveBeenCalled();
+    expect(Sentry.captureException).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/infra-sentry/src/fastify.ts
+++ b/packages/infra-sentry/src/fastify.ts
@@ -48,35 +48,22 @@ export function setupSentryErrorHandler(app: FastifyInstance): void {
       return;
     }
 
-    // Log to Pino FIRST - this is our reliable error log
-    request.log.error({ err: error }, 'Unhandled error');
-
-    // Try to send to Sentry, but don't let it break error handling
-    try {
-      Sentry.withScope((scope) => {
-        scope.setTag('url', request.url);
-        scope.setTag('method', request.method);
-        scope.setContext('request', {
-          url: request.url,
-          method: request.method,
-          headers: sanitizeHeaders(request.headers),
-        });
-        Sentry.captureException(error);
-      });
-    } catch (sentryError) {
-      // Log that Sentry failed but don't crash the error handler
-      request.log.warn({ err: sentryError }, 'Failed to send error to Sentry');
-    }
-
-    // Handle Fastify-specific errors
-    // Defense-in-depth: the custom JSON parser in intexuraFastifyPlugin handles empty bodies,
-    // but if the parser is not registered, this catches the error as a 400 instead of 500.
+    // Fastify request parsing and schema validation errors are client/input
+    // failures. Return a structured 4xx without promoting them to Sentry issues.
     if (
       fastifyError.code === 'FST_ERR_CTP_INVALID_JSON_BODY' ||
       fastifyError.code === 'FST_ERR_CTP_EMPTY_JSON_BODY'
     ) {
+      request.log.info({ err: error }, 'Invalid JSON request body');
       reply.status(400);
       await fastifyReply.fail('INVALID_REQUEST', 'Invalid JSON body');
+      return;
+    }
+
+    if (fastifyError.code === 'FST_ERR_CTP_INVALID_MEDIA_TYPE') {
+      request.log.info({ err: error }, 'Unsupported request media type');
+      reply.status(400);
+      await fastifyReply.fail('INVALID_REQUEST', error.message);
       return;
     }
 
@@ -102,10 +89,31 @@ export function setupSentryErrorHandler(app: FastifyInstance): void {
           };
         });
 
+        request.log.info({ err: error }, 'Request validation failed');
         reply.status(400);
         await fastifyReply.fail('INVALID_REQUEST', 'Validation failed', undefined, { errors });
         return;
       }
+    }
+
+    // Log to Pino FIRST - this is our reliable error log
+    request.log.error({ err: error }, 'Unhandled error');
+
+    // Try to send to Sentry, but don't let it break error handling
+    try {
+      Sentry.withScope((scope) => {
+        scope.setTag('url', request.url);
+        scope.setTag('method', request.method);
+        scope.setContext('request', {
+          url: request.url,
+          method: request.method,
+          headers: sanitizeHeaders(request.headers),
+        });
+        Sentry.captureException(error);
+      });
+    } catch (sentryError) {
+      // Log that Sentry failed but don't crash the error handler
+      request.log.warn({ err: sentryError }, 'Failed to send error to Sentry');
     }
 
     // Return error response

--- a/scripts/__tests__/hetzner-runtime.test.ts
+++ b/scripts/__tests__/hetzner-runtime.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
@@ -675,6 +676,15 @@ describe('Hetzner async edge cutover', () => {
     expect(script).toContain('PUBLIC_ORIGIN must be exactly https://intexuraos.cloud');
     expect(script).toContain('gcloud pubsub subscriptions update');
     expect(script).toContain('gcloud scheduler jobs update http');
+    expect(script).toContain('--update-headers=Content-Type=application/json');
+    expect(script).toContain('args+=(--message-body="${message_body}")');
+    const cutoverDryRun = execFileSync('bash', [cutoverEdgePath], { encoding: 'utf8' });
+    expect(cutoverDryRun).toContain(
+      'intexuraos-code-tasks-zombie-sweep-dev --project=intexuraos-dev-pbuchman'
+    );
+    expect(cutoverDryRun).toContain(
+      '--update-headers=Content-Type=application/json --message-body=\\{\\}'
+    );
     expect(script).toContain('--push-auth-token-audience="${PUBLIC_ORIGIN}"');
     expect(script).toContain('--oidc-token-audience="${PUBLIC_ORIGIN}"');
     expect(script).toContain('/internal/linear/sync-all');

--- a/scripts/hetzner/cutover-gcp-edge.sh
+++ b/scripts/hetzner/cutover-gcp-edge.sh
@@ -24,18 +24,18 @@ PUBSUB_ROUTES=(
 )
 
 SCHEDULER_ROUTES=(
-  "mobile-notifications-digest-yesterday|/internal/notifications/digest/run-yesterday"
-  "intexuraos-linear-sync-hourly|/internal/linear/sync-all"
-  "intexuraos-linear-issues-prune-hourly|/internal/linear/prune-issues"
-  "intexuraos-drain-task-queue|/internal/drain-queue"
-  "intexuraos-merge-conflict-reconcile|/internal/merge-conflicts/reconcile"
-  "intexuraos-merge-queue-tick|/internal/merge-queue/tick"
-  "intexuraos-code-tasks-zombie-sweep|/internal/code/detect-zombies"
-  "intexuraos-archive-stale-groups|/internal/archive-stale-groups"
-  "intexuraos-auto-archive-merged-tasks|/internal/auto-archive-merged-tasks"
-  "intexuraos-execution-memory-process|/internal/execution-memory/process"
-  "intexuraos-execution-memory-sweep-errored|/internal/execution-memory/sweep-errored"
-  "intexuraos-execution-memory-prune-stale|/internal/execution-memory/prune-stale"
+  "mobile-notifications-digest-yesterday|/internal/notifications/digest/run-yesterday|"
+  "intexuraos-linear-sync-hourly|/internal/linear/sync-all|"
+  "intexuraos-linear-issues-prune-hourly|/internal/linear/prune-issues|"
+  "intexuraos-drain-task-queue|/internal/drain-queue|"
+  "intexuraos-merge-conflict-reconcile|/internal/merge-conflicts/reconcile|"
+  "intexuraos-merge-queue-tick|/internal/merge-queue/tick|"
+  "intexuraos-code-tasks-zombie-sweep|/internal/code/detect-zombies|{}"
+  "intexuraos-archive-stale-groups|/internal/archive-stale-groups|"
+  "intexuraos-auto-archive-merged-tasks|/internal/auto-archive-merged-tasks|"
+  "intexuraos-execution-memory-process|/internal/execution-memory/process|"
+  "intexuraos-execution-memory-sweep-errored|/internal/execution-memory/sweep-errored|"
+  "intexuraos-execution-memory-prune-stale|/internal/execution-memory/prune-stale|{\"maxAgeDays\":30}"
 )
 
 usage() {
@@ -123,17 +123,27 @@ cutover_scheduler() {
   local route=""
   local job_stem=""
   local path=""
+  local message_body=""
   local job_name=""
 
   for route in "${SCHEDULER_ROUTES[@]}"; do
-    IFS='|' read -r job_stem path <<< "${route}"
+    IFS='|' read -r job_stem path message_body <<< "${route}"
     job_name="${job_stem}-${ENVIRONMENT}"
-    run_or_print gcloud scheduler jobs update http "${job_name}" \
-      --project="${PROJECT_ID}" \
-      --location="${REGION}" \
-      --uri="${PUBLIC_ORIGIN}${path}" \
-      --oidc-service-account-email="${SCHEDULER_SERVICE_ACCOUNT_EMAIL}" \
+    local args=(
+      gcloud scheduler jobs update http "${job_name}"
+      --project="${PROJECT_ID}"
+      --location="${REGION}"
+      --uri="${PUBLIC_ORIGIN}${path}"
+      --oidc-service-account-email="${SCHEDULER_SERVICE_ACCOUNT_EMAIL}"
       --oidc-token-audience="${PUBLIC_ORIGIN}"
+    )
+
+    if [[ -n "${message_body}" ]]; then
+      args+=(--update-headers=Content-Type=application/json)
+      args+=(--message-body="${message_body}")
+    fi
+
+    run_or_print "${args[@]}"
   done
 }
 


### PR DESCRIPTION
Summary:
- classify Fastify JSON parser, unsupported media type, and schema validation failures as structured 400 responses before Sentry capture
- add regressions proving malformed request bodies and octet-stream posts are not captured as Sentry exceptions
- update Hetzner GCP edge scheduler cutover so jobs with request bodies keep JSON content-type/message-body config
- corrected the live prod zombie sweep scheduler job to Content-Type: application/json with body {}

Evidence:
- Sentry /internal/logs showed Fastify schema validation error "body must be object" from client input, but the old handler captured it before checking validation
- Sentry /internal/code/detect-zombies showed Fastify unsupported media type for application/octet-stream; live Cloud Scheduler job had prod URI but stale/local GCP scheduler config sending octet-stream

Verification:
- pnpm exec vitest run packages/infra-sentry/src/__tests__/fastify.test.ts scripts/__tests__/hetzner-runtime.test.ts
- pnpm run ci:tracked

Linear: omitted by $commit-push; GitHub automation will create or link the Linear issue after PR creation.