### PR TITLE
[INT-1775] Refresh stale Sentry dedupe reservations

### DIFF
--- a/apps/code-agent/src/__tests__/usecases/processSentryWebhook.test.ts
+++ b/apps/code-agent/src/__tests__/usecases/processSentryWebhook.test.ts
@@ -4,12 +4,14 @@
 
 import { createHmac } from 'node:crypto';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Timestamp } from '@google-cloud/firestore';
 import { err, ok } from '@intexuraos/common-core';
 import { resetServices, setServices, type ServiceContainer } from '../../services.js';
 import { processSentryWebhook, type ProcessSentryWebhookInput } from '../../domain/usecases/processSentryWebhook.js';
 import { verifySentrySignature } from '../../infra/sentry-webhook-auth.js';
 import { parseSentryIssueEvent } from '../../infra/sentry-event-parser.js';
 import { createMockLogger } from '../helpers/mockLogger.js';
+import { createFakeTask } from '../helpers/mockFirestore.js';
 
 const WEBHOOK_SECRET = 'sentry-webhook-secret';
 const ORCHESTRATOR_SECRET = 'orchestrator-secret';
@@ -100,7 +102,7 @@ interface MocksShape {
   };
   workerSettingsRepo: { getSettings: ReturnType<typeof vi.fn> };
   linearIssueService: { ensureIssueExists: ReturnType<typeof vi.fn> };
-  codeTaskRepo: { create: ReturnType<typeof vi.fn> };
+  codeTaskRepo: { create: ReturnType<typeof vi.fn>; findById?: ReturnType<typeof vi.fn> };
   taskEnqueueService: { enqueue: ReturnType<typeof vi.fn> };
 }
 
@@ -168,6 +170,11 @@ function installMocks(overrides: Partial<MocksShape> = {}): MocksShape {
     }),
   };
   const codeTaskRepo = overrides.codeTaskRepo ?? {
+    findById: vi.fn().mockResolvedValue(ok(createFakeTask({
+      id: 'task_existing',
+      status: 'queued',
+      agentType: 'sentry',
+    }))),
     create: vi.fn().mockImplementation(async (input: Record<string, unknown>) => ok({
       id: input['id'],
       ...input,
@@ -334,6 +341,253 @@ describe('processSentryWebhook', () => {
     expect(mocks.taskEnqueueService.enqueue).not.toHaveBeenCalled();
   });
 
+  it('does not create a second task when the issue reservation points to a finished Sentry task with an open PR', async () => {
+    resetServices();
+    mocks = installMocks({
+      sentryIssueEventRepo: {
+        reserve: vi.fn().mockResolvedValue(ok({
+          created: false,
+          record: {
+            dedupeKey: 'sentry:intexuraos-dev-pbuchman:intexuraos-development:4509001:issue:created',
+            codeTaskId: 'task_completed_open_pr',
+            linearIssueId: 'INT-200',
+          },
+        })),
+        reserveTaskForProblem: vi.fn(),
+        markCodeTaskCreated: vi.fn().mockResolvedValue(ok(undefined)),
+      },
+      codeTaskRepo: {
+        findById: vi.fn().mockResolvedValue(ok(createFakeTask({
+          id: 'task_completed_open_pr',
+          status: 'implemented',
+          agentType: 'sentry',
+          result: {
+            sentry_outcome: 'fixed',
+            prUrl: 'https://github.com/pbuchman/intexuraos/pull/123',
+          },
+        }))),
+        create: vi.fn(),
+      },
+    });
+
+    const result = await processSentryWebhook(buildInput());
+
+    expect(result).toEqual({
+      ok: true,
+      outcome: 'duplicate',
+      message: 'Sentry issue already has a code task',
+      codeTaskId: 'task_completed_open_pr',
+    });
+    expect(mocks.sentryIssueEventRepo.reserveTaskForProblem).not.toHaveBeenCalled();
+    expect(mocks.codeTaskRepo.create).not.toHaveBeenCalled();
+  });
+
+  it('does not create a second task when the issue reservation points to an implemented task with an open PR number', async () => {
+    resetServices();
+    mocks = installMocks({
+      sentryIssueEventRepo: {
+        reserve: vi.fn().mockResolvedValue(ok({
+          created: false,
+          record: {
+            dedupeKey: 'sentry:intexuraos-dev-pbuchman:intexuraos-development:4509001:issue:created',
+            codeTaskId: 'task_implemented_open_pr',
+            linearIssueId: 'INT-200',
+          },
+        })),
+        reserveTaskForProblem: vi.fn(),
+        markCodeTaskCreated: vi.fn().mockResolvedValue(ok(undefined)),
+      },
+      codeTaskRepo: {
+        findById: vi.fn().mockResolvedValue(ok(createFakeTask({
+          id: 'task_implemented_open_pr',
+          status: 'implemented',
+          agentType: 'sentry',
+          prNumber: 123,
+        }))),
+        create: vi.fn(),
+      },
+    });
+
+    const result = await processSentryWebhook(buildInput());
+
+    expect(result).toEqual({
+      ok: true,
+      outcome: 'duplicate',
+      message: 'Sentry issue already has a code task',
+      codeTaskId: 'task_implemented_open_pr',
+    });
+    expect(mocks.sentryIssueEventRepo.reserveTaskForProblem).not.toHaveBeenCalled();
+    expect(mocks.codeTaskRepo.create).not.toHaveBeenCalled();
+  });
+
+  it('creates a new task when the existing issue reservation points to an archived Sentry task without completion evidence', async () => {
+    resetServices();
+    mocks = installMocks({
+      sentryIssueEventRepo: {
+        reserve: vi.fn().mockResolvedValue(ok({
+          created: false,
+          record: {
+            dedupeKey: 'sentry:intexuraos-dev-pbuchman:intexuraos-development:4509001:issue:created',
+            codeTaskId: 'task_archived_duplicate',
+            linearIssueId: 'INT-1775',
+          },
+        })),
+        reserveTaskForProblem: vi.fn().mockResolvedValue(ok({
+          created: true,
+          record: {
+            dedupeKey: 'sentry-task:intexuraos-dev-pbuchman:intexuraos-development:task-problem',
+            duplicateCount: 0,
+          },
+        })),
+        markCodeTaskCreated: vi.fn().mockResolvedValue(ok(undefined)),
+      },
+      codeTaskRepo: {
+        findById: vi.fn().mockResolvedValue(ok(createFakeTask({
+          id: 'task_archived_duplicate',
+          status: 'archived',
+          agentType: 'sentry',
+        }))),
+        create: vi.fn().mockImplementation(async (input: Record<string, unknown>) => ok({
+          id: input['id'],
+          ...input,
+          status: 'queued',
+        })),
+      },
+    });
+
+    const result = await processSentryWebhook(buildInput());
+
+    expect(result.ok).toBe(true);
+    if (!result.ok || result.outcome !== 'processed') {
+      throw new Error('Expected stale Sentry reservation to create a new task');
+    }
+    expect(mocks.codeTaskRepo.findById).toHaveBeenCalledWith('task_archived_duplicate');
+    expect(mocks.linearIssueService.ensureIssueExists).toHaveBeenCalledTimes(1);
+    expect(mocks.codeTaskRepo.create).toHaveBeenCalledTimes(1);
+    expect(mocks.sentryIssueEventRepo.reserveTaskForProblem).toHaveBeenCalledTimes(1);
+    expect(mocks.sentryIssueEventRepo.markCodeTaskCreated).toHaveBeenNthCalledWith(1, {
+      dedupeKey: 'sentry:intexuraos-dev-pbuchman:intexuraos-development:4509001:issue:created',
+      codeTaskId: result.codeTaskId,
+      linearIssueId: 'INT-200',
+    });
+  });
+
+  it('creates a new task when the existing issue reservation points to a merged Sentry PR', async () => {
+    resetServices();
+    mocks = installMocks({
+      sentryIssueEventRepo: {
+        reserve: vi.fn().mockResolvedValue(ok({
+          created: false,
+          record: {
+            dedupeKey: 'sentry:intexuraos-dev-pbuchman:intexuraos-development:4509001:issue:created',
+            codeTaskId: 'task_merged_duplicate',
+            linearIssueId: 'INT-1775',
+          },
+        })),
+        reserveTaskForProblem: vi.fn().mockResolvedValue(ok({
+          created: true,
+          record: {
+            dedupeKey: 'sentry-task:intexuraos-dev-pbuchman:intexuraos-development:task-problem',
+            duplicateCount: 0,
+          },
+        })),
+        markCodeTaskCreated: vi.fn().mockResolvedValue(ok(undefined)),
+      },
+      codeTaskRepo: {
+        findById: vi.fn().mockResolvedValue(ok(createFakeTask({
+          id: 'task_merged_duplicate',
+          status: 'implemented',
+          agentType: 'sentry',
+          prNumber: 123,
+          prMergedAt: Timestamp.fromDate(new Date('2026-06-29T02:00:00Z')),
+        }))),
+        create: vi.fn().mockImplementation(async (input: Record<string, unknown>) => ok({
+          id: input['id'],
+          ...input,
+          status: 'queued',
+        })),
+      },
+    });
+
+    const result = await processSentryWebhook(buildInput());
+
+    expect(result.ok).toBe(true);
+    if (!result.ok || result.outcome !== 'processed') {
+      throw new Error('Expected merged Sentry PR reservation to create a replacement');
+    }
+    expect(mocks.codeTaskRepo.findById).toHaveBeenCalledWith('task_merged_duplicate');
+    expect(mocks.codeTaskRepo.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('creates a new task when the existing issue reservation points to a missing task', async () => {
+    resetServices();
+    mocks = installMocks({
+      sentryIssueEventRepo: {
+        reserve: vi.fn().mockResolvedValue(ok({
+          created: false,
+          record: {
+            dedupeKey: 'sentry:intexuraos-dev-pbuchman:intexuraos-development:4509001:issue:created',
+            codeTaskId: 'task_missing',
+            linearIssueId: 'INT-1775',
+          },
+        })),
+        reserveTaskForProblem: vi.fn().mockResolvedValue(ok({
+          created: true,
+          record: {
+            dedupeKey: 'sentry-task:intexuraos-dev-pbuchman:intexuraos-development:task-problem',
+            duplicateCount: 0,
+          },
+        })),
+        markCodeTaskCreated: vi.fn().mockResolvedValue(ok(undefined)),
+      },
+      codeTaskRepo: {
+        findById: vi.fn().mockResolvedValue(err({ code: 'NOT_FOUND', message: 'task missing' })),
+        create: vi.fn().mockImplementation(async (input: Record<string, unknown>) => ok({
+          id: input['id'],
+          ...input,
+          status: 'queued',
+        })),
+      },
+    });
+
+    const result = await processSentryWebhook(buildInput());
+
+    expect(result.ok).toBe(true);
+    if (!result.ok || result.outcome !== 'processed') {
+      throw new Error('Expected missing linked Sentry task to create a replacement');
+    }
+    expect(mocks.codeTaskRepo.findById).toHaveBeenCalledWith('task_missing');
+    expect(mocks.codeTaskRepo.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns internal_error when duplicate reservation task lookup fails', async () => {
+    resetServices();
+    mocks = installMocks({
+      sentryIssueEventRepo: {
+        reserve: vi.fn().mockResolvedValue(ok({
+          created: false,
+          record: {
+            dedupeKey: 'sentry:intexuraos-dev-pbuchman:intexuraos-development:4509001:issue:created',
+            codeTaskId: 'task_lookup_error',
+            linearIssueId: 'INT-1775',
+          },
+        })),
+        reserveTaskForProblem: vi.fn(),
+        markCodeTaskCreated: vi.fn(),
+      },
+      codeTaskRepo: {
+        findById: vi.fn().mockResolvedValue(err({ code: 'FIRESTORE_ERROR', message: 'lookup failed' })),
+        create: vi.fn(),
+      },
+    });
+
+    const result = await processSentryWebhook(buildInput());
+
+    expect(result).toEqual({ ok: false, reason: 'internal_error', message: 'lookup failed' });
+    expect(mocks.sentryIssueEventRepo.reserveTaskForProblem).not.toHaveBeenCalled();
+    expect(mocks.codeTaskRepo.create).not.toHaveBeenCalled();
+  });
+
   it('does not create a task when the same Sentry problem already has a task for another issue id', async () => {
     resetServices();
     mocks = installMocks({
@@ -368,6 +622,91 @@ describe('processSentryWebhook', () => {
     expect(mocks.linearIssueService.ensureIssueExists).not.toHaveBeenCalled();
     expect(mocks.codeTaskRepo.create).not.toHaveBeenCalled();
     expect(mocks.taskEnqueueService.enqueue).not.toHaveBeenCalled();
+    expect(mocks.sentryIssueEventRepo.markCodeTaskCreated).not.toHaveBeenCalled();
+  });
+
+  it('creates a new task when the same Sentry problem reservation points to an archived task without completion evidence', async () => {
+    resetServices();
+    mocks = installMocks({
+      sentryIssueEventRepo: {
+        reserve: vi.fn().mockResolvedValue(ok({
+          created: true,
+          record: {
+            dedupeKey: 'sentry:intexuraos-dev-pbuchman:intexuraos-development:4509002:issue:created',
+            duplicateCount: 0,
+          },
+        })),
+        reserveTaskForProblem: vi.fn().mockResolvedValue(ok({
+          created: false,
+          record: {
+            dedupeKey: 'sentry-task:intexuraos-dev-pbuchman:intexuraos-development:task-problem',
+            codeTaskId: 'task_archived_problem_duplicate',
+            linearIssueId: 'INT-1775',
+          },
+        })),
+        markCodeTaskCreated: vi.fn().mockResolvedValue(ok(undefined)),
+      },
+      codeTaskRepo: {
+        findById: vi.fn().mockResolvedValue(ok(createFakeTask({
+          id: 'task_archived_problem_duplicate',
+          status: 'archived',
+          agentType: 'sentry',
+        }))),
+        create: vi.fn().mockImplementation(async (input: Record<string, unknown>) => ok({
+          id: input['id'],
+          ...input,
+          status: 'queued',
+        })),
+      },
+    });
+
+    const result = await processSentryWebhook(buildInput());
+
+    expect(result.ok).toBe(true);
+    if (!result.ok || result.outcome !== 'processed') {
+      throw new Error('Expected stale Sentry problem reservation to create a new task');
+    }
+    expect(mocks.codeTaskRepo.findById).toHaveBeenCalledWith('task_archived_problem_duplicate');
+    expect(mocks.linearIssueService.ensureIssueExists).toHaveBeenCalledTimes(1);
+    expect(mocks.codeTaskRepo.create).toHaveBeenCalledTimes(1);
+    expect(mocks.sentryIssueEventRepo.markCodeTaskCreated).toHaveBeenNthCalledWith(2, {
+      dedupeKey: 'sentry-task:intexuraos-dev-pbuchman:intexuraos-development:task-problem',
+      codeTaskId: result.codeTaskId,
+      linearIssueId: 'INT-200',
+    });
+  });
+
+  it('returns internal_error when problem reservation task lookup fails', async () => {
+    resetServices();
+    mocks = installMocks({
+      sentryIssueEventRepo: {
+        reserve: vi.fn().mockResolvedValue(ok({
+          created: true,
+          record: {
+            dedupeKey: 'sentry:intexuraos-dev-pbuchman:intexuraos-development:4509002:issue:created',
+            duplicateCount: 0,
+          },
+        })),
+        reserveTaskForProblem: vi.fn().mockResolvedValue(ok({
+          created: false,
+          record: {
+            dedupeKey: 'sentry-task:intexuraos-dev-pbuchman:intexuraos-development:task-problem',
+            codeTaskId: 'task_problem_lookup_error',
+            linearIssueId: 'INT-1775',
+          },
+        })),
+        markCodeTaskCreated: vi.fn(),
+      },
+      codeTaskRepo: {
+        findById: vi.fn().mockResolvedValue(err({ code: 'FIRESTORE_ERROR', message: 'problem lookup failed' })),
+        create: vi.fn(),
+      },
+    });
+
+    const result = await processSentryWebhook(buildInput());
+
+    expect(result).toEqual({ ok: false, reason: 'internal_error', message: 'problem lookup failed' });
+    expect(mocks.codeTaskRepo.create).not.toHaveBeenCalled();
     expect(mocks.sentryIssueEventRepo.markCodeTaskCreated).not.toHaveBeenCalled();
   });
 

--- a/apps/code-agent/src/domain/usecases/processSentryWebhook.ts
+++ b/apps/code-agent/src/domain/usecases/processSentryWebhook.ts
@@ -5,16 +5,20 @@ import { getServices } from '../../services.js';
 import type {
   NormalizedSentryIssueEvent,
   SentryIssueEventParseError,
+  SentryIssueEventRecord,
   SentryIssueTaskContext,
 } from '../models/sentryIssueEvent.js';
 import { sanitizePrompt } from '../utils/promptSanitization.js';
 import { sanitizePromptForInjection } from '../utils/promptInjectionSanitizer.js';
 import { generateWebhookSecret } from '../utils/secrets.js';
 import { resolveDefaultWorkerType } from '../utils/defaultWorkerTypeResolution.js';
+import type { CodeTask, TaskStatus } from '../models/codeTask.js';
+import type { CodeTaskRepository } from '../repositories/codeTaskRepository.js';
 
 const SYSTEM_PROMPT_HASH_PLACEHOLDER = 'sentry-agent-system-prompt-v1';
 const ACTIONABLE_ISSUE_ACTIONS = new Set(['created', 'regressed', 'unresolved', 'reopened']);
 const TERMINAL_ISSUE_STATUSES = new Set(['resolved', 'ignored', 'muted', 'archived', 'deleted']);
+const ACTIVE_DUPLICATE_TASK_STATUSES = new Set<TaskStatus>(['queued', 'dispatched', 'running']);
 const SENTRY_AUTOMATION_SELF_ALERT_TITLES = new Set([
   'failed to reserve sentry issue event',
   'failed to record task completion metric',
@@ -149,6 +153,51 @@ function classifySentryIssueEvent(event: NormalizedSentryIssueEvent):
   return { actionable: true };
 }
 
+function hasOpenPullRequest(task: CodeTask): boolean {
+  const hasPullRequest = task.prNumber !== undefined || task.result?.prUrl !== undefined;
+  return hasPullRequest && task.prMergedAt === undefined && task.prClosedAt === undefined;
+}
+
+function isLinkedSentryTaskBlocking(task: CodeTask): boolean {
+  if (ACTIVE_DUPLICATE_TASK_STATUSES.has(task.status)) {
+    return true;
+  }
+
+  if (task.result?.sentry_outcome !== undefined && hasOpenPullRequest(task)) {
+    return true;
+  }
+
+  return task.status === 'implemented' && hasOpenPullRequest(task);
+}
+
+async function inspectDuplicateReservation(input: {
+  record: SentryIssueEventRecord;
+  codeTaskRepo: CodeTaskRepository;
+}): Promise<
+  | { ok: true; duplicate: true; codeTaskId?: string | undefined }
+  | { ok: true; duplicate: false }
+  | { ok: false; message: string }
+> {
+  const { record, codeTaskRepo } = input;
+  if (record.codeTaskId === undefined) {
+    return { ok: true, duplicate: true };
+  }
+
+  const taskResult = await codeTaskRepo.findById(record.codeTaskId);
+  if (!taskResult.ok) {
+    if (taskResult.error.code === 'NOT_FOUND') {
+      return { ok: true, duplicate: false };
+    }
+    return { ok: false, message: taskResult.error.message };
+  }
+
+  if (!isLinkedSentryTaskBlocking(taskResult.value)) {
+    return { ok: true, duplicate: false };
+  }
+
+  return { ok: true, duplicate: true, codeTaskId: record.codeTaskId };
+}
+
 export async function processSentryWebhook(
   input: ProcessSentryWebhookInput
 ): Promise<ProcessSentryWebhookResult> {
@@ -220,14 +269,28 @@ export async function processSentryWebhook(
   }
 
   if (!reserveResult.value.created) {
-    return {
-      ok: true,
-      outcome: 'duplicate',
-      message: 'Sentry issue already has a code task',
-      ...(reserveResult.value.record.codeTaskId !== undefined && {
+    const duplicate = await inspectDuplicateReservation({
+      record: reserveResult.value.record,
+      codeTaskRepo,
+    });
+    if (!duplicate.ok) {
+      return { ok: false, reason: 'internal_error', message: duplicate.message };
+    }
+    if (!duplicate.duplicate) {
+      logger.info({
+        dedupeKey: reserveResult.value.record.dedupeKey,
         codeTaskId: reserveResult.value.record.codeTaskId,
-      }),
-    };
+      }, 'Sentry issue reservation points to stale task; creating a replacement code task');
+    } else {
+      return {
+        ok: true,
+        outcome: 'duplicate',
+        message: 'Sentry issue already has a code task',
+        ...(duplicate.codeTaskId !== undefined && {
+          codeTaskId: duplicate.codeTaskId,
+        }),
+      };
+    }
   }
 
   const problemReserveResult = await sentryIssueEventRepo.reserveTaskForProblem({
@@ -241,14 +304,28 @@ export async function processSentryWebhook(
   }
 
   if (!problemReserveResult.value.created) {
-    return {
-      ok: true,
-      outcome: 'duplicate',
-      message: 'Sentry problem already has a code task',
-      ...(problemReserveResult.value.record.codeTaskId !== undefined && {
+    const duplicate = await inspectDuplicateReservation({
+      record: problemReserveResult.value.record,
+      codeTaskRepo,
+    });
+    if (!duplicate.ok) {
+      return { ok: false, reason: 'internal_error', message: duplicate.message };
+    }
+    if (!duplicate.duplicate) {
+      logger.info({
+        dedupeKey: problemReserveResult.value.record.dedupeKey,
         codeTaskId: problemReserveResult.value.record.codeTaskId,
-      }),
-    };
+      }, 'Sentry problem reservation points to stale task; creating a replacement code task');
+    } else {
+      return {
+        ok: true,
+        outcome: 'duplicate',
+        message: 'Sentry problem already has a code task',
+        ...(duplicate.codeTaskId !== undefined && {
+          codeTaskId: duplicate.codeTaskId,
+        }),
+      };
+    }
   }
 
   const settingsResult = await workerSettingsRepo.getSettings(automationUserId);


### PR DESCRIPTION
Fixes INT-1775

## Summary
- Treat Sentry dedupe reservations as blocking only when the linked code task is active or still has an open PR that could resolve the issue.
- Allow a new Sentry code task when the linked reservation points to a missing, archived, cancelled, failed, interrupted, merged, or closed task without active completion evidence.
- Preserve duplicate suppression for queued/dispatched/running tasks and implemented/Sentry-outcome tasks with open PRs.

## Verification
- `pnpm --filter code-agent exec vitest run src/__tests__/usecases/processSentryWebhook.test.ts`
- `pnpm run verify:workspace:tracked code-agent`
- `pnpm run ci:tracked`
