### PR TITLE
[INT-1734] Suppress log-forwarder upload retry Sentry noise

### DIFF
--- a/workers/orchestrator/src/__tests__/log-forwarder.test.ts
+++ b/workers/orchestrator/src/__tests__/log-forwarder.test.ts
@@ -357,6 +357,52 @@ describe('LogForwarder', () => {
       }
     });
 
+    it('suppresses thrown fetch retry warnings from Sentry while preserving retry logs', async () => {
+      vi.useFakeTimers();
+      try {
+        let attempts = 0;
+        vi.mocked(mockLogger.warn).mockReset();
+
+        mockFetch.mockImplementation(async () => {
+          attempts++;
+          if (attempts < 3) {
+            throw new Error('boom');
+          }
+          return {
+            ok: true,
+            json: async () => ({ received: true }),
+          } as Response;
+        });
+
+        const forwarder = new LogForwarder(
+          { logBasePath, codeAgentUrl, orchestratorSecret, internalAuthToken },
+          mockLogger
+        );
+
+        const logFile = join(logBasePath, 'task-thrown-retry-skip-sentry.log');
+        forwarder.startForwarding('task-thrown-retry-skip-sentry', logFile);
+
+        writeFileSync(logFile, 'Test content\n');
+
+        await vi.advanceTimersByTimeAsync(7000);
+        await forwarder.stopForwarding('task-thrown-retry-skip-sentry');
+
+        expect(mockLogger.warn).toHaveBeenCalledWith(
+          expect.objectContaining({
+            taskId: 'task-thrown-retry-skip-sentry',
+            attempt: 1,
+            url: 'https://code-agent.test/internal/logs',
+            name: 'Error',
+            message: 'boom',
+            [SKIP_SENTRY_KEY]: true,
+          }),
+          'Log upload failed, retrying'
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it('suppresses final upload failure errors from Sentry while tracking dropped chunks', async () => {
       vi.useFakeTimers();
       try {

--- a/workers/orchestrator/src/__tests__/log-forwarder.test.ts
+++ b/workers/orchestrator/src/__tests__/log-forwarder.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { LogForwarder } from '../services/log-forwarder.js';
 import type { Logger } from '@intexuraos/common-core';
+import { SKIP_SENTRY_KEY } from '@intexuraos/infra-sentry';
 
 // Mock fetch globally
 const mockFetch = vi.fn();
@@ -302,6 +303,98 @@ describe('LogForwarder', () => {
 
         // Should succeed on 3rd attempt
         expect(attempts).toBe(3);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('suppresses retry warnings from Sentry while preserving retry logs', async () => {
+      vi.useFakeTimers();
+      try {
+        let attempts = 0;
+        vi.mocked(mockLogger.warn).mockReset();
+
+        mockFetch.mockImplementation(async () => {
+          attempts++;
+          if (attempts < 3) {
+            return {
+              ok: false,
+              status: 502,
+              json: async () => ({}),
+            } as Response;
+          }
+          return {
+            ok: true,
+            json: async () => ({ received: true }),
+          } as Response;
+        });
+
+        const forwarder = new LogForwarder(
+          { logBasePath, codeAgentUrl, orchestratorSecret, internalAuthToken },
+          mockLogger
+        );
+
+        const logFile = join(logBasePath, 'task-retry-skip-sentry.log');
+        forwarder.startForwarding('task-retry-skip-sentry', logFile);
+
+        writeFileSync(logFile, 'Test content\n');
+
+        await vi.advanceTimersByTimeAsync(7000);
+        await forwarder.stopForwarding('task-retry-skip-sentry');
+
+        expect(mockLogger.warn).toHaveBeenCalledWith(
+          expect.objectContaining({
+            taskId: 'task-retry-skip-sentry',
+            attempt: 1,
+            status: 502,
+            url: expect.stringContaining('/internal/logs'),
+            [SKIP_SENTRY_KEY]: true,
+          }),
+          'Log upload failed, retrying'
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('suppresses final upload failure errors from Sentry while tracking dropped chunks', async () => {
+      vi.useFakeTimers();
+      try {
+        vi.mocked(mockLogger.error).mockReset();
+
+        mockFetch.mockImplementation(async () => {
+          return {
+            ok: false,
+            status: 500,
+            json: async () => ({}),
+          } as Response;
+        });
+
+        const forwarder = new LogForwarder(
+          { logBasePath, codeAgentUrl, orchestratorSecret, internalAuthToken },
+          mockLogger
+        );
+
+        const logFile = join(logBasePath, 'task-upload-failed-skip-sentry.log');
+        forwarder.startForwarding('task-upload-failed-skip-sentry', logFile);
+
+        writeFileSync(logFile, 'Test\n');
+
+        await vi.advanceTimersByTimeAsync(7000);
+
+        expect(forwarder.getDroppedChunkCount('task-upload-failed-skip-sentry')).toBe(1);
+
+        await forwarder.stopForwarding('task-upload-failed-skip-sentry');
+
+        expect(mockLogger.error).toHaveBeenCalledWith(
+          expect.objectContaining({
+            taskId: 'task-upload-failed-skip-sentry',
+            count: 1,
+            url: 'https://code-agent.test/internal/logs',
+            [SKIP_SENTRY_KEY]: true,
+          }),
+          'Failed to upload log chunks after retries'
+        );
       } finally {
         vi.useRealTimers();
       }

--- a/workers/orchestrator/src/services/log-forwarder.ts
+++ b/workers/orchestrator/src/services/log-forwarder.ts
@@ -1,6 +1,7 @@
 import { readFileSync, existsSync } from 'node:fs';
 import { createHmac } from 'node:crypto';
 import { getErrorCauseChain, type Logger } from '@intexuraos/common-core';
+import { SKIP_SENTRY_KEY } from '@intexuraos/infra-sentry';
 import { stripDockerHeaders, stripBulkMetadata } from './log-formatter.js';
 import { deriveCallbackBaseUrl } from './callback-url.js';
 
@@ -441,7 +442,12 @@ export class LogForwarder {
     } else {
       state.droppedChunks += chunks.length;
       this.logger.error(
-        { taskId, count: chunks.length, url: `${state.callbackBaseUrl}/internal/logs` },
+        {
+          taskId,
+          count: chunks.length,
+          url: `${state.callbackBaseUrl}/internal/logs`,
+          [SKIP_SENTRY_KEY]: true,
+        },
         'Failed to upload log chunks after retries'
       );
     }
@@ -491,7 +497,13 @@ export class LogForwarder {
         }
 
         this.logger.warn(
-          { taskId: payload.taskId, attempt: i + 1, status: response.status, url },
+          {
+            taskId: payload.taskId,
+            attempt: i + 1,
+            status: response.status,
+            url,
+            [SKIP_SENTRY_KEY]: true,
+          },
           'Log upload failed, retrying'
         );
       } catch (error) {
@@ -500,7 +512,7 @@ export class LogForwarder {
             ? { name: error.name, message: error.message, cause: getErrorCauseChain(error) }
             : { error };
         this.logger.warn(
-          { taskId: payload.taskId, attempt: i + 1, url, ...errorInfo },
+          { taskId: payload.taskId, attempt: i + 1, url, ...errorInfo, [SKIP_SENTRY_KEY]: true },
           'Log upload failed, retrying'
         );
       }


### PR DESCRIPTION
Fixes INT-1734

## Summary
- add `_skipSentry` to log-forwarder retry warnings for `Log upload failed, retrying`
- add `_skipSentry` to final upload failure errors for `Failed to upload log chunks after retries`
- keep retry/drop accounting and stdout logging intact
- add review-remediation coverage for thrown `fetch` retry warnings

### Key Decisions
- Continue the existing PR branch for INT-1734 remediation rather than opening a new PR.
- Keep the implementation scoped to log-forwarder Sentry suppression and review-requested test coverage.

### Decision Log
| Decision | Source | Impact |
|----------|--------|--------|
| Remediate the current Sentry issues `130878214` and `130876710` on PR #2231 | @Piotr Buchman (2026-06-29T07:01:23.152Z) | Focused this pass on the existing log-forwarder suppression PR rather than the older Sentry issue in the original description. |
| Limit changes to the active log-forwarder `_skipSentry` suppression scope | @Piotr Buchman (2026-06-29T07:01:23.152Z) | Addressed only the review coverage gap for thrown `fetch` retry warnings and skipped unrelated automation/status comments. |

## Sentry
- https://sentry.io/organizations/piotr-buchman/issues/130878214/
- https://sentry.io/organizations/piotr-buchman/issues/130876710/

## Verification
- `pnpm --filter orchestrator test -- --run workers/orchestrator/src/__tests__/log-forwarder.test.ts`
- `pnpm run ci:tracked`
