### PR TITLE
fix(code-agent): skip remediation for closed PR reviews [INT-1775]

### DIFF
--- a/apps/code-agent/src/__tests__/domain/usecases/handleTaskCompletion.test.ts
+++ b/apps/code-agent/src/__tests__/domain/usecases/handleTaskCompletion.test.ts
@@ -325,6 +325,74 @@ describe('handleTaskCompletion', () => {
       });
       expect(remediationCall?.[0]).toMatchObject({ repository: 'a/b', prNumber: 42 });
     });
+
+    it.each([
+      ['merged', { prMergedAt: Timestamp.fromDate(new Date('2026-06-29T04:39:58Z')) }],
+      ['closed', { prClosedAt: Timestamp.fromDate(new Date('2026-06-29T04:39:58Z')) }],
+    ])('records the review decision but skips remediation creation when the PR is already %s', async (_state, prLifecycle) => {
+      const update = vi.fn().mockResolvedValue(ok(undefined));
+      const automationRecord = vi.fn().mockResolvedValue(undefined);
+      const notifyTaskComplete = vi.fn().mockResolvedValue(ok(undefined));
+      const incrementTasksCompleted = vi.fn().mockResolvedValue(undefined);
+      const recordTaskDuration = vi.fn().mockResolvedValue(undefined);
+      const createRemediationTaskFn = vi.fn().mockResolvedValue(ok({ taskId: 'remed-1' }));
+      const findOriginTaskByPR = vi.fn().mockResolvedValue(ok(null));
+      const removeLabel = vi.fn().mockResolvedValue(undefined);
+
+      setServices({
+        codeTaskRepo: {
+          findById: vi.fn().mockResolvedValue(ok({
+            userId: 'u1',
+            repository: 'a/b',
+            workerType: 'claude-opus',
+            status: 'running',
+            agentType: 'review',
+            linearIssueId: 'INT-1',
+            prNumber: 42,
+            ...prLifecycle,
+          })),
+          update,
+          findOriginTaskByPR,
+        } as never,
+        whatsappNotifier: { notifyTaskComplete } as never,
+        metricsClient: { incrementTasksCompleted, recordTaskDuration } as never,
+        automationLog: { record: automationRecord } as never,
+        linearIssueService: {
+          removeLabel,
+          markInReview: vi.fn().mockResolvedValue(undefined),
+        } as never,
+        logger: createMockLogger() as never,
+        createRemediationTaskFn,
+      } as unknown as ServiceContainer);
+
+      const result = await handleTaskCompletion(createMockLogger(), buildInput({
+        taskId: 't-review-closed',
+        status: 'completed',
+        result: {
+          review_id: 'rev-1',
+          review_comments_posted: '1',
+          review_types: 'code_quality',
+          prUrl: 'https://github.com/a/b/pull/42',
+          needs_remediation: '1',
+        },
+      }));
+
+      expect(result).toEqual({ kind: 'received' });
+      expect(createRemediationTaskFn).not.toHaveBeenCalled();
+      expect(findOriginTaskByPR).not.toHaveBeenCalled();
+      expect(removeLabel).not.toHaveBeenCalled();
+      const remediationCall = automationRecord.mock.calls.find((call) => {
+        const event = call[1] as { type?: string; required?: boolean; signal?: string; taskId?: string };
+        return event.type === 'remediation_decision';
+      });
+      expect(remediationCall?.[1]).toMatchObject({
+        type: 'remediation_decision',
+        required: true,
+        signal: '1',
+        source: 'review_result',
+      });
+      expect(remediationCall?.[1]).not.toHaveProperty('taskId');
+    });
   });
 
   describe('completed path — Sentry agent', () => {

--- a/apps/code-agent/src/domain/usecases/handleTaskCompletion.ts
+++ b/apps/code-agent/src/domain/usecases/handleTaskCompletion.ts
@@ -1482,93 +1482,16 @@ export async function handleTaskCompletion(
 
               await applyReadyToMergeLabel(prNumber);
             } else {
-              // Best-effort: remove stale review-outcome label from the associated Linear issue.
-              // A prior passing review may have set ready-to-merge / ready-to-implement;
-              // now that remediation is needed, clear it so the UI no longer shows merge-ready.
-              try {
-                const originResult = await codeTaskRepo.findOriginTaskByPR(task.repository, prNumber);
-                let targetLinearIssueId: string | undefined; // @allow-undefined-type -- let binding requires union, not optional property
-                let targetUserId: string;
-                let labelToRemove: string;
-
-                if (originResult.ok && originResult.value !== null && originResult.value.linearIssueId !== undefined) {
-                  targetLinearIssueId = originResult.value.linearIssueId;
-                  targetUserId = originResult.value.userId;
-                  labelToRemove = originResult.value.agentType === 'planning' ? 'ready-to-implement' : 'ready-to-merge';
-                } else {
-                  targetLinearIssueId = task.linearIssueId;
-                  targetUserId = task.userId;
-                  labelToRemove = 'ready-to-merge';
-                }
-
-                if (targetLinearIssueId !== undefined) {
-                  await linearIssueService.removeLabel(targetUserId, targetLinearIssueId, labelToRemove);
-                  requestLog.info({ taskId, prNumber, label: labelToRemove, linearIssueId: targetLinearIssueId },
-                    'Removed stale review-outcome label after negative review');
-
-                  // Passing [] clears all label flags in the summary (same pattern as handlePrClose).
-                  // Safe because latestReviewNeedsRemediation is already true, which independently
-                  // blocks the merge-readiness check in deriveAggregateStatusFromSummary.
-                  const { groupSummaryRepo: summaryRepoForRemoval } = getServices();
-                  if (summaryRepoForRemoval !== undefined) {
-                    void summaryRepoForRemoval.recomputeWithLabels(
-                      targetUserId, targetLinearIssueId, [], completedAt.toISOString(),
-                    ).catch((recomputeErr: unknown) => {
-                      requestLog.warn({ linearIssueId: targetLinearIssueId, error: recomputeErr },
-                        'Failed to recompute group summary after label removal (best-effort)');
-                    });
-                  }
-                }
-              } catch (labelRemovalError: unknown) {
-                requestLog.warn({ error: labelRemovalError, taskId, prNumber },
-                  'Failed to remove stale review-outcome label (best-effort)');
-              }
-
-              const { createRemediationTaskFn, logger: remediationLogger } = getServices();
-              if (createRemediationTaskFn !== undefined) {
-                const remediationResult = await createRemediationTaskFn(
-                  remediationLogger,
+              if (task.prMergedAt !== undefined || task.prClosedAt !== undefined) {
+                requestLog.info(
                   {
-                    repository: task.repository,
+                    taskId,
                     prNumber,
-                    /* v8 ignore start -- ts-type: noUncheckedIndexedAccess guard, repository always contains '/' @preserve */
-                    senderLogin: task.repository.split('/')[0] ?? task.userId,
-                    /* v8 ignore stop @preserve */
-                    workerType: 'auto',
-                    eventId: taskId,
-                    ...(task.baseBranch !== undefined && { baseBranch: task.baseBranch }),
-                    ...(task.linearIssueId !== undefined && { linearIssueId: task.linearIssueId }),
-                    ...(task.prBranch !== undefined && { prBranch: task.prBranch }),
+                    hasPrMergedAt: task.prMergedAt !== undefined,
+                    hasPrClosedAt: task.prClosedAt !== undefined,
                   },
+                  'Skipping remediation task creation because PR is already merged or closed',
                 );
-                if (remediationResult.ok) {
-                  requestLog.info(
-                    { taskId, prNumber, remediationTaskId: remediationResult.value.taskId },
-                    'Created remediation task from review task-complete',
-                  );
-                  recordRemediationDecision({
-                    repository: task.repository,
-                    prNumber,
-                    userId: task.userId,
-                    required: true,
-                    signal: remediationSignal,
-                    taskId: remediationResult.value.taskId,
-                  });
-                } else {
-                  requestLog.warn(
-                    { taskId, prNumber, error: remediationResult.error },
-                    'Failed to create remediation task from review task-complete (best-effort)',
-                  );
-                  recordRemediationDecision({
-                    repository: task.repository,
-                    prNumber,
-                    userId: task.userId,
-                    required: true,
-                    signal: remediationSignal,
-                  });
-                }
-              } else {
-                requestLog.warn({ taskId, prNumber }, 'createRemediationTaskFn not configured, skipping remediation creation');
                 recordRemediationDecision({
                   repository: task.repository,
                   prNumber,
@@ -1576,6 +1499,102 @@ export async function handleTaskCompletion(
                   required: true,
                   signal: remediationSignal,
                 });
+              } else {
+                // Best-effort: remove stale review-outcome label from the associated Linear issue.
+                // A prior passing review may have set ready-to-merge / ready-to-implement;
+                // now that remediation is needed, clear it so the UI no longer shows merge-ready.
+                try {
+                  const originResult = await codeTaskRepo.findOriginTaskByPR(task.repository, prNumber);
+                  let targetLinearIssueId: string | undefined; // @allow-undefined-type -- let binding requires union, not optional property
+                  let targetUserId: string;
+                  let labelToRemove: string;
+
+                  if (originResult.ok && originResult.value !== null && originResult.value.linearIssueId !== undefined) {
+                    targetLinearIssueId = originResult.value.linearIssueId;
+                    targetUserId = originResult.value.userId;
+                    labelToRemove = originResult.value.agentType === 'planning' ? 'ready-to-implement' : 'ready-to-merge';
+                  } else {
+                    targetLinearIssueId = task.linearIssueId;
+                    targetUserId = task.userId;
+                    labelToRemove = 'ready-to-merge';
+                  }
+
+                  if (targetLinearIssueId !== undefined) {
+                    await linearIssueService.removeLabel(targetUserId, targetLinearIssueId, labelToRemove);
+                    requestLog.info({ taskId, prNumber, label: labelToRemove, linearIssueId: targetLinearIssueId },
+                      'Removed stale review-outcome label after negative review');
+
+                    // Passing [] clears all label flags in the summary (same pattern as handlePrClose).
+                    // Safe because latestReviewNeedsRemediation is already true, which independently
+                    // blocks the merge-readiness check in deriveAggregateStatusFromSummary.
+                    const { groupSummaryRepo: summaryRepoForRemoval } = getServices();
+                    if (summaryRepoForRemoval !== undefined) {
+                      void summaryRepoForRemoval.recomputeWithLabels(
+                        targetUserId, targetLinearIssueId, [], completedAt.toISOString(),
+                      ).catch((recomputeErr: unknown) => {
+                        requestLog.warn({ linearIssueId: targetLinearIssueId, error: recomputeErr },
+                          'Failed to recompute group summary after label removal (best-effort)');
+                      });
+                    }
+                  }
+                } catch (labelRemovalError: unknown) {
+                  requestLog.warn({ error: labelRemovalError, taskId, prNumber },
+                    'Failed to remove stale review-outcome label (best-effort)');
+                }
+
+                const { createRemediationTaskFn, logger: remediationLogger } = getServices();
+                if (createRemediationTaskFn !== undefined) {
+                  const remediationResult = await createRemediationTaskFn(
+                    remediationLogger,
+                    {
+                      repository: task.repository,
+                      prNumber,
+                      /* v8 ignore start -- ts-type: noUncheckedIndexedAccess guard, repository always contains '/' @preserve */
+                      senderLogin: task.repository.split('/')[0] ?? task.userId,
+                      /* v8 ignore stop @preserve */
+                      workerType: 'auto',
+                      eventId: taskId,
+                      ...(task.baseBranch !== undefined && { baseBranch: task.baseBranch }),
+                      ...(task.linearIssueId !== undefined && { linearIssueId: task.linearIssueId }),
+                      ...(task.prBranch !== undefined && { prBranch: task.prBranch }),
+                    },
+                  );
+                  if (remediationResult.ok) {
+                    requestLog.info(
+                      { taskId, prNumber, remediationTaskId: remediationResult.value.taskId },
+                      'Created remediation task from review task-complete',
+                    );
+                    recordRemediationDecision({
+                      repository: task.repository,
+                      prNumber,
+                      userId: task.userId,
+                      required: true,
+                      signal: remediationSignal,
+                      taskId: remediationResult.value.taskId,
+                    });
+                  } else {
+                    requestLog.warn(
+                      { taskId, prNumber, error: remediationResult.error },
+                      'Failed to create remediation task from review task-complete (best-effort)',
+                    );
+                    recordRemediationDecision({
+                      repository: task.repository,
+                      prNumber,
+                      userId: task.userId,
+                      required: true,
+                      signal: remediationSignal,
+                    });
+                  }
+                } else {
+                  requestLog.warn({ taskId, prNumber }, 'createRemediationTaskFn not configured, skipping remediation creation');
+                  recordRemediationDecision({
+                    repository: task.repository,
+                    prNumber,
+                    userId: task.userId,
+                    required: true,
+                    signal: remediationSignal,
+                  });
+                }
               }
             }
           } catch (remediationError: unknown) {


### PR DESCRIPTION
Fixes INT-1775

## Summary
- skip automatic remediation creation when a review task reports `needs_remediation=1` after its PR has already been merged or closed
- still record the remediation decision for auditability, without removing Linear labels or creating a follow-up task
- add regression coverage for both `prMergedAt` and `prClosedAt` review-task lifecycle states

## Why
During the Sentry/code-task cleanup, a late review callback for merged PR #2223 created remediation task `task_fc0e587e-78f7-4a70-af2e-7521253034a1`. That task pushed a commit to the old branch after the PR was already merged, leaving a dead branch commit outside the merged history. Closed PR review callbacks should be recorded, not allowed to spawn new remediation work.

## Verification
- `pnpm exec vitest run apps/code-agent/src/__tests__/domain/useCases/handleTaskCompletion.test.ts`
- `pnpm run verify:workspace:tracked code-agent`
- `pnpm run ci:tracked`
