### PR TITLE
[INT-1716] Fix WhatsApp image preview display

### DIFF
--- a/apps/web/src/components/ImageThumbnail.tsx
+++ b/apps/web/src/components/ImageThumbnail.tsx
@@ -10,16 +10,21 @@ interface ImageThumbnailProps {
   messageId: string;
   accessToken: string;
   onClick: () => void;
+  size?: 'compact' | 'preview';
 }
 
 export function ImageThumbnail({
   messageId,
   accessToken,
   onClick,
+  size = 'preview',
 }: ImageThumbnailProps): React.JSX.Element {
   const [thumbnailUrl, setThumbnailUrl] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const boxClass = size === 'compact' ? 'h-8 w-8 rounded-md' : 'h-32 w-32 rounded-lg';
+  const iconClass = size === 'compact' ? 'h-4 w-4' : 'h-8 w-8';
+  const loaderClass = size === 'compact' ? 'h-4 w-4' : 'h-6 w-6';
 
   const fetchThumbnailUrl = useCallback(async (): Promise<void> => {
     try {
@@ -40,8 +45,8 @@ export function ImageThumbnail({
 
   if (isLoading) {
     return (
-      <div className="flex h-32 w-32 items-center justify-center rounded-lg bg-slate-100 dark:bg-slate-700">
-        <Loader2 className="h-6 w-6 animate-spin text-slate-400 dark:text-slate-500" />
+      <div className={`flex ${boxClass} items-center justify-center bg-slate-100 dark:bg-slate-700`}>
+        <Loader2 className={`${loaderClass} animate-spin text-slate-400 dark:text-slate-500`} />
       </div>
     );
   }
@@ -49,39 +54,50 @@ export function ImageThumbnail({
   if (error !== null) {
     return (
       <button
-        onClick={(): void => {
+        type="button"
+        onClick={(event): void => {
+          event.stopPropagation();
           void fetchThumbnailUrl();
         }}
-        className="flex h-32 w-32 flex-col items-center justify-center gap-2 rounded-lg bg-red-50 transition hover:bg-red-100 dark:bg-red-900/30 dark:hover:bg-red-900/50"
+        className={`flex ${boxClass} flex-col items-center justify-center gap-2 bg-red-50 transition hover:bg-red-100 dark:bg-red-900/30 dark:hover:bg-red-900/50`}
+        title="Retry thumbnail"
       >
-        <AlertCircle className="h-6 w-6 text-red-400" />
-        <span className="text-xs text-red-600 dark:text-red-400">Retry</span>
+        <AlertCircle className={`${loaderClass} text-red-400`} />
+        <span className={size === 'compact' ? 'sr-only' : 'text-xs text-red-600 dark:text-red-400'}>Retry</span>
       </button>
     );
   }
 
   if (thumbnailUrl === null) {
     return (
-      <div className="flex h-32 w-32 items-center justify-center rounded-lg bg-slate-100 dark:bg-slate-700">
-        <ImageIcon className="h-8 w-8 text-slate-400 dark:text-slate-500" />
+      <div className={`flex ${boxClass} items-center justify-center bg-slate-100 dark:bg-slate-700`}>
+        <ImageIcon className={`${iconClass} text-slate-400 dark:text-slate-500`} />
       </div>
     );
   }
 
   return (
     <button
-      onClick={onClick}
-      className="group relative overflow-hidden rounded-lg transition hover:ring-2 hover:ring-blue-400"
+      type="button"
+      onClick={(event): void => {
+        event.stopPropagation();
+        onClick();
+      }}
+      className={`group relative shrink-0 overflow-hidden ${boxClass} transition hover:ring-2 hover:ring-blue-400`}
+      aria-label="View image"
+      title="View image"
     >
       <img
         src={thumbnailUrl}
         alt="Message thumbnail"
-        className="h-32 w-32 object-cover transition group-hover:scale-105"
+        className={`${boxClass} object-cover transition group-hover:scale-105`}
       />
       <div className="absolute inset-0 flex items-center justify-center bg-black/0 transition group-hover:bg-black/20">
-        <span className="translate-y-4 text-xs font-medium text-white opacity-0 transition group-hover:translate-y-0 group-hover:opacity-100">
-          Click to view
-        </span>
+        {size === 'preview' ? (
+          <span className="translate-y-4 text-xs font-medium text-white opacity-0 transition group-hover:translate-y-0 group-hover:opacity-100">
+            Click to view
+          </span>
+        ) : null}
       </div>
     </button>
   );

--- a/apps/web/src/components/whatsapp/MessageItem.tsx
+++ b/apps/web/src/components/whatsapp/MessageItem.tsx
@@ -25,13 +25,20 @@ function getDesktopMediaIndicator(
 ): React.JSX.Element {
   if (message.mediaType === 'image' && message.hasMedia) {
     return (
-      <ImageThumbnail
-        messageId={message.id}
-        accessToken={accessToken}
-        onClick={(): void => {
-          onImageClick(message.id);
+      <div
+        onClick={(event): void => {
+          event.stopPropagation();
         }}
-      />
+      >
+        <ImageThumbnail
+          messageId={message.id}
+          accessToken={accessToken}
+          size="compact"
+          onClick={(): void => {
+            onImageClick(message.id);
+          }}
+        />
+      </div>
     );
   }
   if (message.mediaType === 'audio') {

--- a/apps/web/src/components/whatsapp/__tests__/MessageItem.test.tsx
+++ b/apps/web/src/components/whatsapp/__tests__/MessageItem.test.tsx
@@ -17,12 +17,14 @@ vi.mock('@/components', () => ({
   ImageThumbnail: ({
     messageId,
     onClick,
+    size,
   }: {
     messageId: string;
     accessToken: string;
     onClick: () => void;
+    size?: 'compact' | 'preview';
   }): React.JSX.Element => (
-    <button type="button" onClick={onClick}>
+    <button type="button" onClick={onClick} data-size={size}>
       {`Image thumbnail ${messageId}`}
     </button>
   ),
@@ -133,7 +135,36 @@ describe('MessageItem', () => {
     expect(within(mobileShell).getByText('https://example.com/reference-image-caption')).toHaveClass('line-clamp-2');
     expect(within(mobileShell).getByTitle('View note')).toBeInTheDocument();
     expect(within(mobileShell).getByLabelText('Copy message')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Image thumbnail image-1' })).toHaveAttribute('data-size', 'compact');
     expect(screen.getByTitle('Open full size in new tab')).toBeInTheDocument();
+  });
+
+  it('opens image previews without also opening the note modal from the row click', () => {
+    const onImageClick = vi.fn();
+    const onNoteClick = vi.fn();
+
+    render(
+      <MessageItem
+        message={createMessage({
+          id: 'image-1',
+          mediaType: 'image',
+          hasMedia: true,
+          text: '',
+          caption: 'Reference image caption',
+        })}
+        accessToken="token"
+        onDelete={vi.fn()}
+        onImageClick={onImageClick}
+        onNoteClick={onNoteClick}
+        onTranscriptionClick={vi.fn()}
+        isDeleting={false}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Image thumbnail image-1' }));
+
+    expect(onImageClick).toHaveBeenCalledWith('image-1');
+    expect(onNoteClick).not.toHaveBeenCalled();
   });
 
   it('shows a transcription action for completed audio messages and hides it for processing audio messages', () => {


### PR DESCRIPTION
## Summary

- Render WhatsApp message thumbnails in compact row mode so image rows no longer overflow the list layout.
- Stop thumbnail and retry clicks from bubbling into the message row, so image preview opens directly without a note modal overlay hiding it.

## Verification

- `pnpm --filter web test -- MessageItem.test.tsx`
- Temporary rendered Playwright harness: compact thumbnail 32x32, note clicks stayed 0, one image preview dialog visible after click
- `pnpm run verify:workspace:tracked web`
- `pnpm run ci:tracked`

## Linear

Linear: omitted by `$commit-push`; GitHub automation will create or link the Linear issue after PR creation.
