### PR TITLE
[INT-1758] Filter Sentry webhook task creation

### DIFF
--- a/apps/code-agent/src/__tests__/infra/firestore/sentryIssueEventRepository.test.ts
+++ b/apps/code-agent/src/__tests__/infra/firestore/sentryIssueEventRepository.test.ts
@@ -43,7 +43,13 @@ describe('createFirestoreSentryIssueEventRepository', () => {
 
   it('creates a deterministic dedupe key for a Sentry issue', () => {
     expect(createSentryIssueDedupeKey(buildEvent())).toBe(
-      'sentry:intexuraos-dev-pbuchman:intexuraos-development:4509001'
+      'sentry:intexuraos-dev-pbuchman:intexuraos-development:4509001:issue:created'
+    );
+  });
+
+  it('uses unknown for blank action dedupe key segments', () => {
+    expect(createSentryIssueDedupeKey(buildEvent({ action: '   ' }))).toBe(
+      'sentry:intexuraos-dev-pbuchman:intexuraos-development:4509001:issue:unknown'
     );
   });
 
@@ -65,7 +71,7 @@ describe('createFirestoreSentryIssueEventRepository', () => {
       expect(result.value).toEqual({
         created: true,
         record: expect.objectContaining({
-          dedupeKey: 'sentry:intexuraos-dev-pbuchman:intexuraos-development:4509001',
+          dedupeKey: 'sentry:intexuraos-dev-pbuchman:intexuraos-development:4509001:issue:created',
           organizationSlug: 'intexuraos-dev-pbuchman',
           projectSlug: 'intexuraos-development',
           projectId: '100',
@@ -132,13 +138,13 @@ describe('createFirestoreSentryIssueEventRepository', () => {
     expect(first.ok && first.value.created).toBe(true);
 
     await repo.markCodeTaskCreated({
-      dedupeKey: 'sentry:intexuraos-dev-pbuchman:intexuraos-development:4509001',
+      dedupeKey: 'sentry:intexuraos-dev-pbuchman:intexuraos-development:4509001:issue:created',
       codeTaskId: 'task_sentry',
       linearIssueId: 'INT-200',
     });
 
     const second = await repo.reserve({
-      event: buildEvent({ action: 'triggered', resource: 'event_alert', eventId: 'event-1' }),
+      event: buildEvent({ issueTitle: 'Updated title' }),
       receivedAt: secondReceivedAt,
       payload: { delivery: 2 },
     });
@@ -148,16 +154,53 @@ describe('createFirestoreSentryIssueEventRepository', () => {
       expect(second.value).toEqual({
         created: false,
         record: expect.objectContaining({
-          dedupeKey: 'sentry:intexuraos-dev-pbuchman:intexuraos-development:4509001',
+          dedupeKey: 'sentry:intexuraos-dev-pbuchman:intexuraos-development:4509001:issue:created',
           codeTaskId: 'task_sentry',
           linearIssueId: 'INT-200',
-          action: 'triggered',
-          resource: 'event_alert',
-          eventId: 'event-1',
+          action: 'created',
+          resource: 'issue',
+          eventId: undefined,
           receivedAt: firstReceivedAt,
           latestReceivedAt: secondReceivedAt,
           duplicateCount: 1,
           payload: { delivery: 2 },
+        }),
+      });
+    }
+  });
+
+  it('reserves regressed Sentry issues separately from the prior created occurrence', async () => {
+    const repo = createFirestoreSentryIssueEventRepository({
+      firestore: fakeFirestore as unknown as Firestore,
+      logger: pino({ level: 'silent' }),
+    });
+    const firstReceivedAt = new Date('2026-06-28T10:00:00.000Z');
+    const secondReceivedAt = new Date('2026-06-28T11:00:00.000Z');
+
+    const created = await repo.reserve({
+      event: buildEvent({ action: 'created' }),
+      receivedAt: firstReceivedAt,
+      payload: { delivery: 1 },
+    });
+    expect(created.ok && created.value.created).toBe(true);
+
+    const regressed = await repo.reserve({
+      event: buildEvent({ action: 'regressed', status: 'regressed' }),
+      receivedAt: secondReceivedAt,
+      payload: { delivery: 2 },
+    });
+
+    expect(regressed.ok).toBe(true);
+    if (regressed.ok) {
+      expect(regressed.value).toEqual({
+        created: true,
+        record: expect.objectContaining({
+          dedupeKey: 'sentry:intexuraos-dev-pbuchman:intexuraos-development:4509001:issue:regressed',
+          action: 'regressed',
+          status: 'regressed',
+          duplicateCount: 0,
+          receivedAt: secondReceivedAt,
+          latestReceivedAt: secondReceivedAt,
         }),
       });
     }
@@ -231,7 +274,7 @@ describe('createFirestoreSentryIssueEventRepository', () => {
     expect(reserved.ok).toBe(true);
 
     const result = await repo.markCodeTaskCreated({
-      dedupeKey: 'sentry:intexuraos-dev-pbuchman:intexuraos-development:4509001',
+      dedupeKey: 'sentry:intexuraos-dev-pbuchman:intexuraos-development:4509001:issue:created',
       codeTaskId: 'task_sentry',
     });
 

--- a/apps/code-agent/src/__tests__/routes/webhooks/sentry.test.ts
+++ b/apps/code-agent/src/__tests__/routes/webhooks/sentry.test.ts
@@ -40,6 +40,7 @@ function sign(rawBody: string): string {
 describe('POST /webhooks/sentry', () => {
   let app: FastifyInstance;
   let codeTaskCreate: ReturnType<typeof vi.fn>;
+  let sentryIssueEventReserve: ReturnType<typeof vi.fn>;
 
   beforeEach(async () => {
     process.env['INTEXURAOS_SENTRY_WEBHOOK_SECRET'] = WEBHOOK_SECRET;
@@ -50,16 +51,17 @@ describe('POST /webhooks/sentry', () => {
       id: input['id'],
       ...input,
     }));
+    sentryIssueEventReserve = vi.fn().mockResolvedValue(ok({
+      created: true,
+      record: {
+        dedupeKey: 'sentry:intexuraos-dev-pbuchman:intexuraos-development:4509001:issue:created',
+        duplicateCount: 0,
+      },
+    }));
     setServices({
       logger: pino({ level: 'silent' }),
       sentryIssueEventRepo: {
-        reserve: vi.fn().mockResolvedValue(ok({
-          created: true,
-          record: {
-            dedupeKey: 'sentry:intexuraos-dev-pbuchman:intexuraos-development:4509001',
-            duplicateCount: 0,
-          },
-        })),
+        reserve: sentryIssueEventReserve,
         markCodeTaskCreated: vi.fn().mockResolvedValue(ok(undefined)),
       },
       workerSettingsRepo: {
@@ -179,6 +181,33 @@ describe('POST /webhooks/sentry', () => {
         message: 'Sentry webhook payload did not include an issue id or issue URL',
       },
     }));
+    expect(codeTaskCreate).not.toHaveBeenCalled();
+  });
+
+  it('returns 200 ignored for signed Sentry lifecycle cleanup events without reserving dedupe state', async () => {
+    const body = buildIssueBody();
+    body['action'] = 'resolved';
+    const rawBody = JSON.stringify(body);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/webhooks/sentry',
+      headers: {
+        'content-type': 'application/json',
+        'sentry-hook-resource': 'issue',
+        'sentry-hook-signature': sign(rawBody),
+      },
+      payload: rawBody,
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.body)).toEqual({
+      success: true,
+      data: {
+        message: 'Ignored non-actionable Sentry issue event: issue.resolved',
+      },
+    });
+    expect(sentryIssueEventReserve).not.toHaveBeenCalled();
     expect(codeTaskCreate).not.toHaveBeenCalled();
   });
 

--- a/apps/code-agent/src/__tests__/usecases/processSentryWebhook.test.ts
+++ b/apps/code-agent/src/__tests__/usecases/processSentryWebhook.test.ts
@@ -49,6 +49,43 @@ function buildEventAlertBody(): Record<string, unknown> {
   };
 }
 
+function buildResolvedEventAlertBody(): Record<string, unknown> {
+  return {
+    action: 'triggered',
+    data: {
+      event: {
+        event_id: 'event-resolved',
+        title: 'Resolved issue',
+        issue: {
+          id: '4509003',
+          title: 'Resolved issue',
+          status: 'resolved',
+          url: 'https://intexuraos-dev-pbuchman.sentry.io/issues/4509003/',
+          project: {
+            slug: 'intexuraos-web-development',
+          },
+        },
+      },
+    },
+  };
+}
+
+function buildSampleEventAlertBody(): Record<string, unknown> {
+  return {
+    action: 'triggered',
+    data: {
+      event: {
+        event_id: 'sample-event',
+        project: 4510702691024976,
+        title: 'This is an example node-fastify exception',
+        web_url: 'https://sentry.io/organizations/intexuraos/issues/1117540176/events/sample-event/',
+        issue_url: 'https://sentry.io/api/0/issues/1117540176/',
+        issue_id: '1117540176',
+      },
+    },
+  };
+}
+
 function signBody(body: unknown): { rawBody: Buffer; signatureHeader: string } {
   const rawBody = Buffer.from(JSON.stringify(body), 'utf-8');
   const signatureHeader = createHmac('sha256', WEBHOOK_SECRET).update(rawBody).digest('hex');
@@ -71,7 +108,7 @@ function installMocks(overrides: Partial<MocksShape> = {}): MocksShape {
     reserve: vi.fn().mockResolvedValue(ok({
       created: true,
       record: {
-        dedupeKey: 'sentry:intexuraos-dev-pbuchman:intexuraos-development:4509001',
+        dedupeKey: 'sentry:intexuraos-dev-pbuchman:intexuraos-development:4509001:issue:created',
         organizationSlug: 'intexuraos-dev-pbuchman',
         projectSlug: 'intexuraos-development',
         issueId: '4509001',
@@ -229,7 +266,7 @@ describe('processSentryWebhook', () => {
       userId: AUTOMATION_USER_ID,
     });
     expect(mocks.sentryIssueEventRepo.markCodeTaskCreated).toHaveBeenCalledWith({
-      dedupeKey: 'sentry:intexuraos-dev-pbuchman:intexuraos-development:4509001',
+      dedupeKey: 'sentry:intexuraos-dev-pbuchman:intexuraos-development:4509001:issue:created',
       codeTaskId: expect.stringMatching(/^task_/),
       linearIssueId: 'INT-200',
     });
@@ -242,7 +279,7 @@ describe('processSentryWebhook', () => {
         reserve: vi.fn().mockResolvedValue(ok({
           created: false,
           record: {
-            dedupeKey: 'sentry:intexuraos-dev-pbuchman:intexuraos-development:4509001',
+            dedupeKey: 'sentry:intexuraos-dev-pbuchman:intexuraos-development:4509001:issue:created',
             codeTaskId: 'task_existing',
             linearIssueId: 'INT-200',
           },
@@ -264,6 +301,77 @@ describe('processSentryWebhook', () => {
     expect(mocks.taskEnqueueService.enqueue).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ['resolved'],
+    ['ignored'],
+    ['muted'],
+    ['assigned'],
+    ['unassigned'],
+    ['archived'],
+    ['deleted'],
+    ['unknown'],
+  ])('ignores non-actionable issue.%s deliveries without reserving dedupe state', async (action) => {
+    const body = buildIssueBody();
+    body['action'] = action;
+
+    const result = await processSentryWebhook(buildInput({ body }));
+
+    expect(result).toEqual({
+      ok: true,
+      outcome: 'ignored',
+      message: `Ignored non-actionable Sentry issue event: issue.${action}`,
+    });
+    expect(mocks.sentryIssueEventRepo.reserve).not.toHaveBeenCalled();
+    expect(mocks.linearIssueService.ensureIssueExists).not.toHaveBeenCalled();
+    expect(mocks.codeTaskRepo.create).not.toHaveBeenCalled();
+  });
+
+  it('ignores normalized issue deliveries with blank actions as unknown without reserving dedupe state', async () => {
+    const result = await processSentryWebhook(buildInput({
+      parseIssueEvent: () => ok({
+        resource: 'issue',
+        action: '   ',
+        organizationSlug: 'intexuraos-dev-pbuchman',
+        projectSlug: 'intexuraos-development',
+        projectId: '100',
+        issueId: '4509001',
+        issueShortId: 'INTEXURAOS-DEVELOPMENT-7',
+        issueTitle: 'TypeError: Cannot read properties of undefined',
+        issueUrl: 'https://intexuraos-dev-pbuchman.sentry.io/issues/4509001/',
+        status: 'unresolved',
+        eventId: undefined,
+      }),
+    }));
+
+    expect(result).toEqual({
+      ok: true,
+      outcome: 'ignored',
+      message: 'Ignored non-actionable Sentry issue event: issue.unknown',
+    });
+    expect(mocks.sentryIssueEventRepo.reserve).not.toHaveBeenCalled();
+    expect(mocks.codeTaskRepo.create).not.toHaveBeenCalled();
+  });
+
+  it('creates a task for issue.unresolved as Sentry reopen semantics', async () => {
+    const body = buildIssueBody();
+    body['action'] = 'unresolved';
+
+    const result = await processSentryWebhook(buildInput({ body }));
+
+    expect(result.ok).toBe(true);
+    if (!result.ok || result.outcome !== 'processed') {
+      throw new Error('Expected Sentry issue.unresolved webhook to be processed');
+    }
+    expect(mocks.sentryIssueEventRepo.reserve).toHaveBeenCalledWith(expect.objectContaining({
+      event: expect.objectContaining({
+        resource: 'issue',
+        action: 'unresolved',
+        issueId: '4509001',
+      }),
+    }));
+    expect(mocks.codeTaskRepo.create).toHaveBeenCalledTimes(1);
+  });
+
   it('creates a queued task for event_alert webhooks and carries the event id', async () => {
     const result = await processSentryWebhook(buildInput({
       body: buildEventAlertBody(),
@@ -282,6 +390,54 @@ describe('processSentryWebhook', () => {
         eventId: 'event-4509002',
       }),
     }));
+  });
+
+  it('ignores event_alert.triggered deliveries for terminal Sentry issues before reservation', async () => {
+    const result = await processSentryWebhook(buildInput({
+      body: buildResolvedEventAlertBody(),
+      resourceHeader: 'event_alert',
+    }));
+
+    expect(result).toEqual({
+      ok: true,
+      outcome: 'ignored',
+      message: 'Ignored non-actionable Sentry issue event: event_alert.triggered',
+    });
+    expect(mocks.sentryIssueEventRepo.reserve).not.toHaveBeenCalled();
+    expect(mocks.codeTaskRepo.create).not.toHaveBeenCalled();
+  });
+
+  it('ignores event_alert deliveries that are not triggered actions before reservation', async () => {
+    const body = buildEventAlertBody();
+    body['action'] = 'resolved';
+
+    const result = await processSentryWebhook(buildInput({
+      body,
+      resourceHeader: 'event_alert',
+    }));
+
+    expect(result).toEqual({
+      ok: true,
+      outcome: 'ignored',
+      message: 'Ignored non-actionable Sentry issue event: event_alert.resolved',
+    });
+    expect(mocks.sentryIssueEventRepo.reserve).not.toHaveBeenCalled();
+    expect(mocks.codeTaskRepo.create).not.toHaveBeenCalled();
+  });
+
+  it('ignores Sentry event_alert sample deliveries before reservation', async () => {
+    const result = await processSentryWebhook(buildInput({
+      body: buildSampleEventAlertBody(),
+      resourceHeader: 'event_alert',
+    }));
+
+    expect(result).toEqual({
+      ok: true,
+      outcome: 'ignored',
+      message: 'Ignored Sentry sample event_alert delivery',
+    });
+    expect(mocks.sentryIssueEventRepo.reserve).not.toHaveBeenCalled();
+    expect(mocks.codeTaskRepo.create).not.toHaveBeenCalled();
   });
 
   it('ignores unsupported Sentry webhook resources without reserving an event', async () => {
@@ -331,7 +487,7 @@ describe('processSentryWebhook', () => {
         reserve: vi.fn().mockResolvedValue(ok({
           created: false,
           record: {
-            dedupeKey: 'sentry:intexuraos-dev-pbuchman:intexuraos-development:4509001',
+            dedupeKey: 'sentry:intexuraos-dev-pbuchman:intexuraos-development:4509001:issue:created',
           },
         })),
         markCodeTaskCreated: vi.fn(),
@@ -498,7 +654,7 @@ describe('processSentryWebhook', () => {
         reserve: vi.fn().mockResolvedValue(ok({
           created: true,
           record: {
-            dedupeKey: 'sentry:intexuraos-dev-pbuchman:intexuraos-development:4509001',
+            dedupeKey: 'sentry:intexuraos-dev-pbuchman:intexuraos-development:4509001:issue:created',
             duplicateCount: 0,
           },
         })),

--- a/apps/code-agent/src/domain/usecases/processSentryWebhook.ts
+++ b/apps/code-agent/src/domain/usecases/processSentryWebhook.ts
@@ -13,6 +13,8 @@ import { generateWebhookSecret } from '../utils/secrets.js';
 import { resolveDefaultWorkerType } from '../utils/defaultWorkerTypeResolution.js';
 
 const SYSTEM_PROMPT_HASH_PLACEHOLDER = 'sentry-agent-system-prompt-v1';
+const ACTIONABLE_ISSUE_ACTIONS = new Set(['created', 'regressed', 'unresolved', 'reopened']);
+const TERMINAL_ISSUE_STATUSES = new Set(['resolved', 'ignored', 'muted', 'archived', 'deleted']);
 
 export type VerifySentrySignature = (payload: Buffer, signature: string, secret: string) => boolean;
 export type ParseSentryIssueEvent = (
@@ -73,6 +75,58 @@ function toTaskContext(event: NormalizedSentryIssueEvent, receivedAt: Date): Sen
   };
 }
 
+function normalizeToken(value: string | undefined): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const normalized = value.trim().toLowerCase();
+  return normalized === '' ? undefined : normalized;
+}
+
+function isTerminalIssueStatus(event: NormalizedSentryIssueEvent): boolean {
+  const status = normalizeToken(event.status);
+  return status !== undefined && TERMINAL_ISSUE_STATUSES.has(status);
+}
+
+function isSentrySampleEventAlert(event: NormalizedSentryIssueEvent): boolean {
+  const title = event.issueTitle.trim().toLowerCase();
+  return title.startsWith('this is an example ')
+    || title.includes('sentry sample')
+    || title.includes('sample event')
+    || title.includes('test event');
+}
+
+function classifySentryIssueEvent(event: NormalizedSentryIssueEvent):
+  | { actionable: true }
+  | { actionable: false; message: string } {
+  const action = normalizeToken(event.action) ?? 'unknown';
+  if (event.resource === 'issue') {
+    if (ACTIONABLE_ISSUE_ACTIONS.has(action)) {
+      return { actionable: true };
+    }
+    return {
+      actionable: false,
+      message: `Ignored non-actionable Sentry issue event: issue.${action}`,
+    };
+  }
+
+  if (action !== 'triggered' || isTerminalIssueStatus(event)) {
+    return {
+      actionable: false,
+      message: `Ignored non-actionable Sentry issue event: event_alert.${action}`,
+    };
+  }
+
+  if (isSentrySampleEventAlert(event)) {
+    return {
+      actionable: false,
+      message: 'Ignored Sentry sample event_alert delivery',
+    };
+  }
+
+  return { actionable: true };
+}
+
 export async function processSentryWebhook(
   input: ProcessSentryWebhookInput
 ): Promise<ProcessSentryWebhookResult> {
@@ -110,6 +164,11 @@ export async function processSentryWebhook(
       return { ok: true, outcome: 'ignored', message: parsed.error.message };
     }
     return { ok: false, reason: 'invalid_payload', message: parsed.error.message };
+  }
+
+  const classification = classifySentryIssueEvent(parsed.value);
+  if (!classification.actionable) {
+    return { ok: true, outcome: 'ignored', message: classification.message };
   }
 
   const { sentryIssueEventRepo, workerSettingsRepo, linearIssueService, codeTaskRepo, taskEnqueueService } =

--- a/apps/code-agent/src/infra/firestore/sentryIssueEventRepository.ts
+++ b/apps/code-agent/src/infra/firestore/sentryIssueEventRepository.ts
@@ -105,7 +105,8 @@ function toFirestoreDoc(input: {
 }
 
 export function createSentryIssueDedupeKey(event: NormalizedSentryIssueEvent): string {
-  return `sentry:${event.organizationSlug}:${event.projectSlug}:${event.issueId}`;
+  const action = event.action.trim().toLowerCase() || 'unknown';
+  return `sentry:${event.organizationSlug}:${event.projectSlug}:${event.issueId}:${event.resource}:${action}`;
 }
 
 function firestoreError(error: unknown): SentryIssueEventRepositoryError {

--- a/docs/operations/sentry-code-task-automation.md
+++ b/docs/operations/sentry-code-task-automation.md
@@ -92,16 +92,24 @@ unset and the normal worker resolution fallback is desired for development.
 2. Code-agent verifies `Sentry-Hook-Signature`.
 3. Code-agent parses the Sentry org, project, issue ID, issue URL, title,
    action, event ID when present, and received time.
-4. Code-agent persists an audit/dedupe record in `sentry-issue-events`.
-5. Duplicate deliveries for the same Sentry issue return success without
-   creating another task.
-6. Code-agent creates or links the Linear issue for the Sentry issue.
-7. Code-agent queues a CodeTask with `agentType: "sentry"` and the configured
+4. Code-agent classifies the parsed delivery before reserving dedupe state.
+   `issue.created`, `issue.regressed`, `issue.unresolved`, `issue.reopened`,
+   and active `event_alert.triggered` deliveries are actionable. Lifecycle
+   cleanup, assignment, terminal, unknown, and Sentry sample/test deliveries
+   return `200` with an ignored message.
+5. Code-agent persists an audit/dedupe record in `sentry-issue-events` only for
+   actionable deliveries. Ignored deliveries do not reserve task dedupe state.
+6. Duplicate deliveries for the same Sentry issue transition return success
+   without creating another task. Later regressed or reopened transitions use a
+   separate dedupe key so a resolved issue can create a new task when it becomes
+   active again.
+7. Code-agent creates or links the Linear issue for the Sentry issue.
+8. Code-agent queues a CodeTask with `agentType: "sentry"` and the configured
    Sentry worker type.
-8. The orchestrator dispatches the worker with Linear and Sentry access.
-9. The worker fetches current Sentry issue details and recent events, attempts
+9. The orchestrator dispatches the worker with Linear and Sentry access.
+10. The worker fetches current Sentry issue details and recent events, attempts
    reproduction when feasible, and opens a PR.
-10. Completion is rejected unless the worker reports a PR URL and the outcome is
+11. Completion is rejected unless the worker reports a PR URL and the outcome is
     `fixed` or `suppressed`.
 
 The task final result records the PR URL, Sentry issue URL, Linear issue ID,
@@ -119,14 +127,16 @@ For a live smoke test:
 
 1. Use Sentry's test delivery or trigger an issue alert for a low-risk project.
 2. Confirm the Sentry integration delivery log shows a 2xx response.
-3. Confirm code-agent stores one `sentry-issue-events` record for the Sentry
-   issue.
-4. Confirm one Linear issue is created or linked.
-5. Confirm one queued CodeTask exists with `agentType: "sentry"`.
-6. Confirm the task worker type matches the automation user's
+3. Confirm Sentry test/sample deliveries return ignored and do not create a
+   `sentry-issue-events` record.
+4. Trigger an actionable delivery and confirm code-agent stores one
+   `sentry-issue-events` record for the Sentry issue transition.
+5. Confirm one Linear issue is created or linked.
+6. Confirm one queued CodeTask exists with `agentType: "sentry"`.
+7. Confirm the task worker type matches the automation user's
    `defaultSentryWorkerType`.
-7. Confirm the worker can fetch Sentry details using `SENTRY_AUTH_TOKEN`.
-8. Confirm successful completion includes a PR URL and a final outcome of
+8. Confirm the worker can fetch Sentry details using `SENTRY_AUTH_TOKEN`.
+9. Confirm successful completion includes a PR URL and a final outcome of
    `fixed` or `suppressed`.
 
 To test signature rejection locally, send the same payload with a bogus


### PR DESCRIPTION
## Summary

- Filter Sentry webhook deliveries before task dedupe so cleanup/sample events return ignored 200 responses without creating tasks.
- Scope Sentry issue dedupe keys to the webhook transition so regressed/reopened issues can create fresh tasks.

## Verification

- `pnpm run ci:tracked`

## Linear

Linear: omitted by `$commit-push`; GitHub automation will create or link the Linear issue after PR creation.