### PR TITLE
[INT-1720] Fix Sentry event_alert webhook parsing

### DIFF
--- a/apps/code-agent/src/__tests__/infra/sentry-event-parser.test.ts
+++ b/apps/code-agent/src/__tests__/infra/sentry-event-parser.test.ts
@@ -155,6 +155,39 @@ describe('parseSentryIssueEvent', () => {
     }
   });
 
+  it('normalizes official event_alert issue fields with numeric project IDs', () => {
+    const result = parseSentryIssueEvent('event_alert', {
+      action: 'triggered',
+      data: {
+        event: {
+          event_id: '58839a7c3e2c4205a1a847c1ad3839c6',
+          project: 4510702691024976,
+          title: 'This is an example node-fastify exception',
+          web_url: 'https://sentry.io/organizations/intexuraos/issues/1117540176/events/58839a7c3e2c4205a1a847c1ad3839c6/',
+          issue_url: 'https://sentry.io/api/0/issues/1117540176/',
+          issue_id: '1117540176',
+        },
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toEqual({
+        resource: 'event_alert',
+        action: 'triggered',
+        organizationSlug: 'intexuraos',
+        projectSlug: '4510702691024976',
+        projectId: '4510702691024976',
+        issueId: '1117540176',
+        issueShortId: undefined,
+        issueTitle: 'This is an example node-fastify exception',
+        issueUrl: 'https://sentry.io/organizations/intexuraos/issues/1117540176/',
+        status: undefined,
+        eventId: '58839a7c3e2c4205a1a847c1ad3839c6',
+      });
+    }
+  });
+
   it('normalizes event_alert webhooks from nested issue objects', () => {
     const result = parseSentryIssueEvent('event_alert', {
       action: 'resolved',

--- a/apps/code-agent/src/infra/sentry-event-parser.ts
+++ b/apps/code-agent/src/infra/sentry-event-parser.ts
@@ -44,7 +44,9 @@ function extractUrlParts(url: string): {
     const issueId = issueMatch?.[1];
     const issueUrl = issueId === undefined
       ? undefined
-      : `${parsed.origin}/issues/${issueId}/`;
+      : organizationMatch?.[1] === undefined
+        ? `${parsed.origin}/issues/${issueId}/`
+        : `${parsed.origin}/organizations/${organizationMatch[1]}/issues/${issueId}/`;
 
     return {
       organizationSlug: organizationMatch?.[1] ?? hostOrg,
@@ -63,6 +65,9 @@ function extractUrlParts(url: string): {
 function readProject(value: unknown): { projectSlug: string | undefined; projectId: string | undefined } {
   if (typeof value === 'string' && value.trim() !== '') {
     return { projectSlug: value, projectId: undefined };
+  }
+  if (typeof value === 'number') {
+    return { projectSlug: undefined, projectId: String(value) };
   }
   if (isRecord(value)) {
     return {
@@ -137,25 +142,39 @@ function parseEventAlertWebhook(payload: unknown): Result<NormalizedSentryIssueE
 
   const issueValue = event['issue'];
   const issueObject = isRecord(issueValue) ? issueValue : null;
-  const issueUrlRaw =
+  const eventWebUrlRaw = readString(event, 'web_url');
+  const eventIssueUrlRaw = readString(event, 'issue_url');
+  const issueLinkRaw =
     typeof issueValue === 'string'
       ? issueValue
       : issueObject !== null
         ? readString(issueObject, 'permalink') ?? readString(issueObject, 'web_url') ?? readString(issueObject, 'url')
         : undefined;
-  const fallbackUrlParts = readString(event, 'web_url') !== undefined
-    ? extractUrlParts(readString(event, 'web_url') as string)
-    : undefined;
-  const urlParts = issueUrlRaw !== undefined ? extractUrlParts(issueUrlRaw) : fallbackUrlParts;
-  const issueId = issueObject !== null ? readString(issueObject, 'id') ?? urlParts?.issueId : urlParts?.issueId;
-  const issueUrl = issueUrlRaw ?? urlParts?.issueUrl;
+  const issueLinkUrlParts = issueLinkRaw !== undefined ? extractUrlParts(issueLinkRaw) : undefined;
+  const eventWebUrlParts = eventWebUrlRaw !== undefined ? extractUrlParts(eventWebUrlRaw) : undefined;
+  const eventIssueUrlParts = eventIssueUrlRaw !== undefined ? extractUrlParts(eventIssueUrlRaw) : undefined;
+  const urlParts = issueLinkUrlParts ?? eventWebUrlParts ?? eventIssueUrlParts;
+  const issueId = issueObject !== null
+    ? readString(issueObject, 'id') ?? readString(event, 'issue_id') ?? urlParts?.issueId
+    : readString(event, 'issue_id') ?? urlParts?.issueId;
+  const issueUrl =
+    issueLinkUrlParts?.issueUrl
+    ?? eventWebUrlParts?.issueUrl
+    ?? eventIssueUrlParts?.issueUrl
+    ?? issueLinkRaw
+    ?? eventIssueUrlRaw;
   if (issueId === undefined || issueUrl === undefined) {
     return invalidMissingIssue();
   }
 
   const project = readProject(event['project'] ?? issueObject?.['project']);
+  const projectSlug =
+    project.projectSlug
+    ?? readString(event, 'project_slug')
+    ?? readString(event, 'project_name')
+    ?? project.projectId;
   const organizationSlug = urlParts?.organizationSlug;
-  if (organizationSlug === undefined || project.projectSlug === undefined) {
+  if (organizationSlug === undefined || projectSlug === undefined) {
     return err({
       code: 'INVALID_PAYLOAD',
       message: 'Sentry webhook payload did not include organization or project identity',
@@ -166,7 +185,7 @@ function parseEventAlertWebhook(payload: unknown): Result<NormalizedSentryIssueE
     resource: 'event_alert',
     action: readAction(payload),
     organizationSlug,
-    projectSlug: project.projectSlug,
+    projectSlug,
     projectId: project.projectId,
     issueId,
     issueShortId: issueObject !== null


### PR DESCRIPTION
## Summary

- Fix code-agent normalization for Sentry Integration Platform issue-alert `event_alert` payloads that contain `data.event.issue_id`, `data.event.issue_url`, `data.event.web_url`, and numeric `data.event.project`.
- Preserve organization issue URLs from `sentry.io/organizations/...` so generated Sentry tasks link to the canonical issue page.
- Add regression coverage for the production-shaped Sentry notification payload.

## Production Evidence

- Sentry reached production at `POST /api/code/webhooks/sentry` on `2026-06-28T21:49:16Z` and `2026-06-28T21:51:12Z`; nginx recorded `400` responses.
- code-agent logged `Received Sentry webhook event` for both deliveries with `Sentry-Hook-Resource: event_alert`.
- Firestore had `0` recent `sentry-issue-events` records and `0` recent `agentType: sentry` code tasks after the notification, confirming the webhook died before audit/task creation.
- Sentry issue-alert docs define `event_alert` payloads with `data.event.issue_id` and `data.event.issue_url`: https://docs.sentry.io/integrations/integration-platform/webhooks/issue-alerts/

## Verification

- `pnpm --filter @intexuraos/code-agent test -- src/__tests__/infra/sentry-event-parser.test.ts`
- `pnpm --filter @intexuraos/code-agent typecheck`
- `pnpm run ci:tracked` before commit
- `pnpm run ci:tracked` after rebase with `origin/development`

## Linear

Linear: omitted by `$commit-push`; GitHub automation will create or link the Linear issue after PR creation.

---

- Linear: [INT-1720](https://linear.app/pbuchman/issue/INT-1720)
- IntexuraOS Code Task: [View task](https://intexuraos.cloud/#/code-tasks/task_ae9faff9-7725-48e2-ade3-a3af9264edb7)
- Worker Type: `mimo-pro`
- Model: `mimo-v2.5-pro`