### PR TITLE
[INT-1824] Fix private WhatsApp media backfill

### DIFF
--- a/apps/web/src/pages/IntexAgentPreferencesPage.tsx
+++ b/apps/web/src/pages/IntexAgentPreferencesPage.tsx
@@ -273,28 +273,36 @@ export function IntexAgentPreferencesPage(): React.JSX.Element {
 
   return (
     <Layout>
-      <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
-        <div className="mb-5 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
-          <div>
-            <h1 className="text-2xl font-semibold text-slate-950 dark:text-slate-50">
-              Intex Agent Preferences
-            </h1>
-            <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-sm text-slate-600 dark:text-slate-300">
-              <span>Current version {String(current?.currentVersion ?? 0)}</span>
-              <span>Last updated {displayDate(current?.updatedAt)}</span>
-              <span>Updated by {actorLabel(current?.updatedBy ?? null)}</span>
+      <div className="mx-auto max-w-6xl px-4 py-6 sm:px-6 lg:px-8">
+        <div className="mb-6 border-b border-slate-200 pb-5 dark:border-slate-800">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+            <div className="min-w-0">
+              <h1 className="text-2xl font-semibold text-slate-950 dark:text-slate-50">
+                Intex Agent Preferences
+              </h1>
+              <div className="mt-3 flex flex-wrap gap-2 text-xs text-slate-600 dark:text-slate-300">
+                <span className="rounded-md border border-slate-200 bg-white px-2.5 py-1 dark:border-slate-700 dark:bg-slate-900">
+                  Current version {String(current?.currentVersion ?? 0)}
+                </span>
+                <span className="rounded-md border border-slate-200 bg-white px-2.5 py-1 dark:border-slate-700 dark:bg-slate-900">
+                  Last updated {displayDate(current?.updatedAt)}
+                </span>
+                <span className="rounded-md border border-slate-200 bg-white px-2.5 py-1 dark:border-slate-700 dark:bg-slate-900">
+                  Updated by {actorLabel(current?.updatedBy ?? null)}
+                </span>
+              </div>
             </div>
+            <button
+              type="button"
+              onClick={() => {
+                void refreshAll();
+              }}
+              className="inline-flex w-full items-center justify-center gap-2 rounded-md border border-slate-300 bg-white px-3 py-2 text-sm font-medium text-slate-700 shadow-sm hover:bg-slate-50 sm:w-auto dark:border-slate-600 dark:bg-slate-900 dark:text-slate-200 dark:hover:bg-slate-800"
+            >
+              <RefreshCw className="h-4 w-4" />
+              Refresh
+            </button>
           </div>
-          <button
-            type="button"
-            onClick={() => {
-              void refreshAll();
-            }}
-            className="inline-flex items-center gap-2 rounded-md border border-slate-300 px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 dark:border-slate-600 dark:text-slate-200 dark:hover:bg-slate-800"
-          >
-            <RefreshCw className="h-4 w-4" />
-            Refresh
-          </button>
         </div>
 
         {error !== null ? (
@@ -314,14 +322,16 @@ export function IntexAgentPreferencesPage(): React.JSX.Element {
             Loading preferences
           </div>
         ) : (
-          <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_380px]">
+          <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_360px]">
             <main className="space-y-6">
               <section className="space-y-3">
-                <div className="flex items-center justify-between gap-4">
+                <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
                   <h2 className="text-lg font-semibold text-slate-950 dark:text-slate-50">
                     Preference Rows
                   </h2>
-                  <span className="text-sm text-slate-500">{String(current?.items.length ?? 0)}/50 rows</span>
+                  <span className="text-sm text-slate-500">
+                    {String(current?.items.length ?? 0)}/50 rows
+                  </span>
                 </div>
 
                 <AddPreferenceForm
@@ -370,19 +380,6 @@ export function IntexAgentPreferencesPage(): React.JSX.Element {
                   </div>
                 )}
 
-                <AddPreferenceForm
-                  label="Add another preference"
-                  value={newText}
-                  validation={newTextValidation}
-                  pending={pending === 'add'}
-                  disabled={current === null || pending !== null}
-                  compact
-                  buttonLabel="Add below"
-                  onChange={setNewText}
-                  onSubmit={() => {
-                    void handleAdd();
-                  }}
-                />
               </section>
 
               <PromptPreview
@@ -391,7 +388,7 @@ export function IntexAgentPreferencesPage(): React.JSX.Element {
               />
             </main>
 
-            <aside className="space-y-4">
+            <aside className="space-y-4 xl:sticky xl:top-6 xl:self-start">
               <section>
                 <h2 className="mb-3 text-lg font-semibold text-slate-950 dark:text-slate-50">
                   Versions
@@ -409,7 +406,7 @@ export function IntexAgentPreferencesPage(): React.JSX.Element {
                         onClick={() => {
                           void handleSelectVersion(version.version);
                         }}
-                        className="block w-full rounded-md border border-slate-200 p-3 text-left text-sm hover:bg-slate-50 dark:border-slate-700 dark:hover:bg-slate-800"
+                        className="block w-full rounded-md border border-slate-200 bg-white p-3 text-left text-sm shadow-sm transition hover:border-slate-300 hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-900 dark:hover:border-slate-600 dark:hover:bg-slate-800"
                       >
                         <span className="font-medium text-slate-950 dark:text-slate-50">
                           Version {String(version.version)}
@@ -419,17 +416,17 @@ export function IntexAgentPreferencesPage(): React.JSX.Element {
                           {displayDate(version.createdAt)} · {actorLabel(version.createdBy)}
                         </span>
                         {version.changedItemId !== undefined ? (
-                          <span className="mt-1 block font-mono text-xs text-slate-500">
+                          <span className="mt-1 block break-all font-mono text-xs text-slate-500">
                             {version.changedItemId}
                           </span>
                         ) : null}
                         {version.previousText !== undefined ? (
-                          <span className="mt-2 block text-xs text-slate-500">
+                          <span className="mt-2 block break-words text-xs text-slate-500">
                             Previous: {version.previousText}
                           </span>
                         ) : null}
                         {version.nextText !== undefined ? (
-                          <span className="mt-1 block text-xs text-slate-500">
+                          <span className="mt-1 block break-words text-xs text-slate-500">
                             Next: {version.nextText}
                           </span>
                         ) : null}
@@ -499,8 +496,6 @@ interface AddPreferenceFormProps {
   validation: string | null;
   pending: boolean;
   disabled: boolean;
-  compact?: boolean;
-  buttonLabel?: string;
   onChange: (value: string) => void;
   onSubmit: () => void;
 }
@@ -508,11 +503,11 @@ interface AddPreferenceFormProps {
 function AddPreferenceForm(props: AddPreferenceFormProps): React.JSX.Element {
   const canSubmit = !props.disabled && props.validation === null && props.value.trim() !== '';
   return (
-    <div className={props.compact === true ? 'rounded-md border border-slate-200 p-3 dark:border-slate-700' : ''}>
+    <div className="rounded-md border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900">
       <label className="block text-sm font-medium text-slate-700 dark:text-slate-200">
         {props.label}
         <textarea
-          className="mt-1 min-h-20 w-full resize-y rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
+          className="mt-2 min-h-24 w-full resize-y rounded-md border border-slate-300 bg-slate-50 px-3 py-2 text-sm text-slate-900 shadow-inner focus:border-blue-500 focus:bg-white focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-slate-600 dark:bg-slate-950 dark:text-slate-100 dark:focus:bg-slate-900"
           value={props.value}
           maxLength={MAX_PREFERENCE_LENGTH}
           onChange={(event) => {
@@ -520,18 +515,18 @@ function AddPreferenceForm(props: AddPreferenceFormProps): React.JSX.Element {
           }}
         />
       </label>
-      <div className="mt-2 flex flex-wrap items-center justify-between gap-2">
+      <div className="mt-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <span className="text-xs text-slate-500">
           {props.validation ?? `${String(props.value.trim().length)}/${String(MAX_PREFERENCE_LENGTH)}`}
         </span>
         <button
           type="button"
-          className="inline-flex items-center gap-2 rounded-md bg-blue-600 px-3 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:bg-slate-300 dark:disabled:bg-slate-700"
+          className="inline-flex w-full items-center justify-center gap-2 rounded-md bg-blue-600 px-3 py-2 text-sm font-medium text-white shadow-sm hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-slate-300 sm:w-auto dark:disabled:bg-slate-700"
           disabled={!canSubmit || props.pending}
           onClick={props.onSubmit}
         >
           {props.pending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />}
-          {props.buttonLabel ?? 'Add preference'}
+          Add preference
         </button>
       </div>
     </div>
@@ -560,15 +555,15 @@ function PreferenceRow(props: PreferenceRowProps): React.JSX.Element {
     editedText.trim() === props.item.text ||
     props.pending !== null;
   return (
-    <article className="rounded-md border border-slate-200 bg-white p-4 dark:border-slate-700 dark:bg-slate-900">
+    <article className="rounded-md border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-700 dark:bg-slate-900">
       <div className="mb-3 flex items-start justify-between gap-3">
-        <div>
+        <div className="min-w-0">
           <div className="text-sm font-semibold text-slate-950 dark:text-slate-50">
             {String(props.ordinal)}.
           </div>
-          <div className="font-mono text-xs text-slate-500">{props.item.id}</div>
+          <div className="break-all font-mono text-xs text-slate-500">{props.item.id}</div>
         </div>
-        <div className="flex gap-2">
+        <div className="flex shrink-0 gap-2">
           {isEditing ? (
             <button
               type="button"
@@ -612,14 +607,14 @@ function PreferenceRow(props: PreferenceRowProps): React.JSX.Element {
               }}
             />
           </label>
-          <div className="mt-2 flex flex-wrap items-center justify-between gap-2">
+          <div className="mt-2 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
             <span className="text-xs text-slate-500">
               {props.validation ?? `${String(editedText.trim().length)}/${String(MAX_PREFERENCE_LENGTH)}`}
             </span>
             <button
               type="button"
               aria-label={`Save ${props.item.id}`}
-              className="inline-flex items-center gap-2 rounded-md bg-blue-600 px-3 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:bg-slate-300 dark:disabled:bg-slate-700"
+              className="inline-flex w-full items-center justify-center gap-2 rounded-md bg-blue-600 px-3 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:bg-slate-300 sm:w-auto dark:disabled:bg-slate-700"
               disabled={saveDisabled}
               onClick={props.onSave}
             >
@@ -644,7 +639,7 @@ function PromptPreview(props: { title: string; block: string }): React.JSX.Eleme
   return (
     <section>
       <h2 className="mb-3 text-lg font-semibold text-slate-950 dark:text-slate-50">{props.title}</h2>
-      <pre className="max-h-96 overflow-auto rounded-md border border-slate-200 bg-slate-950 p-4 text-sm leading-6 text-slate-50 dark:border-slate-700">
+      <pre className="max-h-96 overflow-auto whitespace-pre-wrap break-words rounded-md border border-slate-200 border-l-4 border-l-cyan-400 bg-slate-50 p-4 text-sm leading-6 text-slate-800 shadow-sm dark:border-slate-700 dark:border-l-cyan-500 dark:bg-slate-900 dark:text-slate-100">
         {props.block.trim() === '' ? EMPTY_PROMPT_BLOCK : props.block}
       </pre>
     </section>

--- a/apps/web/src/pages/__tests__/IntexAgentPreferencesPage.test.tsx
+++ b/apps/web/src/pages/__tests__/IntexAgentPreferencesPage.test.tsx
@@ -106,6 +106,21 @@ describe('IntexAgentPreferencesPage', () => {
     });
   });
 
+  it('uses a single add flow and a neutral wrapping prompt preview', async () => {
+    const { IntexAgentPreferencesPage } = await import('../IntexAgentPreferencesPage');
+    render(<IntexAgentPreferencesPage />);
+
+    await screen.findByText('Intex Agent Preferences');
+
+    expect(screen.getAllByLabelText(/new preference/i)).toHaveLength(1);
+    expect(screen.queryByLabelText(/add another preference/i)).not.toBeInTheDocument();
+
+    const promptPreview = screen.getByText(/User Preferences v1:/).closest('pre');
+    expect(promptPreview).not.toHaveClass('bg-slate-950');
+    expect(promptPreview).toHaveClass('whitespace-pre-wrap');
+    expect(promptPreview).toHaveClass('break-words');
+  });
+
   it('adds, edits, and deletes preference rows', async () => {
     const addedPreferences = {
       ...currentPreferences,

--- a/apps/whatsapp-service/src/__tests__/fakes.ts
+++ b/apps/whatsapp-service/src/__tests__/fakes.ts
@@ -66,6 +66,8 @@ import type {
   ThumbnailResult,
   TranscriptionState,
   UpdatePrivateWhatsAppChatTranscriptionInput,
+  UpdatePrivateWhatsAppMessageStoredMediaInput,
+  UpdatePrivateWhatsAppMessageStoredMediaResult,
   UpdatePrivateWhatsAppMessageTranscriptionInput,
   UploadResult,
   WebhookProcessEvent,
@@ -956,6 +958,88 @@ export class FakePrivateWhatsAppRepository implements PrivateWhatsAppRepository 
         : {}),
     });
     return Promise.resolve(ok(updated));
+  }
+
+  updateMessageStoredMedia(
+    input: UpdatePrivateWhatsAppMessageStoredMediaInput
+  ): Promise<Result<UpdatePrivateWhatsAppMessageStoredMediaResult, WhatsAppError>> {
+    const failure = this.consumeFailure();
+    if (failure !== null) {
+      return Promise.resolve(err(failure));
+    }
+    if (input.media.storageStatus !== 'stored' || input.media.gcsPath === undefined) {
+      return Promise.resolve(
+        err({
+          code: 'VALIDATION_ERROR',
+          message: 'Stored private WhatsApp media requires a storage status and GCS path',
+        })
+      );
+    }
+
+    const stored = Array.from(this.stored.values()).find(
+      (candidate) => this.toMessage(candidate).id === input.messageId
+    );
+    if (stored === undefined || stored.sourceAccountId !== input.sourceAccountId) {
+      return Promise.resolve(
+        err({ code: 'NOT_FOUND', message: 'Private WhatsApp message not found' })
+      );
+    }
+
+    const existingMedia = stored.message.media;
+    if (existingMedia === undefined) {
+      return Promise.resolve(
+        err({
+          code: 'VALIDATION_ERROR',
+          message: 'Private WhatsApp message does not contain media metadata',
+        })
+      );
+    }
+    if (existingMedia.mxcUri !== input.media.mxcUri) {
+      return Promise.resolve(
+        err({
+          code: 'VALIDATION_ERROR',
+          message: 'Stored private WhatsApp media does not match the message media id',
+        })
+      );
+    }
+
+    const chat = this.buildChats().get(`chat:${stored.sourceAccountId}:${stored.chat.matrixRoomId}`);
+    if (chat === undefined) {
+      return Promise.resolve(
+        err({ code: 'NOT_FOUND', message: 'Private WhatsApp message not found' })
+      );
+    }
+
+    if (existingMedia.gcsPath !== undefined) {
+      if (existingMedia.gcsPath === input.media.gcsPath) {
+        return Promise.resolve(
+          ok({
+            status: 'already_stored',
+            message: this.toMessage(stored),
+            chat,
+          })
+        );
+      }
+      return Promise.resolve(
+        err({
+          code: 'VALIDATION_ERROR',
+          message: 'Private WhatsApp message already references different stored media',
+        })
+      );
+    }
+
+    stored.message.media = {
+      ...existingMedia,
+      ...input.media,
+      storageStatus: 'stored',
+    };
+    return Promise.resolve(
+      ok({
+        status: 'updated',
+        message: this.toMessage(stored),
+        chat,
+      })
+    );
   }
 
   updateMessageTranscription(

--- a/apps/whatsapp-service/src/__tests__/infra/privateWhatsAppRepository.test.ts
+++ b/apps/whatsapp-service/src/__tests__/infra/privateWhatsAppRepository.test.ts
@@ -51,6 +51,21 @@ function createStoreInput(
   };
 }
 
+function createAudioStoreInput(
+  matrixEventId: string,
+  media: NonNullable<StorePrivateWhatsAppMessageInput['message']['media']>
+): StorePrivateWhatsAppMessageInput {
+  const { text: _text, ...baseMessage } = createStoreInput().message;
+  return createStoreInput({
+    message: {
+      ...baseMessage,
+      matrixEventId,
+      type: 'audio',
+      media,
+    },
+  });
+}
+
 describe('privateWhatsAppRepository', () => {
   let fakeFirestore: ReturnType<typeof createFakeFirestore>;
   let repository: ReturnType<typeof createPrivateWhatsAppRepository>;
@@ -114,6 +129,282 @@ describe('privateWhatsAppRepository', () => {
     expect(result.ok).toBe(true);
     if (!result.ok) throw new Error(result.error.message);
     expect(result.value).toBeNull();
+  });
+
+  it('updates stored private WhatsApp media metadata idempotently', async () => {
+    const input = createAudioStoreInput('$event-audio-media', {
+      mxcUri: 'mxc://home-dev/audio-media',
+      mimeType: 'audio/ogg',
+      fileName: 'Voice message.ogg',
+    });
+    const stored = await repository.storeIncomingMessage(input);
+    expect(stored.ok).toBe(true);
+    if (!stored.ok) throw new Error(stored.error.message);
+
+    const messageId = deterministicId(input.sourceAccountId, '$event-audio-media');
+    const updated = await repository.updateMessageStoredMedia({
+      sourceAccountId: input.sourceAccountId,
+      messageId,
+      media: {
+        mxcUri: 'mxc://home-dev/audio-media',
+        mimeType: 'audio/ogg',
+        fileName: 'Voice message.ogg',
+        storageStatus: 'stored',
+        gcsPath: 'whatsapp/private/user-123/audio-media/audio.ogg',
+        storedMimeType: 'audio/ogg',
+        storedSizeBytes: 2048,
+      },
+      now: '2026-06-22T10:03:00.000Z',
+    });
+    expect(updated.ok).toBe(true);
+    if (!updated.ok) throw new Error(updated.error.message);
+    expect(updated.value).toMatchObject({
+      status: 'updated',
+      message: {
+        id: messageId,
+        media: {
+          mxcUri: 'mxc://home-dev/audio-media',
+          storageStatus: 'stored',
+          gcsPath: 'whatsapp/private/user-123/audio-media/audio.ogg',
+          storedMimeType: 'audio/ogg',
+        },
+      },
+    });
+
+    const repeated = await repository.updateMessageStoredMedia({
+      sourceAccountId: input.sourceAccountId,
+      messageId,
+      media: {
+        mxcUri: 'mxc://home-dev/audio-media',
+        storageStatus: 'stored',
+        gcsPath: 'whatsapp/private/user-123/audio-media/audio.ogg',
+      },
+      now: '2026-06-22T10:04:00.000Z',
+    });
+    expect(repeated.ok).toBe(true);
+    if (!repeated.ok) throw new Error(repeated.error.message);
+    expect(repeated.value.status).toBe('already_stored');
+
+    const persisted = await repository.getMessageById(messageId);
+    expect(persisted.ok).toBe(true);
+    if (!persisted.ok) throw new Error(persisted.error.message);
+    expect(persisted.value?.media).toMatchObject({
+      mxcUri: 'mxc://home-dev/audio-media',
+      storageStatus: 'stored',
+      gcsPath: 'whatsapp/private/user-123/audio-media/audio.ogg',
+    });
+  });
+
+  it('updates stored media when a private WhatsApp message document relies on the document id', async () => {
+    const input = createAudioStoreInput('$event-audio-without-embedded-id', {
+      mxcUri: 'mxc://home-dev/audio-without-embedded-id',
+      mimeType: 'audio/ogg',
+    });
+    const stored = await repository.storeIncomingMessage(input);
+    expect(stored.ok).toBe(true);
+    if (!stored.ok) throw new Error(stored.error.message);
+    const messageId = deterministicId(input.sourceAccountId, '$event-audio-without-embedded-id');
+    const messageRef = fakeFirestore.collection(PRIVATE_WHATSAPP_MESSAGES_COLLECTION).doc(messageId);
+    const messageDoc = await messageRef.get();
+    const { id: _id, ...messageWithoutEmbeddedId } = messageDoc.data() as Record<string, unknown>;
+    await messageRef.set(messageWithoutEmbeddedId);
+
+    const updated = await repository.updateMessageStoredMedia({
+      sourceAccountId: input.sourceAccountId,
+      messageId,
+      media: {
+        mxcUri: 'mxc://home-dev/audio-without-embedded-id',
+        storageStatus: 'stored',
+        gcsPath: 'whatsapp/private/user-123/audio-without-embedded-id/audio.ogg',
+      },
+      now: '2026-06-22T10:03:00.000Z',
+    });
+
+    expect(updated.ok).toBe(true);
+    if (!updated.ok) throw new Error(updated.error.message);
+    expect(updated.value.message.id).toBe(messageId);
+    expect(updated.value.status).toBe('updated');
+  });
+
+  it('rejects invalid private WhatsApp stored media updates', async () => {
+    const input = createAudioStoreInput('$event-audio-invalid-media', {
+      mxcUri: 'mxc://home-dev/audio-invalid-media',
+      mimeType: 'audio/ogg',
+    });
+    const stored = await repository.storeIncomingMessage(input);
+    expect(stored.ok).toBe(true);
+    if (!stored.ok) throw new Error(stored.error.message);
+    const messageId = deterministicId(input.sourceAccountId, '$event-audio-invalid-media');
+
+    const missingPath = await repository.updateMessageStoredMedia({
+      sourceAccountId: input.sourceAccountId,
+      messageId,
+      media: {
+        mxcUri: 'mxc://home-dev/audio-invalid-media',
+        storageStatus: 'stored',
+      },
+      now: '2026-06-22T10:03:00.000Z',
+    });
+    expect(missingPath.ok).toBe(false);
+    if (missingPath.ok) throw new Error('Expected missing path to fail');
+    expect(missingPath.error.code).toBe('VALIDATION_ERROR');
+
+    const missingMessage = await repository.updateMessageStoredMedia({
+      sourceAccountId: input.sourceAccountId,
+      messageId: 'missing-message',
+      media: {
+        mxcUri: 'mxc://home-dev/audio-invalid-media',
+        storageStatus: 'stored',
+        gcsPath: 'whatsapp/private/user-123/audio-invalid-media/audio.ogg',
+      },
+      now: '2026-06-22T10:03:00.000Z',
+    });
+    expect(missingMessage.ok).toBe(false);
+    if (missingMessage.ok) throw new Error('Expected missing message to fail');
+    expect(missingMessage.error.code).toBe('NOT_FOUND');
+
+    const wrongSource = await repository.updateMessageStoredMedia({
+      sourceAccountId: 'wrong-source',
+      messageId,
+      media: {
+        mxcUri: 'mxc://home-dev/audio-invalid-media',
+        storageStatus: 'stored',
+        gcsPath: 'whatsapp/private/user-123/audio-invalid-media/audio.ogg',
+      },
+      now: '2026-06-22T10:03:00.000Z',
+    });
+    expect(wrongSource.ok).toBe(false);
+    if (wrongSource.ok) throw new Error('Expected wrong source to fail');
+    expect(wrongSource.error.code).toBe('NOT_FOUND');
+
+    const mismatchedMxc = await repository.updateMessageStoredMedia({
+      sourceAccountId: input.sourceAccountId,
+      messageId,
+      media: {
+        mxcUri: 'mxc://home-dev/different-media',
+        storageStatus: 'stored',
+        gcsPath: 'whatsapp/private/user-123/audio-invalid-media/audio.ogg',
+      },
+      now: '2026-06-22T10:03:00.000Z',
+    });
+    expect(mismatchedMxc.ok).toBe(false);
+    if (mismatchedMxc.ok) throw new Error('Expected mismatched media to fail');
+    expect(mismatchedMxc.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('rejects stored media updates for text messages and conflicting stored paths', async () => {
+    const textInput = createStoreInput({
+      message: {
+        ...createStoreInput().message,
+        matrixEventId: '$event-text-no-media',
+      },
+    });
+    const textStored = await repository.storeIncomingMessage(textInput);
+    expect(textStored.ok).toBe(true);
+    if (!textStored.ok) throw new Error(textStored.error.message);
+    const textMessageId = deterministicId(textInput.sourceAccountId, '$event-text-no-media');
+    const noMedia = await repository.updateMessageStoredMedia({
+      sourceAccountId: textInput.sourceAccountId,
+      messageId: textMessageId,
+      media: {
+        mxcUri: 'mxc://home-dev/no-media',
+        storageStatus: 'stored',
+        gcsPath: 'whatsapp/private/user-123/no-media/audio.ogg',
+      },
+      now: '2026-06-22T10:03:00.000Z',
+    });
+    expect(noMedia.ok).toBe(false);
+    if (noMedia.ok) throw new Error('Expected no-media update to fail');
+    expect(noMedia.error.code).toBe('VALIDATION_ERROR');
+
+    const audioInput = createAudioStoreInput('$event-audio-conflicting-path', {
+      mxcUri: 'mxc://home-dev/audio-conflicting-path',
+      mimeType: 'audio/ogg',
+    });
+    const audioStored = await repository.storeIncomingMessage(audioInput);
+    expect(audioStored.ok).toBe(true);
+    if (!audioStored.ok) throw new Error(audioStored.error.message);
+    const audioMessageId = deterministicId(audioInput.sourceAccountId, '$event-audio-conflicting-path');
+    const firstUpdate = await repository.updateMessageStoredMedia({
+      sourceAccountId: audioInput.sourceAccountId,
+      messageId: audioMessageId,
+      media: {
+        mxcUri: 'mxc://home-dev/audio-conflicting-path',
+        storageStatus: 'stored',
+        gcsPath: 'whatsapp/private/user-123/audio-conflicting-path/audio.ogg',
+      },
+      now: '2026-06-22T10:03:00.000Z',
+    });
+    expect(firstUpdate.ok).toBe(true);
+    if (!firstUpdate.ok) throw new Error(firstUpdate.error.message);
+
+    const conflictingPath = await repository.updateMessageStoredMedia({
+      sourceAccountId: audioInput.sourceAccountId,
+      messageId: audioMessageId,
+      media: {
+        mxcUri: 'mxc://home-dev/audio-conflicting-path',
+        storageStatus: 'stored',
+        gcsPath: 'whatsapp/private/user-123/audio-conflicting-path/different.ogg',
+      },
+      now: '2026-06-22T10:04:00.000Z',
+    });
+    expect(conflictingPath.ok).toBe(false);
+    if (conflictingPath.ok) throw new Error('Expected conflicting stored path to fail');
+    expect(conflictingPath.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('returns not found when stored media update cannot resolve the matching chat', async () => {
+    const input = createAudioStoreInput('$event-audio-missing-chat', {
+      mxcUri: 'mxc://home-dev/audio-missing-chat',
+      mimeType: 'audio/ogg',
+    });
+    const stored = await repository.storeIncomingMessage(input);
+    expect(stored.ok).toBe(true);
+    if (!stored.ok) throw new Error(stored.error.message);
+    const messageId = deterministicId(input.sourceAccountId, '$event-audio-missing-chat');
+    const chatId = deterministicId(input.sourceAccountId, input.chat.matrixRoomId);
+
+    await fakeFirestore.collection(PRIVATE_WHATSAPP_CHATS_COLLECTION).doc(chatId).delete();
+    const missingChat = await repository.updateMessageStoredMedia({
+      sourceAccountId: input.sourceAccountId,
+      messageId,
+      media: {
+        mxcUri: 'mxc://home-dev/audio-missing-chat',
+        storageStatus: 'stored',
+        gcsPath: 'whatsapp/private/user-123/audio-missing-chat/audio.ogg',
+      },
+      now: '2026-06-22T10:03:00.000Z',
+    });
+    expect(missingChat.ok).toBe(false);
+    if (missingChat.ok) throw new Error('Expected missing chat to fail');
+    expect(missingChat.error.code).toBe('NOT_FOUND');
+
+    await fakeFirestore
+      .collection(PRIVATE_WHATSAPP_CHATS_COLLECTION)
+      .doc(chatId)
+      .set({
+        id: chatId,
+        userId: input.userId,
+        sourceAccountId: 'wrong-source',
+        matrixRoomId: input.chat.matrixRoomId,
+        chatType: 'direct',
+        firstSeenAt: input.message.eventTimestamp,
+        lastEventAt: input.message.eventTimestamp,
+        updatedAt: input.receivedAt,
+      });
+    const wrongChatSource = await repository.updateMessageStoredMedia({
+      sourceAccountId: input.sourceAccountId,
+      messageId,
+      media: {
+        mxcUri: 'mxc://home-dev/audio-missing-chat',
+        storageStatus: 'stored',
+        gcsPath: 'whatsapp/private/user-123/audio-missing-chat/audio.ogg',
+      },
+      now: '2026-06-22T10:04:00.000Z',
+    });
+    expect(wrongChatSource.ok).toBe(false);
+    if (wrongChatSource.ok) throw new Error('Expected wrong chat source to fail');
+    expect(wrongChatSource.error.code).toBe('NOT_FOUND');
   });
 
   it('updates a private WhatsApp chat transcription setting and preserves it across later messages', async () => {

--- a/apps/whatsapp-service/src/__tests__/privateSyncRoutes.test.ts
+++ b/apps/whatsapp-service/src/__tests__/privateSyncRoutes.test.ts
@@ -1176,6 +1176,469 @@ describe('Private WhatsApp Sync Routes', () => {
     ]);
   });
 
+  it('backfills stored private audio media and publishes one transcription job', async () => {
+    await ctx.app.inject({
+      method: 'POST',
+      url: '/internal/whatsapp/private/events',
+      headers: { 'x-internal-auth': 'test-internal-token' },
+      payload: createPayload(),
+    });
+    const token = await createToken({ sub: 'user-123' });
+    const chatsResponse = await ctx.app.inject({
+      method: 'GET',
+      url: '/private/chats?limit=1',
+      headers: { authorization: `Bearer ${token}` },
+    });
+    const chatsBody = JSON.parse(chatsResponse.body) as { data: { chats: { id: string }[] } };
+    const chatId = chatsBody.data.chats[0]?.id ?? '';
+    await ctx.app.inject({
+      method: 'PATCH',
+      url: `/private/chats/${encodeURIComponent(chatId)}/transcription`,
+      headers: { authorization: `Bearer ${token}` },
+      payload: { enabled: true },
+    });
+
+    const messageId = 'message:pbuchman-private-whatsapp:$event-private-audio-placeholder';
+    const sparseAudioPayload = createPayload({
+      events: [
+        {
+          ...(createPayload()['events'] as Record<string, unknown>[])[0],
+          matrixEventId: '$event-private-audio-placeholder',
+          message: {
+            direction: 'incoming',
+            type: 'audio',
+            media: {
+              mxcUri: 'mxc://home-dev/private-audio-placeholder',
+              mimeType: 'audio/ogg',
+              fileName: 'Voice message.ogg',
+            },
+          },
+        },
+      ],
+    });
+    const ingestResponse = await ctx.app.inject({
+      method: 'POST',
+      url: '/internal/whatsapp/private/events',
+      headers: { 'x-internal-auth': 'test-internal-token' },
+      payload: sparseAudioPayload,
+    });
+    expect(ingestResponse.statusCode).toBe(200);
+    expect(ctx.eventPublisher.getAudioStoredEvents()).toEqual([]);
+
+    const backfillPayload = {
+      sourceAccountId: 'pbuchman-private-whatsapp',
+      messageId,
+      media: {
+        mxcUri: 'mxc://home-dev/private-audio-placeholder',
+        mimeType: 'audio/ogg',
+        fileName: 'Voice message.ogg',
+        storageStatus: 'stored',
+        gcsPath: 'whatsapp/private/user-123/private-audio-placeholder/audio.ogg',
+        storedMimeType: 'audio/ogg',
+        storedSizeBytes: 2048,
+        storedAt: '2026-06-22T10:05:00.000Z',
+      },
+    };
+    const firstBackfill = await ctx.app.inject({
+      method: 'POST',
+      url: '/internal/whatsapp/private/media/backfill',
+      headers: { 'x-internal-auth': 'test-internal-token' },
+      payload: backfillPayload,
+    });
+    const secondBackfill = await ctx.app.inject({
+      method: 'POST',
+      url: '/internal/whatsapp/private/media/backfill',
+      headers: { 'x-internal-auth': 'test-internal-token' },
+      payload: backfillPayload,
+    });
+
+    expect(firstBackfill.statusCode).toBe(200);
+    expect(secondBackfill.statusCode).toBe(200);
+    const firstBody = JSON.parse(firstBackfill.body) as {
+      data: { status: string; transcriptionPublished: boolean };
+    };
+    const secondBody = JSON.parse(secondBackfill.body) as {
+      data: { status: string; transcriptionPublished: boolean };
+    };
+    expect(firstBody.data).toEqual({ status: 'updated', transcriptionPublished: true });
+    expect(secondBody.data).toEqual({
+      status: 'already_stored',
+      transcriptionPublished: false,
+    });
+    expect(ctx.eventPublisher.getAudioStoredEvents()).toEqual([
+      {
+        type: 'whatsapp.audio.stored',
+        messageSource: 'private_whatsapp',
+        userId: 'user-123',
+        messageId,
+        mediaId: 'mxc://home-dev/private-audio-placeholder',
+        gcsPath: 'whatsapp/private/user-123/private-audio-placeholder/audio.ogg',
+        mimeType: 'audio/ogg',
+        timestamp: expect.any(String),
+      },
+    ]);
+
+    const storedMessageResult = await ctx.privateWhatsAppRepository.getMessageById(messageId);
+    expect(storedMessageResult.ok).toBe(true);
+    if (storedMessageResult.ok) {
+      expect(storedMessageResult.value?.media).toMatchObject({
+        mxcUri: 'mxc://home-dev/private-audio-placeholder',
+        storageStatus: 'stored',
+        gcsPath: 'whatsapp/private/user-123/private-audio-placeholder/audio.ogg',
+        storedMimeType: 'audio/ogg',
+      });
+    }
+  });
+
+  it('requires internal auth for private WhatsApp media backfills', async () => {
+    const response = await ctx.app.inject({
+      method: 'POST',
+      url: '/internal/whatsapp/private/media/backfill',
+      payload: {
+        sourceAccountId: 'pbuchman-private-whatsapp',
+        messageId: 'message:pbuchman-private-whatsapp:$event-private-audio-placeholder',
+        media: {
+          mxcUri: 'mxc://home-dev/private-audio-placeholder',
+          storageStatus: 'stored',
+          gcsPath: 'whatsapp/private/user-123/private-audio-placeholder/audio.ogg',
+        },
+      },
+    });
+
+    expect(response.statusCode).toBe(401);
+  });
+
+  it('validates private WhatsApp media backfill request bodies before mutation', async () => {
+    const response = await ctx.app.inject({
+      method: 'POST',
+      url: '/internal/whatsapp/private/media/backfill',
+      headers: { 'x-internal-auth': 'test-internal-token' },
+      payload: {
+        sourceAccountId: 'pbuchman-private-whatsapp',
+        messageId: 'message:pbuchman-private-whatsapp:$event-private-audio-placeholder',
+        media: {
+          mxcUri: 'mxc://home-dev/private-audio-placeholder',
+          storageStatus: 'stored',
+        },
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+  });
+
+  it('logs malformed private WhatsApp media backfill bodies without inspecting contents', async () => {
+    const nonObjectResponse = await ctx.app.inject({
+      method: 'POST',
+      url: '/internal/whatsapp/private/media/backfill',
+      headers: {
+        'content-type': 'application/json',
+        'x-internal-auth': 'test-internal-token',
+      },
+      payload: 'null',
+    });
+    const missingMediaResponse = await ctx.app.inject({
+      method: 'POST',
+      url: '/internal/whatsapp/private/media/backfill',
+      headers: { 'x-internal-auth': 'test-internal-token' },
+      payload: {
+        sourceAccountId: 'pbuchman-private-whatsapp',
+        messageId: 'message:pbuchman-private-whatsapp:$event-private-audio-placeholder',
+      },
+    });
+
+    expect(nonObjectResponse.statusCode).toBe(400);
+    expect(missingMediaResponse.statusCode).toBe(400);
+    expect(commonHttpState.logIncomingRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        bodyPreviewLength: 0,
+        additionalFields: expect.objectContaining({
+          route: 'internal_whatsapp_private_media_backfill',
+        }),
+      })
+    );
+  });
+
+  it('returns not found when media backfill targets an inactive private source account', async () => {
+    const response = await ctx.app.inject({
+      method: 'POST',
+      url: '/internal/whatsapp/private/media/backfill',
+      headers: { 'x-internal-auth': 'test-internal-token' },
+      payload: {
+        sourceAccountId: 'unknown-private-whatsapp',
+        messageId: 'message:unknown-private-whatsapp:$event-private-audio-placeholder',
+        media: {
+          mxcUri: 'mxc://home-dev/private-audio-placeholder',
+          storageStatus: 'stored',
+          gcsPath: 'whatsapp/private/user-123/private-audio-placeholder/audio.ogg',
+        },
+      },
+    });
+
+    expect(response.statusCode).toBe(404);
+  });
+
+  it('returns internal error when media backfill account lookup fails', async () => {
+    ctx.privateWhatsAppRepository.failNext({
+      code: 'PERSISTENCE_ERROR',
+      message: 'Simulated account lookup failure',
+    });
+
+    const response = await ctx.app.inject({
+      method: 'POST',
+      url: '/internal/whatsapp/private/media/backfill',
+      headers: { 'x-internal-auth': 'test-internal-token' },
+      payload: {
+        sourceAccountId: 'pbuchman-private-whatsapp',
+        messageId: 'message:pbuchman-private-whatsapp:$event-private-audio-placeholder',
+        media: {
+          mxcUri: 'mxc://home-dev/private-audio-placeholder',
+          storageStatus: 'stored',
+          gcsPath: 'whatsapp/private/user-123/private-audio-placeholder/audio.ogg',
+        },
+      },
+    });
+
+    expect(response.statusCode).toBe(500);
+  });
+
+  it('returns not found when media backfill targets a missing private message', async () => {
+    const response = await ctx.app.inject({
+      method: 'POST',
+      url: '/internal/whatsapp/private/media/backfill',
+      headers: { 'x-internal-auth': 'test-internal-token' },
+      payload: {
+        sourceAccountId: 'pbuchman-private-whatsapp',
+        messageId: 'message:pbuchman-private-whatsapp:$missing-audio',
+        media: {
+          mxcUri: 'mxc://home-dev/private-audio-placeholder',
+          storageStatus: 'stored',
+          gcsPath: 'whatsapp/private/user-123/private-audio-placeholder/audio.ogg',
+        },
+      },
+    });
+
+    expect(response.statusCode).toBe(404);
+  });
+
+  it('returns invalid request when media backfill does not match stored message media', async () => {
+    await ctx.app.inject({
+      method: 'POST',
+      url: '/internal/whatsapp/private/events',
+      headers: { 'x-internal-auth': 'test-internal-token' },
+      payload: createPayload({
+        events: [
+          {
+            ...(createPayload()['events'] as Record<string, unknown>[])[0],
+            matrixEventId: '$event-private-audio-mismatch',
+            message: {
+              direction: 'incoming',
+              type: 'audio',
+              media: {
+                mxcUri: 'mxc://home-dev/original-audio',
+                mimeType: 'audio/ogg',
+              },
+            },
+          },
+        ],
+      }),
+    });
+
+    const response = await ctx.app.inject({
+      method: 'POST',
+      url: '/internal/whatsapp/private/media/backfill',
+      headers: { 'x-internal-auth': 'test-internal-token' },
+      payload: {
+        sourceAccountId: 'pbuchman-private-whatsapp',
+        messageId: 'message:pbuchman-private-whatsapp:$event-private-audio-mismatch',
+        media: {
+          mxcUri: 'mxc://home-dev/different-audio',
+          storageStatus: 'stored',
+          gcsPath: 'whatsapp/private/user-123/private-audio-mismatch/audio.ogg',
+        },
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+  });
+
+  it('returns internal error when media backfill transcription publishing fails', async () => {
+    await ctx.app.inject({
+      method: 'POST',
+      url: '/internal/whatsapp/private/events',
+      headers: { 'x-internal-auth': 'test-internal-token' },
+      payload: createPayload(),
+    });
+    const token = await createToken({ sub: 'user-123' });
+    const chatsResponse = await ctx.app.inject({
+      method: 'GET',
+      url: '/private/chats?limit=1',
+      headers: { authorization: `Bearer ${token}` },
+    });
+    const chatsBody = JSON.parse(chatsResponse.body) as { data: { chats: { id: string }[] } };
+    const chatId = chatsBody.data.chats[0]?.id ?? '';
+    await ctx.app.inject({
+      method: 'PATCH',
+      url: `/private/chats/${encodeURIComponent(chatId)}/transcription`,
+      headers: { authorization: `Bearer ${token}` },
+      payload: { enabled: true },
+    });
+    await ctx.app.inject({
+      method: 'POST',
+      url: '/internal/whatsapp/private/events',
+      headers: { 'x-internal-auth': 'test-internal-token' },
+      payload: createPayload({
+        events: [
+          {
+            ...(createPayload()['events'] as Record<string, unknown>[])[0],
+            matrixEventId: '$event-private-audio-publish-failure',
+            message: {
+              direction: 'incoming',
+              type: 'audio',
+              media: {
+                mxcUri: 'mxc://home-dev/private-audio-publish-failure',
+                mimeType: 'audio/ogg',
+              },
+            },
+          },
+        ],
+      }),
+    });
+    ctx.eventPublisher.setAudioStoredFailure('Simulated audio publish failure');
+
+    const response = await ctx.app.inject({
+      method: 'POST',
+      url: '/internal/whatsapp/private/media/backfill',
+      headers: { 'x-internal-auth': 'test-internal-token' },
+      payload: {
+        sourceAccountId: 'pbuchman-private-whatsapp',
+        messageId: 'message:pbuchman-private-whatsapp:$event-private-audio-publish-failure',
+        media: {
+          mxcUri: 'mxc://home-dev/private-audio-publish-failure',
+          mimeType: 'audio/ogg',
+          storageStatus: 'stored',
+          gcsPath: 'whatsapp/private/user-123/private-audio-publish-failure/audio.ogg',
+        },
+      },
+    });
+
+    expect(response.statusCode).toBe(500);
+  });
+
+  it('backfills private audio media without publishing when chat transcription is disabled', async () => {
+    await ctx.app.inject({
+      method: 'POST',
+      url: '/internal/whatsapp/private/events',
+      headers: { 'x-internal-auth': 'test-internal-token' },
+      payload: createPayload({
+        events: [
+          {
+            ...(createPayload()['events'] as Record<string, unknown>[])[0],
+            matrixEventId: '$event-private-audio-transcription-disabled',
+            message: {
+              direction: 'incoming',
+              type: 'audio',
+              media: {
+                mxcUri: 'mxc://home-dev/private-audio-transcription-disabled',
+                mimeType: 'audio/ogg',
+              },
+            },
+          },
+        ],
+      }),
+    });
+
+    const response = await ctx.app.inject({
+      method: 'POST',
+      url: '/internal/whatsapp/private/media/backfill',
+      headers: { 'x-internal-auth': 'test-internal-token' },
+      payload: {
+        sourceAccountId: 'pbuchman-private-whatsapp',
+        messageId: 'message:pbuchman-private-whatsapp:$event-private-audio-transcription-disabled',
+        media: {
+          mxcUri: 'mxc://home-dev/private-audio-transcription-disabled',
+          mimeType: 'audio/ogg',
+          storageStatus: 'stored',
+          gcsPath: 'whatsapp/private/user-123/private-audio-transcription-disabled/audio.ogg',
+        },
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body) as {
+      data: { status: string; transcriptionPublished: boolean };
+    };
+    expect(body.data).toEqual({ status: 'updated', transcriptionPublished: false });
+    expect(ctx.eventPublisher.getAudioStoredEvents()).toEqual([]);
+  });
+
+  it('backfills private image media without publishing a transcription job', async () => {
+    await ctx.app.inject({
+      method: 'POST',
+      url: '/internal/whatsapp/private/events',
+      headers: { 'x-internal-auth': 'test-internal-token' },
+      payload: createPayload(),
+    });
+    const token = await createToken({ sub: 'user-123' });
+    const chatsResponse = await ctx.app.inject({
+      method: 'GET',
+      url: '/private/chats?limit=1',
+      headers: { authorization: `Bearer ${token}` },
+    });
+    const chatsBody = JSON.parse(chatsResponse.body) as { data: { chats: { id: string }[] } };
+    const chatId = chatsBody.data.chats[0]?.id ?? '';
+    await ctx.app.inject({
+      method: 'PATCH',
+      url: `/private/chats/${encodeURIComponent(chatId)}/transcription`,
+      headers: { authorization: `Bearer ${token}` },
+      payload: { enabled: true },
+    });
+    await ctx.app.inject({
+      method: 'POST',
+      url: '/internal/whatsapp/private/events',
+      headers: { 'x-internal-auth': 'test-internal-token' },
+      payload: createPayload({
+        events: [
+          {
+            ...(createPayload()['events'] as Record<string, unknown>[])[0],
+            matrixEventId: '$event-private-image-backfill',
+            message: {
+              direction: 'incoming',
+              type: 'image',
+              media: {
+                mxcUri: 'mxc://home-dev/private-image-backfill',
+                mimeType: 'image/jpeg',
+              },
+            },
+          },
+        ],
+      }),
+    });
+
+    const response = await ctx.app.inject({
+      method: 'POST',
+      url: '/internal/whatsapp/private/media/backfill',
+      headers: { 'x-internal-auth': 'test-internal-token' },
+      payload: {
+        sourceAccountId: 'pbuchman-private-whatsapp',
+        messageId: 'message:pbuchman-private-whatsapp:$event-private-image-backfill',
+        media: {
+          mxcUri: 'mxc://home-dev/private-image-backfill',
+          mimeType: 'image/jpeg',
+          storageStatus: 'stored',
+          gcsPath: 'whatsapp/private/user-123/private-image-backfill/image.jpg',
+        },
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body) as {
+      data: { status: string; transcriptionPublished: boolean };
+    };
+    expect(body.data).toEqual({ status: 'updated', transcriptionPublished: false });
+    expect(ctx.eventPublisher.getMediaTranscriptionRequestedEvents()).toEqual([]);
+  });
+
   it('publishes one private video transcription job after chat transcription is enabled', async () => {
     await ctx.app.inject({
       method: 'POST',

--- a/apps/whatsapp-service/src/__tests__/usecases/backfillPrivateWhatsAppStoredMedia.test.ts
+++ b/apps/whatsapp-service/src/__tests__/usecases/backfillPrivateWhatsAppStoredMedia.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from 'vitest';
+import { BackfillPrivateWhatsAppStoredMediaUseCase } from '../../domain/whatsapp/index.js';
+import type { Logger } from '../../domain/whatsapp/utils/logger.js';
+import { publishPrivateStoredMediaTranscriptionRequest } from '../../domain/whatsapp/usecases/privateStoredMediaTranscription.js';
+import { FakeEventPublisher, FakePrivateWhatsAppRepository } from '../fakes.js';
+
+const logger: Logger = {
+  info: (): void => undefined,
+  error: (): void => undefined,
+};
+
+describe('BackfillPrivateWhatsAppStoredMediaUseCase', () => {
+  it('rejects stored media backfill without a GCS path before repository mutation', async () => {
+    const repository = new FakePrivateWhatsAppRepository();
+    const useCase = new BackfillPrivateWhatsAppStoredMediaUseCase({
+      privateWhatsAppRepository: repository,
+      eventPublisher: new FakeEventPublisher(),
+    });
+
+    const result = await useCase.execute(
+      {
+        sourceAccountId: 'pbuchman-private-whatsapp',
+        messageId: 'message:pbuchman-private-whatsapp:$event-without-path',
+        media: {
+          mxcUri: 'mxc://home-dev/audio-without-path',
+          storageStatus: 'stored',
+        },
+      },
+      logger
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('Expected missing GCS path to fail');
+    expect(result.error.code).toBe('VALIDATION_ERROR');
+    expect(repository.getAll()).toEqual([]);
+  });
+
+  it('returns the publisher error when private stored media transcription publishing fails', async () => {
+    const eventPublisher = new FakeEventPublisher();
+    const error = vi.fn();
+    eventPublisher.setAudioStoredFailure('Simulated audio publish failure');
+
+    const result = await publishPrivateStoredMediaTranscriptionRequest({
+      sourceAccountId: 'pbuchman-private-whatsapp',
+      userId: 'user-123',
+      messageId: 'message:pbuchman-private-whatsapp:$event-audio-publish-failure',
+      matrixEventId: '$event-audio-publish-failure',
+      messageType: 'audio',
+      media: {
+        mxcUri: 'mxc://home-dev/audio-publish-failure',
+        storageStatus: 'stored',
+        gcsPath: 'whatsapp/private/user-123/audio-publish-failure/audio.ogg',
+        storedMimeType: 'audio/ogg',
+      },
+      chatTranscriptionEnabled: true,
+      eventPublisher,
+      logger: {
+        info: (): void => undefined,
+        error,
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('Expected publish failure to fail');
+    expect(result.error.code).toBe('INTERNAL_ERROR');
+    expect(error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mediaKind: 'audio',
+        messageId: 'message:pbuchman-private-whatsapp:$event-audio-publish-failure',
+      }),
+      'Failed to publish private WhatsApp media transcription event'
+    );
+  });
+});

--- a/apps/whatsapp-service/src/__tests__/usecases/ingestPrivateWhatsAppEvents.test.ts
+++ b/apps/whatsapp-service/src/__tests__/usecases/ingestPrivateWhatsAppEvents.test.ts
@@ -29,6 +29,8 @@ import {
   type PrivateWhatsAppTranscriptionState,
   type StorePrivateWhatsAppMessageInput,
   type UpdatePrivateWhatsAppChatTranscriptionInput,
+  type UpdatePrivateWhatsAppMessageStoredMediaInput,
+  type UpdatePrivateWhatsAppMessageStoredMediaResult,
   type UpdatePrivateWhatsAppMessageTranscriptionInput,
   type UpsertPrivateWhatsAppAccountInput,
   type WebhookProcessEvent,
@@ -159,6 +161,14 @@ class TestPrivateWhatsAppRepository implements PrivateWhatsAppRepository {
   ): Promise<Result<PrivateWhatsAppChat, WhatsAppError>> {
     return Promise.resolve(
       err({ code: 'NOT_FOUND', message: 'Chat writes are not used by this fake' })
+    );
+  }
+
+  updateMessageStoredMedia(
+    _input: UpdatePrivateWhatsAppMessageStoredMediaInput
+  ): Promise<Result<UpdatePrivateWhatsAppMessageStoredMediaResult, WhatsAppError>> {
+    return Promise.resolve(
+      err({ code: 'NOT_FOUND', message: 'Stored media writes are not used by this fake' })
     );
   }
 

--- a/apps/whatsapp-service/src/domain/whatsapp/index.ts
+++ b/apps/whatsapp-service/src/domain/whatsapp/index.ts
@@ -74,6 +74,8 @@ export type {
   PrivateWhatsAppSummaryStatus,
   StorePrivateWhatsAppMessageInput,
   UpdatePrivateWhatsAppChatTranscriptionInput,
+  UpdatePrivateWhatsAppMessageStoredMediaInput,
+  UpdatePrivateWhatsAppMessageStoredMediaResult,
   UpdatePrivateWhatsAppMessageTranscriptionInput,
   UpsertPrivateWhatsAppAccountInput,
 } from './models/PrivateWhatsApp.js';
@@ -193,6 +195,13 @@ export {
   type IngestPrivateWhatsAppEventsDeps,
   type IngestPrivateWhatsAppEventsInput,
 } from './usecases/ingestPrivateWhatsAppEvents.js';
+
+export {
+  BackfillPrivateWhatsAppStoredMediaUseCase,
+  type BackfillPrivateWhatsAppStoredMediaDeps,
+  type BackfillPrivateWhatsAppStoredMediaInput,
+  type BackfillPrivateWhatsAppStoredMediaResult,
+} from './usecases/backfillPrivateWhatsAppStoredMedia.js';
 
 export {
   shouldDeliverMessage,

--- a/apps/whatsapp-service/src/domain/whatsapp/models/PrivateWhatsApp.ts
+++ b/apps/whatsapp-service/src/domain/whatsapp/models/PrivateWhatsApp.ts
@@ -314,6 +314,19 @@ export interface UpdatePrivateWhatsAppMessageTranscriptionInput {
   transcription: PrivateWhatsAppTranscriptionState;
 }
 
+export interface UpdatePrivateWhatsAppMessageStoredMediaInput {
+  sourceAccountId: string;
+  messageId: string;
+  media: PrivateWhatsAppMediaInfo;
+  now: string;
+}
+
+export interface UpdatePrivateWhatsAppMessageStoredMediaResult {
+  status: 'updated' | 'already_stored';
+  message: PrivateWhatsAppMessage;
+  chat: PrivateWhatsAppChat;
+}
+
 export interface PrivateWhatsAppChatQueryInput {
   sourceAccountId: string;
   limit: number;

--- a/apps/whatsapp-service/src/domain/whatsapp/ports/privateWhatsAppRepository.ts
+++ b/apps/whatsapp-service/src/domain/whatsapp/ports/privateWhatsAppRepository.ts
@@ -20,6 +20,8 @@ import type {
   PrivateWhatsAppSenderDayQueryResult,
   StorePrivateWhatsAppMessageInput,
   UpdatePrivateWhatsAppChatTranscriptionInput,
+  UpdatePrivateWhatsAppMessageStoredMediaInput,
+  UpdatePrivateWhatsAppMessageStoredMediaResult,
   UpdatePrivateWhatsAppMessageTranscriptionInput,
   UpsertPrivateWhatsAppAccountInput,
 } from '../models/PrivateWhatsApp.js';
@@ -50,6 +52,9 @@ export interface PrivateWhatsAppRepository {
   updateChatTranscriptionSetting(
     input: UpdatePrivateWhatsAppChatTranscriptionInput
   ): Promise<Result<PrivateWhatsAppChat, WhatsAppError>>;
+  updateMessageStoredMedia(
+    input: UpdatePrivateWhatsAppMessageStoredMediaInput
+  ): Promise<Result<UpdatePrivateWhatsAppMessageStoredMediaResult, WhatsAppError>>;
   updateMessageTranscription(
     input: UpdatePrivateWhatsAppMessageTranscriptionInput
   ): Promise<Result<void, WhatsAppError>>;

--- a/apps/whatsapp-service/src/domain/whatsapp/usecases/backfillPrivateWhatsAppStoredMedia.ts
+++ b/apps/whatsapp-service/src/domain/whatsapp/usecases/backfillPrivateWhatsAppStoredMedia.ts
@@ -1,0 +1,77 @@
+import { err, ok, type Result } from '@intexuraos/common-core';
+import type { WhatsAppError } from '../models/error.js';
+import type { PrivateWhatsAppMediaInfo } from '../models/PrivateWhatsApp.js';
+import type { EventPublisherPort } from '../ports/eventPublisher.js';
+import type { PrivateWhatsAppRepository } from '../ports/privateWhatsAppRepository.js';
+import type { Logger } from '../utils/logger.js';
+import { publishPrivateStoredMediaTranscriptionRequest } from './privateStoredMediaTranscription.js';
+
+export interface BackfillPrivateWhatsAppStoredMediaInput {
+  sourceAccountId: string;
+  messageId: string;
+  media: PrivateWhatsAppMediaInfo;
+}
+
+export interface BackfillPrivateWhatsAppStoredMediaResult {
+  status: 'updated' | 'already_stored';
+  transcriptionPublished: boolean;
+}
+
+export interface BackfillPrivateWhatsAppStoredMediaDeps {
+  privateWhatsAppRepository: PrivateWhatsAppRepository;
+  eventPublisher: EventPublisherPort;
+}
+
+export class BackfillPrivateWhatsAppStoredMediaUseCase {
+  constructor(private readonly deps: BackfillPrivateWhatsAppStoredMediaDeps) {}
+
+  async execute(
+    input: BackfillPrivateWhatsAppStoredMediaInput,
+    logger: Logger
+  ): Promise<Result<BackfillPrivateWhatsAppStoredMediaResult, WhatsAppError>> {
+    if (input.media.storageStatus !== 'stored' || input.media.gcsPath === undefined) {
+      return err({
+        code: 'VALIDATION_ERROR',
+        message: 'Stored private WhatsApp media backfill requires a GCS path',
+      });
+    }
+
+    const updateResult = await this.deps.privateWhatsAppRepository.updateMessageStoredMedia({
+      sourceAccountId: input.sourceAccountId,
+      messageId: input.messageId,
+      media: input.media,
+      now: new Date().toISOString(),
+    });
+    if (!updateResult.ok) {
+      return err(updateResult.error);
+    }
+
+    if (updateResult.value.status === 'already_stored') {
+      return ok({
+        status: 'already_stored',
+        transcriptionPublished: false,
+      });
+    }
+
+    const { message, chat } = updateResult.value;
+    const publishResult = await publishPrivateStoredMediaTranscriptionRequest({
+      sourceAccountId: input.sourceAccountId,
+      userId: message.userId,
+      messageId: message.id,
+      matrixEventId: message.matrixEventId,
+      messageType: message.messageType,
+      media: message.media,
+      chatTranscriptionEnabled: chat.transcriptionEnabled === true,
+      eventPublisher: this.deps.eventPublisher,
+      logger,
+    });
+    if (!publishResult.ok) {
+      return err(publishResult.error);
+    }
+
+    return ok({
+      status: 'updated',
+      transcriptionPublished: publishResult.value,
+    });
+  }
+}

--- a/apps/whatsapp-service/src/domain/whatsapp/usecases/ingestPrivateWhatsAppEvents.ts
+++ b/apps/whatsapp-service/src/domain/whatsapp/usecases/ingestPrivateWhatsAppEvents.ts
@@ -13,6 +13,7 @@ import type {
 import type { EventPublisherPort } from '../ports/eventPublisher.js';
 import type { PrivateWhatsAppRepository } from '../ports/privateWhatsAppRepository.js';
 import type { Logger } from '../utils/logger.js';
+import { publishPrivateStoredMediaTranscriptionRequest } from './privateStoredMediaTranscription.js';
 
 export interface IngestPrivateWhatsAppEventsInput {
   sourceAccountId: string;
@@ -186,48 +187,19 @@ async function publishPrivateTranscriptionRequestIfNeeded(
   if (storeInput.message.type !== 'audio' && storeInput.message.type !== 'video') {
     return ok(undefined);
   }
-  const media = storeInput.message.media;
-  const gcsPath = media?.gcsPath;
-  const mimeType = media?.storedMimeType ?? media?.mimeType;
-  if (media?.storageStatus !== 'stored' || gcsPath === undefined || mimeType === undefined) {
-    return ok(undefined);
-  }
 
-  const timestamp = new Date().toISOString();
-  const publishResult =
-    storeInput.message.type === 'audio'
-      ? await eventPublisher.publishAudioStored({
-          type: 'whatsapp.audio.stored',
-          messageSource: 'private_whatsapp',
-          userId: storeInput.userId,
-          messageId: outcome.messageId,
-          mediaId: media.mxcUri,
-          gcsPath,
-          mimeType,
-          timestamp,
-        })
-      : await eventPublisher.publishMediaTranscriptionRequested({
-          type: 'whatsapp.media.transcription.requested',
-          messageSource: 'private_whatsapp',
-          mediaKind: 'video',
-          userId: storeInput.userId,
-          messageId: outcome.messageId,
-          mediaId: media.mxcUri,
-          gcsPath,
-          mimeType,
-          timestamp,
-        });
+  const publishResult = await publishPrivateStoredMediaTranscriptionRequest({
+    sourceAccountId: storeInput.sourceAccountId,
+    userId: storeInput.userId,
+    messageId: outcome.messageId,
+    matrixEventId: event.matrixEventId,
+    messageType: storeInput.message.type,
+    media: storeInput.message.media,
+    chatTranscriptionEnabled: true,
+    eventPublisher,
+    logger,
+  });
   if (!publishResult.ok) {
-    logger.error(
-      {
-        matrixEventId: event.matrixEventId,
-        sourceAccountId: storeInput.sourceAccountId,
-        messageId: outcome.messageId,
-        mediaKind: storeInput.message.type,
-        error: publishResult.error,
-      },
-      'Failed to publish private WhatsApp media transcription event'
-    );
     return err(publishResult.error);
   }
   return ok(undefined);

--- a/apps/whatsapp-service/src/domain/whatsapp/usecases/privateStoredMediaTranscription.ts
+++ b/apps/whatsapp-service/src/domain/whatsapp/usecases/privateStoredMediaTranscription.ts
@@ -1,0 +1,77 @@
+import { err, ok, type Result } from '@intexuraos/common-core';
+import type { WhatsAppError } from '../models/error.js';
+import type {
+  PrivateWhatsAppMediaInfo,
+  PrivateWhatsAppMessageType,
+} from '../models/PrivateWhatsApp.js';
+import type { EventPublisherPort } from '../ports/eventPublisher.js';
+import type { Logger } from '../utils/logger.js';
+
+export interface PublishPrivateStoredMediaTranscriptionInput {
+  sourceAccountId: string;
+  userId: string;
+  messageId: string;
+  matrixEventId?: string;
+  messageType: PrivateWhatsAppMessageType;
+  media: PrivateWhatsAppMediaInfo | undefined;
+  chatTranscriptionEnabled: boolean;
+  eventPublisher: EventPublisherPort;
+  logger: Logger;
+}
+
+export async function publishPrivateStoredMediaTranscriptionRequest(
+  input: PublishPrivateStoredMediaTranscriptionInput
+): Promise<Result<boolean, WhatsAppError>> {
+  if (!input.chatTranscriptionEnabled) {
+    return ok(false);
+  }
+  if (input.messageType !== 'audio' && input.messageType !== 'video') {
+    return ok(false);
+  }
+  const media = input.media;
+  const gcsPath = media?.gcsPath;
+  const mimeType = media?.storedMimeType ?? media?.mimeType;
+  if (media?.storageStatus !== 'stored' || gcsPath === undefined || mimeType === undefined) {
+    return ok(false);
+  }
+
+  const timestamp = new Date().toISOString();
+  const publishResult =
+    input.messageType === 'audio'
+      ? await input.eventPublisher.publishAudioStored({
+          type: 'whatsapp.audio.stored',
+          messageSource: 'private_whatsapp',
+          userId: input.userId,
+          messageId: input.messageId,
+          mediaId: media.mxcUri,
+          gcsPath,
+          mimeType,
+          timestamp,
+        })
+      : await input.eventPublisher.publishMediaTranscriptionRequested({
+          type: 'whatsapp.media.transcription.requested',
+          messageSource: 'private_whatsapp',
+          mediaKind: 'video',
+          userId: input.userId,
+          messageId: input.messageId,
+          mediaId: media.mxcUri,
+          gcsPath,
+          mimeType,
+          timestamp,
+        });
+  if (!publishResult.ok) {
+    input.logger.error(
+      {
+        matrixEventId: input.matrixEventId,
+        sourceAccountId: input.sourceAccountId,
+        messageId: input.messageId,
+        mediaKind: input.messageType,
+        error: publishResult.error,
+      },
+      'Failed to publish private WhatsApp media transcription event'
+    );
+    return err(publishResult.error);
+  }
+
+  return ok(true);
+}

--- a/apps/whatsapp-service/src/infra/firestore/privateWhatsAppRepository.ts
+++ b/apps/whatsapp-service/src/infra/firestore/privateWhatsAppRepository.ts
@@ -29,6 +29,8 @@ import type {
   PrivateWhatsAppSenderDayQueryResult,
   StorePrivateWhatsAppMessageInput,
   UpdatePrivateWhatsAppChatTranscriptionInput,
+  UpdatePrivateWhatsAppMessageStoredMediaInput,
+  UpdatePrivateWhatsAppMessageStoredMediaResult,
   UpdatePrivateWhatsAppMessageTranscriptionInput,
   UpsertPrivateWhatsAppAccountInput,
 } from '../../domain/whatsapp/index.js';
@@ -77,6 +79,7 @@ export function createPrivateWhatsAppRepository(): PrivateWhatsAppRepository {
     getMessageById,
     getChatById,
     updateChatTranscriptionSetting,
+    updateMessageStoredMedia,
     updateMessageTranscription,
     findMessages,
     findConversationContextMessages,
@@ -494,6 +497,115 @@ async function updateMessageTranscription(
     return err({
       code: 'PERSISTENCE_ERROR',
       message: `Failed to update private WhatsApp message transcription: ${getErrorMessage(error, 'Unknown Firestore error')}`,
+    });
+  }
+}
+
+async function updateMessageStoredMedia(
+  input: UpdatePrivateWhatsAppMessageStoredMediaInput
+): Promise<Result<UpdatePrivateWhatsAppMessageStoredMediaResult, WhatsAppError>> {
+  if (input.media.storageStatus !== 'stored' || input.media.gcsPath === undefined) {
+    return err({
+      code: 'VALIDATION_ERROR',
+      message: 'Stored private WhatsApp media requires a storage status and GCS path',
+    });
+  }
+
+  try {
+    const db = getFirestore();
+    const messageRef = db.collection(PRIVATE_WHATSAPP_MESSAGES_COLLECTION).doc(input.messageId);
+    const outcome = await db.runTransaction(
+      async (
+        transaction
+      ): Promise<
+        | { status: 'not_found' }
+        | { status: 'validation_error'; message: string }
+        | UpdatePrivateWhatsAppMessageStoredMediaResult
+      > => {
+        const messageDoc = await transaction.get(messageRef);
+        if (!messageDoc.exists) {
+          return { status: 'not_found' };
+        }
+
+        const rawMessage = messageDoc.data() as Omit<PrivateWhatsAppMessage, 'id'> & { id?: string };
+        const existingMessage: PrivateWhatsAppMessage = {
+          ...rawMessage,
+          id: rawMessage.id ?? messageDoc.id,
+        };
+        if (existingMessage.sourceAccountId !== input.sourceAccountId) {
+          return { status: 'not_found' };
+        }
+        if (existingMessage.media === undefined) {
+          return {
+            status: 'validation_error',
+            message: 'Private WhatsApp message does not contain media metadata',
+          };
+        }
+        if (existingMessage.media.mxcUri !== input.media.mxcUri) {
+          return {
+            status: 'validation_error',
+            message: 'Stored private WhatsApp media does not match the message media id',
+          };
+        }
+
+        const chatRef = db.collection(PRIVATE_WHATSAPP_CHATS_COLLECTION).doc(existingMessage.chatId);
+        const chatDoc = await transaction.get(chatRef);
+        if (!chatDoc.exists) {
+          return { status: 'not_found' };
+        }
+        const chat = normalizeChat(chatDoc.id, chatDoc.data());
+        if (chat.sourceAccountId !== input.sourceAccountId) {
+          return { status: 'not_found' };
+        }
+
+        if (existingMessage.media.gcsPath !== undefined) {
+          if (existingMessage.media.gcsPath === input.media.gcsPath) {
+            return {
+              status: 'already_stored',
+              message: existingMessage,
+              chat,
+            };
+          }
+          return {
+            status: 'validation_error',
+            message: 'Private WhatsApp message already references different stored media',
+          };
+        }
+
+        const media: PrivateWhatsAppMessage['media'] = {
+          ...existingMessage.media,
+          ...input.media,
+          storageStatus: 'stored',
+        };
+        const updatedMessage: PrivateWhatsAppMessage = {
+          ...existingMessage,
+          media,
+          schemaVersion: PRIVATE_WHATSAPP_SCHEMA_VERSION,
+        };
+        transaction.update(messageRef, {
+          media,
+          schemaVersion: PRIVATE_WHATSAPP_SCHEMA_VERSION,
+        });
+
+        return {
+          status: 'updated',
+          message: updatedMessage,
+          chat,
+        };
+      }
+    );
+
+    if (outcome.status === 'not_found') {
+      return err({ code: 'NOT_FOUND', message: 'Private WhatsApp message not found' });
+    }
+    if (outcome.status === 'validation_error') {
+      return err({ code: 'VALIDATION_ERROR', message: outcome.message });
+    }
+    return ok(outcome);
+  } catch (error) {
+    return err({
+      code: 'PERSISTENCE_ERROR',
+      message: `Failed to update private WhatsApp stored media: ${getErrorMessage(error, 'Unknown Firestore error')}`,
     });
   }
 }

--- a/apps/whatsapp-service/src/routes/privateSyncRoutes.ts
+++ b/apps/whatsapp-service/src/routes/privateSyncRoutes.ts
@@ -2,9 +2,11 @@ import type { FastifyPluginCallback, FastifyReply, FastifyRequest } from 'fastif
 import { logIncomingRequest, validateInternalAuth } from '@intexuraos/common-http';
 import { projectPrivateConversationContext } from '../domain/conversation-assistant/transcriptFormatting.js';
 import {
+  BackfillPrivateWhatsAppStoredMediaUseCase,
   IngestPrivateWhatsAppEventsUseCase,
   type IngestPrivateWhatsAppEventsInput,
   type PrivateWhatsAppAggregateRebuildInput,
+  type PrivateWhatsAppMediaInfo,
   type PrivateWhatsAppMessage,
   type PrivateWhatsAppMessageQueryInput,
   type PrivateWhatsAppSenderDayQueryInput,
@@ -37,6 +39,12 @@ interface PrivateAggregateRebuildBody {
   from?: string;
   to?: string;
   limit?: number;
+}
+
+interface PrivateMediaBackfillBody {
+  sourceAccountId: string;
+  messageId: string;
+  media: PrivateWhatsAppMediaInfo;
 }
 
 interface PrivateConversationContextBody {
@@ -81,6 +89,28 @@ function getPrivateMessagesQueryLogMetadata(query: Partial<PrivateMessagesQuerys
     hasEventDayKey: typeof query.eventDayKey === 'string',
     hasCursor: typeof query.cursor === 'string',
     limit: normalizeLimit(query.limit),
+  };
+}
+
+function getPrivateMediaBackfillLogMetadata(body: unknown): Record<string, unknown> {
+  if (body === null || typeof body !== 'object') {
+    return {
+      route: 'internal_whatsapp_private_media_backfill',
+      bodyType: typeof body,
+    };
+  }
+
+  const payload = body as Partial<PrivateMediaBackfillBody>;
+  const media = payload.media;
+  return {
+    route: 'internal_whatsapp_private_media_backfill',
+    hasSourceAccountId: typeof payload.sourceAccountId === 'string',
+    hasMessageId: typeof payload.messageId === 'string',
+    hasMedia: typeof media === 'object',
+    mediaStorageStatus:
+      typeof media === 'object' && typeof media.storageStatus === 'string'
+        ? media.storageStatus
+        : 'unknown',
   };
 }
 
@@ -315,6 +345,164 @@ export const privateSyncRoutes: FastifyPluginCallback = (fastify, _opts, done) =
       );
 
       if (!result.ok) {
+        return await reply.fail('INTERNAL_ERROR', result.error.message);
+      }
+
+      return await reply.ok(result.value);
+    }
+  );
+
+  fastify.post<{ Body: PrivateMediaBackfillBody }>(
+    '/internal/whatsapp/private/media/backfill',
+    {
+      attachValidation: true,
+      schema: {
+        operationId: 'backfillPrivateWhatsAppStoredMedia',
+        summary: 'Backfill stored private WhatsApp media',
+        description:
+          'Internal endpoint for a Matrix/mautrix bridge to attach stored media metadata to an existing private WhatsApp message.',
+        tags: ['internal'],
+        body: {
+          type: 'object',
+          additionalProperties: false,
+          properties: {
+            sourceAccountId: { type: 'string', minLength: 1 },
+            messageId: { type: 'string', minLength: 1 },
+            media: {
+              type: 'object',
+              additionalProperties: false,
+              properties: {
+                mxcUri: { type: 'string', minLength: 1 },
+                mimeType: { type: 'string', minLength: 1 },
+                fileName: { type: 'string', minLength: 1 },
+                sizeBytes: { type: 'number', minimum: 0 },
+                width: { type: 'number', minimum: 0 },
+                height: { type: 'number', minimum: 0 },
+                durationMs: { type: 'number', minimum: 0 },
+                sha256: { type: 'string', minLength: 1 },
+                storageStatus: { type: 'string', const: 'stored' },
+                gcsPath: { type: 'string', minLength: 1 },
+                thumbnailGcsPath: { type: 'string', minLength: 1 },
+                storedMimeType: { type: 'string', minLength: 1 },
+                storedSizeBytes: { type: 'number', minimum: 0 },
+                storedAt: { type: 'string', minLength: 1 },
+              },
+              required: ['mxcUri', 'storageStatus', 'gcsPath'],
+            },
+          },
+          required: ['sourceAccountId', 'messageId', 'media'],
+        },
+        response: {
+          200: {
+            description: 'Private WhatsApp media backfill completed',
+            type: 'object',
+            properties: {
+              success: { type: 'boolean', const: true },
+              data: {
+                type: 'object',
+                properties: {
+                  status: { type: 'string', enum: ['updated', 'already_stored'] },
+                  transcriptionPublished: { type: 'boolean' },
+                },
+                required: ['status', 'transcriptionPublished'],
+              },
+            },
+            required: ['success', 'data'],
+          },
+          400: {
+            description: 'Invalid request',
+            type: 'object',
+            properties: {
+              success: { type: 'boolean', const: false },
+              error: { $ref: 'ErrorBody#' },
+            },
+            required: ['success', 'error'],
+          },
+          401: {
+            description: 'Unauthorized',
+            type: 'object',
+            properties: {
+              success: { type: 'boolean', const: false },
+              error: { $ref: 'ErrorBody#' },
+            },
+            required: ['success', 'error'],
+          },
+          404: {
+            description: 'Private WhatsApp account or message not found',
+            type: 'object',
+            properties: {
+              success: { type: 'boolean', const: false },
+              error: { $ref: 'ErrorBody#' },
+            },
+            required: ['success', 'error'],
+          },
+          500: {
+            description: 'Persistence failure',
+            type: 'object',
+            properties: {
+              success: { type: 'boolean', const: false },
+              error: { $ref: 'ErrorBody#' },
+            },
+            required: ['success', 'error'],
+          },
+        },
+      },
+    },
+    async (request: FastifyRequest<{ Body: PrivateMediaBackfillBody }>, reply: FastifyReply) => {
+      logIncomingRequest(request, {
+        message: 'Received request to /internal/whatsapp/private/media/backfill',
+        bodyPreviewLength: 0,
+        additionalFields: getPrivateMediaBackfillLogMetadata(request.body),
+      });
+
+      const authResult = validateInternalAuth(request);
+      if (!authResult.valid) {
+        request.log.warn(
+          { reason: authResult.reason },
+          'Internal auth failed for private WhatsApp media backfill'
+        );
+        return await reply.fail(
+          'UNAUTHORIZED',
+          'Internal auth failed for private WhatsApp media backfill'
+        );
+      }
+
+      const validatedRequest = request as ValidatedRequest;
+      if (validatedRequest.validationError !== undefined) {
+        return await reply.fail('INVALID_REQUEST', 'Validation failed');
+      }
+
+      const services = getServices();
+      const accountResult =
+        await services.privateWhatsAppRepository.getActiveAccountBySourceAccountId(
+          request.body.sourceAccountId
+        );
+      if (!accountResult.ok) {
+        return await reply.fail('INTERNAL_ERROR', accountResult.error.message);
+      }
+      if (accountResult.value === null) {
+        return await reply.fail('NOT_FOUND', 'Private WhatsApp source account is not active');
+      }
+
+      const useCase = new BackfillPrivateWhatsAppStoredMediaUseCase({
+        privateWhatsAppRepository: services.privateWhatsAppRepository,
+        eventPublisher: services.eventPublisher,
+      });
+      const result = await useCase.execute(
+        {
+          sourceAccountId: request.body.sourceAccountId,
+          messageId: request.body.messageId,
+          media: request.body.media,
+        },
+        request.log
+      );
+      if (!result.ok) {
+        if (result.error.code === 'VALIDATION_ERROR') {
+          return await reply.fail('INVALID_REQUEST', result.error.message);
+        }
+        if (result.error.code === 'NOT_FOUND') {
+          return await reply.fail('NOT_FOUND', result.error.message);
+        }
         return await reply.fail('INTERNAL_ERROR', result.error.message);
       }
 

--- a/tools/whatsapp-private-matrix-sync/README.md
+++ b/tools/whatsapp-private-matrix-sync/README.md
@@ -10,7 +10,7 @@ This tool is intentionally placed under `tools/`, not `apps/`, because it is dep
 - This adapter runs a Matrix `/sync` loop with a stored `next_batch` token.
 - On the first successful sync it stores the batch token and skips historical events.
 - Later sync batches are mapped to the private WhatsApp ingest payload and posted to IntexuraOS.
-- For new Matrix `m.image` events, the adapter downloads media through the authenticated Matrix media API, uploads bytes to IntexuraOS, and only then posts the ingest event.
+- For new Matrix image, audio, and video events, the adapter downloads media through the authenticated Matrix media API, uploads bytes to IntexuraOS, and only then posts the ingest event.
 - The adapter is read-only with respect to WhatsApp. It only observes Matrix events and posts ingest batches.
 
 ## IntexuraOS Contract
@@ -56,6 +56,7 @@ The adapter requires:
 - `MATRIX_ACCESS_TOKEN_FILE`
 - `INTEXURAOS_WHATSAPP_PRIVATE_EVENTS_URL`
 - `INTEXURAOS_WHATSAPP_PRIVATE_MEDIA_URL`
+- `INTEXURAOS_WHATSAPP_PRIVATE_MEDIA_BACKFILL_URL` (optional, defaults from the events URL)
 - `INTEXURAOS_GOOGLE_APPLICATION_CREDENTIALS_FILE` or `GOOGLE_APPLICATION_CREDENTIALS`
 - `INTEXURAOS_OIDC_AUDIENCE`
 - `INTEXURAOS_OIDC_IMPERSONATE_SERVICE_ACCOUNT`
@@ -74,6 +75,16 @@ Docker image build:
 
 ```bash
 docker build -t whatsapp-private-matrix-sync:local tools/whatsapp-private-matrix-sync
+```
+
+Stored media backfill for a message ingested before media upload metadata existed:
+
+```bash
+pnpm --filter whatsapp-private-matrix-sync backfill:media -- \
+  --message-id 'message:pbuchman-private-whatsapp:$event-id' \
+  --mxc-uri 'mxc://home-dev/media-id' \
+  --mime-type 'audio/ogg' \
+  --file-name 'Voice message.ogg'
 ```
 
 ## Relationship To Home Dev

--- a/tools/whatsapp-private-matrix-sync/package.json
+++ b/tools/whatsapp-private-matrix-sync/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "backfill:media": "node src/backfill-private-media.mjs",
     "start": "node src/server.mjs",
     "test": "node --test src/*.test.mjs"
   },

--- a/tools/whatsapp-private-matrix-sync/src/backfill-private-media.mjs
+++ b/tools/whatsapp-private-matrix-sync/src/backfill-private-media.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+import { backfillPrivateMedia, createConfig } from './server.mjs';
+
+function parseArgs(argv) {
+  const args = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const entry = argv[index];
+    if (!entry.startsWith('--')) {
+      throw new Error(`unexpected_argument:${entry}`);
+    }
+    const key = entry.slice(2);
+    const value = argv[index + 1];
+    if (value === undefined || value.startsWith('--')) {
+      throw new Error(`missing_argument_value:${key}`);
+    }
+    args[key] = value;
+    index += 1;
+  }
+  return args;
+}
+
+function buildInput(args) {
+  if (typeof args['message-id'] !== 'string' || args['message-id'] === '') {
+    throw new Error('missing_message_id');
+  }
+  if (typeof args['mxc-uri'] !== 'string' || args['mxc-uri'] === '') {
+    throw new Error('missing_mxc_uri');
+  }
+
+  const media = {
+    mxcUri: args['mxc-uri'],
+  };
+  if (typeof args['mime-type'] === 'string') {
+    media.mimeType = args['mime-type'];
+  }
+  if (typeof args['file-name'] === 'string') {
+    media.fileName = args['file-name'];
+  }
+  if (typeof args['sha256'] === 'string') {
+    media.sha256 = args['sha256'];
+  }
+
+  const input = {
+    messageId: args['message-id'],
+    media,
+  };
+  if (typeof args['matrix-event-id'] === 'string') {
+    input.matrixEventId = args['matrix-event-id'];
+  }
+  return input;
+}
+
+async function main() {
+  try {
+    const args = parseArgs(process.argv.slice(2));
+    const result = await backfillPrivateMedia(createConfig(), buildInput(args));
+    process.stdout.write(`${JSON.stringify({ success: true, data: result })}\n`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`${JSON.stringify({ success: false, error: message })}\n`);
+    process.exitCode = 1;
+  }
+}
+
+await main();

--- a/tools/whatsapp-private-matrix-sync/src/server.mjs
+++ b/tools/whatsapp-private-matrix-sync/src/server.mjs
@@ -19,6 +19,11 @@ export function defaultMediaUploadUrl(ingestUrl) {
   return ingestUrl.replace(/\/events$/, '/media');
 }
 
+export function defaultMediaBackfillUrl(ingestUrl) {
+  if (typeof ingestUrl !== 'string' || ingestUrl === '') return '';
+  return ingestUrl.replace(/\/events$/, '/media/backfill');
+}
+
 export function createConfig(env = process.env) {
   return {
     port: Number(env.PORT ?? DEFAULT_PORT),
@@ -29,6 +34,9 @@ export function createConfig(env = process.env) {
     mediaUploadUrl:
       env.INTEXURAOS_WHATSAPP_PRIVATE_MEDIA_URL ??
       defaultMediaUploadUrl(env.INTEXURAOS_WHATSAPP_PRIVATE_EVENTS_URL ?? ''),
+    mediaBackfillUrl:
+      env.INTEXURAOS_WHATSAPP_PRIVATE_MEDIA_BACKFILL_URL ??
+      defaultMediaBackfillUrl(env.INTEXURAOS_WHATSAPP_PRIVATE_EVENTS_URL ?? ''),
     googleApplicationCredentialsFile:
       env.INTEXURAOS_GOOGLE_APPLICATION_CREDENTIALS_FILE ??
       env.GOOGLE_APPLICATION_CREDENTIALS ??
@@ -482,6 +490,41 @@ export async function prepareEventsForIngest(config, matrixAccessToken, events, 
     });
   }
   return prepared;
+}
+
+export async function backfillPrivateMedia(config, input, deps = {}) {
+  const readAccessTokenFn = deps.readAccessToken ?? readAccessToken;
+  const fetchMatrixMediaFn = deps.fetchMatrixMedia ?? fetchMatrixMedia;
+  const uploadPrivateMediaFn = deps.uploadPrivateMedia ?? uploadPrivateMedia;
+  const postPrivateMediaBackfillFn = deps.postPrivateMediaBackfill ?? postPrivateMediaBackfill;
+
+  const matrixAccessToken = readAccessTokenFn(config.matrixAccessTokenFile);
+  if (matrixAccessToken === '') {
+    throw new Error('missing_matrix_access_token');
+  }
+  if (!isRecord(input) || typeof input.messageId !== 'string' || !isRecord(input.media)) {
+    throw new Error('invalid_private_media_backfill_input');
+  }
+
+  const matrixEventId =
+    typeof input.matrixEventId === 'string' && input.matrixEventId !== ''
+      ? input.matrixEventId
+      : matrixEventIdFromPrivateMessageId(input.messageId, config.sourceAccountId);
+  const media = input.media;
+  if (typeof media.mxcUri !== 'string' || media.mxcUri === '') {
+    throw new Error('missing_private_media_mxc_uri');
+  }
+
+  const downloaded = await fetchMatrixMediaFn(config, matrixAccessToken, media.mxcUri);
+  const storedMedia = await uploadPrivateMediaFn(config, { matrixEventId }, media, downloaded);
+  return await postPrivateMediaBackfillFn(config, {
+    sourceAccountId: config.sourceAccountId,
+    messageId: input.messageId,
+    media: {
+      ...media,
+      ...storedMedia,
+    },
+  });
 }
 
 function isPrivateMediaUploadMessageType(messageType) {
@@ -1003,7 +1046,7 @@ async function postEvents(config, events) {
   }
 }
 
-async function uploadPrivateMedia(config, event, media, downloaded) {
+export async function uploadPrivateMedia(config, event, media, downloaded) {
   if (config.mediaUploadUrl === '') {
     throw new Error('missing_private_media_upload_url');
   }
@@ -1044,6 +1087,42 @@ async function uploadPrivateMedia(config, event, media, downloaded) {
     throw new Error('intexuraos_private_media_upload_invalid_response');
   }
   return body.data.media;
+}
+
+export async function postPrivateMediaBackfill(config, payload) {
+  if (config.mediaBackfillUrl === '') {
+    throw new Error('missing_private_media_backfill_url');
+  }
+  const authorization = await createGoogleIdentityAuthorizationHeader(config);
+  const response = await fetch(config.mediaBackfillUrl, {
+    method: 'POST',
+    headers: {
+      authorization,
+      'content-type': 'application/json',
+      'user-agent': 'home-dev-whatsapp-sync/1.0',
+    },
+    body: JSON.stringify(payload),
+  });
+  if (!response.ok) {
+    throw new Error(`intexuraos_private_media_backfill_failed_${response.status}`);
+  }
+  const body = await response.json();
+  if (!isRecord(body) || body.success !== true || !isRecord(body.data)) {
+    throw new Error('intexuraos_private_media_backfill_invalid_response');
+  }
+  return body.data;
+}
+
+export function matrixEventIdFromPrivateMessageId(messageId, sourceAccountId) {
+  const prefix = `message:${sourceAccountId}:`;
+  if (typeof messageId !== 'string' || !messageId.startsWith(prefix)) {
+    throw new Error('invalid_private_message_id');
+  }
+  const matrixEventId = messageId.slice(prefix.length);
+  if (matrixEventId === '') {
+    throw new Error('invalid_private_message_id');
+  }
+  return matrixEventId;
 }
 
 async function createGoogleIdentityAuthorizationHeader(config) {

--- a/tools/whatsapp-private-matrix-sync/src/server.test.mjs
+++ b/tools/whatsapp-private-matrix-sync/src/server.test.mjs
@@ -5,6 +5,7 @@ import os from 'node:os';
 import path from 'node:path';
 
 import {
+  backfillPrivateMedia,
   buildHealthPayload,
   buildImpersonatedIdTokenRequest,
   buildIngestPayload,
@@ -1228,6 +1229,101 @@ test('prepareEventsForIngest uploads new Matrix video before posting ingest even
     storedSizeBytes: 'video-bytes'.length,
     storedAt: '2026-06-30T12:55:00.000Z',
   });
+});
+
+test('backfillPrivateMedia uploads Matrix media and posts stored metadata to IntexuraOS', async () => {
+  const calls = [];
+
+  const result = await backfillPrivateMedia(
+    {
+      ...config,
+      mediaBackfillUrl: 'https://intexuraos.cloud/internal/whatsapp/private/media/backfill',
+    },
+    {
+      messageId: 'message:pbuchman-private-whatsapp:$event-private-audio-placeholder',
+      media: {
+        mxcUri: 'mxc://home-dev/private-audio-placeholder',
+        mimeType: 'audio/ogg',
+        fileName: 'Voice message.ogg',
+      },
+    },
+    {
+      readAccessToken: () => 'matrix-token',
+      fetchMatrixMedia: async (_config, accessToken, mxcUri) => {
+        calls.push({ step: 'fetch', accessToken, mxcUri });
+        return {
+          buffer: Buffer.from('audio-bytes'),
+          contentType: 'audio/ogg',
+        };
+      },
+      uploadPrivateMedia: async (_config, event, media, downloaded) => {
+        calls.push({
+          step: 'upload',
+          matrixEventId: event.matrixEventId,
+          media,
+          bytes: downloaded.buffer.length,
+        });
+        return {
+          mxcUri: media.mxcUri,
+          mimeType: media.mimeType,
+          fileName: media.fileName,
+          sizeBytes: downloaded.buffer.length,
+          storageStatus: 'stored',
+          gcsPath: 'whatsapp/private/user-123/private-audio-placeholder/audio.ogg',
+          storedMimeType: 'audio/ogg',
+          storedSizeBytes: downloaded.buffer.length,
+          storedAt: '2026-06-30T22:02:00.000Z',
+        };
+      },
+      postPrivateMediaBackfill: async (_config, payload) => {
+        calls.push({ step: 'backfill', payload });
+        return {
+          status: 'updated',
+          transcriptionPublished: true,
+        };
+      },
+    }
+  );
+
+  assert.deepEqual(result, {
+    status: 'updated',
+    transcriptionPublished: true,
+  });
+  assert.deepEqual(calls, [
+    {
+      step: 'fetch',
+      accessToken: 'matrix-token',
+      mxcUri: 'mxc://home-dev/private-audio-placeholder',
+    },
+    {
+      step: 'upload',
+      matrixEventId: '$event-private-audio-placeholder',
+      media: {
+        mxcUri: 'mxc://home-dev/private-audio-placeholder',
+        mimeType: 'audio/ogg',
+        fileName: 'Voice message.ogg',
+      },
+      bytes: 'audio-bytes'.length,
+    },
+    {
+      step: 'backfill',
+      payload: {
+        sourceAccountId: 'pbuchman-private-whatsapp',
+        messageId: 'message:pbuchman-private-whatsapp:$event-private-audio-placeholder',
+        media: {
+          mxcUri: 'mxc://home-dev/private-audio-placeholder',
+          mimeType: 'audio/ogg',
+          fileName: 'Voice message.ogg',
+          sizeBytes: 'audio-bytes'.length,
+          storageStatus: 'stored',
+          gcsPath: 'whatsapp/private/user-123/private-audio-placeholder/audio.ogg',
+          storedMimeType: 'audio/ogg',
+          storedSizeBytes: 'audio-bytes'.length,
+          storedAt: '2026-06-30T22:02:00.000Z',
+        },
+      },
+    },
+  ]);
 });
 
 test('runSyncIteration does not persist Matrix state when image upload fails', async () => {


### PR DESCRIPTION
## Summary
- improve the Intex Agent Preferences page mobile layout and prompt preview styling
- add an internal private WhatsApp media backfill endpoint that updates existing placeholder media rows and publishes one transcription request
- add Matrix sync-tool media backfill support and docs

## Verification
- pnpm --filter web test -- IntexAgentPreferencesPage
- pnpm test apps/whatsapp-service/src/__tests__/privateSyncRoutes.test.ts
- pnpm --filter whatsapp-private-matrix-sync test
- pnpm --filter web typecheck
- pnpm --filter @intexuraos/whatsapp-service typecheck
- pnpm run typecheck:tests

- Linear: [INT-1824](https://linear.app/pbuchman/issue/INT-1824)
- IntexuraOS Code Task: [View task](https://intexuraos.cloud/#/code-tasks/task_a6106792-2d52-4927-bc7a-036b0f4e9351)
- Worker Type: `codex-xhigh`
- Model: `default`
