### PR TITLE
[INT-1820] fix: prevent stale review completions from resetting Linear state

### DIFF
--- a/apps/code-agent/src/__tests__/domain/usecases/handleTaskCompletion.test.ts
+++ b/apps/code-agent/src/__tests__/domain/usecases/handleTaskCompletion.test.ts
@@ -268,6 +268,7 @@ describe('handleTaskCompletion', () => {
       const notifyTaskComplete = vi.fn().mockResolvedValue(ok(undefined));
       const incrementTasksCompleted = vi.fn().mockResolvedValue(undefined);
       const recordTaskDuration = vi.fn().mockResolvedValue(undefined);
+      const markInReview = vi.fn().mockResolvedValue(undefined);
 
       setServices({
         codeTaskRepo: {
@@ -288,7 +289,7 @@ describe('handleTaskCompletion', () => {
         automationLog: { record: automationRecord } as never,
         linearIssueService: {
           removeLabel: vi.fn().mockResolvedValue(undefined),
-          markInReview: vi.fn().mockResolvedValue(undefined),
+          markInReview,
         } as never,
         logger: createMockLogger() as never,
         // No createRemediationTaskFn → the branch that records the decision
@@ -324,6 +325,7 @@ describe('handleTaskCompletion', () => {
         source: 'review_result',
       });
       expect(remediationCall?.[0]).toMatchObject({ repository: 'a/b', prNumber: 42 });
+      expect(markInReview).toHaveBeenCalledWith('u1', 'INT-1');
     });
 
     it.each([

--- a/apps/code-agent/src/__tests__/domain/usecases/handleTaskCompletion.test.ts
+++ b/apps/code-agent/src/__tests__/domain/usecases/handleTaskCompletion.test.ts
@@ -338,6 +338,7 @@ describe('handleTaskCompletion', () => {
       const createRemediationTaskFn = vi.fn().mockResolvedValue(ok({ taskId: 'remed-1' }));
       const findOriginTaskByPR = vi.fn().mockResolvedValue(ok(null));
       const removeLabel = vi.fn().mockResolvedValue(undefined);
+      const markInReview = vi.fn().mockResolvedValue(undefined);
 
       setServices({
         codeTaskRepo: {
@@ -359,7 +360,7 @@ describe('handleTaskCompletion', () => {
         automationLog: { record: automationRecord } as never,
         linearIssueService: {
           removeLabel,
-          markInReview: vi.fn().mockResolvedValue(undefined),
+          markInReview,
         } as never,
         logger: createMockLogger() as never,
         createRemediationTaskFn,
@@ -381,6 +382,7 @@ describe('handleTaskCompletion', () => {
       expect(createRemediationTaskFn).not.toHaveBeenCalled();
       expect(findOriginTaskByPR).not.toHaveBeenCalled();
       expect(removeLabel).not.toHaveBeenCalled();
+      expect(markInReview).not.toHaveBeenCalled();
       const remediationCall = automationRecord.mock.calls.find((call) => {
         const event = call[1] as { type?: string; required?: boolean; signal?: string; taskId?: string };
         return event.type === 'remediation_decision';

--- a/apps/code-agent/src/domain/usecases/handleTaskCompletion.ts
+++ b/apps/code-agent/src/domain/usecases/handleTaskCompletion.ts
@@ -1397,6 +1397,21 @@ export async function handleTaskCompletion(
         if (prNumber === undefined && task.prNumber !== undefined) {
           prNumber = task.prNumber;
         }
+        const isPrStillOpen = (): boolean => task.prMergedAt === undefined && task.prClosedAt === undefined;
+        const getInReviewTransitionIssueId = (): string | undefined => {
+          if (
+            task.agentType === 'execution' ||
+            task.agentType === 'pull_request' ||
+            task.agentType === 'planning' ||
+            task.agentType === 'remediation' ||
+            prNumber === undefined ||
+            !isPrStillOpen()
+          ) {
+            return undefined;
+          }
+
+          return task.linearIssueId;
+        };
 
         const resolvedStatus = resolveCompletedTaskStatus(task.agentType);
         const executionMemoryPostRun = shouldQueueExecutionMemoryPostRun({
@@ -1482,7 +1497,7 @@ export async function handleTaskCompletion(
 
               await applyReadyToMergeLabel(prNumber);
             } else {
-              if (task.prMergedAt !== undefined || task.prClosedAt !== undefined) {
+              if (!isPrStillOpen()) {
                 requestLog.info(
                   {
                     taskId,
@@ -1634,8 +1649,9 @@ export async function handleTaskCompletion(
 
         // Best-effort In Review transition for agent types without deterministic enforcement.
         // If the PR is already merged/closed, handlePrClose owns the final Linear state.
-        if (task.agentType !== 'execution' && task.agentType !== 'pull_request' && task.agentType !== 'planning' && task.agentType !== 'remediation' && prNumber !== undefined && task.linearIssueId !== undefined && task.prMergedAt === undefined && task.prClosedAt === undefined) {
-          await linearIssueService.markInReview(task.userId, task.linearIssueId);
+        const inReviewTransitionIssueId = getInReviewTransitionIssueId();
+        if (inReviewTransitionIssueId !== undefined) {
+          await linearIssueService.markInReview(task.userId, inReviewTransitionIssueId);
         }
 
         // Send WhatsApp notification (use updated task with result populated)

--- a/apps/code-agent/src/domain/usecases/handleTaskCompletion.ts
+++ b/apps/code-agent/src/domain/usecases/handleTaskCompletion.ts
@@ -1632,9 +1632,9 @@ export async function handleTaskCompletion(
           await applyReadyToMergeLabel(prNumber);
         }
 
-        // Best-effort In Review transition for agent types without deterministic enforcement
-        // (planning, execution, and pull_request agents handle this in their own enforcement paths)
-        if (task.agentType !== 'execution' && task.agentType !== 'pull_request' && task.agentType !== 'planning' && task.agentType !== 'remediation' && prNumber !== undefined && task.linearIssueId !== undefined) {
+        // Best-effort In Review transition for agent types without deterministic enforcement.
+        // If the PR is already merged/closed, handlePrClose owns the final Linear state.
+        if (task.agentType !== 'execution' && task.agentType !== 'pull_request' && task.agentType !== 'planning' && task.agentType !== 'remediation' && prNumber !== undefined && task.linearIssueId !== undefined && task.prMergedAt === undefined && task.prClosedAt === undefined) {
           await linearIssueService.markInReview(task.userId, task.linearIssueId);
         }
 


### PR DESCRIPTION
## Summary

- Prevent late review-style task completions from moving a Linear issue back to In Review after its PR was already merged or closed.
- Add regression coverage for merged/closed PR lifecycle cases so stale review completions leave the Linear state owned by handlePrClose.

## Root Cause

After a PR merge, handlePrClose correctly moves the linked Linear issue to QA. A delayed review task completion could arrive afterwards and the generic best-effort completion path would call markInReview without checking prMergedAt/prClosedAt, overwriting QA with In Review.

## Verification

- `node_modules/.bin/vitest run src/__tests__/domain/useCases/handleTaskCompletion.test.ts -t "records the review decision but skips remediation creation when the PR is already"`
- `node_modules/.bin/vitest run src/__tests__/domain/useCases/handleTaskCompletion.test.ts`
- `pnpm run verify:workspace:tracked code-agent`
- `pnpm run ci:tracked`

## Linear

Linear: omitted by `$commit-push`; GitHub automation will create or link the Linear issue after PR creation.