### PR TITLE
[INT-1773] Fix duplicate Sentry code task creation

### DIFF
--- a/apps/code-agent/src/__tests__/infra/firestore/sentryIssueEventRepository.test.ts
+++ b/apps/code-agent/src/__tests__/infra/firestore/sentryIssueEventRepository.test.ts
@@ -10,6 +10,7 @@ import type { NormalizedSentryIssueEvent } from '../../../domain/models/sentryIs
 import {
   createFirestoreSentryIssueEventRepository,
   createSentryIssueDedupeKey,
+  createSentryProblemDedupeKey,
 } from '../../../infra/firestore/sentryIssueEventRepository.js';
 
 function buildEvent(overrides: Partial<NormalizedSentryIssueEvent> = {}): NormalizedSentryIssueEvent {
@@ -53,6 +54,28 @@ describe('createFirestoreSentryIssueEventRepository', () => {
     );
   });
 
+  it('creates the same problem task key for different issue ids with the same project and title', () => {
+    const firstKey = createSentryProblemDedupeKey(buildEvent({
+      issueId: '4509001',
+      action: 'created',
+      issueTitle: ' Failed to record task completion metric ',
+    }));
+    const secondKey = createSentryProblemDedupeKey(buildEvent({
+      issueId: '4509002',
+      action: 'regressed',
+      issueTitle: 'failed   to record task completion metric',
+    }));
+
+    expect(firstKey).toBe(secondKey);
+    expect(firstKey).toMatch(/^sentry-task:intexuraos-dev-pbuchman:intexuraos-development:/);
+  });
+
+  it('uses unknown for blank problem title task key fingerprints', () => {
+    expect(createSentryProblemDedupeKey(buildEvent({ issueTitle: '   ' }))).toBe(
+      createSentryProblemDedupeKey(buildEvent({ issueTitle: 'unknown' }))
+    );
+  });
+
   it('reserves a new Sentry issue event and persists audit fields', async () => {
     const repo = createFirestoreSentryIssueEventRepository({
       firestore: fakeFirestore as unknown as Firestore,
@@ -86,9 +109,45 @@ describe('createFirestoreSentryIssueEventRepository', () => {
           receivedAt,
           latestReceivedAt: receivedAt,
           duplicateCount: 0,
-          payload: { raw: true },
+          payload: '{"raw":true}',
         }),
       });
+    }
+  });
+
+  it('serializes raw payloads before storing them in Firestore audit records', async () => {
+    const repo = createFirestoreSentryIssueEventRepository({
+      firestore: fakeFirestore as unknown as Firestore,
+      logger: pino({ level: 'silent' }),
+    });
+
+    const result = await repo.reserve({
+      event: buildEvent(),
+      receivedAt: new Date('2026-06-28T10:00:00.000Z'),
+      payload: { '': [['nested', 'array']], raw: true },
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.record.payload).toBe('{"":[["nested","array"]],"raw":true}');
+    }
+  });
+
+  it('serializes undefined payloads as null before storing Firestore audit records', async () => {
+    const repo = createFirestoreSentryIssueEventRepository({
+      firestore: fakeFirestore as unknown as Firestore,
+      logger: pino({ level: 'silent' }),
+    });
+
+    const result = await repo.reserve({
+      event: buildEvent(),
+      receivedAt: new Date('2026-06-28T10:00:00.000Z'),
+      payload: undefined,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.record.payload).toBe('null');
     }
   });
 
@@ -163,7 +222,68 @@ describe('createFirestoreSentryIssueEventRepository', () => {
           receivedAt: firstReceivedAt,
           latestReceivedAt: secondReceivedAt,
           duplicateCount: 1,
-          payload: { delivery: 2 },
+          payload: '{"delivery":2}',
+        }),
+      });
+    }
+  });
+
+  it('returns an existing problem task reservation for a new issue id with the same problem title', async () => {
+    const repo = createFirestoreSentryIssueEventRepository({
+      firestore: fakeFirestore as unknown as Firestore,
+      logger: pino({ level: 'silent' }),
+    });
+    const firstReceivedAt = new Date('2026-06-28T10:00:00.000Z');
+    const secondReceivedAt = new Date('2026-06-28T11:00:00.000Z');
+    const firstEvent = buildEvent({
+      issueId: '4509001',
+      issueTitle: 'Failed to record task duration metric',
+    });
+    const secondEvent = buildEvent({
+      issueId: '4509002',
+      issueUrl: 'https://intexuraos-dev-pbuchman.sentry.io/issues/4509002/',
+      action: 'regressed',
+      resource: 'event_alert',
+      eventId: 'event-4509002',
+      issueTitle: 'failed   to record task duration metric',
+    });
+    const problemKey = createSentryProblemDedupeKey(firstEvent);
+
+    const first = await repo.reserveTaskForProblem({
+      event: firstEvent,
+      receivedAt: firstReceivedAt,
+      payload: { delivery: 1 },
+    });
+    expect(first.ok && first.value.created).toBe(true);
+
+    await repo.markCodeTaskCreated({
+      dedupeKey: problemKey,
+      codeTaskId: 'task_existing_problem',
+      linearIssueId: 'INT-200',
+    });
+
+    const second = await repo.reserveTaskForProblem({
+      event: secondEvent,
+      receivedAt: secondReceivedAt,
+      payload: { delivery: 2 },
+    });
+
+    expect(second.ok).toBe(true);
+    if (second.ok) {
+      expect(second.value).toEqual({
+        created: false,
+        record: expect.objectContaining({
+          dedupeKey: problemKey,
+          codeTaskId: 'task_existing_problem',
+          linearIssueId: 'INT-200',
+          issueId: '4509002',
+          action: 'regressed',
+          resource: 'event_alert',
+          eventId: 'event-4509002',
+          receivedAt: firstReceivedAt,
+          latestReceivedAt: secondReceivedAt,
+          duplicateCount: 1,
+          payload: '{"delivery":2}',
         }),
       });
     }

--- a/apps/code-agent/src/__tests__/routes/webhooks/sentry.test.ts
+++ b/apps/code-agent/src/__tests__/routes/webhooks/sentry.test.ts
@@ -41,6 +41,7 @@ describe('POST /webhooks/sentry', () => {
   let app: FastifyInstance;
   let codeTaskCreate: ReturnType<typeof vi.fn>;
   let sentryIssueEventReserve: ReturnType<typeof vi.fn>;
+  let sentryProblemReserve: ReturnType<typeof vi.fn>;
 
   beforeEach(async () => {
     process.env['INTEXURAOS_SENTRY_WEBHOOK_SECRET'] = WEBHOOK_SECRET;
@@ -58,10 +59,18 @@ describe('POST /webhooks/sentry', () => {
         duplicateCount: 0,
       },
     }));
+    sentryProblemReserve = vi.fn().mockResolvedValue(ok({
+      created: true,
+      record: {
+        dedupeKey: 'sentry-task:intexuraos-dev-pbuchman:intexuraos-development:task-problem',
+        duplicateCount: 0,
+      },
+    }));
     setServices({
       logger: pino({ level: 'silent' }),
       sentryIssueEventRepo: {
         reserve: sentryIssueEventReserve,
+        reserveTaskForProblem: sentryProblemReserve,
         markCodeTaskCreated: vi.fn().mockResolvedValue(ok(undefined)),
       },
       workerSettingsRepo: {
@@ -133,6 +142,12 @@ describe('POST /webhooks/sentry', () => {
     expect(codeTaskCreate).toHaveBeenCalledWith(expect.objectContaining({
       agentType: 'sentry',
       workerType: 'codex-xhigh',
+    }));
+    expect(sentryProblemReserve).toHaveBeenCalledWith(expect.objectContaining({
+      event: expect.objectContaining({
+        issueId: '4509001',
+        issueTitle: 'TypeError: Cannot read properties of undefined',
+      }),
     }));
   });
 
@@ -216,6 +231,7 @@ describe('POST /webhooks/sentry', () => {
       logger: pino({ level: 'silent' }),
       sentryIssueEventRepo: {
         reserve: vi.fn().mockResolvedValue(err({ code: 'FIRESTORE_ERROR', message: 'reserve failed' })),
+        reserveTaskForProblem: vi.fn(),
         markCodeTaskCreated: vi.fn(),
       },
     } as unknown as ServiceContainer);

--- a/apps/code-agent/src/__tests__/usecases/processSentryWebhook.test.ts
+++ b/apps/code-agent/src/__tests__/usecases/processSentryWebhook.test.ts
@@ -95,6 +95,7 @@ function signBody(body: unknown): { rawBody: Buffer; signatureHeader: string } {
 interface MocksShape {
   sentryIssueEventRepo: {
     reserve: ReturnType<typeof vi.fn>;
+    reserveTaskForProblem: ReturnType<typeof vi.fn>;
     markCodeTaskCreated: ReturnType<typeof vi.fn>;
   };
   workerSettingsRepo: { getSettings: ReturnType<typeof vi.fn> };
@@ -109,6 +110,22 @@ function installMocks(overrides: Partial<MocksShape> = {}): MocksShape {
       created: true,
       record: {
         dedupeKey: 'sentry:intexuraos-dev-pbuchman:intexuraos-development:4509001:issue:created',
+        organizationSlug: 'intexuraos-dev-pbuchman',
+        projectSlug: 'intexuraos-development',
+        issueId: '4509001',
+        issueUrl: 'https://intexuraos-dev-pbuchman.sentry.io/issues/4509001/',
+        issueTitle: 'TypeError: Cannot read properties of undefined',
+        action: 'created',
+        resource: 'issue',
+        receivedAt: new Date('2026-06-28T10:00:00.000Z'),
+        latestReceivedAt: new Date('2026-06-28T10:00:00.000Z'),
+        duplicateCount: 0,
+      },
+    })),
+    reserveTaskForProblem: vi.fn().mockResolvedValue(ok({
+      created: true,
+      record: {
+        dedupeKey: 'sentry-task:intexuraos-dev-pbuchman:intexuraos-development:task-problem',
         organizationSlug: 'intexuraos-dev-pbuchman',
         projectSlug: 'intexuraos-development',
         issueId: '4509001',
@@ -240,6 +257,15 @@ describe('processSentryWebhook', () => {
         issueTitle: 'TypeError: Cannot read properties of undefined',
       }),
     }));
+    expect(mocks.sentryIssueEventRepo.reserveTaskForProblem).toHaveBeenCalledWith(expect.objectContaining({
+      event: expect.objectContaining({
+        resource: 'issue',
+        organizationSlug: 'intexuraos-dev-pbuchman',
+        projectSlug: 'intexuraos-development',
+        issueId: '4509001',
+        issueTitle: 'TypeError: Cannot read properties of undefined',
+      }),
+    }));
     expect(mocks.linearIssueService.ensureIssueExists).toHaveBeenCalledWith({
       userId: AUTOMATION_USER_ID,
       taskPrompt: expect.stringContaining('https://intexuraos-dev-pbuchman.sentry.io/issues/4509001/'),
@@ -265,8 +291,13 @@ describe('processSentryWebhook', () => {
       taskId: expect.stringMatching(/^task_/),
       userId: AUTOMATION_USER_ID,
     });
-    expect(mocks.sentryIssueEventRepo.markCodeTaskCreated).toHaveBeenCalledWith({
+    expect(mocks.sentryIssueEventRepo.markCodeTaskCreated).toHaveBeenNthCalledWith(1, {
       dedupeKey: 'sentry:intexuraos-dev-pbuchman:intexuraos-development:4509001:issue:created',
+      codeTaskId: expect.stringMatching(/^task_/),
+      linearIssueId: 'INT-200',
+    });
+    expect(mocks.sentryIssueEventRepo.markCodeTaskCreated).toHaveBeenNthCalledWith(2, {
+      dedupeKey: 'sentry-task:intexuraos-dev-pbuchman:intexuraos-development:task-problem',
       codeTaskId: expect.stringMatching(/^task_/),
       linearIssueId: 'INT-200',
     });
@@ -284,6 +315,7 @@ describe('processSentryWebhook', () => {
             linearIssueId: 'INT-200',
           },
         })),
+        reserveTaskForProblem: vi.fn(),
         markCodeTaskCreated: vi.fn().mockResolvedValue(ok(undefined)),
       },
     });
@@ -297,8 +329,91 @@ describe('processSentryWebhook', () => {
       codeTaskId: 'task_existing',
     });
     expect(mocks.linearIssueService.ensureIssueExists).not.toHaveBeenCalled();
+    expect(mocks.sentryIssueEventRepo.reserveTaskForProblem).not.toHaveBeenCalled();
     expect(mocks.codeTaskRepo.create).not.toHaveBeenCalled();
     expect(mocks.taskEnqueueService.enqueue).not.toHaveBeenCalled();
+  });
+
+  it('does not create a task when the same Sentry problem already has a task for another issue id', async () => {
+    resetServices();
+    mocks = installMocks({
+      sentryIssueEventRepo: {
+        reserve: vi.fn().mockResolvedValue(ok({
+          created: true,
+          record: {
+            dedupeKey: 'sentry:intexuraos-dev-pbuchman:intexuraos-development:4509002:issue:created',
+            duplicateCount: 0,
+          },
+        })),
+        reserveTaskForProblem: vi.fn().mockResolvedValue(ok({
+          created: false,
+          record: {
+            dedupeKey: 'sentry-task:intexuraos-dev-pbuchman:intexuraos-development:task-problem',
+            codeTaskId: 'task_existing_problem',
+            linearIssueId: 'INT-200',
+          },
+        })),
+        markCodeTaskCreated: vi.fn().mockResolvedValue(ok(undefined)),
+      },
+    });
+
+    const result = await processSentryWebhook(buildInput());
+
+    expect(result).toEqual({
+      ok: true,
+      outcome: 'duplicate',
+      message: 'Sentry problem already has a code task',
+      codeTaskId: 'task_existing_problem',
+    });
+    expect(mocks.linearIssueService.ensureIssueExists).not.toHaveBeenCalled();
+    expect(mocks.codeTaskRepo.create).not.toHaveBeenCalled();
+    expect(mocks.taskEnqueueService.enqueue).not.toHaveBeenCalled();
+    expect(mocks.sentryIssueEventRepo.markCodeTaskCreated).not.toHaveBeenCalled();
+  });
+
+  it('returns internal_error when reserving the Sentry problem task fails', async () => {
+    resetServices();
+    mocks = installMocks({
+      sentryIssueEventRepo: {
+        reserve: vi.fn().mockResolvedValue(ok({
+          created: true,
+          record: {
+            dedupeKey: 'sentry:intexuraos-dev-pbuchman:intexuraos-development:4509001:issue:created',
+            duplicateCount: 0,
+          },
+        })),
+        reserveTaskForProblem: vi.fn().mockResolvedValue(err({
+          code: 'FIRESTORE_ERROR',
+          message: 'problem reserve failed',
+        })),
+        markCodeTaskCreated: vi.fn(),
+      },
+    });
+
+    const result = await processSentryWebhook(buildInput());
+
+    expect(result).toEqual({ ok: false, reason: 'internal_error', message: 'problem reserve failed' });
+    expect(mocks.linearIssueService.ensureIssueExists).not.toHaveBeenCalled();
+    expect(mocks.codeTaskRepo.create).not.toHaveBeenCalled();
+    expect(mocks.taskEnqueueService.enqueue).not.toHaveBeenCalled();
+  });
+
+  it('ignores Sentry automation self-alerts before reservation', async () => {
+    const body = buildIssueBody();
+    const data = body['data'] as { issue: { title: string } };
+    data.issue.title = 'Failed to record task completion metric';
+
+    const result = await processSentryWebhook(buildInput({ body }));
+
+    expect(result).toEqual({
+      ok: true,
+      outcome: 'ignored',
+      message: 'Ignored Sentry automation self-alert: Failed to record task completion metric',
+    });
+    expect(mocks.sentryIssueEventRepo.reserve).not.toHaveBeenCalled();
+    expect(mocks.sentryIssueEventRepo.reserveTaskForProblem).not.toHaveBeenCalled();
+    expect(mocks.linearIssueService.ensureIssueExists).not.toHaveBeenCalled();
+    expect(mocks.codeTaskRepo.create).not.toHaveBeenCalled();
   });
 
   it.each([
@@ -470,6 +585,7 @@ describe('processSentryWebhook', () => {
     mocks = installMocks({
       sentryIssueEventRepo: {
         reserve: vi.fn().mockResolvedValue(err({ code: 'FIRESTORE_ERROR', message: 'reserve failed' })),
+        reserveTaskForProblem: vi.fn(),
         markCodeTaskCreated: vi.fn(),
       },
     });
@@ -490,6 +606,7 @@ describe('processSentryWebhook', () => {
             dedupeKey: 'sentry:intexuraos-dev-pbuchman:intexuraos-development:4509001:issue:created',
           },
         })),
+        reserveTaskForProblem: vi.fn(),
         markCodeTaskCreated: vi.fn(),
       },
     });
@@ -658,6 +775,13 @@ describe('processSentryWebhook', () => {
             duplicateCount: 0,
           },
         })),
+        reserveTaskForProblem: vi.fn().mockResolvedValue(ok({
+          created: true,
+          record: {
+            dedupeKey: 'sentry-task:intexuraos-dev-pbuchman:intexuraos-development:task-problem',
+            duplicateCount: 0,
+          },
+        })),
         markCodeTaskCreated: vi.fn().mockResolvedValue(err({ code: 'FIRESTORE_ERROR', message: 'link failed' })),
       },
     });
@@ -665,5 +789,35 @@ describe('processSentryWebhook', () => {
     const result = await processSentryWebhook(buildInput());
 
     expect(result).toEqual({ ok: false, reason: 'internal_error', message: 'link failed' });
+  });
+
+  it('returns internal_error when linking the problem task record to the code task fails', async () => {
+    resetServices();
+    mocks = installMocks({
+      sentryIssueEventRepo: {
+        reserve: vi.fn().mockResolvedValue(ok({
+          created: true,
+          record: {
+            dedupeKey: 'sentry:intexuraos-dev-pbuchman:intexuraos-development:4509001:issue:created',
+            duplicateCount: 0,
+          },
+        })),
+        reserveTaskForProblem: vi.fn().mockResolvedValue(ok({
+          created: true,
+          record: {
+            dedupeKey: 'sentry-task:intexuraos-dev-pbuchman:intexuraos-development:task-problem',
+            duplicateCount: 0,
+          },
+        })),
+        markCodeTaskCreated: vi.fn()
+          .mockResolvedValueOnce(ok(undefined))
+          .mockResolvedValueOnce(err({ code: 'FIRESTORE_ERROR', message: 'problem link failed' })),
+      },
+    });
+
+    const result = await processSentryWebhook(buildInput());
+
+    expect(result).toEqual({ ok: false, reason: 'internal_error', message: 'problem link failed' });
+    expect(mocks.sentryIssueEventRepo.markCodeTaskCreated).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/code-agent/src/domain/repositories/sentryIssueEventRepository.ts
+++ b/apps/code-agent/src/domain/repositories/sentryIssueEventRepository.ts
@@ -15,6 +15,10 @@ export interface SentryIssueEventRepository {
     input: ReserveSentryIssueEventInput
   ): Promise<Result<ReserveSentryIssueEventResult, SentryIssueEventRepositoryError>>;
 
+  reserveTaskForProblem(
+    input: ReserveSentryIssueEventInput
+  ): Promise<Result<ReserveSentryIssueEventResult, SentryIssueEventRepositoryError>>;
+
   markCodeTaskCreated(input: {
     dedupeKey: string;
     codeTaskId: string;

--- a/apps/code-agent/src/domain/usecases/processSentryWebhook.ts
+++ b/apps/code-agent/src/domain/usecases/processSentryWebhook.ts
@@ -15,6 +15,17 @@ import { resolveDefaultWorkerType } from '../utils/defaultWorkerTypeResolution.j
 const SYSTEM_PROMPT_HASH_PLACEHOLDER = 'sentry-agent-system-prompt-v1';
 const ACTIONABLE_ISSUE_ACTIONS = new Set(['created', 'regressed', 'unresolved', 'reopened']);
 const TERMINAL_ISSUE_STATUSES = new Set(['resolved', 'ignored', 'muted', 'archived', 'deleted']);
+const SENTRY_AUTOMATION_SELF_ALERT_TITLES = new Set([
+  'failed to reserve sentry issue event',
+  'failed to record task completion metric',
+  'failed to record task duration metric',
+  'issue not found for comment',
+  'dispatch blocked by worker capability or health state',
+  'log upload failed, retrying',
+  'error: failed to upload log chunks after retries',
+  'code worker auth not ready',
+  'code worker auth not ready at startup',
+]);
 
 export type VerifySentrySignature = (payload: Buffer, signature: string, secret: string) => boolean;
 export type ParseSentryIssueEvent = (
@@ -83,17 +94,27 @@ function normalizeToken(value: string | undefined): string | undefined {
   return normalized === '' ? undefined : normalized;
 }
 
+function normalizeTitle(value: string): string {
+  return value.trim().toLowerCase().replace(/\s+/g, ' ');
+}
+
 function isTerminalIssueStatus(event: NormalizedSentryIssueEvent): boolean {
   const status = normalizeToken(event.status);
   return status !== undefined && TERMINAL_ISSUE_STATUSES.has(status);
 }
 
 function isSentrySampleEventAlert(event: NormalizedSentryIssueEvent): boolean {
-  const title = event.issueTitle.trim().toLowerCase();
+  const title = normalizeTitle(event.issueTitle);
   return title.startsWith('this is an example ')
     || title.includes('sentry sample')
     || title.includes('sample event')
     || title.includes('test event');
+}
+
+function isSentryAutomationSelfAlert(event: NormalizedSentryIssueEvent): boolean {
+  const title = normalizeTitle(event.issueTitle);
+  return SENTRY_AUTOMATION_SELF_ALERT_TITLES.has(title)
+    || title.startsWith('detected phantom summaries with no displayable tasks');
 }
 
 function classifySentryIssueEvent(event: NormalizedSentryIssueEvent):
@@ -171,6 +192,14 @@ export async function processSentryWebhook(
     return { ok: true, outcome: 'ignored', message: classification.message };
   }
 
+  if (isSentryAutomationSelfAlert(parsed.value)) {
+    return {
+      ok: true,
+      outcome: 'ignored',
+      message: `Ignored Sentry automation self-alert: ${parsed.value.issueTitle}`,
+    };
+  }
+
   const { sentryIssueEventRepo, workerSettingsRepo, linearIssueService, codeTaskRepo, taskEnqueueService } =
     getServices();
   if (sentryIssueEventRepo === undefined) {
@@ -196,6 +225,27 @@ export async function processSentryWebhook(
       message: 'Sentry issue already has a code task',
       ...(reserveResult.value.record.codeTaskId !== undefined && {
         codeTaskId: reserveResult.value.record.codeTaskId,
+      }),
+    };
+  }
+
+  const problemReserveResult = await sentryIssueEventRepo.reserveTaskForProblem({
+    event: parsed.value,
+    receivedAt,
+    payload: body,
+  });
+  if (!problemReserveResult.ok) {
+    logger.error({ error: problemReserveResult.error }, 'Failed to reserve Sentry problem task');
+    return { ok: false, reason: 'internal_error', message: problemReserveResult.error.message };
+  }
+
+  if (!problemReserveResult.value.created) {
+    return {
+      ok: true,
+      outcome: 'duplicate',
+      message: 'Sentry problem already has a code task',
+      ...(problemReserveResult.value.record.codeTaskId !== undefined && {
+        codeTaskId: problemReserveResult.value.record.codeTaskId,
       }),
     };
   }
@@ -283,6 +333,16 @@ export async function processSentryWebhook(
   if (!markResult.ok) {
     logger.error({ error: markResult.error, taskId: task.id }, 'Failed to link Sentry issue event to code task');
     return { ok: false, reason: 'internal_error', message: markResult.error.message };
+  }
+
+  const markProblemResult = await sentryIssueEventRepo.markCodeTaskCreated({
+    dedupeKey: problemReserveResult.value.record.dedupeKey,
+    codeTaskId: task.id,
+    linearIssueId: issueResult.linearIssueId,
+  });
+  if (!markProblemResult.ok) {
+    logger.error({ error: markProblemResult.error, taskId: task.id }, 'Failed to link Sentry problem task to code task');
+    return { ok: false, reason: 'internal_error', message: markProblemResult.error.message };
   }
 
   return {

--- a/apps/code-agent/src/infra/firestore/sentryIssueEventRepository.ts
+++ b/apps/code-agent/src/infra/firestore/sentryIssueEventRepository.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { err, getErrorMessage, ok, type Result } from '@intexuraos/common-core';
 import { Timestamp, type Firestore } from '@intexuraos/infra-firestore';
 import type { Logger } from 'pino';
@@ -109,6 +110,23 @@ export function createSentryIssueDedupeKey(event: NormalizedSentryIssueEvent): s
   return `sentry:${event.organizationSlug}:${event.projectSlug}:${event.issueId}:${event.resource}:${action}`;
 }
 
+function normalizeProblemTitle(title: string): string {
+  const normalized = title.trim().toLowerCase().replace(/\s+/g, ' ');
+  return normalized === '' ? 'unknown' : normalized;
+}
+
+export function createSentryProblemDedupeKey(event: NormalizedSentryIssueEvent): string {
+  const fingerprint = createHash('sha256')
+    .update(`${event.organizationSlug}\0${event.projectSlug}\0${normalizeProblemTitle(event.issueTitle)}`)
+    .digest('hex')
+    .slice(0, 32);
+  return `sentry-task:${event.organizationSlug}:${event.projectSlug}:${fingerprint}`;
+}
+
+function serializePayload(payload: unknown): string {
+  return JSON.stringify(payload ?? null);
+}
+
 function firestoreError(error: unknown): SentryIssueEventRepositoryError {
   return {
     code: 'FIRESTORE_ERROR',
@@ -123,69 +141,84 @@ export function createFirestoreSentryIssueEventRepository(deps: {
   const { firestore, logger } = deps;
   const collection = firestore.collection(COLLECTION_NAME);
 
+  async function reserveWithDedupeKey(
+    input: ReserveSentryIssueEventInput,
+    dedupeKey: string
+  ): Promise<Result<ReserveSentryIssueEventResult, SentryIssueEventRepositoryError>> {
+    try {
+      return await firestore.runTransaction(async (transaction) => {
+        const docRef = collection.doc(dedupeKey);
+        const snapshot = await transaction.get(docRef);
+        const payload = serializePayload(input.payload);
+        if (!snapshot.exists) {
+          const createdDoc = toFirestoreDoc({
+            dedupeKey,
+            event: input.event,
+            receivedAt: input.receivedAt,
+            latestReceivedAt: input.receivedAt,
+            duplicateCount: 0,
+            payload,
+          });
+          transaction.set(docRef, createdDoc);
+          return ok({
+            created: true,
+            record: toRecord(createdDoc),
+          });
+        }
+
+        const existing = snapshot.data() as SentryIssueEventDoc;
+        const duplicateCount = (typeof existing.duplicateCount === 'number' ? existing.duplicateCount : 0) + 1;
+        const merged: SentryIssueEventDoc = {
+          ...existing,
+          action: input.event.action,
+          resource: input.event.resource,
+          issueId: input.event.issueId,
+          issueTitle: input.event.issueTitle,
+          issueUrl: input.event.issueUrl,
+          projectId: input.event.projectId ?? null,
+          issueShortId: input.event.issueShortId ?? null,
+          status: input.event.status ?? null,
+          eventId: input.event.eventId ?? null,
+          latestReceivedAt: Timestamp.fromDate(input.receivedAt),
+          duplicateCount,
+          payload,
+        };
+        transaction.update(docRef, {
+          action: merged.action,
+          resource: merged.resource,
+          issueId: merged.issueId,
+          issueTitle: merged.issueTitle,
+          issueUrl: merged.issueUrl,
+          projectId: merged.projectId,
+          issueShortId: merged.issueShortId,
+          status: merged.status,
+          eventId: merged.eventId,
+          latestReceivedAt: merged.latestReceivedAt,
+          duplicateCount: merged.duplicateCount,
+          payload: merged.payload,
+        });
+        return ok({
+          created: false,
+          record: toRecord(merged),
+        });
+      });
+    } catch (error) {
+      logger.error({ error }, 'Failed to reserve Sentry issue event');
+      return err(firestoreError(error));
+    }
+  }
+
   return {
-    async reserve(
+    reserve(
       input: ReserveSentryIssueEventInput
     ): Promise<Result<ReserveSentryIssueEventResult, SentryIssueEventRepositoryError>> {
-      try {
-        return await firestore.runTransaction(async (transaction) => {
-          const dedupeKey = createSentryIssueDedupeKey(input.event);
-          const docRef = collection.doc(dedupeKey);
-          const snapshot = await transaction.get(docRef);
-          if (!snapshot.exists) {
-            const createdDoc = toFirestoreDoc({
-              dedupeKey,
-              event: input.event,
-              receivedAt: input.receivedAt,
-              latestReceivedAt: input.receivedAt,
-              duplicateCount: 0,
-              payload: input.payload,
-            });
-            transaction.set(docRef, createdDoc);
-            return ok({
-              created: true,
-              record: toRecord(createdDoc),
-            });
-          }
+      return reserveWithDedupeKey(input, createSentryIssueDedupeKey(input.event));
+    },
 
-          const existing = snapshot.data() as SentryIssueEventDoc;
-          const duplicateCount = (typeof existing.duplicateCount === 'number' ? existing.duplicateCount : 0) + 1;
-          const merged: SentryIssueEventDoc = {
-            ...existing,
-            action: input.event.action,
-            resource: input.event.resource,
-            issueTitle: input.event.issueTitle,
-            issueUrl: input.event.issueUrl,
-            projectId: input.event.projectId ?? null,
-            issueShortId: input.event.issueShortId ?? null,
-            status: input.event.status ?? null,
-            eventId: input.event.eventId ?? null,
-            latestReceivedAt: Timestamp.fromDate(input.receivedAt),
-            duplicateCount,
-            payload: input.payload,
-          };
-          transaction.update(docRef, {
-            action: merged.action,
-            resource: merged.resource,
-            issueTitle: merged.issueTitle,
-            issueUrl: merged.issueUrl,
-            projectId: merged.projectId,
-            issueShortId: merged.issueShortId,
-            status: merged.status,
-            eventId: merged.eventId,
-            latestReceivedAt: merged.latestReceivedAt,
-            duplicateCount: merged.duplicateCount,
-            payload: merged.payload,
-          });
-          return ok({
-            created: false,
-            record: toRecord(merged),
-          });
-        });
-      } catch (error) {
-        logger.error({ error }, 'Failed to reserve Sentry issue event');
-        return err(firestoreError(error));
-      }
+    reserveTaskForProblem(
+      input: ReserveSentryIssueEventInput
+    ): Promise<Result<ReserveSentryIssueEventResult, SentryIssueEventRepositoryError>> {
+      return reserveWithDedupeKey(input, createSentryProblemDedupeKey(input.event));
     },
 
     async markCodeTaskCreated(input): Promise<Result<SentryIssueEventRecord, SentryIssueEventRepositoryError>> {

--- a/docs/superpowers/plans/2026-06-29-sentry-task-dedupe.md
+++ b/docs/superpowers/plans/2026-06-29-sentry-task-dedupe.md
@@ -1,0 +1,75 @@
+# Sentry Task Dedupe Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop duplicate Sentry code tasks for the same underlying problem while preserving webhook audit records and leaving existing code tasks untouched.
+
+**Architecture:** Keep `sentry-issue-events` as the webhook audit ledger, but add a separate problem-level task reservation before Linear/code-task creation. Quarantine known code-agent/orchestrator control-plane self-alerts before any reservation so automation failures do not recursively create Sentry repair tasks.
+
+**Tech Stack:** TypeScript, Vitest, Fastify service DI, Firestore repository adapter, in-memory Firestore fakes.
+
+## Global Constraints
+
+- Do not cancel, delete, or mutate existing `code_tasks`.
+- Follow TDD: write failing tests, confirm failure, then implement.
+- Firestore investigations use `GOOGLE_APPLICATION_CREDENTIALS=$HOME/.config/gcloud/sa-key.json`.
+- Keep webhook audit behavior separate from task-creation behavior.
+- No new external dependencies.
+
+---
+
+### Task 1: Problem-Level Reservation Contract
+
+**Files:**
+- Modify: `apps/code-agent/src/domain/models/sentryIssueEvent.ts`
+- Modify: `apps/code-agent/src/domain/repositories/sentryIssueEventRepository.ts`
+- Modify: `apps/code-agent/src/infra/firestore/sentryIssueEventRepository.ts`
+- Test: `apps/code-agent/src/__tests__/infra/firestore/sentryIssueEventRepository.test.ts`
+
+**Interfaces:**
+- Produces `reserveTaskForProblem({ event, receivedAt, payload }): Result<ReserveSentryIssueEventResult, SentryIssueEventRepositoryError>`.
+- Reuses `markCodeTaskCreated({ dedupeKey, codeTaskId, linearIssueId })` for both audit and problem-lock records.
+- Produces `createSentryProblemDedupeKey(event)`.
+
+- [x] Write a failing repository test showing two different Sentry issue IDs with the same org/project/title reserve the same problem task key and return the first task once linked.
+- [x] Write a failing repository test showing issue/event_alert deliveries for the same problem share the same task key.
+- [x] Implement normalized problem-key generation.
+- [x] Store task locks in `sentry-issue-events` with `sentry-task:` doc IDs to avoid adding a collection and index.
+- [x] Run the repository test file and confirm it passes.
+
+### Task 2: Use Case Guarding
+
+**Files:**
+- Modify: `apps/code-agent/src/domain/usecases/processSentryWebhook.ts`
+- Test: `apps/code-agent/src/__tests__/usecases/processSentryWebhook.test.ts`
+
+**Interfaces:**
+- Consumes repository task reservation methods from Task 1.
+- Produces duplicate outcome before Linear/code-task creation when a problem-level reservation exists.
+
+- [x] Write a failing use-case test where an existing problem-level reservation prevents Linear/code-task/enqueue calls for a new Sentry issue ID with the same title.
+- [x] Write a failing use-case test where known automation self-alert titles are ignored before reservation.
+- [x] Call `reserveTaskForProblem` after webhook audit reservation and before worker settings/Linear/code-task creation.
+- [x] Link both the webhook audit record and the problem task record after task creation.
+- [x] Run the use-case test file and confirm it passes.
+
+### Task 3: Verification and Runtime Check
+
+**Files:**
+- No production file changes beyond Tasks 1-2.
+
+- [x] Run `pnpm --filter code-agent test -- src/__tests__/infra/firestore/sentryIssueEventRepository.test.ts src/__tests__/usecases/processSentryWebhook.test.ts src/__tests__/routes/webhooks/sentry.test.ts`.
+- [x] Run `pnpm run verify:workspace:tracked code-agent`.
+- [x] Run `pnpm run ci:tracked`.
+- [ ] Query Firestore read-only and confirm no active code task was killed or mutated by this local change.
+- [ ] Create a PR targeting `development`; do not merge until CI and review conditions are satisfied.
+
+## Endpoint Changes
+
+Modified: none.
+
+Created: none.
+
+Removed: none.
+
+Unchanged: `POST /api/code/webhooks/sentry` keeps the same request and response contract.


### PR DESCRIPTION
## Summary
- add a problem-level Sentry task reservation keyed by org/project/normalized title so repeat occurrences do not spawn parallel code tasks
- keep the existing event/action audit reservation and link both reservations to the created code task
- ignore known automation self-alerts before reservation so the integration does not create tasks for its own operational noise
- serialize raw webhook payloads consistently for Firestore audit records

## Verification
- pnpm --filter code-agent test -- src/__tests__/infra/firestore/sentryIssueEventRepository.test.ts src/__tests__/usecases/processSentryWebhook.test.ts src/__tests__/routes/webhooks/sentry.test.ts
- pnpm run verify:workspace:tracked code-agent
- pnpm run ci:tracked