### PR TITLE
[INT-1759] Fix private WhatsApp media edge auth

### DIFF
--- a/docs/operations/hetzner-prod-runbook.md
+++ b/docs/operations/hetzner-prod-runbook.md
@@ -404,9 +404,11 @@ expected retained-GCP Pub/Sub push service accounts or the Cloud Scheduler
 service account.
 
 Private WhatsApp sync uses the same edge-auth path. The external bridge machine
-must call `POST https://intexuraos.cloud/internal/whatsapp/private/events` with
-a Google OIDC bearer token whose audience is `https://intexuraos.cloud` and
-whose email claim is
+must call both
+`POST https://intexuraos.cloud/internal/whatsapp/private/events` and
+`POST https://intexuraos.cloud/internal/whatsapp/private/media` with a Google
+OIDC bearer token whose audience is `https://intexuraos.cloud` and whose email
+claim is
 `intexuraos-wa-private-sync-dev@intexuraos-dev-pbuchman.iam.gserviceaccount.com`.
 The public `/api/whatsapp/internal/*` prefix is blocked and must not be used.
 

--- a/docs/setup/16-private-whatsapp-matrix-sync.md
+++ b/docs/setup/16-private-whatsapp-matrix-sync.md
@@ -47,6 +47,12 @@ Ingest URL:
 https://intexuraos.cloud/internal/whatsapp/private/events
 ```
 
+Media upload URL:
+
+```text
+https://intexuraos.cloud/internal/whatsapp/private/media
+```
+
 OIDC audience:
 
 ```text
@@ -64,6 +70,11 @@ The request body must include:
 - `sourceAccountId`
 - `deliveryMode`
 - `events`
+
+Image and audio events upload media bytes to
+`POST /internal/whatsapp/private/media` before the adapter posts the event batch
+to `POST /internal/whatsapp/private/events`. Both endpoints require the same
+private-sync service account OIDC identity.
 
 `sourceAccountId` is generated per user in `Settings > WhatsApp > Private WhatsApp Mirror`. The adapter may still send a legacy `userId` field, but IntexuraOS ignores it and resolves ownership from `whatsapp_private_accounts`.
 

--- a/scripts/__tests__/hetzner-runtime.test.ts
+++ b/scripts/__tests__/hetzner-runtime.test.ts
@@ -231,8 +231,11 @@ describe('Hetzner nginx runtime config', () => {
   it('requires edge OIDC verification for internal routes and injects trusted internal auth', () => {
     const config = readRequired(nginxConfigPath);
     const verifier = readRequired(jwtVerifierPath);
+    const hetznerMain = readRequired(terraformHetznerMainPath);
+    const runbook = readRequired(runbookPath);
 
     expect(config).toContain('access_by_lua_file /etc/nginx/lua/jwt-verify.lua;');
+    expect(config).toContain('client_max_body_size 25m;');
     expect(verifier).toContain('EXPECTED_AUD = "https://intexuraos.cloud"');
     expect(verifier).toContain('GLOBAL_ALLOWED_SERVICE_ACCOUNTS');
     expect(verifier).toContain('ROUTE_ALLOWED_SERVICE_ACCOUNTS');
@@ -283,9 +286,14 @@ describe('Hetzner nginx runtime config', () => {
       'intexuraos-wa-private-sync-dev@intexuraos-dev-pbuchman.iam.gserviceaccount.com'
     );
     expect(routeAllowlist).toContain('["/internal/whatsapp/private/events"]');
+    expect(routeAllowlist).toContain('["/internal/whatsapp/private/media"]');
     expect(routeAllowlist).toContain(
       'intexuraos-wa-private-sync-dev@intexuraos-dev-pbuchman.iam.gserviceaccount.com'
     );
+    expect(hetznerMain).toContain('"/internal/whatsapp/private/events"');
+    expect(hetznerMain).toContain('"/internal/whatsapp/private/media"');
+    expect(runbook).toContain('POST https://intexuraos.cloud/internal/whatsapp/private/events');
+    expect(runbook).toContain('POST https://intexuraos.cloud/internal/whatsapp/private/media');
 
     const allowFunction = verifier.slice(
       verifier.indexOf('local function is_service_account_allowed'),

--- a/scripts/hetzner/nginx/intexuraos.conf
+++ b/scripts/hetzner/nginx/intexuraos.conf
@@ -71,7 +71,7 @@ server {
     proxy_connect_timeout 10s;
     proxy_buffers 16 16k;
     proxy_buffer_size 32k;
-    client_max_body_size 20m;
+    client_max_body_size 25m;
 
     set $edge_internal_auth_token "";
     proxy_set_header X-Internal-Auth $edge_internal_auth_token;

--- a/scripts/hetzner/nginx/jwt-verify.lua
+++ b/scripts/hetzner/nginx/jwt-verify.lua
@@ -18,6 +18,9 @@ local ROUTE_ALLOWED_SERVICE_ACCOUNTS = {
   ["/internal/whatsapp/private/events"] = {
     ["intexuraos-wa-private-sync-dev@intexuraos-dev-pbuchman.iam.gserviceaccount.com"] = true,
   },
+  ["/internal/whatsapp/private/media"] = {
+    ["intexuraos-wa-private-sync-dev@intexuraos-dev-pbuchman.iam.gserviceaccount.com"] = true,
+  },
 }
 
 local opts = {

--- a/terraform/hetzner-prod/main.tf
+++ b/terraform/hetzner-prod/main.tf
@@ -71,6 +71,7 @@ locals {
     "/internal/merge-queue/tick"                        = "code-agent"
     "/internal/notifications/digest/run-yesterday"      = "mobile-notifications-service"
     "/internal/whatsapp/private/events"                 = "whatsapp-service"
+    "/internal/whatsapp/private/media"                  = "whatsapp-service"
     "/internal/whatsapp/pubsub/media-cleanup"           = "whatsapp-service"
     "/internal/whatsapp/pubsub/process-webhook"         = "whatsapp-service"
     "/internal/whatsapp/pubsub/send-message"            = "whatsapp-service"


### PR DESCRIPTION
## Summary

- Allow the private WhatsApp sync service account to call the private media upload edge route.
- Add `/internal/whatsapp/private/media` to the Hetzner route inventory and private sync docs.
- Align the Hetzner nginx upload body limit with the app/adapter 25 MB media limit.

## Verification

- `pnpm run ci:tracked`
- `pnpm run ci:tracked` after rebasing onto latest `origin/development`
- `terraform -chdir=terraform/hetzner-prod plan -target="terraform_data.bootstrap_prod[0]"`
- `terraform -chdir=terraform/hetzner-prod apply /tmp/intexuraos-hetzner-bootstrap-retry.tfplan`
- `terraform -chdir=terraform/hetzner-prod plan -refresh-only`
- `terraform -chdir=terraform/hetzner-prod apply /tmp/intexuraos-hetzner-refresh.tfplan`
- Live smoke: private-sync OIDC reaches `/internal/whatsapp/private/events` and `/internal/whatsapp/private/media` at the app layer
- Live health: `whatsapp-matrix-sync` running and `whatsapp-service` online after Terraform bootstrap reload

## Linear

Linear: omitted by $commit-push; GitHub automation will create or link the Linear issue after PR creation.
