### PR TITLE
[INT-1719] Add Intex Agent confirmation gate

### DIFF
--- a/apps/intex-agent/src/__tests__/domain/handleIncomingMessage.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/handleIncomingMessage.test.ts
@@ -9,6 +9,7 @@ import type {
   IntexAgentSession,
   IntexAgentSessionEvent,
   IntexAgentSessionEventType,
+  IntexAgentToolName,
 } from '../../domain/sessions/types.js';
 import {
   handleIncomingMessage,
@@ -50,19 +51,15 @@ function message(overrides: Partial<IntexIncomingMessage> = {}): IntexIncomingMe
 }
 
 describe('handleIncomingMessage', () => {
-  it('creates a new session, executes a note request, replies, and keeps the session open', async () => {
+  it('creates a confirmation request for a note mutation and sends Tak/Nie buttons', async () => {
     const repo = new FakeSessionRepository();
     const runner = new FakeRunner([
       {
-        outcome: 'completed',
-        reply: 'Zapisałem notatkę.',
+        outcome: 'needs_confirmation',
+        reply: 'Czy dodać notatkę?\n\nTytuł: Door code\nTreść: The door code is 1234.',
         summary: 'Saved door code note.',
         toolName: 'create_note',
-        toolResult: { status: 'completed', id: 'note-1' },
-        ctaUrl: {
-          displayText: 'Open Note',
-          url: 'https://intexuraos.cloud/#/notes/note-1',
-        },
+        toolArgs: { title: 'Door code', content: 'The door code is 1234.' },
       },
     ]);
     const replies = new FakeReplyPublisher();
@@ -74,15 +71,138 @@ describe('handleIncomingMessage', () => {
       id: 'session-1',
       status: 'waiting_for_user',
       summary: 'Saved door code note.',
+      activeTool: 'create_note',
     });
     expect(repo.sessions[0]?.endedAt).toBeUndefined();
     expect(repo.sessions[0]?.endReason).toBeUndefined();
     expect(eventTypes(repo)).toEqual([
       'session_started',
       'user_message',
-      'tool_call_completed',
+      'confirmation_requested',
       'assistant_message',
     ]);
+    expect(eventPayloads(repo, 'confirmation_requested')[0]).toEqual({
+      confirmationId: 'confirmation-3',
+      toolName: 'create_note',
+      toolArgs: { title: 'Door code', content: 'The door code is 1234.' },
+      message: 'Czy dodać notatkę?\n\nTytuł: Door code\nTreść: The door code is 1234.',
+      sourceMessageId: 'wamid-1',
+      summary: 'Saved door code note.',
+    });
+    expect(replies.messages).toEqual([
+      {
+        userId: 'user-1',
+        message: 'Czy dodać notatkę?\n\nTytuł: Door code\nTreść: The door code is 1234.',
+        replyToMessageId: 'wamid-1',
+        correlationId: 'session-1',
+        buttons: [
+          {
+            type: 'reply',
+            reply: {
+              id: 'intex_confirm:confirmation-3:yes',
+              title: 'Tak',
+            },
+          },
+          {
+            type: 'reply',
+            reply: {
+              id: 'intex_confirm:confirmation-3:no',
+              title: 'Nie',
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('stores confirmation requests without optional summaries when the runner omits one', async () => {
+    const repo = new FakeSessionRepository();
+    const runner = new FakeRunner([
+      {
+        outcome: 'needs_confirmation',
+        reply: 'Czy dodać notatkę?\nTreść: The door code is 1234.',
+        toolName: 'create_note',
+        toolArgs: { content: 'The door code is 1234.' },
+      },
+    ]);
+    const replies = new FakeReplyPublisher();
+
+    await handleIncomingMessage(message(), deps(repo, runner, replies));
+
+    expect(repo.sessions[0]).toMatchObject({
+      id: 'session-1',
+      status: 'waiting_for_user',
+      activeTool: 'create_note',
+    });
+    expect(repo.sessions[0]?.summary).toBeUndefined();
+    expect(eventPayloads(repo, 'confirmation_requested')[0]).toEqual({
+      confirmationId: 'confirmation-3',
+      toolName: 'create_note',
+      toolArgs: { content: 'The door code is 1234.' },
+      message: 'Czy dodać notatkę?\nTreść: The door code is 1234.',
+      sourceMessageId: 'wamid-1',
+    });
+  });
+
+  it('executes exactly stored confirmation args after a matching Tak button', async () => {
+    const repo = new FakeSessionRepository();
+    repo.seedSession({
+      id: 'session-existing',
+      userId: 'user-1',
+      channel: 'whatsapp',
+      status: 'waiting_for_user',
+      startedAt: '2026-06-24T09:50:00.000Z',
+      lastUserMessageAt: '2026-06-24T09:50:00.000Z',
+      lastAssistantMessageAt: '2026-06-24T09:51:00.000Z',
+      startReason: 'no_active_session',
+      activeTool: 'create_note',
+    });
+    repo.seedEvent('session-existing', 'confirmation_requested', {
+      confirmationId: 'confirm-1',
+      toolName: 'create_note',
+      toolArgs: { title: 'Door code', content: 'The door code is 1234.' },
+      message: 'Czy dodać notatkę?',
+      sourceMessageId: 'wamid-original',
+    });
+    const runner = new FakeRunner([], [
+      {
+        outcome: 'completed',
+        reply: 'Zapisałem notatkę.',
+        toolName: 'create_note',
+        toolResult: { status: 'completed', id: 'note-1' },
+      },
+    ]);
+    const replies = new FakeReplyPublisher();
+
+    const result = await handleIncomingMessage(
+      message({
+        messageId: 'wamid-button',
+        text: '',
+        sourceType: 'whatsapp_button',
+        buttonResponse: {
+          buttonId: 'intex_confirm:confirm-1:yes',
+          buttonTitle: 'Tak',
+          replyToWamid: 'wamid-confirmation-message',
+        },
+      }),
+      deps(repo, runner, replies)
+    );
+
+    expect(result).toEqual({ sessionId: 'session-existing' });
+    expect(runner.calls).toEqual([]);
+    expect(runner.executeConfirmedCalls).toHaveLength(1);
+    expect(runner.executeConfirmedCalls[0]).toMatchObject({
+      session: { id: 'session-existing' },
+      toolName: 'create_note',
+      toolArgs: { title: 'Door code', content: 'The door code is 1234.' },
+      currentDateTime: NOW,
+      messageId: 'wamid-button',
+    });
+    expect(eventPayloads(repo, 'confirmation_resolved')[0]).toMatchObject({
+      confirmationId: 'confirm-1',
+      resolution: 'accepted',
+      buttonId: 'intex_confirm:confirm-1:yes',
+    });
     expect(eventPayloads(repo, 'tool_call_completed')[0]).toEqual({
       toolName: 'create_note',
       result: { status: 'completed', id: 'note-1' },
@@ -91,14 +211,336 @@ describe('handleIncomingMessage', () => {
       {
         userId: 'user-1',
         message: 'Zapisałem notatkę.',
-        replyToMessageId: 'wamid-1',
-        correlationId: 'session-1',
-        ctaUrl: {
-          displayText: 'Open Note',
-          url: 'https://intexuraos.cloud/#/notes/note-1',
-        },
+        replyToMessageId: 'wamid-button',
+        correlationId: 'session-existing',
       },
     ]);
+  });
+
+  it('records a failed confirmed execution and does not reinterpret the request', async () => {
+    const repo = new FakeSessionRepository();
+    seedPendingConfirmation(repo, {
+      confirmationId: 'confirm-1',
+      toolName: 'create_note',
+      toolArgs: { content: 'The door code is 1234.' },
+    });
+    const runner = new FakeRunner([], [
+      {
+        outcome: 'tool_failed',
+        reply: 'Nie udało się wykonać tej akcji: downstream denied it. Spróbuj ponownie później.',
+        toolName: 'create_note',
+        error: 'downstream denied it',
+      },
+    ]);
+    const replies = new FakeReplyPublisher();
+
+    await handleIncomingMessage(
+      message({
+        messageId: 'wamid-button-failed',
+        text: '',
+        sourceType: 'whatsapp_button',
+        buttonResponse: {
+          buttonId: 'intex_confirm:confirm-1:yes',
+          buttonTitle: 'Tak',
+          replyToWamid: 'wamid-confirmation-message',
+        },
+      }),
+      deps(repo, runner, replies)
+    );
+
+    expect(runner.calls).toEqual([]);
+    expect(runner.executeConfirmedCalls).toHaveLength(1);
+    expect(eventPayloads(repo, 'confirmation_resolved')[0]).toMatchObject({
+      confirmationId: 'confirm-1',
+      resolution: 'accepted',
+    });
+    expect(eventPayloads(repo, 'tool_call_failed')[0]).toEqual({
+      toolName: 'create_note',
+      error: 'downstream denied it',
+    });
+    expect(replies.messages[0]?.message).toBe(
+      'Nie udało się wykonać tej akcji: downstream denied it. Spróbuj ponownie później.'
+    );
+  });
+
+  it('rejects a pending confirmation after a matching Nie button', async () => {
+    const repo = new FakeSessionRepository();
+    seedPendingConfirmation(repo, {
+      confirmationId: 'confirm-1',
+      toolName: 'create_note',
+      toolArgs: { content: 'The door code is 1234.' },
+    });
+    const runner = new FakeRunner([]);
+    const replies = new FakeReplyPublisher();
+
+    await handleIncomingMessage(
+      message({
+        messageId: 'wamid-button-no',
+        text: '',
+        sourceType: 'whatsapp_button',
+        buttonResponse: {
+          buttonId: 'intex_confirm:confirm-1:no',
+          buttonTitle: 'Nie',
+          replyToWamid: 'wamid-confirmation-message',
+        },
+      }),
+      deps(repo, runner, replies)
+    );
+
+    expect(runner.calls).toEqual([]);
+    expect(runner.executeConfirmedCalls).toEqual([]);
+    expect(eventPayloads(repo, 'confirmation_resolved')[0]).toMatchObject({
+      confirmationId: 'confirm-1',
+      resolution: 'rejected',
+    });
+    expect(eventPayloads(repo, 'tool_call_completed')).toEqual([]);
+    expect(replies.messages[0]?.message).toBe('Okej, nie wykonuję tej akcji.');
+  });
+
+  it('rejects confirmation buttons when no active session exists', async () => {
+    const repo = new FakeSessionRepository();
+    const runner = new FakeRunner([]);
+    const replies = new FakeReplyPublisher();
+
+    const result = await handleIncomingMessage(
+      message({
+        messageId: 'wamid-button-without-session',
+        text: '',
+        sourceType: 'whatsapp_button',
+        buttonResponse: {
+          buttonId: 'intex_confirm:confirm-1:yes',
+          buttonTitle: 'Tak',
+          replyToWamid: 'wamid-confirmation-message',
+        },
+      }),
+      deps(repo, runner, replies)
+    );
+
+    expect(result).toEqual({ sessionId: 'wamid-button-without-session' });
+    expect(runner.calls).toEqual([]);
+    expect(runner.executeConfirmedCalls).toEqual([]);
+    expect(repo.events).toEqual([]);
+    expect(replies.messages).toEqual([
+      {
+        userId: 'user-1',
+        message: 'To potwierdzenie nie jest już aktualne. Wyślij prośbę jeszcze raz.',
+        replyToMessageId: 'wamid-button-without-session',
+        correlationId: 'wamid-button-without-session',
+      },
+    ]);
+  });
+
+  it('does not execute stale or mismatched confirmation buttons', async () => {
+    const repo = new FakeSessionRepository();
+    seedPendingConfirmation(repo, {
+      confirmationId: 'confirm-current',
+      toolName: 'create_note',
+      toolArgs: { content: 'The door code is 1234.' },
+    });
+    const runner = new FakeRunner([]);
+    const replies = new FakeReplyPublisher();
+
+    await handleIncomingMessage(
+      message({
+        messageId: 'wamid-stale-button',
+        text: '',
+        sourceType: 'whatsapp_button',
+        buttonResponse: {
+          buttonId: 'intex_confirm:confirm-old:yes',
+          buttonTitle: 'Tak',
+          replyToWamid: 'wamid-confirmation-message',
+        },
+      }),
+      deps(repo, runner, replies)
+    );
+
+    expect(runner.calls).toEqual([]);
+    expect(runner.executeConfirmedCalls).toEqual([]);
+    expect(eventPayloads(repo, 'confirmation_resolved')).toEqual([]);
+    expect(eventPayloads(repo, 'tool_call_completed')).toEqual([]);
+    expect(replies.messages[0]?.message).toBe(
+      'To potwierdzenie nie jest już aktualne. Wyślij prośbę jeszcze raz.'
+    );
+  });
+
+  it('does not execute malformed structured button messages', async () => {
+    const repo = new FakeSessionRepository();
+    seedPendingConfirmation(repo, {
+      confirmationId: 'confirm-current',
+      toolName: 'create_note',
+      toolArgs: { content: 'The door code is 1234.' },
+    });
+    const runner = new FakeRunner([]);
+    const replies = new FakeReplyPublisher();
+
+    await handleIncomingMessage(
+      message({
+        messageId: 'wamid-button-missing-payload',
+        text: '',
+        sourceType: 'whatsapp_button',
+      }),
+      deps(repo, runner, replies)
+    );
+
+    expect(runner.calls).toEqual([]);
+    expect(runner.executeConfirmedCalls).toEqual([]);
+    expect(eventPayloads(repo, 'user_message').at(-1)).toEqual({
+      messageId: 'wamid-button-missing-payload',
+      text: '',
+      sourceType: 'whatsapp_button',
+    });
+    expect(replies.messages[0]?.message).toBe(
+      'To potwierdzenie nie jest już aktualne. Wyślij prośbę jeszcze raz.'
+    );
+  });
+
+  it('does not execute structured button messages with malformed confirmation IDs', async () => {
+    const repo = new FakeSessionRepository();
+    seedPendingConfirmation(repo, {
+      confirmationId: 'confirm-current',
+      toolName: 'create_note',
+      toolArgs: { content: 'The door code is 1234.' },
+    });
+    const runner = new FakeRunner([]);
+    const replies = new FakeReplyPublisher();
+
+    await handleIncomingMessage(
+      message({
+        messageId: 'wamid-button-malformed-id',
+        text: '',
+        sourceType: 'whatsapp_button',
+        buttonResponse: {
+          buttonId: 'intex_confirm:confirm-current:maybe',
+          buttonTitle: 'Tak',
+          replyToWamid: 'wamid-confirmation-message',
+        },
+      }),
+      deps(repo, runner, replies)
+    );
+
+    expect(runner.calls).toEqual([]);
+    expect(runner.executeConfirmedCalls).toEqual([]);
+    expect(replies.messages[0]?.message).toBe(
+      'To potwierdzenie nie jest już aktualne. Wyślij prośbę jeszcze raz.'
+    );
+  });
+
+  it('does not execute already resolved or malformed pending confirmation events', async () => {
+    const repo = new FakeSessionRepository();
+    seedPendingConfirmation(repo, {
+      confirmationId: 'confirm-current',
+      toolName: 'create_note',
+      toolArgs: { content: 'The door code is 1234.' },
+    });
+    repo.seedEvent('session-existing', 'confirmation_resolved', {
+      confirmationId: 123,
+      resolution: 'ignored-malformed-id',
+    });
+    repo.seedEvent('session-existing', 'confirmation_requested', {
+      confirmationId: 'confirm-invalid-tool',
+      toolName: 'query_calendar_events',
+      toolArgs: { mode: 'list' },
+      message: 'Invalid read-only pending confirmation.',
+      sourceMessageId: 'wamid-invalid-tool',
+    });
+    repo.seedEvent('session-existing', 'confirmation_requested', {
+      confirmationId: 'confirm-invalid-args',
+      toolName: 'create_note',
+      toolArgs: [],
+      message: 'Invalid args pending confirmation.',
+      sourceMessageId: 'wamid-invalid-args',
+    });
+    repo.seedEvent('session-existing', 'confirmation_resolved', {
+      confirmationId: 'confirm-current',
+      resolution: 'rejected',
+    });
+    const runner = new FakeRunner([]);
+    const replies = new FakeReplyPublisher();
+
+    await handleIncomingMessage(
+      message({
+        messageId: 'wamid-resolved-button',
+        text: '',
+        sourceType: 'whatsapp_button',
+        buttonResponse: {
+          buttonId: 'intex_confirm:confirm-current:yes',
+          buttonTitle: 'Tak',
+          replyToWamid: 'wamid-confirmation-message',
+        },
+      }),
+      deps(repo, runner, replies)
+    );
+
+    expect(runner.calls).toEqual([]);
+    expect(runner.executeConfirmedCalls).toEqual([]);
+    expect(replies.messages[0]?.message).toBe(
+      'To potwierdzenie nie jest już aktualne. Wyślij prośbę jeszcze raz.'
+    );
+  });
+
+  it('treats plain text tak as a new message instead of executing a pending confirmation', async () => {
+    const repo = new FakeSessionRepository();
+    seedPendingConfirmation(repo, {
+      confirmationId: 'confirm-1',
+      toolName: 'create_note',
+      toolArgs: { content: 'The door code is 1234.' },
+    });
+    const runner = new FakeRunner([
+      {
+        outcome: 'no_action',
+        reply: 'Nie wykonuję żadnej akcji bez przycisku potwierdzenia.',
+      },
+    ]);
+    const replies = new FakeReplyPublisher();
+
+    await handleIncomingMessage(
+      message({ messageId: 'wamid-text-tak', text: 'tak', sourceType: 'whatsapp_text' }),
+      deps(repo, runner, replies)
+    );
+
+    expect(runner.calls).toHaveLength(1);
+    expect(runner.executeConfirmedCalls).toEqual([]);
+    expect(eventPayloads(repo, 'confirmation_resolved')[0]).toEqual({
+      confirmationId: 'confirm-1',
+      resolution: 'superseded',
+    });
+    expect(eventPayloads(repo, 'tool_call_completed')).toEqual([]);
+  });
+
+  it('supersedes a pending confirmation when a new text request arrives', async () => {
+    const repo = new FakeSessionRepository();
+    seedPendingConfirmation(repo, {
+      confirmationId: 'confirm-1',
+      toolName: 'create_note',
+      toolArgs: { content: 'The door code is 1234.' },
+    });
+    const runner = new FakeRunner([
+      {
+        outcome: 'completed',
+        reply: 'Masz jedno wydarzenie jutro.',
+        toolName: 'query_calendar_events',
+      },
+    ]);
+    const replies = new FakeReplyPublisher();
+
+    await handleIncomingMessage(
+      message({
+        messageId: 'wamid-new-text',
+        text: 'Jakie wydarzenia mam zaplanowane na jutro?',
+        sourceType: 'whatsapp_text',
+      }),
+      deps(repo, runner, replies)
+    );
+
+    expect(runner.executeConfirmedCalls).toEqual([]);
+    expect(eventPayloads(repo, 'confirmation_resolved')[0]).toEqual({
+      confirmationId: 'confirm-1',
+      resolution: 'superseded',
+    });
+    expect(eventPayloads(repo, 'tool_call_completed')[0]).toEqual({
+      toolName: 'query_calendar_events',
+    });
+    expect(replies.messages[0]?.message).toBe('Masz jedno wydarzenie jutro.');
   });
 
   it('passes only prior events to the runner after storing the current user message', async () => {
@@ -192,6 +634,53 @@ describe('handleIncomingMessage', () => {
     expect(call.events.some((event) => event.payload['messageId'] === 'wamid-current')).toBe(false);
   });
 
+  it('stores unexpected button metadata on non-button messages without treating it as approval', async () => {
+    const repo = new FakeSessionRepository();
+    seedPendingConfirmation(repo, {
+      confirmationId: 'confirm-1',
+      toolName: 'create_note',
+      toolArgs: { content: 'The door code is 1234.' },
+    });
+    const runner = new FakeRunner([
+      {
+        outcome: 'no_action',
+        reply: 'Nie wykonuję żadnej akcji bez przycisku potwierdzenia.',
+      },
+    ]);
+    const replies = new FakeReplyPublisher();
+
+    await handleIncomingMessage(
+      message({
+        messageId: 'wamid-text-with-button-payload',
+        text: 'tak',
+        sourceType: 'whatsapp_text',
+        buttonResponse: {
+          buttonId: 'intex_confirm:confirm-1:yes',
+          buttonTitle: 'Tak',
+          replyToWamid: 'wamid-confirmation-message',
+        },
+      }),
+      deps(repo, runner, replies)
+    );
+
+    expect(runner.calls).toHaveLength(1);
+    expect(runner.executeConfirmedCalls).toEqual([]);
+    expect(eventPayloads(repo, 'user_message').at(-1)).toEqual({
+      messageId: 'wamid-text-with-button-payload',
+      text: 'tak',
+      sourceType: 'whatsapp_text',
+      buttonResponse: {
+        buttonId: 'intex_confirm:confirm-1:yes',
+        buttonTitle: 'Tak',
+        replyToWamid: 'wamid-confirmation-message',
+      },
+    });
+    expect(eventPayloads(repo, 'confirmation_resolved')[0]).toEqual({
+      confirmationId: 'confirm-1',
+      resolution: 'superseded',
+    });
+  });
+
   it('passes source URLs to the runner without storing the full URL in session events', async () => {
     const repo = new FakeSessionRepository();
     const runner = new FakeRunner([
@@ -263,6 +752,36 @@ describe('handleIncomingMessage', () => {
         correlationId: 'session-1',
       },
     ]);
+  });
+
+  it('publishes completed runner CTA URLs when the tool result includes one', async () => {
+    const repo = new FakeSessionRepository();
+    const runner = new FakeRunner([
+      {
+        outcome: 'completed',
+        reply: 'Zapisałem notatkę.',
+        toolName: 'create_note',
+        toolResult: { status: 'completed', id: 'note-1' },
+        ctaUrl: {
+          displayText: 'Open Note',
+          url: 'https://intexuraos.cloud/#/notes/note-1',
+        },
+      },
+    ]);
+    const replies = new FakeReplyPublisher();
+
+    await handleIncomingMessage(
+      message({ text: 'remember that the door code is 1234' }),
+      deps(repo, runner, replies)
+    );
+
+    expect(replies.messages[0]).toMatchObject({
+      message: 'Zapisałem notatkę.',
+      ctaUrl: {
+        displayText: 'Open Note',
+        url: 'https://intexuraos.cloud/#/notes/note-1',
+      },
+    });
   });
 
   it('creates a calendar event in one message when the request has complete date and time details', async () => {
@@ -696,6 +1215,7 @@ function deps(
     ids: {
       sessionId: () => `session-${String(sessionRepository.createdSessions.length + 1)}`,
       eventId: () => `event-${String(sessionRepository.events.length + 1)}`,
+      confirmationId: () => `confirmation-${String(sessionRepository.events.length + 1)}`,
     },
     sessionTimeoutMs: 30 * 60 * 1000,
   };
@@ -725,6 +1245,34 @@ function eventPayloads(
   type: IntexAgentSessionEventType
 ): Record<string, unknown>[] {
   return repo.events.filter((event) => event.type === type).map((event) => event.payload);
+}
+
+function seedPendingConfirmation(
+  repo: FakeSessionRepository,
+  pending: {
+    confirmationId: string;
+    toolName: IntexAgentToolName;
+    toolArgs: Record<string, unknown>;
+  }
+): void {
+  repo.seedSession({
+    id: 'session-existing',
+    userId: 'user-1',
+    channel: 'whatsapp',
+    status: 'waiting_for_user',
+    startedAt: '2026-06-24T09:50:00.000Z',
+    lastUserMessageAt: '2026-06-24T09:50:00.000Z',
+    lastAssistantMessageAt: '2026-06-24T09:51:00.000Z',
+    startReason: 'no_active_session',
+    activeTool: pending.toolName,
+  });
+  repo.seedEvent('session-existing', 'confirmation_requested', {
+    confirmationId: pending.confirmationId,
+    toolName: pending.toolName,
+    toolArgs: pending.toolArgs,
+    message: 'Czy wykonać tę akcję?',
+    sourceMessageId: 'wamid-original',
+  });
 }
 
 class FakeSessionRepository implements SessionRepository {
@@ -810,8 +1358,27 @@ class FakeRunner implements IntexAgentRunner {
     sourceUrl?: string;
     currentDateTime: string;
   }[] = [];
+  readonly executeConfirmedCalls: {
+    session: IntexAgentSession;
+    toolName: IntexAgentToolName;
+    toolArgs: Record<string, unknown>;
+    currentDateTime: string;
+    messageId?: string;
+  }[] = [];
 
-  constructor(private readonly results: IntexAgentRunnerResult[]) {}
+  constructor(
+    private readonly results: IntexAgentRunnerResult[],
+    private readonly confirmedResults: IntexAgentRunnerResult[] = []
+  ) {}
+
+  executeConfirmed(input: Parameters<IntexAgentRunner['executeConfirmed']>[0]): Promise<IntexAgentRunnerResult> {
+    this.executeConfirmedCalls.push(input);
+    const next = this.confirmedResults.shift();
+    if (next === undefined) {
+      throw new Error('No fake confirmed runner result configured');
+    }
+    return Promise.resolve(next);
+  }
 
   run(input: {
     session: IntexAgentSession;
@@ -841,6 +1408,7 @@ class FakeReplyPublisher implements WhatsAppReplyPublisher {
       displayText: string;
       url: string;
     };
+    buttons?: Parameters<WhatsAppReplyPublisher['publishReply']>[0]['buttons'];
   }[] = [];
 
   publishReply(input: {
@@ -852,6 +1420,7 @@ class FakeReplyPublisher implements WhatsAppReplyPublisher {
       displayText: string;
       url: string;
     };
+    buttons?: Parameters<WhatsAppReplyPublisher['publishReply']>[0]['buttons'];
   }): Promise<void> {
     this.messages.push(input);
     return Promise.resolve();

--- a/apps/intex-agent/src/__tests__/domain/intentGate.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/intentGate.test.ts
@@ -79,6 +79,7 @@ describe('classifyIntexAgentIntent', () => {
     'Ile razy w zeszlym miesiacu mialem dentyste?',
     'Ciekawy jestem, co jutro jest w kalendarzu',
     'Nie możesz dla mnie sprawdzić, co jest jutro w kalendarzu?',
+    'Jakie wydarzenia mam zaplanowane na jutro?',
     'Podaj listę wszystkich wydarzeń, które mam jutro w kalendarzu',
     'Podaj mi liste wydarzen z kalendarza na jutro',
     'Wypisz wszystkie wydarzenia w kalendarzu na jutro',

--- a/apps/intex-agent/src/__tests__/domain/intexAgentRunner.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/intexAgentRunner.test.ts
@@ -38,6 +38,14 @@ const EXTERNAL_SAVE_FAILED_REPLY =
 const EXTERNAL_SAVE_UNKNOWN_FAILURE_REPLY =
   'I could not deliver this to the external system. The external save request failed: Unknown external save error. Please check the external system configuration and try again.';
 
+type PreviewToolName =
+  | 'create_calendar_event'
+  | 'create_research'
+  | 'create_link'
+  | 'create_code_task'
+  | 'save_external'
+  | 'add_user_preference';
+
 describe('createIntexAgentRunner', () => {
   it('uses the versioned prompt, transcript messages, and supported tools', async () => {
     const client = new ToolExecutingFakeToolCallingClient({
@@ -64,9 +72,10 @@ describe('createIntexAgentRunner', () => {
     });
 
     expect(result).toEqual({
-      outcome: 'completed',
-      reply: 'Saved.',
+      outcome: 'needs_confirmation',
+      reply: 'Czy dodać notatkę?\n\nTytuł: Door code\nTreść: The door code is 1234.',
       toolName: 'create_note',
+      toolArgs: { content: 'The door code is 1234.', title: 'Door code' },
     });
     expect(client.calls[0]?.systemPrompt).toBe(
       `${INTEX_AGENT_SYSTEM_PROMPT.text}\n\nCurrent date-time: ${CURRENT_DATE_TIME}`
@@ -96,6 +105,47 @@ describe('createIntexAgentRunner', () => {
     expect(client.calls[0]?.tools.map((tool) => tool.name)).toEqual(['create_note']);
     expect(client.calls[0]?.toolChoice).toBe('auto');
     expect(client.calls[0]?.promptType).toBe('intex-agent-whatsapp-session');
+  });
+
+  it('returns a confirmation preview for note creation without writing the note', async () => {
+    let createNoteCalls = 0;
+    const client = new ToolExecutingFakeToolCallingClient({
+      toolName: 'create_note',
+      args: { content: 'Door code is 1234.', title: 'Door code' },
+    }, [
+      ok(
+        toolResult({
+          outcome: 'completed',
+          reply: 'The note is ready.',
+          toolName: 'create_note',
+        })
+      ),
+    ]);
+    const runner = createIntexAgentRunner({
+      client,
+      toolExecutor: fakeToolExecutor({
+        createNote: async () => {
+          createNoteCalls += 1;
+          return JSON.stringify({ status: 'completed' });
+        },
+      }),
+    });
+
+    const result = await runner.run({
+      session: session(),
+      events: [],
+      message: 'Zapisz notatkę: Door code is 1234',
+      currentDateTime: CURRENT_DATE_TIME,
+    });
+
+    expect(result).toEqual({
+      outcome: 'needs_confirmation',
+      reply: 'Czy dodać notatkę?\n\nTytuł: Door code\nTreść: Door code is 1234.',
+      toolName: 'create_note',
+      toolArgs: { content: 'Door code is 1234.', title: 'Door code' },
+    });
+    expect(createNoteCalls).toBe(0);
+    expect(client.calls[0]?.tools.map((tool) => tool.name)).toEqual(['create_note']);
   });
 
   it('formats replied-message context as context-only user message content', async () => {
@@ -497,6 +547,61 @@ describe('createIntexAgentRunner', () => {
     expect(client.calls[0]?.systemPrompt).toContain('Current date-time: 2026-06-26T17:00:00.000Z');
   });
 
+  it('executes exact Polish natural calendar lookup immediately without confirmation', async () => {
+    const client = new ToolExecutingFakeToolCallingClient({
+      toolName: 'query_calendar_events',
+      args: {
+        mode: 'list',
+        timeMin: '2026-06-25T00:00:00.000Z',
+        timeMax: '2026-06-26T00:00:00.000Z',
+        maxResults: 20,
+      },
+    }, [
+      ok(
+        toolResult({
+          outcome: 'completed',
+          reply: 'Jutro masz jedno wydarzenie: Dentist o 09:00.',
+          toolName: 'query_calendar_events',
+        })
+      ),
+    ]);
+    const runner = createIntexAgentRunner({
+      client,
+      toolExecutor: fakeToolExecutor({
+        queryCalendarEvents: async () =>
+          JSON.stringify({
+            status: 'completed',
+            mode: 'list',
+            count: 1,
+            timeMin: '2026-06-25T00:00:00.000Z',
+            timeMax: '2026-06-26T00:00:00.000Z',
+            events: [
+              {
+                id: 'event-1',
+                summary: 'Dentist',
+                start: { dateTime: '2026-06-25T09:00:00.000Z' },
+                end: { dateTime: '2026-06-25T10:00:00.000Z' },
+              },
+            ],
+          }),
+      }),
+    });
+
+    const result = await runner.run({
+      session: session(),
+      events: [],
+      message: 'Jakie wydarzenia mam zaplanowane na jutro?',
+      currentDateTime: '2026-06-24T17:00:00.000Z',
+    });
+
+    expect(result).toMatchObject({
+      outcome: 'completed',
+      reply: 'Jutro masz jedno wydarzenie: Dentist o 09:00.',
+      toolName: 'query_calendar_events',
+    });
+    expect(client.calls[0]?.tools.map((tool) => tool.name)).toEqual(['query_calendar_events']);
+  });
+
   it('exposes the calendar query tool and current date for last-month count questions', async () => {
     const client = new ToolExecutingFakeToolCallingClient({
       toolName: 'query_calendar_events',
@@ -597,10 +702,11 @@ describe('createIntexAgentRunner', () => {
         ],
       })
     ).resolves.toEqual({
-      outcome: 'completed',
-      reply: 'Done.',
+      outcome: 'needs_confirmation',
+      reply: 'Czy dodać notatkę?\nTreść: Parking spot is B12.',
       summary: 'Saved note',
       toolName: 'create_note',
+      toolArgs: { content: 'Parking spot is B12.' },
     });
     expect(client.calls[0]?.messages).toEqual([
       { role: 'user', content: 'remember the parking spot' },
@@ -640,9 +746,10 @@ describe('createIntexAgentRunner', () => {
         ],
       })
     ).resolves.toEqual({
-      outcome: 'completed',
-      reply: 'Saved.',
+      outcome: 'needs_confirmation',
+      reply: 'Czy dodać notatkę?\nTreść: Office pin is 2468.',
       toolName: 'create_note',
+      toolArgs: { content: 'Office pin is 2468.' },
     });
     expect(client.calls[0]?.messages).toEqual([
       { role: 'assistant', content: 'Saved the previous item.' },
@@ -716,8 +823,15 @@ describe('createIntexAgentRunner', () => {
     });
   });
 
-  it.each(['create_research', 'create_link', 'create_code_task'] as const)(
-    'keeps supported completed tool names: %s',
+  it.each([
+    'create_calendar_event',
+    'create_research',
+    'create_link',
+    'create_code_task',
+    'save_external',
+    'add_user_preference',
+  ] as const)(
+    'returns confirmation previews for supported mutating tool names: %s',
     async (toolName) => {
       const client = new ToolExecutingFakeToolCallingClient({
         toolName,
@@ -742,30 +856,17 @@ describe('createIntexAgentRunner', () => {
           currentDateTime: CURRENT_DATE_TIME,
         })
       ).resolves.toEqual({
-        outcome: 'completed',
-        reply: 'Done.',
+        outcome: 'needs_confirmation',
+        reply: expectedConfirmationReplyFor(toolName),
         summary: 'Handled request.',
         toolName,
+        toolArgs: toolArgsFor(toolName),
       });
     }
   );
 
-  it('uses the executed tool result and deterministic link reply when the final model JSON omits toolName', async () => {
-    const client = new ToolExecutingFakeToolCallingClient({
-      toolName: 'create_research',
-      args: {
-        title: 'Calendar events tomorrow',
-        prompt: 'Prepare a research draft about tomorrow calendar events.',
-      },
-    }, [
-      ok(
-        toolResult({
-          outcome: 'completed',
-          reply: 'Created a research draft without the link.',
-          summary: 'Calendar events tomorrow',
-        })
-      ),
-    ]);
+  it('uses the confirmed tool result and deterministic link reply without calling the LLM', async () => {
+    const client = new FakeToolCallingClient([]);
     const runner = createIntexAgentRunner({
       client,
       toolExecutor: fakeToolExecutor({
@@ -779,17 +880,19 @@ describe('createIntexAgentRunner', () => {
     });
 
     await expect(
-      runner.run({
+      runner.executeConfirmed({
         session: session(),
-        events: [],
-        message: 'Create research draft: calendar events tomorrow',
+        toolName: 'create_research',
+        toolArgs: {
+          title: 'Calendar events tomorrow',
+          prompt: 'Prepare a research draft about tomorrow calendar events.',
+        },
         currentDateTime: CURRENT_DATE_TIME,
       })
     ).resolves.toEqual({
       outcome: 'completed',
       reply:
         'Utworzyłem szkic researchu.',
-      summary: 'Calendar events tomorrow',
       toolName: 'create_research',
       ctaUrl: {
         displayText: 'Open Research',
@@ -800,6 +903,30 @@ describe('createIntexAgentRunner', () => {
         message: 'Research created',
         resourceUrl: 'https://intexuraos.cloud/#/research/research-1',
       },
+    });
+    expect(client.calls).toEqual([]);
+  });
+
+  it('rejects confirmed execution requests for read-only tools', async () => {
+    const runner = createIntexAgentRunner({
+      client: new FakeToolCallingClient([]),
+      toolExecutor: fakeToolExecutor(),
+    });
+
+    await expect(
+      runner.executeConfirmed({
+        session: session(),
+        toolName: 'query_calendar_events',
+        toolArgs: {
+          mode: 'list',
+          timeMin: '2026-06-25T00:00:00.000Z',
+          timeMax: '2026-06-26T00:00:00.000Z',
+        },
+        currentDateTime: CURRENT_DATE_TIME,
+      })
+    ).resolves.toEqual({
+      outcome: 'unsupported',
+      reply: SUPPORTED_CAPABILITIES_REPLY,
     });
   });
 
@@ -903,7 +1030,7 @@ describe('createIntexAgentRunner', () => {
             status: 'completed',
           }),
       },
-      expectedReply: 'The model reply should not be the source of truth.',
+      expectedReply: 'Zapisałem notatkę.',
       expectedCtaUrl: undefined,
     },
     {
@@ -939,7 +1066,7 @@ describe('createIntexAgentRunner', () => {
           }),
       },
       expectedReply:
-        'The model reply should not be the source of truth. https://intexuraos.cloud/#/calendar/events/event-1',
+        'Utworzyłem wydarzenie w kalendarzu. https://intexuraos.cloud/#/calendar/events/event-1',
       expectedCtaUrl: undefined,
     },
     {
@@ -1128,29 +1255,18 @@ describe('createIntexAgentRunner', () => {
       expectedReply: 'Saved externally',
       expectedCtaUrl: undefined,
     },
-  ])('builds deterministic confirmations from %s tool results', async (testCase) => {
-    const client = new ToolExecutingFakeToolCallingClient({
-      toolName: testCase.toolName,
-      args: testCase.args,
-    }, [
-      ok(
-        toolResult({
-          outcome: 'completed',
-          reply: 'The model reply should not be the source of truth.',
-          toolName: testCase.toolName,
-        })
-      ),
-    ]);
+  ])('builds deterministic confirmed replies from %s tool results', async (testCase) => {
+    const client = new FakeToolCallingClient([]);
     const runner = createIntexAgentRunner({
       client,
       toolExecutor: fakeToolExecutor(testCase.executorOverride),
       ...(testCase.runnerWebAppUrl !== undefined ? { webAppUrl: testCase.runnerWebAppUrl } : {}),
     });
 
-    const result = await runner.run({
+    const result = await runner.executeConfirmed({
       session: session(),
-      events: [],
-      message: testCase.message,
+      toolName: testCase.toolName,
+      toolArgs: testCase.args,
       currentDateTime: CURRENT_DATE_TIME,
     });
 
@@ -1163,9 +1279,10 @@ describe('createIntexAgentRunner', () => {
       throw new Error(`Expected completed outcome, received ${result.outcome}`);
     }
     expect(result.ctaUrl).toEqual(testCase.expectedCtaUrl);
+    expect(client.calls).toEqual([]);
   });
 
-  it('automatically saves WhatsApp images externally without calling the LLM', async () => {
+  it('returns a confirmation preview for WhatsApp images without calling the LLM or external save', async () => {
     const client = new FakeToolCallingClient([]);
     const saveCalls: { message: string; sourceUrl?: string }[] = [];
     const runner = createIntexAgentRunner({
@@ -1188,17 +1305,16 @@ describe('createIntexAgentRunner', () => {
     });
 
     expect(client.calls).toEqual([]);
-    expect(saveCalls).toEqual([
-      {
+    expect(saveCalls).toEqual([]);
+    expect(result).toEqual({
+      outcome: 'needs_confirmation',
+      reply:
+        'Czy wysłać tę treść do zewnętrznego systemu?\n\nTreść: Lunch receipt\nŹródło: https://storage.example.com/signed/receipt.jpg',
+      toolName: 'save_external',
+      toolArgs: {
         message: 'Lunch receipt',
         sourceUrl: 'https://storage.example.com/signed/receipt.jpg',
       },
-    ]);
-    expect(result).toEqual({
-      outcome: 'completed',
-      reply: 'Saved externally',
-      toolName: 'save_external',
-      toolResult: { status: 'completed', message: 'Saved externally' },
     });
   });
 
@@ -1214,7 +1330,7 @@ describe('createIntexAgentRunner', () => {
       }),
     });
 
-    await runner.run({
+    const result = await runner.run({
       session: session(),
       events: [],
       message: '   ',
@@ -1223,15 +1339,18 @@ describe('createIntexAgentRunner', () => {
       currentDateTime: CURRENT_DATE_TIME,
     });
 
-    expect(saveCalls).toEqual([
-      {
+    expect(saveCalls).toEqual([]);
+    expect(result).toMatchObject({
+      outcome: 'needs_confirmation',
+      toolName: 'save_external',
+      toolArgs: {
         message: 'Image shared via WhatsApp.',
         sourceUrl: 'https://storage.example.com/signed/no-caption.jpg',
       },
-    ]);
+    });
   });
 
-  it('uses a fallback reply when WhatsApp image external save returns no JSON message payload', async () => {
+  it('uses a fallback reply when confirmed external save returns no JSON message payload', async () => {
     const runner = createIntexAgentRunner({
       client: new FakeToolCallingClient([]),
       toolExecutor: fakeToolExecutor({
@@ -1240,12 +1359,13 @@ describe('createIntexAgentRunner', () => {
     });
 
     await expect(
-      runner.run({
+      runner.executeConfirmed({
         session: session(),
-        events: [],
-        message: 'Lunch receipt',
-        sourceType: 'whatsapp_image',
-        sourceUrl: 'https://storage.example.com/signed/receipt.jpg',
+        toolName: 'save_external',
+        toolArgs: {
+          message: 'Lunch receipt',
+          sourceUrl: 'https://storage.example.com/signed/receipt.jpg',
+        },
         currentDateTime: CURRENT_DATE_TIME,
       })
     ).resolves.toEqual({
@@ -1255,7 +1375,7 @@ describe('createIntexAgentRunner', () => {
     });
   });
 
-  it('explains that WhatsApp images cannot be processed when external save is not configured', async () => {
+  it('explains that confirmed external save cannot run when it is not configured', async () => {
     const runner = createIntexAgentRunner({
       client: new FakeToolCallingClient([]),
       toolExecutor: fakeToolExecutor({
@@ -1266,21 +1386,24 @@ describe('createIntexAgentRunner', () => {
     });
 
     await expect(
-      runner.run({
+      runner.executeConfirmed({
         session: session(),
-        events: [],
-        message: 'Lunch receipt',
-        sourceType: 'whatsapp_image',
-        sourceUrl: 'https://storage.example.com/signed/receipt.jpg',
+        toolName: 'save_external',
+        toolArgs: {
+          message: 'Lunch receipt',
+          sourceUrl: 'https://storage.example.com/signed/receipt.jpg',
+        },
         currentDateTime: CURRENT_DATE_TIME,
       })
     ).resolves.toEqual({
-      outcome: 'unsupported',
+      outcome: 'tool_failed',
       reply: EXTERNAL_SAVE_NOT_CONFIGURED_REPLY,
+      toolName: 'save_external',
+      error: 'External save is not configured',
     });
   });
 
-  it('notifies the user when WhatsApp image external save processing fails', async () => {
+  it('notifies the user when confirmed external save processing fails', async () => {
     const runner = createIntexAgentRunner({
       client: new FakeToolCallingClient([]),
       toolExecutor: fakeToolExecutor({
@@ -1291,21 +1414,24 @@ describe('createIntexAgentRunner', () => {
     });
 
     await expect(
-      runner.run({
+      runner.executeConfirmed({
         session: session(),
-        events: [],
-        message: 'Lunch receipt',
-        sourceType: 'whatsapp_image',
-        sourceUrl: 'https://storage.example.com/signed/receipt.jpg',
+        toolName: 'save_external',
+        toolArgs: {
+          message: 'Lunch receipt',
+          sourceUrl: 'https://storage.example.com/signed/receipt.jpg',
+        },
         currentDateTime: CURRENT_DATE_TIME,
       })
     ).resolves.toEqual({
-      outcome: 'unsupported',
+      outcome: 'tool_failed',
       reply: EXTERNAL_SAVE_FAILED_REPLY,
+      toolName: 'save_external',
+      error: 'Failed to save externally: HTTP 403: Forbidden',
     });
   });
 
-  it('uses a fallback detail when WhatsApp image external save fails without details', async () => {
+  it('uses a fallback detail when confirmed external save fails without details', async () => {
     const runner = createIntexAgentRunner({
       client: new FakeToolCallingClient([]),
       toolExecutor: fakeToolExecutor({
@@ -1316,21 +1442,47 @@ describe('createIntexAgentRunner', () => {
     });
 
     await expect(
-      runner.run({
+      runner.executeConfirmed({
         session: session(),
-        events: [],
-        message: 'Lunch receipt',
-        sourceType: 'whatsapp_image',
-        sourceUrl: 'https://storage.example.com/signed/receipt.jpg',
+        toolName: 'save_external',
+        toolArgs: {
+          message: 'Lunch receipt',
+          sourceUrl: 'https://storage.example.com/signed/receipt.jpg',
+        },
         currentDateTime: CURRENT_DATE_TIME,
       })
     ).resolves.toEqual({
-      outcome: 'unsupported',
+      outcome: 'tool_failed',
       reply: EXTERNAL_SAVE_UNKNOWN_FAILURE_REPLY,
+      toolName: 'save_external',
+      error: 'Failed to save externally:   ',
     });
   });
 
-  it('overrides model text when external save tool delivery fails', async () => {
+  it('uses a Polish failure reply when a confirmed non-external action fails validation', async () => {
+    const runner = createIntexAgentRunner({
+      client: new FakeToolCallingClient([]),
+      toolExecutor: fakeToolExecutor(),
+    });
+
+    await expect(
+      runner.executeConfirmed({
+        session: session(),
+        toolName: 'create_note',
+        toolArgs: {},
+        currentDateTime: CURRENT_DATE_TIME,
+      })
+    ).resolves.toEqual({
+      outcome: 'tool_failed',
+      reply:
+        'Nie udało się wykonać tej akcji: Tool argument content must be a string. Spróbuj ponownie później.',
+      toolName: 'create_note',
+      error: 'Tool argument content must be a string',
+    });
+  });
+
+  it('returns confirmation when the model hides an external-save tool call behind no_action', async () => {
+    let saveCalls = 0;
     const client = new ToolExecutingFakeToolCallingClient({
       toolName: 'save_external',
       args: { message: 'Save externally this copied LinkedIn detail' },
@@ -1341,7 +1493,8 @@ describe('createIntexAgentRunner', () => {
       client,
       toolExecutor: fakeToolExecutor({
         saveExternal: async (): Promise<string> => {
-          throw new Error('External save is not configured');
+          saveCalls += 1;
+          return JSON.stringify({ status: 'completed', message: 'Saved externally' });
         },
       }),
     });
@@ -1354,8 +1507,82 @@ describe('createIntexAgentRunner', () => {
         currentDateTime: CURRENT_DATE_TIME,
       })
     ).resolves.toEqual({
-      outcome: 'unsupported',
-      reply: EXTERNAL_SAVE_NOT_CONFIGURED_REPLY,
+      outcome: 'needs_confirmation',
+      reply:
+        'Czy wysłać tę treść do zewnętrznego systemu?\n\nTreść: Save externally this copied LinkedIn detail',
+      toolName: 'save_external',
+      toolArgs: { message: 'Save externally this copied LinkedIn detail' },
+    });
+    expect(saveCalls).toBe(0);
+  });
+
+  it('uses default planning mode when building a code task confirmation without explicit mode', async () => {
+    const client = new ToolExecutingFakeToolCallingClient({
+      toolName: 'create_code_task',
+      args: { prompt: 'Investigate the webhook retry path.' },
+    }, [
+      ok(
+        toolResult({
+          outcome: 'completed',
+          reply: 'Done.',
+          toolName: 'create_code_task',
+        })
+      ),
+    ]);
+    const runner = createIntexAgentRunner({ client, toolExecutor: fakeToolExecutor() });
+
+    await expect(
+      runner.run({
+        session: session(),
+        events: [],
+        message: 'Create code task to investigate the webhook retry path.',
+        currentDateTime: CURRENT_DATE_TIME,
+      })
+    ).resolves.toEqual({
+      outcome: 'needs_confirmation',
+      reply:
+        'Czy utworzyć zadanie programistyczne?\n\nPrompt: Investigate the webhook retry path.\nTryb: planning',
+      toolName: 'create_code_task',
+      toolArgs: { prompt: 'Investigate the webhook retry path.' },
+    });
+  });
+
+  it('omits optional calendar confirmation fields when they are absent', async () => {
+    const client = new ToolExecutingFakeToolCallingClient({
+      toolName: 'create_calendar_event',
+      args: {
+        summary: 'Dentist',
+        start: '2026-06-25T09:00:00+02:00',
+        end: '2026-06-25T10:00:00+02:00',
+      },
+    }, [
+      ok(
+        toolResult({
+          outcome: 'completed',
+          reply: 'Done.',
+          toolName: 'create_calendar_event',
+        })
+      ),
+    ]);
+    const runner = createIntexAgentRunner({ client, toolExecutor: fakeToolExecutor() });
+
+    await expect(
+      runner.run({
+        session: session(),
+        events: [],
+        message: 'Create a calendar event for Dentist tomorrow 9-10am.',
+        currentDateTime: CURRENT_DATE_TIME,
+      })
+    ).resolves.toEqual({
+      outcome: 'needs_confirmation',
+      reply:
+        'Czy dodać wydarzenie w kalendarzu?\n\nTytuł: Dentist\nStart: 2026-06-25T09:00:00+02:00\nKoniec: 2026-06-25T10:00:00+02:00',
+      toolName: 'create_calendar_event',
+      toolArgs: {
+        summary: 'Dentist',
+        start: '2026-06-25T09:00:00+02:00',
+        end: '2026-06-25T10:00:00+02:00',
+      },
     });
   });
 
@@ -1471,6 +1698,249 @@ describe('createIntexAgentRunner', () => {
     });
   });
 
+  it('includes previous and next text in preference update and delete confirmations', async () => {
+    let updatePreferenceCalls = 0;
+    let deletePreferenceCalls = 0;
+    const promptBlock = [
+      'User Preferences v2:',
+      '1. (id: pref_jakub) "When I ask to invite Jakub, invite jakub.old@example.com."',
+      '2. (id: pref_mood) "Prefer concise morning summaries."',
+    ].join('\n');
+    const updateClient = new ToolExecutingFakeToolCallingClient(
+      {
+        toolName: 'update_user_preference',
+        args: {
+          itemId: 'pref_jakub',
+          text: 'When I ask to invite Jakub, invite jakub.new@example.com.',
+          expectedVersion: 2,
+        },
+      },
+      [
+        ok(
+          toolResult({
+            outcome: 'completed',
+            reply: 'Updated preference.',
+            toolName: 'update_user_preference',
+          })
+        ),
+      ]
+    );
+    const updateRunner = createIntexAgentRunner({
+      client: updateClient,
+      toolExecutor: fakeToolExecutor({
+        updateUserPreference: async (): Promise<string> => {
+          updatePreferenceCalls += 1;
+          return JSON.stringify({ status: 'completed' });
+        },
+      }),
+      userPreferences: promptBlock,
+    });
+    const deleteClient = new ToolExecutingFakeToolCallingClient(
+      {
+        toolName: 'delete_user_preference',
+        args: {
+          itemId: 'pref_mood',
+          expectedVersion: 2,
+        },
+      },
+      [
+        ok(
+          toolResult({
+            outcome: 'completed',
+            reply: 'Deleted preference.',
+            toolName: 'delete_user_preference',
+          })
+        ),
+      ]
+    );
+    const deleteRunner = createIntexAgentRunner({
+      client: deleteClient,
+      toolExecutor: fakeToolExecutor({
+        deleteUserPreference: async (): Promise<string> => {
+          deletePreferenceCalls += 1;
+          return JSON.stringify({ status: 'completed' });
+        },
+      }),
+      userPreferences: promptBlock,
+    });
+
+    await expect(
+      updateRunner.run({
+        session: session(),
+        events: [],
+        message: 'Update the Jakub invitation preference to use jakub.new@example.com.',
+        currentDateTime: CURRENT_DATE_TIME,
+      })
+    ).resolves.toEqual({
+      outcome: 'needs_confirmation',
+      reply:
+        'Czy zmodyfikować wpis w pamięci instrukcji?\n\nWpis: pref_jakub\nWcześniej: When I ask to invite Jakub, invite jakub.old@example.com.\nPo zmianie: When I ask to invite Jakub, invite jakub.new@example.com.',
+      toolName: 'update_user_preference',
+      toolArgs: {
+        itemId: 'pref_jakub',
+        text: 'When I ask to invite Jakub, invite jakub.new@example.com.',
+        expectedVersion: 2,
+      },
+    });
+
+    await expect(
+      deleteRunner.run({
+        session: session(),
+        events: [],
+        message: 'Delete the mood preference.',
+        currentDateTime: CURRENT_DATE_TIME,
+      })
+    ).resolves.toEqual({
+      outcome: 'needs_confirmation',
+      reply:
+        'Czy usunąć wpis z pamięci instrukcji?\n\nWpis: pref_mood\nTreść: Prefer concise morning summaries.',
+      toolName: 'delete_user_preference',
+      toolArgs: {
+        itemId: 'pref_mood',
+        expectedVersion: 2,
+      },
+    });
+
+    expect(updatePreferenceCalls).toBe(0);
+    expect(deletePreferenceCalls).toBe(0);
+  });
+
+  it('omits missing previous preference text when a stored preference row cannot be resolved', async () => {
+    const promptBlock = [
+      'User Preferences v2:',
+      '1. (id: pref_non_string) 123',
+    ].join('\n');
+    const updateClient = new ToolExecutingFakeToolCallingClient(
+      {
+        toolName: 'update_user_preference',
+        args: {
+          itemId: 'pref_missing',
+          text: 'Always use the short project codename.',
+          expectedVersion: 2,
+        },
+      },
+      [
+        ok(
+          toolResult({
+            outcome: 'completed',
+            reply: 'Updated preference.',
+            toolName: 'update_user_preference',
+          })
+        ),
+      ]
+    );
+    const deleteClient = new ToolExecutingFakeToolCallingClient(
+      {
+        toolName: 'delete_user_preference',
+        args: {
+          itemId: 'pref_non_string',
+          expectedVersion: 2,
+        },
+      },
+      [
+        ok(
+          toolResult({
+            outcome: 'completed',
+            reply: 'Deleted preference.',
+            toolName: 'delete_user_preference',
+          })
+        ),
+      ]
+    );
+
+    const updateRunner = createIntexAgentRunner({
+      client: updateClient,
+      toolExecutor: fakeToolExecutor(),
+      userPreferences: promptBlock,
+    });
+    const deleteRunner = createIntexAgentRunner({
+      client: deleteClient,
+      toolExecutor: fakeToolExecutor(),
+      userPreferences: promptBlock,
+    });
+
+    await expect(
+      updateRunner.run({
+        session: session(),
+        events: [],
+        message: 'Update preference pref_missing to always use the short project codename.',
+        currentDateTime: CURRENT_DATE_TIME,
+      })
+    ).resolves.toEqual({
+      outcome: 'needs_confirmation',
+      reply:
+        'Czy zmodyfikować wpis w pamięci instrukcji?\n\nWpis: pref_missing\nPo zmianie: Always use the short project codename.',
+      toolName: 'update_user_preference',
+      toolArgs: {
+        itemId: 'pref_missing',
+        text: 'Always use the short project codename.',
+        expectedVersion: 2,
+      },
+    });
+
+    await expect(
+      deleteRunner.run({
+        session: session(),
+        events: [],
+        message: 'Delete preference pref_non_string.',
+        currentDateTime: CURRENT_DATE_TIME,
+      })
+    ).resolves.toEqual({
+      outcome: 'needs_confirmation',
+      reply: 'Czy usunąć wpis z pamięci instrukcji?\n\nWpis: pref_non_string',
+      toolName: 'delete_user_preference',
+      toolArgs: {
+        itemId: 'pref_non_string',
+        expectedVersion: 2,
+      },
+    });
+  });
+
+  it('omits previous preference text when no preference block is configured', async () => {
+    const client = new ToolExecutingFakeToolCallingClient(
+      {
+        toolName: 'update_user_preference',
+        args: {
+          itemId: 'pref_unknown',
+          text: 'Prefer compact summaries.',
+          expectedVersion: 0,
+        },
+      },
+      [
+        ok(
+          toolResult({
+            outcome: 'completed',
+            reply: 'Updated preference.',
+            toolName: 'update_user_preference',
+          })
+        ),
+      ]
+    );
+    const runner = createIntexAgentRunner({
+      client,
+      toolExecutor: fakeToolExecutor(),
+    });
+
+    await expect(
+      runner.run({
+        session: session(),
+        events: [],
+        message: 'Update preference pref_unknown to prefer compact summaries.',
+        currentDateTime: CURRENT_DATE_TIME,
+      })
+    ).resolves.toEqual({
+      outcome: 'needs_confirmation',
+      reply:
+        'Czy zmodyfikować wpis w pamięci instrukcji?\n\nWpis: pref_unknown\nPo zmianie: Prefer compact summaries.',
+      toolName: 'update_user_preference',
+      toolArgs: {
+        itemId: 'pref_unknown',
+        text: 'Prefer compact summaries.',
+        expectedVersion: 0,
+      },
+    });
+  });
+
   it('returns the exact current preference block after a preference read tool succeeds', async () => {
     const promptBlock =
       'User Preferences v1:\n1. (id: pref_jakub) "When I ask to invite Jakub, invite jakub@gmail.com."';
@@ -1513,6 +1983,49 @@ describe('createIntexAgentRunner', () => {
       'update_user_preference',
       'delete_user_preference',
     ]);
+  });
+
+  it('keeps read-only completed summaries even when the tool result is plain text', async () => {
+    const client = new ToolExecutingFakeToolCallingClient(
+      {
+        toolName: 'query_calendar_events',
+        args: {
+          mode: 'list',
+          timeMin: '2026-06-25T00:00:00.000Z',
+          timeMax: '2026-06-26T00:00:00.000Z',
+        },
+      },
+      [
+        ok(
+          toolResult({
+            outcome: 'completed',
+            reply: 'Jutro masz jedno wydarzenie.',
+            summary: 'Listed tomorrow calendar events.',
+            toolName: 'query_calendar_events',
+          })
+        ),
+      ]
+    );
+    const runner = createIntexAgentRunner({
+      client,
+      toolExecutor: fakeToolExecutor({
+        queryCalendarEvents: async () => 'calendar-query-1',
+      }),
+    });
+
+    await expect(
+      runner.run({
+        session: session(),
+        events: [],
+        message: 'Jakie wydarzenia mam zaplanowane na jutro?',
+        currentDateTime: CURRENT_DATE_TIME,
+      })
+    ).resolves.toEqual({
+      outcome: 'completed',
+      reply: 'Jutro masz jedno wydarzenie.',
+      summary: 'Listed tomorrow calendar events.',
+      toolName: 'query_calendar_events',
+    });
   });
 
   it('returns the required empty preference sentence when no rows exist', async () => {
@@ -1582,6 +2095,35 @@ describe('createIntexAgentRunner', () => {
       outcome: 'completed',
       reply: 'No INTEX Agent preferences are defined yet.',
       toolName: 'get_user_preferences',
+    });
+  });
+
+  it('returns the updated preference block after a confirmed preference add succeeds', async () => {
+    const promptBlock =
+      'User Preferences v1:\n1. (id: pref_focus) "Prefer focus blocks before noon."';
+    const runner = createIntexAgentRunner({
+      client: new FakeToolCallingClient([]),
+      toolExecutor: fakeToolExecutor({
+        addUserPreference: async () =>
+          JSON.stringify({ status: 'completed', currentVersion: 1, promptBlock }),
+      }),
+    });
+
+    await expect(
+      runner.executeConfirmed({
+        session: session(),
+        toolName: 'add_user_preference',
+        toolArgs: {
+          text: 'Prefer focus blocks before noon.',
+          expectedVersion: 0,
+        },
+        currentDateTime: CURRENT_DATE_TIME,
+      })
+    ).resolves.toMatchObject({
+      outcome: 'completed',
+      reply: promptBlock,
+      toolName: 'add_user_preference',
+      toolResult: { status: 'completed', currentVersion: 1, promptBlock },
     });
   });
 
@@ -1688,24 +2230,95 @@ function fakeToolExecutor(overrides: Partial<IntexAgentToolExecutor> = {}): Inte
   };
 }
 
-function toolArgsFor(toolName: 'create_research' | 'create_link' | 'create_code_task'): Record<string, unknown> {
+function toolArgsFor(toolName: PreviewToolName): Record<string, unknown> {
+  if (toolName === 'create_calendar_event') {
+    return {
+      summary: 'Dentist',
+      start: '2026-06-25T09:00:00+02:00',
+      end: '2026-06-25T10:00:00+02:00',
+      location: 'Dental Clinic',
+      attendees: ['pat@example.com'],
+    };
+  }
   if (toolName === 'create_research') {
     return { title: 'Research topic', prompt: 'Research this topic.' };
   }
   if (toolName === 'create_link') {
     return { url: 'https://example.com', title: 'Example' };
   }
-  return { prompt: 'Investigate this code issue.' };
+  if (toolName === 'create_code_task') {
+    return {
+      prompt: 'Investigate this code issue.',
+      taskMode: 'execution',
+      workerType: 'codex-xhigh',
+      linearIssueId: 'LIN-123',
+    };
+  }
+  if (toolName === 'save_external') {
+    return {
+      message: 'Save externally this copied LinkedIn detail',
+      sourceUrl: 'https://example.com/post',
+    };
+  }
+  return { text: 'Prefer concise morning summaries.', expectedVersion: 0 };
 }
 
-function explicitMessageFor(toolName: 'create_research' | 'create_link' | 'create_code_task'): string {
+function explicitMessageFor(toolName: PreviewToolName): string {
+  if (toolName === 'create_calendar_event') {
+    return 'Create a calendar event for Dentist tomorrow 9-10am.';
+  }
   if (toolName === 'create_research') {
     return 'Create research draft about this topic.';
   }
   if (toolName === 'create_link') {
     return 'Save link https://example.com/post';
   }
-  return 'Create code task to investigate this issue.';
+  if (toolName === 'create_code_task') {
+    return 'Create code task execution to investigate this issue with codex-xhigh and Linear LIN-123.';
+  }
+  if (toolName === 'save_external') {
+    return 'Save externally this copied LinkedIn detail';
+  }
+  return 'Add a preference to prefer concise morning summaries.';
+}
+
+function expectedConfirmationReplyFor(toolName: PreviewToolName): string {
+  if (toolName === 'create_calendar_event') {
+    return [
+      'Czy dodać wydarzenie w kalendarzu?',
+      '',
+      'Tytuł: Dentist',
+      'Start: 2026-06-25T09:00:00+02:00',
+      'Koniec: 2026-06-25T10:00:00+02:00',
+      'Miejsce: Dental Clinic',
+      'Uczestnicy: pat@example.com',
+    ].join('\n');
+  }
+  if (toolName === 'create_research') {
+    return 'Czy utworzyć szkic researchu?\n\nTytuł: Research topic\nPrompt: Research this topic.';
+  }
+  if (toolName === 'create_link') {
+    return 'Czy zapisać bookmark?\n\nURL: https://example.com\nTytuł: Example';
+  }
+  if (toolName === 'create_code_task') {
+    return [
+      'Czy utworzyć zadanie programistyczne?',
+      '',
+      'Prompt: Investigate this code issue.',
+      'Tryb: execution',
+      'Worker: codex-xhigh',
+      'Linear: LIN-123',
+    ].join('\n');
+  }
+  if (toolName === 'save_external') {
+    return [
+      'Czy wysłać tę treść do zewnętrznego systemu?',
+      '',
+      'Treść: Save externally this copied LinkedIn detail',
+      'Źródło: https://example.com/post',
+    ].join('\n');
+  }
+  return 'Czy dodać wpis w pamięci instrukcji?\n\nNowy wpis: Prefer concise morning summaries.';
 }
 
 class FakeToolCallingClient implements ToolCallingClient {

--- a/apps/intex-agent/src/__tests__/infra/pubsub/decoder.test.ts
+++ b/apps/intex-agent/src/__tests__/infra/pubsub/decoder.test.ts
@@ -63,6 +63,24 @@ describe('decodeIntexMessageIngestPush', () => {
     expect(decodeIntexMessageIngestPush(push(event))).toEqual(event);
   });
 
+  it('decodes optional WhatsApp button responses', () => {
+    const event = {
+      type: 'intex.message.ingest',
+      userId: 'user-1',
+      messageId: 'wamid-button',
+      text: '',
+      sourceType: 'whatsapp_button',
+      timestamp: '2026-06-24T10:00:00.000Z',
+      buttonResponse: {
+        buttonId: 'intex_confirm:confirm-1:yes',
+        buttonTitle: 'Tak',
+        replyToWamid: 'wamid-confirmation',
+      },
+    };
+
+    expect(decodeIntexMessageIngestPush(push(event))).toEqual(event);
+  });
+
   it('decodes inbound replied-message context', () => {
     const event = {
       type: 'intex.message.ingest',
@@ -124,6 +142,52 @@ describe('decodeIntexMessageIngestPush', () => {
         })
       )
     ).toThrow('Invalid intex.message.ingest event: truncated must be a boolean');
+  });
+
+  it('rejects malformed WhatsApp button responses', () => {
+    const baseEvent = {
+      type: 'intex.message.ingest',
+      userId: 'user-1',
+      messageId: 'wamid-button',
+      text: '',
+      sourceType: 'whatsapp_button',
+      timestamp: '2026-06-24T10:00:00.000Z',
+    };
+
+    expect(() =>
+      decodeIntexMessageIngestPush(push({ ...baseEvent, buttonResponse: null }))
+    ).toThrow('Invalid intex.message.ingest event: buttonResponse must be an object');
+    expect(() =>
+      decodeIntexMessageIngestPush(
+        push({
+          ...baseEvent,
+          buttonResponse: {
+            buttonId: 'intex_confirm:confirm-1:yes',
+            buttonTitle: 'Tak',
+          },
+        })
+      )
+    ).toThrow('Invalid intex.message.ingest event: replyToWamid must be a string');
+  });
+
+  it('rejects button messages when the empty text placeholder is not a string', () => {
+    const event = {
+      type: 'intex.message.ingest',
+      userId: 'user-1',
+      messageId: 'wamid-button',
+      text: null,
+      sourceType: 'whatsapp_button',
+      timestamp: '2026-06-24T10:00:00.000Z',
+      buttonResponse: {
+        buttonId: 'intex_confirm:confirm-1:yes',
+        buttonTitle: 'Tak',
+        replyToWamid: 'wamid-confirmation',
+      },
+    };
+
+    expect(() => decodeIntexMessageIngestPush(push(event))).toThrow(
+      'Invalid intex.message.ingest event: text must be a string'
+    );
   });
 
   it('rejects messages with another event type', () => {

--- a/apps/intex-agent/src/__tests__/infra/pubsub/whatsappReplyPublisher.test.ts
+++ b/apps/intex-agent/src/__tests__/infra/pubsub/whatsappReplyPublisher.test.ts
@@ -33,6 +33,34 @@ describe('createWhatsAppReplyPublisher', () => {
     ]);
   });
 
+  it('forwards WhatsApp reply buttons through the shared send-message publisher', async () => {
+    const sendPublisher = new FakeWhatsAppSendPublisher();
+    const publisher = createWhatsAppReplyPublisher({ sendPublisher });
+    const buttons = [
+      { type: 'reply' as const, reply: { id: 'intex_confirm:confirm-1:yes', title: 'Tak' } },
+      { type: 'reply' as const, reply: { id: 'intex_confirm:confirm-1:no', title: 'Nie' } },
+    ];
+
+    await publisher.publishReply({
+      userId: 'user-1',
+      message: 'Czy dodać notatkę?',
+      replyToMessageId: 'wamid-1',
+      correlationId: 'session-1',
+      buttons,
+    });
+
+    expect(sendPublisher.calls).toEqual([
+      {
+        userId: 'user-1',
+        message: 'Czy dodać notatkę?',
+        replyToMessageId: 'wamid-1',
+        correlationId: 'session-1',
+        buttons,
+        important: true,
+      },
+    ]);
+  });
+
   it('throws when the shared send-message publisher fails', async () => {
     const sendPublisher = new FakeWhatsAppSendPublisher();
     sendPublisher.result = err({ code: 'PUBLISH_FAILED', message: 'Pub/Sub unavailable' });

--- a/apps/intex-agent/src/domain/agent/intentGate.ts
+++ b/apps/intex-agent/src/domain/agent/intentGate.ts
@@ -103,7 +103,7 @@ function isReadOnlyCalendarQueryRequest(text: string): boolean {
       text
     );
   const listIntent =
-    /\b(show|list|check|inspect|see|find|search|what|when|pokaz\w*|podaj\w*|sprawdz\w*|zobac\w*|znajdz\w*|szukaj|wypisz\w*|wyswietl\w*|lista|liste|listy|co jest)\b/u.test(
+    /\b(show|list|check|inspect|see|find|search|what|when|pokaz\w*|podaj\w*|sprawdz\w*|zobac\w*|znajdz\w*|szukaj|wypisz\w*|wyswietl\w*|jakie|jaki|jaka|zaplanowan\w*|lista|liste|listy|co jest)\b/u.test(
       text
     ) || /\bco\b.*\bjest\b/u.test(text);
   const countIntent = /\b(how many times|how many|count|ile razy|ile)\b/u.test(text);

--- a/apps/intex-agent/src/domain/agent/intexAgentRunner.ts
+++ b/apps/intex-agent/src/domain/agent/intexAgentRunner.ts
@@ -28,6 +28,22 @@ import {
 } from './capabilities.js';
 
 const DEFAULT_WEB_APP_URL = 'https://intexuraos.cloud';
+type MutatingIntexAgentToolName = Exclude<
+  IntexAgentToolName,
+  'query_calendar_events' | 'get_user_preferences'
+>;
+
+const MUTATING_TOOL_NAMES = new Set<MutatingIntexAgentToolName>([
+  'create_note',
+  'create_calendar_event',
+  'create_research',
+  'create_link',
+  'create_code_task',
+  'save_external',
+  'add_user_preference',
+  'update_user_preference',
+  'delete_user_preference',
+]);
 
 export interface IntexAgentRunnerConfig {
   client: ToolCallingClient;
@@ -38,9 +54,67 @@ export interface IntexAgentRunnerConfig {
 
 export function createIntexAgentRunner(config: IntexAgentRunnerConfig): IntexAgentRunner {
   return {
+    async executeConfirmed(input): Promise<IntexAgentRunnerResult> {
+      if (!isMutatingToolName(input.toolName)) {
+        return malformedResult();
+      }
+
+      const toolExecutions: IntexAgentToolExecution[] = [];
+      const tools = createIntexAgentToolDefinitions(
+        createTrackingToolExecutor(config.toolExecutor, toolExecutions)
+      );
+      const tool = tools.find((candidate) => candidate.name === input.toolName);
+      /* v8 ignore start -- schema: mutating tool registry and tool definitions cannot diverge without breaking startup tests @preserve */
+      if (tool === undefined) {
+        return malformedResult();
+      }
+      /* v8 ignore stop @preserve */
+
+      try {
+        const rawResult = await tool.run(input.toolArgs);
+        const toolExecution = getCompletedToolExecution(toolExecutions);
+        /* v8 ignore start -- schema: every mutating tool definition executes through the tracking executor after argument validation @preserve */
+        if (toolExecution === undefined) {
+          return malformedResult();
+        }
+        /* v8 ignore stop @preserve */
+        const parsedResult = parseToolResult(rawResult);
+        const completedReply = buildCompletedReply(
+          input.toolName,
+          parsedResult,
+          defaultCompletedReply(input.toolName),
+          config.webAppUrl ?? DEFAULT_WEB_APP_URL
+        );
+
+        return {
+          outcome: 'completed',
+          reply: completedReply.reply,
+          toolName: input.toolName,
+          ...(parsedResult !== undefined ? { toolResult: parsedResult } : {}),
+          ...(completedReply.ctaUrl !== undefined ? { ctaUrl: completedReply.ctaUrl } : {}),
+        };
+      } catch (error) {
+        const errorMessage = getErrorMessage(error, 'Unknown tool execution error');
+        return {
+          outcome: 'tool_failed',
+          reply: buildConfirmedExecutionFailureReply(input.toolName, errorMessage),
+          toolName: input.toolName,
+          error: errorMessage,
+        };
+      }
+    },
     async run(input): Promise<IntexAgentRunnerResult> {
       if (input.sourceType === 'whatsapp_image' && input.sourceUrl !== undefined) {
-        return await saveWhatsAppImageExternally(input.message, input.sourceUrl, config.toolExecutor);
+        const args = {
+          message: input.message.trim() === '' ? 'Image shared via WhatsApp.' : input.message.trim(),
+          sourceUrl: input.sourceUrl,
+        };
+        return {
+          outcome: 'needs_confirmation',
+          reply: buildConfirmationReply('save_external', args, config.userPreferences ?? null),
+          toolName: 'save_external',
+          toolArgs: args,
+        };
       }
 
       const intent = classifyIntexAgentIntent(input.message);
@@ -60,7 +134,7 @@ export function createIntexAgentRunner(config: IntexAgentRunnerConfig): IntexAge
 
       const toolExecutions: IntexAgentToolExecution[] = [];
       const tools = createIntexAgentToolDefinitions(
-        createTrackingToolExecutor(config.toolExecutor, toolExecutions)
+        createTrackingToolExecutor(createConfirmationPreviewExecutor(config.toolExecutor), toolExecutions)
       ).filter(
         (tool) =>
           intent.kind === 'tool' && intent.allowedToolNames.includes(tool.name as IntexAgentToolName)
@@ -78,14 +152,6 @@ export function createIntexAgentRunner(config: IntexAgentRunnerConfig): IntexAge
         maxIterations: 5,
       });
 
-      const externalSaveFailure = getExternalSaveFailure(toolExecutions);
-      if (externalSaveFailure !== undefined) {
-        return {
-          outcome: 'unsupported',
-          reply: buildExternalSaveFailureReply(externalSaveFailure),
-        };
-      }
-
       if (!result.ok) {
         return {
           outcome: 'unsupported',
@@ -96,7 +162,8 @@ export function createIntexAgentRunner(config: IntexAgentRunnerConfig): IntexAge
       return parseRunnerContent(
         result.value.content,
         toolExecutions,
-        config.webAppUrl ?? DEFAULT_WEB_APP_URL
+        config.webAppUrl ?? DEFAULT_WEB_APP_URL,
+        config.userPreferences ?? null
       );
     },
   };
@@ -220,7 +287,8 @@ function parseReplyContext(value: unknown): IntexIncomingMessageReplyContext | u
 function parseRunnerContent(
   content: string,
   toolExecutions: IntexAgentToolExecution[],
-  webAppUrl: string
+  webAppUrl: string,
+  userPreferences: string | null
 ): IntexAgentRunnerResult {
   const parsed = parseJsonObject(content);
   if (parsed === null) {
@@ -231,6 +299,18 @@ function parseRunnerContent(
   const reply = parsed['reply'];
   if (typeof outcome !== 'string' || typeof reply !== 'string') {
     return malformedResult();
+  }
+
+  const toolExecution = getCompletedToolExecution(toolExecutions);
+  if (toolExecution !== undefined && isMutatingToolName(toolExecution.toolName)) {
+    const summary = parsed['summary'];
+    return {
+      outcome: 'needs_confirmation',
+      reply: buildConfirmationReply(toolExecution.toolName, toolExecution.args, userPreferences),
+      toolName: toolExecution.toolName,
+      toolArgs: toolExecution.args,
+      ...(typeof summary === 'string' ? { summary } : {}),
+    };
   }
 
   if (outcome === 'needs_clarification') {
@@ -247,13 +327,12 @@ function parseRunnerContent(
 
   if (outcome === 'completed') {
     const summary = parsed['summary'];
-    const completedToolExecution = getCompletedToolExecution(toolExecutions);
-    if (completedToolExecution === undefined) {
+    if (toolExecution === undefined) {
       return malformedResult();
     }
     const completedReply = buildCompletedReply(
-      completedToolExecution.toolName,
-      completedToolExecution.result,
+      toolExecution.toolName,
+      toolExecution.result,
       reply,
       webAppUrl
     );
@@ -262,15 +341,63 @@ function parseRunnerContent(
       outcome,
       reply: completedReply.reply,
       ...(typeof summary === 'string' ? { summary } : {}),
-      toolName: completedToolExecution.toolName,
-      ...(completedToolExecution.result !== undefined
-        ? { toolResult: completedToolExecution.result }
+      toolName: toolExecution.toolName,
+      ...(toolExecution.result !== undefined
+        ? { toolResult: toolExecution.result }
         : {}),
+      /* v8 ignore start -- schema: normal completed turns cannot produce CTA URLs because mutating tools are confirmation-gated and read-only tools have no CTA results @preserve */
       ...(completedReply.ctaUrl !== undefined ? { ctaUrl: completedReply.ctaUrl } : {}),
+      /* v8 ignore stop @preserve */
     };
   }
 
   return malformedResult();
+}
+
+function createConfirmationPreviewExecutor(executor: IntexAgentToolExecutor): IntexAgentToolExecutor {
+  return {
+    createNote(): Promise<string> {
+      return Promise.resolve(previewToolResult());
+    },
+    createCalendarEvent(): Promise<string> {
+      return Promise.resolve(previewToolResult());
+    },
+    async queryCalendarEvents(args: QueryCalendarEventsToolArgs): Promise<string> {
+      return await executor.queryCalendarEvents(args);
+    },
+    createResearch(): Promise<string> {
+      return Promise.resolve(previewToolResult());
+    },
+    createLink(): Promise<string> {
+      return Promise.resolve(previewToolResult());
+    },
+    createCodeTask(): Promise<string> {
+      return Promise.resolve(previewToolResult());
+    },
+    saveExternal(): Promise<string> {
+      return Promise.resolve(previewToolResult());
+    },
+    async getUserPreferences(): Promise<string> {
+      return await executor.getUserPreferences();
+    },
+    addUserPreference(): Promise<string> {
+      return Promise.resolve(previewToolResult());
+    },
+    updateUserPreference(): Promise<string> {
+      return Promise.resolve(previewToolResult());
+    },
+    deleteUserPreference(): Promise<string> {
+      return Promise.resolve(previewToolResult());
+    },
+  };
+}
+
+function previewToolResult(): string {
+  return JSON.stringify({ status: 'needs_confirmation' });
+}
+
+function isMutatingToolName(toolName: IntexAgentToolName): toolName is MutatingIntexAgentToolName {
+  return MUTATING_TOOL_NAMES.has(toolName as MutatingIntexAgentToolName);
 }
 
 function createTrackingToolExecutor(
@@ -358,40 +485,6 @@ function createTrackingToolExecutor(
   };
 }
 
-async function saveWhatsAppImageExternally(
-  message: string,
-  sourceUrl: string,
-  executor: IntexAgentToolExecutor
-): Promise<IntexAgentRunnerResult> {
-  try {
-    const rawResult = await executor.saveExternal({
-      message: message.trim() === '' ? 'Image shared via WhatsApp.' : message.trim(),
-      sourceUrl,
-    });
-    const result = parseToolResult(rawResult);
-    const reply = result !== undefined ? readString(result, 'message') : undefined;
-    return {
-      outcome: 'completed',
-      reply: reply ?? 'Saved externally',
-      toolName: 'save_external',
-      ...(result !== undefined ? { toolResult: result } : {}),
-    };
-  } catch (error) {
-    return {
-      outcome: 'unsupported',
-      reply: buildExternalSaveFailureReply(getErrorMessage(error, 'Unknown external save error')),
-    };
-  }
-}
-
-function getExternalSaveFailure(
-  toolExecutions: IntexAgentToolExecution[]
-): string | undefined {
-  return toolExecutions.find(
-    (execution) => execution.toolName === 'save_external' && execution.error !== undefined
-  )?.error;
-}
-
 function buildExternalSaveFailureReply(errorMessage: string): string {
   if (isExternalSaveNotConfiguredError(errorMessage)) {
     return 'No external system is configured for this message, so I cannot process it. Configure External Save in Intex Agent preferences and send it again.';
@@ -399,6 +492,18 @@ function buildExternalSaveFailureReply(errorMessage: string): string {
 
   const detail = normalizeExternalSaveFailureDetail(errorMessage);
   return `I could not deliver this to the external system. The external save request failed: ${detail}. Please check the external system configuration and try again.`;
+}
+
+function buildConfirmedExecutionFailureReply(
+  toolName: IntexAgentToolName,
+  errorMessage: string
+): string {
+  if (toolName === 'save_external') {
+    return buildExternalSaveFailureReply(errorMessage);
+  }
+
+  const detail = normalizeExternalSaveFailureDetail(errorMessage);
+  return `Nie udało się wykonać tej akcji: ${detail}. Spróbuj ponownie później.`;
 }
 
 function isExternalSaveNotConfiguredError(errorMessage: string): boolean {
@@ -434,6 +539,130 @@ function getCompletedToolExecution(
 
 function parseToolResult(rawResult: string): Record<string, unknown> | undefined {
   return parseJsonObject(rawResult) ?? undefined;
+}
+
+function buildConfirmationReply(
+  toolName: MutatingIntexAgentToolName,
+  args: Record<string, unknown>,
+  userPreferences: string | null
+): string {
+  if (toolName === 'create_note') {
+    const lines = ['Czy dodać notatkę?'];
+    const title = readRawString(args, 'title');
+    const content = readRawString(args, 'content');
+    if (title !== undefined) lines.push('', `Tytuł: ${title}`);
+    /* v8 ignore start -- schema: create_note preview args cannot omit content because validation runs before confirmation text is built @preserve */
+    if (content !== undefined) lines.push(`Treść: ${content}`);
+    /* v8 ignore stop @preserve */
+    return lines.join('\n');
+  }
+
+  if (toolName === 'create_calendar_event') {
+    const lines = ['Czy dodać wydarzenie w kalendarzu?'];
+    appendConfirmationLine(lines, 'Tytuł', readRawString(args, 'summary'));
+    appendConfirmationLine(lines, 'Start', readRawString(args, 'start'));
+    appendConfirmationLine(lines, 'Koniec', readRawString(args, 'end'));
+    appendConfirmationLine(lines, 'Miejsce', readRawString(args, 'location'));
+    appendConfirmationListLine(lines, 'Uczestnicy', readStringArray(args, 'attendees'));
+    return lines.join('\n');
+  }
+
+  if (toolName === 'create_research') {
+    const lines = ['Czy utworzyć szkic researchu?'];
+    appendConfirmationLine(lines, 'Tytuł', readRawString(args, 'title'));
+    appendConfirmationLine(lines, 'Prompt', readRawString(args, 'prompt'));
+    return lines.join('\n');
+  }
+
+  if (toolName === 'create_link') {
+    const lines = ['Czy zapisać bookmark?'];
+    appendConfirmationLine(lines, 'URL', readRawString(args, 'url'));
+    appendConfirmationLine(lines, 'Tytuł', readRawString(args, 'title'));
+    return lines.join('\n');
+  }
+
+  if (toolName === 'create_code_task') {
+    const lines = ['Czy utworzyć zadanie programistyczne?'];
+    appendConfirmationLine(lines, 'Prompt', readRawString(args, 'prompt'));
+    appendConfirmationLine(lines, 'Tryb', readRawString(args, 'taskMode') ?? 'planning');
+    appendConfirmationLine(lines, 'Worker', readRawString(args, 'workerType'));
+    appendConfirmationLine(lines, 'Linear', readRawString(args, 'linearIssueId'));
+    return lines.join('\n');
+  }
+
+  if (toolName === 'save_external') {
+    const lines = ['Czy wysłać tę treść do zewnętrznego systemu?'];
+    appendConfirmationLine(lines, 'Treść', readRawString(args, 'message'));
+    appendConfirmationLine(lines, 'Źródło', readRawString(args, 'sourceUrl'));
+    return lines.join('\n');
+  }
+
+  if (toolName === 'add_user_preference') {
+    const lines = ['Czy dodać wpis w pamięci instrukcji?'];
+    appendConfirmationLine(lines, 'Nowy wpis', readRawString(args, 'text'));
+    return lines.join('\n');
+  }
+
+  if (toolName === 'update_user_preference') {
+    const lines = ['Czy zmodyfikować wpis w pamięci instrukcji?'];
+    const itemId = readRawString(args, 'itemId');
+    appendConfirmationLine(lines, 'Wpis', itemId);
+    appendConfirmationLine(lines, 'Wcześniej', findPreferenceText(userPreferences, itemId));
+    appendConfirmationLine(lines, 'Po zmianie', readRawString(args, 'text'));
+    return lines.join('\n');
+  }
+
+  const lines = ['Czy usunąć wpis z pamięci instrukcji?'];
+  const itemId = readRawString(args, 'itemId');
+  appendConfirmationLine(lines, 'Wpis', itemId);
+  appendConfirmationLine(lines, 'Treść', findPreferenceText(userPreferences, itemId));
+  return lines.join('\n');
+}
+
+function appendConfirmationLine(lines: string[], label: string, value: string | undefined): void {
+  if (value === undefined || value.trim() === '') {
+    return;
+  }
+  if (lines.length === 1) {
+    lines.push('');
+  }
+  lines.push(`${label}: ${value}`);
+}
+
+function appendConfirmationListLine(
+  lines: string[],
+  label: string,
+  value: string[] | undefined
+): void {
+  if (value === undefined || value.length === 0) {
+    return;
+  }
+  appendConfirmationLine(lines, label, value.join(', '));
+}
+
+function readStringArray(record: Record<string, unknown>, key: string): string[] | undefined {
+  const value = record[key];
+  if (!Array.isArray(value) || !value.every((item) => typeof item === 'string')) {
+    return undefined;
+  }
+  return value;
+}
+
+function findPreferenceText(userPreferences: string | null, itemId: string | undefined): string | undefined {
+  if (userPreferences === null || itemId === undefined) {
+    return undefined;
+  }
+  const line = userPreferences.split('\n').find((candidate) => candidate.includes(`(id: ${itemId}) `));
+  if (line === undefined) {
+    return undefined;
+  }
+  const quotedText = line.slice(line.indexOf(') ') + 2).trim();
+  try {
+    const parsed: unknown = JSON.parse(quotedText);
+    return typeof parsed === 'string' ? parsed : undefined;
+  } catch {
+    return quotedText;
+  }
 }
 
 function buildCompletedReply(
@@ -523,6 +752,28 @@ function buildCompletedReply(
     return { reply: message };
   }
   return { reply: message ?? fallbackReply };
+}
+
+function defaultCompletedReply(toolName: MutatingIntexAgentToolName): string {
+  if (toolName === 'create_note') {
+    return 'Zapisałem notatkę.';
+  }
+  if (toolName === 'create_calendar_event') {
+    return 'Utworzyłem wydarzenie w kalendarzu.';
+  }
+  if (toolName === 'create_research') {
+    return 'Utworzyłem szkic researchu.';
+  }
+  if (toolName === 'create_link') {
+    return 'Zapisałem bookmark.';
+  }
+  if (toolName === 'create_code_task') {
+    return 'Utworzyłem zadanie programistyczne.';
+  }
+  if (toolName === 'save_external') {
+    return 'Saved externally';
+  }
+  return 'Zaktualizowałem pamięć instrukcji.';
 }
 
 function isPreferenceToolName(toolName: IntexAgentToolName): boolean {

--- a/apps/intex-agent/src/domain/messages/handleIncomingMessage.ts
+++ b/apps/intex-agent/src/domain/messages/handleIncomingMessage.ts
@@ -1,3 +1,5 @@
+import { getErrorMessage } from '@intexuraos/common-core';
+import type { WhatsAppInteractiveButton } from '@intexuraos/whatsapp-pubsub-client';
 import type { IntexIncomingMessage, IncomingMessageHandlerResult } from '../ports/incomingMessageHandler.js';
 import type { SessionRepository } from '../ports/sessionRepository.js';
 import {
@@ -29,6 +31,19 @@ export type IntexAgentRunnerResult =
       };
     }
   | {
+      outcome: 'needs_confirmation';
+      reply: string;
+      toolName: IntexAgentToolName;
+      toolArgs: Record<string, unknown>;
+      summary?: string;
+    }
+  | {
+      outcome: 'tool_failed';
+      reply: string;
+      toolName: IntexAgentToolName;
+      error: string;
+    }
+  | {
       outcome: 'needs_clarification';
       reply: string;
     }
@@ -42,6 +57,13 @@ export type IntexAgentRunnerResult =
     };
 
 export interface IntexAgentRunner {
+  executeConfirmed(input: {
+    session: IntexAgentSession;
+    toolName: IntexAgentToolName;
+    toolArgs: Record<string, unknown>;
+    currentDateTime: string;
+    messageId?: string;
+  }): Promise<IntexAgentRunnerResult>;
   run(input: {
     session: IntexAgentSession;
     events: IntexAgentSessionEvent[];
@@ -64,6 +86,7 @@ export interface WhatsAppReplyPublisher {
       displayText: string;
       url: string;
     };
+    buttons?: WhatsAppInteractiveButton[];
   }): Promise<void>;
 }
 
@@ -74,6 +97,7 @@ export interface Clock {
 export interface IdGenerator {
   sessionId(): string;
   eventId(): string;
+  confirmationId(): string;
 }
 
 export interface HandleIncomingMessageDeps {
@@ -85,6 +109,18 @@ export interface HandleIncomingMessageDeps {
   sessionTimeoutMs: number;
 }
 
+const CONFIRMABLE_TOOL_NAMES = new Set<IntexAgentToolName>([
+  'create_note',
+  'create_calendar_event',
+  'create_research',
+  'create_link',
+  'create_code_task',
+  'save_external',
+  'add_user_preference',
+  'update_user_preference',
+  'delete_user_preference',
+]);
+
 export async function handleIncomingMessage(
   input: IntexIncomingMessage,
   deps: HandleIncomingMessageDeps
@@ -92,6 +128,11 @@ export async function handleIncomingMessage(
   const now = deps.clock.now();
   const normalizedUserTimestamp = normalizeSessionTimestamp(input.timestamp);
   const currentSession = await deps.sessionRepository.findContinuableSession(input.userId);
+
+  if (input.sourceType === 'whatsapp_button') {
+    return await handleConfirmationButton(input, deps, currentSession, now, normalizedUserTimestamp);
+  }
+
   const decision = decideSessionTransition({
     currentSession,
     now,
@@ -121,6 +162,7 @@ export async function handleIncomingMessage(
     sourceType: input.sourceType,
     ...(input.sourceUrl !== undefined ? { hasSourceUrl: true } : {}),
     ...(input.replyContext !== undefined ? { replyContext: input.replyContext } : {}),
+    ...(input.buttonResponse !== undefined ? { buttonResponse: input.buttonResponse } : {}),
   });
   await deps.sessionRepository.updateSession(session.id, {
     status: 'active',
@@ -128,6 +170,7 @@ export async function handleIncomingMessage(
   });
 
   const events = await deps.sessionRepository.listEvents(session.id, input.userId);
+  await supersedePendingConfirmationIfNeeded(session, deps, events);
   const missingLinkReply = buildMissingLinkReply(effectiveMessage, events);
   if (missingLinkReply !== null) {
     const assistantAt = await appendAssistantMessage(session, deps, missingLinkReply);
@@ -152,6 +195,99 @@ export async function handleIncomingMessage(
   await applyRunnerResult(input, deps, session, runnerResult);
 
   return { sessionId: session.id };
+}
+
+async function handleConfirmationButton(
+  input: IntexIncomingMessage,
+  deps: HandleIncomingMessageDeps,
+  currentSession: IntexAgentSession | null,
+  now: string,
+  normalizedUserTimestamp: string
+): Promise<IncomingMessageHandlerResult> {
+  if (currentSession === null) {
+    await deps.replyPublisher.publishReply({
+      userId: input.userId,
+      message: staleConfirmationReply(),
+      replyToMessageId: input.messageId,
+      correlationId: input.messageId,
+    });
+    return { sessionId: input.messageId };
+  }
+
+  const buttonResponse = input.buttonResponse;
+  const parsedButton =
+    buttonResponse === undefined ? null : parseConfirmationButtonId(buttonResponse.buttonId);
+  const events = await deps.sessionRepository.listEvents(currentSession.id, input.userId);
+
+  await appendEvent(deps, currentSession, 'user_message', {
+    messageId: input.messageId,
+    text: input.text,
+    sourceType: input.sourceType,
+    ...(buttonResponse !== undefined ? { buttonResponse } : {}),
+  });
+  await deps.sessionRepository.updateSession(currentSession.id, {
+    status: 'active',
+    lastUserMessageAt: normalizedUserTimestamp,
+  });
+
+  const pendingConfirmation = findLatestPendingConfirmation(events);
+  if (
+    buttonResponse === undefined ||
+    parsedButton === null ||
+    parsedButton.confirmationId !== pendingConfirmation?.confirmationId
+  ) {
+    const reply = staleConfirmationReply();
+    const assistantAt = await appendAssistantMessage(currentSession, deps, reply);
+    await deps.sessionRepository.updateSession(currentSession.id, {
+      status: 'waiting_for_user',
+      lastAssistantMessageAt: assistantAt,
+    });
+    await publishReply(input, deps, currentSession.id, reply);
+    return { sessionId: currentSession.id };
+  }
+
+  await appendEvent(deps, currentSession, 'confirmation_resolved', {
+    confirmationId: pendingConfirmation.confirmationId,
+    resolution: parsedButton.decision === 'yes' ? 'accepted' : 'rejected',
+    buttonId: buttonResponse.buttonId,
+    buttonTitle: buttonResponse.buttonTitle,
+    replyToWamid: buttonResponse.replyToWamid,
+  });
+
+  if (parsedButton.decision === 'no') {
+    const reply = 'Okej, nie wykonuję tej akcji.';
+    const assistantAt = await appendAssistantMessage(currentSession, deps, reply);
+    await deps.sessionRepository.updateSession(currentSession.id, {
+      status: 'waiting_for_user',
+      lastAssistantMessageAt: assistantAt,
+    });
+    await publishReply(input, deps, currentSession.id, reply);
+    return { sessionId: currentSession.id };
+  }
+
+  let executionResult: IntexAgentRunnerResult;
+  try {
+    executionResult = await deps.runner.executeConfirmed({
+      session: currentSession,
+      toolName: pendingConfirmation.toolName,
+      toolArgs: pendingConfirmation.toolArgs,
+      currentDateTime: now,
+      messageId: input.messageId,
+    });
+  } catch (error) {
+    executionResult = {
+      outcome: 'tool_failed',
+      reply: `Nie udało się wykonać tej akcji: ${getErrorMessage(
+        error,
+        'Unknown tool execution error'
+      )}. Spróbuj ponownie później.`,
+      toolName: pendingConfirmation.toolName,
+      error: getErrorMessage(error, 'Unknown tool execution error'),
+    };
+  }
+
+  await applyRunnerResult(input, deps, currentSession, executionResult);
+  return { sessionId: currentSession.id };
 }
 
 async function closePreviousSessionIfNeeded(
@@ -230,6 +366,44 @@ async function applyRunnerResult(
     return;
   }
 
+  if (runnerResult.outcome === 'needs_confirmation') {
+    const reply = stripDuplicateSessionPrefix(runnerResult.reply);
+    const confirmationId = deps.ids.confirmationId();
+    await appendEvent(deps, session, 'confirmation_requested', {
+      confirmationId,
+      toolName: runnerResult.toolName,
+      toolArgs: runnerResult.toolArgs,
+      message: reply,
+      sourceMessageId: input.messageId,
+      ...(runnerResult.summary !== undefined ? { summary: runnerResult.summary } : {}),
+    });
+    const assistantAt = await appendAssistantMessage(session, deps, reply);
+    await deps.sessionRepository.updateSession(session.id, {
+      status: 'waiting_for_user',
+      lastAssistantMessageAt: assistantAt,
+      activeTool: runnerResult.toolName,
+      ...(runnerResult.summary !== undefined ? { summary: runnerResult.summary } : {}),
+    });
+    await publishReply(input, deps, session.id, reply, undefined, confirmationButtons(confirmationId));
+    return;
+  }
+
+  if (runnerResult.outcome === 'tool_failed') {
+    const reply = stripDuplicateSessionPrefix(runnerResult.reply);
+    await appendEvent(deps, session, 'tool_call_failed', {
+      toolName: runnerResult.toolName,
+      error: runnerResult.error,
+    });
+    const assistantAt = await appendAssistantMessage(session, deps, reply);
+    await deps.sessionRepository.updateSession(session.id, {
+      status: 'waiting_for_user',
+      lastAssistantMessageAt: assistantAt,
+      activeTool: runnerResult.toolName,
+    });
+    await publishReply(input, deps, session.id, reply);
+    return;
+  }
+
   if (runnerResult.outcome === 'unsupported') {
     const reply = stripDuplicateSessionPrefix(runnerResult.reply);
     await appendEvent(deps, session, 'unsupported_request', { message: runnerResult.reply });
@@ -297,7 +471,8 @@ async function publishReply(
   ctaUrl?: {
     displayText: string;
     url: string;
-  }
+  },
+  buttons?: WhatsAppInteractiveButton[]
 ): Promise<void> {
   await deps.replyPublisher.publishReply({
     userId: input.userId,
@@ -305,6 +480,7 @@ async function publishReply(
     replyToMessageId: input.messageId,
     correlationId: sessionId,
     ...(ctaUrl !== undefined ? { ctaUrl } : {}),
+    ...(buttons !== undefined ? { buttons } : {}),
   });
 }
 
@@ -348,6 +524,121 @@ function malformedRunnerResult(): Extract<IntexAgentRunnerResult, { outcome: 'un
     outcome: 'unsupported',
     reply: buildUnsupportedCapabilitiesReply(),
   };
+}
+
+interface ParsedConfirmationButton {
+  confirmationId: string;
+  decision: 'yes' | 'no';
+}
+
+interface PendingConfirmation {
+  confirmationId: string;
+  toolName: IntexAgentToolName;
+  toolArgs: Record<string, unknown>;
+}
+
+function confirmationButtons(confirmationId: string): WhatsAppInteractiveButton[] {
+  return [
+    {
+      type: 'reply',
+      reply: {
+        id: `intex_confirm:${confirmationId}:yes`,
+        title: 'Tak',
+      },
+    },
+    {
+      type: 'reply',
+      reply: {
+        id: `intex_confirm:${confirmationId}:no`,
+        title: 'Nie',
+      },
+    },
+  ];
+}
+
+function parseConfirmationButtonId(buttonId: string): ParsedConfirmationButton | null {
+  const match = /^intex_confirm:([^:]+):(yes|no)$/u.exec(buttonId);
+  if (match === null) {
+    return null;
+  }
+  const confirmationId = match[1];
+  const decision = match[2];
+  /* v8 ignore start -- schema: successful confirmation button regex cannot omit id or yes/no decision captures @preserve */
+  if (confirmationId === undefined || (decision !== 'yes' && decision !== 'no')) {
+    return null;
+  }
+  /* v8 ignore stop @preserve */
+  return {
+    confirmationId,
+    decision,
+  };
+}
+
+function findLatestPendingConfirmation(
+  events: IntexAgentSessionEvent[]
+): PendingConfirmation | null {
+  const resolvedConfirmationIds = new Set<string>();
+  for (const event of events) {
+    if (event.type !== 'confirmation_resolved') {
+      continue;
+    }
+    const confirmationId = event.payload['confirmationId'];
+    if (typeof confirmationId === 'string') {
+      resolvedConfirmationIds.add(confirmationId);
+    }
+  }
+
+  for (const event of [...events].reverse()) {
+    if (event.type !== 'confirmation_requested') {
+      continue;
+    }
+    const confirmationId = event.payload['confirmationId'];
+    const toolName = event.payload['toolName'];
+    const toolArgs = event.payload['toolArgs'];
+    if (
+      typeof confirmationId !== 'string' ||
+      resolvedConfirmationIds.has(confirmationId) ||
+      !isConfirmableToolName(toolName) ||
+      !isRecord(toolArgs)
+    ) {
+      continue;
+    }
+    return {
+      confirmationId,
+      toolName,
+      toolArgs,
+    };
+  }
+
+  return null;
+}
+
+async function supersedePendingConfirmationIfNeeded(
+  session: IntexAgentSession,
+  deps: HandleIncomingMessageDeps,
+  events: IntexAgentSessionEvent[]
+): Promise<void> {
+  const pendingConfirmation = findLatestPendingConfirmation(events);
+  if (pendingConfirmation === null) {
+    return;
+  }
+
+  await appendEvent(deps, session, 'confirmation_resolved', {
+    confirmationId: pendingConfirmation.confirmationId,
+    resolution: 'superseded',
+  });
+}
+
+function staleConfirmationReply(): string {
+  return 'To potwierdzenie nie jest już aktualne. Wyślij prośbę jeszcze raz.';
+}
+
+function isConfirmableToolName(value: unknown): value is IntexAgentToolName {
+  return typeof value === 'string' && CONFIRMABLE_TOOL_NAMES.has(value as IntexAgentToolName);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
 function buildMissingLinkReply(message: string, events: IntexAgentSessionEvent[]): string | null {

--- a/apps/intex-agent/src/domain/ports/incomingMessageHandler.ts
+++ b/apps/intex-agent/src/domain/ports/incomingMessageHandler.ts
@@ -9,6 +9,12 @@ export interface IntexIncomingMessageReplyContext {
   truncated: boolean;
 }
 
+export interface IntexIncomingMessageButtonResponse {
+  buttonId: string;
+  buttonTitle: string;
+  replyToWamid: string;
+}
+
 export interface IntexIncomingMessage {
   type: 'intex.message.ingest';
   userId: string;
@@ -18,6 +24,7 @@ export interface IntexIncomingMessage {
   sourceUrl?: string;
   whatsappSender?: string;
   replyContext?: IntexIncomingMessageReplyContext;
+  buttonResponse?: IntexIncomingMessageButtonResponse;
   timestamp: string;
 }
 

--- a/apps/intex-agent/src/domain/sessions/types.ts
+++ b/apps/intex-agent/src/domain/sessions/types.ts
@@ -59,6 +59,8 @@ export type IntexAgentSessionEventType =
   | 'user_message'
   | 'assistant_message'
   | 'clarification_requested'
+  | 'confirmation_requested'
+  | 'confirmation_resolved'
   | 'tool_call_started'
   | 'tool_call_completed'
   | 'tool_call_failed'

--- a/apps/intex-agent/src/infra/firestore/sessionRepository.ts
+++ b/apps/intex-agent/src/infra/firestore/sessionRepository.ts
@@ -25,6 +25,8 @@ const OPEN_STATUSES = new Set(['active', 'waiting_for_user', 'executing_tool']);
 const EVENT_TYPE_ORDER: Record<IntexAgentSessionEventType, number> = {
   session_started: 0,
   user_message: 10,
+  confirmation_requested: 20,
+  confirmation_resolved: 20,
   tool_call_started: 20,
   tool_call_completed: 30,
   tool_call_failed: 30,

--- a/apps/intex-agent/src/infra/pubsub/decoder.ts
+++ b/apps/intex-agent/src/infra/pubsub/decoder.ts
@@ -1,5 +1,6 @@
 import type {
   IntexIncomingMessage,
+  IntexIncomingMessageButtonResponse,
   IntexIncomingMessageReplyContext,
 } from '../../domain/ports/incomingMessageHandler.js';
 
@@ -53,12 +54,13 @@ function toIntexIncomingMessage(value: unknown): IntexIncomingMessage {
   const type = requiredString(event, 'type');
   const userId = requiredString(event, 'userId');
   const messageId = requiredString(event, 'messageId');
-  const text = requiredString(event, 'text');
+  const text = requiredStringAllowingEmpty(event, 'text');
   const sourceType = requiredString(event, 'sourceType');
   const sourceUrl = optionalString(event, 'sourceUrl');
   const timestamp = requiredString(event, 'timestamp');
   const whatsappSender = optionalString(event, 'whatsappSender');
   const replyContext = optionalReplyContext(event);
+  const buttonResponse = optionalButtonResponse(event);
 
   return {
     type: type as IntexIncomingMessage['type'],
@@ -70,6 +72,7 @@ function toIntexIncomingMessage(value: unknown): IntexIncomingMessage {
     timestamp,
     ...(whatsappSender !== undefined ? { whatsappSender } : {}),
     ...(replyContext !== undefined ? { replyContext } : {}),
+    ...(buttonResponse !== undefined ? { buttonResponse } : {}),
   };
 }
 
@@ -85,6 +88,14 @@ function extractEventType(value: unknown): string | null {
 function requiredString(event: Record<string, unknown>, key: string): string {
   const value = event[key];
   if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`Invalid intex.message.ingest event: ${key} must be a string`);
+  }
+  return value;
+}
+
+function requiredStringAllowingEmpty(event: Record<string, unknown>, key: string): string {
+  const value = event[key];
+  if (typeof value !== 'string') {
     throw new Error(`Invalid intex.message.ingest event: ${key} must be a string`);
   }
   return value;
@@ -123,6 +134,25 @@ function optionalReplyContext(
     source,
     text,
     truncated,
+  };
+}
+
+function optionalButtonResponse(
+  event: Record<string, unknown>
+): IntexIncomingMessageButtonResponse | undefined {
+  const value = event['buttonResponse'];
+  if (value === undefined) {
+    return undefined;
+  }
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('Invalid intex.message.ingest event: buttonResponse must be an object');
+  }
+
+  const button = value as Record<string, unknown>;
+  return {
+    buttonId: requiredString(button, 'buttonId'),
+    buttonTitle: requiredString(button, 'buttonTitle'),
+    replyToWamid: requiredString(button, 'replyToWamid'),
   };
 }
 

--- a/apps/intex-agent/src/infra/pubsub/whatsappReplyPublisher.ts
+++ b/apps/intex-agent/src/infra/pubsub/whatsappReplyPublisher.ts
@@ -16,6 +16,7 @@ export function createWhatsAppReplyPublisher(
         replyToMessageId: input.replyToMessageId,
         correlationId: input.correlationId,
         ...(input.ctaUrl !== undefined ? { ctaUrl: input.ctaUrl } : {}),
+        ...(input.buttons !== undefined ? { buttons: input.buttons } : {}),
         important: true,
       });
 

--- a/apps/intex-agent/src/services.ts
+++ b/apps/intex-agent/src/services.ts
@@ -110,6 +110,39 @@ export function initServices(config: ServiceConfig): void {
   };
 
   const runner: IntexAgentRunner = {
+    async executeConfirmed(
+      input: Parameters<ReturnType<typeof createIntexAgentRunner>['executeConfirmed']>[0]
+    ): Promise<IntexAgentRunnerResult> {
+      const [preferences, promptPreferences] = await Promise.all([
+        preferencesRepository.getPreferences(input.session.userId),
+        promptPreferencesRepository.getCurrent(input.session.userId),
+      ]);
+      const toolExecutor = createIntexAgentToolExecutor({
+        userId: input.session.userId,
+        sessionId: input.session.id,
+        messageId: input.messageId ?? input.session.id,
+        notesClient,
+        calendarClient,
+        researchClient,
+        bookmarksClient,
+        codeClient,
+        externalSaveClient: createExternalSaveToolClient(preferences?.externalSave),
+        promptPreferencesRepository,
+      });
+
+      return await createIntexAgentRunner({
+        client: {
+          run() {
+            return Promise.reject(
+              new Error('Confirmed INTEX Agent execution must not invoke the LLM')
+            );
+          },
+        },
+        toolExecutor,
+        webAppUrl: config.webAppUrl,
+        userPreferences: promptPreferences.renderedPromptBlock,
+      }).executeConfirmed(input);
+    },
     async run(
       input: Parameters<ReturnType<typeof createIntexAgentRunner>['run']>[0]
     ): Promise<IntexAgentRunnerResult> {
@@ -160,6 +193,7 @@ export function initServices(config: ServiceConfig): void {
         ids: {
           sessionId: () => `intex_session_${randomUUID()}`,
           eventId: () => `intex_event_${randomUUID()}`,
+          confirmationId: () => `intex_confirmation_${randomUUID()}`,
         },
         sessionTimeoutMs: config.sessionTimeoutMs,
       });

--- a/apps/whatsapp-service/src/__tests__/usecases/processWebhookEventTextOnly.test.ts
+++ b/apps/whatsapp-service/src/__tests__/usecases/processWebhookEventTextOnly.test.ts
@@ -222,6 +222,70 @@ describe('ProcessWebhookEventUseCase text-only branches', () => {
     );
   });
 
+  it('publishes Intex confirmation button messages to the ingest topic', async () => {
+    const { savedEvent, useCase, userMappingRepository, webhookEventRepository, eventPublisher } =
+      await createHarness();
+    await userMappingRepository.saveMapping('user-1', ['15551234567']);
+
+    await useCase.execute(
+      createButtonWebhookPayload({
+        buttonId: 'intex_confirm:confirm-1:yes',
+        buttonTitle: 'Tak',
+        replyToWamid: 'wamid.confirmation',
+      }) as WebhookPayload,
+      savedEvent,
+      logger()
+    );
+
+    const eventResult = await webhookEventRepository.getEvent(savedEvent.id);
+    expect(eventResult.ok && eventResult.value?.status).toBe('completed');
+    expect(eventPublisher.getIntexMessageIngestEvents()).toEqual([
+      {
+        type: 'intex.message.ingest',
+        userId: 'user-1',
+        messageId: expect.stringMatching(/^wamid\.button/),
+        sourceType: 'whatsapp_button',
+        text: '',
+        whatsappSender: '15551234567',
+        buttonResponse: {
+          buttonId: 'intex_confirm:confirm-1:yes',
+          buttonTitle: 'Tak',
+          replyToWamid: 'wamid.confirmation',
+        },
+        timestamp: '1234567890',
+      },
+    ]);
+  });
+
+  it('marks Intex confirmation button publishing failures as retryable', async () => {
+    const { savedEvent, useCase, userMappingRepository, webhookEventRepository, eventPublisher } =
+      await createHarness();
+    await userMappingRepository.saveMapping('user-1', ['15551234567']);
+    eventPublisher.setIntexMessageIngestFailure('pubsub unavailable');
+
+    const result = await useCase.execute(
+      createButtonWebhookPayload({
+        buttonId: 'intex_confirm:confirm-1:yes',
+        buttonTitle: 'Tak',
+        replyToWamid: 'wamid.confirmation',
+      }) as WebhookPayload,
+      savedEvent,
+      logger()
+    );
+
+    const eventResult = await webhookEventRepository.getEvent(savedEvent.id);
+    expect(result).toEqual({
+      ok: false,
+      retryable: true,
+      failureDetails: 'Failed to publish intex message ingest: pubsub unavailable',
+    });
+    expect(eventResult.ok && eventResult.value?.status).toBe('failed');
+    expect(eventResult.ok && eventResult.value?.failureDetails).toBe(
+      'Failed to publish intex message ingest: pubsub unavailable'
+    );
+    expect(eventPublisher.getIntexMessageIngestEvents()).toEqual([]);
+  });
+
   it('ignores button messages without attempting read receipts when phoneNumberId is missing', async () => {
     const { savedEvent, useCase, userMappingRepository, webhookEventRepository, whatsappCloudApi } =
       await createHarness();

--- a/apps/whatsapp-service/src/__tests__/webhookAsyncProcessing.test.ts
+++ b/apps/whatsapp-service/src/__tests__/webhookAsyncProcessing.test.ts
@@ -1737,6 +1737,49 @@ describe('Webhook async processing', () => {
     const senderPhone = '15551234567';
     const testUserId = 'user-buttons-test';
 
+    it('publishes Intex confirmation buttons as structured Intex messages', async () => {
+      await ctx.userMappingRepository.saveMapping(testUserId, [senderPhone]);
+
+      const payload = createButtonWebhookPayload({
+        replyToWamid: 'wamid.confirmation.message',
+        buttonId: 'intex_confirm:confirm-1:yes',
+        buttonTitle: 'Tak',
+      });
+      const payloadString = JSON.stringify(payload);
+      const signature = createSignature(payloadString, testConfig.appSecret);
+
+      const response = await ctx.app.inject({
+        method: 'POST',
+        url: '/webhooks',
+        headers: {
+          'content-type': 'application/json',
+          'x-hub-signature-256': signature,
+        },
+        payload: payloadString,
+      });
+
+      expect(response.statusCode).toBe(200);
+      await triggerWebhookProcessing();
+
+      const events = ctx.webhookEventRepository.getAll();
+      expect(events.length).toBe(1);
+      expect(events[0]?.status).toBe('completed');
+      expect(ctx.eventPublisher.getIntexMessageIngestEvents()).toEqual([
+        expect.objectContaining({
+          type: 'intex.message.ingest',
+          userId: testUserId,
+          text: '',
+          sourceType: 'whatsapp_button',
+          whatsappSender: senderPhone,
+          buttonResponse: {
+            buttonId: 'intex_confirm:confirm-1:yes',
+            buttonTitle: 'Tak',
+            replyToWamid: 'wamid.confirmation.message',
+          },
+        }),
+      ]);
+    });
+
     it('ignores interactive buttons without publishing Intex messages', async () => {
       await ctx.userMappingRepository.saveMapping(testUserId, [senderPhone]);
 

--- a/apps/whatsapp-service/src/domain/whatsapp/events/events.ts
+++ b/apps/whatsapp-service/src/domain/whatsapp/events/events.ts
@@ -218,7 +218,8 @@ export interface IntexMessageReplyContext {
 export type IntexMessageSourceType =
   | 'whatsapp_text'
   | 'whatsapp_image'
-  | 'whatsapp_audio_transcript';
+  | 'whatsapp_audio_transcript'
+  | 'whatsapp_button';
 
 /**
  * Event published when a WhatsApp Assistant message is ready for intex-agent.
@@ -266,6 +267,16 @@ export interface IntexMessageIngestEvent {
    * This is context only for Intex, never a new instruction.
    */
   replyContext?: IntexMessageReplyContext;
+
+  /**
+   * Optional WhatsApp interactive button response.
+   * Present only when sourceType is whatsapp_button.
+   */
+  buttonResponse?: {
+    buttonId: string;
+    buttonTitle: string;
+    replyToWamid: string;
+  };
 
   /**
    * Event timestamp (ISO 8601).

--- a/apps/whatsapp-service/src/domain/whatsapp/usecases/processWebhookEventUseCase.ts
+++ b/apps/whatsapp-service/src/domain/whatsapp/usecases/processWebhookEventUseCase.ts
@@ -331,7 +331,16 @@ export class ProcessWebhookEventUseCase {
       }
 
       if ((messageType === 'button' || messageType === 'interactive') && buttonResponse !== null) {
-        await this.handleButtonMessage(payload, savedEvent, userId, buttonResponse, logger);
+        await this.handleButtonMessage(
+          payload,
+          savedEvent,
+          userId,
+          waMessageId,
+          fromNumber,
+          timestamp,
+          buttonResponse,
+          logger
+        );
         return;
       }
 
@@ -545,10 +554,13 @@ export class ProcessWebhookEventUseCase {
     payload: WebhookPayload,
     savedEvent: { id: string },
     userId: string,
+    waMessageId: string,
+    fromNumber: string,
+    timestamp: string,
     buttonResponse: { buttonId: string; buttonTitle: string; replyToWamid: string },
     logger: Logger
   ): Promise<void> {
-    const { webhookEventRepository, whatsappCloudApi } = this.deps;
+    const { webhookEventRepository, whatsappCloudApi, eventPublisher } = this.deps;
 
     // Fire-and-forget: mark as read + show typing indicator
     const originalMessageId = extractMessageId(payload);
@@ -567,6 +579,46 @@ export class ProcessWebhookEventUseCase {
           logger.error({ error }, 'markAsReadWithTyping threw unexpectedly');
         }
       );
+    }
+
+    if (buttonResponse.buttonId.startsWith('intex_confirm:')) {
+      logger.info(
+        {
+          eventId: savedEvent.id,
+          userId,
+          buttonId: buttonResponse.buttonId,
+          buttonTitle: buttonResponse.buttonTitle,
+          replyToWamid: buttonResponse.replyToWamid,
+        },
+        'Publishing Intex confirmation button response'
+      );
+
+      const ingestPublishResult = await eventPublisher.publishIntexMessageIngest({
+        type: 'intex.message.ingest',
+        userId,
+        messageId: waMessageId,
+        sourceType: 'whatsapp_button',
+        text: '',
+        whatsappSender: fromNumber,
+        buttonResponse,
+        timestamp,
+      });
+
+      if (!ingestPublishResult.ok) {
+        const failureDetails = `Failed to publish intex message ingest: ${ingestPublishResult.error.message}`;
+        logger.error(
+          { eventId: savedEvent.id, error: ingestPublishResult.error },
+          'Failed to publish intex.message.ingest button event'
+        );
+        await webhookEventRepository.updateEventStatus(savedEvent.id, 'failed', {
+          failureDetails,
+          retryable: true,
+        });
+        throw new RetryableWebhookProcessingError(failureDetails);
+      }
+
+      await webhookEventRepository.updateEventStatus(savedEvent.id, 'completed', {});
+      return;
     }
 
     logger.info(


### PR DESCRIPTION
## Summary
- add mandatory WhatsApp button confirmation before mutating Intex Agent actions
- keep read-only calendar/preference lookups immediate and structured
- forward Intex confirmation button replies from whatsapp-service into Intex Agent ingest

## Verification
- pnpm run verify:workspace:tracked intex-agent
- pnpm run verify:workspace:tracked whatsapp-service
- pnpm run ci:tracked