### PR TITLE
[INT-1717] Fix Intex Agent external delivery failure replies

### DIFF
--- a/apps/intex-agent/src/__tests__/domain/intexAgentRunner.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/intexAgentRunner.test.ts
@@ -29,6 +29,12 @@ const COMPLETION_FAILURE_CAPABILITIES_REPLY =
     '- save bookmarks',
     '- create code tasks for planning or execution',
   ].join('\n');
+const EXTERNAL_SAVE_NOT_CONFIGURED_REPLY =
+  'No external system is configured for this message, so I cannot process it. Configure External Save in Intex Agent preferences and send it again.';
+const EXTERNAL_SAVE_FAILED_REPLY =
+  'I could not deliver this to the external system. The external save request failed: HTTP 403: Forbidden. Please check the external system configuration and try again.';
+const EXTERNAL_SAVE_UNKNOWN_FAILURE_REPLY =
+  'I could not deliver this to the external system. The external save request failed: Unknown external save error. Please check the external system configuration and try again.';
 
 describe('createIntexAgentRunner', () => {
   it('uses the versioned prompt, transcript messages, and supported tools', async () => {
@@ -1246,6 +1252,110 @@ describe('createIntexAgentRunner', () => {
     });
   });
 
+  it('explains that WhatsApp images cannot be processed when external save is not configured', async () => {
+    const runner = createIntexAgentRunner({
+      client: new FakeToolCallingClient([]),
+      toolExecutor: fakeToolExecutor({
+        saveExternal: async (): Promise<string> => {
+          throw new Error('External save is not configured');
+        },
+      }),
+    });
+
+    await expect(
+      runner.run({
+        session: session(),
+        events: [],
+        message: 'Lunch receipt',
+        sourceType: 'whatsapp_image',
+        sourceUrl: 'https://storage.example.com/signed/receipt.jpg',
+        currentDateTime: CURRENT_DATE_TIME,
+      })
+    ).resolves.toEqual({
+      outcome: 'unsupported',
+      reply: EXTERNAL_SAVE_NOT_CONFIGURED_REPLY,
+    });
+  });
+
+  it('notifies the user when WhatsApp image external save processing fails', async () => {
+    const runner = createIntexAgentRunner({
+      client: new FakeToolCallingClient([]),
+      toolExecutor: fakeToolExecutor({
+        saveExternal: async (): Promise<string> => {
+          throw new Error('Failed to save externally: HTTP 403: Forbidden');
+        },
+      }),
+    });
+
+    await expect(
+      runner.run({
+        session: session(),
+        events: [],
+        message: 'Lunch receipt',
+        sourceType: 'whatsapp_image',
+        sourceUrl: 'https://storage.example.com/signed/receipt.jpg',
+        currentDateTime: CURRENT_DATE_TIME,
+      })
+    ).resolves.toEqual({
+      outcome: 'unsupported',
+      reply: EXTERNAL_SAVE_FAILED_REPLY,
+    });
+  });
+
+  it('uses a fallback detail when WhatsApp image external save fails without details', async () => {
+    const runner = createIntexAgentRunner({
+      client: new FakeToolCallingClient([]),
+      toolExecutor: fakeToolExecutor({
+        saveExternal: async (): Promise<string> => {
+          throw new Error('Failed to save externally:   ');
+        },
+      }),
+    });
+
+    await expect(
+      runner.run({
+        session: session(),
+        events: [],
+        message: 'Lunch receipt',
+        sourceType: 'whatsapp_image',
+        sourceUrl: 'https://storage.example.com/signed/receipt.jpg',
+        currentDateTime: CURRENT_DATE_TIME,
+      })
+    ).resolves.toEqual({
+      outcome: 'unsupported',
+      reply: EXTERNAL_SAVE_UNKNOWN_FAILURE_REPLY,
+    });
+  });
+
+  it('overrides model text when external save tool delivery fails', async () => {
+    const client = new ToolExecutingFakeToolCallingClient({
+      toolName: 'save_external',
+      args: { message: 'Save externally this copied LinkedIn detail' },
+    }, [
+      ok(toolResult({ outcome: 'no_action', reply: 'The model should not hide this failure.' })),
+    ]);
+    const runner = createIntexAgentRunner({
+      client,
+      toolExecutor: fakeToolExecutor({
+        saveExternal: async (): Promise<string> => {
+          throw new Error('External save is not configured');
+        },
+      }),
+    });
+
+    await expect(
+      runner.run({
+        session: session(),
+        events: [],
+        message: 'Save externally this copied LinkedIn detail',
+        currentDateTime: CURRENT_DATE_TIME,
+      })
+    ).resolves.toEqual({
+      outcome: 'unsupported',
+      reply: EXTERNAL_SAVE_NOT_CONFIGURED_REPLY,
+    });
+  });
+
   it('rejects completed responses when no tool actually ran and no supported toolName is present', async () => {
     const client = new FakeToolCallingClient([
       ok(
@@ -1501,7 +1611,12 @@ class ToolExecutingFakeToolCallingClient extends FakeToolCallingClient {
       if (tool === undefined) {
         throw new Error(`Missing fake tool ${toolCall.toolName}`);
       }
-      await tool.run(toolCall.args);
+      try {
+        await tool.run(toolCall.args);
+      } catch {
+        // Match the real OpenRouter tool client: callback errors are returned
+        // as tool messages and the model still gets a final response chance.
+      }
     }
     return await super.run(params);
   }

--- a/apps/intex-agent/src/domain/agent/intexAgentRunner.ts
+++ b/apps/intex-agent/src/domain/agent/intexAgentRunner.ts
@@ -1,3 +1,4 @@
+import { getErrorMessage } from '@intexuraos/common-core';
 import type { ToolCallingClient, ToolCallingMessage } from '@intexuraos/llm-contract';
 import type {
   IntexAgentRunner,
@@ -74,6 +75,14 @@ export function createIntexAgentRunner(config: IntexAgentRunnerConfig): IntexAge
         maxIterations: 5,
       });
 
+      const externalSaveFailure = getExternalSaveFailure(toolExecutions);
+      if (externalSaveFailure !== undefined) {
+        return {
+          outcome: 'unsupported',
+          reply: buildExternalSaveFailureReply(externalSaveFailure),
+        };
+      }
+
       if (!result.ok) {
         return {
           outcome: 'unsupported',
@@ -94,6 +103,7 @@ interface IntexAgentToolExecution {
   toolName: IntexAgentToolName;
   args: Record<string, unknown>;
   result?: Record<string, unknown>;
+  error?: string;
 }
 
 interface CompletedReply {
@@ -269,14 +279,23 @@ function createTrackingToolExecutor(
     args: Record<string, unknown>,
     run: () => Promise<string>
   ): Promise<string> {
-    const rawResult = await run();
-    const parsedResult = parseToolResult(rawResult);
-    toolExecutions.push({
-      toolName,
-      args,
-      ...(parsedResult !== undefined ? { result: parsedResult } : {}),
-    });
-    return rawResult;
+    try {
+      const rawResult = await run();
+      const parsedResult = parseToolResult(rawResult);
+      toolExecutions.push({
+        toolName,
+        args,
+        ...(parsedResult !== undefined ? { result: parsedResult } : {}),
+      });
+      return rawResult;
+    } catch (error) {
+      toolExecutions.push({
+        toolName,
+        args,
+        error: getErrorMessage(error, 'Unknown external save error'),
+      });
+      throw error;
+    }
   }
 
   return {
@@ -330,12 +349,39 @@ async function saveWhatsAppImageExternally(
       toolName: 'save_external',
       ...(result !== undefined ? { toolResult: result } : {}),
     };
-  } catch {
+  } catch (error) {
     return {
       outcome: 'unsupported',
-      reply: buildCompletionFailureCapabilitiesReply(),
+      reply: buildExternalSaveFailureReply(getErrorMessage(error, 'Unknown external save error')),
     };
   }
+}
+
+function getExternalSaveFailure(
+  toolExecutions: IntexAgentToolExecution[]
+): string | undefined {
+  return toolExecutions.find(
+    (execution) => execution.toolName === 'save_external' && execution.error !== undefined
+  )?.error;
+}
+
+function buildExternalSaveFailureReply(errorMessage: string): string {
+  if (isExternalSaveNotConfiguredError(errorMessage)) {
+    return 'No external system is configured for this message, so I cannot process it. Configure External Save in Intex Agent preferences and send it again.';
+  }
+
+  const detail = normalizeExternalSaveFailureDetail(errorMessage);
+  return `I could not deliver this to the external system. The external save request failed: ${detail}. Please check the external system configuration and try again.`;
+}
+
+function isExternalSaveNotConfiguredError(errorMessage: string): boolean {
+  return errorMessage.trim() === 'External save is not configured';
+}
+
+function normalizeExternalSaveFailureDetail(errorMessage: string): string {
+  const normalized = errorMessage.trim().replace(/^Failed to save externally:\s*/i, '');
+  const withoutTrailingPeriod = normalized.replace(/\.+$/u, '').trim();
+  return withoutTrailingPeriod === '' ? 'Unknown external save error' : withoutTrailingPeriod;
 }
 
 function toRecord(args: object): Record<string, unknown> {


### PR DESCRIPTION
## Summary
- Add deterministic Intex Agent replies when External Save is not configured.
- Notify users when external delivery processing fails instead of falling back to generic assistant text.
- Track `save_external` tool exceptions so delivery failures cannot be hidden by model output.

## Verification
- `pnpm run ci:tracked`

Linear: omitted by $commit-push; GitHub automation will create or link the Linear issue after PR creation.