### PR TITLE
[INT-1776] Validate WhatsApp send-message user IDs

### DIFF
--- a/apps/whatsapp-service/src/__tests__/pubsubRoutes.test.ts
+++ b/apps/whatsapp-service/src/__tests__/pubsubRoutes.test.ts
@@ -331,6 +331,53 @@ describe('Pub/Sub Routes', () => {
       expect(messageSender.getSentMessages()).toHaveLength(0);
     });
 
+    it('returns 400 before phone lookup when userId is missing', async () => {
+      const body = createPubSubBody({
+        type: 'whatsapp.message.send',
+        message: 'Hello',
+        correlationId: 'corr-missing-user',
+        timestamp: new Date().toISOString(),
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/internal/whatsapp/pubsub/send-message',
+        headers: { 'x-internal-auth': INTERNAL_AUTH_TOKEN },
+        payload: body,
+      });
+
+      expect(response.statusCode).toBe(400);
+      const responseBody = JSON.parse(response.body) as {
+        success: boolean;
+        error: { code: string; message: string };
+      };
+      expect(responseBody.error.message).toBe('Invalid send message event');
+      expect(messageSender.getSentMessages()).toHaveLength(0);
+    });
+
+    it('returns 400 before phone lookup when userId and correlationId are missing', async () => {
+      const body = createPubSubBody({
+        type: 'whatsapp.message.send',
+        message: 'Hello',
+        timestamp: new Date().toISOString(),
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/internal/whatsapp/pubsub/send-message',
+        headers: { 'x-internal-auth': INTERNAL_AUTH_TOKEN },
+        payload: body,
+      });
+
+      expect(response.statusCode).toBe(400);
+      const responseBody = JSON.parse(response.body) as {
+        success: boolean;
+        error: { code: string; message: string };
+      };
+      expect(responseBody.error.message).toBe('Invalid send message event');
+      expect(messageSender.getSentMessages()).toHaveLength(0);
+    });
+
     it('returns 500 when message sending fails', async () => {
       await userMappingRepository.saveMapping('user-123', ['+48123456789']);
       messageSender.setFail(true, { code: 'INTERNAL_ERROR', message: 'WhatsApp API error' });

--- a/apps/whatsapp-service/src/routes/pubsubRoutes.ts
+++ b/apps/whatsapp-service/src/routes/pubsubRoutes.ts
@@ -4,6 +4,7 @@
  */
 import type { FastifyPluginCallback, FastifyRequest, FastifyReply } from 'fastify';
 import { validateInternalAuth, logIncomingRequest } from '@intexuraos/common-http';
+import { SKIP_SENTRY_KEY } from '@intexuraos/infra-sentry';
 import { getServices } from '../services.js';
 import type {
   ExtractLinkPreviewsEvent,
@@ -231,6 +232,19 @@ export function createPubsubRoutes(): FastifyPluginCallback {
         if (parsedType !== 'whatsapp.message.send') {
           request.log.warn({ type: parsedType }, 'Unexpected event type');
           return await reply.fail('INVALID_REQUEST', 'Unexpected event type');
+        }
+
+        if (typeof eventData.userId !== 'string' || eventData.userId.trim() === '') {
+          request.log.warn(
+            {
+              messageId: body.message.messageId,
+              correlationId:
+                typeof eventData.correlationId === 'string' ? eventData.correlationId : undefined,
+              [SKIP_SENTRY_KEY]: true,
+            },
+            'Invalid send message event: userId is required'
+          );
+          return await reply.fail('INVALID_REQUEST', 'Invalid send message event');
         }
 
         request.log.info(

--- a/packages/whatsapp-pubsub-client/src/__tests__/whatsappSendPublisher.test.ts
+++ b/packages/whatsapp-pubsub-client/src/__tests__/whatsappSendPublisher.test.ts
@@ -83,6 +83,22 @@ describe('createWhatsAppSendPublisher', () => {
       expect((publishedData['correlationId'] as string).length).toBeGreaterThan(0);
     });
 
+    it('rejects blank userId before publishing', async () => {
+      const publisher = createWhatsAppSendPublisher(config);
+
+      const result = await publisher.publishSendMessage({
+        userId: '   ',
+        message: 'Hello',
+      });
+
+      expect(result.ok).toBe(false);
+      expect(mockPublishMessage).not.toHaveBeenCalled();
+      if (!result.ok) {
+        expect(result.error.code).toBe('PUBLISH_FAILED');
+        expect(result.error.message).toContain('userId is required');
+      }
+    });
+
     it('includes replyToMessageId when provided', async () => {
       const publisher = createWhatsAppSendPublisher(config);
 

--- a/packages/whatsapp-pubsub-client/src/whatsappSendPublisher.ts
+++ b/packages/whatsapp-pubsub-client/src/whatsappSendPublisher.ts
@@ -2,7 +2,7 @@
  * WhatsApp Send Message Publisher.
  * Publishes SendMessageEvent to Pub/Sub for whatsapp-service to process.
  */
-import { type Result } from '@intexuraos/common-core';
+import { err, type Result } from '@intexuraos/common-core';
 import { BasePubSubPublisher, type PublishError } from '@intexuraos/infra-pubsub';
 import type {
   SendMessageEvent,
@@ -50,11 +50,19 @@ class WhatsAppSendPublisherImpl extends BasePubSubPublisher implements WhatsAppS
     important?: boolean;
     correlationId?: string;
   }): Promise<Result<void, PublishError>> {
+    const userId = params.userId.trim();
+    if (userId === '') {
+      return err({
+        code: 'PUBLISH_FAILED',
+        message: 'WhatsApp send message userId is required',
+      });
+    }
+
     const correlationId = params.correlationId ?? crypto.randomUUID();
 
     const event: SendMessageEvent = {
       type: 'whatsapp.message.send',
-      userId: params.userId,
+      userId,
       message: params.message,
       correlationId,
       timestamp: new Date().toISOString(),
@@ -81,7 +89,7 @@ class WhatsAppSendPublisherImpl extends BasePubSubPublisher implements WhatsAppS
     return await this.publishToTopic(
       this.topicName,
       event,
-      { correlationId, userId: params.userId },
+      { correlationId, userId },
       'WhatsApp send message'
     );
   }


### PR DESCRIPTION
## Summary
- Fixes INT-1776 / Sentry issue 130876727: `Failed to look up phone number for user`.
- Rejects malformed `whatsapp.message.send` Pub/Sub events before Firestore phone lookup when `userId` is missing or blank.
- Adds publisher-side validation so blank user IDs are not published downstream.
- Marks the expected invalid-event warning with `[SKIP_SENTRY_KEY]: true` so malformed inputs do not create noisy Sentry regressions.

## Verification
- `pnpm exec vitest run apps/whatsapp-service/src/__tests__/pubsubRoutes.test.ts` — 75/75 passed.
- `pnpm exec vitest run packages/whatsapp-pubsub-client/src/__tests__/whatsappSendPublisher.test.ts` — 14/14 passed.
- `pnpm run verify:workspace:tracked whatsapp-pubsub-client` — passed, 17083/17083 tests.
- `pnpm run verify:workspace:tracked whatsapp-service` — broad run hit one unrelated transient timeout in `apps/code-agent/src/__tests__/routes/code/groupSummaryRecompute.test.ts`; focused rerun of that exact failing test passed.
- `pnpm run ci:tracked` — passed.