### PR TITLE
INT-1774 INT-1775 Harden Sentry task dedupe

### DIFF
--- a/apps/code-agent/src/__tests__/domain/services/unifiedEvaluator/scoring.test.ts
+++ b/apps/code-agent/src/__tests__/domain/services/unifiedEvaluator/scoring.test.ts
@@ -65,7 +65,7 @@ describe('scoring/handleFallback', () => {
     expect(deps.dispatchService.dispatch).toHaveBeenCalled();
   });
 
-  it('logs warning when dispatch fails', async () => {
+  it('logs Sentry-suppressed warning when dispatch fails', async () => {
     const deps = createDeps({
       dispatchService: {
         dispatch: vi.fn().mockResolvedValue({ success: false, error: 'boom' }),
@@ -73,7 +73,7 @@ describe('scoring/handleFallback', () => {
     });
     await handleFallback(deps, createFakeEvent({ eventType: 'issue_comment' }), 'x', Date.now(), logger);
     expect(logger.warn).toHaveBeenCalledWith(
-      expect.objectContaining({ error: 'boom' }),
+      expect.objectContaining({ error: 'boom', _skipSentry: true }),
       'Dispatch failed for fallback decision',
     );
     expect(deps.eventDecisionRepo.save).toHaveBeenCalledWith(

--- a/apps/code-agent/src/__tests__/infra/firestore/sentryIssueEventRepository.test.ts
+++ b/apps/code-agent/src/__tests__/infra/firestore/sentryIssueEventRepository.test.ts
@@ -67,13 +67,23 @@ describe('createFirestoreSentryIssueEventRepository', () => {
     }));
 
     expect(firstKey).toBe(secondKey);
-    expect(firstKey).toMatch(/^sentry-task:intexuraos-dev-pbuchman:intexuraos-development:/);
+    expect(firstKey).toMatch(/^sentry-task:intexuraos-dev-pbuchman:100:/);
   });
 
   it('uses unknown for blank problem title task key fingerprints', () => {
     expect(createSentryProblemDedupeKey(buildEvent({ issueTitle: '   ' }))).toBe(
       createSentryProblemDedupeKey(buildEvent({ issueTitle: 'unknown' }))
     );
+  });
+
+  it('falls back to project slug for problem task keys when Sentry omits project id', () => {
+    const key = createSentryProblemDedupeKey(buildEvent({
+      projectId: undefined,
+      projectSlug: 'intexuraos-development',
+      issueTitle: 'Failed to record task completion metric',
+    }));
+
+    expect(key).toMatch(/^sentry-task:intexuraos-dev-pbuchman:intexuraos-development:/);
   });
 
   it('reserves a new Sentry issue event and persists audit fields', async () => {
@@ -284,6 +294,82 @@ describe('createFirestoreSentryIssueEventRepository', () => {
           latestReceivedAt: secondReceivedAt,
           duplicateCount: 1,
           payload: '{"delivery":2}',
+        }),
+      });
+    }
+  });
+
+  it('returns an existing problem task reservation when Sentry changes project slug shape for the same issue', async () => {
+    const repo = createFirestoreSentryIssueEventRepository({
+      firestore: fakeFirestore as unknown as Firestore,
+      logger: pino({ level: 'silent' }),
+    });
+    const firstReceivedAt = new Date('2026-06-29T01:19:18.085Z');
+    const secondReceivedAt = new Date('2026-06-29T01:19:29.105Z');
+    const firstEvent = buildEvent({
+      organizationSlug: 'piotr-buchman',
+      projectSlug: 'intexuraos-hetzner',
+      projectId: '4510702691024976',
+      issueId: '130876727',
+      issueShortId: 'INTEXURAOS-HETZNER-39',
+      issueTitle: 'Error: Failed to look up phone number for user',
+      issueUrl: 'https://piotr-buchman.sentry.io/issues/130876727/',
+      action: 'unresolved',
+      resource: 'issue',
+      status: 'unresolved',
+    });
+    const secondEvent = buildEvent({
+      organizationSlug: 'piotr-buchman',
+      projectSlug: '4510702691024976',
+      projectId: '4510702691024976',
+      issueId: '130876727',
+      issueShortId: undefined,
+      issueTitle: 'Error: Failed to look up phone number for user',
+      issueUrl: 'https://sentry.io/organizations/piotr-buchman/issues/130876727/',
+      action: 'triggered',
+      resource: 'event_alert',
+      status: undefined,
+      eventId: '6e36caa957e54c03963c63afccc684cb',
+    });
+    const problemKey = createSentryProblemDedupeKey(firstEvent);
+
+    expect(createSentryProblemDedupeKey(secondEvent)).toBe(problemKey);
+
+    const first = await repo.reserveTaskForProblem({
+      event: firstEvent,
+      receivedAt: firstReceivedAt,
+      payload: { delivery: 'issue' },
+    });
+    expect(first.ok && first.value.created).toBe(true);
+
+    await repo.markCodeTaskCreated({
+      dedupeKey: problemKey,
+      codeTaskId: 'task_existing_problem',
+      linearIssueId: 'INT-1775',
+    });
+
+    const second = await repo.reserveTaskForProblem({
+      event: secondEvent,
+      receivedAt: secondReceivedAt,
+      payload: { delivery: 'event-alert' },
+    });
+
+    expect(second.ok).toBe(true);
+    if (second.ok) {
+      expect(second.value).toEqual({
+        created: false,
+        record: expect.objectContaining({
+          dedupeKey: problemKey,
+          codeTaskId: 'task_existing_problem',
+          linearIssueId: 'INT-1775',
+          issueId: '130876727',
+          action: 'triggered',
+          resource: 'event_alert',
+          eventId: '6e36caa957e54c03963c63afccc684cb',
+          receivedAt: firstReceivedAt,
+          latestReceivedAt: secondReceivedAt,
+          duplicateCount: 1,
+          payload: '{"delivery":"event-alert"}',
         }),
       });
     }

--- a/apps/code-agent/src/__tests__/usecases/processSentryWebhook.test.ts
+++ b/apps/code-agent/src/__tests__/usecases/processSentryWebhook.test.ts
@@ -398,17 +398,20 @@ describe('processSentryWebhook', () => {
     expect(mocks.taskEnqueueService.enqueue).not.toHaveBeenCalled();
   });
 
-  it('ignores Sentry automation self-alerts before reservation', async () => {
+  it.each([
+    ['Failed to record task completion metric'],
+    ['Dispatch failed for fallback decision'],
+  ])('ignores Sentry automation self-alert %s before reservation', async (title) => {
     const body = buildIssueBody();
     const data = body['data'] as { issue: { title: string } };
-    data.issue.title = 'Failed to record task completion metric';
+    data.issue.title = title;
 
     const result = await processSentryWebhook(buildInput({ body }));
 
     expect(result).toEqual({
       ok: true,
       outcome: 'ignored',
-      message: 'Ignored Sentry automation self-alert: Failed to record task completion metric',
+      message: `Ignored Sentry automation self-alert: ${title}`,
     });
     expect(mocks.sentryIssueEventRepo.reserve).not.toHaveBeenCalled();
     expect(mocks.sentryIssueEventRepo.reserveTaskForProblem).not.toHaveBeenCalled();

--- a/apps/code-agent/src/domain/services/unifiedEvaluator/scoring.ts
+++ b/apps/code-agent/src/domain/services/unifiedEvaluator/scoring.ts
@@ -44,7 +44,7 @@ export async function handleFallback(
       logger,
     });
     if (!fallbackResult.success) {
-      logger.warn({ eventId: event.id, error: fallbackResult.error }, 'Dispatch failed for fallback decision');
+      logger.warn({ eventId: event.id, error: fallbackResult.error, _skipSentry: true }, 'Dispatch failed for fallback decision');
     }
     await recordDecision(deps, event, {
       decidedBy: 'hard_rules',

--- a/apps/code-agent/src/domain/usecases/processSentryWebhook.ts
+++ b/apps/code-agent/src/domain/usecases/processSentryWebhook.ts
@@ -21,6 +21,7 @@ const SENTRY_AUTOMATION_SELF_ALERT_TITLES = new Set([
   'failed to record task duration metric',
   'issue not found for comment',
   'dispatch blocked by worker capability or health state',
+  'dispatch failed for fallback decision',
   'log upload failed, retrying',
   'error: failed to upload log chunks after retries',
   'code worker auth not ready',

--- a/apps/code-agent/src/infra/firestore/sentryIssueEventRepository.ts
+++ b/apps/code-agent/src/infra/firestore/sentryIssueEventRepository.ts
@@ -115,12 +115,19 @@ function normalizeProblemTitle(title: string): string {
   return normalized === '' ? 'unknown' : normalized;
 }
 
+function getProblemProjectIdentity(event: NormalizedSentryIssueEvent): string {
+  const projectId = event.projectId?.trim();
+  if (projectId !== undefined && projectId !== '') return projectId;
+  return event.projectSlug.trim();
+}
+
 export function createSentryProblemDedupeKey(event: NormalizedSentryIssueEvent): string {
+  const projectIdentity = getProblemProjectIdentity(event);
   const fingerprint = createHash('sha256')
-    .update(`${event.organizationSlug}\0${event.projectSlug}\0${normalizeProblemTitle(event.issueTitle)}`)
+    .update(`${event.organizationSlug}\0${projectIdentity}\0${normalizeProblemTitle(event.issueTitle)}`)
     .digest('hex')
     .slice(0, 32);
-  return `sentry-task:${event.organizationSlug}:${event.projectSlug}:${fingerprint}`;
+  return `sentry-task:${event.organizationSlug}:${projectIdentity}:${fingerprint}`;
 }
 
 function serializePayload(payload: unknown): string {

--- a/workers/orchestrator/src/bootstrap/api-key-validator.ts
+++ b/workers/orchestrator/src/bootstrap/api-key-validator.ts
@@ -252,10 +252,7 @@ export async function validateWorkerApiKeys(
     // expected (tokens are refreshed on first use), so this warn is informational
     // and must not become alert noise. The Pino Sentry transport honors
     // `_skipSentry` and still writes the log to stdout for Cloud Logging.
-    logger.warn(
-      { state: claudeState, _skipSentry: true },
-      'Code worker auth not ready at startup'
-    );
+    logger.warn({ state: claudeState, _skipSentry: true }, 'Code worker auth not ready at startup');
   }
 
   const codexState = workerAuthRegistry.getState('codex');
@@ -270,10 +267,7 @@ export async function validateWorkerApiKeys(
     );
   } else {
     // Same rationale as Claude: do not page on an informational startup state.
-    logger.warn(
-      { state: codexState, _skipSentry: true },
-      'Codex worker auth not ready at startup'
-    );
+    logger.warn({ state: codexState, _skipSentry: true }, 'Codex worker auth not ready at startup');
   }
 
   // Validate all third-party API keys in parallel.


### PR DESCRIPTION
## Summary
- suppress the fallback-dispatch warning from Sentry and quarantine that self-alert before task reservation
- make Sentry problem-task dedupe prefer stable projectId over projectSlug, so issue webhooks and event_alert webhooks for the same project collapse to one reservation
- cover the live duplicate pattern where Sentry sends projectSlug=intexuraos-hetzner for the issue webhook and projectSlug=4510702691024976 for the event_alert webhook

Fixes INT-1774
Fixes INT-1775
Fixes INT-1778

## Verification
- RED: pnpm --filter code-agent test -- src/__tests__/infra/firestore/sentryIssueEventRepository.test.ts failed on the projectSlug/projectId mismatch
- GREEN: pnpm --filter code-agent test -- src/__tests__/infra/firestore/sentryIssueEventRepository.test.ts
- GREEN: pnpm run verify:workspace:tracked code-agent
- GREEN: pnpm run ci:tracked

## Runtime cleanup
- cancelled queued duplicate Sentry tasks task_f6a09a67-7251-41b9-8af4-5790b1ec4564 and task_2ce77f1b-35df-452f-b21e-8782029deb23 using an app-level no-op worker dispatcher; no Docker/container operation was performed
- left running duplicate tasks INT-1777/INT-1778 alone because they are already executing on home-dev and Docker containers must not be killed