### PR TITLE
Add private WhatsApp chat transcripts

### DIFF
--- a/apps/web/src/hooks/__tests__/usePrivateWhatsAppLog.test.tsx
+++ b/apps/web/src/hooks/__tests__/usePrivateWhatsAppLog.test.tsx
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
   getAccessToken: vi.fn(),
   listPrivateWhatsAppChats: vi.fn(),
   listPrivateWhatsAppChatMessages: vi.fn(),
+  updatePrivateWhatsAppChatTranscription: vi.fn(),
 }));
 
 vi.mock('@/context', () => ({
@@ -23,6 +24,7 @@ vi.mock('@/context', () => ({
 vi.mock('@/services/whatsappApi', () => ({
   listPrivateWhatsAppChats: mocks.listPrivateWhatsAppChats,
   listPrivateWhatsAppChatMessages: mocks.listPrivateWhatsAppChatMessages,
+  updatePrivateWhatsAppChatTranscription: mocks.updatePrivateWhatsAppChatTranscription,
 }));
 
 import { usePrivateWhatsAppLog } from '../usePrivateWhatsAppLog.js';
@@ -139,6 +141,12 @@ describe('usePrivateWhatsAppLog', () => {
       messages: [groupIncomingMessage, groupOutgoingMessage],
       nextCursor: 'messages-next',
     });
+    mocks.updatePrivateWhatsAppChatTranscription.mockResolvedValue({
+      ...groupChat,
+      transcriptionEnabled: true,
+      transcriptionEnabledAt: '2026-06-22T10:00:00.000Z',
+      transcriptionUpdatedAt: '2026-06-22T10:00:00.000Z',
+    });
   });
 
   it('loads chats, auto-selects the first chat, and loads the whole conversation', async () => {
@@ -213,5 +221,23 @@ describe('usePrivateWhatsAppLog', () => {
 
     expect(result.current.selectedChatId).toBe(directChat.id);
     expect(result.current.messages).toEqual([directMessage]);
+  });
+
+  it('updates a selected chat transcription setting through the API', async () => {
+    const { result } = renderHook(() => usePrivateWhatsAppLog(), { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(result.current.selectedChat?.id).toBe(groupChat.id);
+    });
+
+    await act(async () => {
+      await result.current.setChatTranscriptionEnabled(groupChat.id, true);
+    });
+
+    expect(mocks.updatePrivateWhatsAppChatTranscription).toHaveBeenCalledWith('tok', groupChat.id, {
+      enabled: true,
+    });
+    expect(result.current.selectedChat?.transcriptionEnabled).toBe(true);
+    expect(result.current.chats[0]?.transcriptionUpdatedAt).toBe('2026-06-22T10:00:00.000Z');
   });
 });

--- a/apps/web/src/hooks/usePrivateWhatsAppLog.ts
+++ b/apps/web/src/hooks/usePrivateWhatsAppLog.ts
@@ -6,6 +6,7 @@ import {
   listPrivateWhatsAppChatMessages,
   listPrivateWhatsAppChats,
   type ListPrivateWhatsAppChatMessagesOptions,
+  updatePrivateWhatsAppChatTranscription,
 } from '@/services/whatsappApi';
 import type { PrivateWhatsAppChat, PrivateWhatsAppMessage } from '@/types';
 
@@ -28,11 +29,13 @@ export interface UsePrivateWhatsAppLogResult {
   loadingMoreChats: boolean;
   loadingMoreMessages: boolean;
   refreshing: boolean;
+  transcriptionToggleChatId: string | undefined;
   error: string | null;
   setChatSearch: (value: string) => void;
   selectChat: (chatId: string) => void;
   selectDay: (dayKey: string) => void;
   clearDay: () => void;
+  setChatTranscriptionEnabled: (chatId: string, enabled: boolean) => Promise<void>;
   refresh: () => Promise<void>;
   loadMoreChats: () => Promise<void>;
   loadMoreMessages: () => Promise<void>;
@@ -56,6 +59,9 @@ export function usePrivateWhatsAppLog(): UsePrivateWhatsAppLogResult {
   const [loadingMoreChats, setLoadingMoreChats] = useState(false);
   const [loadingMoreMessages, setLoadingMoreMessages] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
+  const [transcriptionToggleChatId, setTranscriptionToggleChatId] = useState<string | undefined>(
+    undefined
+  );
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -229,6 +235,25 @@ export function usePrivateWhatsAppLog(): UsePrivateWhatsAppLogResult {
     }
   }, [setSelectionParams]);
 
+  const setChatTranscriptionEnabled = useCallback(
+    async (chatId: string, enabled: boolean): Promise<void> => {
+      setTranscriptionToggleChatId(chatId);
+      setError(null);
+      try {
+        const token = await getAccessToken();
+        const updatedChat = await updatePrivateWhatsAppChatTranscription(token, chatId, {
+          enabled,
+        });
+        setChats((prev) => prev.map((chat) => (chat.id === chatId ? updatedChat : chat)));
+      } catch (err) {
+        setError(getErrorMessage(err, 'Failed to update private WhatsApp transcription setting'));
+      } finally {
+        setTranscriptionToggleChatId(undefined);
+      }
+    },
+    [getAccessToken]
+  );
+
   const selectedChat = useMemo(
     () => chats.find((chat) => chat.id === selectedChatId),
     [chats, selectedChatId]
@@ -267,11 +292,13 @@ export function usePrivateWhatsAppLog(): UsePrivateWhatsAppLogResult {
     loadingMoreChats,
     loadingMoreMessages,
     refreshing,
+    transcriptionToggleChatId,
     error,
     setChatSearch,
     selectChat,
     selectDay,
     clearDay,
+    setChatTranscriptionEnabled,
     refresh,
     loadMoreChats,
     loadMoreMessages,

--- a/apps/web/src/pages/PrivateWhatsAppLogPage.tsx
+++ b/apps/web/src/pages/PrivateWhatsAppLogPage.tsx
@@ -3,7 +3,9 @@ import {
   CalendarDays,
   FileText,
   Image,
+  Loader2,
   MessageSquare,
+  Mic,
   RefreshCw,
   Search,
   UserRound,
@@ -104,8 +106,51 @@ function hasStoredImage(message: PrivateWhatsAppMessage): boolean {
   );
 }
 
+function MessageTranscription({ message }: { message: PrivateWhatsAppMessage }): React.JSX.Element | null {
+  const transcription = message.messageType === 'audio' ? message.transcription : undefined;
+  if (transcription === undefined) {
+    return null;
+  }
+
+  if (transcription.status === 'completed' && transcription.text !== undefined) {
+    return (
+      <div className="rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-2 dark:border-emerald-800 dark:bg-emerald-950/30">
+        <div className="mb-1 flex items-center gap-2 text-xs font-semibold text-emerald-700 dark:text-emerald-300">
+          <Mic className="h-3.5 w-3.5" />
+          <span>Transcript</span>
+        </div>
+        <p className="whitespace-pre-wrap break-words text-sm leading-6 text-slate-900 dark:text-slate-100">
+          {transcription.text}
+        </p>
+      </div>
+    );
+  }
+
+  if (transcription.status === 'failed') {
+    return (
+      <div className="rounded-lg border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700 dark:border-rose-800 dark:bg-rose-950/30 dark:text-rose-300">
+        <div className="mb-1 flex items-center gap-2 text-xs font-semibold">
+          <Mic className="h-3.5 w-3.5" />
+          <span>Transcript failed</span>
+        </div>
+        {transcription.error?.message !== undefined ? (
+          <p className="break-words">{transcription.error.message}</p>
+        ) : null}
+      </div>
+    );
+  }
+
+  return (
+    <div className="inline-flex items-center gap-2 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-600 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-300">
+      <Loader2 className="h-4 w-4 animate-spin" />
+      <span>{transcription.status === 'pending' ? 'Queued' : 'Transcribing'}</span>
+    </div>
+  );
+}
+
 function MessageBody({ message }: { message: PrivateWhatsAppMessage }): React.JSX.Element {
   const hasText = message.text !== undefined && message.text.trim() !== '';
+  const transcription = <MessageTranscription message={message} />;
 
   if (hasStoredImage(message)) {
     return (
@@ -116,15 +161,19 @@ function MessageBody({ message }: { message: PrivateWhatsAppMessage }): React.JS
             {message.text}
           </p>
         ) : null}
+        {transcription}
       </div>
     );
   }
 
   if (hasText) {
     return (
-      <p className="whitespace-pre-wrap break-words text-sm leading-6 text-slate-900 dark:text-slate-100">
-        {message.text}
-      </p>
+      <div className="space-y-3">
+        <p className="whitespace-pre-wrap break-words text-sm leading-6 text-slate-900 dark:text-slate-100">
+          {message.text}
+        </p>
+        {transcription}
+      </div>
     );
   }
 
@@ -133,9 +182,12 @@ function MessageBody({ message }: { message: PrivateWhatsAppMessage }): React.JS
   const Icon = message.messageType === 'image' ? Image : FileText;
 
   return (
-    <div className="inline-flex max-w-full items-center gap-2 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-600 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-300">
-      <Icon className="h-4 w-4 shrink-0" />
-      <span className="truncate">{mediaName}</span>
+    <div className="space-y-3">
+      <div className="inline-flex max-w-full items-center gap-2 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-600 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-300">
+        <Icon className="h-4 w-4 shrink-0" />
+        <span className="truncate">{mediaName}</span>
+      </div>
+      {transcription}
     </div>
   );
 }
@@ -330,6 +382,42 @@ export function PrivateWhatsAppLogPage(): React.JSX.Element {
                     </p>
                   ) : null}
                 </div>
+                {log.selectedChat !== undefined ? (
+                  <label className="inline-flex select-none items-center gap-3 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-sm font-medium text-slate-700 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200">
+                    <Mic className="h-4 w-4 text-slate-400" />
+                    <span>Transcripts</span>
+                    <input
+                      role="switch"
+                      type="checkbox"
+                      className="sr-only"
+                      checked={log.selectedChat.transcriptionEnabled === true}
+                      disabled={log.transcriptionToggleChatId === log.selectedChat.id}
+                      aria-label="Transcripts"
+                      onChange={(event): void => {
+                        void log.setChatTranscriptionEnabled(
+                          log.selectedChat?.id ?? '',
+                          event.currentTarget.checked
+                        );
+                      }}
+                    />
+                    <span
+                      aria-hidden="true"
+                      className={`relative h-5 w-9 rounded-full transition-colors ${
+                        log.selectedChat.transcriptionEnabled === true
+                          ? 'bg-blue-600'
+                          : 'bg-slate-300 dark:bg-slate-600'
+                      }`}
+                    >
+                      <span
+                        className={`absolute top-0.5 h-4 w-4 rounded-full bg-white shadow transition-transform ${
+                          log.selectedChat.transcriptionEnabled === true
+                            ? 'translate-x-4'
+                            : 'translate-x-0.5'
+                        }`}
+                      />
+                    </span>
+                  </label>
+                ) : null}
               </div>
 
               {log.selectedChatId !== undefined ? (

--- a/apps/web/src/pages/__tests__/PrivateWhatsAppLogPage.test.tsx
+++ b/apps/web/src/pages/__tests__/PrivateWhatsAppLogPage.test.tsx
@@ -130,11 +130,13 @@ function createHookResult(
     loadingMoreChats: false,
     loadingMoreMessages: false,
     refreshing: false,
+    transcriptionToggleChatId: undefined,
     error: null,
     setChatSearch: vi.fn(),
     selectChat: vi.fn(),
     selectDay: vi.fn(),
     clearDay: vi.fn(),
+    setChatTranscriptionEnabled: vi.fn(),
     refresh: vi.fn(),
     loadMoreChats: vi.fn(),
     loadMoreMessages: vi.fn(),
@@ -287,5 +289,90 @@ describe('PrivateWhatsAppLogPage', () => {
     expect(screen.getByText('stored image')).toBeInTheDocument();
     expect(screen.getByText('image.jpg')).toBeInTheDocument();
     expect(screen.getByText('original-only.jpg')).toBeInTheDocument();
+  });
+
+  it('toggles chat transcripts and renders private audio transcription state', async () => {
+    const user = userEvent.setup();
+    const setChatTranscriptionEnabled = vi.fn();
+    mockUsePrivateWhatsAppLog.mockReturnValueOnce(
+      createHookResult({
+        selectedChat: {
+          id: 'chat-group',
+          displayName: 'Fishing Crew (WA)',
+          chatType: 'group',
+          firstEventAt: '2026-06-22T08:00:00.000Z',
+          lastEventAt: '2026-06-22T09:00:00.000Z',
+          messageCount: 3,
+          participantCount: 2,
+          transcriptionEnabled: false,
+          updatedAt: '2026-06-22T09:01:00.000Z',
+          schemaVersion: 2,
+        },
+        setChatTranscriptionEnabled,
+        messages: [
+          {
+            id: 'audio-completed',
+            chatId: 'chat-group',
+            direction: 'incoming',
+            messageType: 'audio',
+            media: {
+              mxcUri: 'mxc://home-dev/audio-completed',
+              mimeType: 'audio/ogg',
+              fileName: 'voice.ogg',
+              storageStatus: 'stored',
+              hasMedia: true,
+            },
+            transcription: {
+              status: 'completed',
+              jobId: 'job-completed',
+              text: 'Bring the documents tomorrow.',
+              completedAt: '2026-06-22T09:03:00.000Z',
+            },
+            eventTimestamp: '2026-06-22T09:02:00.000Z',
+            eventDayKey: '2026-06-22',
+            receivedAt: '2026-06-22T09:02:02.000Z',
+            ingestedAt: '2026-06-22T09:02:03.000Z',
+            deliveryMode: 'live',
+          },
+          {
+            id: 'audio-failed',
+            chatId: 'chat-group',
+            direction: 'incoming',
+            messageType: 'audio',
+            media: {
+              mxcUri: 'mxc://home-dev/audio-failed',
+              mimeType: 'audio/ogg',
+              fileName: 'broken.ogg',
+            },
+            transcription: {
+              status: 'failed',
+              jobId: 'job-failed',
+              error: {
+                code: 'TRANSCRIPTION_FAILED',
+                message: 'Audio format was not supported',
+              },
+              completedAt: '2026-06-22T09:04:00.000Z',
+            },
+            eventTimestamp: '2026-06-22T09:04:00.000Z',
+            eventDayKey: '2026-06-22',
+            receivedAt: '2026-06-22T09:04:02.000Z',
+            ingestedAt: '2026-06-22T09:04:03.000Z',
+            deliveryMode: 'live',
+          },
+        ],
+      })
+    );
+
+    render(
+      <MemoryRouter>
+        <PrivateWhatsAppLogPage />
+      </MemoryRouter>
+    );
+
+    await user.click(screen.getByRole('switch', { name: /transcripts/i }));
+
+    expect(setChatTranscriptionEnabled).toHaveBeenCalledWith('chat-group', true);
+    expect(screen.getByText('Bring the documents tomorrow.')).toBeInTheDocument();
+    expect(screen.getByText('Audio format was not supported')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/services/__tests__/whatsappApi.private.test.ts
+++ b/apps/web/src/services/__tests__/whatsappApi.private.test.ts
@@ -13,6 +13,7 @@ import {
   listPrivateWhatsAppMessages,
   listPrivateWhatsAppSenderDays,
   listPrivateWhatsAppSenders,
+  updatePrivateWhatsAppChatTranscription,
   upsertPrivateWhatsAppAccount,
 } from '../whatsappApi.js';
 
@@ -164,6 +165,26 @@ describe('whatsappApi private read helpers', () => {
     const call = vi.mocked(apiRequest).mock.calls[0];
     expect(call?.[1]).toBe('/private/account');
     expect(call?.[3]).toEqual({ method: 'DELETE' });
+  });
+
+  it('updates private chat transcription settings without sourceAccountId', async () => {
+    const { apiRequest } = await import('../apiClient.js');
+    vi.mocked(apiRequest).mockResolvedValue({ id: 'chat-a', transcriptionEnabled: true });
+
+    const result = await updatePrivateWhatsAppChatTranscription(TOKEN, 'chat-a', {
+      enabled: true,
+    });
+
+    expect(result.transcriptionEnabled).toBe(true);
+    const call = vi.mocked(apiRequest).mock.calls[0];
+    expect(call?.[0]).toBe('/api/whatsapp');
+    expect(call?.[1]).toBe('/private/chats/chat-a/transcription');
+    expect(call?.[1]).not.toContain('sourceAccountId');
+    expect(call?.[2]).toBe(TOKEN);
+    expect(call?.[3]).toEqual({
+      method: 'PATCH',
+      body: { enabled: true },
+    });
   });
 
   it('prefixes service-relative private media access URLs with the configured web API base', async () => {

--- a/apps/web/src/services/whatsappApi.ts
+++ b/apps/web/src/services/whatsappApi.ts
@@ -169,6 +169,10 @@ export interface UpsertPrivateWhatsAppAccountRequest {
   phoneNumber: string;
 }
 
+export interface UpdatePrivateWhatsAppChatTranscriptionRequest {
+  enabled: boolean;
+}
+
 function normalizePrivateMediaAccessUrl(url: string): string {
   if (!url.startsWith('/private/')) {
     return url;
@@ -320,6 +324,23 @@ export async function disablePrivateWhatsAppAccount(
     '/private/account',
     accessToken,
     { method: 'DELETE' }
+  );
+}
+
+export async function updatePrivateWhatsAppChatTranscription(
+  accessToken: string,
+  chatId: string,
+  request: UpdatePrivateWhatsAppChatTranscriptionRequest
+): Promise<PrivateWhatsAppChatsResponse['chats'][number]> {
+  const encodedChatId = encodeURIComponent(chatId);
+  return await apiRequest<PrivateWhatsAppChatsResponse['chats'][number]>(
+    config.whatsappServiceUrl,
+    `/private/chats/${encodedChatId}/transcription`,
+    accessToken,
+    {
+      method: 'PATCH',
+      body: request,
+    }
   );
 }
 

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -169,6 +169,11 @@ export type PrivateWhatsAppMessageType =
   | 'unknown';
 
 export type PrivateWhatsAppDeliveryMode = 'live' | 'backfill';
+export type PrivateWhatsAppTranscriptionStatus =
+  | 'pending'
+  | 'processing'
+  | 'completed'
+  | 'failed';
 
 export interface PrivateWhatsAppMedia {
   mxcUri?: string;
@@ -185,6 +190,22 @@ export interface PrivateWhatsAppMedia {
   width?: number;
   height?: number;
   durationMs?: number;
+}
+
+export interface PrivateWhatsAppTranscriptionError {
+  code: string;
+  message: string;
+}
+
+export interface PrivateWhatsAppTranscriptionState {
+  status: PrivateWhatsAppTranscriptionStatus;
+  jobId?: string;
+  text?: string;
+  summary?: string;
+  detectedLanguage?: string;
+  error?: PrivateWhatsAppTranscriptionError;
+  startedAt?: string;
+  completedAt?: string;
 }
 
 export interface MediaUrlResponse {
@@ -213,6 +234,9 @@ export interface PrivateWhatsAppChat {
   avatarMxcUri?: string;
   messageCount: number;
   participantCount: number;
+  transcriptionEnabled?: boolean;
+  transcriptionEnabledAt?: string;
+  transcriptionUpdatedAt?: string;
   firstSeenAt: string;
   lastEventAt: string;
   updatedAt: string;
@@ -238,6 +262,7 @@ export interface PrivateWhatsAppMessage {
   receivedAt: string;
   ingestedAt: string;
   deliveryMode: PrivateWhatsAppDeliveryMode;
+  transcription?: PrivateWhatsAppTranscriptionState;
   schemaVersion?: number;
 }
 

--- a/apps/whatsapp-service/src/__tests__/fakes.ts
+++ b/apps/whatsapp-service/src/__tests__/fakes.ts
@@ -48,12 +48,15 @@ import type {
   PrivateWhatsAppSenderDay,
   PrivateWhatsAppSenderDayQueryInput,
   PrivateWhatsAppSenderDayQueryResult,
+  PrivateWhatsAppTranscriptionState,
   SendMessageResult,
   StorePrivateWhatsAppMessageInput,
   TextMessageSendResult,
   ThumbnailGeneratorPort,
   ThumbnailResult,
   TranscriptionState,
+  UpdatePrivateWhatsAppChatTranscriptionInput,
+  UpdatePrivateWhatsAppMessageTranscriptionInput,
   UploadResult,
   WebhookProcessEvent,
   WebhookProcessingStatus,
@@ -618,12 +621,25 @@ interface FakeDisablePrivateWhatsAppAccountInput {
   now: string;
 }
 
+interface FakePrivateWhatsAppChatTranscriptionSetting {
+  transcriptionEnabled: boolean;
+  transcriptionUpdatedAt: string;
+  transcriptionEnabledAt?: string;
+}
+
 export class FakePrivateWhatsAppRepository implements PrivateWhatsAppRepository {
   private readonly stored = new Map<string, StorePrivateWhatsAppMessageInput>();
   private readonly accounts = new Map<string, FakePrivateWhatsAppAccount>();
+  private readonly chatTranscriptionSettings = new Map<
+    string,
+    FakePrivateWhatsAppChatTranscriptionSetting
+  >();
+  private readonly messageTranscriptions = new Map<string, PrivateWhatsAppTranscriptionState>();
   private failNextError: WhatsAppError | null = null;
   private failNextStoreError: WhatsAppError | null = null;
   private failNextDataQueryError: WhatsAppError | null = null;
+  private failNextMessageLookupError: WhatsAppError | null = null;
+  private failNextChatTranscriptionUpdateError: WhatsAppError | null = null;
 
   failNext(error: WhatsAppError): void {
     this.failNextError = error;
@@ -635,6 +651,14 @@ export class FakePrivateWhatsAppRepository implements PrivateWhatsAppRepository 
 
   failNextDataQuery(error: WhatsAppError): void {
     this.failNextDataQueryError = error;
+  }
+
+  failNextMessageLookup(error: WhatsAppError): void {
+    this.failNextMessageLookupError = error;
+  }
+
+  failNextChatTranscriptionUpdate(error: WhatsAppError): void {
+    this.failNextChatTranscriptionUpdateError = error;
   }
 
   setAccount(account: FakePrivateWhatsAppAccount): void {
@@ -733,6 +757,8 @@ export class FakePrivateWhatsAppRepository implements PrivateWhatsAppRepository 
     const existing = this.stored.get(input.message.matrixEventId);
     const chatId = `chat:${input.sourceAccountId}:${input.chat.matrixRoomId}`;
     const messageId = `message:${input.sourceAccountId}:${input.message.matrixEventId}`;
+    const chatTranscriptionEnabled =
+      this.chatTranscriptionSettings.get(chatId)?.transcriptionEnabled === true;
 
     if (existing !== undefined) {
       return Promise.resolve(
@@ -752,11 +778,17 @@ export class FakePrivateWhatsAppRepository implements PrivateWhatsAppRepository 
         chatId,
         messageId,
         matrixEventId: input.message.matrixEventId,
+        ...(chatTranscriptionEnabled ? { chatTranscriptionEnabled: true } : {}),
       })
     );
   }
 
   getMessageById(messageId: string): Promise<Result<PrivateWhatsAppMessage | null, WhatsAppError>> {
+    const lookupFailure = this.consumeMessageLookupFailure();
+    if (lookupFailure !== null) {
+      return Promise.resolve(err(lookupFailure));
+    }
+
     const stored = Array.from(this.stored.values()).find(
       (candidate) => this.toMessage(candidate).id === messageId
     );
@@ -764,6 +796,66 @@ export class FakePrivateWhatsAppRepository implements PrivateWhatsAppRepository 
       return Promise.resolve(ok(null));
     }
     return Promise.resolve(ok(this.toMessage(stored)));
+  }
+
+  updateChatTranscriptionSetting(
+    input: UpdatePrivateWhatsAppChatTranscriptionInput
+  ): Promise<Result<PrivateWhatsAppChat, WhatsAppError>> {
+    const updateFailure = this.consumeChatTranscriptionUpdateFailure();
+    if (updateFailure !== null) {
+      return Promise.resolve(err(updateFailure));
+    }
+
+    const failure = this.consumeFailure();
+    if (failure !== null) {
+      return Promise.resolve(err(failure));
+    }
+
+    const existing = this.buildChats().get(input.chatId);
+    if (existing === undefined || existing.sourceAccountId !== input.sourceAccountId) {
+      return Promise.resolve(err({ code: 'NOT_FOUND', message: 'Private WhatsApp chat not found' }));
+    }
+
+    const updated: PrivateWhatsAppChat = {
+      ...existing,
+      transcriptionEnabled: input.enabled,
+      transcriptionUpdatedAt: input.now,
+      updatedAt: input.now,
+    };
+    if (input.enabled && existing.transcriptionEnabledAt === undefined) {
+      updated.transcriptionEnabledAt = input.now;
+    } else if (existing.transcriptionEnabledAt !== undefined) {
+      updated.transcriptionEnabledAt = existing.transcriptionEnabledAt;
+    }
+    this.chatTranscriptionSettings.set(input.chatId, {
+      transcriptionEnabled: input.enabled,
+      transcriptionUpdatedAt: input.now,
+      ...(updated.transcriptionEnabledAt !== undefined
+        ? { transcriptionEnabledAt: updated.transcriptionEnabledAt }
+        : {}),
+    });
+    return Promise.resolve(ok(updated));
+  }
+
+  updateMessageTranscription(
+    input: UpdatePrivateWhatsAppMessageTranscriptionInput
+  ): Promise<Result<void, WhatsAppError>> {
+    const failure = this.consumeFailure();
+    if (failure !== null) {
+      return Promise.resolve(err(failure));
+    }
+
+    const stored = Array.from(this.stored.values()).find(
+      (candidate) => this.toMessage(candidate).id === input.messageId
+    );
+    if (stored === undefined || stored.userId !== input.userId) {
+      return Promise.resolve(
+        err({ code: 'NOT_FOUND', message: 'Private WhatsApp message not found' })
+      );
+    }
+
+    this.messageTranscriptions.set(input.messageId, input.transcription);
+    return Promise.resolve(ok(undefined));
   }
 
   findMessages(
@@ -964,9 +1056,13 @@ export class FakePrivateWhatsAppRepository implements PrivateWhatsAppRepository 
   clear(): void {
     this.stored.clear();
     this.accounts.clear();
+    this.chatTranscriptionSettings.clear();
+    this.messageTranscriptions.clear();
     this.failNextError = null;
     this.failNextStoreError = null;
     this.failNextDataQueryError = null;
+    this.failNextMessageLookupError = null;
+    this.failNextChatTranscriptionUpdateError = null;
   }
 
   private consumeFailure(): WhatsAppError | null {
@@ -993,6 +1089,24 @@ export class FakePrivateWhatsAppRepository implements PrivateWhatsAppRepository 
     }
     const error = this.failNextDataQueryError;
     this.failNextDataQueryError = null;
+    return error;
+  }
+
+  private consumeMessageLookupFailure(): WhatsAppError | null {
+    if (this.failNextMessageLookupError === null) {
+      return null;
+    }
+    const error = this.failNextMessageLookupError;
+    this.failNextMessageLookupError = null;
+    return error;
+  }
+
+  private consumeChatTranscriptionUpdateFailure(): WhatsAppError | null {
+    if (this.failNextChatTranscriptionUpdateError === null) {
+      return null;
+    }
+    const error = this.failNextChatTranscriptionUpdateError;
+    this.failNextChatTranscriptionUpdateError = null;
     return error;
   }
 
@@ -1041,6 +1155,10 @@ export class FakePrivateWhatsAppRepository implements PrivateWhatsAppRepository 
     }
     if (input.message.media !== undefined) {
       message.media = input.message.media;
+    }
+    const transcription = this.messageTranscriptions.get(message.id);
+    if (transcription !== undefined) {
+      message.transcription = transcription;
     }
     return message;
   }
@@ -1200,6 +1318,16 @@ export class FakePrivateWhatsAppRepository implements PrivateWhatsAppRepository 
       }
       if (message.chatType !== undefined && message.chatType !== 'unknown') {
         existing.chatType = message.chatType;
+      }
+    }
+    for (const chat of chats.values()) {
+      const setting = this.chatTranscriptionSettings.get(chat.id);
+      if (setting !== undefined) {
+        chat.transcriptionEnabled = setting.transcriptionEnabled;
+        chat.transcriptionUpdatedAt = setting.transcriptionUpdatedAt;
+        if (setting.transcriptionEnabledAt !== undefined) {
+          chat.transcriptionEnabledAt = setting.transcriptionEnabledAt;
+        }
       }
     }
     return chats;

--- a/apps/whatsapp-service/src/__tests__/infra/privateWhatsAppRepository.test.ts
+++ b/apps/whatsapp-service/src/__tests__/infra/privateWhatsAppRepository.test.ts
@@ -116,6 +116,290 @@ describe('privateWhatsAppRepository', () => {
     expect(result.value).toBeNull();
   });
 
+  it('updates a private WhatsApp chat transcription setting and preserves it across later messages', async () => {
+    const input = createStoreInput();
+    const stored = await repository.storeIncomingMessage(input);
+    expect(stored.ok).toBe(true);
+    if (!stored.ok) throw new Error(stored.error.message);
+
+    const chatId = deterministicId(input.sourceAccountId, input.chat.matrixRoomId);
+    const enabled = await repository.updateChatTranscriptionSetting({
+      sourceAccountId: input.sourceAccountId,
+      chatId,
+      enabled: true,
+      now: '2026-06-22T10:05:00.000Z',
+    });
+    expect(enabled.ok).toBe(true);
+    if (!enabled.ok) throw new Error(enabled.error.message);
+    expect(enabled.value).toMatchObject({
+      id: chatId,
+      transcriptionEnabled: true,
+      transcriptionEnabledAt: '2026-06-22T10:05:00.000Z',
+      transcriptionUpdatedAt: '2026-06-22T10:05:00.000Z',
+    });
+
+    const later = await repository.storeIncomingMessage(
+      createStoreInput({
+        message: {
+          ...input.message,
+          matrixEventId: '$event-2',
+          text: 'later message',
+          eventTimestamp: '2026-06-22T10:06:00.000Z',
+        },
+      })
+    );
+    expect(later.ok).toBe(true);
+    if (!later.ok) throw new Error(later.error.message);
+
+    const chats = await repository.findChats({
+      sourceAccountId: input.sourceAccountId,
+      limit: 10,
+    });
+    expect(chats.ok).toBe(true);
+    if (!chats.ok) throw new Error(chats.error.message);
+    expect(chats.value.chats[0]).toMatchObject({
+      id: chatId,
+      transcriptionEnabled: true,
+      transcriptionEnabledAt: '2026-06-22T10:05:00.000Z',
+      transcriptionUpdatedAt: '2026-06-22T10:05:00.000Z',
+      messageCount: 2,
+    });
+  });
+
+  it('keeps the original private WhatsApp chat transcription enabled timestamp when disabling', async () => {
+    const input = createStoreInput();
+    const stored = await repository.storeIncomingMessage(input);
+    expect(stored.ok).toBe(true);
+    if (!stored.ok) throw new Error(stored.error.message);
+
+    const chatId = deterministicId(input.sourceAccountId, input.chat.matrixRoomId);
+    const enabled = await repository.updateChatTranscriptionSetting({
+      sourceAccountId: input.sourceAccountId,
+      chatId,
+      enabled: true,
+      now: '2026-06-22T10:05:00.000Z',
+    });
+    expect(enabled.ok).toBe(true);
+    if (!enabled.ok) throw new Error(enabled.error.message);
+
+    const disabled = await repository.updateChatTranscriptionSetting({
+      sourceAccountId: input.sourceAccountId,
+      chatId,
+      enabled: false,
+      now: '2026-06-22T10:08:00.000Z',
+    });
+
+    expect(disabled.ok).toBe(true);
+    if (!disabled.ok) throw new Error(disabled.error.message);
+    expect(disabled.value).toMatchObject({
+      id: chatId,
+      transcriptionEnabled: false,
+      transcriptionEnabledAt: '2026-06-22T10:05:00.000Z',
+      transcriptionUpdatedAt: '2026-06-22T10:08:00.000Z',
+    });
+  });
+
+  it('leaves private WhatsApp chat transcription enabled timestamp unset when disabling before first enable', async () => {
+    const input = createStoreInput();
+    const stored = await repository.storeIncomingMessage(input);
+    expect(stored.ok).toBe(true);
+    if (!stored.ok) throw new Error(stored.error.message);
+
+    const chatId = deterministicId(input.sourceAccountId, input.chat.matrixRoomId);
+    const disabled = await repository.updateChatTranscriptionSetting({
+      sourceAccountId: input.sourceAccountId,
+      chatId,
+      enabled: false,
+      now: '2026-06-22T10:08:00.000Z',
+    });
+
+    expect(disabled.ok).toBe(true);
+    if (!disabled.ok) throw new Error(disabled.error.message);
+    expect(disabled.value).toMatchObject({
+      id: chatId,
+      transcriptionEnabled: false,
+      transcriptionUpdatedAt: '2026-06-22T10:08:00.000Z',
+    });
+    expect(disabled.value.transcriptionEnabledAt).toBeUndefined();
+  });
+
+  it('returns not found for missing or cross-account private WhatsApp chat transcription updates', async () => {
+    const missing = await repository.updateChatTranscriptionSetting({
+      sourceAccountId: 'pbuchman-private-whatsapp',
+      chatId: 'missing-chat',
+      enabled: true,
+      now: '2026-06-22T10:05:00.000Z',
+    });
+    expect(missing.ok).toBe(false);
+    if (missing.ok) throw new Error('Expected missing chat to be rejected');
+    expect(missing.error.code).toBe('NOT_FOUND');
+
+    const input = createStoreInput();
+    const stored = await repository.storeIncomingMessage(input);
+    expect(stored.ok).toBe(true);
+    if (!stored.ok) throw new Error(stored.error.message);
+
+    const chatId = deterministicId(input.sourceAccountId, input.chat.matrixRoomId);
+    const wrongSource = await repository.updateChatTranscriptionSetting({
+      sourceAccountId: 'other-private-source',
+      chatId,
+      enabled: true,
+      now: '2026-06-22T10:05:00.000Z',
+    });
+
+    expect(wrongSource.ok).toBe(false);
+    if (wrongSource.ok) throw new Error('Expected cross-account chat update to be rejected');
+    expect(wrongSource.error.code).toBe('NOT_FOUND');
+  });
+
+  it('stores private WhatsApp message transcription success and failure states', async () => {
+    const input = createStoreInput({
+      message: {
+        ...createStoreInput().message,
+        type: 'audio',
+        media: {
+          mxcUri: 'mxc://matrix.example/audio',
+          mimeType: 'audio/ogg',
+          storageStatus: 'stored',
+          gcsPath: 'whatsapp/private/user-123/audio-message/audio.ogg',
+        },
+      },
+    });
+    const stored = await repository.storeIncomingMessage(input);
+    expect(stored.ok).toBe(true);
+    if (!stored.ok) throw new Error(stored.error.message);
+
+    const completed = await repository.updateMessageTranscription({
+      userId: 'user-123',
+      messageId: stored.value.messageId,
+      transcription: {
+        status: 'completed',
+        jobId: 'job-private-1',
+        text: 'Pick up milk.',
+        summary: 'Errand reminder.',
+        detectedLanguage: 'en',
+        completedAt: '2026-06-22T10:10:00.000Z',
+      },
+    });
+    expect(completed.ok).toBe(true);
+    if (!completed.ok) throw new Error(completed.error.message);
+
+    const completedMessage = await repository.getMessageById(stored.value.messageId);
+    expect(completedMessage.ok).toBe(true);
+    if (!completedMessage.ok) throw new Error(completedMessage.error.message);
+    expect(completedMessage.value?.transcription).toEqual({
+      status: 'completed',
+      jobId: 'job-private-1',
+      text: 'Pick up milk.',
+      summary: 'Errand reminder.',
+      detectedLanguage: 'en',
+      completedAt: '2026-06-22T10:10:00.000Z',
+    });
+
+    const failed = await repository.updateMessageTranscription({
+      userId: 'user-123',
+      messageId: stored.value.messageId,
+      transcription: {
+        status: 'failed',
+        jobId: 'job-private-2',
+        error: {
+          code: 'TRANSCRIPTION_FAILED',
+          message: 'Audio format was not supported',
+        },
+        completedAt: '2026-06-22T10:11:00.000Z',
+      },
+    });
+    expect(failed.ok).toBe(true);
+    if (!failed.ok) throw new Error(failed.error.message);
+
+    const failedMessage = await repository.getMessageById(stored.value.messageId);
+    expect(failedMessage.ok).toBe(true);
+    if (!failedMessage.ok) throw new Error(failedMessage.error.message);
+    expect(failedMessage.value?.transcription).toEqual({
+      status: 'failed',
+      jobId: 'job-private-2',
+      error: {
+        code: 'TRANSCRIPTION_FAILED',
+        message: 'Audio format was not supported',
+      },
+      completedAt: '2026-06-22T10:11:00.000Z',
+    });
+  });
+
+  it('returns not found for missing or cross-user private WhatsApp message transcription updates', async () => {
+    const missing = await repository.updateMessageTranscription({
+      userId: 'user-123',
+      messageId: 'missing-message',
+      transcription: {
+        status: 'failed',
+        jobId: 'job-missing',
+        error: {
+          code: 'TRANSCRIPTION_FAILED',
+          message: 'Missing message',
+        },
+        completedAt: '2026-06-22T10:11:00.000Z',
+      },
+    });
+    expect(missing.ok).toBe(false);
+    if (missing.ok) throw new Error('Expected missing message update to be rejected');
+    expect(missing.error.code).toBe('NOT_FOUND');
+
+    const stored = await repository.storeIncomingMessage(createStoreInput());
+    expect(stored.ok).toBe(true);
+    if (!stored.ok) throw new Error(stored.error.message);
+
+    const wrongUser = await repository.updateMessageTranscription({
+      userId: 'other-user',
+      messageId: stored.value.messageId,
+      transcription: {
+        status: 'failed',
+        jobId: 'job-wrong-user',
+        error: {
+          code: 'TRANSCRIPTION_FAILED',
+          message: 'Wrong user',
+        },
+        completedAt: '2026-06-22T10:12:00.000Z',
+      },
+    });
+
+    expect(wrongUser.ok).toBe(false);
+    if (wrongUser.ok) throw new Error('Expected cross-user message update to be rejected');
+    expect(wrongUser.error.code).toBe('NOT_FOUND');
+  });
+
+  it('updates transcription on legacy private WhatsApp message documents that do not store their id', async () => {
+    await fakeFirestore
+      .collection(PRIVATE_WHATSAPP_MESSAGES_COLLECTION)
+      .doc('legacy-private-message')
+      .set({
+        userId: 'user-123',
+      });
+
+    const result = await repository.updateMessageTranscription({
+      userId: 'user-123',
+      messageId: 'legacy-private-message',
+      transcription: {
+        status: 'completed',
+        jobId: 'job-legacy',
+        text: 'Legacy transcript.',
+        completedAt: '2026-06-22T10:11:00.000Z',
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(result.error.message);
+    const doc = await fakeFirestore
+      .collection(PRIVATE_WHATSAPP_MESSAGES_COLLECTION)
+      .doc('legacy-private-message')
+      .get();
+    expect(doc.data()?.['transcription']).toEqual({
+      status: 'completed',
+      jobId: 'job-legacy',
+      text: 'Legacy transcript.',
+      completedAt: '2026-06-22T10:11:00.000Z',
+    });
+  });
+
   it('projects sparse and legacy private WhatsApp account documents safely', async () => {
     await fakeFirestore.collection(PRIVATE_WHATSAPP_ACCOUNTS_COLLECTION).doc('legacy-user').set({});
     await fakeFirestore.collection(PRIVATE_WHATSAPP_ACCOUNTS_COLLECTION).doc('disabled-user').set({

--- a/apps/whatsapp-service/src/__tests__/privateMediaRoutes.test.ts
+++ b/apps/whatsapp-service/src/__tests__/privateMediaRoutes.test.ts
@@ -107,6 +107,53 @@ describe('Private WhatsApp Media Routes', () => {
     expect(ctx.mediaStorage.getFile(body.data.media.thumbnailGcsPath)).toBeDefined();
   });
 
+  it('uploads private audio originals without generating thumbnails', async () => {
+    const response = await ctx.app.inject({
+      method: 'POST',
+      url: '/internal/whatsapp/private/media?sourceAccountId=private-source-123&matrixEventId=%24audio&mxcUri=mxc%3A%2F%2Fhome-dev%2Faudio&mimeType=audio%2Fogg&fileName=voice.ogg&mediaId=home-dev-audio',
+      headers: {
+        'x-internal-auth': 'test-internal-token',
+        'content-type': 'application/octet-stream',
+      },
+      payload: Buffer.from('audio-bytes'),
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body) as {
+      success: true;
+      data: {
+        media: {
+          mxcUri: string;
+          mimeType: string;
+          fileName: string;
+          sizeBytes: number;
+          storageStatus: string;
+          gcsPath: string;
+          thumbnailGcsPath?: string;
+          storedMimeType: string;
+          storedSizeBytes: number;
+          storedAt: string;
+        };
+      };
+    };
+    const messageId = createPrivateWhatsAppMessageId('private-source-123', '$audio');
+    expect(body.data.media).toStrictEqual({
+      mxcUri: 'mxc://home-dev/audio',
+      mimeType: 'audio/ogg',
+      fileName: 'voice.ogg',
+      sizeBytes: 'audio-bytes'.length,
+      storageStatus: 'stored',
+      gcsPath: `whatsapp/private/user-123/${messageId}/home-dev-audio.ogg`,
+      storedMimeType: 'audio/ogg',
+      storedSizeBytes: 'audio-bytes'.length,
+      storedAt: expect.any(String),
+    });
+    expect(ctx.mediaStorage.getFile(body.data.media.gcsPath)?.buffer.toString()).toBe(
+      'audio-bytes'
+    );
+    expect(body.data.media.thumbnailGcsPath).toBeUndefined();
+  });
+
   it('rejects uploads for unknown private source accounts', async () => {
     const response = await ctx.app.inject({
       method: 'POST',

--- a/apps/whatsapp-service/src/__tests__/privateSyncRoutes.test.ts
+++ b/apps/whatsapp-service/src/__tests__/privateSyncRoutes.test.ts
@@ -960,6 +960,300 @@ describe('Private WhatsApp Sync Routes', () => {
     expect(invalidLimit.statusCode).toBe(400);
   });
 
+  it('updates private WhatsApp chat transcription settings for the authenticated account', async () => {
+    await ctx.app.inject({
+      method: 'POST',
+      url: '/internal/whatsapp/private/events',
+      headers: { 'x-internal-auth': 'test-internal-token' },
+      payload: createPayload(),
+    });
+    const token = await createToken({ sub: 'user-123' });
+    const chatsResponse = await ctx.app.inject({
+      method: 'GET',
+      url: '/private/chats?limit=1',
+      headers: { authorization: `Bearer ${token}` },
+    });
+    const chatsBody = JSON.parse(chatsResponse.body) as {
+      data: { chats: { id: string; transcriptionEnabled?: boolean }[] };
+    };
+    const chatId = chatsBody.data.chats[0]?.id ?? '';
+    expect(chatsBody.data.chats[0]?.transcriptionEnabled).toBeUndefined();
+
+    const updateResponse = await ctx.app.inject({
+      method: 'PATCH',
+      url: `/private/chats/${encodeURIComponent(chatId)}/transcription`,
+      headers: { authorization: `Bearer ${token}` },
+      payload: { enabled: true },
+    });
+
+    expect(updateResponse.statusCode).toBe(200);
+    const updateBody = JSON.parse(updateResponse.body) as {
+      success: boolean;
+      data: {
+        id: string;
+        transcriptionEnabled?: boolean;
+        transcriptionEnabledAt?: string;
+        transcriptionUpdatedAt?: string;
+      };
+    };
+    expect(updateBody.success).toBe(true);
+    expect(updateBody.data).toMatchObject({
+      id: chatId,
+      transcriptionEnabled: true,
+    });
+    expect(updateBody.data.transcriptionEnabledAt).toEqual(expect.any(String));
+    expect(updateBody.data.transcriptionUpdatedAt).toEqual(expect.any(String));
+
+    const updatedChatsResponse = await ctx.app.inject({
+      method: 'GET',
+      url: '/private/chats?limit=1',
+      headers: { authorization: `Bearer ${token}` },
+    });
+    const updatedChatsBody = JSON.parse(updatedChatsResponse.body) as {
+      data: {
+        chats: {
+          id: string;
+          transcriptionEnabled?: boolean;
+          transcriptionEnabledAt?: string;
+          transcriptionUpdatedAt?: string;
+        }[];
+      };
+    };
+    expect(updatedChatsBody.data.chats[0]).toMatchObject({
+      id: chatId,
+      transcriptionEnabled: true,
+      transcriptionEnabledAt: updateBody.data.transcriptionEnabledAt,
+      transcriptionUpdatedAt: updateBody.data.transcriptionUpdatedAt,
+    });
+  });
+
+  it('requires auth before updating private WhatsApp chat transcription settings', async () => {
+    const response = await ctx.app.inject({
+      method: 'PATCH',
+      url: '/private/chats/missing-chat/transcription',
+      payload: { enabled: true },
+    });
+
+    expect(response.statusCode).toBe(401);
+  });
+
+  it('validates private WhatsApp chat transcription update bodies', async () => {
+    const token = await createToken({ sub: 'user-123' });
+
+    const response = await ctx.app.inject({
+      method: 'PATCH',
+      url: '/private/chats/missing-chat/transcription',
+      headers: { authorization: `Bearer ${token}` },
+      payload: { enabled: 'yes' },
+    });
+
+    expect(response.statusCode).toBe(400);
+    const body = JSON.parse(response.body) as { success: boolean; error: { code: string } };
+    expect(body.success).toBe(false);
+    expect(body.error.code).toBe('INVALID_REQUEST');
+  });
+
+  it('returns not found when updating transcription for a user without a private WhatsApp account', async () => {
+    const token = await createToken({ sub: 'user-without-private-whatsapp' });
+
+    const response = await ctx.app.inject({
+      method: 'PATCH',
+      url: '/private/chats/missing-chat/transcription',
+      headers: { authorization: `Bearer ${token}` },
+      payload: { enabled: true },
+    });
+
+    expect(response.statusCode).toBe(404);
+  });
+
+  it('returns not found when updating transcription for a missing private WhatsApp chat', async () => {
+    const token = await createToken({ sub: 'user-123' });
+
+    const response = await ctx.app.inject({
+      method: 'PATCH',
+      url: '/private/chats/missing-chat/transcription',
+      headers: { authorization: `Bearer ${token}` },
+      payload: { enabled: true },
+    });
+
+    expect(response.statusCode).toBe(404);
+    const body = JSON.parse(response.body) as { success: boolean; error: { code: string } };
+    expect(body.success).toBe(false);
+    expect(body.error.code).toBe('NOT_FOUND');
+  });
+
+  it('returns internal error when updating private WhatsApp chat transcription settings fails', async () => {
+    ctx.privateWhatsAppRepository.failNextChatTranscriptionUpdate({
+      code: 'PERSISTENCE_ERROR',
+      message: 'Simulated transcription setting update failure',
+    });
+    const token = await createToken({ sub: 'user-123' });
+
+    const response = await ctx.app.inject({
+      method: 'PATCH',
+      url: '/private/chats/missing-chat/transcription',
+      headers: { authorization: `Bearer ${token}` },
+      payload: { enabled: true },
+    });
+
+    expect(response.statusCode).toBe(500);
+    const body = JSON.parse(response.body) as { success: boolean; error: { code: string } };
+    expect(body.success).toBe(false);
+    expect(body.error.code).toBe('INTERNAL_ERROR');
+  });
+
+  it('publishes one private audio transcription job after chat transcription is enabled', async () => {
+    await ctx.app.inject({
+      method: 'POST',
+      url: '/internal/whatsapp/private/events',
+      headers: { 'x-internal-auth': 'test-internal-token' },
+      payload: createPayload(),
+    });
+    const token = await createToken({ sub: 'user-123' });
+    const chatsResponse = await ctx.app.inject({
+      method: 'GET',
+      url: '/private/chats?limit=1',
+      headers: { authorization: `Bearer ${token}` },
+    });
+    const chatsBody = JSON.parse(chatsResponse.body) as { data: { chats: { id: string }[] } };
+    const chatId = chatsBody.data.chats[0]?.id ?? '';
+    const updateResponse = await ctx.app.inject({
+      method: 'PATCH',
+      url: `/private/chats/${encodeURIComponent(chatId)}/transcription`,
+      headers: { authorization: `Bearer ${token}` },
+      payload: { enabled: true },
+    });
+    expect(updateResponse.statusCode).toBe(200);
+
+    const audioPayload = createPayload({
+      events: [
+        {
+          ...(createPayload()['events'] as Record<string, unknown>[])[0],
+          matrixEventId: '$event-private-audio',
+          message: {
+            direction: 'incoming',
+            type: 'audio',
+            media: {
+              mxcUri: 'mxc://home-dev/private-audio',
+              mimeType: 'audio/ogg',
+              storageStatus: 'stored',
+              gcsPath: 'whatsapp/private/user-123/private-audio/audio.ogg',
+              storedMimeType: 'audio/ogg',
+              storedSizeBytes: 2048,
+            },
+          },
+        },
+      ],
+    });
+
+    const firstIngest = await ctx.app.inject({
+      method: 'POST',
+      url: '/internal/whatsapp/private/events',
+      headers: { 'x-internal-auth': 'test-internal-token' },
+      payload: audioPayload,
+    });
+    const duplicateIngest = await ctx.app.inject({
+      method: 'POST',
+      url: '/internal/whatsapp/private/events',
+      headers: { 'x-internal-auth': 'test-internal-token' },
+      payload: audioPayload,
+    });
+
+    expect(firstIngest.statusCode).toBe(200);
+    expect(duplicateIngest.statusCode).toBe(200);
+    expect(ctx.eventPublisher.getAudioStoredEvents()).toEqual([
+      {
+        type: 'whatsapp.audio.stored',
+        messageSource: 'private_whatsapp',
+        userId: 'user-123',
+        messageId: 'message:pbuchman-private-whatsapp:$event-private-audio',
+        mediaId: 'mxc://home-dev/private-audio',
+        gcsPath: 'whatsapp/private/user-123/private-audio/audio.ogg',
+        mimeType: 'audio/ogg',
+        timestamp: expect.any(String),
+      },
+    ]);
+  });
+
+  it('returns stored private WhatsApp message transcription state in chat messages', async () => {
+    const ingestResponse = await ctx.app.inject({
+      method: 'POST',
+      url: '/internal/whatsapp/private/events',
+      headers: { 'x-internal-auth': 'test-internal-token' },
+      payload: createPayload({
+        events: [
+          {
+            ...(createPayload()['events'] as Record<string, unknown>[])[0],
+            matrixEventId: '$event-transcribed-audio',
+            message: {
+              direction: 'incoming',
+              type: 'audio',
+              media: {
+                mxcUri: 'mxc://home-dev/transcribed-audio',
+                mimeType: 'audio/ogg',
+                storageStatus: 'stored',
+                gcsPath: 'whatsapp/private/user-123/transcribed-audio/audio.ogg',
+              },
+            },
+          },
+        ],
+      }),
+    });
+    const ingestBody = JSON.parse(ingestResponse.body) as {
+      data: { messages: { chatId?: string; messageId?: string }[] };
+    };
+    const chatId = ingestBody.data.messages[0]?.chatId ?? '';
+    const messageId = ingestBody.data.messages[0]?.messageId ?? '';
+    const updateResult = await ctx.privateWhatsAppRepository.updateMessageTranscription({
+      userId: 'user-123',
+      messageId,
+      transcription: {
+        status: 'completed',
+        jobId: 'job-private-api',
+        text: 'Timeline transcript.',
+        detectedLanguage: 'en',
+        completedAt: '2026-06-28T10:10:00.000Z',
+      },
+    });
+    expect(updateResult.ok).toBe(true);
+    if (!updateResult.ok) throw new Error(updateResult.error.message);
+    const token = await createToken({ sub: 'user-123' });
+
+    const response = await ctx.app.inject({
+      method: 'GET',
+      url: `/private/chats/${encodeURIComponent(chatId)}/messages?limit=10`,
+      headers: { authorization: `Bearer ${token}` },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body) as {
+      data: {
+        messages: {
+          id: string;
+          transcription?: {
+            status: string;
+            jobId?: string;
+            text?: string;
+            detectedLanguage?: string;
+            completedAt?: string;
+          };
+        }[];
+      };
+    };
+    expect(body.data.messages[0]).toMatchObject({
+      id: messageId,
+      transcription: {
+        status: 'completed',
+        jobId: 'job-private-api',
+        text: 'Timeline transcript.',
+        detectedLanguage: 'en',
+        completedAt: '2026-06-28T10:10:00.000Z',
+      },
+    });
+    expect(JSON.stringify(body)).not.toContain('sourceAccountId');
+    expect(JSON.stringify(body)).not.toContain('rawMatrixEvent');
+  });
+
   it('returns standard errors when private WhatsApp chat data queries fail', async () => {
     const token = await createToken({ sub: 'user-123' });
     ctx.privateWhatsAppRepository.failNextDataQuery({

--- a/apps/whatsapp-service/src/__tests__/pubsubRoutes.test.ts
+++ b/apps/whatsapp-service/src/__tests__/pubsubRoutes.test.ts
@@ -77,6 +77,7 @@ describe('Pub/Sub Routes', () => {
   let prefs: FakeNotificationPreferencesRepository;
   let eventPublisher: FakeEventPublisher;
   let whatsappCloudApi: FakeWhatsAppCloudApiPort;
+  let privateWhatsAppRepository: FakePrivateWhatsAppRepository;
 
   beforeEach(async () => {
     messageSender = new FakeMessageSender();
@@ -88,6 +89,7 @@ describe('Pub/Sub Routes', () => {
     prefs = new FakeNotificationPreferencesRepository();
     eventPublisher = new FakeEventPublisher();
     whatsappCloudApi = new FakeWhatsAppCloudApiPort();
+    privateWhatsAppRepository = new FakePrivateWhatsAppRepository();
 
     setServices({
       webhookEventRepository: new FakeWhatsAppWebhookEventRepository(),
@@ -102,7 +104,7 @@ describe('Pub/Sub Routes', () => {
       outboundMessageRepository,
       phoneVerificationRepository: new FakePhoneVerificationRepository(),
       notificationPreferencesRepository: prefs,
-      privateWhatsAppRepository: new FakePrivateWhatsAppRepository(),
+      privateWhatsAppRepository,
     });
 
     process.env['INTEXURAOS_INTERNAL_AUTH_TOKEN'] = INTERNAL_AUTH_TOKEN;
@@ -1438,6 +1440,52 @@ describe('Pub/Sub Routes', () => {
       });
     };
 
+    const storePrivateAudioMessage = async (
+      overrides: {
+        matrixEventId?: string;
+        userId?: string;
+        sourceAccountId?: string;
+      } = {}
+    ): Promise<string> => {
+      const matrixEventId = overrides.matrixEventId ?? '$private-audio';
+      const userId = overrides.userId ?? 'user-private';
+      const stored = await privateWhatsAppRepository.storeIncomingMessage({
+        sourceAccountId: overrides.sourceAccountId ?? 'private-source-123',
+        userId,
+        deliveryMode: 'live',
+        receivedAt: '2026-06-28T09:59:30.000Z',
+        chat: {
+          matrixRoomId: '!private-room:matrix.example',
+          type: 'direct',
+          displayName: 'Alice',
+        },
+        message: {
+          matrixRoomId: '!private-room:matrix.example',
+          matrixEventId,
+          matrixSenderId: '@alice:matrix.example',
+          senderKey: 'matrix:@alice:matrix.example',
+          direction: 'incoming',
+          type: 'audio',
+          eventTimestamp: '2026-06-28T09:59:00.000Z',
+          eventDayKey: '2026-06-28',
+          eventTimeZone: 'Europe/Warsaw',
+          media: {
+            mxcUri: `mxc://home-dev/${matrixEventId.replace('$', '')}`,
+            mimeType: 'audio/ogg',
+            storageStatus: 'stored',
+            gcsPath: `whatsapp/private/${userId}/${matrixEventId.replace('$', '')}/audio.ogg`,
+          },
+          rawMatrixEvent: {
+            type: 'm.room.message',
+            event_id: matrixEventId,
+          },
+        },
+      });
+      expect(stored.ok).toBe(true);
+      if (!stored.ok) throw new Error(stored.error.message);
+      return stored.value.messageId;
+    };
+
     it('returns 401 when auth is missing', async () => {
       const body = createPubSubBody({
         type: 'srt.transcription.completed',
@@ -1521,6 +1569,33 @@ describe('Pub/Sub Routes', () => {
         error: { code: string; message: string };
       };
       expect(responseBody.error.message).toBe('Unexpected event type');
+    });
+
+    it('returns 400 when the transcription message source is unexpected', async () => {
+      const body = createPubSubBody({
+        type: 'srt.transcription.completed',
+        messageSource: 'email',
+        userId: 'user-audio',
+        messageId: 'stored-audio-1',
+        jobId: 'job-123',
+        status: 'completed',
+        transcript: 'Buy milk.',
+        timestamp: '2026-06-28T10:00:00.000Z',
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/internal/whatsapp/pubsub/transcription-completed',
+        headers: { 'x-internal-auth': INTERNAL_AUTH_TOKEN },
+        payload: body,
+      });
+
+      expect(response.statusCode).toBe(400);
+      const responseBody = JSON.parse(response.body) as {
+        success: boolean;
+        error: { code: string; message: string };
+      };
+      expect(responseBody.error.message).toBe('Unexpected transcription message source');
     });
 
     it('returns 500 when the stored audio lookup fails', async () => {
@@ -1771,6 +1846,341 @@ describe('Pub/Sub Routes', () => {
           expiresAt: expect.any(Number),
         },
       ]);
+    });
+
+    it('stores a completed private WhatsApp transcription without Intex ingest or WhatsApp replies', async () => {
+      const stored = await privateWhatsAppRepository.storeIncomingMessage({
+        sourceAccountId: 'private-source-123',
+        userId: 'user-private',
+        deliveryMode: 'live',
+        receivedAt: '2026-06-28T09:59:30.000Z',
+        chat: {
+          matrixRoomId: '!private-room:matrix.example',
+          type: 'direct',
+          displayName: 'Alice',
+        },
+        message: {
+          matrixRoomId: '!private-room:matrix.example',
+          matrixEventId: '$private-audio',
+          matrixSenderId: '@alice:matrix.example',
+          senderKey: 'matrix:@alice:matrix.example',
+          direction: 'incoming',
+          type: 'audio',
+          eventTimestamp: '2026-06-28T09:59:00.000Z',
+          eventDayKey: '2026-06-28',
+          eventTimeZone: 'Europe/Warsaw',
+          media: {
+            mxcUri: 'mxc://home-dev/private-audio',
+            mimeType: 'audio/ogg',
+            storageStatus: 'stored',
+            gcsPath: 'whatsapp/private/user-private/private-audio/audio.ogg',
+          },
+          rawMatrixEvent: {
+            type: 'm.room.message',
+            event_id: '$private-audio',
+          },
+        },
+      });
+      expect(stored.ok).toBe(true);
+      if (!stored.ok) throw new Error(stored.error.message);
+
+      const body = createPubSubBody({
+        type: 'srt.transcription.completed',
+        messageSource: 'private_whatsapp',
+        userId: 'user-private',
+        messageId: stored.value.messageId,
+        jobId: 'job-private-123',
+        status: 'completed',
+        transcript: 'Private voice note.',
+        summary: 'Voice note summary.',
+        detectedLanguage: 'en',
+        timestamp: '2026-06-28T10:04:00.000Z',
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/internal/whatsapp/pubsub/transcription-completed',
+        headers: { 'x-internal-auth': INTERNAL_AUTH_TOKEN },
+        payload: body,
+      });
+
+      expect(response.statusCode).toBe(200);
+      const privateMessage = await privateWhatsAppRepository.getMessageById(stored.value.messageId);
+      expect(privateMessage.ok).toBe(true);
+      if (!privateMessage.ok) throw new Error(privateMessage.error.message);
+      expect(privateMessage.value?.transcription).toEqual({
+        status: 'completed',
+        jobId: 'job-private-123',
+        text: 'Private voice note.',
+        summary: 'Voice note summary.',
+        detectedLanguage: 'en',
+        completedAt: '2026-06-28T10:04:00.000Z',
+      });
+      expect(eventPublisher.getIntexMessageIngestEvents()).toHaveLength(0);
+      expect(whatsappCloudApi.getSentMessages()).toHaveLength(0);
+    });
+
+    it('stores a completed private WhatsApp transcription without optional metadata', async () => {
+      const messageId = await storePrivateAudioMessage({
+        matrixEventId: '$private-audio-minimal',
+      });
+
+      const body = createPubSubBody({
+        type: 'srt.transcription.completed',
+        messageSource: 'private_whatsapp',
+        userId: 'user-private',
+        messageId,
+        jobId: 'job-private-minimal',
+        status: 'completed',
+        transcript: 'Private voice note without metadata.',
+        timestamp: '2026-06-28T10:04:00.000Z',
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/internal/whatsapp/pubsub/transcription-completed',
+        headers: { 'x-internal-auth': INTERNAL_AUTH_TOKEN },
+        payload: body,
+      });
+
+      expect(response.statusCode).toBe(200);
+      const privateMessage = await privateWhatsAppRepository.getMessageById(messageId);
+      expect(privateMessage.ok).toBe(true);
+      if (!privateMessage.ok) throw new Error(privateMessage.error.message);
+      expect(privateMessage.value?.transcription).toEqual({
+        status: 'completed',
+        jobId: 'job-private-minimal',
+        text: 'Private voice note without metadata.',
+        completedAt: '2026-06-28T10:04:00.000Z',
+      });
+    });
+
+    it('returns 400 when a completed private WhatsApp transcription has no transcript text', async () => {
+      const messageId = await storePrivateAudioMessage({
+        matrixEventId: '$private-audio-blank-transcript',
+      });
+
+      const body = createPubSubBody({
+        type: 'srt.transcription.completed',
+        messageSource: 'private_whatsapp',
+        userId: 'user-private',
+        messageId,
+        jobId: 'job-private-blank-transcript',
+        status: 'completed',
+        transcript: '   ',
+        timestamp: '2026-06-28T10:04:00.000Z',
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/internal/whatsapp/pubsub/transcription-completed',
+        headers: { 'x-internal-auth': INTERNAL_AUTH_TOKEN },
+        payload: body,
+      });
+
+      expect(response.statusCode).toBe(400);
+      const privateMessage = await privateWhatsAppRepository.getMessageById(messageId);
+      expect(privateMessage.ok).toBe(true);
+      if (!privateMessage.ok) throw new Error(privateMessage.error.message);
+      expect(privateMessage.value?.transcription).toBeUndefined();
+    });
+
+    it('returns 500 when private WhatsApp transcription lookup fails', async () => {
+      privateWhatsAppRepository.failNextMessageLookup({
+        code: 'PERSISTENCE_ERROR',
+        message: 'Simulated private lookup failure',
+      });
+
+      const body = createPubSubBody({
+        type: 'srt.transcription.completed',
+        messageSource: 'private_whatsapp',
+        userId: 'user-private',
+        messageId: 'missing-private-message',
+        jobId: 'job-private-lookup-failure',
+        status: 'completed',
+        transcript: 'Private voice note.',
+        timestamp: '2026-06-28T10:04:00.000Z',
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/internal/whatsapp/pubsub/transcription-completed',
+        headers: { 'x-internal-auth': INTERNAL_AUTH_TOKEN },
+        payload: body,
+      });
+
+      expect(response.statusCode).toBe(500);
+      const responseBody = JSON.parse(response.body) as {
+        success: boolean;
+        error: { code: string; message: string };
+      };
+      expect(responseBody.error.message).toBe('Failed to load private audio message');
+    });
+
+    it('acks private WhatsApp transcription completions when the message is missing', async () => {
+      const body = createPubSubBody({
+        type: 'srt.transcription.completed',
+        messageSource: 'private_whatsapp',
+        userId: 'user-private',
+        messageId: 'missing-private-message',
+        jobId: 'job-private-missing',
+        status: 'completed',
+        transcript: 'Private voice note.',
+        timestamp: '2026-06-28T10:04:00.000Z',
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/internal/whatsapp/pubsub/transcription-completed',
+        headers: { 'x-internal-auth': INTERNAL_AUTH_TOKEN },
+        payload: body,
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(eventPublisher.getIntexMessageIngestEvents()).toHaveLength(0);
+      expect(whatsappCloudApi.getSentMessages()).toHaveLength(0);
+    });
+
+    it('stores a failed private WhatsApp transcription without Intex ingest or WhatsApp replies', async () => {
+      const stored = await privateWhatsAppRepository.storeIncomingMessage({
+        sourceAccountId: 'private-source-123',
+        userId: 'user-private',
+        deliveryMode: 'live',
+        receivedAt: '2026-06-28T09:59:30.000Z',
+        chat: {
+          matrixRoomId: '!private-room:matrix.example',
+          type: 'direct',
+        },
+        message: {
+          matrixRoomId: '!private-room:matrix.example',
+          matrixEventId: '$private-audio-failed',
+          matrixSenderId: '@alice:matrix.example',
+          senderKey: 'matrix:@alice:matrix.example',
+          direction: 'incoming',
+          type: 'audio',
+          eventTimestamp: '2026-06-28T09:59:00.000Z',
+          eventDayKey: '2026-06-28',
+          eventTimeZone: 'Europe/Warsaw',
+          media: {
+            mxcUri: 'mxc://home-dev/private-audio-failed',
+            mimeType: 'audio/ogg',
+            storageStatus: 'stored',
+            gcsPath: 'whatsapp/private/user-private/private-audio-failed/audio.ogg',
+          },
+          rawMatrixEvent: {
+            type: 'm.room.message',
+            event_id: '$private-audio-failed',
+          },
+        },
+      });
+      expect(stored.ok).toBe(true);
+      if (!stored.ok) throw new Error(stored.error.message);
+
+      const body = createPubSubBody({
+        type: 'srt.transcription.completed',
+        messageSource: 'private_whatsapp',
+        userId: 'user-private',
+        messageId: stored.value.messageId,
+        jobId: 'job-private-456',
+        status: 'failed',
+        error: 'Audio format was not supported',
+        timestamp: '2026-06-28T10:05:00.000Z',
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/internal/whatsapp/pubsub/transcription-completed',
+        headers: { 'x-internal-auth': INTERNAL_AUTH_TOKEN },
+        payload: body,
+      });
+
+      expect(response.statusCode).toBe(200);
+      const privateMessage = await privateWhatsAppRepository.getMessageById(stored.value.messageId);
+      expect(privateMessage.ok).toBe(true);
+      if (!privateMessage.ok) throw new Error(privateMessage.error.message);
+      expect(privateMessage.value?.transcription).toEqual({
+        status: 'failed',
+        jobId: 'job-private-456',
+        error: {
+          code: 'TRANSCRIPTION_FAILED',
+          message: 'Audio format was not supported',
+        },
+        completedAt: '2026-06-28T10:05:00.000Z',
+      });
+      expect(eventPublisher.getIntexMessageIngestEvents()).toHaveLength(0);
+      expect(whatsappCloudApi.getSentMessages()).toHaveLength(0);
+    });
+
+    it('uses a default private WhatsApp transcription error when a failed event has no error text', async () => {
+      const messageId = await storePrivateAudioMessage({
+        matrixEventId: '$private-audio-default-error',
+      });
+
+      const body = createPubSubBody({
+        type: 'srt.transcription.completed',
+        messageSource: 'private_whatsapp',
+        userId: 'user-private',
+        messageId,
+        jobId: 'job-private-default-error',
+        status: 'failed',
+        timestamp: '2026-06-28T10:05:00.000Z',
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/internal/whatsapp/pubsub/transcription-completed',
+        headers: { 'x-internal-auth': INTERNAL_AUTH_TOKEN },
+        payload: body,
+      });
+
+      expect(response.statusCode).toBe(200);
+      const privateMessage = await privateWhatsAppRepository.getMessageById(messageId);
+      expect(privateMessage.ok).toBe(true);
+      if (!privateMessage.ok) throw new Error(privateMessage.error.message);
+      expect(privateMessage.value?.transcription).toEqual({
+        status: 'failed',
+        jobId: 'job-private-default-error',
+        error: {
+          code: 'TRANSCRIPTION_FAILED',
+          message: 'Transcription failed',
+        },
+        completedAt: '2026-06-28T10:05:00.000Z',
+      });
+    });
+
+    it('returns 500 when storing a private WhatsApp transcription fails', async () => {
+      const messageId = await storePrivateAudioMessage({
+        matrixEventId: '$private-audio-update-failure',
+      });
+      privateWhatsAppRepository.failNext({
+        code: 'PERSISTENCE_ERROR',
+        message: 'Simulated private transcription update failure',
+      });
+
+      const body = createPubSubBody({
+        type: 'srt.transcription.completed',
+        messageSource: 'private_whatsapp',
+        userId: 'user-private',
+        messageId,
+        jobId: 'job-private-update-failure',
+        status: 'completed',
+        transcript: 'Private voice note.',
+        timestamp: '2026-06-28T10:04:00.000Z',
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/internal/whatsapp/pubsub/transcription-completed',
+        headers: { 'x-internal-auth': INTERNAL_AUTH_TOKEN },
+        payload: body,
+      });
+
+      expect(response.statusCode).toBe(500);
+      const responseBody = JSON.parse(response.body) as {
+        success: boolean;
+        error: { code: string; message: string };
+      };
+      expect(responseBody.error.message).toBe('Failed to update private transcription');
     });
 
     it('stores a failed transcription and replies with the failure without sending to Intex', async () => {

--- a/apps/whatsapp-service/src/__tests__/usecases/ingestPrivateWhatsAppEvents.test.ts
+++ b/apps/whatsapp-service/src/__tests__/usecases/ingestPrivateWhatsAppEvents.test.ts
@@ -1,13 +1,19 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import { err, ok, type Result } from '@intexuraos/common-core';
 import {
+  type AudioStoredEvent,
+  type EventPublisherPort,
+  type ExtractLinkPreviewsEvent,
   IngestPrivateWhatsAppEventsUseCase,
   type DisablePrivateWhatsAppAccountInput,
+  type IntexMessageIngestEvent,
   type IngestPrivateWhatsAppEventInput,
   type IngestPrivateWhatsAppEventsInput,
+  type MediaCleanupEvent,
   type PrivateWhatsAppAccount,
   type PrivateWhatsAppAggregateRebuildInput,
   type PrivateWhatsAppAggregateRebuildResult,
+  type PrivateWhatsAppChat,
   type PrivateWhatsAppChatQueryInput,
   type PrivateWhatsAppChatQueryResult,
   type PrivateWhatsAppIngestOutcome,
@@ -18,8 +24,12 @@ import {
   type PrivateWhatsAppSenderQueryResult,
   type PrivateWhatsAppSenderDayQueryInput,
   type PrivateWhatsAppSenderDayQueryResult,
+  type PrivateWhatsAppTranscriptionState,
   type StorePrivateWhatsAppMessageInput,
+  type UpdatePrivateWhatsAppChatTranscriptionInput,
+  type UpdatePrivateWhatsAppMessageTranscriptionInput,
   type UpsertPrivateWhatsAppAccountInput,
+  type WebhookProcessEvent,
   type WhatsAppError,
 } from '../../domain/whatsapp/index.js';
 import type { Logger } from '../../domain/whatsapp/utils/logger.js';
@@ -70,8 +80,10 @@ function createInput(
 
 class TestPrivateWhatsAppRepository implements PrivateWhatsAppRepository {
   readonly stored: StorePrivateWhatsAppMessageInput[] = [];
+  readonly transcriptions: { messageId: string; transcription: PrivateWhatsAppTranscriptionState }[] = [];
   private readonly seenEventIds = new Map<string, PrivateWhatsAppIngestOutcome>();
   failNextStore = false;
+  chatTranscriptionEnabled = false;
 
   getAccountByUserId(
     _userId: string
@@ -121,6 +133,7 @@ class TestPrivateWhatsAppRepository implements PrivateWhatsAppRepository {
       chatId: `chat-${String(this.stored.length + 1)}`,
       messageId: `message-${String(this.stored.length + 1)}`,
       matrixEventId: input.message.matrixEventId,
+      chatTranscriptionEnabled: this.chatTranscriptionEnabled,
     };
     this.stored.push(input);
     this.seenEventIds.set(input.message.matrixEventId, outcome);
@@ -129,6 +142,24 @@ class TestPrivateWhatsAppRepository implements PrivateWhatsAppRepository {
 
   getMessageById(_messageId: string): Promise<Result<null, WhatsAppError>> {
     return Promise.resolve(ok(null));
+  }
+
+  updateChatTranscriptionSetting(
+    _input: UpdatePrivateWhatsAppChatTranscriptionInput
+  ): Promise<Result<PrivateWhatsAppChat, WhatsAppError>> {
+    return Promise.resolve(
+      err({ code: 'NOT_FOUND', message: 'Chat writes are not used by this fake' })
+    );
+  }
+
+  updateMessageTranscription(
+    input: UpdatePrivateWhatsAppMessageTranscriptionInput
+  ): Promise<Result<void, WhatsAppError>> {
+    this.transcriptions.push({
+      messageId: input.messageId,
+      transcription: input.transcription,
+    });
+    return Promise.resolve(ok(undefined));
   }
 
   findMessages(
@@ -164,14 +195,47 @@ class TestPrivateWhatsAppRepository implements PrivateWhatsAppRepository {
   }
 }
 
+class TestEventPublisher implements EventPublisherPort {
+  readonly audioStoredEvents: AudioStoredEvent[] = [];
+  failNextAudioStored = false;
+
+  publishMediaCleanup(_event: MediaCleanupEvent): Promise<Result<void, WhatsAppError>> {
+    return Promise.resolve(ok(undefined));
+  }
+
+  publishAudioStored(event: AudioStoredEvent): Promise<Result<void, WhatsAppError>> {
+    if (this.failNextAudioStored) {
+      this.failNextAudioStored = false;
+      return Promise.resolve(err({ code: 'INTERNAL_ERROR', message: 'Audio publish failed' }));
+    }
+    this.audioStoredEvents.push(event);
+    return Promise.resolve(ok(undefined));
+  }
+
+  publishIntexMessageIngest(_event: IntexMessageIngestEvent): Promise<Result<void, WhatsAppError>> {
+    return Promise.resolve(ok(undefined));
+  }
+
+  publishWebhookProcess(_event: WebhookProcessEvent): Promise<Result<void, WhatsAppError>> {
+    return Promise.resolve(ok(undefined));
+  }
+
+  publishExtractLinkPreviews(_event: ExtractLinkPreviewsEvent): Promise<Result<void, WhatsAppError>> {
+    return Promise.resolve(ok(undefined));
+  }
+}
+
 describe('IngestPrivateWhatsAppEventsUseCase', () => {
   let repository: TestPrivateWhatsAppRepository;
+  let eventPublisher: TestEventPublisher;
   let useCase: IngestPrivateWhatsAppEventsUseCase;
 
   beforeEach(() => {
     repository = new TestPrivateWhatsAppRepository();
+    eventPublisher = new TestEventPublisher();
     useCase = new IngestPrivateWhatsAppEventsUseCase({
       privateWhatsAppRepository: repository,
+      eventPublisher,
     });
   });
 
@@ -369,6 +433,132 @@ describe('IngestPrivateWhatsAppEventsUseCase', () => {
       messages: [{ matrixEventId: '$event-1', outcome: 'duplicate' }],
     });
     expect(repository.stored).toHaveLength(1);
+  });
+
+  it('publishes private audio transcription jobs only for enabled chats and created events', async () => {
+    repository.chatTranscriptionEnabled = true;
+    const audioEvent = createEvent({
+      matrixEventId: '$audio-event-1',
+      message: {
+        direction: 'incoming',
+        type: 'audio',
+        media: {
+          mxcUri: 'mxc://home-dev/audio-event-1',
+          mimeType: 'audio/ogg',
+          storageStatus: 'stored',
+          gcsPath: 'whatsapp/private/user-123/message-1/audio.ogg',
+          storedMimeType: 'audio/ogg',
+          storedSizeBytes: 1234,
+        },
+      },
+    });
+
+    const firstResult = await useCase.execute(createInput({ events: [audioEvent] }), logger);
+    const duplicateResult = await useCase.execute(createInput({ events: [audioEvent] }), logger);
+
+    expect(firstResult.ok).toBe(true);
+    expect(duplicateResult.ok).toBe(true);
+    expect(eventPublisher.audioStoredEvents).toEqual([
+      {
+        type: 'whatsapp.audio.stored',
+        messageSource: 'private_whatsapp',
+        userId: 'user-123',
+        messageId: 'message-1',
+        mediaId: 'mxc://home-dev/audio-event-1',
+        gcsPath: 'whatsapp/private/user-123/message-1/audio.ogg',
+        mimeType: 'audio/ogg',
+        timestamp: expect.any(String),
+      },
+    ]);
+  });
+
+  it('skips private audio transcription jobs when the chat is disabled or audio is not stored', async () => {
+    const disabledResult = await useCase.execute(
+      createInput({
+        events: [
+          createEvent({
+            matrixEventId: '$disabled-audio',
+            message: {
+              direction: 'incoming',
+              type: 'audio',
+              media: {
+                mxcUri: 'mxc://home-dev/disabled-audio',
+                mimeType: 'audio/ogg',
+                storageStatus: 'stored',
+                gcsPath: 'whatsapp/private/user-123/message-1/audio.ogg',
+              },
+            },
+          }),
+        ],
+      }),
+      logger
+    );
+    repository.chatTranscriptionEnabled = true;
+    const missingStorageResult = await useCase.execute(
+      createInput({
+        events: [
+          createEvent({
+            matrixEventId: '$unstored-audio',
+            message: {
+              direction: 'incoming',
+              type: 'audio',
+              media: {
+                mxcUri: 'mxc://home-dev/unstored-audio',
+                mimeType: 'audio/ogg',
+              },
+            },
+          }),
+        ],
+      }),
+      logger
+    );
+
+    expect(disabledResult.ok).toBe(true);
+    expect(missingStorageResult.ok).toBe(true);
+    expect(eventPublisher.audioStoredEvents).toEqual([]);
+  });
+
+  it('skips private audio transcription jobs for non-audio messages even when chat transcription is enabled', async () => {
+    repository.chatTranscriptionEnabled = true;
+
+    const result = await useCase.execute(createInput(), logger);
+
+    expect(result.ok).toBe(true);
+    expect(eventPublisher.audioStoredEvents).toEqual([]);
+  });
+
+  it('returns a persistence error when publishing a private audio transcription job fails', async () => {
+    repository.chatTranscriptionEnabled = true;
+    eventPublisher.failNextAudioStored = true;
+
+    const result = await useCase.execute(
+      createInput({
+        events: [
+          createEvent({
+            matrixEventId: '$audio-publish-failure',
+            message: {
+              direction: 'incoming',
+              type: 'audio',
+              media: {
+                mxcUri: 'mxc://home-dev/audio-publish-failure',
+                mimeType: 'audio/ogg',
+                storageStatus: 'stored',
+                gcsPath: 'whatsapp/private/user-123/audio-publish-failure/audio.ogg',
+              },
+            },
+          }),
+        ],
+      }),
+      logger
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('Expected publish failure');
+    expect(result.error).toMatchObject({
+      code: 'INTERNAL_ERROR',
+      message: 'Audio publish failed',
+    });
+    expect(eventPublisher.audioStoredEvents).toEqual([]);
   });
 
   it('rejects unsupported directions without writing them', async () => {

--- a/apps/whatsapp-service/src/domain/whatsapp/events/events.ts
+++ b/apps/whatsapp-service/src/domain/whatsapp/events/events.ts
@@ -43,6 +43,11 @@ export interface AudioStoredEvent {
   type: 'whatsapp.audio.stored';
 
   /**
+   * Source collection where the message is stored.
+   */
+  messageSource?: 'public_whatsapp' | 'private_whatsapp';
+
+  /**
    * IntexuraOS user ID.
    */
   userId: string;
@@ -81,6 +86,11 @@ export interface TranscriptionCompletedEvent {
    * Event type identifier.
    */
   type: 'srt.transcription.completed';
+
+  /**
+   * Source collection where the message is stored.
+   */
+  messageSource?: 'public_whatsapp' | 'private_whatsapp';
 
   /**
    * IntexuraOS user ID.

--- a/apps/whatsapp-service/src/domain/whatsapp/index.ts
+++ b/apps/whatsapp-service/src/domain/whatsapp/index.ts
@@ -61,6 +61,9 @@ export type {
   PrivateWhatsAppMessageQueryResult,
   PrivateWhatsAppMessageInput,
   PrivateWhatsAppMessageType,
+  PrivateWhatsAppTranscriptionError,
+  PrivateWhatsAppTranscriptionState,
+  PrivateWhatsAppTranscriptionStatus,
   PrivateWhatsAppSender,
   PrivateWhatsAppSenderQueryInput,
   PrivateWhatsAppSenderQueryResult,
@@ -69,6 +72,8 @@ export type {
   PrivateWhatsAppSenderDayQueryResult,
   PrivateWhatsAppSummaryStatus,
   StorePrivateWhatsAppMessageInput,
+  UpdatePrivateWhatsAppChatTranscriptionInput,
+  UpdatePrivateWhatsAppMessageTranscriptionInput,
   UpsertPrivateWhatsAppAccountInput,
 } from './models/PrivateWhatsApp.js';
 

--- a/apps/whatsapp-service/src/domain/whatsapp/models/PrivateWhatsApp.ts
+++ b/apps/whatsapp-service/src/domain/whatsapp/models/PrivateWhatsApp.ts
@@ -8,6 +8,7 @@ export type PrivateWhatsAppMessageDirection = 'incoming' | 'outgoing';
 export type PrivateWhatsAppSummaryStatus = 'not_started' | 'completed' | 'failed';
 export type PrivateWhatsAppAccountStatus = 'active' | 'disabled';
 export type PrivateWhatsAppMediaStorageStatus = 'stored';
+export type PrivateWhatsAppTranscriptionStatus = 'pending' | 'processing' | 'completed' | 'failed';
 export type PrivateWhatsAppMessageType =
   | 'text'
   | 'image'
@@ -34,6 +35,22 @@ export interface PrivateWhatsAppMediaInfo {
   storedMimeType?: string;
   storedSizeBytes?: number;
   storedAt?: string;
+}
+
+export interface PrivateWhatsAppTranscriptionError {
+  code: string;
+  message: string;
+}
+
+export interface PrivateWhatsAppTranscriptionState {
+  status: PrivateWhatsAppTranscriptionStatus;
+  jobId?: string;
+  text?: string;
+  summary?: string;
+  detectedLanguage?: string;
+  error?: PrivateWhatsAppTranscriptionError;
+  startedAt?: string;
+  completedAt?: string;
 }
 
 export interface PrivateWhatsAppChatInput {
@@ -109,6 +126,9 @@ export interface PrivateWhatsAppChat {
   messageCount?: number;
   participantCount?: number;
   participantKeys?: string[];
+  transcriptionEnabled?: boolean;
+  transcriptionEnabledAt?: string;
+  transcriptionUpdatedAt?: string;
   firstSeenAt: string;
   lastEventAt: string;
   updatedAt: string;
@@ -139,6 +159,7 @@ export interface PrivateWhatsAppMessage {
   receivedAt: string;
   ingestedAt: string;
   deliveryMode: PrivateWhatsAppDeliveryMode;
+  transcription?: PrivateWhatsAppTranscriptionState;
   rawMatrixEvent: unknown;
   schemaVersion?: number;
 }
@@ -186,6 +207,7 @@ export interface PrivateWhatsAppIngestOutcome {
   chatId: string;
   messageId: string;
   matrixEventId: string;
+  chatTranscriptionEnabled?: boolean;
 }
 
 export interface PrivateWhatsAppIngestEventResult {
@@ -217,6 +239,19 @@ export interface PrivateWhatsAppMessageQueryInput {
 export interface PrivateWhatsAppMessageQueryResult {
   messages: PrivateWhatsAppMessage[];
   nextCursor?: string;
+}
+
+export interface UpdatePrivateWhatsAppChatTranscriptionInput {
+  sourceAccountId: string;
+  chatId: string;
+  enabled: boolean;
+  now: string;
+}
+
+export interface UpdatePrivateWhatsAppMessageTranscriptionInput {
+  userId: string;
+  messageId: string;
+  transcription: PrivateWhatsAppTranscriptionState;
 }
 
 export interface PrivateWhatsAppChatQueryInput {

--- a/apps/whatsapp-service/src/domain/whatsapp/ports/privateWhatsAppRepository.ts
+++ b/apps/whatsapp-service/src/domain/whatsapp/ports/privateWhatsAppRepository.ts
@@ -5,6 +5,7 @@ import type {
   PrivateWhatsAppAccount,
   PrivateWhatsAppAggregateRebuildInput,
   PrivateWhatsAppAggregateRebuildResult,
+  PrivateWhatsAppChat,
   PrivateWhatsAppChatQueryInput,
   PrivateWhatsAppChatQueryResult,
   PrivateWhatsAppIngestOutcome,
@@ -16,6 +17,8 @@ import type {
   PrivateWhatsAppSenderDayQueryInput,
   PrivateWhatsAppSenderDayQueryResult,
   StorePrivateWhatsAppMessageInput,
+  UpdatePrivateWhatsAppChatTranscriptionInput,
+  UpdatePrivateWhatsAppMessageTranscriptionInput,
   UpsertPrivateWhatsAppAccountInput,
 } from '../models/PrivateWhatsApp.js';
 
@@ -38,6 +41,12 @@ export interface PrivateWhatsAppRepository {
   getMessageById(
     messageId: string
   ): Promise<Result<PrivateWhatsAppMessage | null, WhatsAppError>>;
+  updateChatTranscriptionSetting(
+    input: UpdatePrivateWhatsAppChatTranscriptionInput
+  ): Promise<Result<PrivateWhatsAppChat, WhatsAppError>>;
+  updateMessageTranscription(
+    input: UpdatePrivateWhatsAppMessageTranscriptionInput
+  ): Promise<Result<void, WhatsAppError>>;
   findMessages(
     input: PrivateWhatsAppMessageQueryInput
   ): Promise<Result<PrivateWhatsAppMessageQueryResult, WhatsAppError>>;

--- a/apps/whatsapp-service/src/domain/whatsapp/usecases/ingestPrivateWhatsAppEvents.ts
+++ b/apps/whatsapp-service/src/domain/whatsapp/usecases/ingestPrivateWhatsAppEvents.ts
@@ -5,10 +5,12 @@ import type {
   PrivateWhatsAppDeliveryMode,
   PrivateWhatsAppIngestEventResult,
   PrivateWhatsAppIngestResult,
+  PrivateWhatsAppIngestOutcome,
   PrivateWhatsAppMessageDirection,
   PrivateWhatsAppMessageType,
   StorePrivateWhatsAppMessageInput,
 } from '../models/PrivateWhatsApp.js';
+import type { EventPublisherPort } from '../ports/eventPublisher.js';
 import type { PrivateWhatsAppRepository } from '../ports/privateWhatsAppRepository.js';
 import type { Logger } from '../utils/logger.js';
 
@@ -60,6 +62,7 @@ export interface IngestPrivateWhatsAppEventInput {
 
 export interface IngestPrivateWhatsAppEventsDeps {
   privateWhatsAppRepository: PrivateWhatsAppRepository;
+  eventPublisher: EventPublisherPort;
 }
 
 type ParseEventResult =
@@ -137,6 +140,17 @@ export class IngestPrivateWhatsAppEventsUseCase {
         messageId: outcome.messageId,
       };
       messages.push(result);
+
+      const publishResult = await publishPrivateAudioStoredIfNeeded({
+        event,
+        outcome,
+        storeInput,
+        eventPublisher: this.deps.eventPublisher,
+        logger,
+      });
+      if (!publishResult.ok) {
+        return err(publishResult.error);
+      }
     }
 
     const summary = summarize(messages);
@@ -152,6 +166,56 @@ export class IngestPrivateWhatsAppEventsUseCase {
     );
     return ok(summary);
   }
+}
+
+interface PublishPrivateAudioStoredInput {
+  event: IngestPrivateWhatsAppEventInput;
+  outcome: PrivateWhatsAppIngestOutcome;
+  storeInput: StorePrivateWhatsAppMessageInput;
+  eventPublisher: EventPublisherPort;
+  logger: Logger;
+}
+
+async function publishPrivateAudioStoredIfNeeded(
+  input: PublishPrivateAudioStoredInput
+): Promise<Result<void, WhatsAppError>> {
+  const { event, outcome, storeInput, eventPublisher, logger } = input;
+  if (outcome.outcome !== 'created' || outcome.chatTranscriptionEnabled !== true) {
+    return ok(undefined);
+  }
+  if (storeInput.message.type !== 'audio') {
+    return ok(undefined);
+  }
+  const media = storeInput.message.media;
+  const gcsPath = media?.gcsPath;
+  const mimeType = media?.storedMimeType ?? media?.mimeType;
+  if (media?.storageStatus !== 'stored' || gcsPath === undefined || mimeType === undefined) {
+    return ok(undefined);
+  }
+
+  const publishResult = await eventPublisher.publishAudioStored({
+    type: 'whatsapp.audio.stored',
+    messageSource: 'private_whatsapp',
+    userId: storeInput.userId,
+    messageId: outcome.messageId,
+    mediaId: media.mxcUri,
+    gcsPath,
+    mimeType,
+    timestamp: new Date().toISOString(),
+  });
+  if (!publishResult.ok) {
+    logger.error(
+      {
+        matrixEventId: event.matrixEventId,
+        sourceAccountId: storeInput.sourceAccountId,
+        messageId: outcome.messageId,
+        error: publishResult.error,
+      },
+      'Failed to publish private WhatsApp audio transcription event'
+    );
+    return err(publishResult.error);
+  }
+  return ok(undefined);
 }
 
 function parseEvent(rawEvent: unknown): ParseEventResult {

--- a/apps/whatsapp-service/src/infra/firestore/privateWhatsAppRepository.ts
+++ b/apps/whatsapp-service/src/infra/firestore/privateWhatsAppRepository.ts
@@ -27,6 +27,8 @@ import type {
   PrivateWhatsAppSenderDayQueryInput,
   PrivateWhatsAppSenderDayQueryResult,
   StorePrivateWhatsAppMessageInput,
+  UpdatePrivateWhatsAppChatTranscriptionInput,
+  UpdatePrivateWhatsAppMessageTranscriptionInput,
   UpsertPrivateWhatsAppAccountInput,
 } from '../../domain/whatsapp/index.js';
 import type { PrivateWhatsAppRepository } from '../../domain/whatsapp/index.js';
@@ -71,6 +73,8 @@ export function createPrivateWhatsAppRepository(): PrivateWhatsAppRepository {
     disableAccount,
     storeIncomingMessage,
     getMessageById,
+    updateChatTranscriptionSetting,
+    updateMessageTranscription,
     findMessages,
     findChats,
     findSenders,
@@ -344,6 +348,7 @@ async function storeIncomingMessage(
         chatId,
         messageId,
         matrixEventId: input.message.matrixEventId,
+        ...(chat.transcriptionEnabled === true ? { chatTranscriptionEnabled: true } : {}),
       };
     });
 
@@ -373,6 +378,93 @@ async function getMessageById(
     return err({
       code: 'PERSISTENCE_ERROR',
       message: `Failed to load private WhatsApp message: ${getErrorMessage(error, 'Unknown Firestore error')}`,
+    });
+  }
+}
+
+async function updateChatTranscriptionSetting(
+  input: UpdatePrivateWhatsAppChatTranscriptionInput
+): Promise<Result<PrivateWhatsAppChat, WhatsAppError>> {
+  try {
+    const db = getFirestore();
+    const chatRef = db.collection(PRIVATE_WHATSAPP_CHATS_COLLECTION).doc(input.chatId);
+    const outcome = await db.runTransaction(
+      async (
+        transaction
+      ): Promise<{ status: 'not_found' } | { status: 'ok'; chat: PrivateWhatsAppChat }> => {
+        const chatDoc = await transaction.get(chatRef);
+        if (!chatDoc.exists) {
+          return { status: 'not_found' };
+        }
+
+        const existingChat = normalizeChat(chatDoc.id, chatDoc.data());
+        if (existingChat.sourceAccountId !== input.sourceAccountId) {
+          return { status: 'not_found' };
+        }
+
+        const chat: PrivateWhatsAppChat = {
+          ...existingChat,
+          transcriptionEnabled: input.enabled,
+          transcriptionUpdatedAt: input.now,
+          updatedAt: input.now,
+          schemaVersion: PRIVATE_WHATSAPP_SCHEMA_VERSION,
+        };
+        if (input.enabled && existingChat.transcriptionEnabledAt === undefined) {
+          chat.transcriptionEnabledAt = input.now;
+        } else if (existingChat.transcriptionEnabledAt !== undefined) {
+          chat.transcriptionEnabledAt = existingChat.transcriptionEnabledAt;
+        }
+
+        transaction.set(chatRef, chat, { merge: true });
+        return { status: 'ok', chat };
+      }
+    );
+
+    if (outcome.status === 'not_found') {
+      return err({ code: 'NOT_FOUND', message: 'Private WhatsApp chat not found' });
+    }
+    return ok(outcome.chat);
+  } catch (error) {
+    return err({
+      code: 'PERSISTENCE_ERROR',
+      message: `Failed to update private WhatsApp chat transcription setting: ${getErrorMessage(error, 'Unknown Firestore error')}`,
+    });
+  }
+}
+
+async function updateMessageTranscription(
+  input: UpdatePrivateWhatsAppMessageTranscriptionInput
+): Promise<Result<void, WhatsAppError>> {
+  try {
+    const db = getFirestore();
+    const messageRef = db.collection(PRIVATE_WHATSAPP_MESSAGES_COLLECTION).doc(input.messageId);
+    const outcome = await db.runTransaction(async (transaction): Promise<'not_found' | 'ok'> => {
+      const messageDoc = await transaction.get(messageRef);
+      if (!messageDoc.exists) {
+        return 'not_found';
+      }
+
+      const rawMessage = messageDoc.data() as Omit<PrivateWhatsAppMessage, 'id'> & { id?: string };
+      const message: PrivateWhatsAppMessage = { ...rawMessage, id: rawMessage.id ?? messageDoc.id };
+      if (message.userId !== input.userId) {
+        return 'not_found';
+      }
+
+      transaction.update(messageRef, {
+        transcription: input.transcription,
+        schemaVersion: PRIVATE_WHATSAPP_SCHEMA_VERSION,
+      });
+      return 'ok';
+    });
+
+    if (outcome === 'not_found') {
+      return err({ code: 'NOT_FOUND', message: 'Private WhatsApp message not found' });
+    }
+    return ok(undefined);
+  } catch (error) {
+    return err({
+      code: 'PERSISTENCE_ERROR',
+      message: `Failed to update private WhatsApp message transcription: ${getErrorMessage(error, 'Unknown Firestore error')}`,
     });
   }
 }
@@ -690,6 +782,15 @@ function buildChat(
   } else if (existingChat?.avatarMxcUri !== undefined) {
     chat.avatarMxcUri = existingChat.avatarMxcUri;
   }
+  if (existingChat?.transcriptionEnabled !== undefined) {
+    chat.transcriptionEnabled = existingChat.transcriptionEnabled;
+  }
+  if (existingChat?.transcriptionEnabledAt !== undefined) {
+    chat.transcriptionEnabledAt = existingChat.transcriptionEnabledAt;
+  }
+  if (existingChat?.transcriptionUpdatedAt !== undefined) {
+    chat.transcriptionUpdatedAt = existingChat.transcriptionUpdatedAt;
+  }
 
   return chat;
 }
@@ -929,6 +1030,15 @@ function normalizeChat(id: string, data: Record<string, unknown> | undefined): P
       (participantKey): participantKey is string => typeof participantKey === 'string'
     );
     projected.participantCount = projected.participantCount ?? projected.participantKeys.length;
+  }
+  if (typeof chat?.transcriptionEnabled === 'boolean') {
+    projected.transcriptionEnabled = chat.transcriptionEnabled;
+  }
+  if (typeof chat?.transcriptionEnabledAt === 'string') {
+    projected.transcriptionEnabledAt = chat.transcriptionEnabledAt;
+  }
+  if (typeof chat?.transcriptionUpdatedAt === 'string') {
+    projected.transcriptionUpdatedAt = chat.transcriptionUpdatedAt;
   }
   return projected;
 }

--- a/apps/whatsapp-service/src/routes/privateMediaRoutes.ts
+++ b/apps/whatsapp-service/src/routes/privateMediaRoutes.ts
@@ -69,6 +69,14 @@ function isImageMimeType(mimeType: string): boolean {
   return mimeType.startsWith('image/');
 }
 
+function isAudioMimeType(mimeType: string): boolean {
+  return mimeType.startsWith('audio/');
+}
+
+function isSupportedUploadMimeType(mimeType: string): boolean {
+  return isImageMimeType(mimeType) || isAudioMimeType(mimeType);
+}
+
 function isPrivateImageMessage(message: PrivateWhatsAppMessage): boolean {
   return message.messageType === 'image';
 }
@@ -316,7 +324,6 @@ export const privateMediaRoutes: FastifyPluginCallback = (fastify, _opts, done) 
                         'sizeBytes',
                         'storageStatus',
                         'gcsPath',
-                        'thumbnailGcsPath',
                         'storedMimeType',
                         'storedSizeBytes',
                         'storedAt',
@@ -370,8 +377,8 @@ export const privateMediaRoutes: FastifyPluginCallback = (fastify, _opts, done) 
         }
 
         const mimeType = request.query.mimeType;
-        if (mimeType === undefined || !isImageMimeType(mimeType)) {
-          return await reply.fail('INVALID_REQUEST', 'mimeType must be an image MIME type');
+        if (mimeType === undefined || !isSupportedUploadMimeType(mimeType)) {
+          return await reply.fail('INVALID_REQUEST', 'mimeType must be an image or audio MIME type');
         }
 
         const services = getServices();
@@ -404,21 +411,25 @@ export const privateMediaRoutes: FastifyPluginCallback = (fastify, _opts, done) 
           return await reply.fail('DOWNSTREAM_ERROR', uploadResult.error.message);
         }
 
-        const thumbnailResult = await services.thumbnailGenerator.generate(buffer);
-        if (!thumbnailResult.ok) {
-          return await reply.fail('DOWNSTREAM_ERROR', thumbnailResult.error.message);
-        }
+        let thumbnailGcsPath: string | undefined;
+        if (isImageMimeType(mimeType)) {
+          const thumbnailResult = await services.thumbnailGenerator.generate(buffer);
+          if (!thumbnailResult.ok) {
+            return await reply.fail('DOWNSTREAM_ERROR', thumbnailResult.error.message);
+          }
 
-        const thumbnailUploadResult = await services.mediaStorage.uploadPrivateThumbnail(
-          accountResult.value.userId,
-          messageId,
-          mediaId,
-          'jpg',
-          thumbnailResult.value.buffer,
-          thumbnailResult.value.mimeType
-        );
-        if (!thumbnailUploadResult.ok) {
-          return await reply.fail('DOWNSTREAM_ERROR', thumbnailUploadResult.error.message);
+          const thumbnailUploadResult = await services.mediaStorage.uploadPrivateThumbnail(
+            accountResult.value.userId,
+            messageId,
+            mediaId,
+            'jpg',
+            thumbnailResult.value.buffer,
+            thumbnailResult.value.mimeType
+          );
+          if (!thumbnailUploadResult.ok) {
+            return await reply.fail('DOWNSTREAM_ERROR', thumbnailUploadResult.error.message);
+          }
+          thumbnailGcsPath = thumbnailUploadResult.value.gcsPath;
         }
 
         return await reply.ok({
@@ -430,7 +441,7 @@ export const privateMediaRoutes: FastifyPluginCallback = (fastify, _opts, done) 
             sha256: request.query.sha256,
             storageStatus: 'stored',
             gcsPath: uploadResult.value.gcsPath,
-            thumbnailGcsPath: thumbnailUploadResult.value.gcsPath,
+            ...(thumbnailGcsPath !== undefined ? { thumbnailGcsPath } : {}),
             storedMimeType: mimeType,
             storedSizeBytes: buffer.length,
             storedAt: new Date().toISOString(),

--- a/apps/whatsapp-service/src/routes/privateReadRoutes.ts
+++ b/apps/whatsapp-service/src/routes/privateReadRoutes.ts
@@ -43,6 +43,14 @@ interface PrivateChatMessagesParams {
   chatId: string;
 }
 
+interface PrivateChatTranscriptionParams {
+  chatId: string;
+}
+
+interface PrivateChatTranscriptionBody {
+  enabled: boolean;
+}
+
 interface PrivateSenderDaysQuerystring {
   senderKey: string;
   fromDay?: string;
@@ -163,6 +171,17 @@ function getPublicChatMessagesLogMetadata(
   };
 }
 
+function getPrivateChatTranscriptionLogMetadata(
+  params: Partial<PrivateChatTranscriptionParams>,
+  body: Partial<PrivateChatTranscriptionBody>
+): Record<string, unknown> {
+  return {
+    route: 'whatsapp_private_chat_transcription_update',
+    hasChatId: typeof params.chatId === 'string',
+    enabled: typeof body.enabled === 'boolean' ? body.enabled : undefined,
+  };
+}
+
 function getPublicMessagesLogMetadata(
   query: Partial<PrivateMessagesQuerystring>
 ): Record<string, unknown> {
@@ -259,6 +278,9 @@ function toPublicChat(chat: PrivateWhatsAppChat): PublicPrivateWhatsAppChat {
     avatarMxcUri: chat.avatarMxcUri,
     messageCount: chat.messageCount,
     participantCount: chat.participantCount,
+    transcriptionEnabled: chat.transcriptionEnabled,
+    transcriptionEnabledAt: chat.transcriptionEnabledAt,
+    transcriptionUpdatedAt: chat.transcriptionUpdatedAt,
     firstSeenAt: chat.firstSeenAt,
     lastEventAt: chat.lastEventAt,
     updatedAt: chat.updatedAt,
@@ -308,6 +330,7 @@ function toPublicMessage(message: PrivateWhatsAppMessage): PublicPrivateWhatsApp
     receivedAt: message.receivedAt,
     ingestedAt: message.ingestedAt,
     deliveryMode: message.deliveryMode,
+    transcription: message.transcription,
     schemaVersion: message.schemaVersion,
   }) as PublicPrivateWhatsAppMessage;
 }
@@ -582,6 +605,99 @@ export function createPrivateReadRoutes(): FastifyPluginCallback {
           response.nextCursor = result.value.nextCursor;
         }
         return await reply.ok(response);
+      }
+    );
+
+    fastify.patch<{
+      Params: PrivateChatTranscriptionParams;
+      Body: PrivateChatTranscriptionBody;
+    }>(
+      '/private/chats/:chatId/transcription',
+      {
+        attachValidation: true,
+        schema: {
+          operationId: 'updatePrivateWhatsAppChatTranscription',
+          summary: 'Update private WhatsApp chat transcription settings',
+          tags: ['whatsapp'],
+          params: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+              chatId: { type: 'string', minLength: 1 },
+            },
+            required: ['chatId'],
+          },
+          body: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+              enabled: { type: 'boolean' },
+            },
+            required: ['enabled'],
+          },
+          response: {
+            200: {
+              description: 'Private WhatsApp chat transcription settings updated successfully',
+              type: 'object',
+              properties: {
+                success: { type: 'boolean', const: true },
+                data: { type: 'object', additionalProperties: true },
+              },
+              required: ['success', 'data'],
+            },
+            ...privateReadErrorResponses(),
+          },
+        },
+      },
+      async (
+        request: FastifyRequest<{
+          Params: PrivateChatTranscriptionParams;
+          Body: PrivateChatTranscriptionBody;
+        }>,
+        reply: FastifyReply
+      ) => {
+        logIncomingRequest(request, {
+          message: 'Received request to PATCH /whatsapp/private/chats/:chatId/transcription',
+          bodyPreviewLength: 0,
+          additionalFields: getPrivateChatTranscriptionLogMetadata(
+            request.params,
+            request.body
+          ),
+        });
+        const user = await requirePrivateWhatsAppOwner(request, reply);
+        if (user === null) {
+          return;
+        }
+        const validatedRequest = request as ValidatedRequest;
+        if (validatedRequest.validationError !== undefined) {
+          return await reply.fail('INVALID_REQUEST', 'Validation failed');
+        }
+        const account = await resolveActivePrivateAccount(user, reply);
+        if (account === null) {
+          return;
+        }
+
+        const result = await getServices().privateWhatsAppRepository.updateChatTranscriptionSetting({
+          sourceAccountId: account.sourceAccountId,
+          chatId: request.params.chatId,
+          enabled: request.body.enabled,
+          now: new Date().toISOString(),
+        });
+        if (!result.ok) {
+          if (result.error.code === 'NOT_FOUND') {
+            return await reply.fail('NOT_FOUND', result.error.message);
+          }
+          return await reply.fail('INTERNAL_ERROR', result.error.message);
+        }
+        request.log.info(
+          {
+            route: 'whatsapp_private_chat_transcription_update',
+            chatId: result.value.id,
+            transcriptionEnabled: result.value.transcriptionEnabled,
+          },
+          'Private WhatsApp chat transcription settings updated'
+        );
+        return await reply.ok(toPublicChat(result.value));
       }
     );
 

--- a/apps/whatsapp-service/src/routes/privateSyncRoutes.ts
+++ b/apps/whatsapp-service/src/routes/privateSyncRoutes.ts
@@ -247,6 +247,7 @@ export const privateSyncRoutes: FastifyPluginCallback = (fastify, _opts, done) =
       }
       const useCase = new IngestPrivateWhatsAppEventsUseCase({
         privateWhatsAppRepository: services.privateWhatsAppRepository,
+        eventPublisher: services.eventPublisher,
       });
       const result = await useCase.execute(
         {

--- a/apps/whatsapp-service/src/routes/pubsubRoutes.ts
+++ b/apps/whatsapp-service/src/routes/pubsubRoutes.ts
@@ -8,6 +8,7 @@ import { getServices } from '../services.js';
 import type {
   ExtractLinkPreviewsEvent,
   MediaCleanupEvent,
+  PrivateWhatsAppTranscriptionState,
   SendMessageEvent,
   TranscriptionCompletedEvent,
   TranscriptionState,
@@ -663,7 +664,20 @@ export function createPubsubRoutes(): FastifyPluginCallback {
         let eventData: TranscriptionCompletedEvent;
         try {
           const decoded = Buffer.from(body.message.data, 'base64').toString('utf-8');
-          eventData = JSON.parse(decoded) as TranscriptionCompletedEvent;
+          const parsedEventData = JSON.parse(decoded) as Omit<
+            TranscriptionCompletedEvent,
+            'messageSource'
+          > & {
+            messageSource?: unknown;
+          };
+          if (
+            parsedEventData.messageSource !== undefined &&
+            parsedEventData.messageSource !== 'public_whatsapp' &&
+            parsedEventData.messageSource !== 'private_whatsapp'
+          ) {
+            return await reply.fail('INVALID_REQUEST', 'Unexpected transcription message source');
+          }
+          eventData = parsedEventData as TranscriptionCompletedEvent;
         } catch {
           request.log.error(
             { messageId: body.message.messageId },
@@ -678,7 +692,97 @@ export function createPubsubRoutes(): FastifyPluginCallback {
           return await reply.fail('INVALID_REQUEST', 'Unexpected event type');
         }
 
-        const { messageRepository, eventPublisher } = getServices();
+        const services = getServices();
+        const { messageRepository, eventPublisher } = services;
+
+        if (eventData.messageSource === 'private_whatsapp') {
+          const privateMessageResult =
+            await services.privateWhatsAppRepository.getMessageById(eventData.messageId);
+          if (!privateMessageResult.ok) {
+            request.log.error(
+              {
+                userId: eventData.userId,
+                messageId: eventData.messageId,
+                error: privateMessageResult.error.message,
+              },
+              'Failed to load private WhatsApp audio message for transcription completion'
+            );
+            return await reply.fail('INTERNAL_ERROR', 'Failed to load private audio message');
+          }
+
+          const privateMessage = privateMessageResult.value;
+          if (privateMessage?.userId !== eventData.userId) {
+            request.log.warn(
+              { userId: eventData.userId, messageId: eventData.messageId },
+              'Private WhatsApp audio message not found for transcription completion'
+            );
+            return await reply.ok({});
+          }
+
+          const completedTranscript =
+            eventData.status === 'completed' ? eventData.transcript?.trim() : undefined;
+          if (
+            eventData.status === 'completed' &&
+            (completedTranscript === undefined || completedTranscript === '')
+          ) {
+            return await reply.fail(
+              'INVALID_REQUEST',
+              'Completed transcription is missing transcript'
+            );
+          }
+          const completedTranscriptText = completedTranscript ?? '';
+
+          const transcription: PrivateWhatsAppTranscriptionState =
+            eventData.status === 'completed'
+              ? {
+                  status: 'completed',
+                  jobId: eventData.jobId,
+                  text: completedTranscriptText,
+                  ...(eventData.summary !== undefined ? { summary: eventData.summary } : {}),
+                  ...(eventData.detectedLanguage !== undefined
+                    ? { detectedLanguage: eventData.detectedLanguage }
+                    : {}),
+                  completedAt: eventData.timestamp,
+                }
+              : {
+                  status: 'failed',
+                  jobId: eventData.jobId,
+                  error: {
+                    code: 'TRANSCRIPTION_FAILED',
+                    message: eventData.error ?? 'Transcription failed',
+                  },
+                  completedAt: eventData.timestamp,
+                };
+
+          const updateResult = await services.privateWhatsAppRepository.updateMessageTranscription({
+            userId: eventData.userId,
+            messageId: eventData.messageId,
+            transcription,
+          });
+          if (!updateResult.ok) {
+            request.log.error(
+              {
+                userId: eventData.userId,
+                messageId: eventData.messageId,
+                error: updateResult.error.message,
+              },
+              'Failed to update private WhatsApp audio message transcription'
+            );
+            return await reply.fail('INTERNAL_ERROR', 'Failed to update private transcription');
+          }
+
+          request.log.info(
+            {
+              userId: eventData.userId,
+              messageId: eventData.messageId,
+              status: eventData.status,
+              messageSource: eventData.messageSource,
+            },
+            'Processed private WhatsApp transcription completion event'
+          );
+          return await reply.ok({});
+        }
+
         const messageResult = await messageRepository.findById(
           eventData.userId,
           eventData.messageId

--- a/tools/whatsapp-private-matrix-sync/src/server.mjs
+++ b/tools/whatsapp-private-matrix-sync/src/server.mjs
@@ -447,7 +447,10 @@ export async function runSyncIteration(config, runtime, deps = {}) {
 export async function prepareEventsForIngest(config, matrixAccessToken, events, deps) {
   const prepared = [];
   for (const event of events) {
-    if (event?.message?.type !== 'image' || event.message.media?.mxcUri === undefined) {
+    if (
+      !isPrivateMediaUploadMessageType(event?.message?.type) ||
+      event.message.media?.mxcUri === undefined
+    ) {
       prepared.push(event);
       continue;
     }
@@ -479,6 +482,10 @@ export async function prepareEventsForIngest(config, matrixAccessToken, events, 
     });
   }
   return prepared;
+}
+
+function isPrivateMediaUploadMessageType(messageType) {
+  return messageType === 'image' || messageType === 'audio';
 }
 
 export function createHealthServer(config, runtime) {

--- a/tools/whatsapp-private-matrix-sync/src/server.test.mjs
+++ b/tools/whatsapp-private-matrix-sync/src/server.test.mjs
@@ -16,6 +16,7 @@ import {
   extractRoomContexts,
   fetchMatrixMedia,
   isIncomingWhatsAppMatrixEvent,
+  prepareEventsForIngest,
   runSyncIteration,
 } from './server.mjs';
 
@@ -1095,6 +1096,71 @@ test('runSyncIteration uploads new Matrix images before posting ingest events', 
     thumbnailGcsPath: 'whatsapp/private/user/message/image_thumb.jpg',
     storedMimeType: 'image/jpeg',
     storedSizeBytes: 'image-bytes'.length,
+    storedAt: '2026-06-26T10:00:00.000Z',
+  });
+});
+
+test('prepareEventsForIngest uploads new Matrix audio before posting ingest events', async () => {
+  const prepared = await prepareEventsForIngest(
+    config,
+    'matrix-token',
+    [
+      {
+        matrixRoomId: '!room:home-dev',
+        matrixEventId: '$audio',
+        matrixSenderId: '@whatsapp_48536911713:home-dev',
+        eventTimestamp: '2026-06-26T10:00:00.000Z',
+        chat: { type: 'direct' },
+        message: {
+          direction: 'incoming',
+          type: 'audio',
+          text: 'voice.ogg',
+          media: {
+            mxcUri: 'mxc://home-dev/audio',
+            mimeType: 'audio/ogg',
+            fileName: 'voice.ogg',
+          },
+        },
+        rawMatrixEvent: {},
+      },
+    ],
+    {
+      fetchMatrixMedia: async (_config, accessToken, mxcUri) => {
+        assert.equal(accessToken, 'matrix-token');
+        assert.equal(mxcUri, 'mxc://home-dev/audio');
+        return {
+          buffer: Buffer.from('audio-bytes'),
+          contentType: 'audio/ogg',
+        };
+      },
+      uploadPrivateMedia: async (_config, event, media, downloaded) => {
+        assert.equal(event.matrixEventId, '$audio');
+        assert.equal(media.mxcUri, 'mxc://home-dev/audio');
+        assert.equal(downloaded.contentType, 'audio/ogg');
+        return {
+          mxcUri: media.mxcUri,
+          mimeType: 'audio/ogg',
+          fileName: 'voice.ogg',
+          sizeBytes: downloaded.buffer.length,
+          storageStatus: 'stored',
+          gcsPath: 'whatsapp/private/user/message/audio.ogg',
+          storedMimeType: 'audio/ogg',
+          storedSizeBytes: downloaded.buffer.length,
+          storedAt: '2026-06-26T10:00:00.000Z',
+        };
+      },
+    }
+  );
+
+  assert.deepEqual(prepared[0]?.message.media, {
+    mxcUri: 'mxc://home-dev/audio',
+    mimeType: 'audio/ogg',
+    fileName: 'voice.ogg',
+    sizeBytes: 'audio-bytes'.length,
+    storageStatus: 'stored',
+    gcsPath: 'whatsapp/private/user/message/audio.ogg',
+    storedMimeType: 'audio/ogg',
+    storedSizeBytes: 'audio-bytes'.length,
     storedAt: '2026-06-26T10:00:00.000Z',
   });
 });

--- a/workers/transcription/src/__tests__/main.test.ts
+++ b/workers/transcription/src/__tests__/main.test.ts
@@ -103,6 +103,16 @@ describe('transcribeAudio', () => {
       expect(event?.transcript).toBe('Hello world');
     });
 
+    it('preserves private WhatsApp source on completed events', async () => {
+      await transcribeAudio(
+        { ...sampleEvent, messageSource: 'private_whatsapp' },
+        deps,
+        mockLogger
+      );
+
+      expect(publishedEvents[0]?.messageSource).toBe('private_whatsapp');
+    });
+
     it('includes summary in completed event when provider returns one', async () => {
       const provider = makeProvider(
         ok({ jobId: 'job-123', apiCall: { timestamp: '', operation: 'submit', success: true } }),
@@ -165,6 +175,18 @@ describe('transcribeAudio', () => {
       expect(publishedEvents).toHaveLength(1);
       expect(publishedEvents[0]?.status).toBe('failed');
       expect(publishedEvents[0]?.error).toContain('GCS access denied');
+    });
+
+    it('preserves private WhatsApp source on failed events', async () => {
+      deps.generateSignedUrl = vi.fn().mockResolvedValue(err({ message: 'GCS access denied' }));
+
+      await transcribeAudio(
+        { ...sampleEvent, messageSource: 'private_whatsapp' },
+        deps,
+        mockLogger
+      );
+
+      expect(publishedEvents[0]?.messageSource).toBe('private_whatsapp');
     });
 
     it('publishes failed event when job submission fails', async () => {

--- a/workers/transcription/src/main.ts
+++ b/workers/transcription/src/main.ts
@@ -73,7 +73,7 @@ export async function transcribeAudio(
 ): Promise<void> {
   // mediaId is part of AudioStoredEvent for audit traceability in consuming services,
   // but is not needed for the transcription workflow itself (GCS path identifies the file).
-  const { userId, messageId, gcsPath, mimeType } = event;
+  const { userId, messageId, gcsPath, mimeType, messageSource } = event;
 
   logger.info(
     { event: 'transcription_start', userId, messageId, gcsPath },
@@ -98,7 +98,7 @@ export async function transcribeAudio(
         { event: 'signed_url_error', userId, messageId, gcsPath, error: errorMessage },
         'Failed to generate signed URL'
       );
-      await publishFailed(deps, userId, messageId, 'unknown', errorMessage, logger);
+      await publishFailed(deps, messageSource, userId, messageId, 'unknown', errorMessage, logger);
       return;
     }
 
@@ -118,7 +118,15 @@ export async function transcribeAudio(
         { event: 'submit_error', userId, messageId, error: rawError },
         'Failed to submit transcription job'
       );
-      await publishFailed(deps, userId, messageId, 'unknown', formattedError, logger);
+      await publishFailed(
+        deps,
+        messageSource,
+        userId,
+        messageId,
+        'unknown',
+        formattedError,
+        logger
+      );
       return;
     }
 
@@ -138,6 +146,7 @@ export async function transcribeAudio(
       );
       await publishFailed(
         deps,
+        messageSource,
         userId,
         messageId,
         jobId,
@@ -154,7 +163,7 @@ export async function transcribeAudio(
         { event: 'job_rejected', userId, messageId, jobId, error: rawError },
         'Transcription job was rejected'
       );
-      await publishFailed(deps, userId, messageId, jobId, formattedError, logger);
+      await publishFailed(deps, messageSource, userId, messageId, jobId, formattedError, logger);
       return;
     }
 
@@ -169,7 +178,7 @@ export async function transcribeAudio(
         { event: 'transcript_error', userId, messageId, jobId, error: rawError },
         'Failed to fetch transcript'
       );
-      await publishFailed(deps, userId, messageId, jobId, formattedError, logger);
+      await publishFailed(deps, messageSource, userId, messageId, jobId, formattedError, logger);
       return;
     }
 
@@ -185,6 +194,9 @@ export async function transcribeAudio(
       transcript: text,
       timestamp: new Date().toISOString(),
     };
+    if (messageSource !== undefined) {
+      completedEvent.messageSource = messageSource;
+    }
     if (summary !== undefined) {
       completedEvent.summary = summary;
     }
@@ -217,7 +229,7 @@ export async function transcribeAudio(
       { event: 'unexpected_error', userId, messageId, error: errorMessage },
       'Unexpected error during transcription'
     );
-    await publishFailed(deps, userId, messageId, 'unknown', errorMessage, logger);
+    await publishFailed(deps, messageSource, userId, messageId, 'unknown', errorMessage, logger);
   }
 }
 
@@ -226,6 +238,7 @@ export async function transcribeAudio(
  */
 async function publishFailed(
   deps: TranscriptionDeps,
+  messageSource: AudioStoredEvent['messageSource'],
   userId: string,
   messageId: string,
   jobId: string,
@@ -241,6 +254,9 @@ async function publishFailed(
     error: errorMessage,
     timestamp: new Date().toISOString(),
   };
+  if (messageSource !== undefined) {
+    failedEvent.messageSource = messageSource;
+  }
 
   const publishResult = await deps.publishEvent(failedEvent);
   if (!publishResult.ok) {

--- a/workers/transcription/src/types.ts
+++ b/workers/transcription/src/types.ts
@@ -12,6 +12,9 @@ export interface AudioStoredEvent {
   /** Event type identifier. */
   type: 'whatsapp.audio.stored';
 
+  /** Source collection where the message is stored. */
+  messageSource?: 'public_whatsapp' | 'private_whatsapp';
+
   /** IntexuraOS user ID. */
   userId: string;
 
@@ -38,6 +41,9 @@ export interface AudioStoredEvent {
 export interface TranscriptionCompletedEvent {
   /** Event type identifier. */
   type: 'srt.transcription.completed';
+
+  /** Source collection where the message is stored. */
+  messageSource?: 'public_whatsapp' | 'private_whatsapp';
 
   /** IntexuraOS user ID. */
   userId: string;


### PR DESCRIPTION
## Summary

- Add per-chat private WhatsApp transcript toggles and transcript timeline display.
- Publish private audio transcription jobs only for enabled chats and persist private transcript success/failure state.
- Preserve private source metadata through transcription worker and Matrix sync audio uploads.

## Verification

- `pnpm run verify:workspace:tracked whatsapp-service`
- `pnpm run verify:workspace:tracked web`
- `pnpm run verify:workspace:tracked transcription`
- `node --test tools/whatsapp-private-matrix-sync/src/server.test.mjs`
- `pnpm run ci:tracked`
- `pnpm run ci:tracked` after fetching/rebasing `origin/development`

## Linear

Linear: omitted by `$commit-push`; GitHub automation will create or link the Linear issue after PR creation.
