### PR TITLE
[INT-1773] Harden duplicate code task guards

### DIFF
--- a/apps/code-agent/src/__tests__/domain/useCases/createTaskForPR.test.ts
+++ b/apps/code-agent/src/__tests__/domain/useCases/createTaskForPR.test.ts
@@ -430,6 +430,186 @@ describe('createTaskForPR', () => {
     expect(capturedCreateInput['trackingCommentId']).toBe('98765');
   });
 
+  it('does not create a task or Linear issue when the PR is already closed', async () => {
+    const ensureIssueExists = vi.fn<LinearIssueService['ensureIssueExists']>().mockResolvedValue({
+      linearIssueId: 'INT-100',
+      linearIssueTitle: 'Test Issue',
+      linearFallback: false,
+      linearIssueLabels: ['code-task'],
+      hasChildren: false,
+      linearIssueUrl: 'https://linear.app/intexura/issue/INT-100',
+    });
+    const create = vi.fn<CodeTaskRepository['create']>();
+    const enqueue = vi.fn<TaskEnqueueService['enqueue']>();
+    const updatePRTitle = vi.fn<GitHubPRClient['updatePRTitle']>();
+
+    deps.linearIssueService = {
+      ...createMockLinearIssueService(),
+      ensureIssueExists,
+    };
+    deps.codeTaskRepo = {
+      ...createMockCodeTaskRepo(),
+      create,
+    };
+    deps.taskEnqueueService = {
+      enqueue,
+    };
+    deps.gitHubPRClient = {
+      ...createMockGitHubPRClient(),
+      async getPullRequestStatus(): ReturnType<GitHubPRClient['getPullRequestStatus']> {
+        return ok({ state: 'closed', mergedAt: null, headRef: 'task_closed_pr_branch' });
+      },
+      updatePRTitle,
+    };
+
+    const result = await createTaskForPR(deps, request);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('pr_not_open');
+      expect(result.error.message).toContain('closed');
+    }
+    expect(ensureIssueExists).not.toHaveBeenCalled();
+    expect(create).not.toHaveBeenCalled();
+    expect(enqueue).not.toHaveBeenCalled();
+    expect(updatePRTitle).not.toHaveBeenCalled();
+  });
+
+  it('does not create a task or Linear issue when the PR has already merged', async () => {
+    const ensureIssueExists = vi.fn<LinearIssueService['ensureIssueExists']>().mockResolvedValue({
+      linearIssueId: 'INT-100',
+      linearIssueTitle: 'Test Issue',
+      linearFallback: false,
+      linearIssueLabels: ['code-task'],
+      hasChildren: false,
+      linearIssueUrl: 'https://linear.app/intexura/issue/INT-100',
+    });
+    const create = vi.fn<CodeTaskRepository['create']>();
+    const enqueue = vi.fn<TaskEnqueueService['enqueue']>();
+    const updatePRTitle = vi.fn<GitHubPRClient['updatePRTitle']>();
+
+    deps.linearIssueService = {
+      ...createMockLinearIssueService(),
+      ensureIssueExists,
+    };
+    deps.codeTaskRepo = {
+      ...createMockCodeTaskRepo(),
+      create,
+    };
+    deps.taskEnqueueService = {
+      enqueue,
+    };
+    deps.gitHubPRClient = {
+      ...createMockGitHubPRClient(),
+      async getPullRequestStatus(): ReturnType<GitHubPRClient['getPullRequestStatus']> {
+        return ok({
+          state: 'open',
+          mergedAt: new Date('2026-06-29T08:14:23Z'),
+          headRef: 'task_merged_pr_branch',
+        });
+      },
+      updatePRTitle,
+    };
+
+    const result = await createTaskForPR(deps, request);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('pr_not_open');
+      expect(result.error.message).toContain('already merged');
+    }
+    expect(ensureIssueExists).not.toHaveBeenCalled();
+    expect(create).not.toHaveBeenCalled();
+    expect(enqueue).not.toHaveBeenCalled();
+    expect(updatePRTitle).not.toHaveBeenCalled();
+  });
+
+  it('does not create a task or Linear issue when the PR status lookup returns not found', async () => {
+    const ensureIssueExists = vi.fn<LinearIssueService['ensureIssueExists']>().mockResolvedValue({
+      linearIssueId: 'INT-100',
+      linearIssueTitle: 'Test Issue',
+      linearFallback: false,
+      linearIssueLabels: ['code-task'],
+      hasChildren: false,
+      linearIssueUrl: 'https://linear.app/intexura/issue/INT-100',
+    });
+    const create = vi.fn<CodeTaskRepository['create']>();
+    const enqueue = vi.fn<TaskEnqueueService['enqueue']>();
+    const updatePRTitle = vi.fn<GitHubPRClient['updatePRTitle']>();
+
+    deps.linearIssueService = {
+      ...createMockLinearIssueService(),
+      ensureIssueExists,
+    };
+    deps.codeTaskRepo = {
+      ...createMockCodeTaskRepo(),
+      create,
+    };
+    deps.taskEnqueueService = {
+      enqueue,
+    };
+    deps.gitHubPRClient = {
+      ...createMockGitHubPRClient(),
+      async getPullRequestStatus(): ReturnType<GitHubPRClient['getPullRequestStatus']> {
+        return err({ code: 'NOT_FOUND', message: 'PR not found' });
+      },
+      updatePRTitle,
+    };
+
+    const result = await createTaskForPR(deps, request);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('pr_not_open');
+      expect(result.error.message).toContain('not found');
+    }
+    expect(ensureIssueExists).not.toHaveBeenCalled();
+    expect(create).not.toHaveBeenCalled();
+    expect(enqueue).not.toHaveBeenCalled();
+    expect(updatePRTitle).not.toHaveBeenCalled();
+  });
+
+  it('continues creating the task when PR status lookup fails unexpectedly', async () => {
+    const ensureIssueExists = vi.fn<LinearIssueService['ensureIssueExists']>().mockResolvedValue({
+      linearIssueId: 'INT-100',
+      linearIssueTitle: 'Test Issue',
+      linearFallback: false,
+      linearIssueLabels: ['code-task'],
+      hasChildren: false,
+      linearIssueUrl: 'https://linear.app/intexura/issue/INT-100',
+    });
+    const create = vi.fn<CodeTaskRepository['create']>().mockResolvedValue(ok({} as never));
+    const enqueue = vi.fn<TaskEnqueueService['enqueue']>().mockResolvedValue(ok({
+      taskId: 'task_mock',
+      queuePosition: 1,
+    }));
+
+    deps.linearIssueService = {
+      ...createMockLinearIssueService(),
+      ensureIssueExists,
+    };
+    deps.codeTaskRepo = {
+      ...createMockCodeTaskRepo(),
+      create,
+    };
+    deps.taskEnqueueService = {
+      enqueue,
+    };
+    deps.gitHubPRClient = {
+      ...createMockGitHubPRClient(),
+      async getPullRequestStatus(): ReturnType<GitHubPRClient['getPullRequestStatus']> {
+        return err({ code: 'NETWORK_ERROR', message: 'GitHub temporarily unavailable' });
+      },
+    };
+
+    const result = await createTaskForPR(deps, request);
+
+    expect(result.ok).toBe(true);
+    expect(ensureIssueExists).toHaveBeenCalledTimes(1);
+    expect(create).toHaveBeenCalledTimes(1);
+    expect(enqueue).toHaveBeenCalledTimes(1);
+  });
+
   it('omits trackingCommentId from createInput when not provided in request', async () => {
     let capturedCreateInput: Record<string, unknown> = {};
 

--- a/apps/code-agent/src/__tests__/usecases/processSentryWebhook.test.ts
+++ b/apps/code-agent/src/__tests__/usecases/processSentryWebhook.test.ts
@@ -420,6 +420,87 @@ describe('processSentryWebhook', () => {
     expect(mocks.codeTaskRepo.create).not.toHaveBeenCalled();
   });
 
+  it('does not create a second task when a prior task has a Sentry outcome and open PR URL', async () => {
+    resetServices();
+    mocks = installMocks({
+      sentryIssueEventRepo: {
+        reserve: vi.fn().mockResolvedValue(ok({
+          created: false,
+          record: {
+            dedupeKey: 'sentry:intexuraos-dev-pbuchman:intexuraos-development:4509001:issue:created',
+            codeTaskId: 'task_sentry_outcome_open_pr_url',
+            linearIssueId: 'INT-200',
+          },
+        })),
+        reserveTaskForProblem: vi.fn(),
+        markCodeTaskCreated: vi.fn().mockResolvedValue(ok(undefined)),
+      },
+      codeTaskRepo: {
+        findById: vi.fn().mockResolvedValue(ok(createFakeTask({
+          id: 'task_sentry_outcome_open_pr_url',
+          status: 'reviewed',
+          agentType: 'review',
+          result: {
+            sentry_outcome: 'fixed',
+            prUrl: 'https://github.com/pbuchman/intexuraos/pull/456',
+          },
+        }))),
+        create: vi.fn(),
+      },
+    });
+
+    const result = await processSentryWebhook(buildInput());
+
+    expect(result).toEqual({
+      ok: true,
+      outcome: 'duplicate',
+      message: 'Sentry issue already has a code task',
+      codeTaskId: 'task_sentry_outcome_open_pr_url',
+    });
+    expect(mocks.sentryIssueEventRepo.reserveTaskForProblem).not.toHaveBeenCalled();
+    expect(mocks.codeTaskRepo.create).not.toHaveBeenCalled();
+  });
+
+  it('does not create a second task when an implemented task has an open PR URL', async () => {
+    resetServices();
+    mocks = installMocks({
+      sentryIssueEventRepo: {
+        reserve: vi.fn().mockResolvedValue(ok({
+          created: false,
+          record: {
+            dedupeKey: 'sentry:intexuraos-dev-pbuchman:intexuraos-development:4509001:issue:created',
+            codeTaskId: 'task_implemented_open_pr_url',
+            linearIssueId: 'INT-200',
+          },
+        })),
+        reserveTaskForProblem: vi.fn(),
+        markCodeTaskCreated: vi.fn().mockResolvedValue(ok(undefined)),
+      },
+      codeTaskRepo: {
+        findById: vi.fn().mockResolvedValue(ok(createFakeTask({
+          id: 'task_implemented_open_pr_url',
+          status: 'implemented',
+          agentType: 'execution',
+          result: {
+            prUrl: 'https://github.com/pbuchman/intexuraos/pull/789',
+          },
+        }))),
+        create: vi.fn(),
+      },
+    });
+
+    const result = await processSentryWebhook(buildInput());
+
+    expect(result).toEqual({
+      ok: true,
+      outcome: 'duplicate',
+      message: 'Sentry issue already has a code task',
+      codeTaskId: 'task_implemented_open_pr_url',
+    });
+    expect(mocks.sentryIssueEventRepo.reserveTaskForProblem).not.toHaveBeenCalled();
+    expect(mocks.codeTaskRepo.create).not.toHaveBeenCalled();
+  });
+
   it('creates a new task when the existing issue reservation points to an archived Sentry task without completion evidence', async () => {
     resetServices();
     mocks = installMocks({
@@ -472,7 +553,7 @@ describe('processSentryWebhook', () => {
     });
   });
 
-  it('creates a new task when the existing issue reservation points to a merged Sentry PR', async () => {
+  it('does not create a second task when the existing issue reservation points to a merged Sentry PR', async () => {
     resetServices();
     mocks = installMocks({
       sentryIssueEventRepo: {
@@ -511,12 +592,69 @@ describe('processSentryWebhook', () => {
 
     const result = await processSentryWebhook(buildInput());
 
-    expect(result.ok).toBe(true);
-    if (!result.ok || result.outcome !== 'processed') {
-      throw new Error('Expected merged Sentry PR reservation to create a replacement');
-    }
+    expect(result).toEqual({
+      ok: true,
+      outcome: 'duplicate',
+      message: 'Sentry issue already has a code task',
+      codeTaskId: 'task_merged_duplicate',
+    });
     expect(mocks.codeTaskRepo.findById).toHaveBeenCalledWith('task_merged_duplicate');
-    expect(mocks.codeTaskRepo.create).toHaveBeenCalledTimes(1);
+    expect(mocks.sentryIssueEventRepo.reserveTaskForProblem).not.toHaveBeenCalled();
+    expect(mocks.codeTaskRepo.create).not.toHaveBeenCalled();
+    expect(mocks.taskEnqueueService.enqueue).not.toHaveBeenCalled();
+  });
+
+  it('does not create a second task when the existing Sentry reservation has only a merged PR URL', async () => {
+    resetServices();
+    mocks = installMocks({
+      sentryIssueEventRepo: {
+        reserve: vi.fn().mockResolvedValue(ok({
+          created: false,
+          record: {
+            dedupeKey: 'sentry:intexuraos-dev-pbuchman:intexuraos-development:4509001:issue:created',
+            codeTaskId: 'task_merged_pr_url_duplicate',
+            linearIssueId: 'INT-1775',
+          },
+        })),
+        reserveTaskForProblem: vi.fn().mockResolvedValue(ok({
+          created: true,
+          record: {
+            dedupeKey: 'sentry-task:intexuraos-dev-pbuchman:intexuraos-development:task-problem',
+            duplicateCount: 0,
+          },
+        })),
+        markCodeTaskCreated: vi.fn().mockResolvedValue(ok(undefined)),
+      },
+      codeTaskRepo: {
+        findById: vi.fn().mockResolvedValue(ok(createFakeTask({
+          id: 'task_merged_pr_url_duplicate',
+          status: 'implemented',
+          agentType: 'sentry',
+          result: {
+            prUrl: 'https://github.com/pbuchman/intexuraos/pull/321',
+          },
+          prMergedAt: Timestamp.fromDate(new Date('2026-06-29T02:00:00Z')),
+        }))),
+        create: vi.fn().mockImplementation(async (input: Record<string, unknown>) => ok({
+          id: input['id'],
+          ...input,
+          status: 'queued',
+        })),
+      },
+    });
+
+    const result = await processSentryWebhook(buildInput());
+
+    expect(result).toEqual({
+      ok: true,
+      outcome: 'duplicate',
+      message: 'Sentry issue already has a code task',
+      codeTaskId: 'task_merged_pr_url_duplicate',
+    });
+    expect(mocks.codeTaskRepo.findById).toHaveBeenCalledWith('task_merged_pr_url_duplicate');
+    expect(mocks.sentryIssueEventRepo.reserveTaskForProblem).not.toHaveBeenCalled();
+    expect(mocks.codeTaskRepo.create).not.toHaveBeenCalled();
+    expect(mocks.taskEnqueueService.enqueue).not.toHaveBeenCalled();
   });
 
   it('creates a new task when the existing issue reservation points to a missing task', async () => {

--- a/apps/code-agent/src/domain/usecases/createTaskForPR.ts
+++ b/apps/code-agent/src/domain/usecases/createTaskForPR.ts
@@ -56,6 +56,7 @@ export interface CreateTaskForPRRequest {
 export type CreateTaskForPRErrorCode =
   | 'user_not_found'
   | 'no_workers_configured'
+  | 'pr_not_open'
   | 'task_creation_failed'
   | 'linear_issue_failed'
   | 'queue_full'
@@ -184,23 +185,55 @@ export async function createTaskForPR(
     }
   }
 
+  const [owner, repo] = repository.split('/');
+  const hasValidRepositoryParts = owner !== undefined && repo !== undefined;
+  const githubToken = hasValidRepositoryParts
+    ? await fetchGitHubToken(deps.userServiceClient, userId, logger)
+    : null;
+
+  if (hasValidRepositoryParts && githubToken !== null) {
+    const statusResult = await deps.gitHubPRClient.getPullRequestStatus(
+      githubToken, owner, repo, prNumber
+    );
+    if (statusResult.ok) {
+      const status = statusResult.value; // @allow-result-access -- narrowed by statusResult.ok
+      if (status.state !== 'open' || status.mergedAt !== null) {
+        logger.info(
+          { repository, prNumber, state: status.state, mergedAt: status.mergedAt },
+          'Skipping PR comment task because PR is not open'
+        );
+        return err({
+          code: 'pr_not_open',
+          message: `Pull request #${String(prNumber)} is ${status.state}${status.mergedAt !== null ? ' and already merged' : ''}`,
+        });
+      }
+    } else if (statusResult.error.code === 'NOT_FOUND') {
+      logger.info({ repository, prNumber }, 'Skipping PR comment task because PR was not found');
+      return err({
+        code: 'pr_not_open',
+        message: `Pull request #${String(prNumber)} was not found`,
+      });
+    } else {
+      logger.warn(
+        { repository, prNumber, error: statusResult.error },
+        'Failed to verify PR status before creating PR comment task'
+      );
+    }
+  }
+
   // Fetch baseBranch from GitHub API when not provided (e.g. issue_comment events
   // where no prior pull_request event was stored)
   let resolvedBaseBranch = request.baseBranch;
   if (resolvedBaseBranch === undefined) {
-    const [owner, repo] = repository.split('/');
-    if (owner !== undefined && repo !== undefined) {
-      const githubToken = await fetchGitHubToken(deps.userServiceClient, userId, logger);
-      if (githubToken !== null) {
-        const branchResult = await deps.gitHubPRClient.getPullRequestBaseBranch(
-          githubToken, owner, repo, prNumber
-        );
-        if (branchResult.ok) {
-          resolvedBaseBranch = branchResult.value; // @allow-result-access -- narrowed by branchResult.ok
-          logger.info({ baseBranch: resolvedBaseBranch, prNumber }, 'Fetched baseBranch from GitHub API');
-        } else {
-          logger.warn({ error: branchResult.error, prNumber }, 'Failed to fetch baseBranch from GitHub API'); // @allow-result-access -- narrowed by !branchResult.ok
-        }
+    if (hasValidRepositoryParts && githubToken !== null) {
+      const branchResult = await deps.gitHubPRClient.getPullRequestBaseBranch(
+        githubToken, owner, repo, prNumber
+      );
+      if (branchResult.ok) {
+        resolvedBaseBranch = branchResult.value; // @allow-result-access -- narrowed by branchResult.ok
+        logger.info({ baseBranch: resolvedBaseBranch, prNumber }, 'Fetched baseBranch from GitHub API');
+      } else {
+        logger.warn({ error: branchResult.error, prNumber }, 'Failed to fetch baseBranch from GitHub API'); // @allow-result-access -- narrowed by !branchResult.ok
       }
     }
   }

--- a/apps/code-agent/src/domain/usecases/processSentryWebhook.ts
+++ b/apps/code-agent/src/domain/usecases/processSentryWebhook.ts
@@ -163,6 +163,14 @@ function isLinkedSentryTaskBlocking(task: CodeTask): boolean {
     return true;
   }
 
+  if (
+    task.agentType === 'sentry'
+    && task.status === 'implemented'
+    && (task.prNumber !== undefined || task.result?.prUrl !== undefined)
+  ) {
+    return true;
+  }
+
   if (task.result?.sentry_outcome !== undefined && hasOpenPullRequest(task)) {
     return true;
   }


### PR DESCRIPTION
## Summary
- keep Sentry issue reservations blocking after an implemented Sentry task has PR evidence, even when that PR is already merged
- skip PR-comment code task creation when the target PR is closed, merged, or no longer exists
- keep transient GitHub status lookup failures fail-open, with coverage for the behavior

## Verification
- pnpm exec vitest run apps/code-agent/src/__tests__/usecases/processSentryWebhook.test.ts apps/code-agent/src/__tests__/domain/useCases/createTaskForPR.test.ts
- pnpm run verify:workspace:tracked code-agent
- pnpm run ci:tracked

## Battlefield Context
This addresses the duplicate-task pattern observed during the Sentry cleanup: new code tasks could be created for already-fixed Sentry issues or for comments/events on PRs that were already closed/merged.