### PR TITLE
INT-1782 INT-1783 INT-1784 INT-1785 Suppress Sentry self-alert fallbacks

### DIFF
--- a/apps/code-agent/src/__tests__/domain/useCases/handlePrClose.test.ts
+++ b/apps/code-agent/src/__tests__/domain/useCases/handlePrClose.test.ts
@@ -223,7 +223,7 @@ describe('handlePrClose (merged and closed-without-merge)', () => {
 
     expect(mockLinearIssueService.markQa).not.toHaveBeenCalled();
     expect(vi.mocked(mockLogger.warn)).toHaveBeenCalledWith(
-      expect.objectContaining({ linearIssueId: 'INT-1000' }),
+      expect.objectContaining({ linearIssueId: 'INT-1000', _skipSentry: true }),
       expect.stringContaining('resolve')
     );
   });
@@ -292,7 +292,7 @@ describe('handlePrClose (merged and closed-without-merge)', () => {
 
     expect(mockLinearIssueService.markQa).not.toHaveBeenCalled();
     expect(vi.mocked(mockLogger.warn)).toHaveBeenCalledWith(
-      expect.objectContaining({ linearIssueId: 'INT-1300' }),
+      expect.objectContaining({ linearIssueId: 'INT-1300', _skipSentry: true }),
       expect.stringContaining('resolve')
     );
   });

--- a/apps/code-agent/src/__tests__/domain/usecases/drainTaskQueue.test.ts
+++ b/apps/code-agent/src/__tests__/domain/usecases/drainTaskQueue.test.ts
@@ -1745,6 +1745,14 @@ describe('drainTaskQueue', () => {
         linearIssueId: 'INT-123',
       })
     );
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        linearIssueId: 'INT-123',
+        error: { code: 'UNAVAILABLE', message: 'Linear down' },
+        _skipSentry: true,
+      }),
+      'Failed to refresh Linear labels during drain'
+    );
   });
 
   it('does not call notifyTaskStarted when update fails', async () => {

--- a/apps/code-agent/src/__tests__/domain/usecases/triageFailedTask.test.ts
+++ b/apps/code-agent/src/__tests__/domain/usecases/triageFailedTask.test.ts
@@ -280,6 +280,10 @@ describe('triageFailedTask', () => {
       // so the persisted delay is exactly COOLOFF_FALLBACK_MS relative to that sample.
       expect(persisted.getTime() - before).toBeGreaterThanOrEqual(COOLOFF_FALLBACK_MS);
       expect(persisted.getTime() - after).toBeLessThanOrEqual(COOLOFF_FALLBACK_MS);
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ taskId: 'task_cooloff_badjson', _skipSentry: true }),
+        expect.stringContaining('Cooloff parser rejected LLM response')
+      );
     });
 
     it('falls back to derivedBy "fallback" when userServiceClient.getLlmClient errors and propagates known user timezone', async () => {
@@ -308,6 +312,10 @@ describe('triageFailedTask', () => {
         | undefined;
       expect(createInput?.dispatchSchedule?.['derivedBy']).toBe('fallback');
       expect(createInput?.dispatchSchedule?.['timezone']).toBe('America/New_York');
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ taskId: 'task_cooloff_nokey', _skipSentry: true }),
+        expect.stringContaining('User LLM unavailable')
+      );
     });
 
     it('still calls LLM with empty log lines when logLineRepo.listRecent returns err', async () => {
@@ -332,7 +340,7 @@ describe('triageFailedTask', () => {
       expect(result.action).toBe('retried_after_cooloff');
       expect(mockGenerate).toHaveBeenCalledOnce();
       expect(mockLogger.warn).toHaveBeenCalledWith(
-        expect.objectContaining({ taskId: 'task_cooloff_logfail' }),
+        expect.objectContaining({ taskId: 'task_cooloff_logfail', _skipSentry: true }),
         expect.stringContaining('Failed to fetch log lines for cooloff parsing')
       );
     });
@@ -364,7 +372,7 @@ describe('triageFailedTask', () => {
 
       expect(result.action).toBe('retried_after_cooloff');
       expect(mockLogger.warn).toHaveBeenCalledWith(
-        expect.objectContaining({ taskId: 'task_cooloff_tz_throw' }),
+        expect.objectContaining({ taskId: 'task_cooloff_tz_throw', _skipSentry: true }),
         expect.stringContaining('Failed to fetch user timezone')
       );
       const createInput = mockCodeTaskRepo.create.mock.calls[0]?.[0] as
@@ -397,7 +405,7 @@ describe('triageFailedTask', () => {
         | undefined;
       expect(createInput?.dispatchSchedule?.['derivedBy']).toBe('fallback');
       expect(mockLogger.warn).toHaveBeenCalledWith(
-        expect.objectContaining({ taskId: 'task_cooloff_gen_err' }),
+        expect.objectContaining({ taskId: 'task_cooloff_gen_err', _skipSentry: true }),
         expect.stringContaining('LLM cooloff call failed')
       );
     });

--- a/apps/code-agent/src/domain/usecases/drainTaskQueue.ts
+++ b/apps/code-agent/src/domain/usecases/drainTaskQueue.ts
@@ -12,6 +12,7 @@ import type { Logger } from '@intexuraos/common-core';
 import { Timestamp } from '@google-cloud/firestore';
 import type { UserServiceClient } from '@intexuraos/internal-clients';
 import type { LlmGenerateClient } from '@intexuraos/llm-factory';
+import { SKIP_SENTRY_KEY } from '@intexuraos/infra-sentry';
 import type { CodeTask, CodeTaskDispatchStatus } from '../models/codeTask.js';
 import type { CodeTaskRepository } from '../repositories/codeTaskRepository.js';
 import type { LogLineRepository } from '../repositories/logLineRepository.js';
@@ -724,7 +725,14 @@ export async function drainTaskQueue(
         hasChildren = validateResult.value.childCount > 0;
         linearIssueUuid = validateResult.value.id;
       } else {
-        logger.warn({ linearIssueId: task.linearIssueId }, 'Failed to refresh Linear labels during drain');
+        logger.warn(
+          {
+            linearIssueId: task.linearIssueId,
+            error: validateResult.error,
+            [SKIP_SENTRY_KEY]: true,
+          },
+          'Failed to refresh Linear labels during drain'
+        );
       }
     }
     // Step 4b: Fan-out check (INT-962) — if parent issue has children with code-task labels,

--- a/apps/code-agent/src/domain/usecases/handlePrClose.ts
+++ b/apps/code-agent/src/domain/usecases/handlePrClose.ts
@@ -18,6 +18,7 @@
  */
 
 import type { Logger } from '@intexuraos/common-core';
+import { SKIP_SENTRY_KEY } from '@intexuraos/infra-sentry';
 import type { CodeTaskRepository } from '../repositories/codeTaskRepository.js';
 import type { LinearIssueService } from '../services/linearIssueService.js';
 import type { TaskDispatcherService } from '../services/taskDispatcher.js';
@@ -107,14 +108,14 @@ export async function handlePrClose(deps: HandlePrCloseDeps, input: HandlePrClos
     if (!userResult.ok) {
       for (const issueId of textIssueIds) {
         logger.warn(
-          { linearIssueId: issueId, login, error: userResult.error },
+          { linearIssueId: issueId, login, error: userResult.error, [SKIP_SENTRY_KEY]: true },
           'handlePrClose: failed to resolve userId for PR body/title issue'
         );
       }
     } else if (userResult.value === null) {
       for (const issueId of textIssueIds) {
         logger.warn(
-          { linearIssueId: issueId, login },
+          { linearIssueId: issueId, login, [SKIP_SENTRY_KEY]: true },
           'handlePrClose: failed to resolve userId — user not found'
         );
       }

--- a/apps/code-agent/src/domain/usecases/triageFailedTask.ts
+++ b/apps/code-agent/src/domain/usecases/triageFailedTask.ts
@@ -8,6 +8,7 @@
  */
 
 import type { Logger } from '@intexuraos/common-core';
+import { SKIP_SENTRY_KEY } from '@intexuraos/infra-sentry';
 import type { UserServiceClient } from '@intexuraos/internal-clients';
 import type { CodeTask, TaskError } from '../models/codeTask.js';
 import type { CodeTaskRepository } from '../repositories/codeTaskRepository.js';
@@ -182,7 +183,7 @@ async function resolveCooloffSchedule(
   const recentLogLines = logResult.ok ? logResult.value.map((line) => line.text) : [];
   if (!logResult.ok) {
     logger.warn(
-      { taskId: task.id, error: logResult.error },
+      { taskId: task.id, error: logResult.error, [SKIP_SENTRY_KEY]: true },
       'Failed to fetch log lines for cooloff parsing'
     );
   }
@@ -193,7 +194,7 @@ async function resolveCooloffSchedule(
     userTimezone = await userServiceClient.getUserTimezone(task.userId);
   } catch (error) {
     logger.warn(
-      { taskId: task.id, userId: task.userId, error },
+      { taskId: task.id, userId: task.userId, error, [SKIP_SENTRY_KEY]: true },
       'Failed to fetch user timezone for cooloff parsing'
     );
     userTimezone = undefined;
@@ -231,7 +232,7 @@ async function resolveCooloffSchedule(
   const llmClientResult = await userServiceClient.getLlmClient(task.userId);
   if (!llmClientResult.ok) {
     logger.warn(
-      { taskId: task.id, userId: task.userId, error: llmClientResult.error },
+      { taskId: task.id, userId: task.userId, error: llmClientResult.error, [SKIP_SENTRY_KEY]: true },
       'User LLM unavailable for cooloff parsing; using fallback delay'
     );
     return fallback;
@@ -250,7 +251,7 @@ async function resolveCooloffSchedule(
   });
   if (!generateResult.ok) {
     logger.warn(
-      { taskId: task.id, error: generateResult.error },
+      { taskId: task.id, error: generateResult.error, [SKIP_SENTRY_KEY]: true },
       'LLM cooloff call failed; using fallback delay'
     );
     return fallback;
@@ -259,7 +260,7 @@ async function resolveCooloffSchedule(
   const parsed = parseCooloffResponse(generateResult.value.content, now);
   if (parsed === null) {
     logger.warn(
-      { taskId: task.id },
+      { taskId: task.id, [SKIP_SENTRY_KEY]: true },
       'Cooloff parser rejected LLM response; using fallback delay'
     );
     return fallback;

--- a/apps/linear-agent/src/__tests__/domain/useCases/validateIssue.test.ts
+++ b/apps/linear-agent/src/__tests__/domain/useCases/validateIssue.test.ts
@@ -328,7 +328,17 @@ describe('validateIssue', () => {
         logger: fakeLogger,
       });
 
-      expect(fakeLogger.warn).toHaveBeenCalled();
+      expect(fakeLogger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          identifier: 'INT-123',
+          error: expect.objectContaining({
+            code: 'API_ERROR',
+            message: 'Rate limit exceeded',
+          }),
+          _skipSentry: true,
+        }),
+        'Failed to fetch issue'
+      );
     });
   });
 });

--- a/apps/linear-agent/src/domain/useCases/validateIssue.ts
+++ b/apps/linear-agent/src/domain/useCases/validateIssue.ts
@@ -6,6 +6,7 @@
 
 import type { Result, Logger } from '@intexuraos/common-core';
 import { ok, err } from '@intexuraos/common-core';
+import { SKIP_SENTRY_KEY } from '@intexuraos/infra-sentry';
 import type { LinearApiClient, LinearConnectionRepository, LinearLabel } from '../index.js';
 
 export interface ValidateIssueDeps {
@@ -70,7 +71,10 @@ export async function validateIssue(
   const issueResult = await linearApiClient.getIssueByIdentifier(connection.apiKey, identifier);
 
   if (!issueResult.ok) {
-    logger.warn({ identifier, error: issueResult.error }, 'Failed to fetch issue');
+    logger.warn(
+      { identifier, error: issueResult.error, [SKIP_SENTRY_KEY]: true },
+      'Failed to fetch issue'
+    );
     return err({
       code: 'API_ERROR',
       message: issueResult.error.message,


### PR DESCRIPTION
## Summary
- mark Linear validation fetch failures and drain label-refresh failures with the Sentry skip flag
- mark PR-close fallback user-resolution misses with the Sentry skip flag
- mark cooloff fallback warning paths with the Sentry skip flag while preserving regular logs

## Links
Fixes INT-1782
Fixes INT-1783
Fixes INT-1784
Fixes INT-1785

## Tests
- RED: pnpm --filter code-agent test -- src/__tests__/domain/useCases/drainTaskQueue.test.ts
- RED: pnpm exec vitest run apps/linear-agent/src/__tests__/domain/useCases/validateIssue.test.ts
- RED: pnpm exec vitest run apps/code-agent/src/__tests__/domain/useCases/handlePrClose.test.ts
- RED: pnpm exec vitest run apps/code-agent/src/__tests__/domain/useCases/triageFailedTask.test.ts
- GREEN: pnpm exec vitest run apps/linear-agent/src/__tests__/domain/useCases/validateIssue.test.ts
- GREEN: pnpm --filter code-agent test -- src/__tests__/domain/useCases/drainTaskQueue.test.ts
- GREEN: pnpm exec vitest run apps/code-agent/src/__tests__/domain/useCases/handlePrClose.test.ts
- GREEN: pnpm exec vitest run apps/code-agent/src/__tests__/domain/useCases/triageFailedTask.test.ts
- GREEN: pnpm run verify:workspace:tracked code-agent linear-agent
- GREEN: pnpm run ci:tracked

## Operational cleanup
- cancelled queued duplicate retry tasks for INT-1784 and INT-1785 via Firestore-only cancellation
- no Docker containers were stopped or killed