### PR TITLE
[INT-1714] feat: add Intex external save

### DIFF
--- a/apps/intex-agent/src/__tests__/domain/handleIncomingMessage.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/handleIncomingMessage.test.ts
@@ -190,6 +190,41 @@ describe('handleIncomingMessage', () => {
     expect(call.events.some((event) => event.payload['messageId'] === 'wamid-current')).toBe(false);
   });
 
+  it('passes source URLs to the runner without storing the full URL in session events', async () => {
+    const repo = new FakeSessionRepository();
+    const runner = new FakeRunner([
+      {
+        outcome: 'completed',
+        reply: 'Saved externally',
+        toolName: 'save_external',
+        toolResult: { status: 'completed', message: 'Saved externally' },
+      },
+    ]);
+    const replies = new FakeReplyPublisher();
+
+    await handleIncomingMessage(
+      message({
+        messageId: 'wamid-image',
+        text: '',
+        sourceType: 'whatsapp_image',
+        sourceUrl: 'https://storage.example.com/signed/whatsapp/user-1/wamid-image/media.jpg',
+      }),
+      deps(repo, runner, replies)
+    );
+
+    expect(eventPayloads(repo, 'user_message')[0]).toEqual({
+      messageId: 'wamid-image',
+      text: '',
+      sourceType: 'whatsapp_image',
+      hasSourceUrl: true,
+    });
+    expect(runner.calls[0]).toMatchObject({
+      message: '',
+      sourceType: 'whatsapp_image',
+      sourceUrl: 'https://storage.example.com/signed/whatsapp/user-1/wamid-image/media.jpg',
+    });
+  });
+
   it('keeps greeting sessions open without publishing lifecycle text', async () => {
     const repo = new FakeSessionRepository();
     const runner = new FakeRunner([
@@ -769,6 +804,8 @@ class FakeRunner implements IntexAgentRunner {
     events: IntexAgentSessionEvent[];
     message: string;
     replyContext?: IntexIncomingMessage['replyContext'];
+    sourceType?: string;
+    sourceUrl?: string;
     currentDateTime: string;
   }[] = [];
 
@@ -779,6 +816,8 @@ class FakeRunner implements IntexAgentRunner {
     events: IntexAgentSessionEvent[];
     message: string;
     replyContext?: IntexIncomingMessage['replyContext'];
+    sourceType?: string;
+    sourceUrl?: string;
     currentDateTime: string;
   }): Promise<IntexAgentRunnerResult> {
     this.calls.push(input);

--- a/apps/intex-agent/src/__tests__/domain/intentGate.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/intentGate.test.ts
@@ -23,6 +23,12 @@ describe('classifyIntexAgentIntent', () => {
     ['Dodaj zakladke https://example.com', ['create_link']],
     ['Create code task to implement explicit intent gating', ['create_code_task']],
     ['Stworz zadanie programistyczne dla intent gating', ['create_code_task']],
+    ['Save externally https://example.com/article', ['save_external']],
+    ['Upload externally this note from LinkedIn', ['save_external']],
+    ['Save for processing this copied conversation detail', ['save_external']],
+    ['Zapisz zewnętrznie ten paragon', ['save_external']],
+    ['Prześlij zewnętrznie https://example.com/post', ['save_external']],
+    ['Zapisz do przetworzenia: ważna informacja z LinkedIn', ['save_external']],
   ] as const)('allows explicit creation intent: %s', (text, expectedToolNames) => {
     expect(classifyIntexAgentIntent(text)).toEqual({
       kind: 'tool',

--- a/apps/intex-agent/src/__tests__/domain/intexAgentRunner.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/intexAgentRunner.test.ts
@@ -314,6 +314,48 @@ describe('createIntexAgentRunner', () => {
     expect(client.calls[0]?.tools.map((tool) => tool.name)).toEqual(['create_link']);
   });
 
+  it('exposes only the external save tool for English external-save text intent', async () => {
+    const client = new FakeToolCallingClient([
+      ok(
+        toolResult({
+          outcome: 'no_action',
+          reply: 'Ready to save externally.',
+        })
+      ),
+    ]);
+    const runner = createIntexAgentRunner({ client, toolExecutor: fakeToolExecutor() });
+
+    await runner.run({
+      session: session(),
+      events: [],
+      message: 'Save externally this copied LinkedIn detail',
+      currentDateTime: CURRENT_DATE_TIME,
+    });
+
+    expect(client.calls[0]?.tools.map((tool) => tool.name)).toEqual(['save_external']);
+  });
+
+  it('exposes only the external save tool for Polish external-save link intent', async () => {
+    const client = new FakeToolCallingClient([
+      ok(
+        toolResult({
+          outcome: 'no_action',
+          reply: 'Ready to save externally.',
+        })
+      ),
+    ]);
+    const runner = createIntexAgentRunner({ client, toolExecutor: fakeToolExecutor() });
+
+    await runner.run({
+      session: session(),
+      events: [],
+      message: 'Zapisz do przetworzenia https://example.com/post',
+      currentDateTime: CURRENT_DATE_TIME,
+    });
+
+    expect(client.calls[0]?.tools.map((tool) => tool.name)).toEqual(['save_external']);
+  });
+
   it('exposes only the calendar query tool for read-only calendar questions', async () => {
     const client = new FakeToolCallingClient([
       ok(
@@ -1060,6 +1102,23 @@ describe('createIntexAgentRunner', () => {
       expectedReply: 'Zapisałem link: mailto:person@example.com',
       expectedCtaUrl: undefined,
     },
+    {
+      toolName: 'save_external' as const,
+      message: 'Save externally https://example.com/post',
+      args: {
+        message: 'Save externally https://example.com/post',
+        sourceUrl: 'https://example.com/post',
+      },
+      executorOverride: {
+        saveExternal: async (): Promise<string> =>
+          JSON.stringify({
+            status: 'completed',
+            message: 'Saved externally',
+          }),
+      },
+      expectedReply: 'Saved externally',
+      expectedCtaUrl: undefined,
+    },
   ])('builds deterministic confirmations from %s tool results', async (testCase) => {
     const client = new ToolExecutingFakeToolCallingClient({
       toolName: testCase.toolName,
@@ -1095,6 +1154,96 @@ describe('createIntexAgentRunner', () => {
       throw new Error(`Expected completed outcome, received ${result.outcome}`);
     }
     expect(result.ctaUrl).toEqual(testCase.expectedCtaUrl);
+  });
+
+  it('automatically saves WhatsApp images externally without calling the LLM', async () => {
+    const client = new FakeToolCallingClient([]);
+    const saveCalls: { message: string; sourceUrl?: string }[] = [];
+    const runner = createIntexAgentRunner({
+      client,
+      toolExecutor: fakeToolExecutor({
+        saveExternal: async (args): Promise<string> => {
+          saveCalls.push(args);
+          return JSON.stringify({ status: 'completed', message: 'Saved externally' });
+        },
+      }),
+    });
+
+    const result = await runner.run({
+      session: session(),
+      events: [],
+      message: 'Lunch receipt',
+      sourceType: 'whatsapp_image',
+      sourceUrl: 'https://storage.example.com/signed/receipt.jpg',
+      currentDateTime: CURRENT_DATE_TIME,
+    });
+
+    expect(client.calls).toEqual([]);
+    expect(saveCalls).toEqual([
+      {
+        message: 'Lunch receipt',
+        sourceUrl: 'https://storage.example.com/signed/receipt.jpg',
+      },
+    ]);
+    expect(result).toEqual({
+      outcome: 'completed',
+      reply: 'Saved externally',
+      toolName: 'save_external',
+      toolResult: { status: 'completed', message: 'Saved externally' },
+    });
+  });
+
+  it('uses a neutral fallback message for captionless WhatsApp images', async () => {
+    const saveCalls: { message: string; sourceUrl?: string }[] = [];
+    const runner = createIntexAgentRunner({
+      client: new FakeToolCallingClient([]),
+      toolExecutor: fakeToolExecutor({
+        saveExternal: async (args): Promise<string> => {
+          saveCalls.push(args);
+          return JSON.stringify({ status: 'completed', message: 'Saved externally' });
+        },
+      }),
+    });
+
+    await runner.run({
+      session: session(),
+      events: [],
+      message: '   ',
+      sourceType: 'whatsapp_image',
+      sourceUrl: 'https://storage.example.com/signed/no-caption.jpg',
+      currentDateTime: CURRENT_DATE_TIME,
+    });
+
+    expect(saveCalls).toEqual([
+      {
+        message: 'Image shared via WhatsApp.',
+        sourceUrl: 'https://storage.example.com/signed/no-caption.jpg',
+      },
+    ]);
+  });
+
+  it('uses a fallback reply when WhatsApp image external save returns no JSON message payload', async () => {
+    const runner = createIntexAgentRunner({
+      client: new FakeToolCallingClient([]),
+      toolExecutor: fakeToolExecutor({
+        saveExternal: async (): Promise<string> => 'external-save-1',
+      }),
+    });
+
+    await expect(
+      runner.run({
+        session: session(),
+        events: [],
+        message: 'Lunch receipt',
+        sourceType: 'whatsapp_image',
+        sourceUrl: 'https://storage.example.com/signed/receipt.jpg',
+        currentDateTime: CURRENT_DATE_TIME,
+      })
+    ).resolves.toEqual({
+      outcome: 'completed',
+      reply: 'Saved externally',
+      toolName: 'save_external',
+    });
   });
 
   it('rejects completed responses when no tool actually ran and no supported toolName is present', async () => {
@@ -1295,6 +1444,7 @@ function fakeToolExecutor(overrides: Partial<IntexAgentToolExecutor> = {}): Inte
     createResearch: async () => 'research-1',
     createLink: async () => 'bookmark-1',
     createCodeTask: async () => 'code-task-1',
+    saveExternal: async () => 'external-save-1',
     ...overrides,
   };
 }

--- a/apps/intex-agent/src/__tests__/domain/toolDefinitions.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/toolDefinitions.test.ts
@@ -15,6 +15,7 @@ describe('createIntexAgentToolDefinitions', () => {
       'create_research',
       'create_link',
       'create_code_task',
+      'save_external',
     ]);
   });
 
@@ -121,6 +122,20 @@ describe('createIntexAgentToolDefinitions', () => {
           /only when explicitly requested.*Codex.*codex.*Codex extra high.*codex-xhigh.*MiniMax.*minimax/
         ),
       },
+    });
+  });
+
+  it('describes external save forwarding without inspecting URLs', () => {
+    const externalSaveTool = createIntexAgentToolDefinitions(createExecutor()).find(
+      (tool) => tool.name === 'save_external'
+    );
+
+    expect(externalSaveTool?.description).toContain('external');
+    expect(externalSaveTool?.description).toContain('Do not fetch');
+    expect(externalSaveTool?.parameters['required']).toEqual(['message']);
+    expect(externalSaveTool?.parameters['properties']).toMatchObject({
+      message: { type: 'string' },
+      sourceUrl: { type: 'string' },
     });
   });
 
@@ -418,6 +433,44 @@ describe('createIntexAgentToolDefinitions', () => {
     expect(executor.codeTaskArgs).toEqual([{ prompt: 'Plan the new import flow.' }]);
   });
 
+  it('delegates external save execution to the injected executor', async () => {
+    const executor = createExecutor();
+    const externalSaveTool = createIntexAgentToolDefinitions(executor).find(
+      (tool) => tool.name === 'save_external'
+    );
+
+    await expect(
+      externalSaveTool?.run({
+        message: 'Save externally this LinkedIn note',
+        sourceUrl: 'https://example.com/post',
+      })
+    ).resolves.toBe('external-saved');
+    expect(executor.externalSaveArgs).toEqual([
+      {
+        message: 'Save externally this LinkedIn note',
+        sourceUrl: 'https://example.com/post',
+      },
+    ]);
+  });
+
+  it('delegates external save execution without optional source URL', async () => {
+    const executor = createExecutor();
+    const externalSaveTool = createIntexAgentToolDefinitions(executor).find(
+      (tool) => tool.name === 'save_external'
+    );
+
+    await expect(
+      externalSaveTool?.run({
+        message: 'Save externally this copied note',
+      })
+    ).resolves.toBe('external-saved');
+    expect(executor.externalSaveArgs).toEqual([
+      {
+        message: 'Save externally this copied note',
+      },
+    ]);
+  });
+
   it('rejects invalid required and optional tool arguments', async () => {
     const [noteTool, calendarTool] = createIntexAgentToolDefinitions(createExecutor());
     const codeTaskTool = createIntexAgentToolDefinitions(createExecutor()).find(
@@ -441,6 +494,16 @@ describe('createIntexAgentToolDefinitions', () => {
     await expect(
       codeTaskTool?.run({ prompt: 'Implement this', taskMode: 'fast' })
     ).rejects.toThrow('Tool argument taskMode must be one of: planning, execution');
+    await expect(
+      createIntexAgentToolDefinitions(createExecutor())
+        .find((tool) => tool.name === 'save_external')
+        ?.run({ message: 123 })
+    ).rejects.toThrow('Tool argument message must be a string');
+    await expect(
+      createIntexAgentToolDefinitions(createExecutor())
+        .find((tool) => tool.name === 'save_external')
+        ?.run({ message: 'ok', sourceUrl: 123 })
+    ).rejects.toThrow('Tool argument sourceUrl must be a string');
     await expect(
       createIntexAgentToolDefinitions(createExecutor())
         .find((tool) => tool.name === 'query_calendar_events')
@@ -525,6 +588,7 @@ function createExecutor(): IntexAgentToolExecutor & {
   researchArgs: unknown[];
   linkArgs: unknown[];
   codeTaskArgs: unknown[];
+  externalSaveArgs: unknown[];
 } {
   return {
     noteArgs: [],
@@ -533,6 +597,7 @@ function createExecutor(): IntexAgentToolExecutor & {
     researchArgs: [],
     linkArgs: [],
     codeTaskArgs: [],
+    externalSaveArgs: [],
     createNote(args): Promise<string> {
       this.noteArgs.push(args);
       return Promise.resolve('note-created');
@@ -556,6 +621,10 @@ function createExecutor(): IntexAgentToolExecutor & {
     createCodeTask(args): Promise<string> {
       this.codeTaskArgs.push(args);
       return Promise.resolve('code-task-created');
+    },
+    saveExternal(args): Promise<string> {
+      this.externalSaveArgs.push(args);
+      return Promise.resolve('external-saved');
     },
   };
 }

--- a/apps/intex-agent/src/__tests__/domain/toolExecutor.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/toolExecutor.test.ts
@@ -14,6 +14,7 @@ import type {
   CalendarToolClient,
   CodeTaskToolClient,
   CreateIntexAgentToolExecutorDeps,
+  ExternalSaveToolClient,
   NotesToolClient,
   ResearchToolClient,
 } from '../../domain/agent/toolExecutor.js';
@@ -643,6 +644,71 @@ describe('createIntexAgentToolExecutor', () => {
     ).rejects.toThrow('Failed to create code task: Worker is not configured');
   });
 
+  it('saves external content through the configured external save client', async () => {
+    const externalSaveClient = new FakeExternalSaveClient();
+    const executor = createIntexAgentToolExecutor(createExecutorDeps({
+      externalSaveClient,
+    }));
+
+    const result = await executor.saveExternal({
+      message: 'Save externally this LinkedIn note',
+      sourceUrl: 'https://example.com/post',
+    });
+
+    expect(externalSaveClient.calls).toEqual([
+      {
+        message: 'Save externally this LinkedIn note',
+        sourceUrl: 'https://example.com/post',
+      },
+    ]);
+    expect(JSON.parse(result)).toEqual({
+      status: 'completed',
+      message: 'Saved externally',
+    });
+  });
+
+  it('saves external content without a source URL when only text is provided', async () => {
+    const externalSaveClient = new FakeExternalSaveClient();
+    const executor = createIntexAgentToolExecutor(createExecutorDeps({
+      externalSaveClient,
+    }));
+
+    await executor.saveExternal({
+      message: 'Upload externally the onboarding detail',
+    });
+
+    expect(externalSaveClient.calls).toEqual([
+      {
+        message: 'Upload externally the onboarding detail',
+      },
+    ]);
+  });
+
+  it('throws when external save is not configured', async () => {
+    const executor = createIntexAgentToolExecutor(createExecutorDeps({
+      externalSaveClient: null,
+    }));
+
+    await expect(
+      executor.saveExternal({ message: 'Save externally this note' })
+    ).rejects.toThrow('External save is not configured');
+  });
+
+  it('throws when the external save client fails', async () => {
+    const externalSaveClient = new FakeExternalSaveClient();
+    externalSaveClient.result = err({
+      code: 'HTTP_ERROR',
+      message: 'HTTP 403: Forbidden',
+    });
+    const executor = createIntexAgentToolExecutor(createExecutorDeps({
+      externalSaveClient,
+    }));
+
+    await expect(
+      executor.saveExternal({ message: 'Save externally this note' })
+    ).rejects.toThrow('Failed to save externally: HTTP 403: Forbidden');
+  });
+
   it('throws when an internal tool client returns a failure', async () => {
     const notesClient = new FakeNotesClient();
     notesClient.result = err(new Error('notes-agent unavailable'));
@@ -667,6 +733,7 @@ function createExecutorDeps(
     researchClient: new FakeResearchClient(),
     bookmarksClient: new FakeBookmarksClient(),
     codeClient: new FakeCodeTaskClient(),
+    externalSaveClient: new FakeExternalSaveClient(),
     ...overrides,
   };
 }
@@ -761,6 +828,19 @@ class FakeCalendarClient implements CalendarToolClient {
   listEvents(input: ListCalendarEventsRequest): Promise<Result<CalendarQueryEvent[]>> {
     this.listCalls.push(input);
     return Promise.resolve(this.listResult);
+  }
+}
+
+class FakeExternalSaveClient implements ExternalSaveToolClient {
+  readonly calls: Parameters<ExternalSaveToolClient['save']>[0][] = [];
+  result: Result<{ status: 'completed'; message: string }, { code: string; message: string }> = ok({
+    status: 'completed',
+    message: 'Saved externally',
+  });
+
+  save(input: Parameters<ExternalSaveToolClient['save']>[0]): Promise<Result<{ status: 'completed'; message: string }, { code: string; message: string }>> {
+    this.calls.push(input);
+    return Promise.resolve(this.result);
   }
 }
 

--- a/apps/intex-agent/src/__tests__/infra/firestore/preferencesRepository.test.ts
+++ b/apps/intex-agent/src/__tests__/infra/firestore/preferencesRepository.test.ts
@@ -26,6 +26,31 @@ describe('FirestorePreferencesRepository', () => {
     expect(fetched).toEqual(saved);
   });
 
+  it('persists and retrieves external save configuration', async () => {
+    const firestore = createFakeFirestore() as unknown as Firestore;
+    const repo = new FirestorePreferencesRepository({ firestore });
+
+    const saved = await repo.savePreferences('user-1', {
+      instructions: '',
+      externalSave: {
+        enabled: true,
+        endpointUrl: 'https://external-save.example.com/intex',
+        cfAccessClientId: 'cf-client-id',
+        cfAccessClientSecret: 'cf-client-secret',
+        source: 'ios-shortcuts',
+      },
+    });
+
+    expect(saved.externalSave).toEqual({
+      enabled: true,
+      endpointUrl: 'https://external-save.example.com/intex',
+      cfAccessClientId: 'cf-client-id',
+      cfAccessClientSecret: 'cf-client-secret',
+      source: 'ios-shortcuts',
+    });
+    await expect(repo.getPreferences('user-1')).resolves.toEqual(saved);
+  });
+
   it('isolates preferences across users', async () => {
     const firestore = createFakeFirestore() as unknown as Firestore;
     const repo = new FirestorePreferencesRepository({ firestore });
@@ -50,6 +75,43 @@ describe('FirestorePreferencesRepository', () => {
 
     await expect(repo.getPreferences('user-1')).resolves.toMatchObject({
       instructions: 'second',
+    });
+  });
+
+  it('removes external save configuration when a later save omits it', async () => {
+    const firestore = createFakeFirestore() as unknown as Firestore;
+    const repo = new FirestorePreferencesRepository({ firestore });
+
+    await repo.savePreferences('user-1', {
+      instructions: 'first',
+      externalSave: {
+        enabled: true,
+        endpointUrl: 'https://external-save.example.com/intex',
+        cfAccessClientId: 'cf-client-id',
+        cfAccessClientSecret: 'cf-client-secret',
+        source: 'ios-shortcuts',
+      },
+    });
+    await repo.savePreferences('user-1', { instructions: 'second' });
+
+    const fetched = await repo.getPreferences('user-1');
+    expect(fetched?.externalSave).toBeUndefined();
+  });
+
+  it('ignores malformed stored external save configuration', async () => {
+    const firestore = createFakeFirestore() as unknown as Firestore;
+    const repo = new FirestorePreferencesRepository({ firestore });
+
+    await firestore.collection('intex_agent_user_preferences').doc('user-1').set({
+      instructions: 'existing',
+      externalSave: null,
+      updatedAt: '2026-06-27T10:00:00.000Z',
+    });
+
+    await expect(repo.getPreferences('user-1')).resolves.toEqual({
+      userId: 'user-1',
+      instructions: 'existing',
+      updatedAt: '2026-06-27T10:00:00.000Z',
     });
   });
 

--- a/apps/intex-agent/src/__tests__/infra/http/externalSaveClient.test.ts
+++ b/apps/intex-agent/src/__tests__/infra/http/externalSaveClient.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createExternalSaveClient } from '../../../infra/http/externalSaveClient.js';
+
+describe('createExternalSaveClient', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('posts external-save payloads with Cloudflare Access service auth headers', async () => {
+    const calls: { url: string; init: RequestInit }[] = [];
+    const fetchFn = async (url: string | URL | Request, init?: RequestInit): Promise<Response> => {
+      calls.push({ url: String(url), init: init ?? {} });
+      return new Response('accepted', { status: 201, statusText: 'Created' });
+    };
+    const client = createExternalSaveClient({
+      endpointUrl: 'https://external-save.example.com/intex',
+      cfAccessClientId: 'cf-client-id',
+      cfAccessClientSecret: 'cf-client-secret',
+      source: 'ios-shortcuts',
+      fetchFn: fetchFn as typeof fetch,
+    });
+
+    const result = await client.save({
+      message: 'Save externally this LinkedIn note',
+      sourceUrl: 'https://example.com/post',
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      value: { status: 'completed', message: 'Saved externally' },
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.url).toBe('https://external-save.example.com/intex');
+    expect(calls[0]?.init).toMatchObject({
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'CF-Access-Client-Id': 'cf-client-id',
+        'CF-Access-Client-Secret': 'cf-client-secret',
+      },
+    });
+    expect(JSON.parse(String(calls[0]?.init.body))).toEqual({
+      source: 'ios-shortcuts',
+      message: 'Save externally this LinkedIn note',
+      source_url: 'https://example.com/post',
+    });
+  });
+
+  it('omits source_url when no source URL is provided', async () => {
+    const calls: RequestInit[] = [];
+    const fetchFn = async (_url: string | URL | Request, init?: RequestInit): Promise<Response> => {
+      calls.push(init ?? {});
+      return new Response('', { status: 200, statusText: 'OK' });
+    };
+    const client = createExternalSaveClient({
+      endpointUrl: 'https://external-save.example.com/intex',
+      cfAccessClientId: 'cf-client-id',
+      cfAccessClientSecret: 'cf-client-secret',
+      source: 'ios-shortcuts',
+      fetchFn: fetchFn as typeof fetch,
+    });
+
+    await client.save({ message: 'Upload externally this note' });
+
+    expect(JSON.parse(String(calls[0]?.body))).toEqual({
+      source: 'ios-shortcuts',
+      message: 'Upload externally this note',
+    });
+  });
+
+  it('uses global fetch when a fetch function is not injected', async () => {
+    const calls: string[] = [];
+    vi.stubGlobal(
+      'fetch',
+      async (url: string | URL | Request): Promise<Response> => {
+        calls.push(String(url));
+        return new Response('', { status: 200, statusText: 'OK' });
+      }
+    );
+    const client = createExternalSaveClient({
+      endpointUrl: 'https://external-save.example.com/intex',
+      cfAccessClientId: 'cf-client-id',
+      cfAccessClientSecret: 'cf-client-secret',
+      source: 'ios-shortcuts',
+    });
+
+    await expect(client.save({ message: 'Save externally this note' })).resolves.toEqual({
+      ok: true,
+      value: { status: 'completed', message: 'Saved externally' },
+    });
+    expect(calls).toEqual(['https://external-save.example.com/intex']);
+  });
+
+  it('returns an error result for non-2xx responses', async () => {
+    const client = createExternalSaveClient({
+      endpointUrl: 'https://external-save.example.com/intex',
+      cfAccessClientId: 'cf-client-id',
+      cfAccessClientSecret: 'cf-client-secret',
+      source: 'ios-shortcuts',
+      fetchFn: (async () =>
+        new Response('forbidden', { status: 403, statusText: 'Forbidden' })) as typeof fetch,
+    });
+
+    const result = await client.save({ message: 'Save externally this note' });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toEqual({
+        code: 'HTTP_ERROR',
+        message: 'HTTP 403: Forbidden',
+      });
+    }
+  });
+
+  it('returns an error result when the request throws', async () => {
+    const client = createExternalSaveClient({
+      endpointUrl: 'https://external-save.example.com/intex',
+      cfAccessClientId: 'cf-client-id',
+      cfAccessClientSecret: 'cf-client-secret',
+      source: 'ios-shortcuts',
+      fetchFn: (async () => {
+        throw new Error('network down');
+      }) as typeof fetch,
+    });
+
+    const result = await client.save({ message: 'Save externally this note' });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toEqual({
+        code: 'NETWORK_ERROR',
+        message: 'network down',
+      });
+    }
+  });
+});

--- a/apps/intex-agent/src/__tests__/infra/pubsub/decoder.test.ts
+++ b/apps/intex-agent/src/__tests__/infra/pubsub/decoder.test.ts
@@ -29,6 +29,21 @@ describe('decodeIntexMessageIngestPush', () => {
     expect(decodeIntexMessageIngestPush(push(event))).toEqual(event);
   });
 
+  it('decodes optional source URLs for external-save image and link forwarding', () => {
+    const event = {
+      type: 'intex.message.ingest',
+      userId: 'user-1',
+      messageId: 'wamid-image',
+      text: 'Receipt from lunch',
+      sourceType: 'whatsapp_image',
+      sourceUrl: 'https://storage.example.com/signed/whatsapp/user-1/wamid-image/media.jpg',
+      whatsappSender: '+48123456789',
+      timestamp: '2026-06-24T10:00:00.000Z',
+    };
+
+    expect(decodeIntexMessageIngestPush(push(event))).toEqual(event);
+  });
+
   it('decodes optional replied-message context', () => {
     const event = {
       type: 'intex.message.ingest',
@@ -172,6 +187,19 @@ describe('decodeIntexMessageIngestPush', () => {
         })
       )
     ).toThrow('Invalid intex.message.ingest event: whatsappSender must be a string');
+    expect(() =>
+      decodeIntexMessageIngestPush(
+        push({
+          type: 'intex.message.ingest',
+          userId: 'user-1',
+          messageId: 'wamid-1',
+          text: 'image',
+          sourceType: 'whatsapp_image',
+          sourceUrl: 123,
+          timestamp: '2026-06-24T10:00:00.000Z',
+        })
+      )
+    ).toThrow('Invalid intex.message.ingest event: sourceUrl must be a string');
   });
 });
 

--- a/apps/intex-agent/src/__tests__/routes/preferencesRoutes.test.ts
+++ b/apps/intex-agent/src/__tests__/routes/preferencesRoutes.test.ts
@@ -5,7 +5,12 @@ import { buildServer } from '../../server.js';
 import { resetServices, setServices, type ServiceContainer } from '../../services.js';
 import type { PreferencesRepository } from '../../domain/ports/preferencesRepository.js';
 import { INTEX_AGENT_MODEL } from '../../domain/agent/systemPrompt.js';
-import type { IntexAgentPreferences } from '../../domain/preferences/types.js';
+import type {
+  ExternalSaveConnectionTestPort,
+  IntexAgentExternalSavePreferences,
+  IntexAgentPreferences,
+  IntexAgentPreferencesUpdate,
+} from '../../domain/preferences/types.js';
 
 vi.mock('@intexuraos/common-http', async () => {
   const actual = await vi.importActual('@intexuraos/common-http');
@@ -18,8 +23,11 @@ vi.mock('@intexuraos/common-http', async () => {
 const INTERNAL_AUTH_TOKEN = 'test-internal-auth-token';
 
 class FakePreferencesRepository implements PreferencesRepository {
-  storage = new Map<string, { instructions: string; updatedAt: string }>();
-  saveCalls: { userId: string; instructions: string }[] = [];
+  storage = new Map<
+    string,
+    { instructions: string; externalSave?: IntexAgentExternalSavePreferences; updatedAt: string }
+  >();
+  saveCalls: { userId: string; update: IntexAgentPreferencesUpdate }[] = [];
   deleteCalls: string[] = [];
 
   async getPreferences(userId: string): Promise<IntexAgentPreferences | null> {
@@ -29,18 +37,38 @@ class FakePreferencesRepository implements PreferencesRepository {
 
   async savePreferences(
     userId: string,
-    update: { instructions: string }
+    update: IntexAgentPreferencesUpdate
   ): Promise<IntexAgentPreferences> {
     const updatedAt = new Date().toISOString();
-    const doc = { instructions: update.instructions, updatedAt };
+    const doc = {
+      instructions: update.instructions,
+      ...(update.externalSave !== undefined ? { externalSave: update.externalSave } : {}),
+      updatedAt,
+    };
     this.storage.set(userId, doc);
-    this.saveCalls.push({ userId, instructions: update.instructions });
+    this.saveCalls.push({ userId, update });
     return { userId, ...doc };
   }
 
   async deletePreferences(userId: string): Promise<void> {
     this.deleteCalls.push(userId);
     this.storage.delete(userId);
+  }
+}
+
+class FakeExternalSaveTester implements ExternalSaveConnectionTestPort {
+  readonly calls: IntexAgentExternalSavePreferences[] = [];
+  result: Awaited<ReturnType<ExternalSaveConnectionTestPort['testConnection']>> = {
+    ok: true,
+    status: 'success',
+    message: 'Connection successful',
+  };
+
+  testConnection(
+    config: IntexAgentExternalSavePreferences
+  ): Promise<Awaited<ReturnType<ExternalSaveConnectionTestPort['testConnection']>>> {
+    this.calls.push(config);
+    return Promise.resolve(this.result);
   }
 }
 
@@ -80,11 +108,13 @@ class FakeIncomingMessageHandler {
 describe('preferences routes', () => {
   let app: FastifyInstance;
   let preferencesRepository: FakePreferencesRepository;
+  let externalSaveTester: FakeExternalSaveTester;
 
   beforeEach(async () => {
     vi.mocked(requireAuth).mockResolvedValue({ userId: 'user-1', claims: {} });
     process.env['INTEXURAOS_INTERNAL_AUTH_TOKEN'] = INTERNAL_AUTH_TOKEN;
     preferencesRepository = new FakePreferencesRepository();
+    externalSaveTester = new FakeExternalSaveTester();
 
     setServices({
       config: {
@@ -106,6 +136,7 @@ describe('preferences routes', () => {
       },
       sessionRepository: new FakeSessionRepository(),
       preferencesRepository,
+      externalSaveTester,
       incomingMessageHandler: new FakeIncomingMessageHandler(),
     } satisfies ServiceContainer);
 
@@ -129,7 +160,17 @@ describe('preferences routes', () => {
     expect(response.statusCode).toBe(200);
     expect(JSON.parse(response.body)).toMatchObject({
       success: true,
-      data: { instructions: '', updatedAt: null },
+      data: {
+        instructions: '',
+        externalSave: {
+          enabled: false,
+          endpointUrl: '',
+          cfAccessClientId: '',
+          cfAccessClientSecret: '',
+          source: 'ios-shortcuts',
+        },
+        updatedAt: null,
+      },
     });
   });
 
@@ -172,6 +213,260 @@ describe('preferences routes', () => {
     expect(preferencesRepository.saveCalls).toHaveLength(0);
   });
 
+  it('saves external save configuration without personal instructions', async () => {
+    const response = await app.inject({
+      method: 'PUT',
+      url: '/preferences',
+      headers: { authorization: 'Bearer test-token' },
+      payload: {
+        instructions: '   ',
+        externalSave: {
+          enabled: true,
+          endpointUrl: 'https://external-save.example.com/intex',
+          cfAccessClientId: 'cf-client-id',
+          cfAccessClientSecret: 'cf-client-secret',
+          source: 'ios-shortcuts',
+        },
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.body)).toMatchObject({
+      success: true,
+      data: {
+        instructions: '',
+        externalSave: {
+          enabled: true,
+          endpointUrl: 'https://external-save.example.com/intex',
+          cfAccessClientId: 'cf-client-id',
+          cfAccessClientSecret: '************',
+          source: 'ios-shortcuts',
+        },
+      },
+    });
+    expect(preferencesRepository.saveCalls).toEqual([
+      {
+        userId: 'user-1',
+        update: {
+          instructions: '',
+          externalSave: {
+            enabled: true,
+            endpointUrl: 'https://external-save.example.com/intex',
+            cfAccessClientId: 'cf-client-id',
+            cfAccessClientSecret: 'cf-client-secret',
+            source: 'ios-shortcuts',
+          },
+        },
+      },
+    ]);
+  });
+
+  it('keeps the stored Cloudflare secret when saving a masked external save secret', async () => {
+    preferencesRepository.storage.set('user-1', {
+      instructions: 'existing',
+      externalSave: {
+        enabled: true,
+        endpointUrl: 'https://old.example.com/intex',
+        cfAccessClientId: 'old-client-id',
+        cfAccessClientSecret: 'stored-secret',
+        source: 'ios-shortcuts',
+      },
+      updatedAt: '2026-06-27T10:00:00.000Z',
+    });
+
+    const response = await app.inject({
+      method: 'PUT',
+      url: '/preferences',
+      headers: { authorization: 'Bearer test-token' },
+      payload: {
+        instructions: 'updated',
+        externalSave: {
+          enabled: true,
+          endpointUrl: 'https://new.example.com/intex',
+          cfAccessClientId: 'new-client-id',
+          cfAccessClientSecret: '************',
+          source: 'ios-shortcuts',
+        },
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(preferencesRepository.saveCalls[0]?.update.externalSave).toMatchObject({
+      endpointUrl: 'https://new.example.com/intex',
+      cfAccessClientId: 'new-client-id',
+      cfAccessClientSecret: 'stored-secret',
+    });
+  });
+
+  it('defaults blank external save source labels and leaves disabled config incomplete', async () => {
+    const response = await app.inject({
+      method: 'PUT',
+      url: '/preferences',
+      headers: { authorization: 'Bearer test-token' },
+      payload: {
+        instructions: '',
+        externalSave: {
+          enabled: false,
+          endpointUrl: '   ',
+          cfAccessClientId: '   ',
+          cfAccessClientSecret: '   ',
+          source: '   ',
+        },
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(preferencesRepository.saveCalls[0]?.update.externalSave).toEqual({
+      enabled: false,
+      endpointUrl: '',
+      cfAccessClientId: '',
+      cfAccessClientSecret: '',
+      source: 'ios-shortcuts',
+    });
+    expect(JSON.parse(response.body)).toMatchObject({
+      success: true,
+      data: {
+        externalSave: {
+          enabled: false,
+          endpointUrl: '',
+          cfAccessClientId: '',
+          cfAccessClientSecret: '',
+          source: 'ios-shortcuts',
+        },
+      },
+    });
+  });
+
+  it('rejects enabled external save config with missing endpoint or Cloudflare credentials', async () => {
+    const response = await app.inject({
+      method: 'PUT',
+      url: '/preferences',
+      headers: { authorization: 'Bearer test-token' },
+      payload: {
+        instructions: '',
+        externalSave: {
+          enabled: true,
+          endpointUrl: '',
+          cfAccessClientId: 'cf-client-id',
+          cfAccessClientSecret: 'cf-client-secret',
+          source: 'ios-shortcuts',
+        },
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(JSON.parse(response.body)).toMatchObject({
+      success: false,
+      error: { code: 'INVALID_REQUEST' },
+    });
+    expect(preferencesRepository.saveCalls).toHaveLength(0);
+  });
+
+  it('tests the saved external save connection', async () => {
+    preferencesRepository.storage.set('user-1', {
+      instructions: '',
+      externalSave: {
+        enabled: true,
+        endpointUrl: 'https://external-save.example.com/intex',
+        cfAccessClientId: 'cf-client-id',
+        cfAccessClientSecret: 'cf-client-secret',
+        source: 'ios-shortcuts',
+      },
+      updatedAt: '2026-06-27T10:00:00.000Z',
+    });
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/preferences/external-save/test',
+      headers: { authorization: 'Bearer test-token' },
+      payload: {},
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.body)).toMatchObject({
+      success: true,
+      data: {
+        status: 'success',
+        message: 'Connection successful',
+      },
+    });
+    expect(externalSaveTester.calls).toEqual([
+      {
+        enabled: true,
+        endpointUrl: 'https://external-save.example.com/intex',
+        cfAccessClientId: 'cf-client-id',
+        cfAccessClientSecret: 'cf-client-secret',
+        source: 'ios-shortcuts',
+      },
+    ]);
+  });
+
+  it('tests a submitted external save connection before it is saved', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/preferences/external-save/test',
+      headers: { authorization: 'Bearer test-token' },
+      payload: {
+        externalSave: {
+          enabled: true,
+          endpointUrl: ' https://submitted.example.com/intex ',
+          cfAccessClientId: ' submitted-client-id ',
+          cfAccessClientSecret: ' submitted-client-secret ',
+          source: ' ',
+        },
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(externalSaveTester.calls).toEqual([
+      {
+        enabled: true,
+        endpointUrl: 'https://submitted.example.com/intex',
+        cfAccessClientId: 'submitted-client-id',
+        cfAccessClientSecret: 'submitted-client-secret',
+        source: 'ios-shortcuts',
+      },
+    ]);
+  });
+
+  it('rejects external save test when no configuration is available', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/preferences/external-save/test',
+      headers: { authorization: 'Bearer test-token' },
+      payload: {},
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(JSON.parse(response.body)).toMatchObject({
+      success: false,
+      error: { code: 'INVALID_REQUEST' },
+    });
+  });
+
+  it('rejects external save test with an incomplete submitted configuration', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/preferences/external-save/test',
+      headers: { authorization: 'Bearer test-token' },
+      payload: {
+        externalSave: {
+          enabled: true,
+          endpointUrl: '',
+          cfAccessClientId: 'cf-client-id',
+          cfAccessClientSecret: 'cf-client-secret',
+          source: 'ios-shortcuts',
+        },
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(JSON.parse(response.body)).toMatchObject({
+      success: false,
+      error: { code: 'INVALID_REQUEST' },
+    });
+  });
+
   it('deletes preferences via DELETE', async () => {
     await app.inject({
       method: 'PUT',
@@ -189,7 +484,17 @@ describe('preferences routes', () => {
     expect(deleteResponse.statusCode).toBe(200);
     expect(JSON.parse(deleteResponse.body)).toMatchObject({
       success: true,
-      data: { instructions: '', updatedAt: null },
+      data: {
+        instructions: '',
+        externalSave: {
+          enabled: false,
+          endpointUrl: '',
+          cfAccessClientId: '',
+          cfAccessClientSecret: '',
+          source: 'ios-shortcuts',
+        },
+        updatedAt: null,
+      },
     });
     expect(preferencesRepository.deleteCalls).toEqual(['user-1']);
 
@@ -200,7 +505,17 @@ describe('preferences routes', () => {
     });
     expect(JSON.parse(getResponse.body)).toMatchObject({
       success: true,
-      data: { instructions: '', updatedAt: null },
+      data: {
+        instructions: '',
+        externalSave: {
+          enabled: false,
+          endpointUrl: '',
+          cfAccessClientId: '',
+          cfAccessClientSecret: '',
+          source: 'ios-shortcuts',
+        },
+        updatedAt: null,
+      },
     });
   });
 
@@ -242,5 +557,19 @@ describe('preferences routes', () => {
 
     expect(response.statusCode).toBe(200);
     expect(preferencesRepository.deleteCalls).toHaveLength(0);
+  });
+
+  it('does not test external save when authentication fails', async () => {
+    vi.mocked(requireAuth).mockResolvedValueOnce(null);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/preferences/external-save/test',
+      headers: { authorization: 'Bearer test-token' },
+      payload: {},
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(externalSaveTester.calls).toHaveLength(0);
   });
 });

--- a/apps/intex-agent/src/__tests__/routes/sessionRoutes.test.ts
+++ b/apps/intex-agent/src/__tests__/routes/sessionRoutes.test.ts
@@ -145,6 +145,11 @@ describe('intex-agent routes', () => {
           /* noop */
         },
       },
+      externalSaveTester: {
+        async testConnection(): Promise<{ ok: true; status: 'success'; message: string }> {
+          return { ok: true, status: 'success', message: 'Connection successful' } as const;
+        },
+      },
       incomingMessageHandler,
     } satisfies ServiceContainer);
 

--- a/apps/intex-agent/src/domain/agent/intentGate.ts
+++ b/apps/intex-agent/src/domain/agent/intentGate.ts
@@ -45,12 +45,20 @@ export function classifyIntexAgentIntent(text: string): IntexAgentIntentDecision
 
 function explicitToolNames(text: string): IntexAgentToolName[] {
   const toolNames: IntexAgentToolName[] = [];
+  if (isExplicitExternalSaveRequest(text)) toolNames.push('save_external');
   if (isExplicitNoteRequest(text)) toolNames.push('create_note');
   if (isExplicitCalendarCreateRequest(text)) toolNames.push('create_calendar_event');
   if (isExplicitResearchRequest(text)) toolNames.push('create_research');
   if (isExplicitLinkRequest(text)) toolNames.push('create_link');
   if (isExplicitCodeTaskRequest(text)) toolNames.push('create_code_task');
   return toolNames;
+}
+
+function isExplicitExternalSaveRequest(text: string): boolean {
+  return (
+    /\b(save externally|upload externally|save for processing)\b/u.test(text) ||
+    /\b(zapisz zewnetrznie|przeslij zewnetrznie|zapisz do przetworzenia)\b/u.test(text)
+  );
 }
 
 function isReadOnlyCalendarQueryRequest(text: string): boolean {

--- a/apps/intex-agent/src/domain/agent/intexAgentRunner.ts
+++ b/apps/intex-agent/src/domain/agent/intexAgentRunner.ts
@@ -13,6 +13,7 @@ import {
   type CreateNoteToolArgs,
   type QueryCalendarEventsToolArgs,
   type CreateResearchToolArgs,
+  type SaveExternalToolArgs,
   type IntexAgentToolExecutor,
 } from './toolDefinitions.js';
 import { buildIntexAgentSystemPrompt } from './systemPrompt.js';
@@ -34,6 +35,10 @@ export interface IntexAgentRunnerConfig {
 export function createIntexAgentRunner(config: IntexAgentRunnerConfig): IntexAgentRunner {
   return {
     async run(input): Promise<IntexAgentRunnerResult> {
+      if (input.sourceType === 'whatsapp_image' && input.sourceUrl !== undefined) {
+        return await saveWhatsAppImageExternally(input.message, input.sourceUrl, config.toolExecutor);
+      }
+
       const intent = classifyIntexAgentIntent(input.message);
       if (intent.kind === 'unsupported') {
         return {
@@ -301,7 +306,36 @@ function createTrackingToolExecutor(
     async createCodeTask(args: CreateCodeTaskToolArgs): Promise<string> {
       return await track('create_code_task', toRecord(args), async () => await executor.createCodeTask(args));
     },
+    async saveExternal(args: SaveExternalToolArgs): Promise<string> {
+      return await track('save_external', toRecord(args), async () => await executor.saveExternal(args));
+    },
   };
+}
+
+async function saveWhatsAppImageExternally(
+  message: string,
+  sourceUrl: string,
+  executor: IntexAgentToolExecutor
+): Promise<IntexAgentRunnerResult> {
+  try {
+    const rawResult = await executor.saveExternal({
+      message: message.trim() === '' ? 'Image shared via WhatsApp.' : message.trim(),
+      sourceUrl,
+    });
+    const result = parseToolResult(rawResult);
+    const reply = result !== undefined ? readString(result, 'message') : undefined;
+    return {
+      outcome: 'completed',
+      reply: reply ?? 'Saved externally',
+      toolName: 'save_external',
+      ...(result !== undefined ? { toolResult: result } : {}),
+    };
+  } catch {
+    return {
+      outcome: 'unsupported',
+      reply: buildCompletionFailureCapabilitiesReply(),
+    };
+  }
 }
 
 function toRecord(args: object): Record<string, unknown> {
@@ -402,6 +436,9 @@ function buildCompletedReply(
   }
 
   const message = readString(result, 'message');
+  if (toolName === 'save_external' && message !== undefined) {
+    return { reply: message };
+  }
   return { reply: message ?? fallbackReply };
 }
 

--- a/apps/intex-agent/src/domain/agent/toolDefinitions.ts
+++ b/apps/intex-agent/src/domain/agent/toolDefinitions.ts
@@ -49,6 +49,11 @@ export interface CreateCodeTaskToolArgs {
   taskMode?: 'planning' | 'execution';
 }
 
+export interface SaveExternalToolArgs {
+  message: string;
+  sourceUrl?: string;
+}
+
 const EXPLICIT_CODE_TASK_WORKER_TYPES = ['codex', 'codex-xhigh', 'minimax'] as const;
 
 export interface IntexAgentToolExecutor {
@@ -58,6 +63,7 @@ export interface IntexAgentToolExecutor {
   createResearch(args: CreateResearchToolArgs): Promise<string>;
   createLink(args: CreateLinkToolArgs): Promise<string>;
   createCodeTask(args: CreateCodeTaskToolArgs): Promise<string>;
+  saveExternal(args: SaveExternalToolArgs): Promise<string>;
 }
 
 export function createIntexAgentToolDefinitions(executor: IntexAgentToolExecutor): ToolDefinition[] {
@@ -277,6 +283,28 @@ export function createIntexAgentToolDefinitions(executor: IntexAgentToolExecutor
       run: async (args: Record<string, unknown>) =>
         await executor.createCodeTask(toCreateCodeTaskArgs(args)),
     },
+    {
+      name: 'save_external',
+      description:
+        'Use only when the user explicitly asks to save externally, upload externally, save for processing, zapisz zewnetrznie, przeslij zewnetrznie, or zapisz do przetworzenia. Forward the raw user message to an external processing/storage system. If the user included a URL, put that URL in sourceUrl. Do not fetch, inspect, summarize, or open sourceUrl.',
+      parameters: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['message'],
+        properties: {
+          message: {
+            type: 'string',
+            description: 'Raw user caption or pasted text to send to the external system.',
+          },
+          sourceUrl: {
+            type: 'string',
+            description:
+              'Optional original shared URL or image URL. Pass it through without fetching or inspecting it.',
+          },
+        },
+      },
+      run: async (args: Record<string, unknown>) => await executor.saveExternal(toSaveExternalArgs(args)),
+    },
   ];
 }
 
@@ -377,6 +405,16 @@ function toCreateCodeTaskArgs(args: Record<string, unknown>): CreateCodeTaskTool
     ...(workerType !== undefined ? { workerType } : {}),
     ...(linearIssueId !== undefined ? { linearIssueId } : {}),
     ...(taskMode !== undefined ? { taskMode } : {}),
+  };
+}
+
+function toSaveExternalArgs(args: Record<string, unknown>): SaveExternalToolArgs {
+  const message = requiredString(args, 'message');
+  const sourceUrl = optionalString(args, 'sourceUrl');
+
+  return {
+    message,
+    ...(sourceUrl !== undefined ? { sourceUrl } : {}),
   };
 }
 

--- a/apps/intex-agent/src/domain/agent/toolExecutor.ts
+++ b/apps/intex-agent/src/domain/agent/toolExecutor.ts
@@ -16,6 +16,7 @@ import type {
   CreateCalendarEventToolArgs,
   CreateCodeTaskToolArgs,
   CreateLinkToolArgs,
+  SaveExternalToolArgs,
   IntexAgentToolExecutor,
 } from './toolDefinitions.js';
 
@@ -61,6 +62,25 @@ export interface CodeTaskToolClient {
   ): Promise<Result<SubmitTaskResponse, SubmitTaskError>>;
 }
 
+export interface ExternalSaveToolInput {
+  message: string;
+  sourceUrl?: string;
+}
+
+export interface ExternalSaveToolResult {
+  status: 'completed';
+  message: string;
+}
+
+export interface ExternalSaveToolError {
+  code: string;
+  message: string;
+}
+
+export interface ExternalSaveToolClient {
+  save(input: ExternalSaveToolInput): Promise<Result<ExternalSaveToolResult, ExternalSaveToolError>>;
+}
+
 export interface CreateIntexAgentToolExecutorDeps {
   userId: string;
   messageId: string;
@@ -69,6 +89,7 @@ export interface CreateIntexAgentToolExecutorDeps {
   researchClient: ResearchToolClient;
   bookmarksClient: BookmarksToolClient;
   codeClient: CodeTaskToolClient;
+  externalSaveClient: ExternalSaveToolClient | null;
 }
 
 export function createIntexAgentToolExecutor(
@@ -200,6 +221,26 @@ export function createIntexAgentToolExecutor(
         status: 'completed',
         codeTaskId: task.codeTaskId,
         resourceUrl: task.resourceUrl,
+      });
+    },
+
+    async saveExternal(args: SaveExternalToolArgs): Promise<string> {
+      if (deps.externalSaveClient === null) {
+        throw new Error('External save is not configured');
+      }
+
+      const result = await deps.externalSaveClient.save({
+        message: args.message,
+        ...(args.sourceUrl !== undefined ? { sourceUrl: args.sourceUrl } : {}),
+      });
+
+      if (!result.ok) {
+        throw new Error(`Failed to save externally: ${result.error.message}`);
+      }
+
+      return JSON.stringify({
+        status: result.value.status, // @allow-result-access -- guarded by !result.ok check above
+        message: result.value.message, // @allow-result-access -- guarded by !result.ok check above
       });
     },
   };

--- a/apps/intex-agent/src/domain/messages/handleIncomingMessage.ts
+++ b/apps/intex-agent/src/domain/messages/handleIncomingMessage.ts
@@ -47,6 +47,8 @@ export interface IntexAgentRunner {
     events: IntexAgentSessionEvent[];
     message: string;
     replyContext?: IntexIncomingMessage['replyContext'];
+    sourceType?: string;
+    sourceUrl?: string;
     currentDateTime: string;
     messageId?: string;
   }): Promise<IntexAgentRunnerResult>;
@@ -117,6 +119,7 @@ export async function handleIncomingMessage(
     messageId: input.messageId,
     text: effectiveMessage,
     sourceType: input.sourceType,
+    ...(input.sourceUrl !== undefined ? { hasSourceUrl: true } : {}),
     ...(input.replyContext !== undefined ? { replyContext: input.replyContext } : {}),
   });
   await deps.sessionRepository.updateSession(session.id, {
@@ -141,6 +144,8 @@ export async function handleIncomingMessage(
     events: excludeCurrentUserMessage(events, input.messageId),
     message: effectiveMessage,
     ...(input.replyContext !== undefined ? { replyContext: input.replyContext } : {}),
+    sourceType: input.sourceType,
+    ...(input.sourceUrl !== undefined ? { sourceUrl: input.sourceUrl } : {}),
     currentDateTime: now,
     messageId: input.messageId,
   });

--- a/apps/intex-agent/src/domain/ports/incomingMessageHandler.ts
+++ b/apps/intex-agent/src/domain/ports/incomingMessageHandler.ts
@@ -15,6 +15,7 @@ export interface IntexIncomingMessage {
   messageId: string;
   text: string;
   sourceType: string;
+  sourceUrl?: string;
   whatsappSender?: string;
   replyContext?: IntexIncomingMessageReplyContext;
   timestamp: string;

--- a/apps/intex-agent/src/domain/ports/preferencesRepository.ts
+++ b/apps/intex-agent/src/domain/ports/preferencesRepository.ts
@@ -1,10 +1,13 @@
-import type { IntexAgentPreferences } from '../preferences/types.js';
+import type {
+  IntexAgentPreferences,
+  IntexAgentPreferencesUpdate,
+} from '../preferences/types.js';
 
 export interface PreferencesRepository {
   getPreferences(userId: string): Promise<IntexAgentPreferences | null>;
   savePreferences(
     userId: string,
-    update: { instructions: string }
+    update: IntexAgentPreferencesUpdate
   ): Promise<IntexAgentPreferences>;
   deletePreferences(userId: string): Promise<void>;
 }

--- a/apps/intex-agent/src/domain/preferences/types.ts
+++ b/apps/intex-agent/src/domain/preferences/types.ts
@@ -1,9 +1,34 @@
 export interface IntexAgentPreferences {
   userId: string;
   instructions: string;
+  externalSave?: IntexAgentExternalSavePreferences;
   updatedAt: string;
 }
 
 export interface IntexAgentPreferencesUpdate {
   instructions: string;
+  externalSave?: IntexAgentExternalSavePreferences;
 }
+
+export interface IntexAgentExternalSavePreferences {
+  enabled: boolean;
+  endpointUrl: string;
+  cfAccessClientId: string;
+  cfAccessClientSecret: string;
+  source: string;
+}
+
+export interface ExternalSaveConnectionTestResult {
+  ok: boolean;
+  status: 'success' | 'failure';
+  message: string;
+}
+
+export interface ExternalSaveConnectionTestPort {
+  testConnection(
+    config: IntexAgentExternalSavePreferences
+  ): Promise<ExternalSaveConnectionTestResult>;
+}
+
+export const DEFAULT_EXTERNAL_SAVE_SOURCE = 'ios-shortcuts';
+export const MASKED_EXTERNAL_SAVE_SECRET = '************';

--- a/apps/intex-agent/src/domain/sessions/types.ts
+++ b/apps/intex-agent/src/domain/sessions/types.ts
@@ -31,7 +31,8 @@ export type IntexAgentToolName =
   | 'query_calendar_events'
   | 'create_research'
   | 'create_link'
-  | 'create_code_task';
+  | 'create_code_task'
+  | 'save_external';
 
 export interface IntexAgentSession {
   id: string;

--- a/apps/intex-agent/src/infra/firestore/preferencesRepository.ts
+++ b/apps/intex-agent/src/infra/firestore/preferencesRepository.ts
@@ -2,7 +2,11 @@ import type { Firestore } from '@intexuraos/infra-firestore';
 import type {
   PreferencesRepository,
 } from '../../domain/ports/preferencesRepository.js';
-import type { IntexAgentPreferences } from '../../domain/preferences/types.js';
+import type {
+  IntexAgentExternalSavePreferences,
+  IntexAgentPreferences,
+  IntexAgentPreferencesUpdate,
+} from '../../domain/preferences/types.js';
 
 export const INTEX_AGENT_USER_PREFERENCES_COLLECTION = 'intex_agent_user_preferences';
 
@@ -33,17 +37,21 @@ export class FirestorePreferencesRepository implements PreferencesRepository {
     return {
       userId,
       instructions: data.instructions,
+      ...(isExternalSavePreferences(data.externalSave)
+        ? { externalSave: data.externalSave }
+        : {}),
       updatedAt: data.updatedAt,
     };
   }
 
   async savePreferences(
     userId: string,
-    update: { instructions: string }
+    update: IntexAgentPreferencesUpdate
   ): Promise<IntexAgentPreferences> {
     const updatedAt = new Date().toISOString();
     const doc: PreferencesDocument = {
       instructions: update.instructions,
+      ...(update.externalSave !== undefined ? { externalSave: update.externalSave } : {}),
       updatedAt,
     };
 
@@ -61,4 +69,21 @@ export class FirestorePreferencesRepository implements PreferencesRepository {
       .doc(userId)
       .delete();
   }
+}
+
+function isExternalSavePreferences(value: unknown): value is IntexAgentExternalSavePreferences {
+  if (value === undefined) {
+    return false;
+  }
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record['enabled'] === 'boolean' &&
+    typeof record['endpointUrl'] === 'string' &&
+    typeof record['cfAccessClientId'] === 'string' &&
+    typeof record['cfAccessClientSecret'] === 'string' &&
+    typeof record['source'] === 'string'
+  );
 }

--- a/apps/intex-agent/src/infra/http/externalSaveClient.ts
+++ b/apps/intex-agent/src/infra/http/externalSaveClient.ts
@@ -1,0 +1,56 @@
+import { err, getErrorMessage, ok, type Result } from '@intexuraos/common-core';
+import type {
+  ExternalSaveToolClient,
+  ExternalSaveToolError,
+  ExternalSaveToolInput,
+  ExternalSaveToolResult,
+} from '../../domain/agent/toolExecutor.js';
+
+export interface ExternalSaveClientConfig {
+  endpointUrl: string;
+  cfAccessClientId: string;
+  cfAccessClientSecret: string;
+  source: string;
+  fetchFn?: typeof fetch;
+}
+
+export function createExternalSaveClient(config: ExternalSaveClientConfig): ExternalSaveToolClient {
+  const fetchFn = config.fetchFn ?? fetch;
+
+  return {
+    async save(input: ExternalSaveToolInput): Promise<Result<ExternalSaveToolResult, ExternalSaveToolError>> {
+      try {
+        const response = await fetchFn(config.endpointUrl, {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            'CF-Access-Client-Id': config.cfAccessClientId,
+            'CF-Access-Client-Secret': config.cfAccessClientSecret,
+          },
+          body: JSON.stringify({
+            source: config.source,
+            message: input.message,
+            ...(input.sourceUrl !== undefined ? { source_url: input.sourceUrl } : {}),
+          }),
+        });
+
+        if (!response.ok) {
+          return err({
+            code: 'HTTP_ERROR',
+            message: `HTTP ${String(response.status)}: ${response.statusText}`,
+          });
+        }
+
+        return ok({
+          status: 'completed',
+          message: 'Saved externally',
+        });
+      } catch (error) {
+        return err({
+          code: 'NETWORK_ERROR',
+          message: getErrorMessage(error),
+        });
+      }
+    },
+  };
+}

--- a/apps/intex-agent/src/infra/pubsub/decoder.ts
+++ b/apps/intex-agent/src/infra/pubsub/decoder.ts
@@ -55,6 +55,7 @@ function toIntexIncomingMessage(value: unknown): IntexIncomingMessage {
   const messageId = requiredString(event, 'messageId');
   const text = requiredString(event, 'text');
   const sourceType = requiredString(event, 'sourceType');
+  const sourceUrl = optionalString(event, 'sourceUrl');
   const timestamp = requiredString(event, 'timestamp');
   const whatsappSender = optionalString(event, 'whatsappSender');
   const replyContext = optionalReplyContext(event);
@@ -65,6 +66,7 @@ function toIntexIncomingMessage(value: unknown): IntexIncomingMessage {
     messageId,
     text,
     sourceType,
+    ...(sourceUrl !== undefined ? { sourceUrl } : {}),
     timestamp,
     ...(whatsappSender !== undefined ? { whatsappSender } : {}),
     ...(replyContext !== undefined ? { replyContext } : {}),

--- a/apps/intex-agent/src/routes/internalRoutes.ts
+++ b/apps/intex-agent/src/routes/internalRoutes.ts
@@ -14,6 +14,7 @@ const incomingMessageBodySchema = {
     messageId: { type: 'string', minLength: 1 },
     text: { type: 'string' },
     sourceType: { type: 'string', minLength: 1 },
+    sourceUrl: { type: 'string' },
     whatsappSender: { type: 'string' },
     replyContext: {
       type: 'object',

--- a/apps/intex-agent/src/routes/preferencesRoutes.ts
+++ b/apps/intex-agent/src/routes/preferencesRoutes.ts
@@ -1,6 +1,12 @@
 import { logIncomingRequest, requireAuth } from '@intexuraos/common-http';
 import type { FastifyPluginCallback, FastifyReply, FastifyRequest } from 'fastify';
 import { getServices } from '../services.js';
+import {
+  DEFAULT_EXTERNAL_SAVE_SOURCE,
+  MASKED_EXTERNAL_SAVE_SECRET,
+  type IntexAgentExternalSavePreferences,
+  type IntexAgentPreferences,
+} from '../domain/preferences/types.js';
 
 const MAX_INSTRUCTIONS_LENGTH = 5000;
 
@@ -9,11 +15,35 @@ const putPreferencesBodySchema = {
   required: ['instructions'],
   properties: {
     instructions: { type: 'string', maxLength: MAX_INSTRUCTIONS_LENGTH },
+    externalSave: {
+      type: 'object',
+      required: ['enabled', 'endpointUrl', 'cfAccessClientId', 'cfAccessClientSecret', 'source'],
+      properties: {
+        enabled: { type: 'boolean' },
+        endpointUrl: { type: 'string' },
+        cfAccessClientId: { type: 'string' },
+        cfAccessClientSecret: { type: 'string' },
+        source: { type: 'string' },
+      },
+    },
   },
 } as const;
 
 function normalizeInstructions(value: string): string {
   return value.trim();
+}
+
+interface ExternalSaveRequestBody {
+  enabled: boolean;
+  endpointUrl: string;
+  cfAccessClientId: string;
+  cfAccessClientSecret: string;
+  source: string;
+}
+
+interface PutPreferencesBody {
+  instructions: string;
+  externalSave?: ExternalSaveRequestBody;
 }
 
 export const preferencesRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
@@ -37,14 +67,11 @@ export const preferencesRoutes: FastifyPluginCallback = (fastify, _opts, done) =
 
       const { preferencesRepository } = getServices();
       const preferences = await preferencesRepository.getPreferences(user.userId);
-      return await reply.ok({
-        instructions: preferences?.instructions ?? '',
-        updatedAt: preferences?.updatedAt ?? null,
-      });
+      return await reply.ok(toPreferencesResponse(preferences));
     }
   );
 
-  fastify.put<{ Body: { instructions: string } }>(
+  fastify.put<{ Body: PutPreferencesBody }>(
     '/preferences',
     {
       schema: {
@@ -57,7 +84,7 @@ export const preferencesRoutes: FastifyPluginCallback = (fastify, _opts, done) =
         body: putPreferencesBodySchema,
       },
     },
-    async (request: FastifyRequest<{ Body: { instructions: string } }>, reply: FastifyReply) => {
+    async (request: FastifyRequest<{ Body: PutPreferencesBody }>, reply: FastifyReply) => {
       logIncomingRequest(request);
       const user = await requireAuth(request, reply);
       if (user === null) {
@@ -65,18 +92,75 @@ export const preferencesRoutes: FastifyPluginCallback = (fastify, _opts, done) =
       }
 
       const instructions = normalizeInstructions(request.body.instructions);
-      if (instructions === '') {
+      const { preferencesRepository } = getServices();
+      const existing = await preferencesRepository.getPreferences(user.userId);
+      const externalSaveResult = normalizeExternalSave(request.body.externalSave, existing);
+      if (!externalSaveResult.ok) {
+        return await reply.fail('INVALID_REQUEST', externalSaveResult.message);
+      }
+
+      if (instructions === '' && externalSaveResult.value === undefined) {
         return await reply.fail(
           'INVALID_REQUEST',
           'instructions cannot be empty. Send DELETE /preferences to clear preferences.'
         );
       }
 
-      const { preferencesRepository } = getServices();
-      const saved = await preferencesRepository.savePreferences(user.userId, { instructions });
+      const saved = await preferencesRepository.savePreferences(user.userId, {
+        instructions,
+        ...(externalSaveResult.value !== undefined
+          ? { externalSave: externalSaveResult.value }
+          : {}),
+      });
+      return await reply.ok(toPreferencesResponse(saved));
+    }
+  );
+
+  fastify.post<{ Body: { externalSave?: ExternalSaveRequestBody } }>(
+    '/preferences/external-save/test',
+    {
+      schema: {
+        operationId: 'testIntexAgentExternalSave',
+        summary: 'Test INTEX Agent external save connection',
+        description:
+          'Test the authenticated user external-save endpoint using configured Cloudflare Access credentials.',
+        tags: ['intex-agent'],
+        security: [{ bearerAuth: [] }],
+        body: {
+          type: 'object',
+          properties: {
+            externalSave: putPreferencesBodySchema.properties.externalSave,
+          },
+        },
+      },
+    },
+    async (
+      request: FastifyRequest<{ Body: { externalSave?: ExternalSaveRequestBody } }>,
+      reply: FastifyReply
+    ) => {
+      logIncomingRequest(request);
+      const user = await requireAuth(request, reply);
+      if (user === null) {
+        return;
+      }
+
+      const { preferencesRepository, externalSaveTester } = getServices();
+      const preferences = await preferencesRepository.getPreferences(user.userId);
+      const externalSave =
+        request.body.externalSave !== undefined
+          ? resolveExternalSaveForTest(request.body.externalSave, preferences)
+          : preferences?.externalSave;
+      if (externalSave === null) {
+        return await reply.fail('INVALID_REQUEST', 'External save is not fully configured');
+      }
+      if (externalSave === undefined || !isExternalSaveReady(externalSave)) {
+        return await reply.fail('INVALID_REQUEST', 'External save is not fully configured');
+      }
+
+      const result = await externalSaveTester.testConnection(externalSave);
       return await reply.ok({
-        instructions: saved.instructions,
-        updatedAt: saved.updatedAt,
+        status: result.status,
+        message: result.message,
       });
     }
   );
@@ -102,7 +186,7 @@ export const preferencesRoutes: FastifyPluginCallback = (fastify, _opts, done) =
 
       const { preferencesRepository } = getServices();
       await preferencesRepository.deletePreferences(user.userId);
-      return await reply.ok({ instructions: '', updatedAt: null });
+      return await reply.ok(toPreferencesResponse(null));
     }
   );
 
@@ -112,3 +196,97 @@ export const preferencesRoutes: FastifyPluginCallback = (fastify, _opts, done) =
 export const preferencesRouteConfig = {
   MAX_INSTRUCTIONS_LENGTH,
 } as const;
+
+function toPreferencesResponse(preferences: IntexAgentPreferences | null): {
+  instructions: string;
+  externalSave: ExternalSaveRequestBody;
+  updatedAt: string | null;
+} {
+  return {
+    instructions: preferences?.instructions ?? '',
+    externalSave: maskExternalSave(preferences?.externalSave),
+    updatedAt: preferences?.updatedAt ?? null,
+  };
+}
+
+function maskExternalSave(
+  externalSave: IntexAgentExternalSavePreferences | undefined
+): ExternalSaveRequestBody {
+  if (externalSave === undefined) {
+    return {
+      enabled: false,
+      endpointUrl: '',
+      cfAccessClientId: '',
+      cfAccessClientSecret: '',
+      source: DEFAULT_EXTERNAL_SAVE_SOURCE,
+    };
+  }
+
+  return {
+    enabled: externalSave.enabled,
+    endpointUrl: externalSave.endpointUrl,
+    cfAccessClientId: externalSave.cfAccessClientId,
+    cfAccessClientSecret:
+      externalSave.cfAccessClientSecret.trim() === '' ? '' : MASKED_EXTERNAL_SAVE_SECRET,
+    source: externalSave.source,
+  };
+}
+
+function normalizeExternalSave(
+  input: ExternalSaveRequestBody | undefined,
+  existing: IntexAgentPreferences | null
+): { ok: true; value: IntexAgentExternalSavePreferences | undefined } | { ok: false; message: string } {
+  if (input === undefined) {
+    return { ok: true, value: undefined };
+  }
+
+  const secret = resolveExternalSaveSecret(input.cfAccessClientSecret, existing?.externalSave);
+  const externalSave: IntexAgentExternalSavePreferences = {
+    enabled: input.enabled,
+    endpointUrl: input.endpointUrl.trim(),
+    cfAccessClientId: input.cfAccessClientId.trim(),
+    cfAccessClientSecret: secret,
+    source: input.source.trim() === '' ? DEFAULT_EXTERNAL_SAVE_SOURCE : input.source.trim(),
+  };
+
+  if (externalSave.enabled && !isExternalSaveReady(externalSave)) {
+    return {
+      ok: false,
+      message:
+        'externalSave endpointUrl, cfAccessClientId, cfAccessClientSecret, and source are required when enabled',
+    };
+  }
+
+  return { ok: true, value: externalSave };
+}
+
+function resolveExternalSaveSecret(
+  inputSecret: string,
+  existing: IntexAgentExternalSavePreferences | undefined
+): string {
+  if (inputSecret === MASKED_EXTERNAL_SAVE_SECRET && existing !== undefined) {
+    return existing.cfAccessClientSecret;
+  }
+  return inputSecret.trim();
+}
+
+function isExternalSaveReady(externalSave: IntexAgentExternalSavePreferences): boolean {
+  return (
+    externalSave.enabled &&
+    externalSave.endpointUrl.trim() !== '' &&
+    externalSave.cfAccessClientId.trim() !== '' &&
+    externalSave.cfAccessClientSecret.trim() !== '' &&
+    externalSave.source.trim() !== ''
+  );
+}
+
+function resolveExternalSaveForTest(
+  input: ExternalSaveRequestBody,
+  existing: IntexAgentPreferences | null
+): IntexAgentExternalSavePreferences | null {
+  const normalized = normalizeExternalSave(input, existing);
+  if (!normalized.ok || normalized.value === undefined) {
+    return null;
+  }
+  return normalized.value;
+}

--- a/apps/intex-agent/src/services.ts
+++ b/apps/intex-agent/src/services.ts
@@ -15,8 +15,15 @@ import type { ServiceConfig } from './config.js';
 import type { IncomingMessageHandler } from './domain/ports/incomingMessageHandler.js';
 import type { PreferencesRepository } from './domain/ports/preferencesRepository.js';
 import type { SessionRepository } from './domain/ports/sessionRepository.js';
+import type {
+  ExternalSaveConnectionTestPort,
+  IntexAgentExternalSavePreferences,
+} from './domain/preferences/types.js';
 import { createIntexAgentRunner } from './domain/agent/intexAgentRunner.js';
-import { createIntexAgentToolExecutor } from './domain/agent/toolExecutor.js';
+import {
+  createIntexAgentToolExecutor,
+  type ExternalSaveToolClient,
+} from './domain/agent/toolExecutor.js';
 import {
   handleIncomingMessage,
   type IntexAgentRunner,
@@ -24,12 +31,14 @@ import {
 } from './domain/messages/handleIncomingMessage.js';
 import { FirestorePreferencesRepository } from './infra/firestore/preferencesRepository.js';
 import { FirestoreSessionRepository } from './infra/firestore/sessionRepository.js';
+import { createExternalSaveClient } from './infra/http/externalSaveClient.js';
 import { createWhatsAppReplyPublisher } from './infra/pubsub/whatsappReplyPublisher.js';
 
 export interface ServiceContainer {
   config: ServiceConfig;
   sessionRepository: SessionRepository;
   preferencesRepository: PreferencesRepository;
+  externalSaveTester: ExternalSaveConnectionTestPort;
   incomingMessageHandler: IncomingMessageHandler;
 }
 
@@ -85,6 +94,16 @@ export function initServices(config: ServiceConfig): void {
     logger: createAppLogger({ name: 'intex-agent-whatsapp-send-publisher' }),
   });
   const replyPublisher = createWhatsAppReplyPublisher({ sendPublisher });
+  const externalSaveTester: ExternalSaveConnectionTestPort = {
+    async testConnection(externalSave) {
+      const result = await createExternalSaveClient(toExternalSaveClientConfig(externalSave)).save({
+        message: 'INTEX Agent external save connection test.',
+      });
+      return result.ok
+        ? { ok: true, status: 'success', message: 'Connection successful' }
+        : { ok: false, status: 'failure', message: result.error.message };
+    },
+  };
 
   const runner: IntexAgentRunner = {
     async run(
@@ -99,6 +118,7 @@ export function initServices(config: ServiceConfig): void {
         ownerType: 'user',
       });
 
+      const preferences = await preferencesRepository.getPreferences(input.session.userId);
       const toolExecutor = createIntexAgentToolExecutor({
         userId: input.session.userId,
         messageId: input.messageId ?? input.session.id,
@@ -107,9 +127,8 @@ export function initServices(config: ServiceConfig): void {
         researchClient,
         bookmarksClient,
         codeClient,
+        externalSaveClient: createExternalSaveToolClient(preferences?.externalSave),
       });
-
-      const preferences = await preferencesRepository.getPreferences(input.session.userId);
 
       return await createIntexAgentRunner({
         client: toolCallingClient,
@@ -142,6 +161,7 @@ export function initServices(config: ServiceConfig): void {
     config,
     sessionRepository,
     preferencesRepository,
+    externalSaveTester,
     incomingMessageHandler,
   };
 }
@@ -159,4 +179,35 @@ export function setServices(services: ServiceContainer): void {
 
 export function resetServices(): void {
   container = null;
+}
+
+function createExternalSaveToolClient(
+  externalSave: IntexAgentExternalSavePreferences | undefined
+): ExternalSaveToolClient | null {
+  if (externalSave?.enabled !== true) {
+    return null;
+  }
+  if (
+    externalSave.endpointUrl.trim() === '' ||
+    externalSave.cfAccessClientId.trim() === '' ||
+    externalSave.cfAccessClientSecret.trim() === '' ||
+    externalSave.source.trim() === ''
+  ) {
+    return null;
+  }
+  return createExternalSaveClient(toExternalSaveClientConfig(externalSave));
+}
+
+function toExternalSaveClientConfig(externalSave: IntexAgentExternalSavePreferences): {
+  endpointUrl: string;
+  cfAccessClientId: string;
+  cfAccessClientSecret: string;
+  source: string;
+} {
+  return {
+    endpointUrl: externalSave.endpointUrl,
+    cfAccessClientId: externalSave.cfAccessClientId,
+    cfAccessClientSecret: externalSave.cfAccessClientSecret,
+    source: externalSave.source,
+  };
 }

--- a/apps/web/src/pages/IntexAgentConfigPage.tsx
+++ b/apps/web/src/pages/IntexAgentConfigPage.tsx
@@ -1,14 +1,23 @@
 import { useCallback, useEffect, useState } from 'react';
-import { Loader2, Save, Trash2 } from 'lucide-react';
+import { Loader2, PlugZap, Save, Trash2 } from 'lucide-react';
 import { Layout } from '@/components';
 import { useAuth } from '@/context';
 import {
   clearIntexAgentPreferences,
   getIntexAgentPreferences,
   saveIntexAgentPreferences,
+  testIntexAgentExternalSave,
+  type IntexAgentExternalSaveConfig,
 } from '@/services/intexAgentApi';
 
 const MAX_INSTRUCTIONS_LENGTH = 5000;
+const DEFAULT_EXTERNAL_SAVE: IntexAgentExternalSaveConfig = {
+  enabled: false,
+  endpointUrl: '',
+  cfAccessClientId: '',
+  cfAccessClientSecret: '',
+  source: 'ios-shortcuts',
+};
 
 function formatUpdatedAt(updatedAt: string | null): string {
   if (updatedAt === null) {
@@ -25,12 +34,17 @@ export function IntexAgentConfigPage(): React.JSX.Element {
   const { getAccessToken } = useAuth();
   const [instructions, setInstructions] = useState('');
   const [originalInstructions, setOriginalInstructions] = useState('');
+  const [externalSave, setExternalSave] = useState<IntexAgentExternalSaveConfig>(DEFAULT_EXTERNAL_SAVE);
+  const [originalExternalSave, setOriginalExternalSave] =
+    useState<IntexAgentExternalSaveConfig>(DEFAULT_EXTERNAL_SAVE);
   const [updatedAt, setUpdatedAt] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [clearing, setClearing] = useState(false);
+  const [testing, setTesting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [savedAt, setSavedAt] = useState<string | null>(null);
+  const [testMessage, setTestMessage] = useState<string | null>(null);
 
   const refresh = useCallback(async (): Promise<void> => {
     setLoading(true);
@@ -40,6 +54,8 @@ export function IntexAgentConfigPage(): React.JSX.Element {
       const data = await getIntexAgentPreferences(token);
       setInstructions(data.instructions);
       setOriginalInstructions(data.instructions);
+      setExternalSave(data.externalSave);
+      setOriginalExternalSave(data.externalSave);
       setUpdatedAt(data.updatedAt);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load preferences');
@@ -53,20 +69,35 @@ export function IntexAgentConfigPage(): React.JSX.Element {
   }, [refresh]);
 
   const trimmedInstructions = instructions.trim();
-  const isDirty = trimmedInstructions !== originalInstructions;
-  const isEmpty = trimmedInstructions === '';
+  const isDirty =
+    trimmedInstructions !== originalInstructions ||
+    JSON.stringify(externalSave) !== JSON.stringify(originalExternalSave);
+  const externalSaveReady =
+    !externalSave.enabled ||
+    (
+      externalSave.endpointUrl.trim() !== '' &&
+      externalSave.cfAccessClientId.trim() !== '' &&
+      externalSave.cfAccessClientSecret.trim() !== '' &&
+      externalSave.source.trim() !== ''
+    );
+  const canSave = isDirty && externalSaveReady && !saving;
 
   const handleSave = useCallback(async (): Promise<void> => {
-    if (isEmpty || saving) {
+    if (!canSave) {
       return;
     }
     setSaving(true);
     setError(null);
     try {
       const token = await getAccessToken();
-      const result = await saveIntexAgentPreferences(token, trimmedInstructions);
+      const result = await saveIntexAgentPreferences(token, {
+        instructions: trimmedInstructions,
+        externalSave: normalizeExternalSave(externalSave),
+      });
       setInstructions(result.instructions);
       setOriginalInstructions(result.instructions);
+      setExternalSave(result.externalSave);
+      setOriginalExternalSave(result.externalSave);
       setUpdatedAt(result.updatedAt);
       setSavedAt(new Date().toISOString());
     } catch (err) {
@@ -74,7 +105,7 @@ export function IntexAgentConfigPage(): React.JSX.Element {
     } finally {
       setSaving(false);
     }
-  }, [getAccessToken, isEmpty, saving, trimmedInstructions]);
+  }, [canSave, externalSave, getAccessToken, trimmedInstructions]);
 
   const handleClear = useCallback(async (): Promise<void> => {
     if (clearing) {
@@ -94,6 +125,8 @@ export function IntexAgentConfigPage(): React.JSX.Element {
       const result = await clearIntexAgentPreferences(token);
       setInstructions(result.instructions);
       setOriginalInstructions(result.instructions);
+      setExternalSave(result.externalSave);
+      setOriginalExternalSave(result.externalSave);
       setUpdatedAt(result.updatedAt);
       setSavedAt(null);
     } catch (err) {
@@ -102,6 +135,35 @@ export function IntexAgentConfigPage(): React.JSX.Element {
       setClearing(false);
     }
   }, [clearing, getAccessToken]);
+
+  const handleExternalSaveChange = useCallback(
+    <K extends keyof IntexAgentExternalSaveConfig>(
+      key: K,
+      value: IntexAgentExternalSaveConfig[K]
+    ): void => {
+      setExternalSave((current) => ({ ...current, [key]: value }));
+      setTestMessage(null);
+    },
+    []
+  );
+
+  const handleTestConnection = useCallback(async (): Promise<void> => {
+    if (testing || !externalSave.enabled || !externalSaveReady) {
+      return;
+    }
+    setTesting(true);
+    setError(null);
+    setTestMessage(null);
+    try {
+      const token = await getAccessToken();
+      const result = await testIntexAgentExternalSave(token, normalizeExternalSave(externalSave));
+      setTestMessage(result.message);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to test external save');
+    } finally {
+      setTesting(false);
+    }
+  }, [externalSave, externalSaveReady, getAccessToken, testing]);
 
   return (
     <Layout>
@@ -158,11 +220,104 @@ export function IntexAgentConfigPage(): React.JSX.Element {
             </span>
           </div>
 
+          <div className="mt-6 border-t border-slate-200 pt-6 dark:border-slate-700">
+            <div className="flex items-center justify-between gap-4">
+              <div>
+                <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100">
+                  External Save
+                </h3>
+                <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                  Cloudflare Access protected endpoint used by Intex when images or explicit
+                  external-save requests arrive.
+                </p>
+              </div>
+              <label className="inline-flex items-center gap-2 text-sm text-slate-700 dark:text-slate-200">
+                <input
+                  type="checkbox"
+                  className="h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-blue-500"
+                  checked={externalSave.enabled}
+                  onChange={(event): void => {
+                    handleExternalSaveChange('enabled', event.target.checked);
+                  }}
+                />
+                Enable external save
+              </label>
+            </div>
+
+            <div className="mt-4 grid gap-4 md:grid-cols-2">
+              <label className="block text-sm font-medium text-slate-700 dark:text-slate-200">
+                Endpoint URL
+                <input
+                  type="url"
+                  className="mt-1 w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-slate-600 dark:bg-slate-700 dark:text-slate-100"
+                  value={externalSave.endpointUrl}
+                  onChange={(event): void => {
+                    handleExternalSaveChange('endpointUrl', event.target.value);
+                  }}
+                />
+              </label>
+              <label className="block text-sm font-medium text-slate-700 dark:text-slate-200">
+                Source label
+                <input
+                  type="text"
+                  className="mt-1 w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-slate-600 dark:bg-slate-700 dark:text-slate-100"
+                  value={externalSave.source}
+                  onChange={(event): void => {
+                    handleExternalSaveChange('source', event.target.value);
+                  }}
+                />
+              </label>
+              <label className="block text-sm font-medium text-slate-700 dark:text-slate-200">
+                Cloudflare Access Client ID
+                <input
+                  type="text"
+                  className="mt-1 w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-slate-600 dark:bg-slate-700 dark:text-slate-100"
+                  value={externalSave.cfAccessClientId}
+                  onChange={(event): void => {
+                    handleExternalSaveChange('cfAccessClientId', event.target.value);
+                  }}
+                />
+              </label>
+              <label className="block text-sm font-medium text-slate-700 dark:text-slate-200">
+                Cloudflare Access Client Secret
+                <input
+                  type="password"
+                  className="mt-1 w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-slate-600 dark:bg-slate-700 dark:text-slate-100"
+                  value={externalSave.cfAccessClientSecret}
+                  onChange={(event): void => {
+                    handleExternalSaveChange('cfAccessClientSecret', event.target.value);
+                  }}
+                />
+              </label>
+            </div>
+
+            <div className="mt-4 flex items-center gap-2">
+              <button
+                type="button"
+                className="inline-flex items-center gap-1.5 rounded-md border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-600 dark:bg-slate-700 dark:text-slate-200 dark:hover:bg-slate-600"
+                disabled={testing || !externalSave.enabled || !externalSaveReady}
+                onClick={(): void => {
+                  void handleTestConnection();
+                }}
+              >
+                {testing ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <PlugZap className="h-4 w-4" />
+                )}
+                Test connection
+              </button>
+              {testMessage !== null ? (
+                <span className="text-xs text-green-600 dark:text-green-400">{testMessage}</span>
+              ) : null}
+            </div>
+          </div>
+
           <div className="mt-4 flex items-center gap-2">
             <button
               type="button"
               className="inline-flex items-center gap-1.5 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
-              disabled={saving || isEmpty || !isDirty}
+              disabled={!canSave}
               onClick={(): void => {
                 void handleSave();
               }}
@@ -193,4 +348,16 @@ export function IntexAgentConfigPage(): React.JSX.Element {
       )}
     </Layout>
   );
+}
+
+function normalizeExternalSave(
+  externalSave: IntexAgentExternalSaveConfig
+): IntexAgentExternalSaveConfig {
+  return {
+    enabled: externalSave.enabled,
+    endpointUrl: externalSave.endpointUrl.trim(),
+    cfAccessClientId: externalSave.cfAccessClientId.trim(),
+    cfAccessClientSecret: externalSave.cfAccessClientSecret.trim(),
+    source: externalSave.source.trim() === '' ? 'ios-shortcuts' : externalSave.source.trim(),
+  };
 }

--- a/apps/web/src/pages/__tests__/IntexAgentConfigPage.test.tsx
+++ b/apps/web/src/pages/__tests__/IntexAgentConfigPage.test.tsx
@@ -9,11 +9,13 @@ const {
   mockGetIntexAgentPreferences,
   mockSaveIntexAgentPreferences,
   mockClearIntexAgentPreferences,
+  mockTestIntexAgentExternalSave,
   mockGetAccessToken,
 } = vi.hoisted(() => ({
   mockGetIntexAgentPreferences: vi.fn(),
   mockSaveIntexAgentPreferences: vi.fn(),
   mockClearIntexAgentPreferences: vi.fn(),
+  mockTestIntexAgentExternalSave: vi.fn(),
   mockGetAccessToken: vi.fn(),
 }));
 
@@ -21,6 +23,7 @@ vi.mock('@/services/intexAgentApi', () => ({
   getIntexAgentPreferences: mockGetIntexAgentPreferences,
   saveIntexAgentPreferences: mockSaveIntexAgentPreferences,
   clearIntexAgentPreferences: mockClearIntexAgentPreferences,
+  testIntexAgentExternalSave: mockTestIntexAgentExternalSave,
 }));
 
 vi.mock('@/context', () => ({
@@ -39,15 +42,40 @@ describe('IntexAgentConfigPage', () => {
     mockGetAccessToken.mockResolvedValue('test-token');
     mockGetIntexAgentPreferences.mockResolvedValue({
       instructions: '',
+      externalSave: {
+        enabled: false,
+        endpointUrl: '',
+        cfAccessClientId: '',
+        cfAccessClientSecret: '',
+        source: 'ios-shortcuts',
+      },
       updatedAt: null,
     });
     mockSaveIntexAgentPreferences.mockResolvedValue({
       instructions: 'hello world',
+      externalSave: {
+        enabled: false,
+        endpointUrl: '',
+        cfAccessClientId: '',
+        cfAccessClientSecret: '',
+        source: 'ios-shortcuts',
+      },
       updatedAt: '2026-06-27T10:00:00.000Z',
     });
     mockClearIntexAgentPreferences.mockResolvedValue({
       instructions: '',
+      externalSave: {
+        enabled: false,
+        endpointUrl: '',
+        cfAccessClientId: '',
+        cfAccessClientSecret: '',
+        source: 'ios-shortcuts',
+      },
       updatedAt: null,
+    });
+    mockTestIntexAgentExternalSave.mockResolvedValue({
+      status: 'success',
+      message: 'Connection successful',
     });
   });
 
@@ -58,6 +86,13 @@ describe('IntexAgentConfigPage', () => {
   it('loads existing preferences on mount', async () => {
     mockGetIntexAgentPreferences.mockResolvedValueOnce({
       instructions: 'Always invite Monika',
+      externalSave: {
+        enabled: true,
+        endpointUrl: 'https://external-save.example.com/intex',
+        cfAccessClientId: 'cf-client-id',
+        cfAccessClientSecret: '************',
+        source: 'ios-shortcuts',
+      },
       updatedAt: '2026-06-27T09:00:00.000Z',
     });
 
@@ -66,6 +101,10 @@ describe('IntexAgentConfigPage', () => {
 
     await waitFor(() => {
       expect(screen.getByDisplayValue('Always invite Monika')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('https://external-save.example.com/intex')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('cf-client-id')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('************')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('ios-shortcuts')).toBeInTheDocument();
     });
     expect(mockGetIntexAgentPreferences).toHaveBeenCalledWith('test-token');
   });
@@ -101,7 +140,89 @@ describe('IntexAgentConfigPage', () => {
     fireEvent.click(saveButton);
 
     await waitFor(() => {
-      expect(mockSaveIntexAgentPreferences).toHaveBeenCalledWith('test-token', 'hello world');
+      expect(mockSaveIntexAgentPreferences).toHaveBeenCalledWith('test-token', {
+        instructions: 'hello world',
+        externalSave: {
+          enabled: false,
+          endpointUrl: '',
+          cfAccessClientId: '',
+          cfAccessClientSecret: '',
+          source: 'ios-shortcuts',
+        },
+      });
+    });
+  });
+
+  it('saves external save configuration without instructions', async () => {
+    const { IntexAgentConfigPage } = await import('../IntexAgentConfigPage');
+    render(<IntexAgentConfigPage />);
+
+    await waitFor(() => {
+      expect(mockGetIntexAgentPreferences).toHaveBeenCalled();
+    });
+
+    fireEvent.click(screen.getByLabelText(/enable external save/i));
+    fireEvent.change(screen.getByLabelText(/endpoint url/i), {
+      target: { value: 'https://external-save.example.com/intex' },
+    });
+    fireEvent.change(screen.getByLabelText(/cloudflare access client id/i), {
+      target: { value: 'cf-client-id' },
+    });
+    fireEvent.change(screen.getByLabelText(/cloudflare access client secret/i), {
+      target: { value: 'cf-client-secret' },
+    });
+
+    const saveButton = screen.getByRole('button', { name: /save/i });
+    await waitFor(() => {
+      expect(saveButton).not.toBeDisabled();
+    });
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(mockSaveIntexAgentPreferences).toHaveBeenCalledWith('test-token', {
+        instructions: '',
+        externalSave: {
+          enabled: true,
+          endpointUrl: 'https://external-save.example.com/intex',
+          cfAccessClientId: 'cf-client-id',
+          cfAccessClientSecret: 'cf-client-secret',
+          source: 'ios-shortcuts',
+        },
+      });
+    });
+  });
+
+  it('tests the external save connection', async () => {
+    mockGetIntexAgentPreferences.mockResolvedValueOnce({
+      instructions: '',
+      externalSave: {
+        enabled: true,
+        endpointUrl: 'https://external-save.example.com/intex',
+        cfAccessClientId: 'cf-client-id',
+        cfAccessClientSecret: '************',
+        source: 'ios-shortcuts',
+      },
+      updatedAt: '2026-06-27T09:00:00.000Z',
+    });
+
+    const { IntexAgentConfigPage } = await import('../IntexAgentConfigPage');
+    render(<IntexAgentConfigPage />);
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('https://external-save.example.com/intex')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /test connection/i }));
+
+    await waitFor(() => {
+      expect(mockTestIntexAgentExternalSave).toHaveBeenCalledWith('test-token', {
+        enabled: true,
+        endpointUrl: 'https://external-save.example.com/intex',
+        cfAccessClientId: 'cf-client-id',
+        cfAccessClientSecret: '************',
+        source: 'ios-shortcuts',
+      });
+      expect(screen.getByText('Connection successful')).toBeInTheDocument();
     });
   });
 
@@ -144,6 +265,13 @@ describe('IntexAgentConfigPage', () => {
   it('clears preferences when Clear is clicked and confirmed', async () => {
     mockGetIntexAgentPreferences.mockResolvedValueOnce({
       instructions: 'existing pref',
+      externalSave: {
+        enabled: false,
+        endpointUrl: '',
+        cfAccessClientId: '',
+        cfAccessClientSecret: '',
+        source: 'ios-shortcuts',
+      },
       updatedAt: '2026-06-27T09:00:00.000Z',
     });
     const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
@@ -168,6 +296,13 @@ describe('IntexAgentConfigPage', () => {
   it('does not clear preferences when confirm is cancelled', async () => {
     mockGetIntexAgentPreferences.mockResolvedValueOnce({
       instructions: 'existing pref',
+      externalSave: {
+        enabled: false,
+        endpointUrl: '',
+        cfAccessClientId: '',
+        cfAccessClientSecret: '',
+        source: 'ios-shortcuts',
+      },
       updatedAt: '2026-06-27T09:00:00.000Z',
     });
     const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);

--- a/apps/web/src/services/__tests__/intexAgentApi.test.ts
+++ b/apps/web/src/services/__tests__/intexAgentApi.test.ts
@@ -4,9 +4,12 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  getIntexAgentPreferences,
   getIntexAgentSession,
   listIntexAgentSessionEvents,
   listIntexAgentSessions,
+  saveIntexAgentPreferences,
+  testIntexAgentExternalSave,
 } from '../intexAgentApi.js';
 import type { IntexAgentSession, IntexAgentSessionEvent } from '../../types/index.js';
 
@@ -81,5 +84,100 @@ describe('intexAgentApi', () => {
     const call = vi.mocked(apiRequest).mock.calls[0];
     expect(call?.[1]).toBe('/sessions/session%201/events');
     expect(result).toEqual([sampleEvent]);
+  });
+
+  it('GETs /preferences from intex-agent', async () => {
+    const { apiRequest } = await import('../apiClient.js');
+    const preferences = {
+      instructions: '',
+      externalSave: {
+        enabled: false,
+        endpointUrl: '',
+        cfAccessClientId: '',
+        cfAccessClientSecret: '',
+        source: 'ios-shortcuts',
+      },
+      updatedAt: null,
+    };
+    vi.mocked(apiRequest).mockResolvedValue(preferences);
+
+    const result = await getIntexAgentPreferences(TOKEN);
+
+    const call = vi.mocked(apiRequest).mock.calls[0];
+    expect(call?.[1]).toBe('/preferences');
+    expect(result).toEqual(preferences);
+  });
+
+  it('PUTs full preferences including external save config', async () => {
+    const { apiRequest } = await import('../apiClient.js');
+    vi.mocked(apiRequest).mockResolvedValue({
+      instructions: '',
+      externalSave: {
+        enabled: true,
+        endpointUrl: 'https://external-save.example.com/intex',
+        cfAccessClientId: 'cf-client-id',
+        cfAccessClientSecret: '************',
+        source: 'ios-shortcuts',
+      },
+      updatedAt: '2026-06-27T10:00:00.000Z',
+    });
+
+    await saveIntexAgentPreferences(TOKEN, {
+      instructions: '',
+      externalSave: {
+        enabled: true,
+        endpointUrl: 'https://external-save.example.com/intex',
+        cfAccessClientId: 'cf-client-id',
+        cfAccessClientSecret: 'cf-client-secret',
+        source: 'ios-shortcuts',
+      },
+    });
+
+    const call = vi.mocked(apiRequest).mock.calls[0];
+    expect(call?.[1]).toBe('/preferences');
+    expect(call?.[3]).toMatchObject({ method: 'PUT' });
+    expect(JSON.parse(String(call?.[3]?.body))).toEqual({
+      instructions: '',
+      externalSave: {
+        enabled: true,
+        endpointUrl: 'https://external-save.example.com/intex',
+        cfAccessClientId: 'cf-client-id',
+        cfAccessClientSecret: 'cf-client-secret',
+        source: 'ios-shortcuts',
+      },
+    });
+  });
+
+  it('POSTs /preferences/external-save/test', async () => {
+    const { apiRequest } = await import('../apiClient.js');
+    vi.mocked(apiRequest).mockResolvedValue({
+      status: 'success',
+      message: 'Connection successful',
+    });
+
+    const result = await testIntexAgentExternalSave(TOKEN, {
+      enabled: true,
+      endpointUrl: 'https://external-save.example.com/intex',
+      cfAccessClientId: 'cf-client-id',
+      cfAccessClientSecret: 'cf-client-secret',
+      source: 'ios-shortcuts',
+    });
+
+    const call = vi.mocked(apiRequest).mock.calls[0];
+    expect(call?.[1]).toBe('/preferences/external-save/test');
+    expect(call?.[3]).toMatchObject({ method: 'POST' });
+    expect(JSON.parse(String(call?.[3]?.body))).toEqual({
+      externalSave: {
+        enabled: true,
+        endpointUrl: 'https://external-save.example.com/intex',
+        cfAccessClientId: 'cf-client-id',
+        cfAccessClientSecret: 'cf-client-secret',
+        source: 'ios-shortcuts',
+      },
+    });
+    expect(result).toEqual({
+      status: 'success',
+      message: 'Connection successful',
+    });
   });
 });

--- a/apps/web/src/services/intexAgentApi.ts
+++ b/apps/web/src/services/intexAgentApi.ts
@@ -4,7 +4,26 @@ import type { IntexAgentSession, IntexAgentSessionEvent } from '@/types';
 
 export interface IntexAgentPreferencesResponse {
   instructions: string;
+  externalSave: IntexAgentExternalSaveConfig;
   updatedAt: string | null;
+}
+
+export interface IntexAgentExternalSaveConfig {
+  enabled: boolean;
+  endpointUrl: string;
+  cfAccessClientId: string;
+  cfAccessClientSecret: string;
+  source: string;
+}
+
+export interface SaveIntexAgentPreferencesRequest {
+  instructions: string;
+  externalSave: IntexAgentExternalSaveConfig;
+}
+
+export interface IntexAgentExternalSaveTestResponse {
+  status: 'success' | 'failure';
+  message: string;
 }
 
 export async function listIntexAgentSessions(accessToken: string): Promise<IntexAgentSession[]> {
@@ -45,7 +64,7 @@ export async function getIntexAgentPreferences(
 
 export async function saveIntexAgentPreferences(
   accessToken: string,
-  instructions: string
+  request: SaveIntexAgentPreferencesRequest
 ): Promise<IntexAgentPreferencesResponse> {
   return await apiRequest<IntexAgentPreferencesResponse>(
     config.intexAgentUrl,
@@ -53,7 +72,22 @@ export async function saveIntexAgentPreferences(
     accessToken,
     {
       method: 'PUT',
-      body: JSON.stringify({ instructions }),
+      body: JSON.stringify(request),
+    }
+  );
+}
+
+export async function testIntexAgentExternalSave(
+  accessToken: string,
+  externalSave: IntexAgentExternalSaveConfig
+): Promise<IntexAgentExternalSaveTestResponse> {
+  return await apiRequest<IntexAgentExternalSaveTestResponse>(
+    config.intexAgentUrl,
+    '/preferences/external-save/test',
+    accessToken,
+    {
+      method: 'POST',
+      body: JSON.stringify({ externalSave }),
     }
   );
 }

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -326,7 +326,8 @@ export type IntexAgentToolName =
   | 'create_calendar_event'
   | 'create_research'
   | 'create_link'
-  | 'create_code_task';
+  | 'create_code_task'
+  | 'save_external';
 
 export interface IntexAgentSession {
   id: string;

--- a/apps/whatsapp-service/src/__tests__/webhookAsyncProcessing.test.ts
+++ b/apps/whatsapp-service/src/__tests__/webhookAsyncProcessing.test.ts
@@ -403,6 +403,20 @@ describe('Webhook async processing', () => {
       // Files should be stored in GCS
       const files = ctx.mediaStorage.getAllFiles();
       expect(files.size).toBe(2); // Original + thumbnail
+
+      const ingestEvents = ctx.eventPublisher.getIntexMessageIngestEvents();
+      expect(ingestEvents).toEqual([
+        expect.objectContaining({
+          type: 'intex.message.ingest',
+          userId,
+          messageId: 'wamid.image.HBgNMTU1NTEyMzQ1Njc4FQIAEhgUM0VCMDRBNzYwREQ0RjMwMjYzMDcA',
+          text: 'Test image caption',
+          sourceType: 'whatsapp_image',
+          whatsappSender: senderPhone,
+          sourceUrl:
+            'https://storage.example.com/signed/whatsapp/test-user-id/wamid.image.HBgNMTU1NTEyMzQ1Njc4FQIAEhgUM0VCMDRBNzYwREQ0RjMwMjYzMDcA/test-media-id-12345.jpg',
+        }),
+      ]);
     });
 
     it('handles image message without caption', async () => {
@@ -444,6 +458,98 @@ describe('Webhook async processing', () => {
       expect(messages.length).toBe(1);
       expect(messages[0]?.text).toBe('');
       expect(messages[0]?.caption).toBeUndefined();
+
+      expect(ctx.eventPublisher.getIntexMessageIngestEvents()).toEqual([
+        expect.objectContaining({
+          type: 'intex.message.ingest',
+          userId,
+          text: '',
+          sourceType: 'whatsapp_image',
+          sourceUrl:
+            'https://storage.example.com/signed/whatsapp/test-user-id/wamid.image.HBgNMTU1NTEyMzQ1Njc4FQIAEhgUM0VCMDRBNzYwREQ0RjMwMjYzMDcA/test-media-id-12345.jpg',
+        }),
+      ]);
+    });
+
+    it('marks image processing retryable when publishing the Intex ingest event fails', async () => {
+      const senderPhone = '15551234567';
+      const userId = 'test-user-id';
+
+      await ctx.userMappingRepository.saveMapping(userId, [senderPhone]);
+      ctx.whatsappCloudApi.setMediaUrl('test-media-id-12345', {
+        url: 'https://example.com/media/test-media-id-12345',
+        mimeType: 'image/jpeg',
+        fileSize: 12345,
+      });
+      ctx.whatsappCloudApi.setMediaContent(
+        'https://example.com/media/test-media-id-12345',
+        SAMPLE_IMAGE_BUFFER
+      );
+      ctx.eventPublisher.setIntexMessageIngestFailure('Simulated intex image ingest failure');
+
+      const payload = createImageWebhookPayload({ caption: 'Receipt' });
+      const payloadString = JSON.stringify(payload);
+      const signature = createSignature(payloadString, testConfig.appSecret);
+
+      const response = await ctx.app.inject({
+        method: 'POST',
+        url: '/webhooks',
+        headers: {
+          'content-type': 'application/json',
+          'x-hub-signature-256': signature,
+        },
+        payload: payloadString,
+      });
+
+      expect(response.statusCode).toBe(200);
+      const processingStatus = await triggerWebhookProcessing();
+      expect(processingStatus).toBe(500);
+
+      const events = ctx.webhookEventRepository.getAll();
+      expect(events[0]?.status).toBe('failed');
+      expect(events[0]?.retryable).toBe(true);
+      expect(events[0]?.failureDetails).toContain('Failed to publish intex image ingest');
+    });
+
+    it('marks image processing retryable when creating the source URL fails', async () => {
+      const senderPhone = '15551234567';
+      const userId = 'test-user-id';
+
+      await ctx.userMappingRepository.saveMapping(userId, [senderPhone]);
+      ctx.whatsappCloudApi.setMediaUrl('test-media-id-12345', {
+        url: 'https://example.com/media/test-media-id-12345',
+        mimeType: 'image/jpeg',
+        fileSize: 12345,
+      });
+      ctx.whatsappCloudApi.setMediaContent(
+        'https://example.com/media/test-media-id-12345',
+        SAMPLE_IMAGE_BUFFER
+      );
+      ctx.mediaStorage.setFailGetSignedUrl(true);
+
+      const payload = createImageWebhookPayload({ caption: 'Receipt' });
+      const payloadString = JSON.stringify(payload);
+      const signature = createSignature(payloadString, testConfig.appSecret);
+
+      const response = await ctx.app.inject({
+        method: 'POST',
+        url: '/webhooks',
+        headers: {
+          'content-type': 'application/json',
+          'x-hub-signature-256': signature,
+        },
+        payload: payloadString,
+      });
+
+      expect(response.statusCode).toBe(200);
+      const processingStatus = await triggerWebhookProcessing();
+      expect(processingStatus).toBe(500);
+
+      const events = ctx.webhookEventRepository.getAll();
+      expect(events[0]?.status).toBe('failed');
+      expect(events[0]?.retryable).toBe(true);
+      expect(events[0]?.failureDetails).toContain('Failed to create image source URL');
+      expect(ctx.eventPublisher.getIntexMessageIngestEvents()).toHaveLength(0);
     });
 
     it('handles getMediaUrl failure gracefully', async () => {

--- a/apps/whatsapp-service/src/domain/whatsapp/events/events.ts
+++ b/apps/whatsapp-service/src/domain/whatsapp/events/events.ts
@@ -137,7 +137,13 @@ export interface IntexMessageIngestEvent {
   /**
    * Source type identifier.
    */
-  sourceType: 'whatsapp_text';
+  sourceType: 'whatsapp_text' | 'whatsapp_image';
+
+  /**
+   * Optional original or media URL for external-save processing.
+   * Consumers must pass this through without fetching unless they own that behavior.
+   */
+  sourceUrl?: string;
 
   /**
    * Optional WhatsApp sender phone number for diagnostics.

--- a/apps/whatsapp-service/src/domain/whatsapp/usecases/processWebhookEventUseCase.ts
+++ b/apps/whatsapp-service/src/domain/whatsapp/usecases/processWebhookEventUseCase.ts
@@ -401,7 +401,14 @@ export class ProcessWebhookEventUseCase {
     imageMedia: { id: string; mimeType: string; sha256?: string; caption?: string },
     logger: Logger
   ): Promise<void> {
-    const { webhookEventRepository, messageRepository, mediaStorage, whatsappCloudApi, thumbnailGenerator } = this.deps;
+    const {
+      webhookEventRepository,
+      messageRepository,
+      mediaStorage,
+      whatsappCloudApi,
+      thumbnailGenerator,
+      eventPublisher,
+    } = this.deps;
 
     const usecase = new ProcessImageMessageUseCase({
       webhookEventRepository,
@@ -426,9 +433,49 @@ export class ProcessWebhookEventUseCase {
       logger
     );
 
-    if (result.ok) {
-      await this.markMessageAsRead(payload, savedEvent, logger);
+    if (!result.ok) {
+      return;
     }
+
+    const sourceUrlResult = await mediaStorage.getSignedUrl(result.value.gcsPath);
+    if (!sourceUrlResult.ok) {
+      const failureDetails = `Failed to create image source URL for intex ingest: ${sourceUrlResult.error.message}`;
+      logger.error(
+        { eventId: savedEvent.id, error: sourceUrlResult.error },
+        'Failed to create image source URL for intex ingest'
+      );
+      await webhookEventRepository.updateEventStatus(savedEvent.id, 'failed', {
+        failureDetails,
+        retryable: true,
+      });
+      throw new RetryableWebhookProcessingError(failureDetails);
+    }
+
+    const ingestPublishResult = await eventPublisher.publishIntexMessageIngest({
+      type: 'intex.message.ingest',
+      userId,
+      messageId: waMessageId,
+      sourceType: 'whatsapp_image',
+      text: imageMedia.caption ?? '',
+      whatsappSender: fromNumber,
+      sourceUrl: sourceUrlResult.value,
+      timestamp,
+    });
+
+    if (!ingestPublishResult.ok) {
+      const failureDetails = `Failed to publish intex image ingest: ${ingestPublishResult.error.message}`;
+      logger.error(
+        { eventId: savedEvent.id, error: ingestPublishResult.error },
+        'Failed to publish intex.message.ingest image event'
+      );
+      await webhookEventRepository.updateEventStatus(savedEvent.id, 'failed', {
+        failureDetails,
+        retryable: true,
+      });
+      throw new RetryableWebhookProcessingError(failureDetails);
+    }
+
+    await this.markMessageAsRead(payload, savedEvent, logger);
   }
 
   /**

--- a/docs/services/intex-agent/agent.md
+++ b/docs/services/intex-agent/agent.md
@@ -19,6 +19,7 @@ Every internal route must log incoming requests before auth validation.
 - `create_link`
 - `create_code_task`
 - `query_calendar_events`
+- `save_external`
 
 ## Implementation Notes
 
@@ -26,7 +27,9 @@ Every internal route must log incoming requests before auth validation.
 - Tool execution lives in `apps/intex-agent/src/domain/agent/toolExecutor.ts`.
 - The system prompt lives in `apps/intex-agent/src/domain/agent/systemPrompt.ts`.
 - Unsupported requests should return an unsupported outcome and explain the currently supported jobs.
-- Intent gating lives in `apps/intex-agent/src/domain/agent/intentGate.ts`. Keep tools hidden unless one supported create/save intent is explicit, a bounded read-only calendar list/count request is detected, or a bare URL routes to `create_link`.
+- Intent gating lives in `apps/intex-agent/src/domain/agent/intentGate.ts`. Keep tools hidden unless one supported create/save intent is explicit, a bounded read-only calendar list/count request is detected, a bare URL routes to `create_link`, or an English/Polish external-save phrase routes to `save_external`.
+- External Save configuration is stored in Intex Agent preferences. Route responses mask `cfAccessClientSecret`; tool execution uses the unmasked stored value.
+- WhatsApp image ingests with `sourceType: whatsapp_image` bypass the LLM and call `save_external` directly with `sourceUrl`.
 - Session transitions live in `apps/intex-agent/src/domain/sessions/sessionController.ts`. Completed, clarification, no-action, and unsupported turns leave the session open for follow-up.
 - WhatsApp replies are published through `apps/intex-agent/src/infra/pubsub/whatsappReplyPublisher.ts` with `replyToMessageId` and session correlation.
 - Do not reintroduce retired command/action-agent compatibility behavior. Add new supported jobs as explicit Intex Agent tools.

--- a/docs/services/intex-agent/features.md
+++ b/docs/services/intex-agent/features.md
@@ -11,6 +11,7 @@ Intex Agent powers WhatsApp text conversations. It keeps a per-user session open
 - Create research drafts for multi-model review.
 - Save links as bookmarks.
 - Create code tasks, defaulting to planning mode.
+- Save images, pasted text, and explicitly shared links to an external processing/storage endpoint.
 
 ## WhatsApp Session Continuity
 
@@ -20,7 +21,13 @@ Users can start fresh with `/new`, `new session`, `start new session`, `start ov
 
 ## Intent Gate
 
-Intex Agent exposes tools only when the message has explicit create/save intent for one supported resource. Bare `http://` and `https://` URL shares are the exception and route to bookmark creation. Read-only calendar list/count questions route only through `query_calendar_events`; other read-only personal-data requests return an unsupported reply instead of being converted into another action.
+Intex Agent exposes tools only when the message has explicit create/save intent for one supported resource. Bare `http://` and `https://` URL shares are the exception and route to bookmark creation. Messages that say "save externally", "upload externally", "save for processing", "zapisz zewnętrznie", "prześlij zewnętrznie", or "zapisz do przetworzenia" route to external save instead. Read-only calendar list/count questions route only through `query_calendar_events`; other read-only personal-data requests return an unsupported reply instead of being converted into another action.
+
+## External Save
+
+External Save is configured in INTEX Agent Configuration. The user needs an endpoint URL, Cloudflare Access Client ID, Cloudflare Access Client Secret, and source label. The default source label is `ios-shortcuts`.
+
+When enabled, WhatsApp image messages are automatically saved externally. If the image has a caption, the caption is sent as `message`; otherwise Intex sends `Image shared via WhatsApp.`. Shared links with external-save intent are passed as `source_url` without fetching or inspecting the URL.
 
 ## Current Limits
 

--- a/docs/services/intex-agent/technical.md
+++ b/docs/services/intex-agent/technical.md
@@ -7,6 +7,10 @@ Intex Agent is the WhatsApp text conversation runtime. It accepts `intex.message
 | Method | Path | Auth | Purpose |
 | --- | --- | --- | --- |
 | `POST` | `/internal/intex-agent/messages` | internal auth or Pub/Sub push OIDC header | Accept a direct or Pub/Sub-wrapped `intex.message.ingest` payload and return `202` with the session ID. |
+| `GET` | `/preferences` | bearer auth | Return prompt instructions and External Save configuration with the Cloudflare secret masked. |
+| `PUT` | `/preferences` | bearer auth | Save prompt instructions and External Save configuration. |
+| `DELETE` | `/preferences` | bearer auth | Clear prompt instructions and External Save configuration. |
+| `POST` | `/preferences/external-save/test` | bearer auth | Test the saved or submitted External Save configuration. |
 | `GET` | `/sessions` | bearer auth | List the authenticated user's Intex Agent sessions. |
 | `GET` | `/sessions/:sessionId` | bearer auth | Return one authenticated-user session. |
 | `GET` | `/sessions/:sessionId/events` | bearer auth | Return ordered timeline events for one authenticated-user session. |
@@ -21,10 +25,13 @@ The current tools are defined in `apps/intex-agent/src/domain/agent/toolDefiniti
 - `create_research`
 - `create_link`
 - `create_code_task`
+- `save_external`
 
 The system prompt in `apps/intex-agent/src/domain/agent/systemPrompt.ts` is the runtime contract. Requests outside those jobs must return `unsupported` rather than being routed through a fallback action system.
 
-`classifyIntexAgentIntent` gates tool exposure before the LLM call. It exposes only the single matched tool for explicit create/save intent, exposes `create_link` for bare URL shares, routes read-only calendar list/count questions only through `query_calendar_events`, and rejects messages that contain multiple supported resource intents. Other read-only personal-data requests remain unsupported.
+`classifyIntexAgentIntent` gates tool exposure before the LLM call. It exposes only the single matched tool for explicit create/save intent, exposes `create_link` for bare URL shares, exposes `save_external` for English and Polish external-save phrases, routes read-only calendar list/count questions only through `query_calendar_events`, and rejects messages that contain multiple supported resource intents. Other read-only personal-data requests remain unsupported.
+
+WhatsApp image messages skip the LLM and call `save_external` directly when External Save is enabled. The signed stored-image URL is passed as `sourceUrl` for the current turn only; the long-lived Intex session event stores `hasSourceUrl: true` instead of the full signed URL.
 
 ## Downstream Services
 
@@ -36,8 +43,38 @@ The system prompt in `apps/intex-agent/src/domain/agent/systemPrompt.ts` is the 
 | `create_research` | research-agent |
 | `create_link` | bookmarks-agent |
 | `create_code_task` | code-agent |
+| `save_external` | User-configured External Save endpoint |
 
 Code tasks default to planning mode unless the user explicitly asks for execution mode.
+
+## External Save Endpoint
+
+The external endpoint is protected by Cloudflare Access Service Auth. Intex sends:
+
+```http
+CF-Access-Client-Id: <client-id>
+CF-Access-Client-Secret: <client-secret>
+content-type: application/json
+```
+
+Request body:
+
+```json
+{
+  "source": "ios-shortcuts",
+  "message": "User caption or pasted text",
+  "source_url": "https://optional-image-or-shared-url"
+}
+```
+
+`source_url` is omitted when no URL is available. Intex does not fetch or inspect `source_url`.
+
+The web client in `apps/web/src/services/intexAgentApi.ts` exposes:
+
+- `getIntexAgentPreferences(token)`
+- `saveIntexAgentPreferences(token, { instructions, externalSave })`
+- `testIntexAgentExternalSave(token, externalSave)`
+- `clearIntexAgentPreferences(token)`
 
 ## Sessions And Replies
 

--- a/docs/services/whatsapp-service/technical.md
+++ b/docs/services/whatsapp-service/technical.md
@@ -59,7 +59,7 @@ Every internal route must call `logIncomingRequest()` before auth validation.
 
 | Event | Purpose |
 | --- | --- |
-| `intex.message.ingest` | Text message payload for Intex Agent |
+| `intex.message.ingest` | Text or stored-image payload for Intex Agent |
 | `whatsapp.message.send` | Outbound message request |
 | `whatsapp.media.cleanup` | Media cleanup request |
 | `whatsapp.webhook.process` | Async processing request for persisted webhook events |
@@ -94,3 +94,9 @@ Existing image messages without stored GCS metadata intentionally remain as plac
 Audio/voice webhook events do not publish transcription jobs for Intex. They send the unsupported voice reply and complete the webhook without creating an Intex message event.
 
 Button and interactive replies from retired workflows are ignored and are not routed into Intex Agent.
+
+## Intex Image Forwarding
+
+Assistant WhatsApp image messages are downloaded, thumbnailed, stored in GCS, and then published to `intex.message.ingest` with `sourceType: whatsapp_image`. The event text is the WhatsApp caption or an empty string. `sourceUrl` is a signed URL for the stored original image.
+
+If the signed URL or Intex ingest publish fails, webhook processing is marked failed and retryable so External Save does not silently miss the image.


### PR DESCRIPTION
## Summary

- add Intex Agent external save preferences, Cloudflare Access connection testing, and save_external tool execution
- automatically external-save WhatsApp image ingests with optional captions and signed image source URLs
- document the client contract and WhatsApp image flow

## Verification

- `pnpm run ci:tracked`

## Linear

Linear: omitted by `$commit-push`; GitHub automation will create or link the Linear issue after PR creation.
