### PR TITLE
[INT-1798] Add WhatsApp video transcription

### DIFF
--- a/apps/web/src/components/whatsapp/MessageItem.tsx
+++ b/apps/web/src/components/whatsapp/MessageItem.tsx
@@ -11,11 +11,16 @@ import {
   MessageSquare,
   Mic,
   Trash2,
+  Video,
 } from 'lucide-react';
 
 import { TextWithLinks } from './shared.js';
 
 const TEXT_PREVIEW_LIMIT = 800;
+
+function isTranscriptionMedia(message: WhatsAppMessage): boolean {
+  return message.mediaType === 'audio' || message.mediaType === 'video';
+}
 
 // Extracted helpers to avoid recomputation on every render
 function getDesktopMediaIndicator(
@@ -44,6 +49,9 @@ function getDesktopMediaIndicator(
   if (message.mediaType === 'audio') {
     return <Mic className="h-4 w-4 text-slate-400" />;
   }
+  if (message.mediaType === 'video') {
+    return <Video className="h-4 w-4 text-slate-400" />;
+  }
   return <MessageSquare className="h-4 w-4 text-slate-400" />;
 }
 
@@ -54,6 +62,9 @@ function getMobileMediaIndicator(message: WhatsAppMessage): React.JSX.Element {
   if (message.mediaType === 'audio') {
     return <Mic className="h-4 w-4 text-slate-400" />;
   }
+  if (message.mediaType === 'video') {
+    return <Video className="h-4 w-4 text-slate-400" />;
+  }
   return <MessageSquare className="h-4 w-4 text-slate-400" />;
 }
 
@@ -61,7 +72,7 @@ function getContentPreviewForMessage(message: WhatsAppMessage): string {
   if (message.mediaType === 'image' && message.caption) {
     return message.caption;
   }
-  if (message.mediaType === 'audio' && message.transcription) {
+  if (isTranscriptionMedia(message) && message.transcription) {
     return message.transcription;
   }
   if (message.text) {
@@ -153,7 +164,7 @@ export function MessageItem({
     const statusBaseClass = variant === 'mobile' ? 'mt-1 text-xs' : 'truncate text-xs';
 
     if (
-      message.mediaType === 'audio' &&
+      isTranscriptionMedia(message) &&
       message.transcriptionStatus !== 'completed' &&
       message.transcriptionStatus !== 'failed'
     ) {
@@ -164,7 +175,7 @@ export function MessageItem({
       );
     }
 
-    if (message.mediaType === 'audio' && message.transcriptionStatus === 'failed') {
+    if (isTranscriptionMedia(message) && message.transcriptionStatus === 'failed') {
       return (
         <p className={`${statusBaseClass} text-red-500 dark:text-red-400`}>
           Transcription failed
@@ -185,7 +196,7 @@ export function MessageItem({
 
     return (
       <div className="flex items-center justify-end gap-1">
-        {message.mediaType === 'audio' ? (
+        {isTranscriptionMedia(message) ? (
           message.transcriptionStatus === 'completed' &&
           message.transcription !== undefined &&
           message.transcription !== '' ? (
@@ -332,8 +343,8 @@ export function MessageItem({
         </div>
       ) : null}
 
-      {/* Expanded content for audio messages (transcription) */}
-      {message.mediaType === 'audio' &&
+      {/* Expanded content for transcribed media messages */}
+      {isTranscriptionMedia(message) &&
         message.transcriptionStatus === 'completed' &&
         message.transcription !== undefined &&
         message.transcription !== '' && (

--- a/apps/web/src/components/whatsapp/__tests__/MessageItem.test.tsx
+++ b/apps/web/src/components/whatsapp/__tests__/MessageItem.test.tsx
@@ -247,6 +247,39 @@ describe('MessageItem', () => {
     expect(within(screen.getByTestId('message-item-desktop')).queryByTitle('View transcription')).not.toBeInTheDocument();
   });
 
+  it('shows transcription actions and transcript content for completed video messages', () => {
+    const onTranscriptionClick = vi.fn();
+
+    render(
+      <MessageItem
+        message={createMessage({
+          id: 'video-complete',
+          mediaType: 'video',
+          hasMedia: true,
+          text: 'Video caption',
+          transcriptionStatus: 'completed',
+          transcription: 'Completed video transcription text',
+        })}
+        accessToken="token"
+        onDelete={vi.fn()}
+        onImageClick={vi.fn()}
+        onNoteClick={vi.fn()}
+        onTranscriptionClick={onTranscriptionClick}
+        isDeleting={false}
+      />
+    );
+
+    const mobileShell = screen.getByTestId('message-item-mobile');
+    const desktopShell = screen.getByTestId('message-item-desktop');
+    expect(within(mobileShell).getByTitle('View transcription')).toBeInTheDocument();
+    expect(within(desktopShell).getByTitle('View transcription')).toBeInTheDocument();
+    expect(screen.getAllByText('Completed video transcription text').length).toBeGreaterThan(0);
+
+    fireEvent.click(within(mobileShell).getByTitle('View transcription'));
+
+    expect(onTranscriptionClick).toHaveBeenCalledTimes(1);
+  });
+
   it('shows transcribing status in mobile shell for processing audio', () => {
     render(
       <MessageItem

--- a/apps/web/src/components/whatsapp/shared.tsx
+++ b/apps/web/src/components/whatsapp/shared.tsx
@@ -52,9 +52,9 @@ export function TextWithLinks({ text }: { text: string }): React.JSX.Element {
 }
 
 // Media type filter config
-export type WhatsAppMediaType = 'all' | 'text' | 'image' | 'audio';
+export type WhatsAppMediaType = 'all' | 'text' | 'image' | 'audio' | 'video';
 
-export const WHATSAPP_MEDIA_TYPES: WhatsAppMediaType[] = ['all', 'text', 'image', 'audio'];
+export const WHATSAPP_MEDIA_TYPES: WhatsAppMediaType[] = ['all', 'text', 'image', 'audio', 'video'];
 
 export const WHATSAPP_MEDIA_FILTER_CONFIG: Record<
   WhatsAppMediaType,
@@ -83,6 +83,12 @@ export const WHATSAPP_MEDIA_FILTER_CONFIG: Record<
     dotClass: 'bg-purple-500',
     activeClass:
       'border-purple-500 bg-purple-50 text-purple-700 dark:border-purple-400 dark:bg-purple-900/30 dark:text-purple-400',
+  },
+  video: {
+    label: 'Video',
+    dotClass: 'bg-amber-500',
+    activeClass:
+      'border-amber-500 bg-amber-50 text-amber-700 dark:border-amber-400 dark:bg-amber-900/30 dark:text-amber-400',
   },
 };
 

--- a/apps/web/src/pages/PrivateWhatsAppLogPage.tsx
+++ b/apps/web/src/pages/PrivateWhatsAppLogPage.tsx
@@ -9,6 +9,7 @@ import {
   RefreshCw,
   Search,
   UserRound,
+  Video,
   UsersRound,
 } from 'lucide-react';
 import { Button, ErrorBanner, Layout } from '@/components';
@@ -107,7 +108,10 @@ function hasStoredImage(message: PrivateWhatsAppMessage): boolean {
 }
 
 function MessageTranscription({ message }: { message: PrivateWhatsAppMessage }): React.JSX.Element | null {
-  const transcription = message.messageType === 'audio' ? message.transcription : undefined;
+  const transcription =
+    message.messageType === 'audio' || message.messageType === 'video'
+      ? message.transcription
+      : undefined;
   if (transcription === undefined) {
     return null;
   }
@@ -179,7 +183,7 @@ function MessageBody({ message }: { message: PrivateWhatsAppMessage }): React.JS
 
   const mediaName =
     message.media?.fileName ?? message.media?.mimeType ?? `${message.messageType} message`;
-  const Icon = message.messageType === 'image' ? Image : FileText;
+  const Icon = message.messageType === 'image' ? Image : message.messageType === 'video' ? Video : FileText;
 
   return (
     <div className="space-y-3">

--- a/apps/web/src/pages/WhatsAppNotesPage.tsx
+++ b/apps/web/src/pages/WhatsAppNotesPage.tsx
@@ -192,11 +192,13 @@ export function WhatsAppNotesPage(): React.JSX.Element {
       text: 0,
       image: 0,
       audio: 0,
+      video: 0,
     };
     for (const msg of messages) {
       if (msg.mediaType === 'text') counts.text++;
       else if (msg.mediaType === 'image') counts.image++;
-      else counts.audio++;
+      else if (msg.mediaType === 'audio') counts.audio++;
+      else counts.video++;
     }
     return counts;
   }, [messages]);

--- a/apps/web/src/pages/__tests__/PrivateWhatsAppLogPage.test.tsx
+++ b/apps/web/src/pages/__tests__/PrivateWhatsAppLogPage.test.tsx
@@ -359,6 +359,30 @@ describe('PrivateWhatsAppLogPage', () => {
             ingestedAt: '2026-06-22T09:04:03.000Z',
             deliveryMode: 'live',
           },
+          {
+            id: 'video-completed',
+            chatId: 'chat-group',
+            direction: 'incoming',
+            messageType: 'video',
+            media: {
+              mxcUri: 'mxc://home-dev/video-completed',
+              mimeType: 'video/mp4',
+              fileName: 'clip.mp4',
+              storageStatus: 'stored',
+              hasMedia: true,
+            },
+            transcription: {
+              status: 'completed',
+              jobId: 'job-video-completed',
+              text: 'The video says to bring the blue folder.',
+              completedAt: '2026-06-22T09:05:00.000Z',
+            },
+            eventTimestamp: '2026-06-22T09:05:00.000Z',
+            eventDayKey: '2026-06-22',
+            receivedAt: '2026-06-22T09:05:02.000Z',
+            ingestedAt: '2026-06-22T09:05:03.000Z',
+            deliveryMode: 'live',
+          },
         ],
       })
     );
@@ -374,5 +398,6 @@ describe('PrivateWhatsAppLogPage', () => {
     expect(setChatTranscriptionEnabled).toHaveBeenCalledWith('chat-group', true);
     expect(screen.getByText('Bring the documents tomorrow.')).toBeInTheDocument();
     expect(screen.getByText('Audio format was not supported')).toBeInTheDocument();
+    expect(screen.getByText('The video says to bring the blue folder.')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -81,7 +81,7 @@ export interface WhatsAppConnectResponse {
 /**
  * WhatsApp message media type
  */
-export type WhatsAppMediaType = 'text' | 'image' | 'audio';
+export type WhatsAppMediaType = 'text' | 'image' | 'audio' | 'video';
 
 /**
  * Transcription status for audio messages.

--- a/apps/whatsapp-service/src/__tests__/fakes.ts
+++ b/apps/whatsapp-service/src/__tests__/fakes.ts
@@ -22,6 +22,7 @@ import type {
   LinkPreviewFetcherPort,
   LinkPreviewState,
   MediaCleanupEvent,
+  MediaTranscriptionRequestedEvent,
   MediaStoragePort,
   MediaUrlInfo,
   NotificationLevel,
@@ -1514,11 +1515,13 @@ export class FakeMediaStorage implements MediaStoragePort {
 export class FakeEventPublisher implements EventPublisherPort {
   private mediaCleanupEvents: MediaCleanupEvent[] = [];
   private audioStoredEvents: AudioStoredEvent[] = [];
+  private mediaTranscriptionRequestedEvents: MediaTranscriptionRequestedEvent[] = [];
   private intexMessageIngestEvents: IntexMessageIngestEvent[] = [];
   private webhookProcessEvents: WebhookProcessEvent[] = [];
   private extractLinkPreviewsEvents: ExtractLinkPreviewsEvent[] = [];
   private extractLinkPreviewsFailureMessage: string | null = null;
   private audioStoredFailureMessage: string | null = null;
+  private mediaTranscriptionRequestedFailureMessage: string | null = null;
   private intexMessageIngestFailureMessage: string | null = null;
   private webhookProcessFailureMessage: string | null = null;
 
@@ -1537,8 +1540,27 @@ export class FakeEventPublisher implements EventPublisherPort {
     return Promise.resolve(ok(undefined));
   }
 
+  publishMediaTranscriptionRequested(
+    event: MediaTranscriptionRequestedEvent
+  ): Promise<Result<void, WhatsAppError>> {
+    if (this.mediaTranscriptionRequestedFailureMessage !== null) {
+      return Promise.resolve(
+        err({
+          code: 'INTERNAL_ERROR' as const,
+          message: this.mediaTranscriptionRequestedFailureMessage,
+        })
+      );
+    }
+    this.mediaTranscriptionRequestedEvents.push(event);
+    return Promise.resolve(ok(undefined));
+  }
+
   setAudioStoredFailure(message: string): void {
     this.audioStoredFailureMessage = message;
+  }
+
+  setMediaTranscriptionRequestedFailure(message: string): void {
+    this.mediaTranscriptionRequestedFailureMessage = message;
   }
 
   publishIntexMessageIngest(event: IntexMessageIngestEvent): Promise<Result<void, WhatsAppError>> {
@@ -1593,6 +1615,10 @@ export class FakeEventPublisher implements EventPublisherPort {
     return [...this.audioStoredEvents];
   }
 
+  getMediaTranscriptionRequestedEvents(): MediaTranscriptionRequestedEvent[] {
+    return [...this.mediaTranscriptionRequestedEvents];
+  }
+
   getIntexMessageIngestEvents(): IntexMessageIngestEvent[] {
     return [...this.intexMessageIngestEvents];
   }
@@ -1608,11 +1634,13 @@ export class FakeEventPublisher implements EventPublisherPort {
   clear(): void {
     this.mediaCleanupEvents = [];
     this.audioStoredEvents = [];
+    this.mediaTranscriptionRequestedEvents = [];
     this.intexMessageIngestEvents = [];
     this.webhookProcessEvents = [];
     this.extractLinkPreviewsEvents = [];
     this.extractLinkPreviewsFailureMessage = null;
     this.audioStoredFailureMessage = null;
+    this.mediaTranscriptionRequestedFailureMessage = null;
     this.intexMessageIngestFailureMessage = null;
     this.webhookProcessFailureMessage = null;
   }

--- a/apps/whatsapp-service/src/__tests__/openapi-contract.test.ts
+++ b/apps/whatsapp-service/src/__tests__/openapi-contract.test.ts
@@ -151,4 +151,10 @@ describe('whatsapp-service OpenAPI contract', () => {
     expect(uploadPrivateMedia).toBeDefined();
     expect(uploadPrivateMedia?.responses?.['413']).toBeDefined();
   });
+
+  it('documents video as a WhatsApp message media type', () => {
+    const messagesRoute = openapiSpec.paths?.['/messages']?.['get'];
+    expect(messagesRoute).toBeDefined();
+    expect(JSON.stringify(messagesRoute)).toContain('"video"');
+  });
 });

--- a/apps/whatsapp-service/src/__tests__/privateMediaRoutes.test.ts
+++ b/apps/whatsapp-service/src/__tests__/privateMediaRoutes.test.ts
@@ -154,6 +154,53 @@ describe('Private WhatsApp Media Routes', () => {
     expect(body.data.media.thumbnailGcsPath).toBeUndefined();
   });
 
+  it('uploads private video originals without generating thumbnails', async () => {
+    const response = await ctx.app.inject({
+      method: 'POST',
+      url: '/internal/whatsapp/private/media?sourceAccountId=private-source-123&matrixEventId=%24video&mxcUri=mxc%3A%2F%2Fhome-dev%2Fvideo&mimeType=video%2Fmp4&fileName=clip.mp4&mediaId=home-dev-video',
+      headers: {
+        'x-internal-auth': 'test-internal-token',
+        'content-type': 'application/octet-stream',
+      },
+      payload: Buffer.from('video-bytes'),
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body) as {
+      success: true;
+      data: {
+        media: {
+          mxcUri: string;
+          mimeType: string;
+          fileName: string;
+          sizeBytes: number;
+          storageStatus: string;
+          gcsPath: string;
+          thumbnailGcsPath?: string;
+          storedMimeType: string;
+          storedSizeBytes: number;
+          storedAt: string;
+        };
+      };
+    };
+    const messageId = createPrivateWhatsAppMessageId('private-source-123', '$video');
+    expect(body.data.media).toStrictEqual({
+      mxcUri: 'mxc://home-dev/video',
+      mimeType: 'video/mp4',
+      fileName: 'clip.mp4',
+      sizeBytes: 'video-bytes'.length,
+      storageStatus: 'stored',
+      gcsPath: `whatsapp/private/user-123/${messageId}/home-dev-video.mp4`,
+      storedMimeType: 'video/mp4',
+      storedSizeBytes: 'video-bytes'.length,
+      storedAt: expect.any(String),
+    });
+    expect(ctx.mediaStorage.getFile(body.data.media.gcsPath)?.buffer.toString()).toBe(
+      'video-bytes'
+    );
+    expect(body.data.media.thumbnailGcsPath).toBeUndefined();
+  });
+
   it('rejects uploads for unknown private source accounts', async () => {
     const response = await ctx.app.inject({
       method: 'POST',
@@ -258,7 +305,7 @@ describe('Private WhatsApp Media Routes', () => {
     expect(response.statusCode).toBe(400);
   });
 
-  it('rejects uploads when mimeType is not an image', async () => {
+  it('rejects uploads when mimeType is not image, audio, or video', async () => {
     const response = await ctx.app.inject({
       method: 'POST',
       url: '/internal/whatsapp/private/media?sourceAccountId=private-source-123&matrixEventId=%24image&mxcUri=mxc%3A%2F%2Fhome-dev%2Fimage&mimeType=application%2Fpdf&fileName=image.pdf&mediaId=image',

--- a/apps/whatsapp-service/src/__tests__/privateSyncRoutes.test.ts
+++ b/apps/whatsapp-service/src/__tests__/privateSyncRoutes.test.ts
@@ -1175,6 +1175,80 @@ describe('Private WhatsApp Sync Routes', () => {
     ]);
   });
 
+  it('publishes one private video transcription job after chat transcription is enabled', async () => {
+    await ctx.app.inject({
+      method: 'POST',
+      url: '/internal/whatsapp/private/events',
+      headers: { 'x-internal-auth': 'test-internal-token' },
+      payload: createPayload(),
+    });
+    const token = await createToken({ sub: 'user-123' });
+    const chatsResponse = await ctx.app.inject({
+      method: 'GET',
+      url: '/private/chats?limit=1',
+      headers: { authorization: `Bearer ${token}` },
+    });
+    const chatsBody = JSON.parse(chatsResponse.body) as { data: { chats: { id: string }[] } };
+    const chatId = chatsBody.data.chats[0]?.id ?? '';
+    const updateResponse = await ctx.app.inject({
+      method: 'PATCH',
+      url: `/private/chats/${encodeURIComponent(chatId)}/transcription`,
+      headers: { authorization: `Bearer ${token}` },
+      payload: { enabled: true },
+    });
+    expect(updateResponse.statusCode).toBe(200);
+
+    const videoPayload = createPayload({
+      events: [
+        {
+          ...(createPayload()['events'] as Record<string, unknown>[])[0],
+          matrixEventId: '$event-private-video',
+          message: {
+            direction: 'incoming',
+            type: 'video',
+            media: {
+              mxcUri: 'mxc://home-dev/private-video',
+              mimeType: 'video/mp4',
+              storageStatus: 'stored',
+              gcsPath: 'whatsapp/private/user-123/private-video/video.mp4',
+              storedMimeType: 'video/mp4',
+              storedSizeBytes: 4096,
+            },
+          },
+        },
+      ],
+    });
+
+    const firstIngest = await ctx.app.inject({
+      method: 'POST',
+      url: '/internal/whatsapp/private/events',
+      headers: { 'x-internal-auth': 'test-internal-token' },
+      payload: videoPayload,
+    });
+    const duplicateIngest = await ctx.app.inject({
+      method: 'POST',
+      url: '/internal/whatsapp/private/events',
+      headers: { 'x-internal-auth': 'test-internal-token' },
+      payload: videoPayload,
+    });
+
+    expect(firstIngest.statusCode).toBe(200);
+    expect(duplicateIngest.statusCode).toBe(200);
+    expect(ctx.eventPublisher.getMediaTranscriptionRequestedEvents()).toEqual([
+      {
+        type: 'whatsapp.media.transcription.requested',
+        messageSource: 'private_whatsapp',
+        mediaKind: 'video',
+        userId: 'user-123',
+        messageId: 'message:pbuchman-private-whatsapp:$event-private-video',
+        mediaId: 'mxc://home-dev/private-video',
+        gcsPath: 'whatsapp/private/user-123/private-video/video.mp4',
+        mimeType: 'video/mp4',
+        timestamp: expect.any(String),
+      },
+    ]);
+  });
+
   it('returns stored private WhatsApp message transcription state in chat messages', async () => {
     const ingestResponse = await ctx.app.inject({
       method: 'POST',

--- a/apps/whatsapp-service/src/__tests__/pubsubRoutes.test.ts
+++ b/apps/whatsapp-service/src/__tests__/pubsubRoutes.test.ts
@@ -1487,6 +1487,34 @@ describe('Pub/Sub Routes', () => {
       });
     };
 
+    const setStoredVideoMessage = (
+      overrides: Partial<Parameters<FakeWhatsAppMessageRepository['setMessage']>[0]> = {}
+    ): void => {
+      messageRepository.setMessage({
+        id: 'stored-video-1',
+        userId: 'user-video',
+        waMessageId: 'wamid.video.1',
+        fromNumber: '15551234567',
+        toNumber: '15557654321',
+        text: 'Original video caption',
+        mediaType: 'video',
+        media: {
+          id: 'media-video-1',
+          mimeType: 'video/mp4',
+          fileSize: 4321,
+        },
+        gcsPath: 'whatsapp/user-video/wamid.video.1/media-video-1.mp4',
+        metadata: {
+          senderName: 'Test User',
+          phoneNumberId: '123456789012345',
+        },
+        timestamp: '1782669600',
+        receivedAt: '2026-06-28T09:59:00.000Z',
+        webhookEventId: 'event-video-1',
+        ...overrides,
+      });
+    };
+
     const storePrivateAudioMessage = async (
       overrides: {
         matrixEventId?: string;
@@ -1891,6 +1919,83 @@ describe('Pub/Sub Routes', () => {
           messageText: 'Transcription:\nBuy milk and call Joanna.',
           sentAt: expect.any(String),
           expiresAt: expect.any(Number),
+        },
+      ]);
+    });
+
+    it('stores a completed video transcription and sends it to Intex as video transcript', async () => {
+      setStoredVideoMessage();
+
+      const body = createPubSubBody({
+        type: 'srt.transcription.completed',
+        messageSource: 'public_whatsapp',
+        mediaKind: 'video',
+        userId: 'user-video',
+        messageId: 'stored-video-1',
+        jobId: 'job-video-123',
+        status: 'completed',
+        transcript: 'Video transcript text.',
+        timestamp: '2026-06-28T10:05:00.000Z',
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/internal/whatsapp/pubsub/transcription-completed',
+        headers: { 'x-internal-auth': INTERNAL_AUTH_TOKEN },
+        payload: body,
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(messageRepository.getMessageSync('stored-video-1')?.transcription).toEqual({
+        status: 'completed',
+        jobId: 'job-video-123',
+        text: 'Video transcript text.',
+        completedAt: '2026-06-28T10:05:00.000Z',
+      });
+      expect(eventPublisher.getIntexMessageIngestEvents()).toEqual([
+        {
+          type: 'intex.message.ingest',
+          userId: 'user-video',
+          messageId: 'wamid.video.1',
+          sourceType: 'whatsapp_video_transcript',
+          text: 'Video transcript text.',
+          whatsappSender: '15551234567',
+          timestamp: '2026-06-28T10:05:00.000Z',
+        },
+      ]);
+    });
+
+    it('falls back to stored video media type when completed event omits mediaKind', async () => {
+      setStoredVideoMessage();
+
+      const body = createPubSubBody({
+        type: 'srt.transcription.completed',
+        messageSource: 'public_whatsapp',
+        userId: 'user-video',
+        messageId: 'stored-video-1',
+        jobId: 'job-video-123',
+        status: 'completed',
+        transcript: 'Video transcript without media kind.',
+        timestamp: '2026-06-28T10:05:00.000Z',
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/internal/whatsapp/pubsub/transcription-completed',
+        headers: { 'x-internal-auth': INTERNAL_AUTH_TOKEN },
+        payload: body,
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(eventPublisher.getIntexMessageIngestEvents()).toEqual([
+        {
+          type: 'intex.message.ingest',
+          userId: 'user-video',
+          messageId: 'wamid.video.1',
+          sourceType: 'whatsapp_video_transcript',
+          text: 'Video transcript without media kind.',
+          whatsappSender: '15551234567',
+          timestamp: '2026-06-28T10:05:00.000Z',
         },
       ]);
     });

--- a/apps/whatsapp-service/src/__tests__/shared.test.ts
+++ b/apps/whatsapp-service/src/__tests__/shared.test.ts
@@ -16,6 +16,7 @@ import {
   extractReplyContext,
   extractSenderName,
   extractSenderPhoneNumber,
+  extractVideoMedia,
   extractWabaId,
   getSupportedCountries,
   normalizePhoneNumber,
@@ -840,6 +841,118 @@ describe('shared utilities', () => {
         entry: [{ changes: [{ value: { messages: [] } }] }],
       };
       expect(extractAudioMedia(payload)).toBeNull();
+    });
+  });
+
+  describe('extractVideoMedia', () => {
+    it('extracts video media info', () => {
+      const payload = {
+        entry: [
+          {
+            changes: [
+              {
+                value: {
+                  messages: [
+                    {
+                      type: 'video',
+                      video: {
+                        id: 'video-123',
+                        mime_type: 'video/mp4',
+                        sha256: 'ghi789',
+                        caption: 'Video caption',
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+      };
+      const result = extractVideoMedia(payload);
+      expect(result).toEqual({
+        id: 'video-123',
+        mimeType: 'video/mp4',
+        sha256: 'ghi789',
+        caption: 'Video caption',
+      });
+    });
+
+    it('returns video media without optional fields', () => {
+      const payload = {
+        entry: [
+          {
+            changes: [
+              {
+                value: {
+                  messages: [
+                    {
+                      type: 'video',
+                      video: {
+                        id: 'video-123',
+                        mime_type: 'video/3gpp',
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+      };
+      const result = extractVideoMedia(payload);
+      expect(result).toEqual({
+        id: 'video-123',
+        mimeType: 'video/3gpp',
+      });
+    });
+
+    it('returns null when video is not present', () => {
+      const payload = {
+        entry: [{ changes: [{ value: { messages: [{ type: 'text' }] } }] }],
+      };
+      expect(extractVideoMedia(payload)).toBeNull();
+    });
+
+    it('returns null when video id is missing', () => {
+      const payload = {
+        entry: [
+          {
+            changes: [
+              {
+                value: {
+                  messages: [{ type: 'video', video: { mime_type: 'video/mp4' } }],
+                },
+              },
+            ],
+          },
+        ],
+      };
+      expect(extractVideoMedia(payload)).toBeNull();
+    });
+
+    it('returns null when mime_type is missing', () => {
+      const payload = {
+        entry: [
+          {
+            changes: [
+              {
+                value: {
+                  messages: [{ type: 'video', video: { id: 'video-123' } }],
+                },
+              },
+            ],
+          },
+        ],
+      };
+      expect(extractVideoMedia(payload)).toBeNull();
+    });
+
+    it('returns null when messages array is empty', () => {
+      const payload = {
+        entry: [{ changes: [{ value: { messages: [] } }] }],
+      };
+      expect(extractVideoMedia(payload)).toBeNull();
     });
   });
 

--- a/apps/whatsapp-service/src/__tests__/testUtils.ts
+++ b/apps/whatsapp-service/src/__tests__/testUtils.ts
@@ -403,6 +403,56 @@ export function createAudioWebhookPayload(options?: { mediaId?: string }): objec
 }
 
 /**
+ * Create a WhatsApp video message webhook payload.
+ * Uses IDs that match testConfig.allowedWabaIds and testConfig.allowedPhoneNumberIds.
+ */
+export function createVideoWebhookPayload(options?: { mediaId?: string; caption?: string }): object {
+  const mediaId = options?.mediaId ?? 'test-video-id-12345';
+  return {
+    object: 'whatsapp_business_account',
+    entry: [
+      {
+        id: '102290129340398',
+        changes: [
+          {
+            field: 'messages',
+            value: {
+              messaging_product: 'whatsapp',
+              metadata: {
+                display_phone_number: '15551234567',
+                phone_number_id: '123456789012345',
+              },
+              contacts: [
+                {
+                  wa_id: '15551234567',
+                  profile: {
+                    name: 'Test User',
+                  },
+                },
+              ],
+              messages: [
+                {
+                  from: '15551234567',
+                  id: 'wamid.video.HBgNMTU1NTEyMzQ1Njc4FQIAEhgUM0VCMDVBNzYwREQ0RjMwMjYzMDcA',
+                  timestamp: '1234567890',
+                  type: 'video',
+                  video: {
+                    id: mediaId,
+                    mime_type: 'video/mp4',
+                    sha256: 'video789abc',
+                    ...(options?.caption !== undefined ? { caption: options.caption } : {}),
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ],
+  };
+}
+
+/**
  * Create a WhatsApp reaction webhook payload.
  * Used to test unsupported reaction handling.
  */

--- a/apps/whatsapp-service/src/__tests__/usecases/ingestPrivateWhatsAppEvents.test.ts
+++ b/apps/whatsapp-service/src/__tests__/usecases/ingestPrivateWhatsAppEvents.test.ts
@@ -10,6 +10,7 @@ import {
   type IngestPrivateWhatsAppEventInput,
   type IngestPrivateWhatsAppEventsInput,
   type MediaCleanupEvent,
+  type MediaTranscriptionRequestedEvent,
   type PrivateWhatsAppAccount,
   type PrivateWhatsAppAggregateRebuildInput,
   type PrivateWhatsAppAggregateRebuildResult,
@@ -197,7 +198,9 @@ class TestPrivateWhatsAppRepository implements PrivateWhatsAppRepository {
 
 class TestEventPublisher implements EventPublisherPort {
   readonly audioStoredEvents: AudioStoredEvent[] = [];
+  readonly mediaTranscriptionRequestedEvents: MediaTranscriptionRequestedEvent[] = [];
   failNextAudioStored = false;
+  failNextMediaTranscriptionRequested = false;
 
   publishMediaCleanup(_event: MediaCleanupEvent): Promise<Result<void, WhatsAppError>> {
     return Promise.resolve(ok(undefined));
@@ -209,6 +212,19 @@ class TestEventPublisher implements EventPublisherPort {
       return Promise.resolve(err({ code: 'INTERNAL_ERROR', message: 'Audio publish failed' }));
     }
     this.audioStoredEvents.push(event);
+    return Promise.resolve(ok(undefined));
+  }
+
+  publishMediaTranscriptionRequested(
+    event: MediaTranscriptionRequestedEvent
+  ): Promise<Result<void, WhatsAppError>> {
+    if (this.failNextMediaTranscriptionRequested) {
+      this.failNextMediaTranscriptionRequested = false;
+      return Promise.resolve(
+        err({ code: 'INTERNAL_ERROR', message: 'Media transcription publish failed' })
+      );
+    }
+    this.mediaTranscriptionRequestedEvents.push(event);
     return Promise.resolve(ok(undefined));
   }
 
@@ -525,6 +541,44 @@ describe('IngestPrivateWhatsAppEventsUseCase', () => {
 
     expect(result.ok).toBe(true);
     expect(eventPublisher.audioStoredEvents).toEqual([]);
+  });
+
+  it('publishes private video transcription jobs only for enabled chats and created events', async () => {
+    repository.chatTranscriptionEnabled = true;
+    const videoEvent = createEvent({
+      matrixEventId: '$video-event-1',
+      message: {
+        direction: 'incoming',
+        type: 'video',
+        media: {
+          mxcUri: 'mxc://home-dev/video-event-1',
+          mimeType: 'video/mp4',
+          storageStatus: 'stored',
+          gcsPath: 'whatsapp/private/user-123/message-1/video.mp4',
+          storedMimeType: 'video/mp4',
+          storedSizeBytes: 4321,
+        },
+      },
+    });
+
+    const firstResult = await useCase.execute(createInput({ events: [videoEvent] }), logger);
+    const duplicateResult = await useCase.execute(createInput({ events: [videoEvent] }), logger);
+
+    expect(firstResult.ok).toBe(true);
+    expect(duplicateResult.ok).toBe(true);
+    expect(eventPublisher.mediaTranscriptionRequestedEvents).toEqual([
+      {
+        type: 'whatsapp.media.transcription.requested',
+        messageSource: 'private_whatsapp',
+        mediaKind: 'video',
+        userId: 'user-123',
+        messageId: 'message-1',
+        mediaId: 'mxc://home-dev/video-event-1',
+        gcsPath: 'whatsapp/private/user-123/message-1/video.mp4',
+        mimeType: 'video/mp4',
+        timestamp: expect.any(String),
+      },
+    ]);
   });
 
   it('returns a persistence error when publishing a private audio transcription job fails', async () => {

--- a/apps/whatsapp-service/src/__tests__/usecases/processVideoMessage.test.ts
+++ b/apps/whatsapp-service/src/__tests__/usecases/processVideoMessage.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Tests for ProcessVideoMessageUseCase.
+ */
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { WhatsAppWebhookEvent } from '../../domain/whatsapp/index.js';
+import {
+  type ProcessVideoMessageDeps,
+  type ProcessVideoMessageInput,
+  type ProcessVideoMessageLogger,
+  ProcessVideoMessageUseCase,
+} from '../../domain/whatsapp/index.js';
+import {
+  FakeEventPublisher,
+  FakeMediaStorage,
+  FakeWhatsAppCloudApiPort,
+  FakeWhatsAppMessageRepository,
+  FakeWhatsAppWebhookEventRepository,
+} from '../fakes.js';
+
+function createTestLogger(): ProcessVideoMessageLogger {
+  return {
+    info: (): void => {
+      // No-op: test logger
+    },
+    error: (): void => {
+      // No-op: test logger
+    },
+  };
+}
+
+function createTestInput(overrides?: Partial<ProcessVideoMessageInput>): ProcessVideoMessageInput {
+  return {
+    eventId: 'test-event-id',
+    userId: 'test-user-id',
+    waMessageId: 'wamid.video123',
+    fromNumber: '48123456789',
+    toNumber: '48987654321',
+    timestamp: '1703673600',
+    senderName: 'Test User',
+    phoneNumberId: '123456789012345',
+    videoMedia: {
+      id: 'video-media-id-123',
+      mimeType: 'video/mp4',
+      sha256: 'video-sha',
+      caption: 'Video caption',
+    },
+    ...overrides,
+  };
+}
+
+function createTestWebhookEvent(eventId = 'test-event-id'): WhatsAppWebhookEvent {
+  return {
+    id: eventId,
+    payload: {},
+    signatureValid: true,
+    receivedAt: new Date().toISOString(),
+    phoneNumberId: '123456789012345',
+    status: 'pending',
+  };
+}
+
+describe('ProcessVideoMessageUseCase', () => {
+  let webhookEventRepository: FakeWhatsAppWebhookEventRepository;
+  let messageRepository: FakeWhatsAppMessageRepository;
+  let mediaStorage: FakeMediaStorage;
+  let whatsappCloudApi: FakeWhatsAppCloudApiPort;
+  let eventPublisher: FakeEventPublisher;
+  let usecase: ProcessVideoMessageUseCase;
+  let deps: ProcessVideoMessageDeps;
+  let logger: ProcessVideoMessageLogger;
+
+  beforeEach(() => {
+    webhookEventRepository = new FakeWhatsAppWebhookEventRepository();
+    messageRepository = new FakeWhatsAppMessageRepository();
+    mediaStorage = new FakeMediaStorage();
+    whatsappCloudApi = new FakeWhatsAppCloudApiPort();
+    eventPublisher = new FakeEventPublisher();
+    logger = createTestLogger();
+    deps = {
+      webhookEventRepository,
+      messageRepository,
+      mediaStorage,
+      whatsappCloudApi,
+      eventPublisher,
+    };
+    usecase = new ProcessVideoMessageUseCase(deps);
+    whatsappCloudApi.setMediaUrl('video-media-id-123', {
+      url: 'https://example.com/media/video.mp4',
+      mimeType: 'video/mp4',
+      fileSize: 7000,
+    });
+    whatsappCloudApi.setMediaContent(
+      'https://example.com/media/video.mp4',
+      Buffer.from('fake-video-content')
+    );
+  });
+
+  it('stores video media and publishes a video transcription request', async () => {
+    webhookEventRepository.setEvent(createTestWebhookEvent());
+    const input = createTestInput();
+
+    const result = await usecase.execute(input, logger);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+
+    expect(result.value.messageId).toBeDefined();
+    expect(result.value.gcsPath).toContain('whatsapp/');
+    expect(result.value.gcsPath).toContain('.mp4');
+    expect(result.value.mimeType).toBe('video/mp4');
+
+    const messages = messageRepository.getAll();
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toMatchObject({
+      userId: 'test-user-id',
+      mediaType: 'video',
+      text: 'Video caption',
+      caption: 'Video caption',
+      media: {
+        id: 'video-media-id-123',
+        mimeType: 'video/mp4',
+        sha256: 'video-sha',
+      },
+    });
+
+    const events = webhookEventRepository.getAll();
+    expect(events[0]?.status).toBe('completed');
+
+    expect(eventPublisher.getMediaTranscriptionRequestedEvents()).toEqual([
+      {
+        type: 'whatsapp.media.transcription.requested',
+        mediaKind: 'video',
+        messageSource: 'public_whatsapp',
+        userId: 'test-user-id',
+        messageId: result.value.messageId,
+        mediaId: 'video-media-id-123',
+        gcsPath: result.value.gcsPath,
+        mimeType: 'video/mp4',
+        timestamp: expect.any(String),
+      },
+    ]);
+  });
+
+  it('handles video without caption, sha256, senderName, and phoneNumberId', async () => {
+    webhookEventRepository.setEvent(createTestWebhookEvent());
+    const input = createTestInput({
+      senderName: null,
+      phoneNumberId: null,
+      videoMedia: {
+        id: 'video-media-id-123',
+        mimeType: 'video/mp4',
+      },
+    });
+
+    const result = await usecase.execute(input, logger);
+
+    expect(result.ok).toBe(true);
+    const messages = messageRepository.getAll();
+    expect(messages).toHaveLength(1);
+    expect(messages[0]?.text).toBe('');
+    expect(messages[0]?.caption).toBeUndefined();
+    expect(messages[0]?.media?.sha256).toBeUndefined();
+    expect(messages[0]?.metadata).toBeUndefined();
+  });
+
+  it('handles video with only senderName metadata', async () => {
+    webhookEventRepository.setEvent(createTestWebhookEvent());
+    const input = createTestInput({ senderName: 'Test User', phoneNumberId: null });
+
+    const result = await usecase.execute(input, logger);
+
+    expect(result.ok).toBe(true);
+    const messages = messageRepository.getAll();
+    expect(messages[0]?.metadata).toEqual({ senderName: 'Test User' });
+  });
+
+  it('handles video with only phoneNumberId metadata', async () => {
+    webhookEventRepository.setEvent(createTestWebhookEvent());
+    const input = createTestInput({ senderName: null, phoneNumberId: '123456789012345' });
+
+    const result = await usecase.execute(input, logger);
+
+    expect(result.ok).toBe(true);
+    const messages = messageRepository.getAll();
+    expect(messages[0]?.metadata).toEqual({ phoneNumberId: '123456789012345' });
+  });
+
+  it('marks the webhook event failed when getting the video URL fails', async () => {
+    webhookEventRepository.setEvent(createTestWebhookEvent());
+    whatsappCloudApi.setFailGetMediaUrl(true);
+    const input = createTestInput();
+
+    const result = await usecase.execute(input, logger);
+
+    expect(result.ok).toBe(false);
+    const events = webhookEventRepository.getAll();
+    expect(events[0]?.status).toBe('failed');
+    expect(events[0]?.failureDetails).toContain('Failed to get video URL');
+  });
+
+  it('marks the webhook event failed when downloading video media fails', async () => {
+    webhookEventRepository.setEvent(createTestWebhookEvent());
+    whatsappCloudApi.setFailDownload(true);
+    const input = createTestInput();
+
+    const result = await usecase.execute(input, logger);
+
+    expect(result.ok).toBe(false);
+    const events = webhookEventRepository.getAll();
+    expect(events[0]?.status).toBe('failed');
+    expect(events[0]?.failureDetails).toContain('Failed to download video');
+  });
+
+  it('marks the webhook event failed when uploading video media fails', async () => {
+    webhookEventRepository.setEvent(createTestWebhookEvent());
+    mediaStorage.setFailUpload(true);
+    const input = createTestInput();
+
+    const result = await usecase.execute(input, logger);
+
+    expect(result.ok).toBe(false);
+    const events = webhookEventRepository.getAll();
+    expect(events[0]?.status).toBe('failed');
+    expect(events[0]?.failureDetails).toContain('Failed to upload video');
+  });
+
+  it('marks the webhook event failed when saving the video message fails', async () => {
+    webhookEventRepository.setEvent(createTestWebhookEvent());
+    messageRepository.setFailSave(true);
+    const input = createTestInput();
+
+    const result = await usecase.execute(input, logger);
+
+    expect(result.ok).toBe(false);
+    const events = webhookEventRepository.getAll();
+    expect(events[0]?.status).toBe('failed');
+    expect(events[0]?.failureDetails).toContain('Failed to save message');
+  });
+
+  it('marks the webhook event failed when publishing the transcription request fails', async () => {
+    webhookEventRepository.setEvent(createTestWebhookEvent());
+    eventPublisher.setMediaTranscriptionRequestedFailure('Pub/Sub unavailable');
+    const input = createTestInput();
+
+    const result = await usecase.execute(input, logger);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toBe('Pub/Sub unavailable');
+    }
+    const events = webhookEventRepository.getAll();
+    expect(events[0]?.status).toBe('failed');
+    expect(events[0]?.failureDetails).toContain('Failed to publish media transcription request');
+  });
+});

--- a/apps/whatsapp-service/src/__tests__/usecases/processWebhookEventTextOnly.test.ts
+++ b/apps/whatsapp-service/src/__tests__/usecases/processWebhookEventTextOnly.test.ts
@@ -13,6 +13,7 @@ import {
 import {
   createAudioWebhookPayload,
   createButtonWebhookPayload,
+  createVideoWebhookPayload,
   createReplyWebhookPayload,
   createWebhookPayload,
 } from '../testUtils.js';
@@ -107,6 +108,18 @@ function prepareAudioMedia(whatsappCloudApi: FakeWhatsAppCloudApiPort, mediaId: 
   );
 }
 
+function prepareVideoMedia(whatsappCloudApi: FakeWhatsAppCloudApiPort, mediaId: string): void {
+  whatsappCloudApi.setMediaUrl(mediaId, {
+    url: `https://cdn.example.com/${mediaId}.mp4`,
+    mimeType: 'video/mp4',
+    fileSize: 3,
+  });
+  whatsappCloudApi.setMediaContent(
+    `https://cdn.example.com/${mediaId}.mp4`,
+    Buffer.from([0x00, 0x01, 0x02])
+  );
+}
+
 describe('ProcessWebhookEventUseCase text-only branches', () => {
   it('completes audio messages without sending a response when phoneNumberId is missing', async () => {
     const {
@@ -165,6 +178,34 @@ describe('ProcessWebhookEventUseCase text-only branches', () => {
     expect(whatsappCloudApi.getSentMessages()).toHaveLength(0);
     expect(whatsappCloudApi.getMarkedAsReadWithTypingMessages()).toHaveLength(1);
     expect(eventPublisher.getAudioStoredEvents()).toHaveLength(1);
+  });
+
+  it('completes video messages without marking read when phoneNumberId is missing', async () => {
+    const {
+      savedEvent,
+      useCase,
+      userMappingRepository,
+      webhookEventRepository,
+      messageRepository,
+      mediaStorage,
+      whatsappCloudApi,
+      eventPublisher,
+    } = await createHarness();
+    await userMappingRepository.saveMapping('user-1', ['15551234567']);
+    prepareVideoMedia(whatsappCloudApi, 'media-video-1');
+
+    const payload = createVideoWebhookPayload({ mediaId: 'media-video-1' }) as MutablePhoneMetadataPayload;
+    delete payload.entry[0]?.changes[0]?.value.metadata.phone_number_id;
+
+    await useCase.execute(payload as unknown as WebhookPayload, savedEvent, logger());
+
+    const eventResult = await webhookEventRepository.getEvent(savedEvent.id);
+    expect(eventResult.ok && eventResult.value?.status).toBe('completed');
+    expect(messageRepository.getAll()).toHaveLength(1);
+    expect(messageRepository.getAll()[0]?.mediaType).toBe('video');
+    expect(mediaStorage.getAllFiles().size).toBe(1);
+    expect(whatsappCloudApi.getMarkedAsReadWithTypingMessages()).toHaveLength(0);
+    expect(eventPublisher.getMediaTranscriptionRequestedEvents()).toHaveLength(1);
   });
 
   it('returns after audio storage fails without sending an unsupported response', async () => {

--- a/apps/whatsapp-service/src/__tests__/webhookAsyncProcessing.test.ts
+++ b/apps/whatsapp-service/src/__tests__/webhookAsyncProcessing.test.ts
@@ -12,6 +12,7 @@ import {
   createReactionWebhookPayload,
   createReplyWebhookPayload,
   createSignature,
+  createVideoWebhookPayload,
   createWebhookPayload,
   describe,
   expect,
@@ -45,6 +46,27 @@ const SAMPLE_IMAGE_BUFFER = Buffer.from([
   0xe7, 0xe8, 0xe9, 0xea, 0xf1, 0xf2, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7, 0xf8, 0xf9, 0xfa, 0xff, 0xda,
   0x00, 0x08, 0x01, 0x01, 0x00, 0x00, 0x3f, 0x00, 0xfb, 0xd5, 0xfb, 0xd5, 0xff, 0xd9,
 ]);
+
+interface MutableVideoWebhookPayload {
+  entry: {
+    changes: {
+      value: {
+        metadata: {
+          display_phone_number: string;
+          phone_number_id?: string;
+        };
+        messages: {
+          video?: {
+            id: string;
+            mime_type: string;
+            sha256?: string;
+            caption?: string;
+          };
+        }[];
+      };
+    }[];
+  }[];
+}
 
 describe('Webhook async processing', () => {
   const ctx = setupTestContext();
@@ -734,6 +756,151 @@ describe('Webhook async processing', () => {
       const sentMessages = ctx.whatsappCloudApi.getSentMessages();
       expect(sentMessages).toHaveLength(0);
     });
+  });
+
+  describe('video message processing', () => {
+    it('stores video media, publishes transcription request, and waits before Intex ingest', async () => {
+      const senderPhone = '15551234567';
+      const userId = 'test-user-id';
+      const mediaId = 'test-video-id-12345';
+
+      await ctx.userMappingRepository.saveMapping(userId, [senderPhone]);
+      ctx.whatsappCloudApi.setMediaUrl(mediaId, {
+        url: 'https://cdn.example.com/video.mp4',
+        mimeType: 'video/mp4',
+        fileSize: 2000,
+      });
+      ctx.whatsappCloudApi.setMediaContent(
+        'https://cdn.example.com/video.mp4',
+        Buffer.from([0x00, 0x01, 0x02])
+      );
+
+      const payload = createVideoWebhookPayload({ mediaId, caption: 'video note' });
+      const payloadString = JSON.stringify(payload);
+      const signature = createSignature(payloadString, testConfig.appSecret);
+
+      const response = await ctx.app.inject({
+        method: 'POST',
+        url: '/webhooks',
+        headers: {
+          'content-type': 'application/json',
+          'x-hub-signature-256': signature,
+        },
+        payload: payloadString,
+      });
+
+      expect(response.statusCode).toBe(200);
+
+      await triggerWebhookProcessing();
+
+      const events = ctx.webhookEventRepository.getAll();
+      expect(events.length).toBe(1);
+      expect(events[0]?.status).toBe('completed');
+
+      const messages = ctx.messageRepository.getAll();
+      expect(messages).toHaveLength(1);
+      expect(messages[0]).toMatchObject({
+        userId,
+        waMessageId: 'wamid.video.HBgNMTU1NTEyMzQ1Njc4FQIAEhgUM0VCMDVBNzYwREQ0RjMwMjYzMDcA',
+        mediaType: 'video',
+        text: 'video note',
+        caption: 'video note',
+        media: {
+          id: mediaId,
+          mimeType: 'video/mp4',
+          fileSize: 3,
+          sha256: 'video789abc',
+        },
+      });
+      expect(ctx.mediaStorage.getAllFiles().size).toBe(1);
+      expect(ctx.eventPublisher.getIntexMessageIngestEvents()).toHaveLength(0);
+      expect(ctx.eventPublisher.getMediaTranscriptionRequestedEvents()).toHaveLength(1);
+      expect(ctx.eventPublisher.getMediaTranscriptionRequestedEvents()[0]).toMatchObject({
+        type: 'whatsapp.media.transcription.requested',
+        mediaKind: 'video',
+        messageSource: 'public_whatsapp',
+        userId,
+        messageId: messages[0]?.id,
+        mediaId,
+        gcsPath: messages[0]?.gcsPath,
+        mimeType: 'video/mp4',
+      });
+
+      const sentMessages = ctx.whatsappCloudApi.getSentMessages();
+      expect(sentMessages).toHaveLength(0);
+    });
+
+    it('ignores video messages without media info', async () => {
+      const senderPhone = '15551234567';
+      const userId = 'test-user-id';
+
+      await ctx.userMappingRepository.saveMapping(userId, [senderPhone]);
+
+      const payload = createVideoWebhookPayload() as MutableVideoWebhookPayload;
+      const message = payload.entry[0]?.changes[0]?.value.messages[0];
+      if (message === undefined) {
+        throw new Error('Expected video message in test payload');
+      }
+      delete message.video;
+      const payloadString = JSON.stringify(payload);
+      const signature = createSignature(payloadString, testConfig.appSecret);
+
+      const response = await ctx.app.inject({
+        method: 'POST',
+        url: '/webhooks',
+        headers: {
+          'content-type': 'application/json',
+          'x-hub-signature-256': signature,
+        },
+        payload: payloadString,
+      });
+
+      expect(response.statusCode).toBe(200);
+
+      await triggerWebhookProcessing();
+
+      const events = ctx.webhookEventRepository.getAll();
+      expect(events).toHaveLength(1);
+      expect(events[0]?.status).toBe('ignored');
+      expect(events[0]?.ignoredReason).toEqual({
+        code: 'NO_VIDEO_MEDIA',
+        message: 'Video message has no media info',
+      });
+      expect(ctx.messageRepository.getAll()).toHaveLength(0);
+    });
+
+    it('marks the webhook event failed when video processing fails', async () => {
+      const senderPhone = '15551234567';
+      const userId = 'test-user-id';
+
+      await ctx.userMappingRepository.saveMapping(userId, [senderPhone]);
+      ctx.whatsappCloudApi.setFailGetMediaUrl(true);
+
+      const payload = createVideoWebhookPayload();
+      const payloadString = JSON.stringify(payload);
+      const signature = createSignature(payloadString, testConfig.appSecret);
+
+      const response = await ctx.app.inject({
+        method: 'POST',
+        url: '/webhooks',
+        headers: {
+          'content-type': 'application/json',
+          'x-hub-signature-256': signature,
+        },
+        payload: payloadString,
+      });
+
+      expect(response.statusCode).toBe(200);
+
+      await triggerWebhookProcessing();
+
+      const events = ctx.webhookEventRepository.getAll();
+      expect(events).toHaveLength(1);
+      expect(events[0]?.status).toBe('failed');
+      expect(events[0]?.failureDetails).toContain('Failed to get video URL');
+      expect(ctx.whatsappCloudApi.getMarkedAsReadWithTypingMessages()).toHaveLength(0);
+    });
+
   });
 
   describe('text message error handling', () => {

--- a/apps/whatsapp-service/src/domain/whatsapp/events/events.ts
+++ b/apps/whatsapp-service/src/domain/whatsapp/events/events.ts
@@ -79,6 +79,57 @@ export interface AudioStoredEvent {
 }
 
 /**
+ * Event published after inbound WhatsApp media has been stored.
+ * Triggers the transcription worker for audio and video inputs.
+ */
+export interface MediaTranscriptionRequestedEvent {
+  /**
+   * Event type identifier.
+   */
+  type: 'whatsapp.media.transcription.requested';
+
+  /**
+   * Source collection where the message is stored.
+   */
+  messageSource?: 'public_whatsapp' | 'private_whatsapp';
+
+  /**
+   * Kind of media the worker should transcribe.
+   */
+  mediaKind: 'audio' | 'video';
+
+  /**
+   * IntexuraOS user ID.
+   */
+  userId: string;
+
+  /**
+   * Stored WhatsApp message document ID.
+   */
+  messageId: string;
+
+  /**
+   * WhatsApp media ID.
+   */
+  mediaId: string;
+
+  /**
+   * GCS path to the original media file.
+   */
+  gcsPath: string;
+
+  /**
+   * MIME type of the stored media file.
+   */
+  mimeType: string;
+
+  /**
+   * Event timestamp (ISO 8601).
+   */
+  timestamp: string;
+}
+
+/**
  * Event received after the transcription worker completes an audio job.
  */
 export interface TranscriptionCompletedEvent {
@@ -91,6 +142,11 @@ export interface TranscriptionCompletedEvent {
    * Source collection where the message is stored.
    */
   messageSource?: 'public_whatsapp' | 'private_whatsapp';
+
+  /**
+   * Kind of media that was transcribed.
+   */
+  mediaKind?: 'audio' | 'video';
 
   /**
    * IntexuraOS user ID.
@@ -219,6 +275,7 @@ export type IntexMessageSourceType =
   | 'whatsapp_text'
   | 'whatsapp_image'
   | 'whatsapp_audio_transcript'
+  | 'whatsapp_video_transcript'
   | 'whatsapp_button';
 
 /**
@@ -312,6 +369,7 @@ export interface ExtractLinkPreviewsEvent {
 export type WhatsAppEvent =
   | MediaCleanupEvent
   | AudioStoredEvent
+  | MediaTranscriptionRequestedEvent
   | TranscriptionCompletedEvent
   | IntexMessageIngestEvent
   | SendMessageEvent

--- a/apps/whatsapp-service/src/domain/whatsapp/events/index.ts
+++ b/apps/whatsapp-service/src/domain/whatsapp/events/index.ts
@@ -9,6 +9,7 @@ export type {
   IntexMessageReplyContextSource,
   IntexMessageSourceType,
   MediaCleanupEvent,
+  MediaTranscriptionRequestedEvent,
   SendMessageEvent,
   TranscriptionCompletedEvent,
   WebhookProcessEvent,

--- a/apps/whatsapp-service/src/domain/whatsapp/index.ts
+++ b/apps/whatsapp-service/src/domain/whatsapp/index.ts
@@ -129,7 +129,9 @@ export type {
   AudioStoredEvent,
   ExtractLinkPreviewsEvent,
   IntexMessageIngestEvent,
+  IntexMessageSourceType,
   MediaCleanupEvent,
+  MediaTranscriptionRequestedEvent,
   SendMessageEvent,
   TranscriptionCompletedEvent,
   WebhookProcessEvent,
@@ -155,6 +157,15 @@ export {
   type ProcessAudioMessageLogger,
   type AudioMediaInfo,
 } from './usecases/processAudioMessage.js';
+
+export {
+  ProcessVideoMessageUseCase,
+  type ProcessVideoMessageInput,
+  type ProcessVideoMessageResult,
+  type ProcessVideoMessageDeps,
+  type ProcessVideoMessageLogger,
+  type VideoMediaInfo,
+} from './usecases/processVideoMessage.js';
 
 export {
   ExtractLinkPreviewsUseCase,

--- a/apps/whatsapp-service/src/domain/whatsapp/models/WhatsAppMessage.ts
+++ b/apps/whatsapp-service/src/domain/whatsapp/models/WhatsAppMessage.ts
@@ -2,13 +2,13 @@ import type { LinkPreviewState } from './LinkPreview.js';
 
 /**
  * Domain model for stored WhatsApp messages.
- * Represents a text, image, or audio message received via WhatsApp webhook.
+ * Represents a text, image, audio, or video message received via WhatsApp webhook.
  */
 
 /**
  * Type of WhatsApp message content.
  */
-export type WhatsAppMediaType = 'text' | 'image' | 'audio';
+export type WhatsAppMediaType = 'text' | 'image' | 'audio' | 'video';
 
 /**
  * Media information from WhatsApp webhook.

--- a/apps/whatsapp-service/src/domain/whatsapp/ports/eventPublisher.ts
+++ b/apps/whatsapp-service/src/domain/whatsapp/ports/eventPublisher.ts
@@ -9,6 +9,7 @@ import type {
   ExtractLinkPreviewsEvent,
   IntexMessageIngestEvent,
   MediaCleanupEvent,
+  MediaTranscriptionRequestedEvent,
   WebhookProcessEvent,
 } from '../events/index.js';
 
@@ -27,6 +28,14 @@ export interface EventPublisherPort {
    * Triggers async transcription.
    */
   publishAudioStored(event: AudioStoredEvent): Promise<Result<void, WhatsAppError>>;
+
+  /**
+   * Publish a media transcription request event.
+   * Triggers async transcription for stored audio/video.
+   */
+  publishMediaTranscriptionRequested(
+    event: MediaTranscriptionRequestedEvent
+  ): Promise<Result<void, WhatsAppError>>;
 
   /**
    * Publish a WhatsApp Assistant message ingest event.

--- a/apps/whatsapp-service/src/domain/whatsapp/usecases/ingestPrivateWhatsAppEvents.ts
+++ b/apps/whatsapp-service/src/domain/whatsapp/usecases/ingestPrivateWhatsAppEvents.ts
@@ -141,7 +141,7 @@ export class IngestPrivateWhatsAppEventsUseCase {
       };
       messages.push(result);
 
-      const publishResult = await publishPrivateAudioStoredIfNeeded({
+      const publishResult = await publishPrivateTranscriptionRequestIfNeeded({
         event,
         outcome,
         storeInput,
@@ -168,7 +168,7 @@ export class IngestPrivateWhatsAppEventsUseCase {
   }
 }
 
-interface PublishPrivateAudioStoredInput {
+interface PublishPrivateTranscriptionRequestInput {
   event: IngestPrivateWhatsAppEventInput;
   outcome: PrivateWhatsAppIngestOutcome;
   storeInput: StorePrivateWhatsAppMessageInput;
@@ -176,14 +176,14 @@ interface PublishPrivateAudioStoredInput {
   logger: Logger;
 }
 
-async function publishPrivateAudioStoredIfNeeded(
-  input: PublishPrivateAudioStoredInput
+async function publishPrivateTranscriptionRequestIfNeeded(
+  input: PublishPrivateTranscriptionRequestInput
 ): Promise<Result<void, WhatsAppError>> {
   const { event, outcome, storeInput, eventPublisher, logger } = input;
   if (outcome.outcome !== 'created' || outcome.chatTranscriptionEnabled !== true) {
     return ok(undefined);
   }
-  if (storeInput.message.type !== 'audio') {
+  if (storeInput.message.type !== 'audio' && storeInput.message.type !== 'video') {
     return ok(undefined);
   }
   const media = storeInput.message.media;
@@ -193,25 +193,40 @@ async function publishPrivateAudioStoredIfNeeded(
     return ok(undefined);
   }
 
-  const publishResult = await eventPublisher.publishAudioStored({
-    type: 'whatsapp.audio.stored',
-    messageSource: 'private_whatsapp',
-    userId: storeInput.userId,
-    messageId: outcome.messageId,
-    mediaId: media.mxcUri,
-    gcsPath,
-    mimeType,
-    timestamp: new Date().toISOString(),
-  });
+  const timestamp = new Date().toISOString();
+  const publishResult =
+    storeInput.message.type === 'audio'
+      ? await eventPublisher.publishAudioStored({
+          type: 'whatsapp.audio.stored',
+          messageSource: 'private_whatsapp',
+          userId: storeInput.userId,
+          messageId: outcome.messageId,
+          mediaId: media.mxcUri,
+          gcsPath,
+          mimeType,
+          timestamp,
+        })
+      : await eventPublisher.publishMediaTranscriptionRequested({
+          type: 'whatsapp.media.transcription.requested',
+          messageSource: 'private_whatsapp',
+          mediaKind: 'video',
+          userId: storeInput.userId,
+          messageId: outcome.messageId,
+          mediaId: media.mxcUri,
+          gcsPath,
+          mimeType,
+          timestamp,
+        });
   if (!publishResult.ok) {
     logger.error(
       {
         matrixEventId: event.matrixEventId,
         sourceAccountId: storeInput.sourceAccountId,
         messageId: outcome.messageId,
+        mediaKind: storeInput.message.type,
         error: publishResult.error,
       },
-      'Failed to publish private WhatsApp audio transcription event'
+      'Failed to publish private WhatsApp media transcription event'
     );
     return err(publishResult.error);
   }

--- a/apps/whatsapp-service/src/domain/whatsapp/usecases/processVideoMessage.ts
+++ b/apps/whatsapp-service/src/domain/whatsapp/usecases/processVideoMessage.ts
@@ -1,0 +1,273 @@
+/**
+ * Use case for processing video messages from WhatsApp.
+ *
+ * Handles the complete flow:
+ * 1. Get media URL from WhatsApp
+ * 2. Download video
+ * 3. Upload video to GCS
+ * 4. Save message to Firestore
+ * 5. Publish media transcription request
+ * 6. Update webhook event status
+ */
+import { err, ok, type Result } from '@intexuraos/common-core';
+import type { WhatsAppError } from '../models/error.js';
+import type { WhatsAppMessage } from '../models/WhatsAppMessage.js';
+import type {
+  WhatsAppMessageRepository,
+  WhatsAppWebhookEventRepository,
+} from '../ports/repositories.js';
+import type { MediaStoragePort } from '../ports/mediaStorage.js';
+import type { WhatsAppCloudApiPort } from '../ports/whatsappCloudApi.js';
+import type { EventPublisherPort } from '../ports/eventPublisher.js';
+import type { Logger } from '../utils/logger.js';
+import { getExtensionFromMimeType } from '../utils/mimeType.js';
+
+/**
+ * Video media information from webhook payload.
+ */
+export interface VideoMediaInfo {
+  id: string;
+  mimeType: string;
+  sha256?: string;
+  caption?: string;
+}
+
+/**
+ * Input for processing a video message.
+ */
+export interface ProcessVideoMessageInput {
+  eventId: string;
+  userId: string;
+  waMessageId: string;
+  fromNumber: string;
+  toNumber: string;
+  timestamp: string;
+  senderName: string | null;
+  phoneNumberId: string | null;
+  videoMedia: VideoMediaInfo;
+}
+
+/**
+ * Result of processing a video message.
+ */
+export interface ProcessVideoMessageResult {
+  messageId: string;
+  gcsPath: string;
+  mimeType: string;
+  mediaId: string;
+}
+
+/**
+ * Logger for the use case.
+ */
+export type ProcessVideoMessageLogger = Logger;
+
+/**
+ * Dependencies for ProcessVideoMessageUseCase.
+ */
+export interface ProcessVideoMessageDeps {
+  webhookEventRepository: WhatsAppWebhookEventRepository;
+  messageRepository: WhatsAppMessageRepository;
+  mediaStorage: MediaStoragePort;
+  whatsappCloudApi: WhatsAppCloudApiPort;
+  eventPublisher: EventPublisherPort;
+}
+
+/**
+ * Use case for processing video messages.
+ */
+export class ProcessVideoMessageUseCase {
+  constructor(private readonly deps: ProcessVideoMessageDeps) {}
+
+  async execute(
+    input: ProcessVideoMessageInput,
+    logger: ProcessVideoMessageLogger
+  ): Promise<Result<ProcessVideoMessageResult, WhatsAppError>> {
+    const {
+      webhookEventRepository,
+      messageRepository,
+      mediaStorage,
+      whatsappCloudApi,
+      eventPublisher,
+    } = this.deps;
+
+    const {
+      eventId,
+      userId,
+      waMessageId,
+      fromNumber,
+      toNumber,
+      timestamp,
+      senderName,
+      phoneNumberId,
+      videoMedia,
+    } = input;
+
+    logger.info(
+      { event: 'video_get_url', eventId, mediaId: videoMedia.id },
+      'Fetching video URL from WhatsApp'
+    );
+
+    const mediaUrlResult = await whatsappCloudApi.getMediaUrl(videoMedia.id);
+    if (!mediaUrlResult.ok) {
+      const failureDetails = `Failed to get video URL: ${mediaUrlResult.error.message}`;
+      logger.error(
+        {
+          event: 'video_get_url_failed',
+          error: mediaUrlResult.error,
+          eventId,
+          mediaId: videoMedia.id,
+        },
+        failureDetails
+      );
+      await webhookEventRepository.updateEventStatus(eventId, 'failed', { failureDetails });
+      return err(mediaUrlResult.error);
+    }
+
+    logger.info(
+      { event: 'video_download', eventId, mediaId: videoMedia.id },
+      'Downloading video from WhatsApp'
+    );
+
+    const downloadResult = await whatsappCloudApi.downloadMedia(mediaUrlResult.value.url);
+    if (!downloadResult.ok) {
+      const failureDetails = `Failed to download video: ${downloadResult.error.message}`;
+      logger.error(
+        {
+          event: 'video_download_failed',
+          error: downloadResult.error,
+          eventId,
+          mediaId: videoMedia.id,
+        },
+        failureDetails
+      );
+      await webhookEventRepository.updateEventStatus(eventId, 'failed', { failureDetails });
+      return err(downloadResult.error);
+    }
+
+    const videoBuffer = downloadResult.value;
+    const extension = getExtensionFromMimeType(videoMedia.mimeType);
+
+    logger.info(
+      { event: 'video_upload', eventId, mediaId: videoMedia.id },
+      'Uploading video to GCS'
+    );
+
+    const uploadResult = await mediaStorage.upload(
+      userId,
+      waMessageId,
+      videoMedia.id,
+      extension,
+      videoBuffer,
+      videoMedia.mimeType
+    );
+
+    if (!uploadResult.ok) {
+      const failureDetails = `Failed to upload video: ${uploadResult.error.message}`;
+      logger.error(
+        {
+          event: 'video_upload_failed',
+          error: uploadResult.error,
+          eventId,
+          mediaId: videoMedia.id,
+        },
+        failureDetails
+      );
+      await webhookEventRepository.updateEventStatus(eventId, 'failed', { failureDetails });
+      return err(uploadResult.error);
+    }
+
+    const messageToSave: Omit<WhatsAppMessage, 'id'> = {
+      userId,
+      waMessageId,
+      fromNumber,
+      toNumber,
+      text: videoMedia.caption ?? '',
+      mediaType: 'video',
+      media: {
+        id: videoMedia.id,
+        mimeType: videoMedia.mimeType,
+        fileSize: videoBuffer.length,
+      },
+      gcsPath: uploadResult.value.gcsPath,
+      timestamp,
+      receivedAt: new Date().toISOString(),
+      webhookEventId: eventId,
+    };
+
+    if (videoMedia.sha256 !== undefined && messageToSave.media !== undefined) {
+      messageToSave.media.sha256 = videoMedia.sha256;
+    }
+
+    if (videoMedia.caption !== undefined) {
+      messageToSave.caption = videoMedia.caption;
+    }
+
+    if (senderName !== null || phoneNumberId !== null) {
+      const metadata: { senderName?: string; phoneNumberId?: string } = {};
+      if (senderName !== null) {
+        metadata.senderName = senderName;
+      }
+      if (phoneNumberId !== null) {
+        metadata.phoneNumberId = phoneNumberId;
+      }
+      messageToSave.metadata = metadata;
+    }
+
+    const saveResult = await messageRepository.saveMessage(messageToSave);
+    if (!saveResult.ok) {
+      const failureDetails = `Failed to save message: ${saveResult.error.message}`;
+      logger.error(
+        { event: 'video_save_failed', error: saveResult.error, eventId },
+        failureDetails
+      );
+      await webhookEventRepository.updateEventStatus(eventId, 'failed', { failureDetails });
+      return err(saveResult.error);
+    }
+
+    const publishResult = await eventPublisher.publishMediaTranscriptionRequested({
+      type: 'whatsapp.media.transcription.requested',
+      messageSource: 'public_whatsapp',
+      mediaKind: 'video',
+      userId,
+      messageId: saveResult.value.id,
+      mediaId: videoMedia.id,
+      gcsPath: uploadResult.value.gcsPath,
+      mimeType: videoMedia.mimeType,
+      timestamp: new Date().toISOString(),
+    });
+
+    if (!publishResult.ok) {
+      const failureDetails = `Failed to publish media transcription request: ${publishResult.error.message}`;
+      logger.error(
+        { event: 'media_transcription_request_publish_failed', error: publishResult.error, eventId },
+        failureDetails
+      );
+      await webhookEventRepository.updateEventStatus(eventId, 'failed', {
+        failureDetails,
+        retryable: true,
+      });
+      return err(publishResult.error);
+    }
+
+    await webhookEventRepository.updateEventStatus(eventId, 'completed', {});
+
+    logger.info(
+      {
+        event: 'video_processed',
+        eventId,
+        userId,
+        messageId: saveResult.value.id,
+        gcsPath: uploadResult.value.gcsPath,
+      },
+      'Video message saved successfully'
+    );
+
+    return ok({
+      messageId: saveResult.value.id,
+      gcsPath: uploadResult.value.gcsPath,
+      mimeType: videoMedia.mimeType,
+      mediaId: videoMedia.id,
+    });
+  }
+}

--- a/apps/whatsapp-service/src/domain/whatsapp/usecases/processWebhookEventUseCase.ts
+++ b/apps/whatsapp-service/src/domain/whatsapp/usecases/processWebhookEventUseCase.ts
@@ -23,6 +23,7 @@ import type { IntexMessageReplyContext } from '../events/index.js';
 import type { WhatsAppMessage } from '../models/WhatsAppMessage.js';
 import { ProcessImageMessageUseCase } from './processImageMessage.js';
 import { ProcessAudioMessageUseCase } from './processAudioMessage.js';
+import { ProcessVideoMessageUseCase } from './processVideoMessage.js';
 import type { WebhookPayload } from '../../../routes/schemas.js';
 import {
   extractAudioMedia,
@@ -38,6 +39,7 @@ import {
   extractReplyContext,
   extractSenderName,
   extractSenderPhoneNumber,
+  extractVideoMedia,
 } from '../../../routes/shared.js';
 
 const MAX_REPLY_CONTEXT_TEXT_LENGTH = 1200;
@@ -112,6 +114,7 @@ export class ProcessWebhookEventUseCase {
       const messageType = extractMessageType(payload);
       const imageMedia = extractImageMedia(payload);
       const audioMedia = extractAudioMedia(payload);
+      const videoMedia = extractVideoMedia(payload);
       const reactionData = extractReactionData(payload);
       const buttonResponse = extractButtonResponse(payload);
 
@@ -123,6 +126,7 @@ export class ProcessWebhookEventUseCase {
           hasText: messageText !== null,
           hasImage: imageMedia !== null,
           hasAudio: audioMedia !== null,
+          hasVideo: videoMedia !== null,
           hasReaction: reactionData !== null,
           reactionEmoji: reactionData?.emoji,
           hasButton: buttonResponse !== null,
@@ -132,7 +136,7 @@ export class ProcessWebhookEventUseCase {
       );
 
       // Validate message type
-      const supportedTypes = ['text', 'image', 'audio', 'reaction', 'button', 'interactive'];
+      const supportedTypes = ['text', 'image', 'audio', 'video', 'reaction', 'button', 'interactive'];
       if (messageType === null || !supportedTypes.includes(messageType)) {
         logger.info(
           { eventId: savedEvent.id, messageType },
@@ -141,7 +145,7 @@ export class ProcessWebhookEventUseCase {
         await webhookEventRepository.updateEventStatus(savedEvent.id, 'ignored', {
           ignoredReason: {
             code: 'UNSUPPORTED_MESSAGE_TYPE',
-            message: `Only text, image, audio, reaction, button, and interactive messages are supported. Received: ${messageType ?? 'unknown'}`,
+            message: `Only text, image, audio, video, reaction, button, and interactive messages are supported. Received: ${messageType ?? 'unknown'}`,
             details: { messageType },
           },
         });
@@ -177,6 +181,17 @@ export class ProcessWebhookEventUseCase {
           ignoredReason: {
             code: 'NO_AUDIO_MEDIA',
             message: 'Audio message has no media info',
+          },
+        });
+        return;
+      }
+
+      if (messageType === 'video' && videoMedia === null) {
+        logger.info({ eventId: savedEvent.id }, 'Ignoring video message without media info');
+        await webhookEventRepository.updateEventStatus(savedEvent.id, 'ignored', {
+          ignoredReason: {
+            code: 'NO_VIDEO_MEDIA',
+            message: 'Video message has no media info',
           },
         });
         return;
@@ -310,6 +325,23 @@ export class ProcessWebhookEventUseCase {
           senderName,
           phoneNumberId,
           audioMedia,
+          logger
+        );
+        return;
+      }
+
+      if (messageType === 'video' && videoMedia !== null) {
+        await this.handleVideoMessage(
+          payload,
+          savedEvent,
+          userId,
+          waMessageId,
+          fromNumber,
+          toNumber,
+          timestamp,
+          senderName,
+          phoneNumberId,
+          videoMedia,
           logger
         );
         return;
@@ -543,6 +575,67 @@ export class ProcessWebhookEventUseCase {
       logger.info(
         { eventId: savedEvent.id },
         'Cannot mark audio message as read with typing because phoneNumberId is missing'
+      );
+    }
+  }
+
+  /**
+   * Handle video messages by storing media and handing it to transcription.
+   */
+  private async handleVideoMessage(
+    payload: WebhookPayload,
+    savedEvent: { id: string },
+    userId: string,
+    waMessageId: string,
+    fromNumber: string,
+    toNumber: string,
+    timestamp: string,
+    senderName: string | null,
+    phoneNumberId: string | null,
+    videoMedia: { id: string; mimeType: string; sha256?: string; caption?: string },
+    logger: Logger
+  ): Promise<void> {
+    const {
+      webhookEventRepository,
+      messageRepository,
+      mediaStorage,
+      whatsappCloudApi,
+      eventPublisher,
+    } = this.deps;
+
+    const usecase = new ProcessVideoMessageUseCase({
+      webhookEventRepository,
+      messageRepository,
+      mediaStorage,
+      whatsappCloudApi,
+      eventPublisher,
+    });
+
+    const processResult = await usecase.execute(
+      {
+        eventId: savedEvent.id,
+        userId,
+        waMessageId,
+        fromNumber,
+        toNumber,
+        timestamp,
+        senderName,
+        phoneNumberId,
+        videoMedia,
+      },
+      logger
+    );
+
+    if (!processResult.ok) {
+      return;
+    }
+
+    if (phoneNumberId !== null) {
+      await this.markAudioAsReadWithTyping(payload, savedEvent, whatsappCloudApi, logger);
+    } else {
+      logger.info(
+        { eventId: savedEvent.id },
+        'Cannot mark video message as read with typing because phoneNumberId is missing'
       );
     }
   }

--- a/apps/whatsapp-service/src/domain/whatsapp/utils/mimeType.ts
+++ b/apps/whatsapp-service/src/domain/whatsapp/utils/mimeType.ts
@@ -13,6 +13,10 @@ const MIME_TO_EXTENSION: Record<string, string> = {
   'image/png': 'png',
   'image/webp': 'webp',
   'image/gif': 'gif',
+  // Video
+  'video/mp4': 'mp4',
+  'video/3gpp': '3gp',
+  'video/quicktime': 'mov',
 };
 
 /**

--- a/apps/whatsapp-service/src/infra/pubsub/publisher.ts
+++ b/apps/whatsapp-service/src/infra/pubsub/publisher.ts
@@ -12,6 +12,7 @@ import type {
   IntexMessageIngestEvent,
   WhatsAppError,
   MediaCleanupEvent,
+  MediaTranscriptionRequestedEvent,
   WebhookProcessEvent,
 } from '../../domain/whatsapp/index.js';
 
@@ -72,6 +73,18 @@ export class GcpPubSubPublisher extends BasePubSubPublisher implements EventPubl
       event,
       { messageId: event.messageId },
       'audio stored'
+    );
+    return this.mapToWhatsAppError(result);
+  }
+
+  async publishMediaTranscriptionRequested(
+    event: MediaTranscriptionRequestedEvent
+  ): Promise<Result<void, WhatsAppError>> {
+    const result = await this.publishToTopic(
+      this.audioStoredTopic,
+      event,
+      { messageId: event.messageId },
+      'media transcription requested'
     );
     return this.mapToWhatsAppError(result);
   }

--- a/apps/whatsapp-service/src/routes/messageRoutes.ts
+++ b/apps/whatsapp-service/src/routes/messageRoutes.ts
@@ -51,7 +51,7 @@ export const messageRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
                         receivedAt: { type: 'string', format: 'date-time' },
                         mediaType: {
                           type: 'string',
-                          enum: ['text', 'image', 'audio'],
+                          enum: ['text', 'image', 'audio', 'video'],
                           description: 'Type of message content',
                         },
                         hasMedia: {
@@ -66,11 +66,11 @@ export const messageRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
                         transcriptionStatus: {
                           type: 'string',
                           enum: ['pending', 'processing', 'completed', 'failed'],
-                          description: 'Transcription status for audio messages',
+                          description: 'Transcription status for audio/video messages',
                         },
                         transcription: {
                           type: 'string',
-                          description: 'Transcription text for completed audio messages',
+                          description: 'Transcription text for completed audio/video messages',
                         },
                         transcriptionError: {
                           type: 'object',
@@ -200,7 +200,7 @@ export const messageRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
           caption: msg.caption ?? null,
         };
 
-        // Add transcription fields for audio messages
+        // Add transcription fields for audio/video messages
         if (msg.transcription !== undefined) {
           base['transcriptionStatus'] = msg.transcription.status;
           base['transcription'] = msg.transcription.text;

--- a/apps/whatsapp-service/src/routes/privateMediaRoutes.ts
+++ b/apps/whatsapp-service/src/routes/privateMediaRoutes.ts
@@ -73,8 +73,12 @@ function isAudioMimeType(mimeType: string): boolean {
   return mimeType.startsWith('audio/');
 }
 
+function isVideoMimeType(mimeType: string): boolean {
+  return mimeType.startsWith('video/');
+}
+
 function isSupportedUploadMimeType(mimeType: string): boolean {
-  return isImageMimeType(mimeType) || isAudioMimeType(mimeType);
+  return isImageMimeType(mimeType) || isAudioMimeType(mimeType) || isVideoMimeType(mimeType);
 }
 
 function isPrivateImageMessage(message: PrivateWhatsAppMessage): boolean {
@@ -378,7 +382,10 @@ export const privateMediaRoutes: FastifyPluginCallback = (fastify, _opts, done) 
 
         const mimeType = request.query.mimeType;
         if (mimeType === undefined || !isSupportedUploadMimeType(mimeType)) {
-          return await reply.fail('INVALID_REQUEST', 'mimeType must be an image or audio MIME type');
+          return await reply.fail(
+            'INVALID_REQUEST',
+            'mimeType must be an image, audio, or video MIME type'
+          );
         }
 
         const services = getServices();

--- a/apps/whatsapp-service/src/routes/pubsubRoutes.ts
+++ b/apps/whatsapp-service/src/routes/pubsubRoutes.ts
@@ -8,6 +8,7 @@ import { SKIP_SENTRY_KEY } from '@intexuraos/infra-sentry';
 import { getServices } from '../services.js';
 import type {
   ExtractLinkPreviewsEvent,
+  IntexMessageSourceType,
   MediaCleanupEvent,
   PrivateWhatsAppTranscriptionState,
   SendMessageEvent,
@@ -42,6 +43,14 @@ function maskPhoneNumber(phone: string): string {
 
 const TRANSCRIPTION_FAILURE_REPLY =
   'I could not transcribe this voice message. Please try again or send text.';
+
+function getTranscriptSourceType(
+  eventData: TranscriptionCompletedEvent,
+  message: WhatsAppMessage
+): IntexMessageSourceType {
+  const mediaKind = eventData.mediaKind ?? (message.mediaType === 'video' ? 'video' : 'audio');
+  return mediaKind === 'video' ? 'whatsapp_video_transcript' : 'whatsapp_audio_transcript';
+}
 
 function formatTranscriptionReply(transcript: string): string {
   return `Transcription:\n${transcript}`;
@@ -875,7 +884,7 @@ export function createPubsubRoutes(): FastifyPluginCallback {
             type: 'intex.message.ingest',
             userId: eventData.userId,
             messageId: message.waMessageId,
-            sourceType: 'whatsapp_audio_transcript',
+            sourceType: getTranscriptSourceType(eventData, message),
             text: completedTranscriptText,
             whatsappSender: message.fromNumber,
             timestamp: eventData.timestamp,

--- a/apps/whatsapp-service/src/routes/shared.ts
+++ b/apps/whatsapp-service/src/routes/shared.ts
@@ -162,6 +162,12 @@ interface WebhookValue {
       mime_type?: string;
       sha256?: string;
     };
+    video?: {
+      id?: string;
+      mime_type?: string;
+      sha256?: string;
+      caption?: string;
+    };
     reaction?: {
       message_id?: string;
       emoji?: string;
@@ -376,6 +382,16 @@ export interface AudioMediaInfo {
 }
 
 /**
+ * Video media info from webhook payload.
+ */
+export interface VideoMediaInfo {
+  id: string;
+  mimeType: string;
+  sha256?: string;
+  caption?: string;
+}
+
+/**
  * Extract image media info from webhook payload.
  *
  * Path: entry[0].changes[0].value.messages[0].image
@@ -427,6 +443,36 @@ export function extractAudioMedia(payload: unknown): AudioMediaInfo | null {
 
   if (typeof audio.sha256 === 'string') {
     result.sha256 = audio.sha256;
+  }
+
+  return result;
+}
+
+/**
+ * Extract video media info from webhook payload.
+ *
+ * Path: entry[0].changes[0].value.messages[0].video
+ *
+ * @see https://developers.facebook.com/docs/whatsapp/cloud-api/webhooks/components#media-messages
+ */
+export function extractVideoMedia(payload: unknown): VideoMediaInfo | null {
+  const value = extractFirstValue(payload);
+  const message = value?.messages?.[0];
+  if (message === undefined) return null;
+  const video = message.video;
+  if (video === undefined) return null;
+  if (typeof video.id !== 'string' || typeof video.mime_type !== 'string') return null;
+
+  const result: VideoMediaInfo = {
+    id: video.id,
+    mimeType: video.mime_type,
+  };
+
+  if (typeof video.sha256 === 'string') {
+    result.sha256 = video.sha256;
+  }
+  if (typeof video.caption === 'string') {
+    result.caption = video.caption;
   }
 
   return result;

--- a/docs/superpowers/plans/2026-06-29-whatsapp-video-transcription.md
+++ b/docs/superpowers/plans/2026-06-29-whatsapp-video-transcription.md
@@ -1,0 +1,141 @@
+# WhatsApp Video Transcription Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add WhatsApp video transcription for public WhatsApp and private WhatsApp video messages using the existing transcription worker pipeline.
+
+**Architecture:** Generalize the current audio-stored transcription trigger into a media transcription request while preserving compatibility with the existing `whatsapp.audio.stored` event. Public WhatsApp video messages will be downloaded, stored in GCS, saved as `mediaType: 'video'`, and queued for transcription. Private WhatsApp video media will be accepted, stored, and queued when chat transcription is enabled.
+
+**Tech Stack:** TypeScript, Fastify, Firestore adapters, Google Cloud Storage, Pub/Sub, Speechmatics Batch API, Vite React web app, Vitest.
+
+## Global Constraints
+
+- Test-first: write failing tests before implementation.
+- Keep apps isolated; use existing `services.ts` DI and domain ports.
+- No new persistent infrastructure unless Terraform, Pub/Sub UI, and test publisher wiring are all updated.
+- No new service env vars are expected for this feature.
+- Preserve compatibility with existing `whatsapp.audio.stored` messages.
+
+---
+
+## Endpoint Changes
+
+**Modified**
+- `POST /internal/whatsapp/private/media`: accept `video/*` uploads in addition to image/audio.
+- `GET /whatsapp/messages`: include `mediaType: "video"` and transcription fields for transcribed videos.
+- `GET /whatsapp/messages/:message_id/media`: already returns original media for any public stored media path; schema/docs remain valid.
+- `GET /private/chats/:chatId/messages`: response shape already passes through message fields; video transcription becomes visible when stored.
+
+**Created**
+- None.
+
+**Removed**
+- None.
+
+**Unchanged**
+- `/internal/whatsapp/pubsub/transcription-completed` keeps consuming `srt.transcription.completed`.
+- Existing `whatsapp.audio.stored` Pub/Sub payloads remain accepted.
+
+## Tasks
+
+### Task 1: Public WhatsApp Video Ingestion
+
+**Files**
+- Modify: `apps/whatsapp-service/src/routes/shared.ts`
+- Modify: `apps/whatsapp-service/src/domain/whatsapp/models/WhatsAppMessage.ts`
+- Modify: `apps/whatsapp-service/src/domain/whatsapp/events/events.ts`
+- Modify: `apps/whatsapp-service/src/domain/whatsapp/ports/eventPublisher.ts`
+- Modify: `apps/whatsapp-service/src/infra/pubsub/publisher.ts`
+- Create or modify: `apps/whatsapp-service/src/domain/whatsapp/usecases/processVideoMessage.ts`
+- Modify: `apps/whatsapp-service/src/domain/whatsapp/usecases/processWebhookEventUseCase.ts`
+- Test: `apps/whatsapp-service/src/__tests__/usecases/processVideoMessage.test.ts`
+- Test: `apps/whatsapp-service/src/__tests__/webhookAsyncProcessing.test.ts`
+
+**Steps**
+- [ ] Write failing tests proving a public WhatsApp `video` webhook stores media, saves `mediaType: 'video'`, and publishes a transcription request with `mediaKind: 'video'`.
+- [ ] Run the focused tests and verify they fail because video extraction/processing is missing.
+- [ ] Add video payload extraction, public `video` media type, media transcription request event type, and publisher method.
+- [ ] Implement the public video use case by following the existing audio use-case storage and hard publish-failure semantics.
+- [ ] Wire `messageType === 'video'` in `ProcessWebhookEventUseCase`.
+- [ ] Run focused whatsapp-service tests and keep them green.
+
+### Task 2: Private WhatsApp Video Transcription
+
+**Files**
+- Modify: `apps/whatsapp-service/src/routes/privateMediaRoutes.ts`
+- Modify: `apps/whatsapp-service/src/domain/whatsapp/usecases/ingestPrivateWhatsAppEvents.ts`
+- Test: `apps/whatsapp-service/src/__tests__/privateMediaRoutes.test.ts`
+- Test: `apps/whatsapp-service/src/__tests__/usecases/ingestPrivateWhatsAppEvents.test.ts`
+- Test: `apps/whatsapp-service/src/__tests__/privateSyncRoutes.test.ts`
+
+**Steps**
+- [ ] Write failing tests proving private video uploads are accepted and stored.
+- [ ] Write failing tests proving a stored private video in a transcription-enabled chat publishes a transcription request.
+- [ ] Run focused tests and verify they fail for the expected missing behavior.
+- [ ] Allow `video/*` in private media upload and add video MIME extension support.
+- [ ] Publish transcription requests for private `audio` and `video`, preserving duplicate and disabled-chat behavior.
+- [ ] Run focused private WhatsApp tests and keep them green.
+
+### Task 3: Transcription Worker Contract
+
+**Files**
+- Modify: `workers/transcription/src/types.ts`
+- Modify: `workers/transcription/src/handler.ts`
+- Modify: `workers/transcription/src/main.ts`
+- Test: `workers/transcription/src/__tests__/handler.test.ts`
+- Test: `workers/transcription/src/__tests__/main.test.ts`
+
+**Steps**
+- [ ] Write failing worker tests proving `whatsapp.media.transcription.requested` with `mediaKind: 'video'` is accepted and transcribed.
+- [ ] Run focused worker tests and verify they fail because only `whatsapp.audio.stored` is accepted.
+- [ ] Add a generic media transcription request type while accepting legacy `whatsapp.audio.stored`.
+- [ ] Rename internal language where useful without changing the function entry point `transcribeAudio`.
+- [ ] Run focused transcription worker tests and keep them green.
+
+### Task 4: Completion Handling And Intex Forwarding
+
+**Files**
+- Modify: `apps/whatsapp-service/src/domain/whatsapp/events/events.ts`
+- Modify: `apps/whatsapp-service/src/routes/pubsubRoutes.ts`
+- Test: `apps/whatsapp-service/src/__tests__/pubsubRoutes.test.ts`
+
+**Steps**
+- [ ] Write failing tests proving a completed public video transcript updates the message and publishes `sourceType: 'whatsapp_video_transcript'`.
+- [ ] Run focused tests and verify they fail because completion always emits `whatsapp_audio_transcript`.
+- [ ] Extend transcription completion events with optional `mediaKind`.
+- [ ] Use message media type or event `mediaKind` to choose audio versus video transcript source type.
+- [ ] Preserve private completion storage-only behavior.
+- [ ] Run focused pubsub route tests and keep them green.
+
+### Task 5: Web API And UI Type Surfaces
+
+**Files**
+- Modify: `apps/whatsapp-service/src/routes/messageRoutes.ts`
+- Modify: `apps/web/src/types/index.ts`
+- Modify: `apps/web/src/components/whatsapp/shared.tsx`
+- Modify: `apps/web/src/components/whatsapp/MessageItem.tsx`
+- Modify: `apps/web/src/pages/WhatsAppNotesPage.tsx`
+- Modify: `apps/web/src/pages/PrivateWhatsAppLogPage.tsx`
+- Test: existing relevant web and whatsapp-service tests.
+
+**Steps**
+- [ ] Write failing tests proving public video appears in API schemas/UI filters and private video transcript rendering is not audio-gated.
+- [ ] Run focused tests and verify they fail for missing video support.
+- [ ] Add `video` to public web/backend media types and filters.
+- [ ] Display video transcript states wherever audio transcripts are currently displayed.
+- [ ] Run focused web and whatsapp-service tests and keep them green.
+
+### Task 6: Final Verification And PR
+
+**Files**
+- All changed files.
+
+**Steps**
+- [ ] Run `pnpm run verify:workspace:tracked -- whatsapp-service`.
+- [ ] Run `pnpm run verify:workspace:tracked -- transcription`.
+- [ ] Run `pnpm run verify:workspace:tracked -- web`.
+- [ ] Run `pnpm run ci:tracked`.
+- [ ] Inspect `git status -sb` and `git diff`.
+- [ ] Commit only after `pnpm run ci:tracked` passes.
+- [ ] Push branch.
+- [ ] Open a draft PR targeting `development`; include `Fixes INT-XXX` only if the real issue ID is provided.

--- a/workers/transcription/src/__tests__/handler.test.ts
+++ b/workers/transcription/src/__tests__/handler.test.ts
@@ -56,6 +56,20 @@ function makeValidAudioStoredEvent(): AudioStoredEvent {
   };
 }
 
+function makeValidVideoTranscriptionRequestedEvent(): Record<string, unknown> {
+  return {
+    type: 'whatsapp.media.transcription.requested',
+    messageSource: 'public_whatsapp',
+    mediaKind: 'video',
+    userId: 'user-123',
+    messageId: 'msg-video-456',
+    mediaId: 'media-video-789',
+    gcsPath: 'whatsapp/user-123/video.mp4',
+    mimeType: 'video/mp4',
+    timestamp: '2026-06-29T00:00:00.000Z',
+  };
+}
+
 describe('createAudioStoredHandler', () => {
   let baseLogger: FakeLogger;
   let publishedCompleted: TranscriptionCompletedEvent[];
@@ -149,6 +163,21 @@ describe('createAudioStoredHandler', () => {
       });
       expect(publishedCompleted).toHaveLength(0);
     });
+
+    it('returns DeadLetter "invalid_event_schema" when media transcription request omits mediaKind', async () => {
+      const handler = createAudioStoredHandler(deps);
+      const payload = makeValidVideoTranscriptionRequestedEvent();
+      delete payload['mediaKind'];
+      const event = makePubSubCloudEvent(payload);
+
+      const result = await handler(event, baseLogger);
+
+      expect(result).toEqual({
+        decision: AckDecision.DeadLetter,
+        reason: 'invalid_event_schema',
+      });
+      expect(publishedCompleted).toHaveLength(0);
+    });
   });
 
   describe('Ack path (happy publish)', () => {
@@ -162,6 +191,25 @@ describe('createAudioStoredHandler', () => {
       expect(publishedCompleted).toHaveLength(1);
       expect(publishedCompleted[0]?.status).toBe('completed');
       expect(publishedCompleted[0]?.userId).toBe('user-123');
+    });
+
+    it('returns Ack and publishes a video completed event for a valid media transcription request', async () => {
+      const handler = createAudioStoredHandler(deps);
+      const event = makePubSubCloudEvent(makeValidVideoTranscriptionRequestedEvent());
+
+      const result = await handler(event, baseLogger);
+
+      expect(result).toEqual({ decision: AckDecision.Ack });
+      expect(deps.generateSignedUrl).toHaveBeenCalledWith('whatsapp/user-123/video.mp4');
+      expect(publishedCompleted).toHaveLength(1);
+      expect(publishedCompleted[0]).toMatchObject({
+        type: 'srt.transcription.completed',
+        messageSource: 'public_whatsapp',
+        mediaKind: 'video',
+        userId: 'user-123',
+        messageId: 'msg-video-456',
+        status: 'completed',
+      });
     });
 
     it('uses extracted requestId as a child binding on the request logger', async () => {

--- a/workers/transcription/src/__tests__/main.test.ts
+++ b/workers/transcription/src/__tests__/main.test.ts
@@ -3,7 +3,11 @@
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { transcribeAudio, type TranscriptionDeps } from '../main.js';
-import type { AudioStoredEvent, TranscriptionCompletedEvent } from '../types.js';
+import type {
+  AudioStoredEvent,
+  TranscriptionCompletedEvent,
+  TranscriptionRequestEvent,
+} from '../types.js';
 import type { SpeechTranscriptionPort } from '../providers/transcription-provider.js';
 import { ok, err } from '@intexuraos/common-core';
 
@@ -29,6 +33,15 @@ const sampleEvent: AudioStoredEvent = {
   gcsPath: 'whatsapp/user-123/msg-456/media-789.ogg',
   mimeType: 'audio/ogg',
   timestamp: '2024-01-01T00:00:00.000Z',
+};
+
+const sampleVideoEvent: TranscriptionRequestEvent = {
+  ...sampleEvent,
+  type: 'whatsapp.media.transcription.requested',
+  messageSource: 'public_whatsapp',
+  mediaKind: 'video',
+  mimeType: 'video/mp4',
+  gcsPath: 'whatsapp/user-123/msg-456/media-789.mp4',
 };
 
 const noopSleep = (): Promise<void> => Promise.resolve();
@@ -113,6 +126,16 @@ describe('transcribeAudio', () => {
       expect(publishedEvents[0]?.messageSource).toBe('private_whatsapp');
     });
 
+    it('preserves video media kind on completed events', async () => {
+      await transcribeAudio(sampleVideoEvent, deps, mockLogger);
+
+      expect(publishedEvents[0]).toMatchObject({
+        messageSource: 'public_whatsapp',
+        mediaKind: 'video',
+        status: 'completed',
+      });
+    });
+
     it('includes summary in completed event when provider returns one', async () => {
       const provider = makeProvider(
         ok({ jobId: 'job-123', apiCall: { timestamp: '', operation: 'submit', success: true } }),
@@ -187,6 +210,19 @@ describe('transcribeAudio', () => {
       );
 
       expect(publishedEvents[0]?.messageSource).toBe('private_whatsapp');
+    });
+
+    it('preserves video media kind on failed events', async () => {
+      deps.generateSignedUrl = vi.fn().mockResolvedValue(err({ message: 'GCS access denied' }));
+
+      await transcribeAudio(sampleVideoEvent, deps, mockLogger);
+
+      expect(publishedEvents[0]).toMatchObject({
+        messageSource: 'public_whatsapp',
+        mediaKind: 'video',
+        status: 'failed',
+        error: expect.stringContaining('GCS access denied'),
+      });
     });
 
     it('publishes failed event when job submission fails', async () => {

--- a/workers/transcription/src/handler.ts
+++ b/workers/transcription/src/handler.ts
@@ -14,7 +14,7 @@ import { err, ok, type Result } from '@intexuraos/common-core';
 import type { PublishError } from '@intexuraos/infra-pubsub';
 import { transcribeAudio } from './main.js';
 import type { PollingConfig } from './polling.js';
-import type { AudioStoredEvent, TranscriptionCompletedEvent } from './types.js';
+import type { TranscriptionCompletedEvent, TranscriptionRequestEvent } from './types.js';
 import { extractCorrelation } from './extractCorrelation.js';
 import { runWithRequestContext } from './requestContextShim.js';
 import {
@@ -67,21 +67,31 @@ export interface AudioStoredHandlerDeps {
 }
 
 /**
- * Validate a parsed Pub/Sub payload has every required `AudioStoredEvent`
+ * Validate a parsed Pub/Sub payload has every required transcription request
  * field. Guards against schema drift between whatsapp-service (the producer)
  * and this worker.
  */
-function isAudioStoredEvent(event: { type?: string }): event is AudioStoredEvent {
+function isSupportedTranscriptionEventType(type: unknown): boolean {
+  return type === 'whatsapp.audio.stored' || type === 'whatsapp.media.transcription.requested';
+}
+
+function isTranscriptionRequestEvent(event: { type?: string }): event is TranscriptionRequestEvent {
   const obj = event as Record<string, unknown>;
-  return (
-    obj['type'] === 'whatsapp.audio.stored' &&
-    typeof obj['userId'] === 'string' &&
-    typeof obj['messageId'] === 'string' &&
-    typeof obj['mediaId'] === 'string' &&
-    typeof obj['gcsPath'] === 'string' &&
-    typeof obj['mimeType'] === 'string' &&
-    typeof obj['timestamp'] === 'string'
-  );
+  if (
+    typeof obj['userId'] !== 'string' ||
+    typeof obj['messageId'] !== 'string' ||
+    typeof obj['mediaId'] !== 'string' ||
+    typeof obj['gcsPath'] !== 'string' ||
+    typeof obj['mimeType'] !== 'string' ||
+    typeof obj['timestamp'] !== 'string'
+  ) {
+    return false;
+  }
+  if (obj['type'] === 'whatsapp.media.transcription.requested') {
+    return obj['mediaKind'] === 'audio' || obj['mediaKind'] === 'video';
+  }
+  // The caller rejects unsupported type literals before this structural guard.
+  return true;
 }
 
 /**
@@ -118,10 +128,10 @@ export function createAudioStoredHandler(
         return { decision: AckDecision.DeadLetter, reason: 'missing_message_data' };
       }
 
-      let audioEvent: { type?: string };
+      let transcriptionEvent: { type?: string };
       try {
         const decoded = Buffer.from(messageData, 'base64').toString('utf-8');
-        audioEvent = JSON.parse(decoded) as { type?: string };
+        transcriptionEvent = JSON.parse(decoded) as { type?: string };
       } catch {
         reqLogger.error(
           { event: 'parse_error', eventId: event.id },
@@ -131,11 +141,10 @@ export function createAudioStoredHandler(
       }
 
       // Explicit type guard before structural validation so we can log the
-      // wrong type value for triage; `isAudioStoredEvent` re-checks the same
-      // literal but doesn't surface the unexpected value in its log line.
-      if (audioEvent.type !== 'whatsapp.audio.stored') {
+      // wrong type value for triage before structural validation.
+      if (!isSupportedTranscriptionEventType(transcriptionEvent.type)) {
         reqLogger.warn(
-          { event: 'unexpected_event_type', type: audioEvent.type, eventId: event.id },
+          { event: 'unexpected_event_type', type: transcriptionEvent.type, eventId: event.id },
           'Unexpected event type, dead-lettering'
         );
         return { decision: AckDecision.DeadLetter, reason: 'unexpected_event_type' };
@@ -143,17 +152,17 @@ export function createAudioStoredHandler(
 
       // Structural validation of the remaining required fields. After the
       // type-literal guard above, this branch only fails on missing
-      // userId / messageId / mediaId / gcsPath / mimeType / timestamp.
-      if (!isAudioStoredEvent(audioEvent)) {
+      // userId / messageId / mediaId / gcsPath / mimeType / timestamp / mediaKind.
+      if (!isTranscriptionRequestEvent(transcriptionEvent)) {
         reqLogger.warn(
           { event: 'invalid_event_schema', eventId: event.id },
-          'Audio stored event is missing required fields, dead-lettering'
+          'Transcription request event is missing required fields, dead-lettering'
         );
         return { decision: AckDecision.DeadLetter, reason: 'invalid_event_schema' };
       }
 
       await transcribeAudio(
-        audioEvent,
+        transcriptionEvent,
         {
           fetchUserProvider: (userId: string) => deps.fetchUserProvider(userId, reqLogger),
           generateSignedUrl: deps.generateSignedUrl,

--- a/workers/transcription/src/main.ts
+++ b/workers/transcription/src/main.ts
@@ -13,7 +13,11 @@
 import type { Result } from '@intexuraos/common-core';
 import type { PublishError } from '@intexuraos/infra-pubsub';
 import { getErrorMessage } from '@intexuraos/common-core';
-import type { AudioStoredEvent, TranscriptionCompletedEvent } from './types.js';
+import type {
+  AudioStoredEvent,
+  TranscriptionCompletedEvent,
+  TranscriptionRequestEvent,
+} from './types.js';
 import type { SpeechTranscriptionPort } from './providers/transcription-provider.js';
 import type { WorkerLogger as Logger } from './__shims__/common-worker.js';
 import { formatSpeechmaticsError } from './format-error.js';
@@ -67,13 +71,14 @@ export interface TranscriptionDeps {
  * @param logger - Logger for progress tracking
  */
 export async function transcribeAudio(
-  event: AudioStoredEvent,
+  event: TranscriptionRequestEvent,
   deps: TranscriptionDeps,
   logger: Logger
 ): Promise<void> {
   // mediaId is part of AudioStoredEvent for audit traceability in consuming services,
   // but is not needed for the transcription workflow itself (GCS path identifies the file).
   const { userId, messageId, gcsPath, mimeType, messageSource } = event;
+  const mediaKind = 'mediaKind' in event ? event.mediaKind : undefined;
 
   logger.info(
     { event: 'transcription_start', userId, messageId, gcsPath },
@@ -98,7 +103,16 @@ export async function transcribeAudio(
         { event: 'signed_url_error', userId, messageId, gcsPath, error: errorMessage },
         'Failed to generate signed URL'
       );
-      await publishFailed(deps, messageSource, userId, messageId, 'unknown', errorMessage, logger);
+      await publishFailed(
+        deps,
+        messageSource,
+        mediaKind,
+        userId,
+        messageId,
+        'unknown',
+        errorMessage,
+        logger
+      );
       return;
     }
 
@@ -121,6 +135,7 @@ export async function transcribeAudio(
       await publishFailed(
         deps,
         messageSource,
+        mediaKind,
         userId,
         messageId,
         'unknown',
@@ -147,6 +162,7 @@ export async function transcribeAudio(
       await publishFailed(
         deps,
         messageSource,
+        mediaKind,
         userId,
         messageId,
         jobId,
@@ -163,7 +179,16 @@ export async function transcribeAudio(
         { event: 'job_rejected', userId, messageId, jobId, error: rawError },
         'Transcription job was rejected'
       );
-      await publishFailed(deps, messageSource, userId, messageId, jobId, formattedError, logger);
+      await publishFailed(
+        deps,
+        messageSource,
+        mediaKind,
+        userId,
+        messageId,
+        jobId,
+        formattedError,
+        logger
+      );
       return;
     }
 
@@ -178,7 +203,16 @@ export async function transcribeAudio(
         { event: 'transcript_error', userId, messageId, jobId, error: rawError },
         'Failed to fetch transcript'
       );
-      await publishFailed(deps, messageSource, userId, messageId, jobId, formattedError, logger);
+      await publishFailed(
+        deps,
+        messageSource,
+        mediaKind,
+        userId,
+        messageId,
+        jobId,
+        formattedError,
+        logger
+      );
       return;
     }
 
@@ -196,6 +230,9 @@ export async function transcribeAudio(
     };
     if (messageSource !== undefined) {
       completedEvent.messageSource = messageSource;
+    }
+    if (mediaKind !== undefined) {
+      completedEvent.mediaKind = mediaKind;
     }
     if (summary !== undefined) {
       completedEvent.summary = summary;
@@ -229,7 +266,16 @@ export async function transcribeAudio(
       { event: 'unexpected_error', userId, messageId, error: errorMessage },
       'Unexpected error during transcription'
     );
-    await publishFailed(deps, messageSource, userId, messageId, 'unknown', errorMessage, logger);
+    await publishFailed(
+      deps,
+      messageSource,
+      mediaKind,
+      userId,
+      messageId,
+      'unknown',
+      errorMessage,
+      logger
+    );
   }
 }
 
@@ -239,6 +285,7 @@ export async function transcribeAudio(
 async function publishFailed(
   deps: TranscriptionDeps,
   messageSource: AudioStoredEvent['messageSource'],
+  mediaKind: TranscriptionCompletedEvent['mediaKind'],
   userId: string,
   messageId: string,
   jobId: string,
@@ -256,6 +303,9 @@ async function publishFailed(
   };
   if (messageSource !== undefined) {
     failedEvent.messageSource = messageSource;
+  }
+  if (mediaKind !== undefined) {
+    failedEvent.mediaKind = mediaKind;
   }
 
   const publishResult = await deps.publishEvent(failedEvent);

--- a/workers/transcription/src/types.ts
+++ b/workers/transcription/src/types.ts
@@ -35,6 +35,41 @@ export interface AudioStoredEvent {
 }
 
 /**
+ * Event received from Pub/Sub when stored WhatsApp media should be transcribed.
+ * Published by whatsapp-service for media types beyond the legacy audio event.
+ */
+export interface MediaTranscriptionRequestedEvent {
+  /** Event type identifier. */
+  type: 'whatsapp.media.transcription.requested';
+
+  /** Source collection where the message is stored. */
+  messageSource?: 'public_whatsapp' | 'private_whatsapp';
+
+  /** Kind of stored media to transcribe. */
+  mediaKind: 'audio' | 'video';
+
+  /** IntexuraOS user ID. */
+  userId: string;
+
+  /** WhatsApp message ID. */
+  messageId: string;
+
+  /** WhatsApp media ID. */
+  mediaId: string;
+
+  /** GCS path to the media file. */
+  gcsPath: string;
+
+  /** MIME type of the media file. */
+  mimeType: string;
+
+  /** Event timestamp (ISO 8601). */
+  timestamp: string;
+}
+
+export type TranscriptionRequestEvent = AudioStoredEvent | MediaTranscriptionRequestedEvent;
+
+/**
  * Event published to Pub/Sub when transcription completes or fails.
  * Consumed by whatsapp-service to update message state.
  */
@@ -44,6 +79,9 @@ export interface TranscriptionCompletedEvent {
 
   /** Source collection where the message is stored. */
   messageSource?: 'public_whatsapp' | 'private_whatsapp';
+
+  /** Kind of media that was transcribed. */
+  mediaKind?: 'audio' | 'video';
 
   /** IntexuraOS user ID. */
   userId: string;


### PR DESCRIPTION
## Summary

- Add public WhatsApp video ingestion, GCS storage, and transcription-request publishing.
- Add private WhatsApp video media upload and transcription request support.
- Teach the transcription worker and WhatsApp completion route to preserve video media kind and emit video transcript source events.
- Update WhatsApp API/web UI surfaces and tests for video transcripts.

## Verification

- `pnpm run ci:tracked`

## Linear

Linear: omitted by `$commit-push`; GitHub automation will create or link the Linear issue after PR creation.
