### PR TITLE
[INT-1814] Tighten Intex Agent fallback handling

### DIFF
--- a/.claude/skills/debug-intex-session/scripts/fetch-session.cjs
+++ b/.claude/skills/debug-intex-session/scripts/fetch-session.cjs
@@ -18,6 +18,7 @@ const EVENT_TYPE_ORDER = {
   tool_call_started: 20,
   tool_call_completed: 30,
   tool_call_failed: 30,
+  agent_fallback: 39,
   unsupported_request: 40,
   clarification_requested: 40,
   assistant_message: 50,

--- a/apps/intex-agent/src/__tests__/domain/handleIncomingMessage.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/handleIncomingMessage.test.ts
@@ -11,6 +11,7 @@ import type {
   IntexAgentSessionEventType,
   IntexAgentToolName,
 } from '../../domain/sessions/types.js';
+import { buildUnsupportedCapabilitiesReply } from '../../domain/agent/capabilities.js';
 import {
   handleIncomingMessage,
   type IntexAgentRunner,
@@ -19,16 +20,6 @@ import {
 } from '../../domain/messages/handleIncomingMessage.js';
 
 const NOW = '2026-06-24T10:00:00.000Z';
-const UNSUPPORTED_CAPABILITIES_REPLY = [
-  'I could not safely handle that request. I can help with:',
-  '- summarize and reason over the current session',
-  '- create notes',
-  '- create and look up calendar events',
-  '- create research drafts',
-  '- save bookmarks',
-  '- create code tasks for planning or execution',
-  '- manage Intex Agent prompt preferences',
-].join('\n');
 const NEW_SESSION_READY_REPLY = [
   'What would you like me to help with? I can help with:',
   '- summarize and reason over the current session',
@@ -38,16 +29,6 @@ const NEW_SESSION_READY_REPLY = [
   '- save bookmarks',
   '- create code tasks for planning or execution',
   '- manage Intex Agent prompt preferences',
-].join('\n');
-const POLISH_UNSUPPORTED_CAPABILITIES_REPLY = [
-  'Nie mogłem bezpiecznie obsłużyć tej prośby. Mogę pomóc z:',
-  '- podsumowywaniem i analizowaniem bieżącej sesji',
-  '- tworzeniem notatek',
-  '- tworzeniem i sprawdzaniem wydarzeń w kalendarzu',
-  '- tworzeniem szkiców researchu',
-  '- zapisywaniem bookmarków',
-  '- tworzeniem zadań programistycznych do planowania lub wykonania',
-  '- zarządzaniem preferencjami promptu agenta Intex',
 ].join('\n');
 const POLISH_NEW_SESSION_READY_REPLY = [
   'W czym mogę pomóc? Mogę pomóc z:',
@@ -1041,6 +1022,27 @@ describe('handleIncomingMessage', () => {
     expect(replies.messages[0]?.message).toBe('Which day should I schedule it for?');
   });
 
+  it('records clarification requests without optional metadata when the runner omits it', async () => {
+    const repo = new FakeSessionRepository();
+    const runner = new FakeRunner([
+      {
+        outcome: 'needs_clarification',
+        reply: 'Which action did you mean?',
+      },
+    ]);
+    const replies = new FakeReplyPublisher();
+
+    await handleIncomingMessage(
+      message({ text: 'make it happen' }),
+      deps(repo, runner, replies)
+    );
+
+    expect(eventPayloads(repo, 'clarification_requested')[0]).toEqual({
+      message: 'Which action did you mean?',
+    });
+    expect(replies.messages[0]?.message).toBe('Which action did you mean?');
+  });
+
   it('continues a waiting session when the user answers a clarification', async () => {
     const repo = new FakeSessionRepository();
     repo.seedSession({
@@ -1098,6 +1100,7 @@ describe('handleIncomingMessage', () => {
         missingFields: ['supported_action'],
         candidateIntents: ['create_note'],
         suggestedNextStep: 'Offer to save the flight details as a note.',
+        fallbackReason: 'runner_declared_unsupported',
       },
     ]);
     const replies = new FakeReplyPublisher();
@@ -1114,15 +1117,21 @@ describe('handleIncomingMessage', () => {
     expect(eventTypes(repo)).toEqual([
       'session_started',
       'user_message',
+      'agent_fallback',
       'unsupported_request',
       'assistant_message',
     ]);
+    expect(eventPayloads(repo, 'agent_fallback')[0]).toEqual({
+      reason: 'runner_declared_unsupported',
+      sourceOutcome: 'unsupported',
+    });
     expect(eventPayloads(repo, 'unsupported_request')[0]).toEqual({
       message: 'I do not support that yet. I can create notes and calendar events.',
       blockerReason: 'unsupported_capability',
       missingFields: ['supported_action'],
       candidateIntents: ['create_note'],
       suggestedNextStep: 'Offer to save the flight details as a note.',
+      fallbackReason: 'runner_declared_unsupported',
     });
     expect(replies.messages[0]?.message).toBe(
       'I do not support that yet. I can create notes and calendar events.'
@@ -1135,6 +1144,9 @@ describe('handleIncomingMessage', () => {
       {
         outcome: 'unsupported',
         reply: 'I can only create notes and calendar events.',
+        blockerReason: 'unsupported_capability',
+        suggestedNextStep: 'I can save the details as a note.',
+        fallbackReason: 'runner_declared_unsupported',
       },
     ]);
     const replies = new FakeReplyPublisher();
@@ -1155,6 +1167,9 @@ describe('handleIncomingMessage', () => {
       {
         outcome: 'unsupported',
         reply: 'I can only create notes and calendar events.',
+        blockerReason: 'unsupported_capability',
+        suggestedNextStep: 'I can save the details as a note.',
+        fallbackReason: 'runner_declared_unsupported',
       },
     ]);
     const replies = new FakeReplyPublisher();
@@ -1448,7 +1463,7 @@ describe('handleIncomingMessage', () => {
     );
   });
 
-  it('expires a stale session and rejects completed runner results without a tool name', async () => {
+  it('expires a stale session and records a diagnostic fallback for completed runner results without a tool name', async () => {
     const repo = new FakeSessionRepository();
     repo.seedSession({
       id: 'session-stale',
@@ -1486,10 +1501,23 @@ describe('handleIncomingMessage', () => {
     expect(repo.sessions[1]?.status).toBe('waiting_for_user');
     expect(repo.sessions[1]?.endReason).toBeUndefined();
     expect(eventPayloads(repo, 'tool_call_completed')).toEqual([]);
-    expect(replies.messages[0]?.message).toBe(UNSUPPORTED_CAPABILITIES_REPLY);
+    expect(eventTypes(repo)).toEqual([
+      'session_closed',
+      'session_started',
+      'user_message',
+      'agent_fallback',
+      'clarification_requested',
+      'assistant_message',
+    ]);
+    expect(eventPayloads(repo, 'agent_fallback')[0]).toEqual({
+      reason: 'tool_result_mismatch',
+      sourceOutcome: 'completed',
+    });
+    expect(eventPayloads(repo, 'unsupported_request')).toEqual([]);
+    expect(replies.messages[0]?.message).toBe('What would you like me to do with this?');
   });
 
-  it('uses prior Polish context when rejecting a malformed completed runner result after a trivial current message', async () => {
+  it('uses prior Polish context when clarifying a malformed completed runner result after a trivial current message', async () => {
     const repo = new FakeSessionRepository();
     repo.seedSession({
       id: 'session-existing',
@@ -1519,7 +1547,66 @@ describe('handleIncomingMessage', () => {
     );
 
     expect(eventPayloads(repo, 'tool_call_completed')).toEqual([]);
-    expect(replies.messages[0]?.message).toBe(POLISH_UNSUPPORTED_CAPABILITIES_REPLY);
+    expect(eventPayloads(repo, 'agent_fallback')[0]).toEqual({
+      reason: 'tool_result_mismatch',
+      sourceOutcome: 'completed',
+    });
+    expect(eventPayloads(repo, 'unsupported_request')).toEqual([]);
+    expect(replies.messages[0]?.message).toBe('Co mam z tym zrobić?');
+  });
+
+  it('keeps a prompt-preference session clarifiable on an ordinary correction without generic unsupported', async () => {
+    const repo = new FakeSessionRepository();
+    const runner = new FakeRunner([
+      {
+        outcome: 'needs_clarification',
+        reply: 'Którą preferencję promptu mam sprawdzić?',
+        blockerReason: 'missing_required_details',
+        missingFields: ['preference_scope'],
+        candidateIntents: ['get_user_preferences'],
+        suggestedNextStep: 'Poproś użytkownika o zakres preferencji promptu.',
+        clarification: 'Którą preferencję promptu mam sprawdzić?',
+      },
+      {
+        outcome: 'completed',
+        reply: 'Jasne, rozumiem.',
+      },
+    ]);
+    const replies = new FakeReplyPublisher();
+
+    await handleIncomingMessage(
+      message({
+        messageId: 'wamid-prompt-preferences',
+        text: 'Czy mamy jakieś preferencje dla promptu agenta?',
+      }),
+      deps(repo, runner, replies)
+    );
+    await handleIncomingMessage(
+      message({
+        messageId: 'wamid-ordinary-correction',
+        text: 'Nie o to chodziło, to była zwykła rozmowa bez akcji.',
+      }),
+      deps(repo, runner, replies)
+    );
+
+    expect(runner.calls.map((call) => call.message)).toEqual([
+      'Czy mamy jakieś preferencje dla promptu agenta?',
+      'Nie o to chodziło, to była zwykła rozmowa bez akcji.',
+    ]);
+    expect(eventPayloads(repo, 'unsupported_request')).toEqual([]);
+    expect(eventPayloads(repo, 'agent_fallback')).toEqual([
+      {
+        reason: 'tool_result_mismatch',
+        sourceOutcome: 'completed',
+      },
+    ]);
+    expect(replies.messages.map((reply) => reply.message)).toEqual([
+      'Którą preferencję promptu mam sprawdzić?',
+      'Co mam z tym zrobić?',
+    ]);
+    expect(replies.messages.map((reply) => reply.message)).not.toContain(
+      buildUnsupportedCapabilitiesReply('pl')
+    );
   });
 
   it('uses prior text-only event context when malformed fallback skips non-text events', async () => {
@@ -1555,7 +1642,12 @@ describe('handleIncomingMessage', () => {
     );
 
     expect(eventPayloads(repo, 'tool_call_completed')).toEqual([]);
-    expect(replies.messages[0]?.message).toBe(POLISH_UNSUPPORTED_CAPABILITIES_REPLY);
+    expect(eventPayloads(repo, 'agent_fallback')[0]).toEqual({
+      reason: 'tool_result_mismatch',
+      sourceOutcome: 'completed',
+    });
+    expect(eventPayloads(repo, 'unsupported_request')).toEqual([]);
+    expect(replies.messages[0]?.message).toBe('Co mam z tym zrobić?');
   });
 });
 

--- a/apps/intex-agent/src/__tests__/domain/intentClassifier.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/intentClassifier.test.ts
@@ -604,6 +604,8 @@ describe('createLlmIntexAgentIntentClassifier', () => {
       question: 'What would you like me to do with this?',
       blockerReason: 'not_enough_context',
       suggestedNextStep: 'Ask the user to restate the action.',
+      fallbackReason: 'llm_call_failed',
+      fallbackSourceOutcome: 'classifier',
     });
 
     await expect(
@@ -617,6 +619,8 @@ describe('createLlmIntexAgentIntentClassifier', () => {
       question: 'What would you like me to do with this?',
       blockerReason: 'not_enough_context',
       suggestedNextStep: 'Ask the user to restate the action.',
+      fallbackReason: 'llm_call_failed',
+      fallbackSourceOutcome: 'classifier',
     });
 
     expect(malformedLogger.warnCalls).toEqual([

--- a/apps/intex-agent/src/__tests__/domain/intentGate.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/intentGate.test.ts
@@ -3,70 +3,22 @@ import { classifyIntexAgentIntent } from '../../domain/agent/intentGate.js';
 
 describe('classifyIntexAgentIntent', () => {
   it.each([
-    ['Create a note: gate code is 4938', ['create_note']],
-    ['Hi, create a note: gate code is 4938', ['create_note']],
-    ['Zapisz notatke: kod do bramy to 4938', ['create_note']],
-    ['Add calendar event for dentist tomorrow at 9', ['create_calendar_event']],
-    ['Dodaj wydarzenie w kalendarzu jutro o 9', ['create_calendar_event']],
-    ['Create research draft about OpenRouter HTTP requests', ['create_research']],
-    ['Przygotuj research draft o cenach GPU', ['create_research']],
-    ['Save link https://example.com', ['create_link']],
-    ['Save https://example.com/article', ['create_link']],
-    ['https://example.com', ['create_link']],
-    ['https://example.com New launch page with pricing details', ['create_link']],
-    ['check this out https://example.com/case-study nice writeup', ['create_link']],
-    ['https://research-world.com/notes-and-calendar-tasks', ['create_link']],
-    ['Create a note including https://example.com', ['create_note']],
-    ['Save note including https://example.com', ['create_note']],
-    ['Create research draft from https://example.com', ['create_research']],
-    ['Add calendar event with https://example.com tomorrow at 9', ['create_calendar_event']],
-    ['Create code task for https://example.com webhook bug', ['create_code_task']],
-    ['Dodaj zakladke https://example.com', ['create_link']],
-    ['Create code task to implement explicit intent gating', ['create_code_task']],
-    ['Stworz zadanie programistyczne dla intent gating', ['create_code_task']],
-    ['Save externally https://example.com/article', ['save_external']],
-    ['Upload externally this note from LinkedIn', ['save_external']],
-    ['Save for processing this copied conversation detail', ['save_external']],
-    ['Zapisz zewnętrznie ten paragon', ['save_external']],
-    ['Prześlij zewnętrznie https://example.com/post', ['save_external']],
-    ['Zapisz do przetworzenia: ważna informacja z LinkedIn', ['save_external']],
-  ] as const)('allows explicit creation intent: %s', (text, expectedToolNames) => {
-    expect(classifyIntexAgentIntent(text)).toEqual({
-      kind: 'tool',
-      allowedToolNames: expectedToolNames,
-    });
-  });
-
-  it.each([
+    'Hej',
     'Hej! Co u Ciebie?',
+    'Hello',
     'So how are you?',
-    'A jakie musisz mieć parametry, żebym mógł stworzyć zadanie programistyczne?',
-    'A jak wygląda taki schemat request o HTTP, który wykonujesz?',
-    'Nie dostałam żadnego linku',
-    'Remember the old days',
-  ])('does not allow implicit resource creation: %s', (text) => {
-    const decision = classifyIntexAgentIntent(text);
-
-    expect(decision.kind).not.toBe('tool');
-  });
-
-  it.each([
-    'Podaj mi numer telefonu do dentysty',
-    'Podaj listę rzeczy do spakowania',
-    'Wypisz moje zadania na dziś',
-    'Wyświetl ostatnie wiadomości',
-  ])('does not route non-calendar Polish list wording to tools: %s', (text) => {
+  ])('keeps obvious greetings as the only local no-action shortcut: %s', (text) => {
     expect(classifyIntexAgentIntent(text)).toEqual({
       kind: 'no_action',
-      reason: 'conversation',
+      reason: 'greeting',
     });
   });
 
   it.each([
-    'https://research-world.com',
-    'https://todo-app.io/notes',
-    'https://calendar-task.example/research-notes',
-  ])('ignores command-like keywords inside URLs: %s', (text) => {
+    'https://example.com',
+    'http://example.com/article?ref=agent',
+    'https://research-world.com/notes-and-calendar-tasks',
+  ])('routes bare URL shares to the link tool: %s', (text) => {
     expect(classifyIntexAgentIntent(text)).toEqual({
       kind: 'tool',
       allowedToolNames: ['create_link'],
@@ -74,6 +26,31 @@ describe('classifyIntexAgentIntent', () => {
   });
 
   it.each([
+    'Create a note: gate code is 4938',
+    'Hi, create a note: gate code is 4938',
+    'Zapisz notatke: kod do bramy to 4938',
+    'Add calendar event for dentist tomorrow at 9',
+    'Dodaj wydarzenie w kalendarzu jutro o 9',
+    'Create research draft about OpenRouter HTTP requests',
+    'Przygotuj research draft o cenach GPU',
+    'Save link https://example.com',
+    'Save https://example.com/article',
+    'https://example.com New launch page with pricing details',
+    'check this out https://example.com/case-study nice writeup',
+    'Create a note including https://example.com',
+    'Save note including https://example.com',
+    'Create research draft from https://example.com',
+    'Add calendar event with https://example.com tomorrow at 9',
+    'Create code task for https://example.com webhook bug',
+    'Dodaj zakladke https://example.com',
+    'Create code task to implement explicit intent gating',
+    'Stworz zadanie programistyczne dla intent gating',
+    'Save externally https://example.com/article',
+    'Upload externally this note from LinkedIn',
+    'Save for processing this copied conversation detail',
+    'Zapisz zewnętrznie ten paragon',
+    'Prześlij zewnętrznie https://example.com/post',
+    'Zapisz do przetworzenia: ważna informacja z LinkedIn',
     'What are my events scheduled for next week?',
     'Show me tomorrow calendar events',
     'How many times last month did I have Dentist?',
@@ -86,16 +63,7 @@ describe('classifyIntexAgentIntent', () => {
     'Wypisz wszystkie wydarzenia w kalendarzu na jutro',
     'Wyświetl moje wydarzenia w kalendarzu na jutro',
     'Czy mam w kalendarzu jakieś wydarzenie pomiędzy 14:00 a 16:00?',
-    'Czy ma w kalendarzu jakieś wydarzenie pomiędzy 14:00 a 16:00?',
     'Jakie terminy mam wolne jutro na godzinne spotkanie?',
-  ])('allows read-only calendar queries: %s', (text) => {
-    expect(classifyIntexAgentIntent(text)).toEqual({
-      kind: 'tool',
-      allowedToolNames: ['query_calendar_events'],
-    });
-  });
-
-  it.each([
     'Tell me my defined user preferences.',
     'Show my Intex instructions.',
     'Add a preference: when I invite Jakub, use jakub@gmail.com.',
@@ -103,51 +71,14 @@ describe('classifyIntexAgentIntent', () => {
     'Remove the row about mood preferences.',
     'Delete preference 2.',
     'Jakie mamy w tej chwili preferencje dla promptu agenta?',
-  ])('allows preference management intent: %s', (text) => {
-    expect(classifyIntexAgentIntent(text)).toEqual({
-      kind: 'tool',
-      allowedToolNames: [
-        'get_user_preferences',
-        'add_user_preference',
-        'update_user_preference',
-        'delete_user_preference',
-      ],
-    });
-  });
-
-  it.each([
     'Show my preferences and calendar events tomorrow',
     'Add a preference and create a note about it',
-  ])('rejects mixed preference and resource intents: %s', (text) => {
-    expect(classifyIntexAgentIntent(text)).toEqual({
-      kind: 'unsupported',
-      reason: 'multiple_resource_intents',
-    });
-  });
-
-  it.each([
-    'How many notes did I create last month?',
-    'How many bookmarks did I save this week?',
-    'How many code tasks did I create last month?',
-    'Ile notatek zapisalem w zeszlym miesiacu?',
-  ])('does not route non-calendar count questions to calendar queries: %s', (text) => {
+    'Create a note and show me next week calendar events',
+    'https://example.com and show me tomorrow calendar events',
+  ])('does not route non-bare tool intents through regex gates: %s', (text) => {
     expect(classifyIntexAgentIntent(text)).toEqual({
       kind: 'no_action',
       reason: 'conversation',
-    });
-  });
-
-  it('rejects mixed creation and calendar query intents', () => {
-    expect(classifyIntexAgentIntent('Create a note and show me next week calendar events')).toEqual({
-      kind: 'unsupported',
-      reason: 'multiple_resource_intents',
-    });
-  });
-
-  it('rejects mixed implicit link and calendar query intents', () => {
-    expect(classifyIntexAgentIntent('https://example.com and show me tomorrow calendar events')).toEqual({
-      kind: 'unsupported',
-      reason: 'multiple_resource_intents',
     });
   });
 });

--- a/apps/intex-agent/src/__tests__/domain/intexAgentRunner.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/intexAgentRunner.test.ts
@@ -7,61 +7,37 @@ import type {
 import type { StructuredClient, StructuredGenerateResult } from '@intexuraos/llm-utils';
 import { describe, expect, it } from 'vitest';
 import type { IntexAgentToolExecutor } from '../../domain/agent/toolDefinitions.js';
-import { createIntexAgentRunner } from '../../domain/agent/intexAgentRunner.js';
+import { createIntexAgentRunner as createBaseIntexAgentRunner } from '../../domain/agent/intexAgentRunner.js';
 import {
   INTEX_AGENT_RUNNER_PROMPT_TYPE,
   INTEX_AGENT_SYSTEM_PROMPT,
 } from '../../domain/agent/systemPrompt.js';
 import type { IntexAgentIntentClassifier } from '../../domain/agent/intentClassifier.js';
-import type { IntexAgentSession, IntexAgentSessionEvent } from '../../domain/sessions/types.js';
+import type {
+  IntexAgentSession,
+  IntexAgentSessionEvent,
+  IntexAgentToolName,
+} from '../../domain/sessions/types.js';
 
 const CURRENT_DATE_TIME = '2026-06-24T10:00:00.000Z';
-const SUPPORTED_CAPABILITIES_REPLY =
-  [
-    'I could not safely handle that request. I can help with:',
-    '- summarize and reason over the current session',
-    '- create notes',
-    '- create and look up calendar events',
-    '- create research drafts',
-    '- save bookmarks',
-    '- create code tasks for planning or execution',
-    '- manage Intex Agent prompt preferences',
-  ].join('\n');
-const COMPLETION_FAILURE_CAPABILITIES_REPLY =
-  [
-    'I could not complete that request right now. I can help with:',
-    '- summarize and reason over the current session',
-    '- create notes',
-    '- create and look up calendar events',
-    '- create research drafts',
-    '- save bookmarks',
-    '- create code tasks for planning or execution',
-    '- manage Intex Agent prompt preferences',
-  ].join('\n');
-const POLISH_SUPPORTED_CAPABILITIES_REPLY =
-  [
-    'Nie mogłem bezpiecznie obsłużyć tej prośby. Mogę pomóc z:',
-    '- podsumowywaniem i analizowaniem bieżącej sesji',
-    '- tworzeniem notatek',
-    '- tworzeniem i sprawdzaniem wydarzeń w kalendarzu',
-    '- tworzeniem szkiców researchu',
-    '- zapisywaniem bookmarków',
-    '- tworzeniem zadań programistycznych do planowania lub wykonania',
-    '- zarządzaniem preferencjami promptu agenta Intex',
-  ].join('\n');
-const POLISH_COMPLETION_FAILURE_CAPABILITIES_REPLY =
-  [
-    'Nie mogłem teraz dokończyć tej prośby. Mogę pomóc z:',
-    '- podsumowywaniem i analizowaniem bieżącej sesji',
-    '- tworzeniem notatek',
-    '- tworzeniem i sprawdzaniem wydarzeń w kalendarzu',
-    '- tworzeniem szkiców researchu',
-    '- zapisywaniem bookmarków',
-    '- tworzeniem zadań programistycznych do planowania lub wykonania',
-    '- zarządzaniem preferencjami promptu agenta Intex',
-  ].join('\n');
 const ENGLISH_GREETING_REPLY = 'Hi! I am doing well. How can I help?';
 const POLISH_GREETING_REPLY = 'Cześć! U mnie wszystko w porządku. W czym mogę pomóc?';
+
+type CreateRunnerConfig = Parameters<typeof createBaseIntexAgentRunner>[0];
+
+function createIntexAgentRunner(config: CreateRunnerConfig): ReturnType<typeof createBaseIntexAgentRunner> {
+  if (
+    config.intentClassifier === undefined &&
+    config.client instanceof ToolExecutingFakeToolCallingClient
+  ) {
+    return createBaseIntexAgentRunner({
+      ...config,
+      intentClassifier: toolIntentClassifier(config.client.toolNames()),
+    });
+  }
+
+  return createBaseIntexAgentRunner(config);
+}
 const EXTERNAL_SAVE_NOT_CONFIGURED_REPLY =
   'No external system is configured for this message, so I cannot process it. Configure external save in Intex Agent preferences and send it again.';
 const EXTERNAL_SAVE_FAILED_REPLY =
@@ -164,6 +140,7 @@ describe('createIntexAgentRunner', () => {
     ]);
     const runner = createIntexAgentRunner({
       client,
+      intentClassifier: toolIntentClassifier(['create_note']),
       toolExecutor: fakeToolExecutor({
         createNote: async () => {
           createNoteCalls += 1;
@@ -474,6 +451,44 @@ describe('createIntexAgentRunner', () => {
     expect(client.calls).toEqual([]);
   });
 
+  it('propagates classifier fallback metadata on clarification results', async () => {
+    const client = new FakeToolCallingClient([]);
+    const intentClassifier: IntexAgentIntentClassifier = {
+      async classify() {
+        return {
+          kind: 'needs_clarification',
+          question: 'What would you like me to do with this?',
+          blockerReason: 'not_enough_context',
+          suggestedNextStep: 'Ask the user to restate the action.',
+          fallbackReason: 'llm_call_failed',
+          fallbackSourceOutcome: 'classifier',
+        };
+      },
+    };
+    const runner = createIntexAgentRunner({
+      client,
+      intentClassifier,
+      toolExecutor: fakeToolExecutor(),
+    });
+
+    await expect(
+      runner.run({
+        session: session(),
+        events: [],
+        message: 'make it happen',
+        currentDateTime: CURRENT_DATE_TIME,
+      })
+    ).resolves.toEqual({
+      outcome: 'needs_clarification',
+      reply: 'What would you like me to do with this?',
+      blockerReason: 'not_enough_context',
+      suggestedNextStep: 'Ask the user to restate the action.',
+      fallbackReason: 'llm_call_failed',
+      fallbackSourceOutcome: 'classifier',
+    });
+    expect(client.calls).toEqual([]);
+  });
+
   it('returns classifier unsupported responses with exact blocker metadata', async () => {
     const client = new FakeToolCallingClient([]);
     const intentClassifier: IntexAgentIntentClassifier = {
@@ -505,6 +520,8 @@ describe('createIntexAgentRunner', () => {
         'I cannot do that with the available Intex Agent tools. I can save the request details as a note.',
       blockerReason: 'tool_boundary',
       suggestedNextStep: 'Offer to save the request details as a note.',
+      fallbackReason: 'classifier_unsupported',
+      fallbackSourceOutcome: 'unsupported',
     });
     expect(client.calls).toEqual([]);
   });
@@ -541,18 +558,64 @@ describe('createIntexAgentRunner', () => {
         'Nie mogę wykonać tej akcji, bo brakuje wymaganych uprawnień albo konfiguracji. Sprawdź konfigurację External Save.',
       blockerReason: 'permission_or_configuration',
       suggestedNextStep: 'Sprawdź konfigurację External Save',
+      fallbackReason: 'classifier_unsupported',
+      fallbackSourceOutcome: 'unsupported',
     });
     expect(client.calls).toEqual([]);
   });
 
-  it('falls back safely for classifier unsupported metadata without a mapped blocker or next step', async () => {
+  it.each([
+    'missing_required_details',
+    'not_enough_context',
+    'multiple_possible_intents',
+    'ambiguous_preference_target',
+  ] as const)(
+    'converts clarification-only classifier unsupported reason %s into clarification',
+    async (blockerReason) => {
+      const client = new FakeToolCallingClient([]);
+      const intentClassifier: IntexAgentIntentClassifier = {
+        async classify() {
+          return {
+            kind: 'unsupported',
+            reason: blockerReason,
+            blockerReason,
+            suggestedNextStep: '',
+          };
+        },
+      };
+      const runner = createIntexAgentRunner({
+        client,
+        intentClassifier,
+        toolExecutor: fakeToolExecutor(),
+      });
+
+      await expect(
+        runner.run({
+          session: session(),
+          events: [],
+          message: 'do it',
+          currentDateTime: CURRENT_DATE_TIME,
+        })
+      ).resolves.toEqual({
+        outcome: 'needs_clarification',
+        reply: 'What would you like me to do with this?',
+        blockerReason,
+        suggestedNextStep: 'Ask the user to restate the action.',
+        fallbackReason: 'classifier_unsupported',
+        fallbackSourceOutcome: 'unsupported',
+      });
+      expect(client.calls).toEqual([]);
+    }
+  );
+
+  it('fills blank classifier unsupported next steps before emitting unsupported', async () => {
     const client = new FakeToolCallingClient([]);
     const intentClassifier: IntexAgentIntentClassifier = {
       async classify() {
         return {
           kind: 'unsupported',
-          reason: 'missing_required_details',
-          blockerReason: 'missing_required_details',
+          reason: 'unsupported_capability',
+          blockerReason: 'unsupported_capability',
           suggestedNextStep: '',
         };
       },
@@ -567,14 +630,92 @@ describe('createIntexAgentRunner', () => {
       runner.run({
         session: session(),
         events: [],
-        message: 'do it',
+        message: 'buy this ticket',
         currentDateTime: CURRENT_DATE_TIME,
       })
     ).resolves.toEqual({
       outcome: 'unsupported',
-      reply: "I cannot perform that action because it is outside Intex Agent's supported capabilities.",
-      blockerReason: 'missing_required_details',
-      suggestedNextStep: '',
+      reply:
+        "I cannot perform that action because it is outside Intex Agent's supported capabilities. Ask the user to describe a supported action.",
+      blockerReason: 'unsupported_capability',
+      suggestedNextStep: 'Ask the user to describe a supported action.',
+      fallbackReason: 'classifier_unsupported',
+      fallbackSourceOutcome: 'unsupported',
+    });
+    expect(client.calls).toEqual([]);
+  });
+
+  it('uses Polish fallback next steps for blank classifier unsupported next steps', async () => {
+    const client = new FakeToolCallingClient([]);
+    const intentClassifier: IntexAgentIntentClassifier = {
+      async classify() {
+        return {
+          kind: 'unsupported',
+          reason: 'unsupported_capability',
+          blockerReason: 'unsupported_capability',
+          suggestedNextStep: '   ',
+          languageOverride: 'pl',
+        };
+      },
+    };
+    const runner = createIntexAgentRunner({
+      client,
+      intentClassifier,
+      toolExecutor: fakeToolExecutor(),
+    });
+
+    await expect(
+      runner.run({
+        session: session(),
+        events: [],
+        message: 'kup bilet',
+        currentDateTime: CURRENT_DATE_TIME,
+      })
+    ).resolves.toEqual({
+      outcome: 'unsupported',
+      reply:
+        'Nie mogę wykonać tej akcji, bo wykracza poza obsługiwane możliwości agenta Intex. Poproś użytkownika o opisanie obsługiwanej akcji.',
+      blockerReason: 'unsupported_capability',
+      suggestedNextStep: 'Poproś użytkownika o opisanie obsługiwanej akcji.',
+      fallbackReason: 'classifier_unsupported',
+      fallbackSourceOutcome: 'unsupported',
+    });
+    expect(client.calls).toEqual([]);
+  });
+
+  it('falls back to generic classifier unsupported text for unmapped blocker reasons', async () => {
+    const client = new FakeToolCallingClient([]);
+    const intentClassifier: IntexAgentIntentClassifier = {
+      async classify() {
+        return {
+          kind: 'unsupported',
+          reason: 'new_blocker_reason',
+          blockerReason: 'new_blocker_reason',
+          suggestedNextStep: 'I can save it as a note.',
+        } as unknown as Awaited<ReturnType<IntexAgentIntentClassifier['classify']>>;
+      },
+    };
+    const runner = createIntexAgentRunner({
+      client,
+      intentClassifier,
+      toolExecutor: fakeToolExecutor(),
+    });
+
+    await expect(
+      runner.run({
+        session: session(),
+        events: [],
+        message: 'buy this ticket',
+        currentDateTime: CURRENT_DATE_TIME,
+      })
+    ).resolves.toEqual({
+      outcome: 'unsupported',
+      reply:
+        "I cannot perform that action because it is outside Intex Agent's supported capabilities. I can save it as a note.",
+      blockerReason: 'new_blocker_reason',
+      suggestedNextStep: 'I can save it as a note.',
+      fallbackReason: 'classifier_unsupported',
+      fallbackSourceOutcome: 'unsupported',
     });
     expect(client.calls).toEqual([]);
   });
@@ -610,6 +751,8 @@ describe('createIntexAgentRunner', () => {
         "I cannot perform that action because it is outside Intex Agent's supported capabilities. I can save it as a note.",
       blockerReason: 'unsupported_capability',
       suggestedNextStep: 'I can save it as a note.',
+      fallbackReason: 'classifier_unsupported',
+      fallbackSourceOutcome: 'unsupported',
     });
     expect(client.calls).toEqual([]);
   });
@@ -702,6 +845,8 @@ describe('createIntexAgentRunner', () => {
       suggestedNextStep: 'Offer to save ticket details as a note.',
       missingFields: ['supported_action'],
       candidateIntents: ['create_note'],
+      fallbackReason: 'runner_declared_unsupported',
+      fallbackSourceOutcome: 'unsupported',
     });
   });
 
@@ -731,6 +876,8 @@ describe('createIntexAgentRunner', () => {
       reply: unsupportedReply,
       blockerReason: 'unsupported_capability',
       suggestedNextStep: 'Offer to save ticket details as a note.',
+      fallbackReason: 'runner_declared_unsupported',
+      fallbackSourceOutcome: 'unsupported',
     });
   });
 
@@ -782,8 +929,12 @@ describe('createIntexAgentRunner', () => {
         currentDateTime: CURRENT_DATE_TIME,
       })
     ).resolves.toEqual({
-      outcome: 'unsupported',
-      reply: POLISH_COMPLETION_FAILURE_CAPABILITIES_REPLY,
+      outcome: 'needs_clarification',
+      reply: 'Nie mogłem teraz przetworzyć tej prośby. Napisz proszę jeszcze raz, co mam zrobić.',
+      blockerReason: 'not_enough_context',
+      suggestedNextStep: 'Poproś użytkownika o doprecyzowanie akcji.',
+      fallbackReason: 'llm_call_failed',
+      fallbackSourceOutcome: 'llm_call_failed',
     });
   });
 
@@ -820,8 +971,12 @@ describe('createIntexAgentRunner', () => {
         currentDateTime: CURRENT_DATE_TIME,
       })
     ).resolves.toEqual({
-      outcome: 'unsupported',
-      reply: POLISH_COMPLETION_FAILURE_CAPABILITIES_REPLY,
+      outcome: 'needs_clarification',
+      reply: 'Nie mogłem teraz przetworzyć tej prośby. Napisz proszę jeszcze raz, co mam zrobić.',
+      blockerReason: 'not_enough_context',
+      suggestedNextStep: 'Poproś użytkownika o doprecyzowanie akcji.',
+      fallbackReason: 'llm_call_failed',
+      fallbackSourceOutcome: 'llm_call_failed',
     });
   });
 
@@ -844,12 +999,16 @@ describe('createIntexAgentRunner', () => {
         currentDateTime: CURRENT_DATE_TIME,
       })
     ).resolves.toEqual({
-      outcome: 'unsupported',
-      reply: POLISH_COMPLETION_FAILURE_CAPABILITIES_REPLY,
+      outcome: 'needs_clarification',
+      reply: 'Nie mogłem teraz przetworzyć tej prośby. Napisz proszę jeszcze raz, co mam zrobić.',
+      blockerReason: 'not_enough_context',
+      suggestedNextStep: 'Poproś użytkownika o doprecyzowanie akcji.',
+      fallbackReason: 'llm_call_failed',
+      fallbackSourceOutcome: 'llm_call_failed',
     });
   });
 
-  it('uses English for a substantive English current message after Polish context', async () => {
+  it('uses English fallback text for a substantive English current message after Polish context', async () => {
     const client = new FakeToolCallingClient([
       ok(
         toolResult({
@@ -868,8 +1027,12 @@ describe('createIntexAgentRunner', () => {
         currentDateTime: CURRENT_DATE_TIME,
       })
     ).resolves.toEqual({
-      outcome: 'unsupported',
-      reply: SUPPORTED_CAPABILITIES_REPLY,
+      outcome: 'needs_clarification',
+      reply: 'What would you like me to do with this?',
+      blockerReason: 'not_enough_context',
+      suggestedNextStep: 'Ask the user to restate the action.',
+      fallbackReason: 'runner_output_malformed',
+      fallbackSourceOutcome: 'raw_response',
     });
   });
 
@@ -1075,7 +1238,7 @@ describe('createIntexAgentRunner', () => {
     await runner.run({
       session: session(),
       events: [],
-      message: 'https://research-world.com/notes-and-calendar-tasks Interesting launch',
+      message: 'https://research-world.com/notes-and-calendar-tasks',
       currentDateTime: CURRENT_DATE_TIME,
     });
 
@@ -1091,7 +1254,11 @@ describe('createIntexAgentRunner', () => {
         })
       ),
     ]);
-    const runner = createIntexAgentRunner({ client, toolExecutor: fakeToolExecutor() });
+    const runner = createIntexAgentRunner({
+      client,
+      intentClassifier: toolIntentClassifier(['save_external']),
+      toolExecutor: fakeToolExecutor(),
+    });
 
     await runner.run({
       session: session(),
@@ -1112,7 +1279,11 @@ describe('createIntexAgentRunner', () => {
         })
       ),
     ]);
-    const runner = createIntexAgentRunner({ client, toolExecutor: fakeToolExecutor() });
+    const runner = createIntexAgentRunner({
+      client,
+      intentClassifier: toolIntentClassifier(['save_external']),
+      toolExecutor: fakeToolExecutor(),
+    });
 
     await runner.run({
       session: session(),
@@ -1133,7 +1304,11 @@ describe('createIntexAgentRunner', () => {
         })
       ),
     ]);
-    const runner = createIntexAgentRunner({ client, toolExecutor: fakeToolExecutor() });
+    const runner = createIntexAgentRunner({
+      client,
+      intentClassifier: toolIntentClassifier(['query_calendar_events']),
+      toolExecutor: fakeToolExecutor(),
+    });
 
     await runner.run({
       session: session(),
@@ -1165,6 +1340,7 @@ describe('createIntexAgentRunner', () => {
     ]);
     const runner = createIntexAgentRunner({
       client,
+      intentClassifier: toolIntentClassifier(['query_calendar_events']),
       toolExecutor: fakeToolExecutor({
         queryCalendarEvents: async () =>
           JSON.stringify({
@@ -1220,6 +1396,7 @@ describe('createIntexAgentRunner', () => {
     ]);
     const runner = createIntexAgentRunner({
       client,
+      intentClassifier: toolIntentClassifier(['query_calendar_events']),
       toolExecutor: fakeToolExecutor({
         queryCalendarEvents: async () =>
           JSON.stringify({
@@ -1276,6 +1453,7 @@ describe('createIntexAgentRunner', () => {
     ]);
     const runner = createIntexAgentRunner({
       client,
+      intentClassifier: toolIntentClassifier(['query_calendar_events']),
       toolExecutor: fakeToolExecutor({
         queryCalendarEvents: async () =>
           JSON.stringify({
@@ -1331,6 +1509,7 @@ describe('createIntexAgentRunner', () => {
     ]);
     const runner = createIntexAgentRunner({
       client,
+      intentClassifier: toolIntentClassifier(['query_calendar_events']),
       toolExecutor: fakeToolExecutor({
         queryCalendarEvents: async () =>
           JSON.stringify({
@@ -1360,7 +1539,7 @@ describe('createIntexAgentRunner', () => {
     expect(client.calls[0]?.systemPrompt).toContain('Current date-time: 2026-06-26T17:00:00.000Z');
   });
 
-  it('returns unsupported when the model result is malformed instead of executing a hidden action', async () => {
+  it('asks for clarification when the successful model result is malformed', async () => {
     const client = new FakeToolCallingClient([
       ok({
         content: 'plain text',
@@ -1379,8 +1558,12 @@ describe('createIntexAgentRunner', () => {
         currentDateTime: CURRENT_DATE_TIME,
       })
     ).resolves.toEqual({
-      outcome: 'unsupported',
-      reply: SUPPORTED_CAPABILITIES_REPLY,
+      outcome: 'needs_clarification',
+      reply: 'What would you like me to do with this?',
+      blockerReason: 'not_enough_context',
+      suggestedNextStep: 'Ask the user to restate the action.',
+      fallbackReason: 'runner_output_malformed',
+      fallbackSourceOutcome: 'raw_response',
     });
   });
 
@@ -1509,7 +1692,7 @@ describe('createIntexAgentRunner', () => {
     ]);
   });
 
-  it('returns unsupported when the model returns a non-object JSON value', async () => {
+  it('asks for clarification when the model returns a non-object JSON value', async () => {
     const client = new FakeToolCallingClient([
       ok({
         content: '[]',
@@ -1528,12 +1711,16 @@ describe('createIntexAgentRunner', () => {
         currentDateTime: CURRENT_DATE_TIME,
       })
     ).resolves.toEqual({
-      outcome: 'unsupported',
-      reply: SUPPORTED_CAPABILITIES_REPLY,
+      outcome: 'needs_clarification',
+      reply: 'What would you like me to do with this?',
+      blockerReason: 'not_enough_context',
+      suggestedNextStep: 'Ask the user to restate the action.',
+      fallbackReason: 'runner_output_malformed',
+      fallbackSourceOutcome: 'raw_response',
     });
   });
 
-  it('returns unsupported when the model omits required response fields', async () => {
+  it('asks for clarification when the model omits required completed fields', async () => {
     const client = new FakeToolCallingClient([ok(toolResult({ outcome: 'completed' }))]);
     const runner = createIntexAgentRunner({ client, toolExecutor: fakeToolExecutor() });
 
@@ -1545,12 +1732,16 @@ describe('createIntexAgentRunner', () => {
         currentDateTime: CURRENT_DATE_TIME,
       })
     ).resolves.toEqual({
-      outcome: 'unsupported',
-      reply: SUPPORTED_CAPABILITIES_REPLY,
+      outcome: 'needs_clarification',
+      reply: 'What would you like me to do with this?',
+      blockerReason: 'not_enough_context',
+      suggestedNextStep: 'Ask the user to restate the action.',
+      fallbackReason: 'tool_result_mismatch',
+      fallbackSourceOutcome: 'completed',
     });
   });
 
-  it('returns unsupported when the model uses an unknown outcome', async () => {
+  it('asks for clarification when the model uses an unknown outcome', async () => {
     const client = new FakeToolCallingClient([
       ok(toolResult({ outcome: 'delegated', reply: 'Working on it.' })),
     ]);
@@ -1564,8 +1755,12 @@ describe('createIntexAgentRunner', () => {
         currentDateTime: CURRENT_DATE_TIME,
       })
     ).resolves.toEqual({
-      outcome: 'unsupported',
-      reply: SUPPORTED_CAPABILITIES_REPLY,
+      outcome: 'needs_clarification',
+      reply: 'What would you like me to do with this?',
+      blockerReason: 'not_enough_context',
+      suggestedNextStep: 'Ask the user to restate the action.',
+      fallbackReason: 'runner_output_malformed',
+      fallbackSourceOutcome: 'raw_response',
     });
   });
 
@@ -1677,6 +1872,7 @@ describe('createIntexAgentRunner', () => {
     const client = new FakeToolCallingClient([]);
     const runner = createIntexAgentRunner({
       client,
+      intentClassifier: toolIntentClassifier(['save_external']),
       toolExecutor: fakeToolExecutor({
         createResearch: async () =>
           JSON.stringify({
@@ -1715,7 +1911,7 @@ describe('createIntexAgentRunner', () => {
     expect(client.calls).toEqual([]);
   });
 
-  it('rejects confirmed execution requests for read-only tools', async () => {
+  it('clarifies confirmed execution requests for read-only tools', async () => {
     const runner = createIntexAgentRunner({
       client: new FakeToolCallingClient([]),
       toolExecutor: fakeToolExecutor(),
@@ -1733,8 +1929,12 @@ describe('createIntexAgentRunner', () => {
         currentDateTime: CURRENT_DATE_TIME,
       })
     ).resolves.toEqual({
-      outcome: 'unsupported',
-      reply: SUPPORTED_CAPABILITIES_REPLY,
+      outcome: 'needs_clarification',
+      reply: 'What would you like me to do with this?',
+      blockerReason: 'not_enough_context',
+      suggestedNextStep: 'Ask the user to restate the action.',
+      fallbackReason: 'tool_result_mismatch',
+      fallbackSourceOutcome: 'confirmed_execution',
     });
   });
 
@@ -1757,8 +1957,12 @@ describe('createIntexAgentRunner', () => {
         currentDateTime: CURRENT_DATE_TIME,
       })
     ).resolves.toEqual({
-      outcome: 'unsupported',
-      reply: POLISH_SUPPORTED_CAPABILITIES_REPLY,
+      outcome: 'needs_clarification',
+      reply: 'Co mam z tym zrobić?',
+      blockerReason: 'not_enough_context',
+      suggestedNextStep: 'Poproś użytkownika o doprecyzowanie akcji.',
+      fallbackReason: 'tool_result_mismatch',
+      fallbackSourceOutcome: 'confirmed_execution',
     });
   });
 
@@ -2660,7 +2864,7 @@ describe('createIntexAgentRunner', () => {
     });
   });
 
-  it('rejects completed responses when no tool actually ran and no supported toolName is present', async () => {
+  it('asks for clarification when a completed response has no matching tool execution', async () => {
     const client = new FakeToolCallingClient([
       ok(
         toolResult({
@@ -2680,12 +2884,16 @@ describe('createIntexAgentRunner', () => {
         currentDateTime: CURRENT_DATE_TIME,
       })
     ).resolves.toEqual({
-      outcome: 'unsupported',
-      reply: SUPPORTED_CAPABILITIES_REPLY,
+      outcome: 'needs_clarification',
+      reply: 'What would you like me to do with this?',
+      blockerReason: 'not_enough_context',
+      suggestedNextStep: 'Ask the user to restate the action.',
+      fallbackReason: 'tool_result_mismatch',
+      fallbackSourceOutcome: 'completed',
     });
   });
 
-  it('rejects completed responses when the model claims a supported toolName but no tool ran', async () => {
+  it('asks for clarification when the model claims a supported toolName but no tool ran', async () => {
     const client = new FakeToolCallingClient([
       ok(
         toolResult({
@@ -2706,14 +2914,39 @@ describe('createIntexAgentRunner', () => {
         currentDateTime: CURRENT_DATE_TIME,
       })
     ).resolves.toEqual({
-      outcome: 'unsupported',
-      reply: SUPPORTED_CAPABILITIES_REPLY,
+      outcome: 'needs_clarification',
+      reply: 'What would you like me to do with this?',
+      blockerReason: 'not_enough_context',
+      suggestedNextStep: 'Ask the user to restate the action.',
+      fallbackReason: 'tool_result_mismatch',
+      fallbackSourceOutcome: 'completed',
     });
   });
 
-  it('rejects completed responses when multiple tools ran in one turn', async () => {
-    const client = new FakeToolCallingClient([]);
-    const runner = createIntexAgentRunner({ client, toolExecutor: fakeToolExecutor() });
+  it('asks for clarification when multiple tools ran in one turn', async () => {
+    const client = new ToolExecutingFakeToolCallingClient([
+      { toolName: 'create_note', args: { content: 'Visit Lisbon.' } },
+      { toolName: 'create_link', args: { url: 'https://example.com', title: 'Example' } },
+    ], [
+      ok(
+        toolResult({
+          outcome: 'completed',
+          reply: 'Done.',
+          summary: 'Handled request.',
+          toolName: 'create_note',
+        })
+      ),
+    ]);
+    const intentClassifier: IntexAgentIntentClassifier = {
+      async classify() {
+        return { kind: 'tool', allowedToolNames: ['create_note', 'create_link'] };
+      },
+    };
+    const runner = createIntexAgentRunner({
+      client,
+      intentClassifier,
+      toolExecutor: fakeToolExecutor(),
+    });
 
     await expect(
       runner.run({
@@ -2723,13 +2956,16 @@ describe('createIntexAgentRunner', () => {
         currentDateTime: CURRENT_DATE_TIME,
       })
     ).resolves.toEqual({
-      outcome: 'unsupported',
-      reply: SUPPORTED_CAPABILITIES_REPLY,
+      outcome: 'needs_clarification',
+      reply: 'What would you like me to do with this?',
+      blockerReason: 'not_enough_context',
+      suggestedNextStep: 'Ask the user to restate the action.',
+      fallbackReason: 'tool_result_mismatch',
+      fallbackSourceOutcome: 'completed',
     });
-    expect(client.calls).toEqual([]);
   });
 
-  it('rejects unsupported completed tool names from normalized responses', async () => {
+  it('asks for clarification when normalized output names an unsupported completed tool', async () => {
     const client = new FakeToolCallingClient([
       ok(
         toolResult({
@@ -2750,12 +2986,16 @@ describe('createIntexAgentRunner', () => {
         currentDateTime: CURRENT_DATE_TIME,
       })
     ).resolves.toEqual({
-      outcome: 'unsupported',
-      reply: SUPPORTED_CAPABILITIES_REPLY,
+      outcome: 'needs_clarification',
+      reply: 'What would you like me to do with this?',
+      blockerReason: 'not_enough_context',
+      suggestedNextStep: 'Ask the user to restate the action.',
+      fallbackReason: 'runner_output_malformed',
+      fallbackSourceOutcome: 'raw_response',
     });
   });
 
-  it('returns unsupported when the tool-calling client fails', async () => {
+  it('asks for clarification when the tool-calling client fails', async () => {
     const client = new FakeToolCallingClient([err({ code: 'API_ERROR', message: 'provider failed' })]);
     const runner = createIntexAgentRunner({ client, toolExecutor: fakeToolExecutor() });
 
@@ -2767,12 +3007,16 @@ describe('createIntexAgentRunner', () => {
         currentDateTime: CURRENT_DATE_TIME,
       })
     ).resolves.toEqual({
-      outcome: 'unsupported',
-      reply: COMPLETION_FAILURE_CAPABILITIES_REPLY,
+      outcome: 'needs_clarification',
+      reply: 'I could not process that request right now. Please restate what you want me to do.',
+      blockerReason: 'not_enough_context',
+      suggestedNextStep: 'Ask the user to restate the action.',
+      fallbackReason: 'llm_call_failed',
+      fallbackSourceOutcome: 'llm_call_failed',
     });
   });
 
-  it('returns Polish capabilities when the tool-calling client fails for a Polish message', async () => {
+  it('asks for Polish clarification when the tool-calling client fails for a Polish message', async () => {
     const client = new FakeToolCallingClient([err({ code: 'API_ERROR', message: 'provider failed' })]);
     const runner = createIntexAgentRunner({ client, toolExecutor: fakeToolExecutor() });
 
@@ -2784,8 +3028,12 @@ describe('createIntexAgentRunner', () => {
         currentDateTime: CURRENT_DATE_TIME,
       })
     ).resolves.toEqual({
-      outcome: 'unsupported',
-      reply: POLISH_COMPLETION_FAILURE_CAPABILITIES_REPLY,
+      outcome: 'needs_clarification',
+      reply: 'Nie mogłem teraz przetworzyć tej prośby. Napisz proszę jeszcze raz, co mam zrobić.',
+      blockerReason: 'not_enough_context',
+      suggestedNextStep: 'Poproś użytkownika o doprecyzowanie akcji.',
+      fallbackReason: 'llm_call_failed',
+      fallbackSourceOutcome: 'llm_call_failed',
     });
   });
 
@@ -3049,6 +3297,12 @@ describe('createIntexAgentRunner', () => {
     );
     const runner = createIntexAgentRunner({
       client,
+      intentClassifier: toolIntentClassifier([
+        'get_user_preferences',
+        'add_user_preference',
+        'update_user_preference',
+        'delete_user_preference',
+      ]),
       toolExecutor: fakeToolExecutor({
         getUserPreferences: async () =>
           JSON.stringify({ status: 'completed', currentVersion: 1, promptBlock }),
@@ -3489,6 +3743,14 @@ function expectedConfirmationReplyFor(toolName: PreviewToolName): string {
   return 'Add this instruction memory entry?\n\nNew entry: Prefer concise morning summaries.';
 }
 
+function toolIntentClassifier(allowedToolNames: IntexAgentToolName[]): IntexAgentIntentClassifier {
+  return {
+    async classify(): ReturnType<IntexAgentIntentClassifier['classify']> {
+      return { kind: 'tool', allowedToolNames };
+    },
+  };
+}
+
 class FakeToolCallingClient implements ToolCallingClient {
   readonly calls: Parameters<ToolCallingClient['run']>[0][] = [];
 
@@ -3533,6 +3795,11 @@ class ToolExecutingFakeToolCallingClient extends FakeToolCallingClient {
     results: Result<ToolCallingResult, LLMError>[]
   ) {
     super(results);
+  }
+
+  toolNames(): IntexAgentToolName[] {
+    const toolCalls = Array.isArray(this.toolCalls) ? this.toolCalls : [this.toolCalls];
+    return [...new Set(toolCalls.map((toolCall) => toolCall.toolName))] as IntexAgentToolName[];
   }
 
   override async run(

--- a/apps/intex-agent/src/domain/agent/intentClassifier.ts
+++ b/apps/intex-agent/src/domain/agent/intentClassifier.ts
@@ -77,6 +77,8 @@ export type IntexAgentIntentClassification =
       missingFields?: string[];
       candidateIntents?: IntexAgentToolName[];
       suggestedNextStep?: string;
+      fallbackReason?: 'llm_call_failed';
+      fallbackSourceOutcome?: string;
       stylePreferenceAction?: IntexAgentStylePreferenceAction;
       languageOverride?: string;
       reason?: string;
@@ -306,6 +308,8 @@ function genericClarification(replyLanguage: IntexAgentReplyLanguage): IntexAgen
     question: GENERIC_CLARIFICATION_QUESTIONS[replyLanguage],
     blockerReason: 'not_enough_context',
     suggestedNextStep: GENERIC_CLARIFICATION_NEXT_STEPS[replyLanguage],
+    fallbackReason: 'llm_call_failed',
+    fallbackSourceOutcome: 'classifier',
   };
 }
 

--- a/apps/intex-agent/src/domain/agent/intentGate.ts
+++ b/apps/intex-agent/src/domain/agent/intentGate.ts
@@ -2,185 +2,20 @@ import type { IntexAgentToolName } from '../sessions/types.js';
 
 export type IntexAgentIntentDecision =
   | { kind: 'tool'; allowedToolNames: IntexAgentToolName[] }
-  | { kind: 'no_action'; reason: 'greeting' | 'conversation' }
-  | { kind: 'unsupported'; reason: 'multiple_resource_intents' };
+  | { kind: 'no_action'; reason: 'greeting' | 'conversation' };
 
 export function classifyIntexAgentIntent(text: string): IntexAgentIntentDecision {
   const normalized = normalizeIntentText(text);
-  const normalizedWithoutUrls = normalizeIntentText(stripUrls(text));
-  const containsUrl = hasUrl(text);
 
-  if (!containsUrl && isGreeting(normalized)) {
+  if (isGreeting(normalized)) {
     return { kind: 'no_action', reason: 'greeting' };
   }
 
-  const isPreferenceRequest = isExplicitPreferenceManagementRequest(normalizedWithoutUrls);
-  const toolNames = explicitToolNames(normalizedWithoutUrls);
-  const isCalendarQuery = isReadOnlyCalendarQueryRequest(normalizedWithoutUrls);
-  if (isPreferenceRequest && (toolNames.length > 0 || isCalendarQuery || containsUrl)) {
-    return { kind: 'unsupported', reason: 'multiple_resource_intents' };
-  }
-  if (isPreferenceRequest) {
-    return {
-      kind: 'tool',
-      allowedToolNames: [
-        'get_user_preferences',
-        'add_user_preference',
-        'update_user_preference',
-        'delete_user_preference',
-      ],
-    };
-  }
-
-  if (toolNames.length > 0 && isCalendarQuery) {
-    return { kind: 'unsupported', reason: 'multiple_resource_intents' };
-  }
-
-  if (toolNames.length === 1) {
-    return { kind: 'tool', allowedToolNames: toolNames };
-  }
-
-  if (toolNames.length > 1) {
-    return { kind: 'unsupported', reason: 'multiple_resource_intents' };
-  }
-
-  if (containsUrl && isCalendarQuery) {
-    return { kind: 'unsupported', reason: 'multiple_resource_intents' };
-  }
-
-  if (toolNames.length === 0 && isCalendarQuery) {
-    return { kind: 'tool', allowedToolNames: ['query_calendar_events'] };
-  }
-
-  if (containsUrl) {
+  if (isBareUrl(text)) {
     return { kind: 'tool', allowedToolNames: ['create_link'] };
   }
 
   return { kind: 'no_action', reason: 'conversation' };
-}
-
-function explicitToolNames(text: string): IntexAgentToolName[] {
-  const toolNames: IntexAgentToolName[] = [];
-  if (isExplicitExternalSaveRequest(text)) toolNames.push('save_external');
-  if (isExplicitNoteRequest(text)) toolNames.push('create_note');
-  if (isExplicitCalendarCreateRequest(text)) toolNames.push('create_calendar_event');
-  if (isExplicitResearchRequest(text)) toolNames.push('create_research');
-  if (isExplicitLinkRequest(text)) toolNames.push('create_link');
-  if (isExplicitCodeTaskRequest(text)) toolNames.push('create_code_task');
-  return toolNames;
-}
-
-function isExplicitExternalSaveRequest(text: string): boolean {
-  return (
-    /\b(save externally|upload externally|save for processing)\b/u.test(text) ||
-    /\b(zapisz zewnetrznie|przeslij zewnetrznie|zapisz do przetworzenia)\b/u.test(text)
-  );
-}
-
-function isExplicitPreferenceManagementRequest(text: string): boolean {
-  const mentionsPreferences =
-    /\b(preference|preferences|instruction|instructions|prompt preference|prompt preferences)\b/u.test(
-      text
-    ) ||
-    /\b(preferencj\w*|instrukcj\w*|promptu agenta|prompt agenta)\b/u.test(text) ||
-    /\b(row|wiersz)\b.*\b(preference|preferences|instruction|instructions|preferencj\w*|instrukcj\w*)\b/u.test(
-      text
-    );
-  const managementIntent =
-    /\b(tell|show|list|what|defined|add|create|update|change|remove|delete)\b/u.test(text) ||
-    /\b(jakie|jaki|jaka|mamy|pokaz\w*|wypisz\w*|dodaj|utworz|stworz|zmien|usun)\b/u.test(
-      text
-    );
-
-  if (mentionsPreferences && managementIntent) {
-    return true;
-  }
-
-  return (
-    /\b(delete|remove)\s+preference\s+\d+\b/u.test(text) ||
-    /\b(add|update|change|remove|delete)\s+(an?\s+)?preference\b/u.test(text) ||
-    /\b(show|tell|list)\b.*\b(intex instructions|user preferences)\b/u.test(text)
-  );
-}
-
-function isReadOnlyCalendarQueryRequest(text: string): boolean {
-  const mentionsCalendar =
-    /\b(calendar|kalendarz\w*|wydarzen\w*|event|events|appointment|appointments|meeting|meetings)\b/u.test(
-      text
-    );
-  const listIntent =
-    /\b(show|list|check|inspect|see|find|search|what|when|pokaz\w*|podaj\w*|sprawdz\w*|zobac\w*|znajdz\w*|szukaj|wypisz\w*|wyswietl\w*|jakie|jaki|jaka|zaplanowan\w*|lista|liste|listy|co jest)\b/u.test(
-      text
-    ) || /\bco\b.*\bjest\b/u.test(text);
-  const countIntent = /\b(how many times|how many|count|ile razy|ile)\b/u.test(text);
-  const existenceIntent =
-    /\b(is there|are there|do i have|have i got|am i free|available|free)\b/u.test(text) ||
-    /\bczy\b.*\b(ma|mam|masz|jest|sa|woln\w*)\b/u.test(text);
-  const availabilityIntent =
-    /\b(available|availability|free|woln\w*)\b/u.test(text) &&
-    /\b(termin\w*|spotkanie|meeting|appointment)\b/u.test(text) &&
-    mentionsCalendarTimeRange(text);
-
-  if ((mentionsCalendar && (listIntent || countIntent || existenceIntent)) || availabilityIntent) {
-    return true;
-  }
-
-  return countIntent && mentionsCalendarTimeRange(text) && !mentionsNonCalendarResource(text);
-}
-
-function isExplicitNoteRequest(text: string): boolean {
-  return (
-    /\b(create|add|save|write down)\b.*\b(note|notat\w*)/u.test(text) ||
-    /\b(note this|write this down)\b/u.test(text) ||
-    /\bremember (that|this)\b/u.test(text) ||
-    /\bremember the\b.*\b(code|password|pin|gate|door|parking|spot)\b/u.test(text) ||
-    /\b(zapisz|stworz|utworz|dodaj)\b.*\b(notat\w*|note)\b/u.test(text)
-  );
-}
-
-function isExplicitCalendarCreateRequest(text: string): boolean {
-  if (/\bresearch\b/u.test(text)) {
-    return false;
-  }
-
-  return (
-    /\b(create|add|schedule|plan)\b.*\b(calendar|event|appointment|meeting)\b/u.test(text) ||
-    /\b(dodaj|stworz|utworz|zaplanuj)\b.*\b(kalendarz|wydarzenie|spotkanie|wizyta)\b/u.test(text)
-  );
-}
-
-function isExplicitResearchRequest(text: string): boolean {
-  return (
-    /\b(create|prepare|start|do)\b.*\b(research|research draft|report)\b/u.test(text) ||
-    /^\s*research\b/u.test(text) ||
-    /\b(stworz|utworz|przygotuj|zrob)\b.*\b(research|szkic badawczy|badanie)\b/u.test(text)
-  );
-}
-
-function isExplicitLinkRequest(text: string): boolean {
-  return (
-    /\b(save|bookmark|add)\b.*\b(link|url|bookmark|zakladk\w*)\b/u.test(text) ||
-    /\b(zapisz|dodaj)\b.*\b(link|url|zakladk\w*)\b/u.test(text)
-  );
-}
-
-function isExplicitCodeTaskRequest(text: string): boolean {
-  return (
-    /\b(create|add|start)\b.*\b(code task|coding task|programming task)\b/u.test(text) ||
-    /\b(stworz|utworz|dodaj)\b.*\b(zadanie programistyczne|code task)\b/u.test(text)
-  );
-}
-
-function mentionsCalendarTimeRange(text: string): boolean {
-  return /\b(today|tomorrow|yesterday|week|month|year|dzis|jutro|wczoraj|tydzien|tygodniu|miesiac|miesiacu|rok|zeszlym|zeszly|nastepny|next|last|this)\b/u.test(
-    text
-  );
-}
-
-function mentionsNonCalendarResource(text: string): boolean {
-  return /\b(note|notes|notat\w*|bookmark|bookmarks|zakladk\w*|link|links|url|urls|research|report|reports|code task|code tasks|coding task|coding tasks|programming task|programming tasks|zadanie programistyczne|zadania programistyczne|message|messages|wiadomosc\w*)\b/u.test(
-    text
-  );
 }
 
 function isGreeting(text: string): boolean {
@@ -197,12 +32,8 @@ function isGreeting(text: string): boolean {
   ]).has(text);
 }
 
-function hasUrl(text: string): boolean {
-  return /\bhttps?:\/\/\S+/iu.test(text);
-}
-
-function stripUrls(text: string): string {
-  return text.replace(/\bhttps?:\/\/\S+/giu, ' ');
+function isBareUrl(text: string): boolean {
+  return /^\s*https?:\/\/\S+\s*$/iu.test(text);
 }
 
 function normalizeIntentText(text: string): string {

--- a/apps/intex-agent/src/domain/agent/intexAgentRunner.ts
+++ b/apps/intex-agent/src/domain/agent/intexAgentRunner.ts
@@ -3,6 +3,7 @@ import type { ToolCallingClient, ToolCallingMessage } from '@intexuraos/llm-cont
 import {
   IntexAgentRunnerOutputSchema,
   intexAgentRunnerOutputRepairPrompt,
+  type IntexAgentBlockerReason,
   type IntexAgentRunnerOutput,
 } from '@intexuraos/llm-prompts';
 import {
@@ -12,6 +13,7 @@ import {
   type StructuredGenerateResult,
 } from '@intexuraos/llm-utils';
 import type {
+  IntexAgentFallbackReason,
   IntexAgentRunner,
   IntexAgentRunnerResult,
 } from '../messages/handleIncomingMessage.js';
@@ -39,8 +41,6 @@ import { buildIntexAgentSystemPrompt, INTEX_AGENT_RUNNER_PROMPT_TYPE } from './s
 import { classifyIntexAgentIntent, type IntexAgentIntentDecision } from './intentGate.js';
 import {
   buildGreetingReply,
-  buildCompletionFailureCapabilitiesReply,
-  buildUnsupportedCapabilitiesReply,
   selectIntexAgentReplyLanguage,
   type IntexAgentReplyLanguage,
 } from './capabilities.js';
@@ -50,6 +50,13 @@ import type {
 } from './intentClassifier.js';
 
 const DEFAULT_WEB_APP_URL = 'https://intexuraos.cloud';
+const CLARIFICATION_ONLY_BLOCKER_REASONS = new Set<IntexAgentBlockerReason>([
+  'missing_required_details',
+  'not_enough_context',
+  'multiple_possible_intents',
+  'ambiguous_preference_target',
+]);
+
 type MutatingIntexAgentToolName = Exclude<
   IntexAgentToolName,
   'query_calendar_events' | 'get_user_preferences'
@@ -208,7 +215,11 @@ export function createIntexAgentRunner(config: IntexAgentRunnerConfig): IntexAge
     async executeConfirmed(input): Promise<IntexAgentRunnerResult> {
       const replyLanguage = detectReplyLanguage(input.events ?? []);
       if (!isMutatingToolName(input.toolName)) {
-        return malformedResult(replyLanguage);
+        return fallbackClarificationResult(
+          replyLanguage,
+          'tool_result_mismatch',
+          'confirmed_execution'
+        );
       }
 
       const toolExecutions: IntexAgentToolExecution[] = [];
@@ -218,7 +229,11 @@ export function createIntexAgentRunner(config: IntexAgentRunnerConfig): IntexAge
       const tool = tools.find((candidate) => candidate.name === input.toolName);
       /* v8 ignore start -- schema: mutating tool registry and tool definitions cannot diverge without breaking startup tests @preserve */
       if (tool === undefined) {
-        return malformedResult(replyLanguage);
+        return fallbackClarificationResult(
+          replyLanguage,
+          'tool_result_mismatch',
+          'confirmed_execution'
+        );
       }
       /* v8 ignore stop @preserve */
 
@@ -227,7 +242,11 @@ export function createIntexAgentRunner(config: IntexAgentRunnerConfig): IntexAge
         const toolExecution = getCompletedToolExecution(toolExecutions);
         /* v8 ignore start -- schema: every mutating tool definition executes through the tracking executor after argument validation @preserve */
         if (toolExecution === undefined) {
-          return malformedResult(replyLanguage);
+          return fallbackClarificationResult(
+            replyLanguage,
+            'tool_result_mismatch',
+            'confirmed_execution'
+          );
         }
         /* v8 ignore stop @preserve */
         const parsedResult = parseToolResult(rawResult);
@@ -294,18 +313,7 @@ export function createIntexAgentRunner(config: IntexAgentRunnerConfig): IntexAge
             });
       const replyLanguage = replyLanguageForIntent(intent, detectedReplyLanguage);
       if (intent.kind === 'unsupported') {
-        const blockerReason = 'blockerReason' in intent ? intent.blockerReason : undefined;
-        const suggestedNextStep =
-          'suggestedNextStep' in intent ? intent.suggestedNextStep : undefined;
-        return {
-          outcome: 'unsupported',
-          reply:
-            blockerReason !== undefined && suggestedNextStep !== undefined
-              ? unsupportedIntentReply(blockerReason, suggestedNextStep, replyLanguage)
-              : unsupportedIntentReplyFromFallbackGate(replyLanguage),
-          ...(blockerReason !== undefined ? { blockerReason } : {}),
-          ...(suggestedNextStep !== undefined ? { suggestedNextStep } : {}),
-        };
+        return normalizeClassifierUnsupportedIntent(intent, replyLanguage);
       }
 
       if (intent.kind === 'needs_clarification') {
@@ -319,6 +327,10 @@ export function createIntexAgentRunner(config: IntexAgentRunnerConfig): IntexAge
             : {}),
           ...(intent.suggestedNextStep !== undefined
             ? { suggestedNextStep: intent.suggestedNextStep }
+            : {}),
+          ...(intent.fallbackReason !== undefined ? { fallbackReason: intent.fallbackReason } : {}),
+          ...(intent.fallbackSourceOutcome !== undefined
+            ? { fallbackSourceOutcome: intent.fallbackSourceOutcome }
             : {}),
         };
       }
@@ -352,10 +364,7 @@ export function createIntexAgentRunner(config: IntexAgentRunnerConfig): IntexAge
       });
 
       if (!result.ok) {
-        return {
-          outcome: 'unsupported',
-          reply: buildCompletionFailureCapabilitiesReply(replyLanguage),
-        };
+        return fallbackClarificationResult(replyLanguage, 'llm_call_failed');
       }
 
       return await parseRunnerContent(
@@ -565,7 +574,10 @@ async function parseRunnerContent(
 ): Promise<IntexAgentRunnerResult> {
   const parsed = await validateRunnerOutput(input);
   if (parsed === null) {
-    return malformedResult(replyLanguage);
+    return fallbackClarificationResult(
+      replyLanguage,
+      fallbackReasonForInvalidRunnerContent(input.content)
+    );
   }
 
   const toolExecution = getCompletedToolExecution(toolExecutions);
@@ -607,6 +619,8 @@ async function parseRunnerContent(
         reply: parsed.reply,
         blockerReason: parsed.blockerReason,
         suggestedNextStep: parsed.suggestedNextStep,
+        fallbackReason: 'runner_declared_unsupported',
+        fallbackSourceOutcome: 'unsupported',
         ...(parsed.missingFields !== undefined ? { missingFields: parsed.missingFields } : {}),
         ...(parsed.candidateIntents !== undefined
           ? { candidateIntents: parsed.candidateIntents }
@@ -614,7 +628,7 @@ async function parseRunnerContent(
       };
     case 'completed': {
       if (toolExecution?.toolName !== parsed.toolName) {
-        return malformedResult(replyLanguage);
+        return fallbackClarificationResult(replyLanguage, 'tool_result_mismatch');
       }
       const completedToolExecution = toolExecution;
       const completedReply = buildCompletedReply(
@@ -1235,10 +1249,96 @@ function parseJsonObject(content: string): Record<string, unknown> | null {
   }
 }
 
-function malformedResult(replyLanguage: IntexAgentReplyLanguage = 'en'): IntexAgentRunnerResult {
+function fallbackReasonForInvalidRunnerContent(content: string): Extract<
+  IntexAgentFallbackReason,
+  'runner_output_malformed' | 'tool_result_mismatch'
+> {
+  const parsed = parseJsonObject(content);
+  if (parsed?.['outcome'] === 'completed' && typeof parsed['toolName'] !== 'string') {
+    return 'tool_result_mismatch';
+  }
+  return 'runner_output_malformed';
+}
+
+function fallbackClarificationResult(
+  replyLanguage: IntexAgentReplyLanguage,
+  fallbackReason: Extract<
+    IntexAgentFallbackReason,
+    'runner_output_malformed' | 'tool_result_mismatch' | 'llm_call_failed'
+  >,
+  fallbackSourceOutcome?: string
+): IntexAgentRunnerResult {
+  return {
+    outcome: 'needs_clarification',
+    reply:
+      fallbackReason === 'llm_call_failed'
+        ? LLM_FAILURE_CLARIFICATION_REPLIES[replyLanguage]
+        : FALLBACK_CLARIFICATION_REPLIES[replyLanguage],
+    blockerReason: 'not_enough_context',
+    suggestedNextStep: FALLBACK_CLARIFICATION_NEXT_STEPS[replyLanguage],
+    fallbackReason,
+    fallbackSourceOutcome:
+      fallbackSourceOutcome ?? defaultFallbackSourceOutcome(fallbackReason),
+  };
+}
+
+function defaultFallbackSourceOutcome(
+  fallbackReason: Extract<
+    IntexAgentFallbackReason,
+    'runner_output_malformed' | 'tool_result_mismatch' | 'llm_call_failed'
+  >
+): string {
+  if (fallbackReason === 'tool_result_mismatch') {
+    return 'completed';
+  }
+  if (fallbackReason === 'runner_output_malformed') {
+    return 'raw_response';
+  }
+  return 'llm_call_failed';
+}
+
+const FALLBACK_CLARIFICATION_REPLIES: Record<IntexAgentReplyLanguage, string> = {
+  en: 'What would you like me to do with this?',
+  pl: 'Co mam z tym zrobić?',
+};
+
+const LLM_FAILURE_CLARIFICATION_REPLIES: Record<IntexAgentReplyLanguage, string> = {
+  en: 'I could not process that request right now. Please restate what you want me to do.',
+  pl: 'Nie mogłem teraz przetworzyć tej prośby. Napisz proszę jeszcze raz, co mam zrobić.',
+};
+
+const FALLBACK_CLARIFICATION_NEXT_STEPS: Record<IntexAgentReplyLanguage, string> = {
+  en: 'Ask the user to restate the action.',
+  pl: 'Poproś użytkownika o doprecyzowanie akcji.',
+};
+
+function normalizeClassifierUnsupportedIntent(
+  intent: Extract<IntexAgentIntentClassification, { kind: 'unsupported' }>,
+  replyLanguage: IntexAgentReplyLanguage
+): IntexAgentRunnerResult {
+  const suggestedNextStep =
+    readNonBlankString(intent.suggestedNextStep) ?? fallbackUnsupportedNextStep(replyLanguage);
+
+  if (CLARIFICATION_ONLY_BLOCKER_REASONS.has(intent.blockerReason)) {
+    return {
+      outcome: 'needs_clarification',
+      reply: FALLBACK_CLARIFICATION_REPLIES[replyLanguage],
+      blockerReason: intent.blockerReason,
+      suggestedNextStep:
+        readNonBlankString(intent.suggestedNextStep) ??
+        FALLBACK_CLARIFICATION_NEXT_STEPS[replyLanguage],
+      fallbackReason: 'classifier_unsupported',
+      fallbackSourceOutcome: 'unsupported',
+    };
+  }
+
   return {
     outcome: 'unsupported',
-    reply: buildUnsupportedCapabilitiesReply(replyLanguage),
+    reply: unsupportedIntentReply(intent.blockerReason, suggestedNextStep, replyLanguage),
+    blockerReason: intent.blockerReason,
+    suggestedNextStep,
+    fallbackReason: 'classifier_unsupported',
+    fallbackSourceOutcome: 'unsupported',
   };
 }
 
@@ -1250,21 +1350,25 @@ function unsupportedIntentReply(
   const languageReplies = CLASSIFIER_UNSUPPORTED_REPLIES[replyLanguage];
   const base = languageReplies[blockerReason] ?? languageReplies.unsupported_capability;
   const nextStep = userFacingSuggestedNextStep(suggestedNextStep, replyLanguage);
-  return nextStep === undefined ? base : `${base} ${nextStep}`;
+  return `${base} ${nextStep}`;
 }
 
-function unsupportedIntentReplyFromFallbackGate(replyLanguage: IntexAgentReplyLanguage): string {
-  return buildUnsupportedCapabilitiesReply(replyLanguage);
+function fallbackUnsupportedNextStep(replyLanguage: IntexAgentReplyLanguage): string {
+  return replyLanguage === 'pl'
+    ? 'Poproś użytkownika o opisanie obsługiwanej akcji.'
+    : 'Ask the user to describe a supported action.';
+}
+
+function readNonBlankString(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed === undefined || trimmed === '' ? undefined : trimmed;
 }
 
 function userFacingSuggestedNextStep(
   suggestedNextStep: string,
   replyLanguage: IntexAgentReplyLanguage
-): string | undefined {
+): string {
   const trimmed = suggestedNextStep.trim();
-  if (trimmed === '') {
-    return undefined;
-  }
   if (replyLanguage === 'en') {
     const offerMatch = /^offer to\s+(.+)$/iu.exec(trimmed);
     if (offerMatch?.[1] !== undefined) {

--- a/apps/intex-agent/src/domain/messages/handleIncomingMessage.ts
+++ b/apps/intex-agent/src/domain/messages/handleIncomingMessage.ts
@@ -15,7 +15,6 @@ import type {
 import { normalizeSessionTimestamp } from '../sessions/sessionTimestamps.js';
 import {
   buildNewSessionReadyText,
-  buildUnsupportedCapabilitiesReply,
   selectIntexAgentReplyLanguage,
   type IntexAgentLanguageMessage,
   type IntexAgentReplyLanguage,
@@ -28,6 +27,13 @@ const CONFIRMATION_BUTTON_LABELS: Record<
   en: { yes: 'Yes', no: 'No' },
   pl: { yes: 'Tak', no: 'Nie' },
 };
+
+export type IntexAgentFallbackReason =
+  | 'classifier_unsupported'
+  | 'runner_declared_unsupported'
+  | 'runner_output_malformed'
+  | 'tool_result_mismatch'
+  | 'llm_call_failed';
 
 export type IntexAgentRunnerResult =
   | {
@@ -65,6 +71,8 @@ export type IntexAgentRunnerResult =
       candidateIntents?: string[];
       suggestedNextStep?: string;
       clarification?: string;
+      fallbackReason?: IntexAgentFallbackReason;
+      fallbackSourceOutcome?: string;
     }
   | {
       outcome: 'no_action';
@@ -73,10 +81,15 @@ export type IntexAgentRunnerResult =
   | {
       outcome: 'unsupported';
       reply: string;
-      blockerReason?: string;
+      blockerReason: string;
       missingFields?: string[];
       candidateIntents?: string[];
-      suggestedNextStep?: string;
+      suggestedNextStep: string;
+      fallbackReason: Extract<
+        IntexAgentFallbackReason,
+        'classifier_unsupported' | 'runner_declared_unsupported'
+      >;
+      fallbackSourceOutcome?: string;
     };
 
 export interface IntexAgentRunner {
@@ -417,6 +430,7 @@ async function applyRunnerResult(
 
   if (runnerResult.outcome === 'needs_clarification') {
     const reply = stripDuplicateSessionPrefix(runnerResult.reply);
+    await appendAgentFallbackIfNeeded(deps, session, runnerResult, 'needs_clarification');
     await appendEvent(deps, session, 'clarification_requested', {
       message: reply,
       ...runnerMetadataPayload(runnerResult),
@@ -484,6 +498,7 @@ async function applyRunnerResult(
 
   if (runnerResult.outcome === 'unsupported') {
     const reply = stripDuplicateSessionPrefix(runnerResult.reply);
+    await appendAgentFallbackIfNeeded(deps, session, runnerResult, 'unsupported');
     await appendEvent(deps, session, 'unsupported_request', {
       message: runnerResult.reply,
       ...runnerMetadataPayload(runnerResult),
@@ -499,7 +514,13 @@ async function applyRunnerResult(
   }
 
   if (runnerResult.toolName === undefined) {
-    await applyUnsupportedRunnerResult(input, deps, session, malformedRunnerResult(input, languageEvents));
+    await applyRunnerResult(
+      input,
+      deps,
+      session,
+      fallbackClarificationResult(input, languageEvents, 'tool_result_mismatch'),
+      languageEvents
+    );
     return;
   }
 
@@ -578,26 +599,6 @@ function stripDuplicateSessionPrefix(text: string): string {
     .trimStart();
 }
 
-async function applyUnsupportedRunnerResult(
-  input: IntexIncomingMessage,
-  deps: HandleIncomingMessageDeps,
-  session: IntexAgentSession,
-  runnerResult: Extract<IntexAgentRunnerResult, { outcome: 'unsupported' }>
-): Promise<void> {
-  const reply = stripDuplicateSessionPrefix(runnerResult.reply);
-  await appendEvent(deps, session, 'unsupported_request', {
-    message: runnerResult.reply,
-    ...runnerMetadataPayload(runnerResult),
-  });
-  const assistantAt = await appendAssistantMessage(session, deps, reply);
-  await deps.sessionRepository.updateSession(session.id, {
-    status: 'waiting_for_user',
-    lastAssistantMessageAt: assistantAt,
-    summary: summarizeUserMessage(input.text),
-  });
-  await publishReply(input, deps, session.id, reply);
-}
-
 function runnerMetadataPayload(
   runnerResult: Extract<
     IntexAgentRunnerResult,
@@ -617,6 +618,9 @@ function runnerMetadataPayload(
     ...(runnerResult.suggestedNextStep !== undefined
       ? { suggestedNextStep: runnerResult.suggestedNextStep }
       : {}),
+    ...(runnerResult.fallbackReason !== undefined
+      ? { fallbackReason: runnerResult.fallbackReason }
+      : {}),
     ...(runnerResult.outcome === 'needs_clarification' &&
     runnerResult.clarification !== undefined
       ? { clarification: runnerResult.clarification }
@@ -632,15 +636,53 @@ function summarizeUserMessage(message: string): string {
   return `${normalized.slice(0, 117)}...`;
 }
 
-function malformedRunnerResult(
+async function appendAgentFallbackIfNeeded(
+  deps: HandleIncomingMessageDeps,
+  session: IntexAgentSession,
+  runnerResult: Extract<
+    IntexAgentRunnerResult,
+    { outcome: 'needs_clarification' } | { outcome: 'unsupported' }
+  >,
+  sourceOutcome: 'needs_clarification' | 'unsupported'
+): Promise<void> {
+  if (runnerResult.fallbackReason === undefined) {
+    return;
+  }
+
+  await appendEvent(deps, session, 'agent_fallback', {
+    reason: runnerResult.fallbackReason,
+    sourceOutcome: runnerResult.fallbackSourceOutcome ?? sourceOutcome,
+  });
+}
+
+function fallbackClarificationResult(
   input: IntexIncomingMessage,
-  events: readonly IntexAgentSessionEvent[]
-): Extract<IntexAgentRunnerResult, { outcome: 'unsupported' }> {
+  events: readonly IntexAgentSessionEvent[],
+  fallbackReason: Extract<
+    IntexAgentFallbackReason,
+    'runner_output_malformed' | 'tool_result_mismatch' | 'llm_call_failed'
+  >
+): Extract<IntexAgentRunnerResult, { outcome: 'needs_clarification' }> {
+  const language = selectReplyLanguage(input, events);
   return {
-    outcome: 'unsupported',
-    reply: buildUnsupportedCapabilitiesReply(selectReplyLanguage(input, events)),
+    outcome: 'needs_clarification',
+    reply: FALLBACK_CLARIFICATION_REPLIES[language],
+    blockerReason: 'not_enough_context',
+    suggestedNextStep: FALLBACK_CLARIFICATION_NEXT_STEPS[language],
+    fallbackReason,
+    fallbackSourceOutcome: 'completed',
   };
 }
+
+const FALLBACK_CLARIFICATION_REPLIES: Record<IntexAgentReplyLanguage, string> = {
+  en: 'What would you like me to do with this?',
+  pl: 'Co mam z tym zrobić?',
+};
+
+const FALLBACK_CLARIFICATION_NEXT_STEPS: Record<IntexAgentReplyLanguage, string> = {
+  en: 'Ask the user to restate the action.',
+  pl: 'Poproś użytkownika o doprecyzowanie akcji.',
+};
 
 interface ParsedConfirmationButton {
   confirmationId: string;

--- a/apps/intex-agent/src/domain/sessions/types.ts
+++ b/apps/intex-agent/src/domain/sessions/types.ts
@@ -58,6 +58,7 @@ export type IntexAgentSessionEventType =
   | 'session_closed'
   | 'user_message'
   | 'assistant_message'
+  | 'agent_fallback'
   | 'clarification_requested'
   | 'confirmation_requested'
   | 'confirmation_resolved'

--- a/apps/intex-agent/src/infra/firestore/sessionRepository.ts
+++ b/apps/intex-agent/src/infra/firestore/sessionRepository.ts
@@ -30,6 +30,7 @@ const EVENT_TYPE_ORDER: Record<IntexAgentSessionEventType, number> = {
   tool_call_started: 20,
   tool_call_completed: 30,
   tool_call_failed: 30,
+  agent_fallback: 39,
   unsupported_request: 40,
   clarification_requested: 40,
   assistant_message: 50,

--- a/apps/web/src/components/intex-agent/IntexSessionTimeline.tsx
+++ b/apps/web/src/components/intex-agent/IntexSessionTimeline.tsx
@@ -34,6 +34,12 @@ function getEventTitle(event: IntexAgentSessionEvent): string {
       return 'IntexuraOS';
     case 'clarification_requested':
       return 'Clarification requested';
+    case 'agent_fallback':
+      return 'Agent fallback';
+    case 'confirmation_requested':
+      return 'Confirmation requested';
+    case 'confirmation_resolved':
+      return 'Confirmation resolved';
     case 'tool_call_started':
       return `${formatSessionValue(getPayloadString(event.payload, 'toolName'))} started`;
     case 'tool_call_completed':
@@ -74,6 +80,7 @@ function EventIcon({ event }: { event: IntexAgentSessionEvent }): React.JSX.Elem
   if (event.type === 'assistant_message' || event.type === 'clarification_requested') {
     return <Bot className="h-4 w-4" />;
   }
+  if (event.type === 'agent_fallback') return <Bot className="h-4 w-4" />;
   if (event.type.startsWith('tool_call')) return <Wrench className="h-4 w-4" />;
   if (event.type === 'session_closed') return <CheckCircle2 className="h-4 w-4" />;
   return <PlayCircle className="h-4 w-4" />;

--- a/apps/web/src/components/intex-agent/sessionPresentation.ts
+++ b/apps/web/src/components/intex-agent/sessionPresentation.ts
@@ -9,9 +9,12 @@ import { formatDateTimeCompact, formatRelative } from '@/utils/dateFormat';
 const EVENT_TYPE_ORDER: Record<IntexAgentSessionEventType, number> = {
   session_started: 0,
   user_message: 10,
+  confirmation_requested: 20,
+  confirmation_resolved: 20,
   tool_call_started: 20,
   tool_call_completed: 30,
   tool_call_failed: 30,
+  agent_fallback: 39,
   unsupported_request: 40,
   clarification_requested: 40,
   assistant_message: 50,
@@ -103,11 +106,14 @@ export function getSessionEventClass(type: IntexAgentSessionEventType): string {
       return 'border-slate-200 bg-white dark:border-slate-800 dark:bg-slate-950';
     case 'assistant_message':
     case 'clarification_requested':
+    case 'confirmation_requested':
+    case 'confirmation_resolved':
       return 'border-blue-200 bg-blue-50/60 dark:border-blue-900 dark:bg-blue-950/20';
     case 'tool_call_started':
     case 'tool_call_completed':
       return 'border-emerald-200 bg-emerald-50/60 dark:border-emerald-900 dark:bg-emerald-950/20';
     case 'tool_call_failed':
+    case 'agent_fallback':
     case 'unsupported_request':
       return 'border-amber-200 bg-amber-50/60 dark:border-amber-900 dark:bg-amber-950/20';
     case 'session_started':

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -349,10 +349,15 @@ export type IntexAgentSessionEndReason =
 export type IntexAgentToolName =
   | 'create_note'
   | 'create_calendar_event'
+  | 'query_calendar_events'
   | 'create_research'
   | 'create_link'
   | 'create_code_task'
-  | 'save_external';
+  | 'save_external'
+  | 'get_user_preferences'
+  | 'add_user_preference'
+  | 'update_user_preference'
+  | 'delete_user_preference';
 
 export interface IntexAgentSession {
   id: string;
@@ -374,7 +379,10 @@ export type IntexAgentSessionEventType =
   | 'session_closed'
   | 'user_message'
   | 'assistant_message'
+  | 'agent_fallback'
   | 'clarification_requested'
+  | 'confirmation_requested'
+  | 'confirmation_resolved'
   | 'tool_call_started'
   | 'tool_call_completed'
   | 'tool_call_failed'


### PR DESCRIPTION
## Summary

- simplify the Intex Agent intent gate to greetings and bare URLs only
- convert malformed runner output and mismatch fallbacks into clarification with countable metadata
- add agent_fallback timeline/debug support and regressions for #2254-style sessions

## Verification

- `npx --yes pnpm@10.29.3 run ci:tracked`

## Linear

Linear: omitted by `$commit-push`; GitHub automation will create or link the Linear issue after PR creation.