### PR TITLE
Fix private WhatsApp video transcription uploads

### DIFF
--- a/docs/setup/16-private-whatsapp-matrix-sync.md
+++ b/docs/setup/16-private-whatsapp-matrix-sync.md
@@ -71,7 +71,7 @@ The request body must include:
 - `deliveryMode`
 - `events`
 
-Image and audio events upload media bytes to
+Image, audio, and video events upload media bytes to
 `POST /internal/whatsapp/private/media` before the adapter posts the event batch
 to `POST /internal/whatsapp/private/events`. Both endpoints require the same
 private-sync service account OIDC identity.
@@ -125,7 +125,7 @@ The adapter should receive Matrix and Google credentials as mounted secret files
 6. IntexuraOS resolves `sourceAccountId` to the canonical user id.
 7. IntexuraOS stores immutable message docs and updates sender/sender-day read models.
 
-For new `m.image` events only, the adapter downloads the Matrix media bytes with its Matrix access token, uploads the bytes to `POST /internal/whatsapp/private/media`, receives GCS metadata, and includes that metadata in the private event sent to `POST /internal/whatsapp/private/events`. Existing image messages without stored media metadata remain placeholders in the private log.
+For new `m.image`, `m.audio`, and `m.video` events, the adapter downloads the Matrix media bytes with its Matrix access token, uploads the bytes to `POST /internal/whatsapp/private/media`, receives GCS metadata, and includes that metadata in the private event sent to `POST /internal/whatsapp/private/events`. Existing media messages without stored media metadata remain placeholders in the private log.
 
 Backfills should use the same endpoint with `deliveryMode: "backfill"` and deterministic Matrix event ids so duplicate ingest does not double-count aggregates.
 

--- a/tools/whatsapp-private-matrix-sync/src/server.mjs
+++ b/tools/whatsapp-private-matrix-sync/src/server.mjs
@@ -485,7 +485,7 @@ export async function prepareEventsForIngest(config, matrixAccessToken, events, 
 }
 
 function isPrivateMediaUploadMessageType(messageType) {
-  return messageType === 'image' || messageType === 'audio';
+  return messageType === 'image' || messageType === 'audio' || messageType === 'video';
 }
 
 export function createHealthServer(config, runtime) {

--- a/tools/whatsapp-private-matrix-sync/src/server.test.mjs
+++ b/tools/whatsapp-private-matrix-sync/src/server.test.mjs
@@ -1165,6 +1165,71 @@ test('prepareEventsForIngest uploads new Matrix audio before posting ingest even
   });
 });
 
+test('prepareEventsForIngest uploads new Matrix video before posting ingest events', async () => {
+  const prepared = await prepareEventsForIngest(
+    config,
+    'matrix-token',
+    [
+      {
+        matrixRoomId: '!room:home-dev',
+        matrixEventId: '$video',
+        matrixSenderId: '@whatsapp_48536911713:home-dev',
+        eventTimestamp: '2026-06-30T12:54:45.000Z',
+        chat: { type: 'group' },
+        message: {
+          direction: 'incoming',
+          type: 'video',
+          text: 'video.mp4',
+          media: {
+            mxcUri: 'mxc://home-dev/video',
+            mimeType: 'video/mp4',
+            fileName: 'video.mp4',
+          },
+        },
+        rawMatrixEvent: {},
+      },
+    ],
+    {
+      fetchMatrixMedia: async (_config, accessToken, mxcUri) => {
+        assert.equal(accessToken, 'matrix-token');
+        assert.equal(mxcUri, 'mxc://home-dev/video');
+        return {
+          buffer: Buffer.from('video-bytes'),
+          contentType: 'video/mp4',
+        };
+      },
+      uploadPrivateMedia: async (_config, event, media, downloaded) => {
+        assert.equal(event.matrixEventId, '$video');
+        assert.equal(media.mxcUri, 'mxc://home-dev/video');
+        assert.equal(downloaded.contentType, 'video/mp4');
+        return {
+          mxcUri: media.mxcUri,
+          mimeType: 'video/mp4',
+          fileName: 'video.mp4',
+          sizeBytes: downloaded.buffer.length,
+          storageStatus: 'stored',
+          gcsPath: 'whatsapp/private/user/message/video.mp4',
+          storedMimeType: 'video/mp4',
+          storedSizeBytes: downloaded.buffer.length,
+          storedAt: '2026-06-30T12:55:00.000Z',
+        };
+      },
+    }
+  );
+
+  assert.deepEqual(prepared[0]?.message.media, {
+    mxcUri: 'mxc://home-dev/video',
+    mimeType: 'video/mp4',
+    fileName: 'video.mp4',
+    sizeBytes: 'video-bytes'.length,
+    storageStatus: 'stored',
+    gcsPath: 'whatsapp/private/user/message/video.mp4',
+    storedMimeType: 'video/mp4',
+    storedSizeBytes: 'video-bytes'.length,
+    storedAt: '2026-06-30T12:55:00.000Z',
+  });
+});
+
 test('runSyncIteration does not persist Matrix state when image upload fails', async () => {
   const stateFile = await createTempStateFile({
     nextBatch: 'batch-1',


### PR DESCRIPTION
## Summary

- Upload private Matrix video media before WhatsApp ingest so MP4 messages include stored GCS metadata.
- Add regression coverage for m.video upload preparation and update private Matrix sync docs.

## Verification

- `CI=true npm exec --package=pnpm@10.29.3 -- pnpm run ci:tracked`

## Linear

Linear: omitted by `$commit-push`; GitHub automation will create or link the Linear issue after PR creation.