### PR TITLE
[INT-1826] Add internal Intex Agent test conversation endpoint

### DIFF
--- a/apps/intex-agent/src/__tests__/domain/runTestConversation.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/runTestConversation.test.ts
@@ -130,6 +130,50 @@ describe('test conversation contract', () => {
     expect(result.behavioralTranscript.turns[1]).not.toHaveProperty('toolOutcome');
   });
 
+  it('does not expose secret-like session summaries in serialized responses', async () => {
+    const repository = new MemorySessionRepository();
+    const result = await runTestConversation(
+      {
+        contractVersion: '2026-07-01',
+        mode: 'live_llm_mock_tools',
+        userId: 'test-intex-agent-intex-e2e-summary',
+        runId: 'intex-e2e-summary',
+        currentDateTime: '2026-07-01T10:00:00.000Z',
+        turns: [
+          {
+            kind: 'message',
+            messageId: 'wamid-summary-1',
+            text: 'Summarize this safely. intex-e2e-summary',
+          },
+        ],
+      },
+      {
+        sessionRepository: repository,
+        runner: new ScriptedRunner([
+          {
+            outcome: 'completed',
+            reply: 'Done.',
+            summary: 'private summary with token abc',
+          },
+        ]),
+        sessionTimeoutMs: 30 * 60 * 1000,
+        ids: fixedTestIds(),
+        toolCalls: [],
+        logger: silentLogger(),
+      }
+    );
+
+    expect(result.sessions).toEqual([
+      expect.objectContaining({
+        id: 'intex_session_test_1',
+        status: 'waiting_for_user',
+      }),
+    ]);
+    expect(JSON.stringify(result)).not.toContain('private summary');
+    expect(JSON.stringify(result)).not.toContain('token abc');
+    expect(result.sessions[0]).not.toHaveProperty('summary');
+  });
+
   it('returns an empty transcript for direct empty-turn use case calls', async () => {
     const result = await runTestConversation(
       {

--- a/apps/intex-agent/src/__tests__/domain/runTestConversation.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/runTestConversation.test.ts
@@ -1,0 +1,573 @@
+import { describe, expect, it } from 'vitest';
+import { runTestConversation } from '../../domain/testConversation/runTestConversation.js';
+import type {
+  CapturedToolCall,
+  TestConversationHttpRequest,
+  TestConversationResponse,
+} from '../../domain/testConversation/testConversationTypes.js';
+import type {
+  IntexAgentRunner,
+  IntexAgentRunnerResult,
+} from '../../domain/messages/handleIncomingMessage.js';
+import type {
+  SessionRepository,
+  SessionRepositorySessionUpdate,
+} from '../../domain/ports/sessionRepository.js';
+import type {
+  IntexAgentSession,
+  IntexAgentSessionEvent,
+} from '../../domain/sessions/types.js';
+
+describe('test conversation contract', () => {
+  it('supports a live mocked-tools request and response transcript', () => {
+    const request: TestConversationHttpRequest = {
+      contractVersion: '2026-07-01',
+      mode: 'live_llm_mock_tools',
+      userId: 'test-intex-agent-intex-e2e-contract',
+      runId: 'intex-e2e-contract',
+      currentDateTime: '2026-07-01T10:00:00.000Z',
+      turns: [
+        {
+          kind: 'message',
+          messageId: 'wamid-contract-1',
+          text: 'Jakie mam jutro wydarzenia? intex-e2e-contract',
+          timestamp: '2026-07-01T10:00:00.000Z',
+          sourceType: 'whatsapp_text',
+        },
+      ],
+      toolMocks: {
+        query_calendar_events: {
+          mode: 'success',
+          result: { status: 'completed', mode: 'list', count: 0, events: [] },
+        },
+      },
+    };
+
+    const response: TestConversationResponse = {
+      runId: request.runId,
+      userId: request.userId,
+      contractVersion: '2026-07-01',
+      mode: 'live_llm_mock_tools',
+      finalSessionId: 'intex_session_1',
+      turns: [
+        {
+          turnIndex: 0,
+          kind: 'message',
+          messageId: 'wamid-contract-1',
+          sessionId: 'intex_session_1',
+          submittedTextPreview: 'Jakie mam jutro wydarzenia? intex-e2e-contract',
+          assistantReplies: [],
+        },
+      ],
+      toolCalls: [],
+      sessions: [],
+      sessionTransitions: [],
+      eventsBySessionId: {},
+      behavioralTranscript: { turns: [] },
+      sideEffectBoundary: 'mocked_tools_no_downstream_writes',
+      warnings: [],
+    };
+
+    expect(response.runId).toBe('intex-e2e-contract');
+  });
+
+  it('runs two message turns through handleIncomingMessage and returns sanitized evidence', async () => {
+    const repository = new MemorySessionRepository();
+    const result = await runTestConversation(
+      {
+        contractVersion: '2026-07-01',
+        mode: 'live_llm_mock_tools',
+        userId: 'test-intex-agent-intex-e2e-scripted',
+        runId: 'intex-e2e-scripted',
+        currentDateTime: '2026-07-01T10:00:00.000Z',
+        turns: [
+          {
+            kind: 'message',
+            messageId: 'wamid-1',
+            text: 'Jakie wydarzenia jutro? intex-e2e-scripted',
+            timestamp: '2026-07-01T10:00:00.000Z',
+          },
+          {
+            kind: 'message',
+            messageId: 'wamid-2',
+            text: 'Co dalej?',
+            timestamp: '2026-07-01T10:01:00.000Z',
+          },
+        ],
+      },
+      {
+        sessionRepository: repository,
+        runner: new ScriptedRunner([
+          {
+            outcome: 'completed',
+            reply: 'Nie masz żadnych wydarzeń jutro.',
+            toolName: 'query_calendar_events',
+            toolResult: { status: 'completed', count: 0, token: 'secret-token' },
+          },
+          { outcome: 'no_action', reply: 'Co mogę teraz dla Ciebie zrobić?' },
+        ]),
+        sessionTimeoutMs: 30 * 60 * 1000,
+        ids: fixedTestIds(),
+        toolCalls: [],
+        logger: silentLogger(),
+      }
+    );
+
+    expect(result.userId).toBe('test-intex-agent-intex-e2e-scripted');
+    expect(result.finalSessionId).toBe('intex_session_test_1');
+    expect(result.turns).toHaveLength(2);
+    expect(result.turns[0]?.assistantReplies[0]?.message).toContain('Nie masz żadnych wydarzeń');
+    expect(result.turns[1]?.assistantReplies[0]?.message).toContain('Co mogę teraz');
+    expect(result.eventsBySessionId['intex_session_test_1']?.map((event) => event.type)).toContain(
+      'assistant_message'
+    );
+    expect(JSON.stringify(result)).not.toContain('toolArgs');
+    expect(JSON.stringify(result)).not.toContain('secret-token');
+    expect(result.behavioralTranscript.turns[0]).toMatchObject({
+      sessionAction: 'started',
+      toolOutcome: { toolName: 'query_calendar_events', status: 'completed' },
+    });
+    expect(result.behavioralTranscript.turns[1]).not.toHaveProperty('toolOutcome');
+  });
+
+  it('returns an empty transcript for direct empty-turn use case calls', async () => {
+    const result = await runTestConversation(
+      {
+        contractVersion: '2026-07-01',
+        mode: 'live_llm_mock_tools',
+        userId: 'test-intex-agent-intex-e2e-empty',
+        runId: 'intex-e2e-empty',
+        currentDateTime: '2026-07-01T10:00:00.000Z',
+        turns: [],
+      },
+      {
+        sessionRepository: new MemorySessionRepository(),
+        runner: new ScriptedRunner([]),
+        sessionTimeoutMs: 30 * 60 * 1000,
+        ids: fixedTestIds(),
+        toolCalls: [],
+        logger: silentLogger(),
+      }
+    );
+
+    expect(result.finalSessionId).toBeNull();
+    expect(result.turns).toEqual([]);
+    expect(result.behavioralTranscript.turns).toEqual([]);
+  });
+
+  it('resolves semantic confirmation accept and records confirmed tool execution events', async () => {
+    const repository = new MemorySessionRepository();
+    const toolCalls: CapturedToolCall[] = [
+      {
+        toolName: 'create_note',
+        status: 'completed',
+        argsSummary: { contentLength: 21 },
+        resultSummary: { status: 'completed' },
+      },
+    ];
+    const result = await runTestConversation(
+      {
+        contractVersion: '2026-07-01',
+        mode: 'live_llm_mock_tools',
+        userId: 'test-intex-agent-intex-e2e-confirm',
+        runId: 'intex-e2e-confirm',
+        currentDateTime: '2026-07-01T10:00:00.000Z',
+        turns: [
+          {
+            kind: 'message',
+            messageId: 'wamid-confirm-1',
+            text: 'Zapamiętaj kod 1234. intex-e2e-confirm',
+          },
+          { kind: 'confirmation_button', previousTurnIndex: 0, decision: 'accept' },
+        ],
+      },
+      {
+        sessionRepository: repository,
+        runner: new ScriptedRunner(
+          [
+            {
+              outcome: 'needs_confirmation',
+              reply: 'Czy dodać notatkę?\nTreść: kod 1234',
+              toolName: 'create_note',
+              toolArgs: { content: 'kod 1234 intex-e2e-confirm' },
+            },
+          ],
+          [{ outcome: 'completed', reply: 'Zapisałem notatkę.', toolName: 'create_note' }]
+        ),
+        sessionTimeoutMs: 30 * 60 * 1000,
+        ids: fixedTestIds(),
+        toolCalls,
+        logger: silentLogger(),
+      }
+    );
+
+    const events = result.eventsBySessionId['intex_session_test_1'] ?? [];
+    expect(events.map((event) => event.type)).toContain('confirmation_resolved');
+    expect(events.map((event) => event.type)).toContain('tool_call_completed');
+    expect(result.turns[1]?.kind).toBe('confirmation_button');
+    expect(result.turns[1]?.assistantReplies[0]?.message).toContain('Zapisałem notatkę');
+    expect(result.toolCalls).toEqual(toolCalls);
+    expect(result.behavioralTranscript.turns[1]).toMatchObject({
+      confirmationAction: 'accepted',
+      toolOutcome: { toolName: 'create_note', status: 'completed' },
+    });
+  });
+
+  it('resolves semantic confirmation rejection without confirmed tool calls', async () => {
+    const repository = new MemorySessionRepository();
+    const result = await runTestConversation(
+      {
+        contractVersion: '2026-07-01',
+        mode: 'live_llm_mock_tools',
+        userId: 'test-intex-agent-intex-e2e-reject',
+        runId: 'intex-e2e-reject',
+        currentDateTime: '2026-07-01T10:00:00.000Z',
+        turns: [
+          {
+            kind: 'message',
+            messageId: 'wamid-reject-1',
+            text: 'Zapamiętaj kod 4321. intex-e2e-reject',
+          },
+          { kind: 'confirmation_button', previousTurnIndex: 0, decision: 'reject' },
+        ],
+      },
+      {
+        sessionRepository: repository,
+        runner: new ScriptedRunner([
+          {
+            outcome: 'needs_confirmation',
+            reply: 'Czy dodać notatkę?\nTreść: kod 4321',
+            toolName: 'create_note',
+            toolArgs: { content: 'kod 4321 intex-e2e-reject' },
+          },
+        ]),
+        sessionTimeoutMs: 30 * 60 * 1000,
+        ids: fixedTestIds(),
+        toolCalls: [],
+        logger: silentLogger(),
+      }
+    );
+
+    const events = result.eventsBySessionId['intex_session_test_1'] ?? [];
+    expect(events.map((event) => event.type)).toContain('confirmation_resolved');
+    expect(events.map((event) => event.type)).not.toContain('tool_call_completed');
+    expect(result.toolCalls).toEqual([]);
+    expect(result.behavioralTranscript.turns[1]).toMatchObject({
+      confirmationAction: 'rejected',
+    });
+  });
+
+  it('expires an old session and reports the transition when timeout starts a new session', async () => {
+    const repository = new MemorySessionRepository();
+    repository.sessions.push({
+      id: 'intex_session_old',
+      userId: 'test-intex-agent-intex-e2e-timeout',
+      channel: 'whatsapp',
+      status: 'waiting_for_user',
+      startedAt: '2026-07-01T09:00:00.000Z',
+      lastUserMessageAt: '2026-07-01T09:00:00.000Z',
+      startReason: 'no_active_session',
+    });
+
+    const result = await runTestConversation(
+      {
+        contractVersion: '2026-07-01',
+        mode: 'live_llm_mock_tools',
+        scenarioId: 'timeout-transition',
+        userId: 'test-intex-agent-intex-e2e-timeout',
+        runId: 'intex-e2e-timeout',
+        currentDateTime: '2026-07-01T10:00:00.000Z',
+        turns: [
+          {
+            kind: 'message',
+            text: 'Nowy temat po przerwie. intex-e2e-timeout',
+            sourceUrl: 'https://example.com/source',
+            whatsappSender: '+48123123123',
+            replyContext: {
+              replyToWamid: 'wamid-old',
+              source: 'inbound_user_message',
+              text: 'Poprzedni tekst',
+              truncated: false,
+            },
+          },
+        ],
+      },
+      {
+        sessionRepository: repository,
+        runner: new ScriptedRunner([{ outcome: 'no_action', reply: 'Jasne, co dalej?' }]),
+        sessionTimeoutMs: 1,
+        ids: fixedTestIds(),
+        toolCalls: [],
+        logger: silentLogger(),
+      }
+    );
+
+    expect(result.scenarioId).toBe('timeout-transition');
+    expect(result.turns[0]).toMatchObject({
+      messageId: 'wamid-test-intex-e2e-timeout-0',
+      sessionId: 'intex_session_test_2',
+    });
+    expect(result.sessionTransitions[0]).toEqual({
+      turnIndex: 0,
+      action: 'expired_previous',
+      sessionId: 'intex_session_test_2',
+      previousSessionId: 'intex_session_old',
+      previousEndReason: 'timeout',
+    });
+  });
+
+  it('reports superseded transitions for explicit new-session commands', async () => {
+    const repository = new MemorySessionRepository();
+    repository.sessions.push({
+      id: 'intex_session_old',
+      userId: 'test-intex-agent-intex-e2e-supersede',
+      channel: 'whatsapp',
+      status: 'waiting_for_user',
+      startedAt: '2026-07-01T09:00:00.000Z',
+      lastUserMessageAt: '2026-07-01T09:59:00.000Z',
+      startReason: 'no_active_session',
+    });
+
+    const result = await runTestConversation(
+      {
+        contractVersion: '2026-07-01',
+        mode: 'live_llm_mock_tools',
+        userId: 'test-intex-agent-intex-e2e-supersede',
+        runId: 'intex-e2e-supersede',
+        currentDateTime: '2026-07-01T10:00:00.000Z',
+        turns: [{ kind: 'message', text: 'new session: fresh topic intex-e2e-supersede' }],
+      },
+      {
+        sessionRepository: repository,
+        runner: new ScriptedRunner([{ outcome: 'no_action', reply: 'Fresh session.' }]),
+        sessionTimeoutMs: 30 * 60 * 1000,
+        ids: fixedTestIds(),
+        toolCalls: [],
+        logger: silentLogger(),
+      }
+    );
+
+    expect(result.sessionTransitions[0]).toMatchObject({
+      action: 'superseded_previous',
+      previousSessionId: 'intex_session_old',
+      previousEndReason: 'superseded_by_user',
+    });
+  });
+
+  it('uses each turn timestamp for the domain clock and generated message timestamp', async () => {
+    const repository = new MemorySessionRepository();
+    const runner = new ScriptedRunner([{ outcome: 'no_action', reply: 'Got it.' }]);
+
+    const result = await runTestConversation(
+      {
+        contractVersion: '2026-07-01',
+        mode: 'live_llm_mock_tools',
+        userId: 'test-intex-agent-intex-e2e-timestamp',
+        runId: 'intex-e2e-timestamp',
+        currentDateTime: '2026-07-01T10:00:00.000Z',
+        turns: [
+          {
+            kind: 'message',
+            text: 'Timestamp check. intex-e2e-timestamp',
+            timestamp: '2026-07-01T11:15:00.000Z',
+          },
+        ],
+      },
+      {
+        sessionRepository: repository,
+        runner,
+        sessionTimeoutMs: 30 * 60 * 1000,
+        ids: fixedTestIds(),
+        toolCalls: [],
+        logger: silentLogger(),
+      }
+    );
+
+    const runnerInput = runner.calls[0] as { currentDateTime: string };
+    expect(runnerInput.currentDateTime).toBe('2026-07-01T11:15:00.000Z');
+    expect(result.turns[0]?.messageId).toBe('wamid-test-intex-e2e-timestamp-0');
+    expect(repository.events.find((event) => event.type === 'user_message')?.createdAt).toBe(
+      '2026-07-01T11:15:00.000Z'
+    );
+  });
+
+  it('fails fast when a semantic confirmation cannot find a captured button', async () => {
+    const repository = new MemorySessionRepository();
+
+    await expect(
+      runTestConversation(
+        {
+          contractVersion: '2026-07-01',
+          mode: 'live_llm_mock_tools',
+          userId: 'test-intex-agent-intex-e2e-missing-button',
+          runId: 'intex-e2e-missing-button',
+          currentDateTime: '2026-07-01T10:00:00.000Z',
+          turns: [
+            {
+              kind: 'message',
+              text: 'Tylko odpowiedz tekstem. intex-e2e-missing-button',
+            },
+            { kind: 'confirmation_button', previousTurnIndex: 0, decision: 'accept' },
+          ],
+        },
+        {
+          sessionRepository: repository,
+          runner: new ScriptedRunner([{ outcome: 'no_action', reply: 'Odpowiedź bez przycisków.' }]),
+          sessionTimeoutMs: 30 * 60 * 1000,
+          ids: fixedTestIds(),
+          toolCalls: [],
+          logger: silentLogger(),
+        }
+      )
+    ).rejects.toThrow('confirmation_button could not resolve a captured confirmation button');
+  });
+
+  it('fails fast when a semantic confirmation references an unexecuted turn', async () => {
+    await expect(
+      runTestConversation(
+        {
+          contractVersion: '2026-07-01',
+          mode: 'live_llm_mock_tools',
+          userId: 'test-intex-agent-intex-e2e-bad-confirm',
+          runId: 'intex-e2e-bad-confirm',
+          currentDateTime: '2026-07-01T10:00:00.000Z',
+          turns: [{ kind: 'confirmation_button', previousTurnIndex: 0, decision: 'accept' }],
+        },
+        {
+          sessionRepository: new MemorySessionRepository(),
+          runner: new ScriptedRunner([]),
+          sessionTimeoutMs: 30 * 60 * 1000,
+          ids: fixedTestIds(),
+          toolCalls: [],
+          logger: silentLogger(),
+        }
+      )
+    ).rejects.toThrow('confirmation_button previousTurnIndex does not reference an executed turn');
+  });
+});
+
+class ScriptedRunner implements IntexAgentRunner {
+  readonly calls: unknown[] = [];
+  readonly executeConfirmedCalls: unknown[] = [];
+  private runIndex = 0;
+  private executeIndex = 0;
+
+  constructor(
+    private readonly runResults: IntexAgentRunnerResult[],
+    private readonly executeResults: IntexAgentRunnerResult[] = []
+  ) {}
+
+  async run(input: Parameters<IntexAgentRunner['run']>[0]): Promise<IntexAgentRunnerResult> {
+    this.calls.push(input);
+    const result = this.runResults[this.runIndex];
+    this.runIndex += 1;
+    if (result === undefined) {
+      throw new Error('Missing scripted run result');
+    }
+    return result;
+  }
+
+  async executeConfirmed(
+    input: Parameters<IntexAgentRunner['executeConfirmed']>[0]
+  ): Promise<IntexAgentRunnerResult> {
+    this.executeConfirmedCalls.push(input);
+    const result = this.executeResults[this.executeIndex];
+    this.executeIndex += 1;
+    if (result === undefined) {
+      throw new Error('Missing scripted execute result');
+    }
+    return result;
+  }
+}
+
+class MemorySessionRepository implements SessionRepository {
+  readonly sessions: IntexAgentSession[] = [];
+  readonly events: IntexAgentSessionEvent[] = [];
+
+  async listSessions(userId: string): Promise<IntexAgentSession[]> {
+    return this.sessions.filter((session) => session.userId === userId);
+  }
+
+  async getSession(sessionId: string, userId: string): Promise<IntexAgentSession | null> {
+    return this.sessions.find((session) => session.id === sessionId && session.userId === userId) ?? null;
+  }
+
+  async listEvents(sessionId: string, userId: string): Promise<IntexAgentSessionEvent[]> {
+    return this.events.filter((event) => event.sessionId === sessionId && event.userId === userId);
+  }
+
+  async findOpenSession(userId: string): Promise<IntexAgentSession | null> {
+    return this.findContinuableSession(userId);
+  }
+
+  async findContinuableSession(userId: string): Promise<IntexAgentSession | null> {
+    return (
+      this.sessions
+        .filter(
+          (session) =>
+            session.userId === userId &&
+            ['active', 'waiting_for_user', 'executing_tool'].includes(session.status)
+        )
+        .sort((left, right) => left.lastUserMessageAt.localeCompare(right.lastUserMessageAt))
+        .at(-1) ?? null
+    );
+  }
+
+  async createSession(draft: IntexAgentSession): Promise<IntexAgentSession> {
+    this.sessions.push(draft);
+    return draft;
+  }
+
+  async updateSession(
+    sessionId: string,
+    update: SessionRepositorySessionUpdate
+  ): Promise<IntexAgentSession> {
+    const index = this.sessions.findIndex((session) => session.id === sessionId);
+    if (index < 0) {
+      throw new Error(`Missing session ${sessionId}`);
+    }
+    const updated = { ...this.sessions[index], ...update } as IntexAgentSession;
+    this.sessions[index] = updated;
+    return updated;
+  }
+
+  async appendEvent(event: IntexAgentSessionEvent): Promise<void> {
+    this.events.push(event);
+  }
+}
+
+function fixedTestIds(): {
+  sessionId(): string;
+  eventId(): string;
+  confirmationId(): string;
+} {
+  let sequence = 0;
+  return {
+    sessionId: (): string => {
+      sequence += 1;
+      return `intex_session_test_${String(sequence)}`;
+    },
+    eventId: (): string => {
+      sequence += 1;
+      return `intex_event_test_${String(sequence)}`;
+    },
+    confirmationId: (): string => {
+      sequence += 1;
+      return `intex_confirmation_test_${String(sequence)}`;
+    },
+  };
+}
+
+function silentLogger(): { info(): void; warn(): void; error(): void } {
+  return {
+    info(): void {
+      return undefined;
+    },
+    warn(): void {
+      return undefined;
+    },
+    error(): void {
+      return undefined;
+    },
+  };
+}

--- a/apps/intex-agent/src/__tests__/domain/testConversationSanitizer.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/testConversationSanitizer.test.ts
@@ -4,6 +4,7 @@ import {
   sanitizeAssistantReplies,
   sanitizeRecord,
   sanitizeEventsBySessionId,
+  sanitizeSessions,
   sanitizeToolCalls,
 } from '../../domain/testConversation/testConversationSanitizer.js';
 import type {
@@ -85,6 +86,69 @@ describe('test conversation sanitizer', () => {
   it('sanitizes captured tool calls that have no optional summaries', () => {
     expect(sanitizeToolCalls([{ toolName: 'create_note', status: 'completed' }])).toEqual([
       { toolName: 'create_note', status: 'completed' },
+    ]);
+  });
+
+  it('sanitizes sessions through an allowlisted DTO without summaries', () => {
+    const sanitized = sanitizeSessions([
+      {
+        id: 'intex_session_1',
+        userId: 'test-intex-agent-run',
+        channel: 'whatsapp',
+        status: 'completed',
+        startedAt: '2026-07-01T10:00:00.000Z',
+        endedAt: '2026-07-01T10:05:00.000Z',
+        lastUserMessageAt: '2026-07-01T10:00:00.000Z',
+        lastAssistantMessageAt: '2026-07-01T10:05:00.000Z',
+        startReason: 'no_active_session',
+        endReason: 'tool_completed',
+        activeTool: 'create_note',
+        summary: 'private summary with token abc',
+      },
+    ]);
+
+    expect(sanitized).toEqual([
+      {
+        id: 'intex_session_1',
+        userId: 'test-intex-agent-run',
+        channel: 'whatsapp',
+        status: 'completed',
+        startedAt: '2026-07-01T10:00:00.000Z',
+        endedAt: '2026-07-01T10:05:00.000Z',
+        lastUserMessageAt: '2026-07-01T10:00:00.000Z',
+        lastAssistantMessageAt: '2026-07-01T10:05:00.000Z',
+        startReason: 'no_active_session',
+        endReason: 'tool_completed',
+        activeTool: 'create_note',
+      },
+    ]);
+    expect(JSON.stringify(sanitized)).not.toContain('private summary');
+    expect(JSON.stringify(sanitized)).not.toContain('token abc');
+  });
+
+  it('sanitizes sessions that have no optional timestamp or tool fields', () => {
+    expect(
+      sanitizeSessions([
+        {
+          id: 'intex_session_2',
+          userId: 'test-intex-agent-run',
+          channel: 'whatsapp',
+          status: 'active',
+          startedAt: '2026-07-01T10:00:00.000Z',
+          lastUserMessageAt: '2026-07-01T10:00:00.000Z',
+          startReason: 'no_active_session',
+        },
+      ])
+    ).toEqual([
+      {
+        id: 'intex_session_2',
+        userId: 'test-intex-agent-run',
+        channel: 'whatsapp',
+        status: 'active',
+        startedAt: '2026-07-01T10:00:00.000Z',
+        lastUserMessageAt: '2026-07-01T10:00:00.000Z',
+        startReason: 'no_active_session',
+      },
     ]);
   });
 

--- a/apps/intex-agent/src/__tests__/domain/testConversationSanitizer.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/testConversationSanitizer.test.ts
@@ -1,0 +1,391 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildBehavioralTranscript,
+  sanitizeAssistantReplies,
+  sanitizeRecord,
+  sanitizeEventsBySessionId,
+  sanitizeToolCalls,
+} from '../../domain/testConversation/testConversationSanitizer.js';
+import type {
+  CapturedToolCall,
+  TestConversationTurnResult,
+} from '../../domain/testConversation/testConversationTypes.js';
+import type { IntexAgentSessionEvent } from '../../domain/sessions/types.js';
+
+describe('test conversation sanitizer', () => {
+  it('omits raw tool args, raw results, source urls, reply contexts, and secret-like payload fields', () => {
+    const event: IntexAgentSessionEvent = {
+      id: 'event-1',
+      sessionId: 'intex_session_1',
+      userId: 'test-intex-agent-run',
+      type: 'confirmation_requested',
+      createdAt: '2026-07-01T10:00:00.000Z',
+      payload: {
+        confirmationId: 'confirm-1',
+        toolName: 'create_note',
+        toolArgs: { content: 'private body', apiKey: 'secret-key' },
+        message: 'Czy dodać notatkę?',
+        sourceUrl: 'https://signed.example/private',
+        whatsappSender: '+48123123123',
+        replyContext: { text: 'previous private text' },
+        token: 'secret-token',
+      },
+    };
+
+    const sanitized = sanitizeEventsBySessionId({ intex_session_1: [event] });
+
+    expect(sanitized).toEqual({
+      intex_session_1: [
+        {
+          id: 'event-1',
+          type: 'confirmation_requested',
+          createdAt: '2026-07-01T10:00:00.000Z',
+          payload: {
+            confirmationId: 'confirm-1',
+            toolName: 'create_note',
+            textPreview: 'Czy dodać notatkę?',
+          },
+        },
+      ],
+    });
+    expect(JSON.stringify(sanitized)).not.toContain('private body');
+    expect(JSON.stringify(sanitized)).not.toContain('secret-key');
+    expect(JSON.stringify(sanitized)).not.toContain('sourceUrl');
+    expect(JSON.stringify(sanitized)).not.toContain('whatsappSender');
+    expect(JSON.stringify(sanitized)).not.toContain('replyContext');
+    expect(JSON.stringify(sanitized)).not.toContain('secret-token');
+  });
+
+  it('sanitizes captured tool call summaries recursively', () => {
+    const calls: CapturedToolCall[] = [
+      {
+        toolName: 'query_calendar_events',
+        status: 'completed',
+        argsSummary: { mode: 'list', token: 'secret-token' },
+        resultSummary: {
+          status: 'completed',
+          count: 1,
+          nested: { password: 'secret-password' },
+        },
+      },
+    ];
+
+    const sanitized = sanitizeToolCalls(calls);
+
+    expect(sanitized).toEqual([
+      {
+        toolName: 'query_calendar_events',
+        status: 'completed',
+        argsSummary: { mode: 'list' },
+        resultSummary: { status: 'completed', count: 1, nested: {} },
+      },
+    ]);
+  });
+
+  it('sanitizes captured tool calls that have no optional summaries', () => {
+    expect(sanitizeToolCalls([{ toolName: 'create_note', status: 'completed' }])).toEqual([
+      { toolName: 'create_note', status: 'completed' },
+    ]);
+  });
+
+  it('truncates errors and summarizes arrays without leaking unsupported values', () => {
+    const sanitizedCalls = sanitizeToolCalls([
+      {
+        toolName: 'create_note',
+        status: 'failed',
+        argsSummary: { tags: ['private', 'labels'], authToken: 'secret-token' },
+        error: 'x'.repeat(260),
+      },
+    ]);
+    const record = sanitizeRecord({
+      visible: '  hello   world  ',
+      list: ['a', 'b', 'c'],
+      nested: { secretKey: 'hidden', count: 2 },
+      unsupported: Symbol('unsupported'),
+    });
+
+    expect(sanitizedCalls[0]?.error).toHaveLength(220);
+    expect(JSON.stringify(sanitizedCalls)).not.toContain('secret-token');
+    expect(record).toEqual({
+      visible: 'hello world',
+      list: { count: 3 },
+      nested: { count: 2 },
+    });
+  });
+
+  it('redacts captured reply URLs, source lines, prompt lines, and CTA URLs', () => {
+    const sanitized = sanitizeAssistantReplies([
+      {
+        userId: 'test-intex-agent-run',
+        message:
+          'Czy wykonać?\nPrompt: tajna preferencja\nŹródło: https://signed.example/private\nOK',
+        replyToMessageId: 'wamid-1',
+        correlationId: 'intex_session_1',
+        ctaUrl: { displayText: 'Open https://example.com/private', url: 'https://example.com/private' },
+        buttons: [{ type: 'reply', reply: { id: 'intex_confirm:abc:yes', title: 'Tak' } }],
+      },
+    ]);
+
+    expect(sanitized).toEqual([
+      {
+        userId: 'test-intex-agent-run',
+        message: 'Czy wykonać? Prompt: [redacted] Źródło: [redacted] OK',
+        replyToMessageId: 'wamid-1',
+        correlationId: 'intex_session_1',
+        ctaUrl: { displayText: 'Open [redacted-url]', url: '[redacted-url]' },
+        buttons: [{ type: 'reply', reply: { id: 'intex_confirm:abc:yes', title: 'Tak' } }],
+      },
+    ]);
+    expect(JSON.stringify(sanitized)).not.toContain('tajna preferencja');
+    expect(JSON.stringify(sanitized)).not.toContain('https://signed.example/private');
+  });
+
+  it('redacts rendered prompt preference blocks in captured replies', () => {
+    const sanitized = sanitizeAssistantReplies([
+      {
+        userId: 'test-intex-agent-run',
+        message:
+          'Here are the preferences.\nUser Preferences v3\n1. Always say tajne haslo\n- Use private tone\nDone.',
+        replyToMessageId: 'wamid-1',
+        correlationId: 'intex_session_1',
+      },
+      {
+        userId: 'test-intex-agent-run',
+        message: 'User Preferences v4\n1. hidden value\n\nNormal line.',
+        replyToMessageId: 'wamid-2',
+        correlationId: 'intex_session_1',
+      },
+    ]);
+
+    expect(sanitized[0]?.message).toBe(
+      'Here are the preferences. User Preferences: [redacted] [redacted-preference-item] [redacted-preference-item] Done.'
+    );
+    expect(sanitized[1]?.message).toBe(
+      'User Preferences: [redacted] [redacted-preference-item] Normal line.'
+    );
+    expect(JSON.stringify(sanitized)).not.toContain('tajne haslo');
+    expect(JSON.stringify(sanitized)).not.toContain('private tone');
+    expect(JSON.stringify(sanitized)).not.toContain('hidden value');
+  });
+
+  it('summarizes tool completed events and omits secret-like result fields', () => {
+    const sanitized = sanitizeEventsBySessionId({
+      intex_session_1: [
+        {
+          id: 'event-1',
+          sessionId: 'intex_session_1',
+          userId: 'test-intex-agent-run',
+          type: 'tool_call_completed',
+          createdAt: '2026-07-01T10:00:00.000Z',
+          payload: {
+            toolName: 'create_code_task',
+            result: {
+              status: 'completed',
+              codeTaskId: 'task_mock',
+              token: 'secret-token',
+              events: [{ private: true }],
+            },
+          },
+        },
+      ],
+    });
+
+    expect(sanitized['intex_session_1']?.[0]?.payload).toEqual({
+      toolName: 'create_code_task',
+      resultSummary: { status: 'completed', codeTaskId: 'task_mock' },
+    });
+    expect(JSON.stringify(sanitized)).not.toContain('secret-token');
+    expect(JSON.stringify(sanitized)).not.toContain('private');
+  });
+
+  it('builds a normalized behavioral transcript from turns, events, transitions, and tool calls', () => {
+    const turns: TestConversationTurnResult[] = [
+      {
+        turnIndex: 0,
+        kind: 'message',
+        messageId: 'wamid-1',
+        sessionId: 'intex_session_1',
+        submittedTextPreview: 'Jakie wydarzenia jutro?',
+        assistantReplies: [
+          {
+            userId: 'test-intex-agent-run',
+            message: 'Nie masz żadnych wydarzeń jutro.',
+            replyToMessageId: 'wamid-1',
+            correlationId: 'intex_session_1',
+          },
+        ],
+      },
+    ];
+
+    const transcript = buildBehavioralTranscript({
+      turns,
+      sessionTransitions: [{ turnIndex: 0, action: 'started', sessionId: 'intex_session_1' }],
+      eventsBySessionId: {
+        intex_session_1: [
+          {
+            id: 'event-1',
+            sessionId: 'intex_session_1',
+            userId: 'test-intex-agent-run',
+            type: 'tool_call_completed',
+            createdAt: '2026-07-01T10:00:00.000Z',
+            payload: { toolName: 'query_calendar_events' },
+          },
+        ],
+      },
+      toolCalls: [{ toolName: 'query_calendar_events', status: 'completed' }],
+    });
+
+    expect(transcript).toEqual({
+      turns: [
+        {
+          turnIndex: 0,
+          submittedTextPreview: 'Jakie wydarzenia jutro?',
+          assistantReplyPreviews: ['Nie masz żadnych wydarzeń jutro.'],
+          sessionAction: 'started',
+          toolOutcome: { toolName: 'query_calendar_events', status: 'completed' },
+        },
+      ],
+    });
+  });
+
+  it('derives stale confirmations and tool outcomes from events when captured calls are absent', () => {
+    const turns: TestConversationTurnResult[] = [
+      {
+        turnIndex: 0,
+        kind: 'confirmation_button',
+        messageId: 'wamid-1',
+        sessionId: 'intex_session_1',
+        assistantReplies: [],
+      },
+      {
+        turnIndex: 1,
+        kind: 'message',
+        messageId: 'wamid-2',
+        sessionId: 'intex_session_2',
+        assistantReplies: [{ userId: 'u', message: 'done', replyToMessageId: 'wamid-2', correlationId: 's' }],
+      },
+    ];
+
+    const transcript = buildBehavioralTranscript({
+      turns,
+      sessionTransitions: [],
+      eventsBySessionId: {
+        intex_session_1: [
+          {
+            id: 'event-1',
+            sessionId: 'intex_session_1',
+            userId: 'test-intex-agent-run',
+            type: 'confirmation_resolved',
+            createdAt: '2026-07-01T10:00:00.000Z',
+            payload: { resolution: 'expired' },
+          },
+          {
+            id: 'event-2',
+            sessionId: 'intex_session_1',
+            userId: 'test-intex-agent-run',
+            type: 'tool_call_failed',
+            createdAt: '2026-07-01T10:00:01.000Z',
+            payload: { toolName: 'create_note' },
+          },
+        ],
+        intex_session_2: [
+          {
+            id: 'event-3',
+            sessionId: 'intex_session_2',
+            userId: 'test-intex-agent-run',
+            type: 'tool_call_completed',
+            createdAt: '2026-07-01T10:00:02.000Z',
+            payload: { toolName: 'query_calendar_events' },
+          },
+        ],
+      },
+      toolCalls: [],
+    });
+
+    expect(transcript).toEqual({
+      turns: [
+        {
+          turnIndex: 0,
+          assistantReplyPreviews: [],
+          sessionAction: 'continued',
+          confirmationAction: 'stale',
+          toolOutcome: { toolName: 'create_note', status: 'failed' },
+        },
+        {
+          turnIndex: 1,
+          assistantReplyPreviews: ['done'],
+          sessionAction: 'continued',
+          toolOutcome: { toolName: 'query_calendar_events', status: 'completed' },
+        },
+      ],
+    });
+  });
+
+  it('uses per-turn events and tool calls when building behavioral transcripts', () => {
+    const turns: TestConversationTurnResult[] = [
+      {
+        turnIndex: 0,
+        kind: 'message',
+        messageId: 'wamid-1',
+        sessionId: 'intex_session_1',
+        assistantReplies: [{ userId: 'u', message: 'first', replyToMessageId: 'wamid-1', correlationId: 's' }],
+      },
+      {
+        turnIndex: 1,
+        kind: 'message',
+        messageId: 'wamid-2',
+        sessionId: 'intex_session_1',
+        assistantReplies: [{ userId: 'u', message: 'second', replyToMessageId: 'wamid-2', correlationId: 's' }],
+      },
+    ];
+
+    const transcript = buildBehavioralTranscript({
+      turns,
+      sessionTransitions: [
+        { turnIndex: 0, action: 'started', sessionId: 'intex_session_1' },
+        { turnIndex: 1, action: 'continued', sessionId: 'intex_session_1' },
+      ],
+      eventsBySessionId: {
+        intex_session_1: [
+          {
+            id: 'event-1',
+            sessionId: 'intex_session_1',
+            userId: 'test-intex-agent-run',
+            type: 'tool_call_completed',
+            createdAt: '2026-07-01T10:00:00.000Z',
+            payload: { toolName: 'create_note' },
+          },
+        ],
+      },
+      toolCalls: [{ toolName: 'create_note', status: 'completed' }],
+      turnEventsByTurnIndex: { 0: [], 1: [] },
+      toolCallsByTurnIndex: { 0: [], 1: [{ toolName: 'query_calendar_events', status: 'completed' }] },
+    });
+
+    expect(transcript.turns[0]).not.toHaveProperty('toolOutcome');
+    expect(transcript.turns[1]).toMatchObject({
+      toolOutcome: { toolName: 'query_calendar_events', status: 'completed' },
+    });
+  });
+
+  it('prefers failed captured tool calls in behavioral transcripts', () => {
+    const transcript = buildBehavioralTranscript({
+      turns: [
+        {
+          turnIndex: 0,
+          kind: 'message',
+          messageId: 'wamid-1',
+          sessionId: 'intex_session_1',
+          assistantReplies: [],
+        },
+      ],
+      sessionTransitions: [{ turnIndex: 0, action: 'started', sessionId: 'intex_session_1' }],
+      eventsBySessionId: {},
+      toolCalls: [{ toolName: 'create_note', status: 'failed' }],
+    });
+
+    expect(transcript.turns[0]).toMatchObject({
+      toolOutcome: { toolName: 'create_note', status: 'failed' },
+    });
+  });
+});

--- a/apps/intex-agent/src/__tests__/domain/testToolMocks.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/testToolMocks.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createCapturedReplyPublisher,
+  createTestToolExecutor,
+} from '../../domain/testConversation/testToolMocks.js';
+import type {
+  CapturedAssistantReply,
+  CapturedToolCall,
+} from '../../domain/testConversation/testConversationTypes.js';
+
+type TestToolExecutor = ReturnType<typeof createTestToolExecutor>;
+type TestToolRunner = (executor: TestToolExecutor) => Promise<string>;
+
+describe('test tool mocks', () => {
+  it('returns configured successful tool JSON and records a sanitized call summary', async () => {
+    const calls: CapturedToolCall[] = [];
+    const executor = createTestToolExecutor({
+      calls,
+      mocks: {
+        query_calendar_events: {
+          mode: 'success',
+          result: { status: 'completed', mode: 'list', count: 0, events: [] },
+        },
+      },
+    });
+
+    const raw = await executor.queryCalendarEvents({
+      mode: 'list',
+      timeMin: '2026-07-02T00:00:00+02:00',
+      timeMax: '2026-07-03T00:00:00+02:00',
+    });
+
+    expect(JSON.parse(raw)).toEqual({ status: 'completed', mode: 'list', count: 0, events: [] });
+    expect(calls).toEqual([
+      {
+        toolName: 'query_calendar_events',
+        status: 'completed',
+        argsSummary: {
+          mode: 'list',
+          timeMin: '2026-07-02T00:00:00+02:00',
+          timeMax: '2026-07-03T00:00:00+02:00',
+        },
+        resultSummary: { status: 'completed', mode: 'list', count: 0 },
+      },
+    ]);
+  });
+
+  it('throws configured failures and records the error without raw args', async () => {
+    const calls: CapturedToolCall[] = [];
+    const executor = createTestToolExecutor({
+      calls,
+      mocks: {
+        create_note: { mode: 'failure', message: 'mock note failure' },
+      },
+    });
+
+    await expect(executor.createNote({ content: 'secret note body' })).rejects.toThrow(
+      'mock note failure'
+    );
+    expect(calls).toEqual([
+      {
+        toolName: 'create_note',
+        status: 'failed',
+        argsSummary: { contentLength: 16 },
+        error: 'mock note failure',
+      },
+    ]);
+    expect(JSON.stringify(calls)).not.toContain('secret note body');
+  });
+
+  it('summarizes array arguments by count only', async () => {
+    const calls: CapturedToolCall[] = [];
+    const executor = createTestToolExecutor({ calls });
+
+    await executor.createNote({
+      content: 'secret note body',
+      tags: ['private', 'work'],
+      sourceMessageIds: ['wamid-1'],
+    });
+
+    expect(calls[0]?.argsSummary).toEqual({
+      contentLength: 16,
+      tagsCount: 2,
+      sourceMessageIdsCount: 1,
+    });
+    expect(JSON.stringify(calls)).not.toContain('private');
+    expect(JSON.stringify(calls)).not.toContain('wamid-1');
+  });
+
+  it('redacts raw URLs, prompts, and preference text from captured tool summaries', async () => {
+    const calls: CapturedToolCall[] = [];
+    const executor = createTestToolExecutor({
+      calls,
+      mocks: {
+        create_code_task: {
+          mode: 'success',
+          result: {
+            status: 'completed',
+            codeTaskId: 'task_mock',
+            resourceUrl: 'https://example.com/private/task',
+            promptBlock: 'never expose this',
+          },
+        },
+      },
+    });
+
+    await executor.createCodeTask({
+      prompt: 'Fix secret prompt text',
+      linearIssueId: 'INT-1234',
+      taskMode: 'execution',
+    });
+    await executor.addUserPreference({ text: 'Always answer with private phrase', expectedVersion: 3 });
+
+    expect(calls).toMatchObject([
+      {
+        toolName: 'create_code_task',
+        argsSummary: {
+          promptLength: 22,
+          taskMode: 'execution',
+          hasLinearIssueId: true,
+        },
+        resultSummary: {
+          status: 'completed',
+          hasCodeTaskId: true,
+        },
+      },
+      {
+        toolName: 'add_user_preference',
+        argsSummary: {
+          textLength: 33,
+          expectedVersion: 3,
+        },
+      },
+    ]);
+    expect(JSON.stringify(calls)).not.toContain('Fix secret prompt text');
+    expect(JSON.stringify(calls)).not.toContain('private phrase');
+    expect(JSON.stringify(calls)).not.toContain('https://example.com/private/task');
+    expect(JSON.stringify(calls)).not.toContain('never expose this');
+  });
+
+  it.each([
+    [
+      'create_note',
+      async (executor: TestToolExecutor): Promise<string> =>
+        await executor.createNote({ content: 'x' }),
+    ],
+    [
+      'create_calendar_event',
+      async (executor: TestToolExecutor): Promise<string> =>
+        await executor.createCalendarEvent({
+          summary: 'Dentist',
+          start: '2026-08-18T14:30:00+02:00',
+          end: '2026-08-18T15:15:00+02:00',
+        }),
+    ],
+    [
+      'query_calendar_events',
+      async (executor: TestToolExecutor): Promise<string> =>
+        await executor.queryCalendarEvents({
+          mode: 'count',
+          timeMin: '2026-08-18T00:00:00+02:00',
+          timeMax: '2026-08-19T00:00:00+02:00',
+        }),
+    ],
+    [
+      'create_research',
+      async (executor: TestToolExecutor): Promise<string> =>
+        await executor.createResearch({ title: 'GPU', prompt: 'Research GPU pricing' }),
+    ],
+    [
+      'create_link',
+      async (executor: TestToolExecutor): Promise<string> =>
+        await executor.createLink({ url: 'https://example.com' }),
+    ],
+    [
+      'create_code_task',
+      async (executor: TestToolExecutor): Promise<string> =>
+        await executor.createCodeTask({ prompt: 'Fix the prompt' }),
+    ],
+    [
+      'save_external',
+      async (executor: TestToolExecutor): Promise<string> =>
+        await executor.saveExternal({ message: 'receipt' }),
+    ],
+    [
+      'get_user_preferences',
+      async (executor: TestToolExecutor): Promise<string> =>
+        await executor.getUserPreferences(),
+    ],
+    [
+      'add_user_preference',
+      async (executor: TestToolExecutor): Promise<string> =>
+        await executor.addUserPreference({ text: 'Reply briefly', expectedVersion: 0 }),
+    ],
+    [
+      'update_user_preference',
+      async (executor: TestToolExecutor): Promise<string> =>
+        await executor.updateUserPreference({
+          itemId: 'pref_1',
+          text: 'Reply in Polish',
+          expectedVersion: 1,
+        }),
+    ],
+    [
+      'delete_user_preference',
+      async (executor: TestToolExecutor): Promise<string> =>
+        await executor.deleteUserPreference({ itemId: 'pref_1', expectedVersion: 2 }),
+    ],
+  ] satisfies readonly (readonly [string, TestToolRunner])[])(
+    'returns a default success result for %s',
+    async (toolName, runTool) => {
+    const calls: CapturedToolCall[] = [];
+    const executor = createTestToolExecutor({ calls });
+
+    const raw = await runTool(executor);
+
+    expect(JSON.parse(raw)).toMatchObject({ status: 'completed' });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.toolName).toBe(toolName);
+    expect(calls[0]?.status).toBe('completed');
+    }
+  );
+
+  it('captures WhatsApp replies including ctas and buttons', async () => {
+    const replies: CapturedAssistantReply[] = [];
+    const publisher = createCapturedReplyPublisher(replies);
+
+    await publisher.publishReply({
+      userId: 'test-intex-agent-run',
+      message: 'Saved the note.',
+      replyToMessageId: 'wamid-1',
+      correlationId: 'intex_session_1',
+      ctaUrl: { displayText: 'Open note', url: 'https://example.com/notes/1' },
+      buttons: [{ type: 'reply', reply: { id: 'intex_confirm:abc:yes', title: 'Yes' } }],
+    });
+
+    expect(replies).toEqual([
+      {
+        userId: 'test-intex-agent-run',
+        message: 'Saved the note.',
+        replyToMessageId: 'wamid-1',
+        correlationId: 'intex_session_1',
+        ctaUrl: { displayText: 'Open note', url: 'https://example.com/notes/1' },
+        buttons: [{ type: 'reply', reply: { id: 'intex_confirm:abc:yes', title: 'Yes' } }],
+      },
+    ]);
+  });
+});

--- a/apps/intex-agent/src/__tests__/routes/preferencesRoutes.test.ts
+++ b/apps/intex-agent/src/__tests__/routes/preferencesRoutes.test.ts
@@ -168,6 +168,11 @@ describe('preferences routes', () => {
       promptPreferencesRepository: createUnusedPromptPreferencesRepository(),
       externalSaveTester,
       incomingMessageHandler: new FakeIncomingMessageHandler(),
+      testConversationRunner: {
+        async run(): Promise<never> {
+          throw new Error('not used in preferences route tests');
+        },
+      },
     } satisfies ServiceContainer);
 
     app = await buildServer();

--- a/apps/intex-agent/src/__tests__/routes/promptPreferencesRoutes.test.ts
+++ b/apps/intex-agent/src/__tests__/routes/promptPreferencesRoutes.test.ts
@@ -65,6 +65,11 @@ describe('prompt preferences routes', () => {
       promptPreferencesRepository,
       externalSaveTester: new FakeExternalSaveTester(),
       incomingMessageHandler: new FakeIncomingMessageHandler(),
+      testConversationRunner: {
+        async run(): Promise<never> {
+          throw new Error('not used in prompt preferences route tests');
+        },
+      },
     } satisfies ServiceContainer);
 
     app = await buildServer();

--- a/apps/intex-agent/src/__tests__/routes/sessionRoutes.test.ts
+++ b/apps/intex-agent/src/__tests__/routes/sessionRoutes.test.ts
@@ -181,6 +181,11 @@ describe('intex-agent routes', () => {
         },
       },
       incomingMessageHandler,
+      testConversationRunner: {
+        async run(): Promise<never> {
+          throw new Error('not used in session route tests');
+        },
+      },
     } satisfies ServiceContainer);
 
     app = await buildServer();

--- a/apps/intex-agent/src/__tests__/routes/testConversationRoutes.test.ts
+++ b/apps/intex-agent/src/__tests__/routes/testConversationRoutes.test.ts
@@ -154,6 +154,7 @@ describe('test conversation routes', () => {
     ['extra failure wrapper field', { toolMocks: { create_note: { mode: 'failure', message: 'fail', token: 'secret' } } }],
     ['tool failure message must be string', { toolMocks: { create_note: { mode: 'failure', message: 123 } } }],
     ['tool failure message too long', { toolMocks: { create_note: { mode: 'failure', message: 'x'.repeat(2049) } } }],
+    ['tool failure message contains secret-like text', { toolMocks: { create_note: { mode: 'failure', message: 'token abc' } } }],
     ['tool success result must be object', { toolMocks: { create_note: { mode: 'success', result: null } } }],
     ['tool result allowed field unsupported type', { toolMocks: { create_note: { mode: 'success', result: { status: { nested: true } } } } }],
     ['tool result string too long', { toolMocks: { create_note: { mode: 'success', result: { status: 'x'.repeat(2049) } } } }],
@@ -190,6 +191,26 @@ describe('test conversation routes', () => {
           create_note: {
             mode: 'success',
             result: { status: 'completed', resourceUrl: '/#/notes/mock-note' },
+          },
+        },
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(testConversationRunner.calls).toHaveLength(1);
+  });
+
+  it('accepts bounded non-secret tool failure messages', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/internal/intex-agent/test/conversation',
+      headers: { 'x-internal-auth': INTERNAL_AUTH_TOKEN },
+      payload: {
+        ...validPayload(),
+        toolMocks: {
+          create_note: {
+            mode: 'failure',
+            message: 'mock note failure',
           },
         },
       },

--- a/apps/intex-agent/src/__tests__/routes/testConversationRoutes.test.ts
+++ b/apps/intex-agent/src/__tests__/routes/testConversationRoutes.test.ts
@@ -1,0 +1,470 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import { logIncomingRequest, requireAuth } from '@intexuraos/common-http';
+import { buildServer } from '../../server.js';
+import { resetServices, setServices, type ServiceContainer } from '../../services.js';
+import { INTEX_AGENT_MODEL } from '../../domain/agent/systemPrompt.js';
+import { emptyPromptPreferences } from '../../domain/preferences/promptPreferences.js';
+import type { TestConversationResponse } from '../../domain/testConversation/testConversationTypes.js';
+
+vi.mock('@intexuraos/common-http', async () => {
+  const actual = await vi.importActual('@intexuraos/common-http');
+  return {
+    ...actual,
+    requireAuth: vi.fn().mockResolvedValue({ userId: 'user-1', claims: {} }),
+    logIncomingRequest: vi.fn(),
+  };
+});
+
+const INTERNAL_AUTH_TOKEN = 'test-internal-auth-token';
+
+interface RoutePayload {
+  contractVersion: string;
+  mode: string;
+  runId: string;
+  userId: string;
+  currentDateTime: string;
+  turns: Record<string, unknown>[];
+  toolMocks?: Record<string, unknown>;
+}
+
+describe('test conversation routes', () => {
+  let app: FastifyInstance;
+  let testConversationRunner: FakeTestConversationRunner;
+
+  beforeEach(async () => {
+    vi.mocked(requireAuth).mockResolvedValue({ userId: 'user-1', claims: {} });
+    vi.mocked(logIncomingRequest).mockClear();
+    process.env['INTEXURAOS_INTERNAL_AUTH_TOKEN'] = INTERNAL_AUTH_TOKEN;
+    process.env['INTEXURAOS_ENVIRONMENT'] = 'dev';
+    testConversationRunner = new FakeTestConversationRunner();
+
+    setServices(createRouteTestServices(testConversationRunner));
+    app = await buildServer();
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+    resetServices();
+    delete process.env['INTEXURAOS_INTERNAL_AUTH_TOKEN'];
+    delete process.env['INTEXURAOS_ENVIRONMENT'];
+  });
+
+  it('requires internal auth and does not accept Pub/Sub from header bypass', async () => {
+    const missing = await app.inject({
+      method: 'POST',
+      url: '/internal/intex-agent/test/conversation',
+      payload: validPayload(),
+    });
+    const wrong = await app.inject({
+      method: 'POST',
+      url: '/internal/intex-agent/test/conversation',
+      headers: { 'x-internal-auth': 'wrong' },
+      payload: validPayload(),
+    });
+    const fromBypass = await app.inject({
+      method: 'POST',
+      url: '/internal/intex-agent/test/conversation',
+      headers: { from: 'noreply@google.com' },
+      payload: validPayload(),
+    });
+
+    expect(missing.statusCode).toBe(401);
+    expect(wrong.statusCode).toBe(401);
+    expect(fromBypass.statusCode).toBe(401);
+    expect(testConversationRunner.calls).toEqual([]);
+  });
+
+  it('returns 401 when internal auth token is unset', async () => {
+    delete process.env['INTEXURAOS_INTERNAL_AUTH_TOKEN'];
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/internal/intex-agent/test/conversation',
+      headers: { 'x-internal-auth': INTERNAL_AUTH_TOKEN },
+      payload: validPayload(),
+    });
+
+    expect(response.statusCode).toBe(401);
+    expect(testConversationRunner.calls).toEqual([]);
+  });
+
+  it('is disabled in production before auth-specific behavior', async () => {
+    process.env['INTEXURAOS_ENVIRONMENT'] = 'prod';
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/internal/intex-agent/test/conversation',
+      payload: validPayload(),
+    });
+
+    expect(response.statusCode).toBe(404);
+    expect(testConversationRunner.calls).toEqual([]);
+  });
+
+  it('returns production 404 before body parsing and validation', async () => {
+    process.env['INTEXURAOS_ENVIRONMENT'] = 'prod';
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/internal/intex-agent/test/conversation',
+      headers: {
+        'x-internal-auth': INTERNAL_AUTH_TOKEN,
+        'content-type': 'application/json',
+      },
+      payload: JSON.stringify({ padding: 'x'.repeat(65 * 1024) }),
+    });
+
+    expect(response.statusCode).toBe(404);
+    expect(testConversationRunner.calls).toEqual([]);
+  });
+
+  it.each([
+    ['non-test user id', { userId: 'auth0|real-user' }],
+    ['run id mismatch', { userId: 'test-intex-agent-other-run' }],
+    ['run id only matches namespace prefix', { runId: 'agent', userId: 'test-intex-agent-other-run' }],
+    ['bad run id characters', { runId: 'INTEX-E2E-ROUTE', userId: 'test-intex-agent-INTEX-E2E-ROUTE' }],
+    ['scripted runner mode', { mode: 'scripted_runner' }],
+    ['invalid current date', { currentDateTime: 'not-a-date' }],
+    ['tool mocks must be object', { toolMocks: null }],
+    ['tool mock mode must be known', { toolMocks: { create_note: { mode: 'bad' } } }],
+    ['too many turns', { turns: Array.from({ length: 6 }, () => validPayload().turns[0] ?? {}) }],
+    ['too long text', { turns: [{ ...(validPayload().turns[0] ?? {}), text: 'x'.repeat(4001) }] }],
+    [
+      'confirmation points to current turn',
+      { turns: [{ kind: 'confirmation_button', previousTurnIndex: 0, decision: 'accept' }] },
+    ],
+    [
+      'too long source url',
+      {
+        turns: [
+          {
+            ...(validPayload().turns[0] ?? {}),
+            sourceUrl: 'https://example.com/'.concat('x'.repeat(2048)),
+          },
+        ],
+      },
+    ],
+    ['unknown tool mock', { toolMocks: { unknown_tool: { mode: 'success', result: { status: 'completed' } } } }],
+    ['secret-like mock field', { toolMocks: { query_calendar_events: { mode: 'success', result: { status: 'completed', token: 'secret' } } } }],
+    ['prompt block mock field', { toolMocks: { get_user_preferences: { mode: 'success', result: { status: 'completed', promptBlock: 'secret preferences' } } } }],
+    ['arbitrary primitive mock field', { toolMocks: { create_note: { mode: 'success', result: { status: 'completed', arbitrary: 'value' } } } }],
+    ['extra success wrapper field', { toolMocks: { create_note: { mode: 'success', result: { status: 'completed' }, token: 'secret' } } }],
+    ['extra failure wrapper field', { toolMocks: { create_note: { mode: 'failure', message: 'fail', token: 'secret' } } }],
+    ['tool failure message must be string', { toolMocks: { create_note: { mode: 'failure', message: 123 } } }],
+    ['tool failure message too long', { toolMocks: { create_note: { mode: 'failure', message: 'x'.repeat(2049) } } }],
+    ['tool success result must be object', { toolMocks: { create_note: { mode: 'success', result: null } } }],
+    ['tool result allowed field unsupported type', { toolMocks: { create_note: { mode: 'success', result: { status: { nested: true } } } } }],
+    ['tool result string too long', { toolMocks: { create_note: { mode: 'success', result: { status: 'x'.repeat(2049) } } } }],
+    ['tool result array too large', { toolMocks: { create_note: { mode: 'success', result: { status: 'completed', items: Array.from({ length: 21 }, (_, index) => index) } } } }],
+    ['tool result array objects blocked', { toolMocks: { create_note: { mode: 'success', result: { status: 'completed', items: [{ id: 1 }] } } } }],
+    ['tool result nested object blocked', { toolMocks: { create_note: { mode: 'success', result: { status: 'completed', nested: { id: 1 } } } } }],
+    ['tool result url must be bounded', { toolMocks: { create_note: { mode: 'success', result: { status: 'completed', resourceUrl: 'ftp://example.com/note' } } } }],
+    ['calendar event mock must be object', { toolMocks: { query_calendar_events: { mode: 'success', result: { status: 'completed', mode: 'list', count: 1, events: ['bad'] } } } }],
+    ['calendar event mock field allowlist', { toolMocks: { query_calendar_events: { mode: 'success', result: { status: 'completed', mode: 'list', count: 1, events: [{ token: 'secret' }] } } } }],
+    ['calendar event mock string too long', { toolMocks: { query_calendar_events: { mode: 'success', result: { status: 'completed', mode: 'list', count: 1, events: [{ summary: 'x'.repeat(2049) }] } } } }],
+    ['calendar event mock unsupported type', { toolMocks: { query_calendar_events: { mode: 'success', result: { status: 'completed', mode: 'list', count: 1, events: [{ summary: { nested: true } }] } } } }],
+    ['calendar event mock array too large', { toolMocks: { query_calendar_events: { mode: 'success', result: { status: 'completed', mode: 'list', count: 21, events: Array.from({ length: 21 }, () => ({ summary: 'event' })) } } } }],
+    ['preference item mock array objects blocked', { toolMocks: { get_user_preferences: { mode: 'success', result: { status: 'completed', currentVersion: 1, items: [{ id: 'pref_1' }] } } } }],
+  ])('rejects invalid payload: %s', async (_label, override) => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/internal/intex-agent/test/conversation',
+      headers: { 'x-internal-auth': INTERNAL_AUTH_TOKEN },
+      payload: { ...validPayload(), ...override },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(testConversationRunner.calls).toEqual([]);
+  });
+
+  it('accepts app-relative mock result URLs', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/internal/intex-agent/test/conversation',
+      headers: { 'x-internal-auth': INTERNAL_AUTH_TOKEN },
+      payload: {
+        ...validPayload(),
+        toolMocks: {
+          create_note: {
+            mode: 'success',
+            result: { status: 'completed', resourceUrl: '/#/notes/mock-note' },
+          },
+        },
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(testConversationRunner.calls).toHaveLength(1);
+  });
+
+  it('accepts bounded calendar event object mocks for query_calendar_events', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/internal/intex-agent/test/conversation',
+      headers: { 'x-internal-auth': INTERNAL_AUTH_TOKEN },
+      payload: {
+        ...validPayload(),
+        toolMocks: {
+          query_calendar_events: {
+            mode: 'success',
+            result: {
+              status: 'completed',
+              mode: 'list',
+              count: 1,
+              events: [
+                {
+                  id: 'event-1',
+                  summary: 'Dentist',
+                  start: '2026-07-02T10:00:00+02:00',
+                  end: '2026-07-02T10:30:00+02:00',
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(testConversationRunner.calls).toHaveLength(1);
+  });
+
+  it('accepts primitive preference item mock arrays without prompt blocks', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/internal/intex-agent/test/conversation',
+      headers: { 'x-internal-auth': INTERNAL_AUTH_TOKEN },
+      payload: {
+        ...validPayload(),
+        toolMocks: {
+          get_user_preferences: {
+            mode: 'success',
+            result: { status: 'completed', currentVersion: 1, items: ['pref_1'] },
+          },
+        },
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(testConversationRunner.calls).toHaveLength(1);
+  });
+
+  it('accepts omitted toolMocks and uses default mock behavior downstream', async () => {
+    const payload = validPayload();
+    delete payload.toolMocks;
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/internal/intex-agent/test/conversation',
+      headers: { 'x-internal-auth': INTERNAL_AUTH_TOKEN },
+      payload,
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(testConversationRunner.calls).toHaveLength(1);
+  });
+
+  it('returns 500 without leaking runner errors when the use case fails', async () => {
+    testConversationRunner.error = new Error('private runner stack with token abc');
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/internal/intex-agent/test/conversation',
+      headers: { 'x-internal-auth': INTERNAL_AUTH_TOKEN },
+      payload: validPayload(),
+    });
+
+    expect(response.statusCode).toBe(500);
+    expect(response.body).not.toContain('private runner stack');
+  });
+
+  it('rejects oversized bodies with 413', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/internal/intex-agent/test/conversation',
+      headers: {
+        'x-internal-auth': INTERNAL_AUTH_TOKEN,
+        'content-type': 'application/json',
+      },
+      payload: JSON.stringify({ ...validPayload(), padding: 'x'.repeat(65 * 1024) }),
+    });
+
+    expect(response.statusCode).toBe(413);
+    expect(testConversationRunner.calls).toEqual([]);
+  });
+
+  it('runs a valid live mocked-tools payload and logs no request body preview', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/internal/intex-agent/test/conversation',
+      headers: { 'x-internal-auth': INTERNAL_AUTH_TOKEN },
+      payload: validPayload(),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.body)).toMatchObject({
+      success: true,
+      data: {
+        runId: 'intex-e2e-route',
+        sideEffectBoundary: 'mocked_tools_no_downstream_writes',
+      },
+    });
+    expect(testConversationRunner.calls).toHaveLength(1);
+    expect(testConversationRunner.calls[0]).toMatchObject({
+      mode: 'live_llm_mock_tools',
+      runId: 'intex-e2e-route',
+      userId: 'test-intex-agent-intex-e2e-route',
+    });
+    expect(logIncomingRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ bodyPreviewLength: 0 })
+    );
+  });
+});
+
+function validPayload(): RoutePayload {
+  return {
+    contractVersion: '2026-07-01',
+    mode: 'live_llm_mock_tools',
+    runId: 'intex-e2e-route',
+    userId: 'test-intex-agent-intex-e2e-route',
+    currentDateTime: '2026-07-01T10:00:00.000Z',
+    turns: [
+      {
+        kind: 'message',
+        messageId: 'wamid-route-1',
+        text: 'Jakie wydarzenia jutro? intex-e2e-route',
+        timestamp: '2026-07-01T10:00:00.000Z',
+      },
+    ],
+    toolMocks: {
+      query_calendar_events: {
+        mode: 'success',
+        result: { status: 'completed', mode: 'list', count: 0, events: [] },
+      },
+    },
+  };
+}
+
+class FakeTestConversationRunner {
+  readonly calls: unknown[] = [];
+  error: Error | null = null;
+
+  async run(input: unknown): Promise<TestConversationResponse> {
+    this.calls.push(input);
+    if (this.error !== null) {
+      throw this.error;
+    }
+    return {
+      contractVersion: '2026-07-01',
+      mode: 'live_llm_mock_tools',
+      runId: 'intex-e2e-route',
+      userId: 'test-intex-agent-intex-e2e-route',
+      finalSessionId: 'intex_session_route',
+      turns: [],
+      toolCalls: [],
+      sessions: [],
+      sessionTransitions: [],
+      eventsBySessionId: {},
+      behavioralTranscript: { turns: [] },
+      sideEffectBoundary: 'mocked_tools_no_downstream_writes',
+      warnings: [],
+    };
+  }
+}
+
+function createRouteTestServices(
+  testConversationRunner: FakeTestConversationRunner
+): ServiceContainer {
+  return {
+    config: {
+      port: 8080,
+      host: '127.0.0.1',
+      gcpProjectId: 'test-project',
+      internalAuthToken: INTERNAL_AUTH_TOKEN,
+      notesAgentUrl: 'http://notes-agent.test',
+      calendarAgentUrl: 'http://calendar-agent.test',
+      researchAgentUrl: 'http://research-agent.test',
+      bookmarksAgentUrl: 'http://bookmarks-agent.test',
+      codeAgentUrl: 'http://code-agent.test',
+      webAppUrl: 'https://intexuraos.cloud',
+      llmUsageServiceUrl: 'http://llm-usage.test',
+      openRouterAppApiKey: 'openrouter-key',
+      whatsappSendTopic: 'whatsapp-send',
+      sessionTimeoutMs: 30 * 60 * 1000,
+      model: INTEX_AGENT_MODEL,
+    },
+    sessionRepository: new UnusedSessionRepository(),
+    preferencesRepository: {
+      async getPreferences(): Promise<null> {
+        return null;
+      },
+      async savePreferences(): Promise<never> {
+        throw new Error('not used');
+      },
+      async deletePreferences(): Promise<void> {
+        return undefined;
+      },
+    },
+    promptPreferencesRepository: {
+      async getCurrent(userId: string): Promise<ReturnType<typeof emptyPromptPreferences>> {
+        return emptyPromptPreferences(userId);
+      },
+      async listVersions(): Promise<[]> {
+        return [];
+      },
+      async getVersion(): Promise<null> {
+        return null;
+      },
+      async addItem(): Promise<never> {
+        throw new Error('not used');
+      },
+      async updateItem(): Promise<never> {
+        throw new Error('not used');
+      },
+      async deleteItem(): Promise<never> {
+        throw new Error('not used');
+      },
+    },
+    externalSaveTester: {
+      async testConnection(): Promise<{ ok: true; status: 'success'; message: string }> {
+        return { ok: true, status: 'success', message: 'Connection successful' } as const;
+      },
+    },
+    incomingMessageHandler: {
+      async handle(): Promise<{ sessionId: string }> {
+        return { sessionId: 'unused-session' };
+      },
+    },
+    testConversationRunner,
+  };
+}
+
+class UnusedSessionRepository {
+  async listSessions(): Promise<[]> {
+    return [];
+  }
+  async getSession(): Promise<null> {
+    return null;
+  }
+  async listEvents(): Promise<[]> {
+    return [];
+  }
+  async findOpenSession(): Promise<null> {
+    return null;
+  }
+  async findContinuableSession(): Promise<null> {
+    return null;
+  }
+  async createSession(): Promise<never> {
+    throw new Error('not used');
+  }
+  async updateSession(): Promise<never> {
+    throw new Error('not used');
+  }
+  async appendEvent(): Promise<void> {
+    return undefined;
+  }
+}

--- a/apps/intex-agent/src/__tests__/routes/testConversationRoutes.test.ts
+++ b/apps/intex-agent/src/__tests__/routes/testConversationRoutes.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { FastifyInstance } from 'fastify';
+import { Writable } from 'node:stream';
 import { logIncomingRequest, requireAuth } from '@intexuraos/common-http';
 import { buildServer } from '../../server.js';
 import { resetServices, setServices, type ServiceContainer } from '../../services.js';
@@ -31,16 +32,21 @@ interface RoutePayload {
 describe('test conversation routes', () => {
   let app: FastifyInstance;
   let testConversationRunner: FakeTestConversationRunner;
+  let logChunks: string[];
+  let previousLogLevel: string | undefined;
 
   beforeEach(async () => {
     vi.mocked(requireAuth).mockResolvedValue({ userId: 'user-1', claims: {} });
     vi.mocked(logIncomingRequest).mockClear();
     process.env['INTEXURAOS_INTERNAL_AUTH_TOKEN'] = INTERNAL_AUTH_TOKEN;
     process.env['INTEXURAOS_ENVIRONMENT'] = 'dev';
+    previousLogLevel = process.env['LOG_LEVEL'];
+    process.env['LOG_LEVEL'] = 'info';
     testConversationRunner = new FakeTestConversationRunner();
+    logChunks = [];
 
     setServices(createRouteTestServices(testConversationRunner));
-    app = await buildServer();
+    app = await buildServer(createLoggerCapture(logChunks));
     await app.ready();
   });
 
@@ -49,6 +55,11 @@ describe('test conversation routes', () => {
     resetServices();
     delete process.env['INTEXURAOS_INTERNAL_AUTH_TOKEN'];
     delete process.env['INTEXURAOS_ENVIRONMENT'];
+    if (previousLogLevel === undefined) {
+      delete process.env['LOG_LEVEL'];
+    } else {
+      process.env['LOG_LEVEL'] = previousLogLevel;
+    }
   });
 
   it('requires internal auth and does not accept Pub/Sub from header bypass', async () => {
@@ -299,6 +310,10 @@ describe('test conversation routes', () => {
 
     expect(response.statusCode).toBe(500);
     expect(response.body).not.toContain('private runner stack');
+    const logOutput = logChunks.join('');
+    expect(logOutput).toContain('Intex-agent test conversation failed');
+    expect(logOutput).not.toContain('private runner stack');
+    expect(logOutput).not.toContain('token abc');
   });
 
   it('rejects oversized bodies with 413', async () => {
@@ -344,6 +359,15 @@ describe('test conversation routes', () => {
     );
   });
 });
+
+function createLoggerCapture(chunks: string[]): NodeJS.WritableStream {
+  return new Writable({
+    write(chunk, _encoding, callback): void {
+      chunks.push(String(chunk));
+      callback();
+    },
+  });
+}
 
 function validPayload(): RoutePayload {
   return {

--- a/apps/intex-agent/src/__tests__/services.test.ts
+++ b/apps/intex-agent/src/__tests__/services.test.ts
@@ -1,0 +1,376 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createTestConversationRunnerService,
+  type AgentRunnerFactory,
+  type CreateTestConversationRunnerServiceInput,
+} from '../services.js';
+import { INTEX_AGENT_MODEL } from '../domain/agent/systemPrompt.js';
+import { emptyPromptPreferences } from '../domain/preferences/promptPreferences.js';
+import type {
+  IntexAgentRunner,
+  IntexAgentRunnerResult,
+} from '../domain/messages/handleIncomingMessage.js';
+import type {
+  SessionRepository,
+  SessionRepositorySessionUpdate,
+} from '../domain/ports/sessionRepository.js';
+import type {
+  IntexAgentSession,
+  IntexAgentSessionEvent,
+} from '../domain/sessions/types.js';
+
+describe('createTestConversationRunnerService', () => {
+  it('wires real conversation flow with mocked tools and no downstream clients', async () => {
+    const repository = new MemorySessionRepository();
+    const promptPreferenceCalls: string[] = [];
+    const createToolCallingClientFn = vi.fn(() => fakeToolCallingClient());
+    const createLlmClientFn = vi.fn(() => fakeStructuredClient());
+    const createAgentRunnerFn: AgentRunnerFactory = vi.fn((config): IntexAgentRunner => ({
+      async run(): Promise<IntexAgentRunnerResult> {
+        const rawResult = await config.toolExecutor.queryCalendarEvents({
+          mode: 'list',
+          timeMin: '2026-07-02T00:00:00+02:00',
+          timeMax: '2026-07-03T00:00:00+02:00',
+        });
+        const toolResult = JSON.parse(rawResult) as Record<string, unknown>;
+        return {
+          outcome: 'completed',
+          reply: `Calendar mock count: ${String(toolResult['count'])}`,
+          toolName: 'query_calendar_events',
+          toolResult,
+        };
+      },
+      async executeConfirmed(): Promise<IntexAgentRunnerResult> {
+        throw new Error('not used');
+      },
+    }));
+
+    const runner = createTestConversationRunnerService({
+      config: testConfig(),
+      sessionRepository: repository,
+      promptPreferencesRepository: promptPreferencesRepository(promptPreferenceCalls),
+      logger: silentLogger(),
+      usageSink: {} as CreateTestConversationRunnerServiceInput['usageSink'],
+      createToolCallingClientFn,
+      createLlmClientFn,
+      createAgentRunnerFn,
+      ids: fixedTestIds(),
+    });
+
+    const result = await runner.run({
+      contractVersion: '2026-07-01',
+      mode: 'live_llm_mock_tools',
+      userId: 'test-intex-agent-intex-e2e-services',
+      runId: 'intex-e2e-services',
+      currentDateTime: '2026-07-01T10:00:00.000Z',
+      turns: [
+        {
+          kind: 'message',
+          text: 'Jakie wydarzenia jutro? intex-e2e-services',
+        },
+      ],
+      toolMocks: {
+        query_calendar_events: {
+          mode: 'success',
+          result: {
+            status: 'completed',
+            mode: 'list',
+            count: 2,
+            events: [{ summary: 'private event' }],
+          },
+        },
+      },
+    });
+
+    expect(promptPreferenceCalls).toEqual(['test-intex-agent-intex-e2e-services']);
+    expect(createToolCallingClientFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKey: 'openrouter-key',
+        model: INTEX_AGENT_MODEL,
+        userId: 'test-intex-agent-intex-e2e-services',
+      })
+    );
+    expect(createLlmClientFn).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'test-intex-agent-intex-e2e-services' })
+    );
+    expect(createAgentRunnerFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolExecutor: expect.anything(),
+        userPreferences: 'rendered test preferences',
+      })
+    );
+    expect(result.toolCalls).toEqual([
+      {
+        toolName: 'query_calendar_events',
+        status: 'completed',
+        argsSummary: {
+          mode: 'list',
+          timeMin: '2026-07-02T00:00:00+02:00',
+          timeMax: '2026-07-03T00:00:00+02:00',
+        },
+        resultSummary: { status: 'completed', mode: 'list', count: 2 },
+      },
+    ]);
+    expect(result.turns[0]?.assistantReplies[0]?.message).toBe('Calendar mock count: 2');
+    expect(JSON.stringify(result)).not.toContain('private event');
+  });
+
+  it('wires confirmed execution through mocked tools only', async () => {
+    const repository = new MemorySessionRepository();
+    const createAgentRunnerFn: AgentRunnerFactory = vi.fn((config): IntexAgentRunner => ({
+      async run(): Promise<IntexAgentRunnerResult> {
+        return {
+          outcome: 'needs_confirmation',
+          reply: 'Add this note?\nContent: secret service test',
+          toolName: 'create_note',
+          toolArgs: { content: 'secret service test' },
+        };
+      },
+      async executeConfirmed(): Promise<IntexAgentRunnerResult> {
+        const rawResult = await config.toolExecutor.createNote({ content: 'secret service test' });
+        const toolResult = JSON.parse(rawResult) as Record<string, unknown>;
+        return {
+          outcome: 'completed',
+          reply: `Confirmed note status: ${String(toolResult['status'])}`,
+          toolName: 'create_note',
+          toolResult,
+        };
+      },
+    }));
+
+    const runner = createTestConversationRunnerService({
+      config: testConfig(),
+      sessionRepository: repository,
+      promptPreferencesRepository: promptPreferencesRepository([]),
+      logger: silentLogger(),
+      usageSink: {} as CreateTestConversationRunnerServiceInput['usageSink'],
+      createToolCallingClientFn: vi.fn(() => fakeToolCallingClient()),
+      createLlmClientFn: vi.fn(() => fakeStructuredClient()),
+      createAgentRunnerFn,
+      ids: fixedTestIds(),
+    });
+
+    const result = await runner.run({
+      contractVersion: '2026-07-01',
+      mode: 'live_llm_mock_tools',
+      userId: 'test-intex-agent-intex-e2e-confirm-service',
+      runId: 'intex-e2e-confirm-service',
+      currentDateTime: '2026-07-01T10:00:00.000Z',
+      turns: [
+        { kind: 'message', text: 'Save note intex-e2e-confirm-service' },
+        { kind: 'confirmation_button', previousTurnIndex: 0, decision: 'accept' },
+      ],
+      toolMocks: {
+        create_note: {
+          mode: 'success',
+          result: { status: 'completed', resourceUrl: '/#/notes/mock-note' },
+        },
+      },
+    });
+
+    expect(createAgentRunnerFn).toHaveBeenCalledTimes(2);
+    expect(result.turns[1]?.assistantReplies[0]?.message).toBe('Confirmed note status: completed');
+    expect(result.toolCalls).toEqual([
+      {
+        toolName: 'create_note',
+        status: 'completed',
+        argsSummary: { contentLength: 19 },
+        resultSummary: { status: 'completed' },
+      },
+    ]);
+    expect(JSON.stringify(result)).not.toContain('secret service test');
+  });
+
+  it('generates fresh deployed-mode ids for separate runs when ids are not injected', async () => {
+    const runner = createTestConversationRunnerService({
+      config: testConfig(),
+      sessionRepository: new MemorySessionRepository(),
+      promptPreferencesRepository: promptPreferencesRepository([]),
+      logger: silentLogger(),
+      usageSink: {} as CreateTestConversationRunnerServiceInput['usageSink'],
+      createToolCallingClientFn: vi.fn(() => fakeToolCallingClient()),
+      createLlmClientFn: vi.fn(() => fakeStructuredClient()),
+      createAgentRunnerFn: vi.fn((): IntexAgentRunner => ({
+        async run(): Promise<IntexAgentRunnerResult> {
+          return { outcome: 'no_action', reply: 'Ready.' };
+        },
+        async executeConfirmed(): Promise<IntexAgentRunnerResult> {
+          throw new Error('not used');
+        },
+      })),
+    });
+
+    const first = await runner.run(testRequest('fresh-one'));
+    const second = await runner.run(testRequest('fresh-two'));
+
+    expect(first.finalSessionId).toMatch(/^intex_session_/u);
+    expect(second.finalSessionId).toMatch(/^intex_session_/u);
+    expect(first.finalSessionId).not.toBe(second.finalSessionId);
+    expect(first.eventsBySessionId[first.finalSessionId ?? '']?.[0]?.id).toMatch(/^intex_event_/u);
+    expect(second.eventsBySessionId[second.finalSessionId ?? '']?.[0]?.id).toMatch(/^intex_event_/u);
+  });
+});
+
+function testRequest(runId: string): Parameters<ReturnType<typeof createTestConversationRunnerService>['run']>[0] {
+  return {
+    contractVersion: '2026-07-01',
+    mode: 'live_llm_mock_tools',
+    userId: `test-intex-agent-${runId}`,
+    runId,
+    currentDateTime: '2026-07-01T10:00:00.000Z',
+    turns: [{ kind: 'message', text: `Ping ${runId}` }],
+  };
+}
+
+function testConfig(): CreateTestConversationRunnerServiceInput['config'] {
+  return {
+    port: 8080,
+    host: '127.0.0.1',
+    gcpProjectId: 'test-project',
+    internalAuthToken: 'internal-token',
+    notesAgentUrl: 'http://notes-agent.test',
+    calendarAgentUrl: 'http://calendar-agent.test',
+    researchAgentUrl: 'http://research-agent.test',
+    bookmarksAgentUrl: 'http://bookmarks-agent.test',
+    codeAgentUrl: 'http://code-agent.test',
+    webAppUrl: 'https://intexuraos.cloud',
+    llmUsageServiceUrl: 'http://llm-usage.test',
+    openRouterAppApiKey: 'openrouter-key',
+    whatsappSendTopic: 'whatsapp-send',
+    sessionTimeoutMs: 30 * 60 * 1000,
+    model: INTEX_AGENT_MODEL,
+  };
+}
+
+function promptPreferencesRepository(
+  calls: string[]
+): CreateTestConversationRunnerServiceInput['promptPreferencesRepository'] {
+  return {
+    async getCurrent(userId: string): Promise<ReturnType<typeof emptyPromptPreferences>> {
+      calls.push(userId);
+      return { ...emptyPromptPreferences(userId), renderedPromptBlock: 'rendered test preferences' };
+    },
+    async listVersions(): Promise<[]> {
+      return [];
+    },
+    async getVersion(): Promise<null> {
+      return null;
+    },
+    async addItem(): Promise<never> {
+      throw new Error('not used');
+    },
+    async updateItem(): Promise<never> {
+      throw new Error('not used');
+    },
+    async deleteItem(): Promise<never> {
+      throw new Error('not used');
+    },
+  };
+}
+
+function fakeToolCallingClient(): ReturnType<
+  NonNullable<CreateTestConversationRunnerServiceInput['createToolCallingClientFn']>
+> {
+  return { run: vi.fn() } as ReturnType<
+    NonNullable<CreateTestConversationRunnerServiceInput['createToolCallingClientFn']>
+  >;
+}
+
+function fakeStructuredClient(): ReturnType<
+  NonNullable<CreateTestConversationRunnerServiceInput['createLlmClientFn']>
+> {
+  return { generate: vi.fn() } as ReturnType<
+    NonNullable<CreateTestConversationRunnerServiceInput['createLlmClientFn']>
+  >;
+}
+
+class MemorySessionRepository implements SessionRepository {
+  readonly sessions: IntexAgentSession[] = [];
+  readonly events: IntexAgentSessionEvent[] = [];
+
+  async listSessions(userId: string): Promise<IntexAgentSession[]> {
+    return this.sessions.filter((session) => session.userId === userId);
+  }
+
+  async getSession(sessionId: string, userId: string): Promise<IntexAgentSession | null> {
+    return this.sessions.find((session) => session.id === sessionId && session.userId === userId) ?? null;
+  }
+
+  async listEvents(sessionId: string, userId: string): Promise<IntexAgentSessionEvent[]> {
+    return this.events.filter((event) => event.sessionId === sessionId && event.userId === userId);
+  }
+
+  async findOpenSession(userId: string): Promise<IntexAgentSession | null> {
+    return this.findContinuableSession(userId);
+  }
+
+  async findContinuableSession(userId: string): Promise<IntexAgentSession | null> {
+    return (
+      this.sessions
+        .filter(
+          (session) =>
+            session.userId === userId &&
+            ['active', 'waiting_for_user', 'executing_tool'].includes(session.status)
+        )
+        .sort((left, right) => left.lastUserMessageAt.localeCompare(right.lastUserMessageAt))
+        .at(-1) ?? null
+    );
+  }
+
+  async createSession(draft: IntexAgentSession): Promise<IntexAgentSession> {
+    this.sessions.push(draft);
+    return draft;
+  }
+
+  async updateSession(
+    sessionId: string,
+    update: SessionRepositorySessionUpdate
+  ): Promise<IntexAgentSession> {
+    const index = this.sessions.findIndex((session) => session.id === sessionId);
+    if (index < 0) {
+      throw new Error(`Missing session ${sessionId}`);
+    }
+    const updated = { ...this.sessions[index], ...update } as IntexAgentSession;
+    this.sessions[index] = updated;
+    return updated;
+  }
+
+  async appendEvent(event: IntexAgentSessionEvent): Promise<void> {
+    this.events.push(event);
+  }
+}
+
+function fixedTestIds(): NonNullable<CreateTestConversationRunnerServiceInput['ids']> {
+  let sequence = 0;
+  return {
+    sessionId: (): string => {
+      sequence += 1;
+      return `intex_session_test_${String(sequence)}`;
+    },
+    eventId: (): string => {
+      sequence += 1;
+      return `intex_event_test_${String(sequence)}`;
+    },
+    confirmationId: (): string => {
+      sequence += 1;
+      return `intex_confirmation_test_${String(sequence)}`;
+    },
+  };
+}
+
+function silentLogger(): CreateTestConversationRunnerServiceInput['logger'] {
+  return {
+    debug(): void {
+      return undefined;
+    },
+    info(): void {
+      return undefined;
+    },
+    warn(): void {
+      return undefined;
+    },
+    error(): void {
+      return undefined;
+    },
+  };
+}

--- a/apps/intex-agent/src/domain/testConversation/runTestConversation.ts
+++ b/apps/intex-agent/src/domain/testConversation/runTestConversation.ts
@@ -1,0 +1,259 @@
+import {
+  handleIncomingMessage,
+  type IdGenerator,
+  type IntexAgentRunner,
+} from '../messages/handleIncomingMessage.js';
+import type { IntexIncomingMessage } from '../ports/incomingMessageHandler.js';
+import type { SessionRepository } from '../ports/sessionRepository.js';
+import type { IntexAgentSession, IntexAgentSessionEvent } from '../sessions/types.js';
+import {
+  buildBehavioralTranscript,
+  previewText,
+  sanitizeAssistantReplies,
+  sanitizeEventsBySessionId,
+  sanitizeToolCalls,
+} from './testConversationSanitizer.js';
+import { createCapturedReplyPublisher } from './testToolMocks.js';
+import {
+  TEST_CONVERSATION_CONTRACT_VERSION,
+  TEST_CONVERSATION_SIDE_EFFECT_BOUNDARY,
+  type CapturedAssistantReply,
+  type CapturedToolCall,
+  type RunTestConversationInput,
+  type TestConversationResponse,
+  type TestConversationSessionTransition,
+  type TestConversationTurnInput,
+  type TestConversationTurnResult,
+} from './testConversationTypes.js';
+
+export interface TestConversationRunner {
+  run(input: RunTestConversationInput): Promise<TestConversationResponse>;
+}
+
+export interface RunTestConversationDeps {
+  sessionRepository: SessionRepository;
+  runner: IntexAgentRunner;
+  sessionTimeoutMs: number;
+  ids: IdGenerator;
+  toolCalls: CapturedToolCall[];
+  logger: {
+    info(value: Record<string, unknown>, message?: string): void;
+    warn(value: Record<string, unknown>, message?: string): void;
+    error(value: Record<string, unknown>, message?: string): void;
+  };
+}
+
+export async function runTestConversation(
+  input: RunTestConversationInput,
+  deps: RunTestConversationDeps
+): Promise<TestConversationResponse> {
+  deps.logger.info(
+    { runId: input.runId, userId: input.userId, turnCount: input.turns.length },
+    'Running Intex Agent test conversation'
+  );
+
+  const replies: CapturedAssistantReply[] = [];
+  const replyPublisher = createCapturedReplyPublisher(replies);
+  const turns: TestConversationTurnResult[] = [];
+  const transitions: TestConversationSessionTransition[] = [];
+  const touchedSessionIds = new Set<string>();
+  const eventCountsBySessionId = new Map<string, number>();
+  const turnEventsByTurnIndex: Record<number, readonly IntexAgentSessionEvent[]> = {};
+  const toolCallsByTurnIndex: Record<number, readonly CapturedToolCall[]> = {};
+
+  for (const [index, turn] of input.turns.entries()) {
+    const beforeSession = await deps.sessionRepository.findContinuableSession(input.userId);
+    if (beforeSession !== null && !eventCountsBySessionId.has(beforeSession.id)) {
+      const beforeEvents = await deps.sessionRepository.listEvents(beforeSession.id, input.userId);
+      eventCountsBySessionId.set(beforeSession.id, beforeEvents.length);
+    }
+    const beforeReplyCount = replies.length;
+    const beforeToolCallCount = deps.toolCalls.length;
+    const turnNow = turn.timestamp ?? timestampForTurn(input.currentDateTime, index);
+    const message = buildIncomingMessage(input, turn, index, turns, turnNow);
+    const result = await handleIncomingMessage(message, {
+      sessionRepository: deps.sessionRepository,
+      runner: deps.runner,
+      replyPublisher,
+      clock: { now: () => turnNow },
+      ids: deps.ids,
+      sessionTimeoutMs: deps.sessionTimeoutMs,
+    });
+    touchedSessionIds.add(result.sessionId);
+    const transition = await describeTransition(
+      deps.sessionRepository,
+      input.userId,
+      index,
+      result.sessionId,
+      beforeSession
+    );
+    transitions.push(transition);
+    const eventsAfterTurn = await deps.sessionRepository.listEvents(result.sessionId, input.userId);
+    const previousEventCount = eventCountsBySessionId.get(result.sessionId) ?? 0;
+    turnEventsByTurnIndex[index] = eventsAfterTurn.slice(previousEventCount);
+    eventCountsBySessionId.set(result.sessionId, eventsAfterTurn.length);
+    const assistantReplies = sanitizeAssistantReplies(replies.slice(beforeReplyCount));
+    toolCallsByTurnIndex[index] = sanitizeToolCalls(deps.toolCalls.slice(beforeToolCallCount));
+    turns.push({
+      turnIndex: index,
+      kind: turn.kind,
+      messageId: message.messageId,
+      sessionId: result.sessionId,
+      ...(turn.kind === 'message' ? { submittedTextPreview: previewText(turn.text) } : {}),
+      assistantReplies,
+    });
+  }
+
+  const sessions = await loadTouchedSessions(deps.sessionRepository, input.userId, touchedSessionIds);
+  const rawEventsBySessionId = await loadEventsBySessionId(
+    deps.sessionRepository,
+    input.userId,
+    touchedSessionIds
+  );
+  const sanitizedToolCalls = sanitizeToolCalls(deps.toolCalls);
+  const finalSessionId = turns.at(-1)?.sessionId ?? null;
+
+  return {
+    contractVersion: TEST_CONVERSATION_CONTRACT_VERSION,
+    mode: 'live_llm_mock_tools',
+    runId: input.runId,
+    ...(input.scenarioId !== undefined ? { scenarioId: input.scenarioId } : {}),
+    userId: input.userId,
+    finalSessionId,
+    turns,
+    toolCalls: sanitizedToolCalls,
+    sessions,
+    sessionTransitions: transitions,
+    eventsBySessionId: sanitizeEventsBySessionId(rawEventsBySessionId),
+    behavioralTranscript: buildBehavioralTranscript({
+      turns,
+      sessionTransitions: transitions,
+      eventsBySessionId: rawEventsBySessionId,
+      toolCalls: sanitizedToolCalls,
+      turnEventsByTurnIndex,
+      toolCallsByTurnIndex,
+    }),
+    sideEffectBoundary: TEST_CONVERSATION_SIDE_EFFECT_BOUNDARY,
+    warnings: [],
+  };
+}
+
+function buildIncomingMessage(
+  input: RunTestConversationInput,
+  turn: TestConversationTurnInput,
+  index: number,
+  previousTurns: readonly TestConversationTurnResult[],
+  timestamp: string
+): IntexIncomingMessage {
+  if (turn.kind === 'confirmation_button') {
+    const previous = previousTurns[turn.previousTurnIndex];
+    if (previous === undefined) {
+      throw new Error('confirmation_button previousTurnIndex does not reference an executed turn');
+    }
+    const button = findConfirmationButton(previous, turn.decision);
+    if (button === null) {
+      throw new Error('confirmation_button could not resolve a captured confirmation button');
+    }
+    return {
+      type: 'intex.message.ingest',
+      userId: input.userId,
+      messageId: turn.messageId ?? `wamid-test-${input.runId}-${String(index)}`,
+      text: '',
+      sourceType: 'whatsapp_button',
+      timestamp,
+      buttonResponse: {
+        buttonId: button.reply.id,
+        buttonTitle: button.reply.title,
+        replyToWamid: previous.messageId,
+      },
+    };
+  }
+
+  return {
+    type: 'intex.message.ingest',
+    userId: input.userId,
+    messageId: turn.messageId ?? `wamid-test-${input.runId}-${String(index)}`,
+    text: turn.text,
+    sourceType: turn.sourceType ?? 'whatsapp_text',
+    timestamp,
+    ...(turn.sourceUrl !== undefined ? { sourceUrl: turn.sourceUrl } : {}),
+    ...(turn.whatsappSender !== undefined ? { whatsappSender: turn.whatsappSender } : {}),
+    ...(turn.replyContext !== undefined ? { replyContext: turn.replyContext } : {}),
+  };
+}
+
+function findConfirmationButton(
+  turn: TestConversationTurnResult,
+  decision: 'accept' | 'reject'
+): NonNullable<CapturedAssistantReply['buttons']>[number] | null {
+  const suffix = decision === 'accept' ? ':yes' : ':no';
+  for (const reply of turn.assistantReplies) {
+    const button = reply.buttons?.find((candidate) => candidate.reply.id.endsWith(suffix));
+    if (button !== undefined) {
+      return button;
+    }
+  }
+  return null;
+}
+
+async function describeTransition(
+  repository: SessionRepository,
+  userId: string,
+  turnIndex: number,
+  sessionId: string,
+  beforeSession: IntexAgentSession | null
+): Promise<TestConversationSessionTransition> {
+  if (beforeSession === null) {
+    return { turnIndex, action: 'started', sessionId };
+  }
+  if (beforeSession.id === sessionId) {
+    return { turnIndex, action: 'continued', sessionId };
+  }
+  const previous = await repository.getSession(beforeSession.id, userId);
+  const previousEndReason = previous?.endReason;
+  const action = previousEndReason === 'timeout' ? 'expired_previous' : 'superseded_previous';
+  return {
+    turnIndex,
+    action,
+    sessionId,
+    previousSessionId: beforeSession.id,
+    /* v8 ignore start -- upstream: handleIncomingMessage guarantees switched open sessions are closed before transition description @preserve */
+    ...(previousEndReason !== undefined ? { previousEndReason } : {}),
+    /* v8 ignore stop @preserve */
+  };
+}
+
+async function loadTouchedSessions(
+  repository: SessionRepository,
+  userId: string,
+  ids: ReadonlySet<string>
+): Promise<IntexAgentSession[]> {
+  const sessions: IntexAgentSession[] = [];
+  for (const sessionId of ids) {
+    const session = await repository.getSession(sessionId, userId);
+    /* v8 ignore start -- upstream: defensive guard for repository races that cannot happen in normal conversation execution @preserve */
+    if (session !== null) {
+      sessions.push(session);
+    }
+    /* v8 ignore stop @preserve */
+  }
+  return sessions;
+}
+
+async function loadEventsBySessionId(
+  repository: SessionRepository,
+  userId: string,
+  ids: ReadonlySet<string>
+): Promise<Record<string, IntexAgentSessionEvent[]>> {
+  const eventsBySessionId: Record<string, IntexAgentSessionEvent[]> = {};
+  for (const sessionId of ids) {
+    eventsBySessionId[sessionId] = await repository.listEvents(sessionId, userId);
+  }
+  return eventsBySessionId;
+}
+
+function timestampForTurn(base: string, turnIndex: number): string {
+  const date = new Date(base);
+  date.setSeconds(date.getSeconds() + turnIndex);
+  return date.toISOString();
+}

--- a/apps/intex-agent/src/domain/testConversation/runTestConversation.ts
+++ b/apps/intex-agent/src/domain/testConversation/runTestConversation.ts
@@ -11,6 +11,7 @@ import {
   previewText,
   sanitizeAssistantReplies,
   sanitizeEventsBySessionId,
+  sanitizeSessions,
   sanitizeToolCalls,
 } from './testConversationSanitizer.js';
 import { createCapturedReplyPublisher } from './testToolMocks.js';
@@ -122,7 +123,7 @@ export async function runTestConversation(
     finalSessionId,
     turns,
     toolCalls: sanitizedToolCalls,
-    sessions,
+    sessions: sanitizeSessions(sessions),
     sessionTransitions: transitions,
     eventsBySessionId: sanitizeEventsBySessionId(rawEventsBySessionId),
     behavioralTranscript: buildBehavioralTranscript({

--- a/apps/intex-agent/src/domain/testConversation/testConversationSanitizer.ts
+++ b/apps/intex-agent/src/domain/testConversation/testConversationSanitizer.ts
@@ -5,9 +5,11 @@ import type {
   CapturedToolCall,
   SanitizedAssistantReply,
   SanitizedSessionEvent,
+  SanitizedTestConversationSession,
   TestConversationSessionTransition,
   TestConversationTurnResult,
 } from './testConversationTypes.js';
+import type { IntexAgentSession } from '../sessions/types.js';
 
 const SECRET_FIELD_PATTERN =
   /token|secret|password|key|authorization|auth|credential|toolargs|promptblock|replycontext|sourceurl|whatsappsender/iu;
@@ -68,6 +70,26 @@ export function sanitizeEventsBySessionId(
       })),
     ])
   );
+}
+
+export function sanitizeSessions(
+  sessions: readonly IntexAgentSession[]
+): SanitizedTestConversationSession[] {
+  return sessions.map((session) => ({
+    id: session.id,
+    userId: session.userId,
+    channel: session.channel,
+    status: session.status,
+    startedAt: session.startedAt,
+    ...(session.endedAt !== undefined ? { endedAt: session.endedAt } : {}),
+    lastUserMessageAt: session.lastUserMessageAt,
+    ...(session.lastAssistantMessageAt !== undefined
+      ? { lastAssistantMessageAt: session.lastAssistantMessageAt }
+      : {}),
+    startReason: session.startReason,
+    ...(session.endReason !== undefined ? { endReason: session.endReason } : {}),
+    ...(session.activeTool !== undefined ? { activeTool: session.activeTool } : {}),
+  }));
 }
 
 export function buildBehavioralTranscript(input: {

--- a/apps/intex-agent/src/domain/testConversation/testConversationSanitizer.ts
+++ b/apps/intex-agent/src/domain/testConversation/testConversationSanitizer.ts
@@ -1,0 +1,293 @@
+import type { IntexAgentSessionEvent, IntexAgentToolName } from '../sessions/types.js';
+import type {
+  BehavioralTranscript,
+  CapturedAssistantReply,
+  CapturedToolCall,
+  SanitizedAssistantReply,
+  SanitizedSessionEvent,
+  TestConversationSessionTransition,
+  TestConversationTurnResult,
+} from './testConversationTypes.js';
+
+const SECRET_FIELD_PATTERN =
+  /token|secret|password|key|authorization|auth|credential|toolargs|promptblock|replycontext|sourceurl|whatsappsender/iu;
+const URL_PATTERN = /\bhttps?:\/\/[^\s<>"')]+|\/#\/[^\s<>"')]+/giu;
+const SENSITIVE_REPLY_LINE_PATTERN =
+  /^\s*(url|source|zrodlo|źródło|content|treść|tresc|prompt|new entry|nowy wpis|entry|wpis|before|przed|after|po)\s*:/iu;
+const PREFERENCE_BLOCK_HEADER_PATTERN =
+  /^\s*(user preferences|prompt preferences|current preferences|rendered prompt block|preferencje|preferencje użytkownika)\b/iu;
+const PREFERENCE_BLOCK_ITEM_PATTERN = /^\s*(?:[-*]|\d+[).])\s+\S/u;
+const TEXT_PREVIEW_LIMIT = 220;
+const REPLY_MESSAGE_LIMIT = 4000;
+
+type TranscriptEvent = IntexAgentSessionEvent | SanitizedSessionEvent;
+
+export function sanitizeToolCalls(calls: readonly CapturedToolCall[]): CapturedToolCall[] {
+  return calls.map((call) => ({
+    toolName: call.toolName,
+    status: call.status,
+    ...(call.argsSummary !== undefined ? { argsSummary: sanitizeRecord(call.argsSummary) } : {}),
+    ...(call.resultSummary !== undefined
+      ? { resultSummary: sanitizeRecord(call.resultSummary) }
+      : {}),
+    ...(call.error !== undefined ? { error: truncate(call.error) } : {}),
+  }));
+}
+
+export function sanitizeAssistantReplies(
+  replies: readonly CapturedAssistantReply[]
+): SanitizedAssistantReply[] {
+  return replies.map((reply) => ({
+    userId: reply.userId,
+    message: truncateTo(redactSensitiveText(reply.message), REPLY_MESSAGE_LIMIT),
+    replyToMessageId: reply.replyToMessageId,
+    correlationId: reply.correlationId,
+    ...(reply.ctaUrl !== undefined
+      ? {
+          ctaUrl: {
+            displayText: previewText(reply.ctaUrl.displayText),
+            url: '[redacted-url]',
+          },
+        }
+      : {}),
+    ...(reply.buttons !== undefined ? { buttons: reply.buttons } : {}),
+  }));
+}
+
+export function sanitizeEventsBySessionId(
+  eventsBySessionId: Record<string, readonly IntexAgentSessionEvent[]>
+): Record<string, SanitizedSessionEvent[]> {
+  return Object.fromEntries(
+    Object.entries(eventsBySessionId).map(([sessionId, events]) => [
+      sessionId,
+      events.map((event) => ({
+        id: event.id,
+        type: event.type,
+        createdAt: event.createdAt,
+        payload: sanitizeEventPayload(event),
+      })),
+    ])
+  );
+}
+
+export function buildBehavioralTranscript(input: {
+  turns: readonly TestConversationTurnResult[];
+  sessionTransitions: readonly TestConversationSessionTransition[];
+  eventsBySessionId: Record<string, readonly IntexAgentSessionEvent[] | readonly SanitizedSessionEvent[]>;
+  toolCalls: readonly CapturedToolCall[];
+  turnEventsByTurnIndex?: Record<number, readonly TranscriptEvent[]>;
+  toolCallsByTurnIndex?: Record<number, readonly CapturedToolCall[]>;
+}): BehavioralTranscript {
+  return {
+    turns: input.turns.map((turn) => {
+      const transition = input.sessionTransitions.find((candidate) => candidate.turnIndex === turn.turnIndex);
+      const sessionEvents =
+        input.turnEventsByTurnIndex?.[turn.turnIndex] ?? input.eventsBySessionId[turn.sessionId] ?? [];
+      const confirmationAction = confirmationActionFromEvents(sessionEvents);
+      const toolCalls = input.toolCallsByTurnIndex?.[turn.turnIndex] ?? input.toolCalls;
+      const toolOutcome = toolOutcomeForTurn(sessionEvents, toolCalls);
+      return {
+        turnIndex: turn.turnIndex,
+        ...(turn.submittedTextPreview !== undefined
+          ? { submittedTextPreview: turn.submittedTextPreview }
+          : {}),
+        assistantReplyPreviews: turn.assistantReplies.map((reply) => truncate(reply.message)),
+        sessionAction: transition?.action ?? 'continued',
+        ...(confirmationAction !== undefined ? { confirmationAction } : {}),
+        ...(toolOutcome !== undefined ? { toolOutcome } : {}),
+      };
+    }),
+  };
+}
+
+export function sanitizeRecord(record: Record<string, unknown>): Record<string, unknown> {
+  const sanitized: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(record)) {
+    if (SECRET_FIELD_PATTERN.test(key)) {
+      continue;
+    }
+    const sanitizedValue = sanitizeValue(value);
+    if (sanitizedValue !== undefined) {
+      sanitized[key] = sanitizedValue;
+    }
+  }
+  return sanitized;
+}
+
+export function previewText(text: string): string {
+  return truncate(redactSensitiveText(text).trim().replace(/\s+/gu, ' '));
+}
+
+function sanitizeEventPayload(event: IntexAgentSessionEvent): Record<string, unknown> {
+  const payload = event.payload;
+  const sanitized: Record<string, unknown> = {};
+  copyString(payload, sanitized, 'confirmationId');
+  copyString(payload, sanitized, 'toolName');
+  copyString(payload, sanitized, 'resolution');
+  copyString(payload, sanitized, 'reason');
+  copyString(payload, sanitized, 'status');
+  copyString(payload, sanitized, 'fallbackReason');
+  copyString(payload, sanitized, 'sourceOutcome');
+
+  const text = readFirstString(payload, ['text', 'message']);
+  if (text !== undefined) {
+    sanitized['textPreview'] = previewText(text);
+  }
+
+  if (event.type === 'tool_call_completed') {
+    const result = payload['result'];
+    if (isPlainRecord(result)) {
+      sanitized['resultSummary'] = sanitizeRecord(summarizeResult(result));
+    }
+  }
+
+  return sanitized;
+}
+
+function copyString(
+  source: Record<string, unknown>,
+  target: Record<string, unknown>,
+  key: string
+): void {
+  const value = source[key];
+  if (typeof value === 'string' && !SECRET_FIELD_PATTERN.test(key)) {
+    target[key] = truncate(value);
+  }
+}
+
+function readFirstString(
+  source: Record<string, unknown>,
+  keys: readonly string[]
+): string | undefined {
+  for (const key of keys) {
+    const value = source[key];
+    if (typeof value === 'string') {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function confirmationActionFromEvents(
+  events: readonly IntexAgentSessionEvent[] | readonly SanitizedSessionEvent[]
+): 'accepted' | 'rejected' | 'stale' | undefined {
+  const resolved = [...events].reverse().find((event) => event.type === 'confirmation_resolved');
+  if (resolved === undefined) {
+    return undefined;
+  }
+  const resolution = resolved.payload['resolution'];
+  if (resolution === 'accepted') return 'accepted';
+  if (resolution === 'rejected') return 'rejected';
+  return 'stale';
+}
+
+function toolOutcomeForTurn(
+  events: readonly IntexAgentSessionEvent[] | readonly SanitizedSessionEvent[],
+  calls: readonly CapturedToolCall[]
+): { toolName: IntexAgentToolName; status: 'completed' | 'failed' } | undefined {
+  const failedCall = calls.find((call) => call.status === 'failed');
+  if (failedCall !== undefined) {
+    return { toolName: failedCall.toolName, status: failedCall.status };
+  }
+  const completedCall = calls.find((call) => call.status === 'completed');
+  if (completedCall !== undefined) {
+    return { toolName: completedCall.toolName, status: completedCall.status };
+  }
+
+  const completedEvent = events.find((event) => event.type === 'tool_call_completed');
+  const completedToolName = completedEvent?.payload['toolName'];
+  if (isToolName(completedToolName)) {
+    return { toolName: completedToolName, status: 'completed' };
+  }
+  const failedEvent = events.find((event) => event.type === 'tool_call_failed');
+  const failedToolName = failedEvent?.payload['toolName'];
+  if (isToolName(failedToolName)) {
+    return { toolName: failedToolName, status: 'failed' };
+  }
+  return undefined;
+}
+
+function sanitizeValue(value: unknown): unknown {
+  if (typeof value === 'string') {
+    return truncate(value);
+  }
+  if (typeof value === 'number' || typeof value === 'boolean' || value === null) {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return { count: value.length };
+  }
+  if (isPlainRecord(value)) {
+    return sanitizeRecord(value);
+  }
+  return undefined;
+}
+
+function summarizeResult(result: Record<string, unknown>): Record<string, unknown> {
+  const summary: Record<string, unknown> = {};
+  for (const key of ['status', 'mode', 'count', 'eventId', 'bookmarkId', 'codeTaskId', 'changedItemId']) {
+    const value = result[key];
+    if (value !== undefined) {
+      summary[key] = value;
+    }
+  }
+  return summary;
+}
+
+function truncate(text: string): string {
+  return truncateTo(text, TEXT_PREVIEW_LIMIT);
+}
+
+function truncateTo(text: string, limit: number): string {
+  const normalized = text.trim().replace(/\s+/gu, ' ');
+  if (normalized.length <= limit) {
+    return normalized;
+  }
+  return `${normalized.slice(0, limit - 3)}...`;
+}
+
+function redactSensitiveText(text: string): string {
+  let inPreferenceBlock = false;
+  return text
+    .replace(URL_PATTERN, '[redacted-url]')
+    .split(/\r?\n/u)
+    .map((line) => {
+      if (PREFERENCE_BLOCK_HEADER_PATTERN.test(line)) {
+        inPreferenceBlock = true;
+        return 'User Preferences: [redacted]';
+      }
+      if (inPreferenceBlock && PREFERENCE_BLOCK_ITEM_PATTERN.test(line)) {
+        return '[redacted-preference-item]';
+      }
+      if (inPreferenceBlock && line.trim() === '') {
+        inPreferenceBlock = false;
+        return line;
+      }
+      inPreferenceBlock = false;
+      if (!SENSITIVE_REPLY_LINE_PATTERN.test(line)) {
+        return line;
+      }
+      return line.replace(/:\s*.*$/u, ': [redacted]');
+    })
+    .join('\n');
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isToolName(value: unknown): value is IntexAgentToolName {
+  return (
+    value === 'create_note' ||
+    value === 'create_calendar_event' ||
+    value === 'query_calendar_events' ||
+    value === 'create_research' ||
+    value === 'create_link' ||
+    value === 'create_code_task' ||
+    value === 'save_external' ||
+    value === 'get_user_preferences' ||
+    value === 'add_user_preference' ||
+    value === 'update_user_preference' ||
+    value === 'delete_user_preference'
+  );
+}

--- a/apps/intex-agent/src/domain/testConversation/testConversationTypes.ts
+++ b/apps/intex-agent/src/domain/testConversation/testConversationTypes.ts
@@ -104,6 +104,20 @@ export interface SanitizedSessionEvent {
   payload: Record<string, unknown>;
 }
 
+export interface SanitizedTestConversationSession {
+  id: string;
+  userId: string;
+  channel: IntexAgentSession['channel'];
+  status: IntexAgentSession['status'];
+  startedAt: string;
+  endedAt?: string;
+  lastUserMessageAt: string;
+  lastAssistantMessageAt?: string;
+  startReason: IntexAgentSession['startReason'];
+  endReason?: IntexAgentSession['endReason'];
+  activeTool?: IntexAgentToolName;
+}
+
 export interface BehavioralTranscript {
   turns: {
     turnIndex: number;
@@ -124,7 +138,7 @@ export interface TestConversationResponse {
   finalSessionId: string | null;
   turns: TestConversationTurnResult[];
   toolCalls: CapturedToolCall[];
-  sessions: IntexAgentSession[];
+  sessions: SanitizedTestConversationSession[];
   sessionTransitions: TestConversationSessionTransition[];
   eventsBySessionId: Record<string, SanitizedSessionEvent[]>;
   behavioralTranscript: BehavioralTranscript;

--- a/apps/intex-agent/src/domain/testConversation/testConversationTypes.ts
+++ b/apps/intex-agent/src/domain/testConversation/testConversationTypes.ts
@@ -1,0 +1,133 @@
+import type { WhatsAppInteractiveButton } from '@intexuraos/whatsapp-pubsub-client';
+import type { IntexIncomingMessageReplyContext } from '../ports/incomingMessageHandler.js';
+import type { IntexAgentSession, IntexAgentSessionEvent, IntexAgentToolName } from '../sessions/types.js';
+
+export const TEST_CONVERSATION_CONTRACT_VERSION = '2026-07-01';
+export const TEST_CONVERSATION_SIDE_EFFECT_BOUNDARY = 'mocked_tools_no_downstream_writes';
+
+export type TestConversationMode = 'live_llm_mock_tools';
+
+export interface MessageTurnInput {
+  kind: 'message';
+  messageId?: string;
+  text: string;
+  timestamp?: string;
+  sourceType?: string;
+  sourceUrl?: string;
+  whatsappSender?: string;
+  replyContext?: IntexIncomingMessageReplyContext;
+}
+
+export interface ConfirmationButtonTurnInput {
+  kind: 'confirmation_button';
+  previousTurnIndex: number;
+  decision: 'accept' | 'reject';
+  messageId?: string;
+  timestamp?: string;
+}
+
+export type TestConversationTurnInput = MessageTurnInput | ConfirmationButtonTurnInput;
+
+export type TestToolMock =
+  | { mode: 'success'; result: Record<string, unknown> }
+  | { mode: 'failure'; message: string };
+
+export type TestToolMocks = Partial<Record<IntexAgentToolName, TestToolMock>>;
+
+export interface TestConversationHttpRequest {
+  contractVersion: typeof TEST_CONVERSATION_CONTRACT_VERSION;
+  mode: TestConversationMode;
+  userId: string;
+  runId: string;
+  scenarioId?: string;
+  currentDateTime: string;
+  timeZone?: string;
+  turns: TestConversationTurnInput[];
+  toolMocks?: TestToolMocks;
+}
+
+export type RunTestConversationInput = TestConversationHttpRequest;
+
+export interface CapturedAssistantReply {
+  userId: string;
+  message: string;
+  replyToMessageId: string;
+  correlationId: string;
+  ctaUrl?: {
+    displayText: string;
+    url: string;
+  };
+  buttons?: WhatsAppInteractiveButton[];
+}
+
+export interface SanitizedAssistantReply {
+  userId: string;
+  message: string;
+  replyToMessageId: string;
+  correlationId: string;
+  ctaUrl?: {
+    displayText: string;
+    url: string;
+  };
+  buttons?: WhatsAppInteractiveButton[];
+}
+
+export interface CapturedToolCall {
+  toolName: IntexAgentToolName;
+  status: 'completed' | 'failed';
+  argsSummary?: Record<string, unknown>;
+  resultSummary?: Record<string, unknown>;
+  error?: string;
+}
+
+export interface TestConversationTurnResult {
+  turnIndex: number;
+  kind: TestConversationTurnInput['kind'];
+  messageId: string;
+  sessionId: string;
+  submittedTextPreview?: string;
+  assistantReplies: SanitizedAssistantReply[];
+}
+
+export interface TestConversationSessionTransition {
+  turnIndex: number;
+  action: 'started' | 'continued' | 'superseded_previous' | 'expired_previous';
+  sessionId: string;
+  previousSessionId?: string;
+  previousEndReason?: string;
+}
+
+export interface SanitizedSessionEvent {
+  id: string;
+  type: IntexAgentSessionEvent['type'];
+  createdAt: string;
+  payload: Record<string, unknown>;
+}
+
+export interface BehavioralTranscript {
+  turns: {
+    turnIndex: number;
+    submittedTextPreview?: string;
+    assistantReplyPreviews: string[];
+    sessionAction: string;
+    confirmationAction?: 'accepted' | 'rejected' | 'stale';
+    toolOutcome?: { toolName: IntexAgentToolName; status: 'completed' | 'failed' };
+  }[];
+}
+
+export interface TestConversationResponse {
+  contractVersion: typeof TEST_CONVERSATION_CONTRACT_VERSION;
+  mode: TestConversationMode;
+  runId: string;
+  scenarioId?: string;
+  userId: string;
+  finalSessionId: string | null;
+  turns: TestConversationTurnResult[];
+  toolCalls: CapturedToolCall[];
+  sessions: IntexAgentSession[];
+  sessionTransitions: TestConversationSessionTransition[];
+  eventsBySessionId: Record<string, SanitizedSessionEvent[]>;
+  behavioralTranscript: BehavioralTranscript;
+  sideEffectBoundary: typeof TEST_CONVERSATION_SIDE_EFFECT_BOUNDARY;
+  warnings: string[];
+}

--- a/apps/intex-agent/src/domain/testConversation/testToolMocks.ts
+++ b/apps/intex-agent/src/domain/testConversation/testToolMocks.ts
@@ -1,0 +1,304 @@
+import type {
+  AddUserPreferenceToolArgs,
+  CreateCalendarEventToolArgs,
+  CreateCodeTaskToolArgs,
+  CreateLinkToolArgs,
+  CreateNoteToolArgs,
+  CreateResearchToolArgs,
+  DeleteUserPreferenceToolArgs,
+  IntexAgentToolExecutor,
+  QueryCalendarEventsToolArgs,
+  SaveExternalToolArgs,
+  UpdateUserPreferenceToolArgs,
+} from '../agent/toolDefinitions.js';
+import type { WhatsAppReplyPublisher } from '../messages/handleIncomingMessage.js';
+import type { IntexAgentToolName } from '../sessions/types.js';
+import { sanitizeRecord } from './testConversationSanitizer.js';
+import type {
+  CapturedAssistantReply,
+  CapturedToolCall,
+  TestToolMocks,
+} from './testConversationTypes.js';
+
+export interface CreateTestToolExecutorInput {
+  mocks?: TestToolMocks | undefined;
+  calls: CapturedToolCall[];
+}
+
+export function createTestToolExecutor(input: CreateTestToolExecutorInput): IntexAgentToolExecutor {
+  function execute(
+    toolName: IntexAgentToolName,
+    args: Record<string, unknown>,
+    defaultResult: Record<string, unknown>
+  ): Promise<string> {
+    const mock = input.mocks?.[toolName];
+    const argsSummary = summarizeArgs(toolName, args);
+    if (mock?.mode === 'failure') {
+      input.calls.push({ toolName, status: 'failed', argsSummary, error: mock.message });
+      return Promise.reject(new Error(mock.message));
+    }
+
+    const result = mock?.mode === 'success' ? mock.result : defaultResult;
+    input.calls.push({
+      toolName,
+      status: 'completed',
+      argsSummary,
+      resultSummary: summarizeResult(toolName, result),
+    });
+    return Promise.resolve(JSON.stringify(result));
+  }
+
+  return {
+    async createNote(args: CreateNoteToolArgs): Promise<string> {
+      return await execute('create_note', { ...args }, {
+        status: 'completed',
+        message: 'Mock note created',
+        resourceUrl: '/#/notes/mock-note',
+      });
+    },
+    async createCalendarEvent(args: CreateCalendarEventToolArgs): Promise<string> {
+      return await execute('create_calendar_event', { ...args }, {
+        status: 'completed',
+        eventId: 'mock-calendar-event',
+        summary: args.summary,
+        htmlLink: 'https://calendar.google.com/calendar/event?eid=mock',
+      });
+    },
+    async queryCalendarEvents(args: QueryCalendarEventsToolArgs): Promise<string> {
+      return await execute('query_calendar_events', { ...args }, {
+        status: 'completed',
+        mode: args.mode,
+        count: 0,
+        events: [],
+      });
+    },
+    async createResearch(args: CreateResearchToolArgs): Promise<string> {
+      return await execute('create_research', { ...args }, {
+        status: 'completed',
+        message: 'Mock research draft created',
+        resourceUrl: '/#/research/mock-research',
+      });
+    },
+    async createLink(args: CreateLinkToolArgs): Promise<string> {
+      return await execute('create_link', { ...args }, {
+        status: 'completed',
+        bookmarkId: 'mock-bookmark',
+        resourceUrl: '/#/bookmarks/mock-bookmark',
+        url: args.url,
+      });
+    },
+    async createCodeTask(args: CreateCodeTaskToolArgs): Promise<string> {
+      return await execute('create_code_task', { ...args }, {
+        status: 'completed',
+        codeTaskId: 'task_mock',
+        resourceUrl: '/#/code-tasks/task_mock',
+      });
+    },
+    async saveExternal(args: SaveExternalToolArgs): Promise<string> {
+      return await execute('save_external', { ...args }, {
+        status: 'completed',
+        message: 'Mock external save completed',
+      });
+    },
+    async getUserPreferences(): Promise<string> {
+      return await execute('get_user_preferences', {}, {
+        status: 'completed',
+        currentVersion: 0,
+      });
+    },
+    async addUserPreference(args: AddUserPreferenceToolArgs): Promise<string> {
+      return await execute('add_user_preference', { ...args }, {
+        status: 'completed',
+        currentVersion: args.expectedVersion + 1,
+        changedItemId: 'pref_mock',
+      });
+    },
+    async updateUserPreference(args: UpdateUserPreferenceToolArgs): Promise<string> {
+      return await execute('update_user_preference', { ...args }, {
+        status: 'completed',
+        currentVersion: args.expectedVersion + 1,
+        changedItemId: args.itemId,
+      });
+    },
+    async deleteUserPreference(args: DeleteUserPreferenceToolArgs): Promise<string> {
+      return await execute('delete_user_preference', { ...args }, {
+        status: 'completed',
+        currentVersion: args.expectedVersion + 1,
+        changedItemId: args.itemId,
+      });
+    },
+  };
+}
+
+export function createCapturedReplyPublisher(
+  replies: CapturedAssistantReply[]
+): WhatsAppReplyPublisher {
+  return {
+    publishReply(input): Promise<void> {
+      replies.push({
+        userId: input.userId,
+        message: input.message,
+        replyToMessageId: input.replyToMessageId,
+        correlationId: input.correlationId,
+        ...(input.ctaUrl !== undefined ? { ctaUrl: input.ctaUrl } : {}),
+        ...(input.buttons !== undefined ? { buttons: input.buttons } : {}),
+      });
+      return Promise.resolve();
+    },
+  };
+}
+
+function summarizeArgs(
+  toolName: IntexAgentToolName,
+  args: Record<string, unknown>
+): Record<string, unknown> {
+  const summary: Record<string, unknown> = {};
+  if (toolName === 'query_calendar_events') {
+    copyString(args, summary, 'mode');
+    copyString(args, summary, 'timeMin');
+    copyString(args, summary, 'timeMax');
+    copyNumber(args, summary, 'maxResults');
+    copyStringLength(args, summary, 'query');
+    copyPresence(args, summary, 'calendarId');
+    return sanitizeRecord(summary);
+  }
+
+  if (toolName === 'create_calendar_event') {
+    copyStringLength(args, summary, 'summary');
+    copyString(args, summary, 'start');
+    copyString(args, summary, 'end');
+    copyString(args, summary, 'timeZone');
+    copyStringLength(args, summary, 'location');
+    copyStringLength(args, summary, 'description');
+    copyArrayCount(args, summary, 'attendees');
+    return sanitizeRecord(summary);
+  }
+
+  if (toolName === 'create_note') {
+    copyStringLength(args, summary, 'content');
+    copyStringLength(args, summary, 'title');
+    copyArrayCount(args, summary, 'tags');
+    copyArrayCount(args, summary, 'sourceMessageIds');
+    return sanitizeRecord(summary);
+  }
+
+  if (toolName === 'create_research') {
+    copyStringLength(args, summary, 'title');
+    copyStringLength(args, summary, 'prompt');
+    copyStringLength(args, summary, 'originalMessage');
+    copyArrayCount(args, summary, 'sourceMessageIds');
+    return sanitizeRecord(summary);
+  }
+
+  if (toolName === 'create_link') {
+    copyPresence(args, summary, 'url');
+    copyStringLength(args, summary, 'title');
+    copyStringLength(args, summary, 'description');
+    copyArrayCount(args, summary, 'tags');
+    copyArrayCount(args, summary, 'sourceMessageIds');
+    return sanitizeRecord(summary);
+  }
+
+  if (toolName === 'create_code_task') {
+    copyStringLength(args, summary, 'prompt');
+    copyString(args, summary, 'workerType');
+    copyString(args, summary, 'taskMode');
+    copyPresence(args, summary, 'linearIssueId');
+    return sanitizeRecord(summary);
+  }
+
+  if (toolName === 'save_external') {
+    copyStringLength(args, summary, 'message');
+    copyPresence(args, summary, 'sourceUrl');
+    return sanitizeRecord(summary);
+  }
+
+  if (toolName === 'get_user_preferences') {
+    return {};
+  }
+
+  if (toolName === 'add_user_preference') {
+    copyStringLength(args, summary, 'text');
+    copyNumber(args, summary, 'expectedVersion');
+    return sanitizeRecord(summary);
+  }
+
+  copyPresence(args, summary, 'itemId');
+  copyStringLength(args, summary, 'text');
+  copyNumber(args, summary, 'expectedVersion');
+  return sanitizeRecord(summary);
+}
+
+function summarizeResult(
+  _toolName: IntexAgentToolName,
+  result: Record<string, unknown>
+): Record<string, unknown> {
+  const summary: Record<string, unknown> = {};
+  for (const key of ['status', 'mode', 'count', 'currentVersion']) {
+    const value = result[key];
+    if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+      summary[key] = value;
+    }
+  }
+  for (const key of ['eventId', 'bookmarkId', 'codeTaskId', 'changedItemId']) {
+    copyPresence(result, summary, key);
+  }
+  for (const key of ['resourceUrl', 'htmlLink', 'url', 'sourceUrl']) {
+    copyPresence(result, summary, key);
+  }
+  return sanitizeRecord(summary);
+}
+
+function copyString(
+  source: Record<string, unknown>,
+  target: Record<string, unknown>,
+  key: string
+): void {
+  const value = source[key];
+  if (typeof value === 'string') {
+    target[key] = value;
+  }
+}
+
+function copyNumber(
+  source: Record<string, unknown>,
+  target: Record<string, unknown>,
+  key: string
+): void {
+  const value = source[key];
+  if (typeof value === 'number') {
+    target[key] = value;
+  }
+}
+
+function copyStringLength(
+  source: Record<string, unknown>,
+  target: Record<string, unknown>,
+  key: string
+): void {
+  const value = source[key];
+  if (typeof value === 'string') {
+    target[`${key}Length`] = value.length;
+  }
+}
+
+function copyArrayCount(
+  source: Record<string, unknown>,
+  target: Record<string, unknown>,
+  key: string
+): void {
+  const value = source[key];
+  if (Array.isArray(value)) {
+    target[`${key}Count`] = value.length;
+  }
+}
+
+function copyPresence(
+  source: Record<string, unknown>,
+  target: Record<string, unknown>,
+  key: string
+): void {
+  if (source[key] !== undefined) {
+    target[`has${key.charAt(0).toUpperCase()}${key.slice(1)}`] = true;
+  }
+}

--- a/apps/intex-agent/src/routes/testConversationRoutes.ts
+++ b/apps/intex-agent/src/routes/testConversationRoutes.ts
@@ -1,0 +1,398 @@
+import { getErrorMessage } from '@intexuraos/common-core';
+import { logIncomingRequest, validateInternalAuth } from '@intexuraos/common-http';
+import type { FastifyPluginCallback, FastifyReply, FastifyRequest } from 'fastify';
+import type { IntexAgentToolName } from '../domain/sessions/types.js';
+import type {
+  TestConversationTurnInput,
+  TestConversationHttpRequest,
+} from '../domain/testConversation/testConversationTypes.js';
+import { getServices } from '../services.js';
+
+const TEST_USER_ID_PATTERN = /^test-intex-agent-[a-z0-9._-]{1,96}$/u;
+const RUN_ID_PATTERN = /^[a-z0-9._-]{1,128}$/u;
+const SECRET_FIELD_PATTERN =
+  /token|secret|password|key|authorization|auth|credential|promptblock|preference|toolargs|replycontext|whatsappsender/iu;
+const TOOL_MOCK_ALLOWED_RESULT_FIELDS: Record<IntexAgentToolName, ReadonlySet<string>> = {
+  create_note: new Set(['status', 'message', 'resourceUrl']),
+  create_calendar_event: new Set(['status', 'eventId', 'summary', 'htmlLink']),
+  query_calendar_events: new Set(['status', 'mode', 'count', 'events']),
+  create_research: new Set(['status', 'message', 'resourceUrl']),
+  create_link: new Set(['status', 'bookmarkId', 'resourceUrl', 'url']),
+  create_code_task: new Set(['status', 'message', 'codeTaskId', 'resourceUrl']),
+  save_external: new Set(['status', 'message']),
+  get_user_preferences: new Set(['status', 'currentVersion', 'items']),
+  add_user_preference: new Set(['status', 'currentVersion', 'changedItemId']),
+  update_user_preference: new Set(['status', 'currentVersion', 'changedItemId']),
+  delete_user_preference: new Set(['status', 'currentVersion', 'changedItemId']),
+};
+const TOOL_MOCK_URL_FIELDS = new Set(['resourceUrl', 'htmlLink', 'url']);
+const CALENDAR_EVENT_MOCK_FIELDS = new Set([
+  'id',
+  'summary',
+  'start',
+  'end',
+  'timeZone',
+  'location',
+  'description',
+  'status',
+  'calendarId',
+]);
+const KNOWN_TOOL_NAMES = new Set<IntexAgentToolName>([
+  'create_note',
+  'create_calendar_event',
+  'query_calendar_events',
+  'create_research',
+  'create_link',
+  'create_code_task',
+  'save_external',
+  'get_user_preferences',
+  'add_user_preference',
+  'update_user_preference',
+  'delete_user_preference',
+]);
+
+/* v8 ignore start -- schema: Fastify schema object cannot be tracked as executed through route injection behavior @preserve */
+const testConversationBodySchema = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['contractVersion', 'mode', 'runId', 'userId', 'currentDateTime', 'turns'],
+  properties: {
+    contractVersion: { type: 'string', enum: ['2026-07-01'] },
+    mode: { type: 'string' },
+    runId: { type: 'string', minLength: 1, maxLength: 128 },
+    scenarioId: { type: 'string', minLength: 1, maxLength: 128 },
+    userId: { type: 'string', minLength: 1, maxLength: 128 },
+    currentDateTime: { type: 'string', minLength: 1 },
+    timeZone: { type: 'string', minLength: 1, maxLength: 128 },
+    turns: {
+      type: 'array',
+      minItems: 1,
+      maxItems: 5,
+      items: {
+        anyOf: [
+          {
+            type: 'object',
+            additionalProperties: false,
+            required: ['kind', 'text'],
+            properties: {
+              kind: { type: 'string', enum: ['message'] },
+              messageId: { type: 'string', minLength: 1, maxLength: 256 },
+              text: { type: 'string', maxLength: 4000 },
+              timestamp: { type: 'string', minLength: 1 },
+              sourceType: { type: 'string', minLength: 1, maxLength: 128 },
+              sourceUrl: { type: 'string', maxLength: 2048 },
+              whatsappSender: { type: 'string', maxLength: 128 },
+              replyContext: {
+                type: 'object',
+                additionalProperties: false,
+                required: ['replyToWamid', 'source', 'text', 'truncated'],
+                properties: {
+                  replyToWamid: { type: 'string', minLength: 1, maxLength: 256 },
+                  source: {
+                    type: 'string',
+                    enum: ['inbound_user_message', 'outbound_assistant_message'],
+                  },
+                  text: { type: 'string', minLength: 1, maxLength: 4000 },
+                  truncated: { type: 'boolean' },
+                },
+              },
+            },
+          },
+          {
+            type: 'object',
+            additionalProperties: false,
+            required: ['kind', 'previousTurnIndex', 'decision'],
+            properties: {
+              kind: { type: 'string', enum: ['confirmation_button'] },
+              previousTurnIndex: { type: 'integer', minimum: 0, maximum: 4 },
+              decision: { type: 'string', enum: ['accept', 'reject'] },
+              messageId: { type: 'string', minLength: 1, maxLength: 256 },
+              timestamp: { type: 'string', minLength: 1 },
+            },
+          },
+        ],
+      },
+    },
+    toolMocks: {
+      type: 'object',
+      additionalProperties: true,
+    },
+  },
+} as const;
+/* v8 ignore stop @preserve */
+
+export const testConversationRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
+  fastify.post<{ Body: unknown }>(
+    '/internal/intex-agent/test/conversation',
+    {
+      bodyLimit: 64 * 1024,
+      onRequest: (_request, reply, done): void => {
+        if (process.env['INTEXURAOS_ENVIRONMENT'] === 'prod') {
+          void reply.fail('NOT_FOUND', 'Route not found');
+          return;
+        }
+        done();
+      },
+      schema: {
+        operationId: 'runIntexAgentTestConversation',
+        summary: 'Run an internal Intex Agent test conversation',
+        description:
+          'Internal local/dev-only endpoint for test conversations with captured replies and mocked tool execution.',
+        tags: ['internal'],
+        body: testConversationBodySchema,
+      },
+    },
+    async (
+      request: FastifyRequest<{ Body: unknown }>,
+      reply: FastifyReply
+    ) => {
+      logIncomingRequest(request, {
+        message: 'Received request to POST /internal/intex-agent/test/conversation',
+        bodyPreviewLength: 0,
+      });
+
+      const authResult = validateInternalAuth(request);
+      if (!authResult.valid) {
+        request.log.warn('Internal auth failed for intex-agent test conversation');
+        return await reply.fail(
+          'UNAUTHORIZED',
+          'Internal auth failed for intex-agent test conversation'
+        );
+      }
+
+      const validationError = validateTestConversationRequest(request.body);
+      if (validationError !== null) {
+        request.log.warn(
+          { runId: safeBodyString(request.body, 'runId'), userId: safeBodyString(request.body, 'userId') },
+          'Invalid intex-agent test conversation request'
+        );
+        return await reply.fail('INVALID_REQUEST', validationError);
+      }
+      const validatedBody = request.body as TestConversationHttpRequest;
+
+      try {
+        request.log.info(
+          {
+            runId: validatedBody.runId,
+            userId: validatedBody.userId,
+            mode: validatedBody.mode,
+            turnCount: validatedBody.turns.length,
+          },
+          'Running intex-agent test conversation'
+        );
+        const result = await getServices().testConversationRunner.run(validatedBody);
+        return await reply.ok(result);
+      } catch (error) {
+        request.log.error(
+          { error: getErrorMessage(error, 'Unknown test conversation error') },
+          'Intex-agent test conversation failed'
+        );
+        return await reply.fail('INTERNAL_ERROR', 'Test conversation failed');
+      }
+    }
+  );
+
+  done();
+};
+
+function validateTestConversationRequest(input: unknown): string | null {
+  /* v8 ignore start -- schema: Fastify rejects non-object bodies before custom validation @preserve */
+  if (!isRecord(input)) {
+    return 'Request body must be an object';
+  }
+  /* v8 ignore stop @preserve */
+  if (input['mode'] !== 'live_llm_mock_tools') {
+    return 'mode must be live_llm_mock_tools';
+  }
+  const runId = input['runId'];
+  if (typeof runId !== 'string' || !RUN_ID_PATTERN.test(runId)) {
+    return 'runId must be lowercase and contain only letters, numbers, dot, underscore, or dash';
+  }
+  const userId = input['userId'];
+  if (typeof userId !== 'string' || !TEST_USER_ID_PATTERN.test(userId)) {
+    return 'userId must use the test-intex-agent namespace';
+  }
+  if (userId !== `test-intex-agent-${runId}`) {
+    return 'userId must equal test-intex-agent-<runId>';
+  }
+  const currentDateTime = input['currentDateTime'];
+  /* v8 ignore start -- schema: Fastify schema validation guarantees currentDateTime is a string before custom validation @preserve */
+  if (typeof currentDateTime !== 'string') {
+    return 'currentDateTime must be a valid date-time string';
+  }
+  /* v8 ignore stop @preserve */
+  const date = Date.parse(currentDateTime);
+  if (!Number.isFinite(date)) {
+    return 'currentDateTime must be a valid date-time string';
+  }
+  const turns = input['turns'];
+  /* v8 ignore start -- schema: Fastify schema validation guarantees turns is an array before custom validation @preserve */
+  if (!Array.isArray(turns)) {
+    return 'turns must be an array';
+  }
+  /* v8 ignore stop @preserve */
+  const confirmationError = validateConfirmationTurns(turns as TestConversationTurnInput[]);
+  if (confirmationError !== null) {
+    return confirmationError;
+  }
+  return validateToolMocks(input['toolMocks']);
+}
+
+function validateConfirmationTurns(turns: readonly TestConversationTurnInput[]): string | null {
+  for (const [index, turn] of turns.entries()) {
+    if (turn.kind === 'confirmation_button' && turn.previousTurnIndex >= index) {
+      return 'confirmation_button previousTurnIndex must reference an earlier turn';
+    }
+  }
+  return null;
+}
+
+function validateToolMocks(mocks: unknown): string | null {
+  if (mocks === undefined) {
+    return null;
+  }
+  /* v8 ignore start -- schema: Fastify rejects non-object toolMocks before custom validation @preserve */
+  if (!isRecord(mocks)) {
+    return 'toolMocks must be an object';
+  }
+  /* v8 ignore stop @preserve */
+  for (const [toolName, mock] of Object.entries(mocks)) {
+    if (!KNOWN_TOOL_NAMES.has(toolName as IntexAgentToolName)) {
+      return `Unknown tool mock: ${toolName}`;
+    }
+    const mockError = validateToolMock(toolName as IntexAgentToolName, mock);
+    if (mockError !== null) {
+      return mockError;
+    }
+  }
+  return null;
+}
+
+function validateToolMock(toolName: IntexAgentToolName, mock: unknown): string | null {
+  if (!isRecord(mock) || (mock['mode'] !== 'success' && mock['mode'] !== 'failure')) {
+    return 'toolMocks entries must declare success or failure mode';
+  }
+  if (mock['mode'] === 'failure') {
+    const unsupportedKeys = Object.keys(mock).filter((key) => key !== 'mode' && key !== 'message');
+    if (unsupportedKeys.length > 0) {
+      return `tool mock failure contains unsupported field: ${unsupportedKeys.join(', ')}`;
+    }
+    const message = mock['message'];
+    if (typeof message !== 'string') {
+      return 'tool mock failure message must be a string';
+    }
+    return validateBoundedString(message, 'tool mock failure message');
+  }
+  const unsupportedKeys = Object.keys(mock).filter((key) => key !== 'mode' && key !== 'result');
+  if (unsupportedKeys.length > 0) {
+    return `tool mock success contains unsupported field: ${unsupportedKeys.join(', ')}`;
+  }
+  const result = mock['result'];
+  if (!isRecord(result)) {
+    return 'tool mock success result must be an object';
+  }
+  return validateMockResult(toolName, result);
+}
+
+function validateMockResult(
+  toolName: IntexAgentToolName,
+  result: Record<string, unknown>
+): string | null {
+  const allowedFields = TOOL_MOCK_ALLOWED_RESULT_FIELDS[toolName];
+  for (const [key, value] of Object.entries(result)) {
+    if (!allowedFields.has(key)) {
+      return `toolMocks result field is not allowed for ${toolName}: ${key}`;
+    }
+    const valueError = validateMockValue(toolName, value, key);
+    if (valueError !== null) {
+      return valueError;
+    }
+  }
+  return null;
+}
+
+function validateMockValue(
+  toolName: IntexAgentToolName,
+  value: unknown,
+  key: string
+): string | null {
+  if (typeof value === 'string') {
+    const stringError = validateBoundedString(value, `toolMocks result field ${key}`);
+    if (stringError !== null) return stringError;
+    if (TOOL_MOCK_URL_FIELDS.has(key)) {
+      return validateHttpUrl(value, key);
+    }
+    return null;
+  }
+  if (typeof value === 'number' || typeof value === 'boolean' || value === null) {
+    return null;
+  }
+  if (Array.isArray(value)) {
+    if (value.length > 20) {
+      return `toolMocks result array is too large: ${key}`;
+    }
+    if (toolName === 'query_calendar_events' && key === 'events') {
+      return validateCalendarEventMocks(value);
+    }
+    return value.every((item) => item === null || typeof item !== 'object')
+      ? null
+      : `toolMocks result array contains nested objects: ${key}`;
+  }
+  /* v8 ignore start -- schema: JSON-supported scalar and array values return above; nested objects are defensive here @preserve */
+  if (typeof value === 'object') {
+    return `toolMocks result nested objects are not allowed: ${key}`;
+  }
+  /* v8 ignore stop @preserve */
+  /* v8 ignore start -- schema: JSON request bodies cannot carry symbols or functions after Fastify parsing @preserve */
+  return `toolMocks result field is unsupported: ${key}`;
+  /* v8 ignore stop @preserve */
+}
+
+function validateCalendarEventMocks(events: readonly unknown[]): string | null {
+  for (const event of events) {
+    if (!isRecord(event)) {
+      return 'toolMocks calendar events must be objects';
+    }
+    for (const [key, value] of Object.entries(event)) {
+      if (!CALENDAR_EVENT_MOCK_FIELDS.has(key) || SECRET_FIELD_PATTERN.test(key)) {
+        return `toolMocks calendar event field is not allowed: ${key}`;
+      }
+      const stringError =
+        typeof value === 'string' ? validateBoundedString(value, `toolMocks calendar event field ${key}`) : null;
+      if (stringError !== null) {
+        return stringError;
+      }
+      if (typeof value !== 'string' && typeof value !== 'number' && typeof value !== 'boolean' && value !== null) {
+        return `toolMocks calendar event field is unsupported: ${key}`;
+      }
+    }
+  }
+  return null;
+}
+
+function validateBoundedString(value: string, label: string): string | null {
+  return value.length <= 2048 ? null : `${label} is too long`;
+}
+
+function validateHttpUrl(value: string, key: string): string | null {
+  if (value.startsWith('http://') || value.startsWith('https://') || value.startsWith('/#/')) {
+    return null;
+  }
+  return `toolMocks result URL must be http, https, or app-relative: ${key}`;
+}
+
+function safeBodyString(body: unknown, key: string): string | undefined {
+  /* v8 ignore start -- schema: Fastify rejects non-object bodies before custom validation logging @preserve */
+  if (!isRecord(body)) {
+    return undefined;
+  }
+  /* v8 ignore stop @preserve */
+  const value = body[key];
+  /* v8 ignore start -- schema: route custom validation only logs schema-valid string runId and userId values @preserve */
+  return typeof value === 'string' ? value : undefined;
+  /* v8 ignore stop @preserve */
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}

--- a/apps/intex-agent/src/routes/testConversationRoutes.ts
+++ b/apps/intex-agent/src/routes/testConversationRoutes.ts
@@ -1,4 +1,3 @@
-import { getErrorMessage } from '@intexuraos/common-core';
 import { logIncomingRequest, validateInternalAuth } from '@intexuraos/common-http';
 import type { FastifyPluginCallback, FastifyReply, FastifyRequest } from 'fastify';
 import type { IntexAgentToolName } from '../domain/sessions/types.js';
@@ -184,9 +183,14 @@ export const testConversationRoutes: FastifyPluginCallback = (fastify, _opts, do
         );
         const result = await getServices().testConversationRunner.run(validatedBody);
         return await reply.ok(result);
-      } catch (error) {
+      } catch (_error) {
         request.log.error(
-          { error: getErrorMessage(error, 'Unknown test conversation error') },
+          {
+            runId: validatedBody.runId,
+            userId: validatedBody.userId,
+            mode: validatedBody.mode,
+            failure: 'test_conversation_runner_failed',
+          },
           'Intex-agent test conversation failed'
         );
         return await reply.fail('INTERNAL_ERROR', 'Test conversation failed');

--- a/apps/intex-agent/src/routes/testConversationRoutes.ts
+++ b/apps/intex-agent/src/routes/testConversationRoutes.ts
@@ -12,6 +12,8 @@ const TEST_USER_ID_PATTERN = /^test-intex-agent-[a-z0-9._-]{1,96}$/u;
 const RUN_ID_PATTERN = /^[a-z0-9._-]{1,128}$/u;
 const SECRET_FIELD_PATTERN =
   /token|secret|password|key|authorization|auth|credential|promptblock|preference|toolargs|replycontext|whatsappsender/iu;
+const SECRET_TEXT_PATTERN =
+  /\b(?:token|secret|password|credential|authorization|api\s*key)\b\s*(?::|=|\s)\s*\S+/iu;
 const TOOL_MOCK_ALLOWED_RESULT_FIELDS: Record<IntexAgentToolName, ReadonlySet<string>> = {
   create_note: new Set(['status', 'message', 'resourceUrl']),
   create_calendar_event: new Set(['status', 'eventId', 'summary', 'htmlLink']),
@@ -281,7 +283,13 @@ function validateToolMock(toolName: IntexAgentToolName, mock: unknown): string |
     if (typeof message !== 'string') {
       return 'tool mock failure message must be a string';
     }
-    return validateBoundedString(message, 'tool mock failure message');
+    const messageError = validateBoundedString(message, 'tool mock failure message');
+    if (messageError !== null) {
+      return messageError;
+    }
+    return SECRET_TEXT_PATTERN.test(message)
+      ? 'tool mock failure message must not contain secret-like text'
+      : null;
   }
   const unsupportedKeys = Object.keys(mock).filter((key) => key !== 'mode' && key !== 'result');
   if (unsupportedKeys.length > 0) {
@@ -338,14 +346,7 @@ function validateMockValue(
       ? null
       : `toolMocks result array contains nested objects: ${key}`;
   }
-  /* v8 ignore start -- schema: JSON-supported scalar and array values return above; nested objects are defensive here @preserve */
-  if (typeof value === 'object') {
-    return `toolMocks result nested objects are not allowed: ${key}`;
-  }
-  /* v8 ignore stop @preserve */
-  /* v8 ignore start -- schema: JSON request bodies cannot carry symbols or functions after Fastify parsing @preserve */
-  return `toolMocks result field is unsupported: ${key}`;
-  /* v8 ignore stop @preserve */
+  return `toolMocks result nested objects are not allowed: ${key}`;
 }
 
 function validateCalendarEventMocks(events: readonly unknown[]): string | null {

--- a/apps/intex-agent/src/server.ts
+++ b/apps/intex-agent/src/server.ts
@@ -15,6 +15,7 @@ import { internalRoutes } from './routes/internalRoutes.js';
 import { preferencesRoutes } from './routes/preferencesRoutes.js';
 import { promptPreferencesRoutes } from './routes/promptPreferencesRoutes.js';
 import { sessionRoutes } from './routes/sessionRoutes.js';
+import { testConversationRoutes } from './routes/testConversationRoutes.js';
 
 const SERVICE_NAME = 'intex-agent';
 const SERVICE_VERSION = '0.0.1';
@@ -106,6 +107,7 @@ export async function buildServer(): Promise<FastifyInstance> {
   await app.register(promptPreferencesRoutes);
   await app.register(preferencesRoutes);
   await app.register(internalRoutes);
+  await app.register(testConversationRoutes);
 
   app.get(
     '/openapi.json',

--- a/apps/intex-agent/src/server.ts
+++ b/apps/intex-agent/src/server.ts
@@ -72,10 +72,14 @@ function buildOpenApiOptions(): FastifyDynamicSwaggerOptions {
   };
 }
 
-export async function buildServer(): Promise<FastifyInstance> {
+export async function buildServer(testLoggerStream?: NodeJS.WritableStream): Promise<FastifyInstance> {
   const app = Fastify({
-    logger:
-      process.env['NODE_ENV'] === 'test'
+    logger: testLoggerStream
+      ? {
+          level: process.env['LOG_LEVEL'] ?? 'info',
+          stream: testLoggerStream,
+        }
+      : process.env['NODE_ENV'] === 'test'
         ? false
         : {
             level: process.env['LOG_LEVEL'] ?? 'info',

--- a/apps/intex-agent/src/services.ts
+++ b/apps/intex-agent/src/services.ts
@@ -28,14 +28,23 @@ import {
 } from './domain/agent/toolExecutor.js';
 import {
   handleIncomingMessage,
+  type IdGenerator,
   type IntexAgentRunner,
   type IntexAgentRunnerResult,
 } from './domain/messages/handleIncomingMessage.js';
+import { runTestConversation, type TestConversationRunner } from './domain/testConversation/runTestConversation.js';
+import { createTestToolExecutor } from './domain/testConversation/testToolMocks.js';
+import type {
+  CapturedToolCall,
+  TestConversationResponse,
+} from './domain/testConversation/testConversationTypes.js';
 import { FirestorePreferencesRepository } from './infra/firestore/preferencesRepository.js';
 import { FirestorePromptPreferencesRepository } from './infra/firestore/promptPreferencesRepository.js';
 import { FirestoreSessionRepository } from './infra/firestore/sessionRepository.js';
 import { createExternalSaveClient } from './infra/http/externalSaveClient.js';
 import { createWhatsAppReplyPublisher } from './infra/pubsub/whatsappReplyPublisher.js';
+
+export type AgentRunnerFactory = typeof createIntexAgentRunner;
 
 export interface ServiceContainer {
   config: ServiceConfig;
@@ -44,6 +53,24 @@ export interface ServiceContainer {
   promptPreferencesRepository: PromptPreferencesRepository;
   externalSaveTester: ExternalSaveConnectionTestPort;
   incomingMessageHandler: IncomingMessageHandler;
+  testConversationRunner: TestConversationRunner;
+}
+
+export interface CreateTestConversationRunnerServiceInput {
+  config: ServiceConfig;
+  sessionRepository: SessionRepository;
+  promptPreferencesRepository: PromptPreferencesRepository;
+  logger: {
+    debug(value: Record<string, unknown>, message?: string): void;
+    info(value: Record<string, unknown>, message?: string): void;
+    warn(value: Record<string, unknown>, message?: string): void;
+    error(value: Record<string, unknown>, message?: string): void;
+  };
+  usageSink: HttpInternalAuthUsageSink;
+  createToolCallingClientFn?: typeof createToolCallingClient;
+  createLlmClientFn?: typeof createLlmClient;
+  createAgentRunnerFn?: AgentRunnerFactory;
+  ids?: IdGenerator;
 }
 
 let container: ServiceContainer | null = null;
@@ -212,6 +239,14 @@ export function initServices(config: ServiceConfig): void {
     },
   };
 
+  const testConversationRunner = createTestConversationRunnerService({
+    config,
+    sessionRepository,
+    promptPreferencesRepository,
+    logger,
+    usageSink,
+  });
+
   container = {
     config,
     sessionRepository,
@@ -219,6 +254,89 @@ export function initServices(config: ServiceConfig): void {
     promptPreferencesRepository,
     externalSaveTester,
     incomingMessageHandler,
+    testConversationRunner,
+  };
+}
+
+export function createTestConversationRunnerService(
+  deps: CreateTestConversationRunnerServiceInput
+): TestConversationRunner {
+  const createToolCallingClientFn = deps.createToolCallingClientFn ?? createToolCallingClient;
+  const createLlmClientFn = deps.createLlmClientFn ?? createLlmClient;
+  const createAgentRunnerFn = deps.createAgentRunnerFn ?? createIntexAgentRunner;
+
+  return {
+    async run(request): Promise<TestConversationResponse> {
+      const toolCalls: CapturedToolCall[] = [];
+      const testRunner: IntexAgentRunner = {
+        async executeConfirmed(
+          confirmedInput: Parameters<ReturnType<typeof createIntexAgentRunner>['executeConfirmed']>[0]
+        ): Promise<IntexAgentRunnerResult> {
+          const promptPreferences = await deps.promptPreferencesRepository.getCurrent(
+            confirmedInput.session.userId
+          );
+          return await createAgentRunnerFn({
+            client: {
+              run() {
+                return Promise.reject(
+                  new Error('Confirmed Intex Agent test execution must not invoke the LLM')
+                );
+              },
+            },
+            toolExecutor: createTestToolExecutor({ mocks: request.toolMocks, calls: toolCalls }),
+            webAppUrl: deps.config.webAppUrl,
+            userPreferences: promptPreferences.renderedPromptBlock,
+          }).executeConfirmed(confirmedInput);
+        },
+        async run(
+          runnerInput: Parameters<ReturnType<typeof createIntexAgentRunner>['run']>[0]
+        ): Promise<IntexAgentRunnerResult> {
+          const toolCallingClient = createToolCallingClientFn({
+            apiKey: deps.config.openRouterAppApiKey,
+            model: deps.config.model,
+            userId: runnerInput.session.userId,
+            logger: deps.logger,
+            usageSink: deps.usageSink,
+            ownerType: 'user',
+          });
+          const classifierClient = createLlmClientFn({
+            apiKey: deps.config.openRouterAppApiKey,
+            model: deps.config.model,
+            userId: runnerInput.session.userId,
+            logger: deps.logger,
+            usageSink: deps.usageSink,
+            ownerType: 'user',
+          });
+          const promptPreferences = await deps.promptPreferencesRepository.getCurrent(
+            runnerInput.session.userId
+          );
+          return await createAgentRunnerFn({
+            client: toolCallingClient,
+            responseRepairClient: classifierClient,
+            toolExecutor: createTestToolExecutor({ mocks: request.toolMocks, calls: toolCalls }),
+            intentClassifier: createLlmIntexAgentIntentClassifier({
+              client: classifierClient,
+              logger: deps.logger,
+            }),
+            webAppUrl: deps.config.webAppUrl,
+            userPreferences: promptPreferences.renderedPromptBlock,
+          }).run(runnerInput);
+        },
+      };
+
+      return await runTestConversation(request, {
+        sessionRepository: deps.sessionRepository,
+        runner: testRunner,
+        sessionTimeoutMs: deps.config.sessionTimeoutMs,
+        ids: deps.ids ?? {
+          sessionId: () => `intex_session_${randomUUID()}`,
+          eventId: () => `intex_event_${randomUUID()}`,
+          confirmationId: () => `intex_confirmation_${randomUUID()}`,
+        },
+        toolCalls,
+        logger: deps.logger,
+      });
+    },
   };
 }
 

--- a/docs/services/intex-agent/features.md
+++ b/docs/services/intex-agent/features.md
@@ -13,6 +13,17 @@ Intex Agent powers WhatsApp text conversations. It keeps a per-user session open
 - Create code tasks, defaulting to planning mode.
 - Save images, pasted text, and explicitly shared links to an external processing/storage endpoint.
 
+## Operator Testing
+
+Local and dev operators can run backend conversation checks through
+`POST /internal/intex-agent/test/conversation`. The endpoint uses internal auth,
+captures assistant replies instead of publishing WhatsApp messages, persists
+test-namespaced sessions/events for inspection, and replaces downstream tools
+with bounded mocks.
+
+The endpoint is for `test-intex-agent-<runId>` users only and is disabled in
+production. The `userId` must exactly equal `test-intex-agent-<runId>`.
+
 ## WhatsApp Session Continuity
 
 After a reply, the session returns to `waiting_for_user` instead of closing. Follow-up messages reuse the same session until the user starts a new session or the configured timeout expires. The session transcript includes prior user messages, assistant replies, clarification requests, and completed tool summaries.

--- a/docs/services/intex-agent/technical.md
+++ b/docs/services/intex-agent/technical.md
@@ -7,6 +7,7 @@ Intex Agent is the WhatsApp text conversation runtime. It accepts `intex.message
 | Method | Path | Auth | Purpose |
 | --- | --- | --- | --- |
 | `POST` | `/internal/intex-agent/messages` | internal auth or Pub/Sub push OIDC header | Accept a direct or Pub/Sub-wrapped `intex.message.ingest` payload and return `202` with the session ID. |
+| `POST` | `/internal/intex-agent/test/conversation` | internal auth only, local/dev only | Run a test conversation with captured replies, real session persistence, real prompt/classifier/runner flow, and mocked tool execution. Production returns `404`. |
 | `GET` | `/preferences` | bearer auth | Return prompt instructions and External Save configuration with the Cloudflare secret masked. |
 | `PUT` | `/preferences` | bearer auth | Save prompt instructions and External Save configuration. |
 | `DELETE` | `/preferences` | bearer auth | Clear prompt instructions and External Save configuration. |
@@ -46,6 +47,107 @@ WhatsApp image messages skip the LLM and call `save_external` directly when Exte
 | `save_external` | User-configured External Save endpoint |
 
 Code tasks default to planning mode unless the user explicitly asks for execution mode.
+
+## Internal Test Conversation Endpoint
+
+`POST /internal/intex-agent/test/conversation` is an operator/testing endpoint for
+local and dev. Call it directly on the host-local `intex-agent` service, for example
+`http://localhost:8134/internal/intex-agent/test/conversation`, with
+`X-Internal-Auth: <INTEXURAOS_INTERNAL_AUTH_TOKEN>`.
+
+Production returns `404` for this endpoint before request-body parsing. On
+nginx-backed public domains, `/api/intex-agent/internal/...` remains blocked by
+nginx. The supported operator path is the direct host-local service URL.
+
+The request must use `contractVersion: "2026-07-01"`, `mode:
+"live_llm_mock_tools"`, a lowercase `runId`, and `userId` exactly equal to
+`test-intex-agent-<runId>`. The endpoint writes sessions and events to the
+normal Intex Agent Firestore collections, so every run must use a unique
+`runId` and test user id.
+
+Example:
+
+```bash
+RUN_ID="intex-e2e-$(date -u +%Y%m%d%H%M%S)"
+
+curl -sS \
+  -H "content-type: application/json" \
+  -H "X-Internal-Auth: ${INTEXURAOS_INTERNAL_AUTH_TOKEN}" \
+  -d "{
+    \"contractVersion\": \"2026-07-01\",
+    \"mode\": \"live_llm_mock_tools\",
+    \"runId\": \"${RUN_ID}\",
+    \"scenarioId\": \"calendar-empty-tomorrow\",
+    \"userId\": \"test-intex-agent-${RUN_ID}\",
+    \"currentDateTime\": \"2026-07-01T10:00:00.000Z\",
+    \"timeZone\": \"Europe/Warsaw\",
+    \"turns\": [
+      {
+        \"kind\": \"message\",
+        \"messageId\": \"wamid-${RUN_ID}-001\",
+        \"text\": \"Jakie wydarzenia mam jutro w kalendarzu? ${RUN_ID}\",
+        \"timestamp\": \"2026-07-01T10:00:00.000Z\",
+        \"sourceType\": \"whatsapp_text\"
+      }
+    ],
+    \"toolMocks\": {
+      \"query_calendar_events\": {
+        \"mode\": \"success\",
+        \"result\": {
+          \"status\": \"completed\",
+          \"mode\": \"list\",
+          \"count\": 0,
+          \"events\": []
+        }
+      }
+    }
+  }" \
+  "http://localhost:8134/internal/intex-agent/test/conversation"
+```
+
+Replies are captured in the API response instead of being published to WhatsApp.
+All downstream tools are mocked, including prompt preference mutation tools.
+The endpoint may read real prompt preferences for prompt context, but it does not
+write notes, calendar events, research drafts, bookmarks, code tasks, external
+save payloads, or prompt preferences.
+
+The response is sanitized: it omits raw `toolArgs`, raw tool results, raw URLs,
+`replyContext`, `sourceUrl`, `whatsappSender`, auth tokens, secret-like fields,
+and prompt preference blocks. Assistant replies are returned as redacted test
+DTOs, not as raw WhatsApp payloads. Behavioral evidence is returned through
+`turns`, `sessions`, `sessionTransitions`, `eventsBySessionId`, `toolCalls`, and
+`behavioralTranscript`.
+
+Cleanup is guarded and defaults to dry-run. It requires service-account
+credentials, refuses non-test users, and requires `userId` to exactly match
+`test-intex-agent-<runId>`. It targets the dev project by default and deletes
+matching documents from `intex_agent_sessions`, `intex_agent_session_events`,
+`intex_agent_prompt_preferences`, and
+`intex_agent_prompt_preference_versions`.
+
+Dry-run first:
+
+```bash
+GOOGLE_APPLICATION_CREDENTIALS="$HOME/.config/gcloud/sa-key.json" \
+node scripts/cleanup-intex-agent-test-conversations.mjs \
+  --user-id "test-intex-agent-${RUN_ID}" \
+  --run-id "$RUN_ID" \
+  --dry-run
+```
+
+Execute deletion only after reviewing the dry-run counts:
+
+```bash
+GOOGLE_APPLICATION_CREDENTIALS="$HOME/.config/gcloud/sa-key.json" \
+node scripts/cleanup-intex-agent-test-conversations.mjs \
+  --user-id "test-intex-agent-${RUN_ID}" \
+  --run-id "$RUN_ID" \
+  --execute
+```
+
+Fastify body-limit parser errors return structured `413` responses without
+Sentry capture. This is a platform-wide app-server behavior because the shared
+`@intexuraos/infra-sentry` Fastify error handler owns request-parser failures.
 
 ## External Save Endpoint
 

--- a/docs/superpowers/plans/2026-07-01-intex-agent-internal-test-conversation-endpoint.md
+++ b/docs/superpowers/plans/2026-07-01-intex-agent-internal-test-conversation-endpoint.md
@@ -1,0 +1,1311 @@
+# Intex Agent Internal Test Conversation Endpoint Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an internal-auth API for testing Intex Agent chat conversations without Auth0, UI, WhatsApp delivery, or real downstream tool side effects.
+
+**Architecture:** Add `POST /internal/intex-agent/test/conversation` inside `apps/intex-agent` for local and dev only; production returns 404. The route authenticates with the existing `X-Internal-Auth` token, accepts only test-namespaced users, then runs the existing `handleIncomingMessage()` domain flow turn-by-turn with real session persistence, real prompt/classifier/runner logic, captured WhatsApp replies, and a mocked `IntexAgentToolExecutor`. Unit tests may call the use case with a scripted runner dependency, but the request mode remains `live_llm_mock_tools`; the HTTP endpoint accepts only live LLM + mocked tools.
+
+**Tech Stack:** TypeScript, Fastify, Vitest, Firestore, existing `@intexuraos/common-http` internal auth, existing `@intexuraos/llm-*`, existing `handleIncomingMessage()`, existing `SessionRepository`.
+
+## Global Constraints
+
+- The test endpoint is internal-only and must never use Auth0; require `X-Internal-Auth: <INTEXURAOS_INTERNAL_AUTH_TOKEN>`.
+- The endpoint is disabled in production: when `INTEXURAOS_ENVIRONMENT === 'prod'`, return 404 before auth-specific behavior.
+- The endpoint must call `logIncomingRequest()` with `bodyPreviewLength: 0`.
+- The endpoint must not publish outbound WhatsApp messages; replies are captured and returned in the response.
+- The endpoint must not call notes, calendar, research, bookmarks, code-agent, or external-save services; all tool executions use mocks.
+- Preference mutation tools are also mock-only; the endpoint may read real prompt preferences for context but must never write prompt preferences.
+- The endpoint must preserve the domain under test: session lifecycle, prompt preferences, classifier, runner, confirmations, fallback handling, and `handleIncomingMessage()` must stay in the execution path.
+- The endpoint writes sessions/events to the same Firestore collections as normal `intex-agent`; request `userId` must match `^test-intex-agent-[a-z0-9._-]{1,96}$` and must include the normalized `runId`.
+- Production/deployed runs must use UUID-based `intex_session_*`, `intex_event_*`, and `intex_confirmation_*` IDs. Deterministic IDs are allowed only through direct unit-test dependency injection.
+- Returned debug data must be sanitized. Do not return secrets, internal auth tokens, raw API keys, private tool credentials, raw `toolArgs`, raw tool result bodies, `replyContext`, `sourceUrl`, `whatsappSender`, or prompt preference blocks.
+- Route payload limits are part of the contract: body limit `64 * 1024`, `turns.maxItems = 5`, `text.maxLength = 4000`, `runId.maxLength = 128`, `userId.maxLength = 128`, `sourceUrl.maxLength = 2048`, and bounded per-tool mock result schemas.
+- Keep the implementation backend-only; no web UI changes.
+- Do not add new env vars; reuse existing `INTEXURAOS_INTERNAL_AUTH_TOKEN`, OpenRouter, service URLs, Firestore, and model config.
+- 100% branch coverage remains required for `apps/intex-agent`.
+- Before commit, run `pnpm run ci:tracked`.
+
+---
+
+## File Structure
+
+Create:
+
+- `apps/intex-agent/src/domain/testConversation/testConversationTypes.ts` - request/response contracts, tool mock config, captured reply/tool-call types.
+- `apps/intex-agent/src/domain/testConversation/testToolMocks.ts` - mock `IntexAgentToolExecutor` implementation that records calls and returns configured JSON.
+- `apps/intex-agent/src/domain/testConversation/testConversationSanitizer.ts` - response DTO redaction and normalized behavioral transcript helpers.
+- `apps/intex-agent/src/domain/testConversation/runTestConversation.ts` - pure use case that drives `handleIncomingMessage()` over multiple turns and returns transcript, sessions, events, and tool calls.
+- `apps/intex-agent/src/routes/testConversationRoutes.ts` - Fastify route for `POST /internal/intex-agent/test/conversation`.
+- `apps/intex-agent/src/__tests__/domain/testToolMocks.test.ts` - tool mock behavior tests.
+- `apps/intex-agent/src/__tests__/domain/runTestConversation.test.ts` - use-case tests with scripted runner.
+- `apps/intex-agent/src/__tests__/domain/testConversationSanitizer.test.ts` - redaction and response-shaping tests.
+- `apps/intex-agent/src/__tests__/routes/testConversationRoutes.test.ts` - internal auth, schema, and route response tests.
+- `scripts/cleanup-intex-agent-test-conversations.mjs` - guarded cleanup for test-namespaced sessions/events and prompt preference docs.
+
+Modify:
+
+- `apps/intex-agent/src/server.ts` - register `testConversationRoutes`.
+- `apps/intex-agent/src/services.ts` - add `testConversationRunner` to `ServiceContainer`; build it in `initServices()`.
+- `apps/intex-agent/src/domain/agent/intexAgentRunner.ts` - export any small helper types needed by the test runner only if already local and safe.
+- `docs/superpowers/specs/2026-06-24-intex-agent-dev-api-test-scenarios.md` - document that API scenario runners should use the new internal endpoint when testing without UI/OAuth.
+- `docs/services/intex-agent/features.md` - add the internal conversation test endpoint as an operator/testing feature.
+- `docs/services/intex-agent/technical.md` - document auth, side-effect boundaries, and Firestore persistence behavior.
+
+Do not modify:
+
+- `apps/web/**` - no UI is needed.
+- `whatsapp-service` - this endpoint bypasses WhatsApp transport intentionally.
+- Downstream agent clients - tools are mocked inside `intex-agent`.
+- Terraform or `ecosystem.config.cjs` - no new env vars or service routes are required.
+
+## Endpoint Changes
+
+### Created
+
+- `POST /internal/intex-agent/test/conversation` - internal test endpoint that runs one or more Intex Agent turns with captured replies and mocked tool execution.
+
+### Modified
+
+- `apps/intex-agent/src/server.ts` registers one additional internal route module.
+
+### Removed
+
+- None.
+
+### Unchanged
+
+- `POST /internal/intex-agent/messages` remains the real Pub/Sub/WhatsApp ingress path.
+- Authenticated user routes under `/sessions`, `/preferences`, and `/prompt-preferences` remain Auth0-protected.
+- Real WhatsApp replies still use the existing Pub/Sub publisher in normal runtime.
+- Real tool execution remains unchanged in normal WhatsApp runtime.
+
+## Endpoint Exposure
+
+- Local: call `http://localhost:8134/internal/intex-agent/test/conversation` with `X-Internal-Auth`.
+- Dev on `home-dev`: call the host-local service URL with `X-Internal-Auth`, for example over SSH to `http://localhost:8134/internal/intex-agent/test/conversation`.
+- Prod: disabled by the app. Public `/internal/intex-agent/...` routing exists for production internals, but this endpoint must return 404 when `INTEXURAOS_ENVIRONMENT === 'prod'`.
+- `/api/intex-agent/internal/...` is not a valid public path and should remain blocked by nginx.
+
+## Endpoint Contract
+
+Request:
+
+```json
+{
+  "contractVersion": "2026-07-01",
+  "mode": "live_llm_mock_tools",
+  "runId": "intex-e2e-20260701-001",
+  "scenarioId": "calendar-empty-tomorrow",
+  "userId": "test-intex-agent-intex-e2e-20260701-001",
+  "currentDateTime": "2026-07-01T10:00:00.000Z",
+  "timeZone": "Europe/Warsaw",
+  "turns": [
+    {
+      "kind": "message",
+      "messageId": "wamid-test-001",
+      "text": "Jakie wydarzenia mam jutro w kalendarzu? intex-e2e-20260701-001",
+      "timestamp": "2026-07-01T10:00:00.000Z",
+      "sourceType": "whatsapp_text"
+    }
+  ],
+  "toolMocks": {
+    "query_calendar_events": {
+      "mode": "success",
+      "result": {
+        "status": "completed",
+        "mode": "list",
+        "count": 0,
+        "events": []
+      }
+    }
+  }
+}
+```
+
+Response:
+
+```json
+{
+  "success": true,
+  "data": {
+    "contractVersion": "2026-07-01",
+    "mode": "live_llm_mock_tools",
+    "runId": "intex-e2e-20260701-001",
+    "scenarioId": "calendar-empty-tomorrow",
+    "userId": "test-intex-agent-intex-e2e-20260701-001",
+    "finalSessionId": "intex_session_...",
+    "turns": [
+      {
+        "turnIndex": 0,
+        "kind": "message",
+        "messageId": "wamid-test-001",
+        "sessionId": "intex_session_...",
+        "assistantReplies": [
+          {
+            "message": "Nie masz żadnych wydarzeń zaplanowanych na jutro.",
+            "replyToMessageId": "wamid-test-001",
+            "correlationId": "intex_session_..."
+          }
+        ]
+      }
+    ],
+    "toolCalls": [
+      {
+        "toolName": "query_calendar_events",
+        "status": "completed",
+        "argsSummary": {
+          "mode": "list",
+          "timeMin": "2026-07-02T00:00:00+02:00",
+          "timeMax": "2026-07-03T00:00:00+02:00"
+        },
+        "resultSummary": {
+          "status": "completed",
+          "mode": "list",
+          "count": 0
+        }
+      }
+    ],
+    "sessions": [
+      {
+        "id": "intex_session_...",
+        "userId": "test-intex-agent-intex-e2e-20260701-001",
+        "status": "waiting_for_user",
+        "startedAt": "2026-07-01T10:00:00.000Z",
+        "lastUserMessageAt": "2026-07-01T10:00:00.000Z",
+        "lastAssistantMessageAt": "2026-07-01T10:00:00.000Z",
+        "startReason": "no_active_session"
+      }
+    ],
+    "sessionTransitions": [
+      {
+        "turnIndex": 0,
+        "action": "started",
+        "sessionId": "intex_session_..."
+      }
+    ],
+    "eventsBySessionId": {
+      "intex_session_...": [
+        {
+          "id": "intex_event_...",
+          "type": "user_message",
+          "createdAt": "2026-07-01T10:00:00.000Z",
+          "payload": {
+            "textPreview": "Jakie wydarzenia mam jutro w kalendarzu? intex-e2e-20260701-001"
+          }
+        },
+        {
+          "id": "intex_event_...",
+          "type": "tool_call_completed",
+          "createdAt": "2026-07-01T10:00:00.000Z",
+          "payload": {
+            "toolName": "query_calendar_events"
+          }
+        },
+        {
+          "id": "intex_event_...",
+          "type": "assistant_message",
+          "createdAt": "2026-07-01T10:00:00.000Z",
+          "payload": {
+            "textPreview": "Nie masz żadnych wydarzeń zaplanowanych na jutro."
+          }
+        }
+      ]
+    },
+    "behavioralTranscript": {
+      "turns": [
+        {
+          "turnIndex": 0,
+          "submittedTextPreview": "Jakie wydarzenia mam jutro w kalendarzu? intex-e2e-20260701-001",
+          "assistantReplyPreviews": ["Nie masz żadnych wydarzeń zaplanowanych na jutro."],
+          "sessionAction": "started",
+          "toolOutcome": {
+            "toolName": "query_calendar_events",
+            "status": "completed"
+          }
+        }
+      ]
+    },
+    "sideEffectBoundary": "mocked_tools_no_downstream_writes",
+    "warnings": []
+  }
+}
+```
+
+Request `turns` supports two forms:
+
+- `{ "kind": "message", "text": "...", "messageId": "...", "timestamp": "...", "sourceType": "whatsapp_text" }`
+- `{ "kind": "confirmation_button", "previousTurnIndex": 0, "decision": "accept" }`
+
+`confirmation_button` is resolved by the use case after the referenced prior turn runs. It reads the captured reply buttons, finds the generated `intex_confirm:<confirmationId>:yes|no` button, and converts the semantic turn into a real `IntexIncomingMessage` with `sourceType: "whatsapp_button"` and `buttonResponse`.
+
+`mode` values:
+
+- `live_llm_mock_tools` - the only HTTP mode. Uses real LLM classifier and runner, real prompt preferences lookup, real Firestore sessions, captured replies, mocked tools.
+
+Direct unit tests may call `runTestConversation()` with a scripted runner dependency, but `scripted_runner` and `scriptedResults` must not exist in any request/input schema.
+
+`toolMocks` values:
+
+```ts
+export type TestToolMock =
+  | { mode: 'success'; result: Record<string, unknown> }
+  | { mode: 'failure'; message: string };
+```
+
+Default mock behavior:
+
+- Read-only calendar query returns an empty successful list.
+- Mutating tools return a successful JSON object with a stable mock id and resource URL.
+- `save_external` returns success without external network access.
+- Preference tools return mock-only preference results and do not write `intex_agent_prompt_preferences` or `intex_agent_prompt_preference_versions`.
+
+`toolMocks` must be validated per tool with explicit schemas. Reject unknown tool names, nested arbitrary objects, secret-like field names (`token`, `secret`, `password`, `key`), huge arrays, and URLs outside `http`/`https` with bounded length.
+
+---
+
+## Task 1: Define Test Conversation Contracts
+
+**Files:**
+
+- Create: `apps/intex-agent/src/domain/testConversation/testConversationTypes.ts`
+- Test: `apps/intex-agent/src/__tests__/domain/runTestConversation.test.ts`
+
+**Interfaces:**
+
+- Produces: `TestConversationHttpRequest`
+- Produces: `RunTestConversationInput`
+- Produces: `TestConversationResponse`
+- Produces: `TestConversationMode`
+- Produces: `TestToolMock`
+- Consumes: `IntexIncomingMessage`, `IntexAgentSession`, `IntexAgentSessionEvent`, `IntexAgentToolName`
+
+- [ ] **Step 1: Write the failing type-use test**
+
+Add this minimal compile-time/runtime test to `apps/intex-agent/src/__tests__/domain/runTestConversation.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import type {
+  TestConversationHttpRequest,
+  TestConversationResponse,
+} from '../../domain/testConversation/testConversationTypes.js';
+
+describe('test conversation contract', () => {
+  it('supports a live mocked-tools request and response transcript', () => {
+    const request: TestConversationHttpRequest = {
+      contractVersion: '2026-07-01',
+      mode: 'live_llm_mock_tools',
+      userId: 'test-intex-agent-intex-e2e-contract',
+      runId: 'intex-e2e-contract',
+      currentDateTime: '2026-07-01T10:00:00.000Z',
+      turns: [
+        {
+          kind: 'message',
+          messageId: 'wamid-contract-1',
+          text: 'Jakie mam jutro wydarzenia? intex-e2e-contract',
+          timestamp: '2026-07-01T10:00:00.000Z',
+          sourceType: 'whatsapp_text',
+        },
+      ],
+      toolMocks: {
+        query_calendar_events: {
+          mode: 'success',
+          result: {
+            status: 'completed',
+            mode: 'list',
+            count: 0,
+            events: [],
+          },
+        },
+      },
+    };
+
+    const response: TestConversationResponse = {
+      runId: request.runId,
+      userId: request.userId,
+      contractVersion: '2026-07-01',
+      mode: 'live_llm_mock_tools',
+      finalSessionId: 'intex_session_1',
+      turns: [
+        {
+          turnIndex: 0,
+          kind: 'message',
+          messageId: 'wamid-contract-1',
+          sessionId: 'intex_session_1',
+          assistantReplies: [],
+        },
+      ],
+      toolCalls: [],
+      sessions: [],
+      sessionTransitions: [],
+      eventsBySessionId: {},
+      behavioralTranscript: { turns: [] },
+      sideEffectBoundary: 'mocked_tools_no_downstream_writes',
+      warnings: [],
+    };
+
+    expect(response.runId).toBe('intex-e2e-contract');
+  });
+});
+```
+
+Run:
+
+```bash
+pnpm --filter @intexuraos/intex-agent test -- --run apps/intex-agent/src/__tests__/domain/runTestConversation.test.ts
+```
+
+Expected: FAIL with missing `testConversationTypes.js`.
+
+- [ ] **Step 2: Implement the contract types**
+
+Create `apps/intex-agent/src/domain/testConversation/testConversationTypes.ts`:
+
+```ts
+import type { WhatsAppInteractiveButton } from '@intexuraos/whatsapp-pubsub-client';
+import type { IntexIncomingMessageReplyContext } from '../ports/incomingMessageHandler.js';
+import type { IntexAgentSession, IntexAgentSessionEvent, IntexAgentToolName } from '../sessions/types.js';
+
+export type TestConversationMode = 'live_llm_mock_tools';
+
+export interface MessageTurnInput {
+  kind: 'message';
+  messageId?: string;
+  text: string;
+  timestamp?: string;
+  sourceType?: string;
+  sourceUrl?: string;
+  whatsappSender?: string;
+  replyContext?: IntexIncomingMessageReplyContext;
+}
+
+export interface ConfirmationButtonTurnInput {
+  kind: 'confirmation_button';
+  previousTurnIndex: number;
+  decision: 'accept' | 'reject';
+  messageId?: string;
+  timestamp?: string;
+}
+
+export type TestConversationTurnInput = MessageTurnInput | ConfirmationButtonTurnInput;
+
+export type TestToolMock =
+  | { mode: 'success'; result: Record<string, unknown> }
+  | { mode: 'failure'; message: string };
+
+export type TestToolMocks = Partial<Record<IntexAgentToolName, TestToolMock>>;
+
+export interface TestConversationHttpRequest {
+  contractVersion: '2026-07-01';
+  mode: TestConversationMode;
+  userId: string;
+  runId: string;
+  scenarioId?: string;
+  currentDateTime: string;
+  timeZone?: string;
+  turns: TestConversationTurnInput[];
+  toolMocks?: TestToolMocks;
+}
+
+export type RunTestConversationInput = TestConversationHttpRequest;
+
+export interface CapturedAssistantReply {
+  userId: string;
+  message: string;
+  replyToMessageId: string;
+  correlationId: string;
+  ctaUrl?: {
+    displayText: string;
+    url: string;
+  };
+  buttons?: WhatsAppInteractiveButton[];
+}
+
+export interface CapturedToolCall {
+  toolName: IntexAgentToolName;
+  status: 'completed' | 'failed';
+  argsSummary?: Record<string, unknown>;
+  resultSummary?: Record<string, unknown>;
+  error?: string;
+}
+
+export interface TestConversationTurnResult {
+  turnIndex: number;
+  kind: TestConversationTurnInput['kind'];
+  messageId: string;
+  sessionId: string;
+  assistantReplies: CapturedAssistantReply[];
+}
+
+export interface TestConversationResponse {
+  contractVersion: '2026-07-01';
+  mode: TestConversationMode;
+  runId: string;
+  scenarioId?: string;
+  userId: string;
+  finalSessionId: string | null;
+  turns: TestConversationTurnResult[];
+  toolCalls: CapturedToolCall[];
+  sessions: IntexAgentSession[];
+  sessionTransitions: Array<{
+    turnIndex: number;
+    action: 'started' | 'continued' | 'superseded_previous' | 'expired_previous';
+    sessionId: string;
+    previousSessionId?: string;
+    previousEndReason?: string;
+  }>;
+  eventsBySessionId: Record<string, Array<{
+    id: string;
+    type: IntexAgentSessionEvent['type'];
+    createdAt: string;
+    payload: Record<string, unknown>;
+  }>>;
+  behavioralTranscript: {
+    turns: Array<{
+      turnIndex: number;
+      submittedTextPreview?: string;
+      assistantReplyPreviews: string[];
+      sessionAction: string;
+      confirmationAction?: 'accepted' | 'rejected' | 'stale';
+      toolOutcome?: { toolName: IntexAgentToolName; status: 'completed' | 'failed' };
+    }>;
+  };
+  sideEffectBoundary: 'mocked_tools_no_downstream_writes';
+  warnings: string[];
+}
+```
+
+Run the same test again.
+
+Expected: PASS.
+
+## Task 2: Mock Tool Executor And Captured Reply Publisher
+
+**Files:**
+
+- Create: `apps/intex-agent/src/domain/testConversation/testToolMocks.ts`
+- Test: `apps/intex-agent/src/__tests__/domain/testToolMocks.test.ts`
+
+**Interfaces:**
+
+- Consumes: `TestToolMocks`
+- Produces: `createTestToolExecutor(input: { mocks?: TestToolMocks; calls: CapturedToolCall[] }): IntexAgentToolExecutor`
+- Produces: `createCapturedReplyPublisher(replies: CapturedAssistantReply[]): WhatsAppReplyPublisher`
+
+- [ ] **Step 1: Write failing tests for mock tool success, failure, and call recording**
+
+Create `apps/intex-agent/src/__tests__/domain/testToolMocks.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { createCapturedReplyPublisher, createTestToolExecutor } from '../../domain/testConversation/testToolMocks.js';
+import type { CapturedAssistantReply, CapturedToolCall } from '../../domain/testConversation/testConversationTypes.js';
+
+describe('test tool mocks', () => {
+  it('returns configured successful tool JSON and records the call', async () => {
+    const calls: CapturedToolCall[] = [];
+    const executor = createTestToolExecutor({
+      calls,
+      mocks: {
+        query_calendar_events: {
+          mode: 'success',
+          result: { status: 'completed', mode: 'list', count: 0, events: [] },
+        },
+      },
+    });
+
+    const raw = await executor.queryCalendarEvents({
+      mode: 'list',
+      timeMin: '2026-07-02T00:00:00+02:00',
+      timeMax: '2026-07-03T00:00:00+02:00',
+    });
+
+    expect(JSON.parse(raw)).toEqual({ status: 'completed', mode: 'list', count: 0, events: [] });
+    expect(calls).toEqual([
+      {
+        toolName: 'query_calendar_events',
+        status: 'completed',
+        argsSummary: {
+          mode: 'list',
+          timeMin: '2026-07-02T00:00:00+02:00',
+          timeMax: '2026-07-03T00:00:00+02:00',
+        },
+        resultSummary: { status: 'completed', mode: 'list', count: 0 },
+      },
+    ]);
+  });
+
+  it('throws configured failures and records the error', async () => {
+    const calls: CapturedToolCall[] = [];
+    const executor = createTestToolExecutor({
+      calls,
+      mocks: {
+        create_note: { mode: 'failure', message: 'mock note failure' },
+      },
+    });
+
+    await expect(executor.createNote({ content: 'x' })).rejects.toThrow('mock note failure');
+    expect(calls).toEqual([
+      {
+        toolName: 'create_note',
+        status: 'failed',
+        error: 'mock note failure',
+      },
+    ]);
+  });
+
+  it('captures assistant replies without publishing to WhatsApp', async () => {
+    const replies: CapturedAssistantReply[] = [];
+    const publisher = createCapturedReplyPublisher(replies);
+
+    await publisher.publishReply({
+      userId: 'user-1',
+      message: 'Reply',
+      replyToMessageId: 'wamid-1',
+      correlationId: 'session-1',
+    });
+
+    expect(replies).toEqual([
+      {
+        userId: 'user-1',
+        message: 'Reply',
+        replyToMessageId: 'wamid-1',
+        correlationId: 'session-1',
+      },
+    ]);
+  });
+});
+```
+
+Run:
+
+```bash
+pnpm --filter @intexuraos/intex-agent test -- --run apps/intex-agent/src/__tests__/domain/testToolMocks.test.ts
+```
+
+Expected: FAIL with missing `testToolMocks.js`.
+
+- [ ] **Step 2: Implement mock tool executor and captured publisher**
+
+Implement every `IntexAgentToolExecutor` method. Test every method with configured success, default success, configured failure, call recording, JSON serialization, zero-arg `getUserPreferences`, and captured reply `ctaUrl`/`buttons`. Use this pattern for each method:
+
+```ts
+function runMockTool(
+  toolName: IntexAgentToolName,
+  args: Record<string, unknown>,
+  mocks: TestToolMocks | undefined,
+  calls: CapturedToolCall[]
+): string {
+  const mock = mocks?.[toolName] ?? defaultMock(toolName, args);
+  if (mock.mode === 'failure') {
+    calls.push({ toolName, status: 'failed', error: mock.message });
+    throw new Error(mock.message);
+  }
+  calls.push({
+    toolName,
+    status: 'completed',
+    argsSummary: summarizeToolArgs(toolName, args),
+    resultSummary: summarizeToolResult(toolName, mock.result),
+  });
+  return JSON.stringify(mock.result);
+}
+```
+
+Default mock results:
+
+```ts
+const DEFAULT_MOCK_RESULTS: Record<IntexAgentToolName, Record<string, unknown>> = {
+  create_note: { status: 'completed', message: 'Mock note created.', resourceUrl: '/#/notes/mock-note' },
+  create_calendar_event: { status: 'completed', eventId: 'mock-calendar-event', summary: 'Mock event', htmlLink: 'https://calendar.test/mock-calendar-event' },
+  query_calendar_events: { status: 'completed', mode: 'list', count: 0, events: [] },
+  create_research: { status: 'completed', message: 'Mock research draft created.', resourceUrl: '/#/research/mock-research' },
+  create_link: { status: 'completed', bookmarkId: 'mock-bookmark', resourceUrl: '/#/bookmarks/mock-bookmark', url: 'https://example.test' },
+  create_code_task: { status: 'completed', codeTaskId: 'task_mock', resourceUrl: '/#/code-tasks/task_mock' },
+  save_external: { status: 'completed', message: 'Mock external save completed.' },
+  get_user_preferences: { status: 'completed', version: 0, items: [] },
+  add_user_preference: { status: 'completed', version: 1, item: { id: 'pref_mock', text: 'Mock preference' } },
+  update_user_preference: { status: 'completed', version: 1, item: { id: 'pref_mock', text: 'Mock preference updated' } },
+  delete_user_preference: { status: 'completed', version: 1, deletedItemId: 'pref_mock' },
+};
+```
+
+Run the test again.
+
+Expected: PASS.
+
+## Task 3: Add Test Conversation Use Case
+
+**Files:**
+
+- Create: `apps/intex-agent/src/domain/testConversation/runTestConversation.ts`
+- Test: `apps/intex-agent/src/__tests__/domain/runTestConversation.test.ts`
+
+**Interfaces:**
+
+- Consumes: `SessionRepository`
+- Consumes: `IntexAgentRunner`
+- Consumes: `RunTestConversationInput`
+- Produces: `runTestConversation(input: RunTestConversationInput, deps: RunTestConversationDeps): Promise<TestConversationResponse>`
+
+- [ ] **Step 1: Write failing tests for domain execution and evidence capture**
+
+Add tests to `apps/intex-agent/src/__tests__/domain/runTestConversation.test.ts` covering:
+
+```ts
+it('runs two message turns through handleIncomingMessage and returns sanitized evidence', async () => {
+  const repository = new MemorySessionRepository();
+  const result = await runTestConversation(
+    {
+      contractVersion: '2026-07-01',
+      mode: 'live_llm_mock_tools',
+      userId: 'test-intex-agent-intex-e2e-scripted',
+      runId: 'intex-e2e-scripted',
+      currentDateTime: '2026-07-01T10:00:00.000Z',
+      turns: [
+        { kind: 'message', messageId: 'wamid-1', text: 'Jakie wydarzenia jutro? intex-e2e-scripted', timestamp: '2026-07-01T10:00:00.000Z' },
+        { kind: 'message', messageId: 'wamid-2', text: 'Co dalej?', timestamp: '2026-07-01T10:01:00.000Z' },
+      ],
+    },
+    {
+      sessionRepository: repository,
+      runner: new ScriptedRunner([
+        { outcome: 'completed', reply: 'Nie masz żadnych wydarzeń jutro.', toolName: 'query_calendar_events', toolResult: { status: 'completed', count: 0 } },
+        { outcome: 'no_action', reply: 'Co mogę teraz dla Ciebie zrobić?' },
+      ]),
+      sessionTimeoutMs: 30 * 60 * 1000,
+      ids: fixedTestIds(),
+      logger: silentLogger(),
+    }
+  );
+
+  expect(result.userId).toBe('test-intex-agent-intex-e2e-scripted');
+  expect(result.finalSessionId).toBe('intex_session_test_1');
+  expect(result.turns).toHaveLength(2);
+  expect(result.turns[0]?.assistantReplies[0]?.message).toContain('Nie masz żadnych wydarzeń');
+  expect(result.turns[1]?.assistantReplies[0]?.message).toContain('Co mogę teraz');
+  expect(result.eventsBySessionId['intex_session_test_1']?.map((event) => event.type)).toContain('assistant_message');
+  expect(JSON.stringify(result)).not.toContain('toolArgs');
+});
+```
+
+Also add a two-turn confirmation test:
+
+- first scripted/live-equivalent turn returns `needs_confirmation` for `create_note`
+- second request turn uses `{ kind: 'confirmation_button', previousTurnIndex: 0, decision: 'accept' }`
+- the use case resolves the captured `intex_confirm:<id>:yes` button into `buttonResponse`
+- assertions cover `confirmation_resolved`, `tool_call_completed`, captured reply, and one mocked tool call
+
+Add rejection/stale button tests:
+
+- `{ decision: 'reject' }` records `confirmation_resolved` with `rejected` and no mocked tool call
+- a mismatched `previousTurnIndex` returns `INVALID_REQUEST` from route-level validation before execution
+
+Run:
+
+```bash
+pnpm --filter @intexuraos/intex-agent test -- --run apps/intex-agent/src/__tests__/domain/runTestConversation.test.ts
+```
+
+Expected: FAIL with missing `runTestConversation.js`.
+
+- [ ] **Step 2: Implement `runTestConversation()` around `handleIncomingMessage()`**
+
+Implementation requirements:
+
+- Build one `IntexIncomingMessage` per requested turn.
+- Resolve semantic `confirmation_button` turns after the referenced prior turn has produced captured buttons.
+- Default `sourceType` to `whatsapp_text`.
+- Default timestamps from `currentDateTime`, incrementing one second per turn when a turn omits `timestamp`.
+- Default message IDs to `wamid-test-${runId}-${index}`.
+- Accept `ids` through `RunTestConversationDeps`. Unit tests pass deterministic IDs; runtime wiring passes UUID-based IDs.
+- Capture replies per turn by slicing the reply array before and after each `handleIncomingMessage()` call.
+- After all turns, load every touched session and event through `SessionRepository`.
+- Return sanitized evidence only. Use `testConversationSanitizer.ts` to build `sessions`, `sessionTransitions`, `eventsBySessionId`, and `behavioralTranscript`.
+
+Core implementation shape:
+
+```ts
+export interface RunTestConversationDeps {
+  sessionRepository: SessionRepository;
+  runner: IntexAgentRunner;
+  sessionTimeoutMs: number;
+  ids: IdGenerator;
+  logger: Pick<Logger, 'info' | 'warn' | 'error'>;
+}
+
+export async function runTestConversation(
+  input: RunTestConversationInput,
+  deps: RunTestConversationDeps
+): Promise<TestConversationResponse> {
+  const replies: CapturedAssistantReply[] = [];
+  const replyPublisher = createCapturedReplyPublisher(replies);
+  let sessionId: string | null = null;
+
+  const turnResults: TestConversationTurnResult[] = [];
+
+  for (const [index, turn] of input.turns.entries()) {
+    const incomingMessage = resolveIncomingMessageForTurn(input, turn, index, replies);
+    const replyStart = replies.length;
+    const result = await handleIncomingMessage(
+      incomingMessage,
+      {
+        sessionRepository: deps.sessionRepository,
+        runner: deps.runner,
+        replyPublisher,
+        clock: { now: () => turn.timestamp ?? timestampForTurn(input.currentDateTime, index) },
+        ids: {
+          sessionId: deps.ids.sessionId,
+          eventId: deps.ids.eventId,
+          confirmationId: deps.ids.confirmationId,
+        },
+        sessionTimeoutMs: deps.sessionTimeoutMs,
+      }
+    );
+    sessionId = result.sessionId;
+    turnResults.push({
+      turnIndex: index,
+      kind: turn.kind,
+      messageId: incomingMessage.messageId,
+      sessionId: result.sessionId,
+      assistantReplies: replies.slice(replyStart),
+    });
+  }
+
+  const evidence = await buildSanitizedConversationEvidence({
+    input,
+    sessionRepository: deps.sessionRepository,
+    turnResults,
+    finalSessionId: sessionId,
+  });
+
+  return {
+    contractVersion: input.contractVersion,
+    mode: 'live_llm_mock_tools',
+    runId: input.runId,
+    ...(input.scenarioId !== undefined ? { scenarioId: input.scenarioId } : {}),
+    userId: input.userId,
+    finalSessionId: sessionId,
+    turns: turnResults,
+    toolCalls: [],
+    ...evidence,
+    sideEffectBoundary: 'mocked_tools_no_downstream_writes',
+    warnings: [],
+  };
+}
+```
+
+Run the test again.
+
+Expected: PASS.
+
+## Task 4: Build Live LLM Runner With Mocked Tools
+
+**Files:**
+
+- Modify: `apps/intex-agent/src/services.ts`
+- Test: `apps/intex-agent/src/__tests__/domain/runTestConversation.test.ts`
+
+**Interfaces:**
+
+- Produces: `createLiveMockedToolRunner(input: CreateLiveMockedToolRunnerInput): IntexAgentRunner` in `apps/intex-agent/src/services.ts`
+- Consumes: `createIntexAgentRunner()`
+- Consumes: `createIntexAgentToolExecutor()` only for normal runtime, not for test endpoint
+
+- [ ] **Step 1: Add a failing test that live mode records mocked tool calls**
+
+Add a test with a fake `IntexAgentRunner` produced from `createIntexAgentRunner()` and a fake `ToolCallingClient` that calls `query_calendar_events`. The test must assert:
+
+- The tool call is captured in `toolCalls`.
+- No downstream client fake is called.
+- The assistant reply is captured, not published.
+
+Use a fake client response that returns a valid runner JSON:
+
+```ts
+const fakeClient = {
+  async run(input: { tools: { name: string; run(args: Record<string, unknown>): Promise<string> }[] }) {
+    const tool = input.tools.find((candidate) => candidate.name === 'query_calendar_events');
+    if (tool === undefined) throw new Error('query_calendar_events not available');
+    await tool.run({
+      mode: 'list',
+      timeMin: '2026-07-02T00:00:00+02:00',
+      timeMax: '2026-07-03T00:00:00+02:00',
+    });
+    return {
+      ok: true,
+      value: {
+        content: JSON.stringify({
+          outcome: 'completed',
+          reply: 'Nie masz żadnych wydarzeń jutro.',
+          toolName: 'query_calendar_events',
+        }),
+      },
+    };
+  },
+};
+```
+
+Expected before implementation: FAIL because live mode does not wire mocks into the runner.
+
+- [ ] **Step 2: Implement live mocked runner creation**
+
+Add a factory that uses `createIntexAgentRunner()` with:
+
+- real `client` and `responseRepairClient` in `initServices()`
+- real `intentClassifier` in `initServices()`
+- `createTestToolExecutor()` instead of `createIntexAgentToolExecutor()`
+- real prompt preferences from `promptPreferencesRepository.getCurrent(userId)`
+- `webAppUrl` from config
+
+The factory must append tool calls to the same `CapturedToolCall[]` returned by the endpoint.
+
+The production `ServiceContainer` shape becomes:
+
+```ts
+export interface ServiceContainer {
+  config: ServiceConfig;
+  sessionRepository: SessionRepository;
+  preferencesRepository: PreferencesRepository;
+  promptPreferencesRepository: PromptPreferencesRepository;
+  externalSaveTester: ExternalSaveConnectionTestPort;
+  incomingMessageHandler: IncomingMessageHandler;
+  testConversationRunner: {
+    run(input: TestConversationHttpRequest): Promise<TestConversationResponse>;
+  };
+}
+```
+
+Run:
+
+```bash
+pnpm --filter @intexuraos/intex-agent test -- --run apps/intex-agent/src/__tests__/domain/runTestConversation.test.ts
+```
+
+Expected: PASS.
+
+## Task 5: Add Internal Test Conversation Route
+
+**Files:**
+
+- Create: `apps/intex-agent/src/routes/testConversationRoutes.ts`
+- Modify: `apps/intex-agent/src/server.ts`
+- Test: `apps/intex-agent/src/__tests__/routes/testConversationRoutes.test.ts`
+
+**Interfaces:**
+
+- Consumes: `getServices().testConversationRunner.run()`
+- Produces: `POST /internal/intex-agent/test/conversation`
+
+- [ ] **Step 1: Write failing route tests**
+
+Create `apps/intex-agent/src/__tests__/routes/testConversationRoutes.test.ts` with these cases:
+
+- missing `x-internal-auth` returns 401 and does not call `testConversationRunner`
+- wrong `x-internal-auth` returns 401 and does not call `testConversationRunner`
+- unset `INTEXURAOS_INTERNAL_AUTH_TOKEN` returns 401 and does not call `testConversationRunner`
+- `from: noreply@google.com` does not bypass this route
+- `INTEXURAOS_ENVIRONMENT=prod` returns 404 and does not call `testConversationRunner`
+- non-test `userId`, e.g. `auth0|real-user`, returns 400 and does not call `testConversationRunner`
+- test `userId` that does not contain normalized `runId` returns 400 and does not call `testConversationRunner`
+- `mode: "scripted_runner"` returns 400 and does not call `testConversationRunner`
+- too many turns, too-long text, too-long `sourceUrl`, oversized body, unknown tool mock, and secret-like mock fields return 400 or 413
+- valid `live_llm_mock_tools` payload returns 200 and passes the sanitized payload to the runner
+- route logging uses `bodyPreviewLength: 0`; captured test logs must not contain turn text, `toolMocks`, `scriptedResults`, auth tokens, or mock result bodies
+
+Use a valid route payload like:
+
+```ts
+const payload = {
+  contractVersion: '2026-07-01',
+  mode: 'live_llm_mock_tools',
+  runId: 'intex-e2e-route',
+  userId: 'test-intex-agent-intex-e2e-route',
+  currentDateTime: '2026-07-01T10:00:00.000Z',
+  turns: [
+    {
+      kind: 'message',
+      messageId: 'wamid-route-1',
+      text: 'Jakie wydarzenia jutro? intex-e2e-route',
+      timestamp: '2026-07-01T10:00:00.000Z',
+    },
+  ],
+  toolMocks: {
+    query_calendar_events: {
+      mode: 'success',
+      result: { status: 'completed', mode: 'list', count: 0, events: [] },
+    },
+  },
+};
+```
+
+Expected before implementation: FAIL with route not found or missing container field.
+
+- [ ] **Step 2: Implement route schema and handler**
+
+Use `validateInternalAuth(request)` exactly like `apps/intex-agent/src/routes/internalRoutes.ts`.
+
+Route behavior:
+
+- `404` when `INTEXURAOS_ENVIRONMENT === 'prod'`.
+- `401` when internal auth fails.
+- `400` when `contractVersion`, `mode`, `runId`, `userId`, `currentDateTime`, or `turns` are invalid.
+- `400` when `mode` is anything except `live_llm_mock_tools`.
+- `400` when `userId` does not match `^test-intex-agent-[a-z0-9._-]{1,96}$` or does not contain normalized `runId`.
+- `400` when `toolMocks` contains unknown tool names, unknown fields, nested arbitrary objects, secret-like field names, or oversized values.
+- `413` when body exceeds `64 * 1024`.
+- `200` with `reply.ok(response)` on success.
+- Call `logIncomingRequest(request, { message: 'Received request to POST /internal/intex-agent/test/conversation', bodyPreviewLength: 0 })`.
+- After validation, log safe metadata only: `runId`, `userId`, turn count, mode.
+
+Register in `apps/intex-agent/src/server.ts`:
+
+```ts
+import { testConversationRoutes } from './routes/testConversationRoutes.js';
+
+await app.register(testConversationRoutes);
+```
+
+Run:
+
+```bash
+pnpm --filter @intexuraos/intex-agent test -- --run apps/intex-agent/src/__tests__/routes/testConversationRoutes.test.ts
+```
+
+Expected: PASS.
+
+## Task 6: Service Wiring For Deployed Live Mode
+
+**Files:**
+
+- Modify: `apps/intex-agent/src/services.ts`
+- Test: `apps/intex-agent/src/__tests__/routes/testConversationRoutes.test.ts`
+- Test: `apps/intex-agent/src/__tests__/domain/runTestConversation.test.ts`
+
+**Interfaces:**
+
+- Consumes: `ServiceConfig`
+- Consumes: `sessionRepository`
+- Consumes: `promptPreferencesRepository`
+- Produces: `testConversationRunner.run(input)`
+
+- [ ] **Step 1: Add failing service-wiring tests**
+
+Add tests proving:
+
+- live mode creates a fresh `createIntexAgentRunner()` per `run()` and per `executeConfirmed()` call
+- prompt preferences are read through `promptPreferencesRepository.getCurrent(userId)`
+- downstream clients (`notesClient`, `calendarClient`, `researchClient`, `bookmarksClient`, `codeClient`, `externalSaveClient`) are throw-on-call fakes and are never invoked
+- two deployed-mode calls generate different session/event/confirmation IDs
+- existing `setServices()` fixtures in `sessionRoutes.test.ts`, `preferencesRoutes.test.ts`, and `promptPreferencesRoutes.test.ts` are updated with an unused fake `testConversationRunner`
+
+- [ ] **Step 2: Wire `testConversationRunner` in `initServices()`**
+
+Implementation outline:
+
+```ts
+const testConversationRunner = {
+  async run(input: TestConversationHttpRequest): Promise<TestConversationResponse> {
+    const toolCalls: CapturedToolCall[] = [];
+    const runner = createLiveMockedRunner({
+      input,
+      config,
+      logger,
+      toolCalls,
+      promptPreferencesRepository,
+      usageSink,
+    });
+
+    const response = await runTestConversation(input, {
+      sessionRepository,
+      runner,
+      sessionTimeoutMs: config.sessionTimeoutMs,
+      ids: {
+        sessionId: () => `intex_session_${randomUUID()}`,
+        eventId: () => `intex_event_${randomUUID()}`,
+        confirmationId: () => `intex_confirmation_${randomUUID()}`,
+      },
+      logger,
+    });
+
+    return { ...response, toolCalls };
+  },
+};
+```
+
+Keep `domain/testConversation/runTestConversation.ts` pure. `createLiveMockedRunner()` belongs in `services.ts` and must create LLM clients the same way the normal runner does, but must pass `createTestToolExecutor({ mocks: input.toolMocks, calls: toolCalls })` into `createIntexAgentRunner()`.
+
+Run:
+
+```bash
+pnpm --filter @intexuraos/intex-agent test -- --run apps/intex-agent/src/__tests__/routes/testConversationRoutes.test.ts apps/intex-agent/src/__tests__/domain/runTestConversation.test.ts
+```
+
+Expected: PASS.
+
+## Task 7: Documentation And Scenario Harness Update
+
+**Files:**
+
+- Modify: `docs/superpowers/specs/2026-06-24-intex-agent-dev-api-test-scenarios.md`
+- Modify: `docs/services/intex-agent/features.md`
+- Modify: `docs/services/intex-agent/technical.md`
+
+**Interfaces:**
+
+- Produces: documented curl/API procedure for local/dev internal testing and explicit production disablement.
+
+- [ ] **Step 1: Update dev API scenario spec**
+
+Add this section after `## Dev API Execution Contract`:
+
+```md
+## Internal Test Conversation Endpoint
+
+When the goal is to test Intex Agent chat behavior without UI login, OAuth, WhatsApp delivery, or real downstream tool mutations, use:
+
+`POST /internal/intex-agent/test/conversation`
+
+Required header:
+
+`X-Internal-Auth: <INTEXURAOS_INTERNAL_AUTH_TOKEN>`
+
+The endpoint preserves the Intex Agent conversation domain: session lifecycle, prompt preferences, classifier, runner, confirmation handling, fallback behavior, and timeline persistence. It replaces WhatsApp publishing with captured replies and replaces downstream tool execution with explicit mocks. It validates conversation/tool behavior, not downstream provider persistence.
+
+Use `mode: "live_llm_mock_tools"` for behavioral prompt scenarios. Use a unique lowercase `runId` marker in every user message and set `userId` to `test-intex-agent-<runId>`. Assert `behavioralTranscript`, `sessions`, `sessionTransitions`, sanitized `eventsBySessionId`, and `toolCalls`; do not assert exact wording when the scenario only requires semantic meaning.
+
+Scenario pass criteria are split:
+
+- `internal_mock_tools`: assert intended tool calls and mocked results; no downstream resources are created.
+- `full_dev_flow`: assert provider resources through real notes/calendar/code APIs.
+
+Current Intex Agent sessions remain `waiting_for_user` after completed, no-action, clarification, and unsupported turns. Scenario docs must assert that current behavior plus outcome evidence events unless a separate implementation explicitly changes session-closing semantics.
+```
+
+- [ ] **Step 2: Add a curl example to `docs/services/intex-agent/technical.md`**
+
+```bash
+RUN_ID="intex-e2e-manual-$(date -u +%Y%m%dT%H%M%SZ)"
+USER_ID="test-intex-agent-${RUN_ID}"
+BASE_URL="${INTEXURAOS_INTEX_AGENT_URL:-http://localhost:8134}"
+PAYLOAD="$(jq -n \
+  --arg runId "$RUN_ID" \
+  --arg userId "$USER_ID" \
+  '{
+    contractVersion: "2026-07-01",
+    mode: "live_llm_mock_tools",
+    runId: $runId,
+    userId: $userId,
+    currentDateTime: "2026-07-01T10:00:00.000Z",
+    turns: [
+      {
+        kind: "message",
+        messageId: ("wamid-" + $runId + "-1"),
+        text: ("Jakie wydarzenia mam jutro w kalendarzu? " + $runId),
+        timestamp: "2026-07-01T10:00:00.000Z"
+      }
+    ],
+    toolMocks: {
+      query_calendar_events: {
+        mode: "success",
+        result: {
+          status: "completed",
+          mode: "list",
+          count: 0,
+          events: []
+        }
+      }
+    }
+  }'
+)"
+
+curl -fsS \
+  -H "content-type: application/json" \
+  -H "x-internal-auth: $INTEXURAOS_INTERNAL_AUTH_TOKEN" \
+  -X POST "${BASE_URL}/internal/intex-agent/test/conversation" \
+  --data "$PAYLOAD" | jq -e '.success == true and (.data.toolCalls | length) >= 1'
+```
+
+- [ ] **Step 3: Verify docs mention the side-effect boundary**
+
+Run:
+
+```bash
+rg -n "test/conversation|mocked tools|captured replies|X-Internal-Auth" docs/superpowers/specs/2026-06-24-intex-agent-dev-api-test-scenarios.md docs/services/intex-agent
+```
+
+Expected: at least one match in each modified documentation area.
+
+## Task 8: Cleanup Strategy
+
+**Files:**
+
+- Create: `scripts/cleanup-intex-agent-test-conversations.mjs`
+- Test: add script validation coverage through existing script test pattern if available; otherwise document manual dry-run verification in this task.
+
+**Interfaces:**
+
+- Produces: guarded cleanup for test-namespaced Firestore documents.
+
+- [ ] **Step 1: Write guarded cleanup script**
+
+The script must:
+
+- require `--user-id test-intex-agent-*`
+- require `--run-id <runId>` and verify the normalized `runId` appears in `userId`
+- use `GOOGLE_APPLICATION_CREDENTIALS=$HOME/.config/gcloud/sa-key.json`
+- refuse to run if the credential file is not a service account key
+- count matching docs before deletion
+- support `--dry-run` by default and require `--execute` for writes
+- delete only matching test docs from `intex_agent_sessions`, `intex_agent_session_events`, `intex_agent_prompt_preferences`, and `intex_agent_prompt_preference_versions`
+- never accept product/Auth0 user IDs
+
+- [ ] **Step 2: Document cleanup command**
+
+Add this to `docs/services/intex-agent/technical.md`:
+
+```bash
+GOOGLE_APPLICATION_CREDENTIALS="$HOME/.config/gcloud/sa-key.json" \
+node scripts/cleanup-intex-agent-test-conversations.mjs \
+  --user-id "test-intex-agent-${RUN_ID}" \
+  --run-id "$RUN_ID" \
+  --dry-run
+```
+
+- [ ] **Step 3: Verify cleanup safety**
+
+Run:
+
+```bash
+node scripts/cleanup-intex-agent-test-conversations.mjs --user-id auth0-real-user --run-id real --dry-run
+```
+
+Expected: non-zero exit with a message that the user id is outside the allowed test namespace.
+
+## Task 9: Verification
+
+**Files:**
+
+- All files from Tasks 1-8.
+
+**Interfaces:**
+
+- Produces: passing tracked CI for the feature branch.
+
+- [ ] **Step 1: Run focused tests**
+
+```bash
+pnpm --filter @intexuraos/intex-agent test -- --run \
+  apps/intex-agent/src/__tests__/domain/testToolMocks.test.ts \
+  apps/intex-agent/src/__tests__/domain/runTestConversation.test.ts \
+  apps/intex-agent/src/__tests__/domain/testConversationSanitizer.test.ts \
+  apps/intex-agent/src/__tests__/routes/testConversationRoutes.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 1b: Verify covered source paths**
+
+Run:
+
+```bash
+pnpm --filter @intexuraos/intex-agent test:coverage -- --run \
+  apps/intex-agent/src/__tests__/domain/testToolMocks.test.ts \
+  apps/intex-agent/src/__tests__/domain/runTestConversation.test.ts \
+  apps/intex-agent/src/__tests__/domain/testConversationSanitizer.test.ts \
+  apps/intex-agent/src/__tests__/routes/testConversationRoutes.test.ts
+```
+
+Expected: PASS with no uncovered branch/function/line entries for `apps/intex-agent/src/domain/testConversation/**` or `apps/intex-agent/src/routes/testConversationRoutes.ts`.
+
+- [ ] **Step 2: Run workspace verification**
+
+```bash
+pnpm run verify:workspace:tracked -- intex-agent
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run full tracked CI**
+
+```bash
+pnpm run ci:tracked
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Manual local API smoke test**
+
+With local services running through `pnpm run dev`, call:
+
+```bash
+RUN_ID="intex-e2e-local-smoke-$(date -u +%Y%m%dT%H%M%SZ)"
+USER_ID="test-intex-agent-${RUN_ID}"
+BASE_URL="${INTEXURAOS_INTEX_AGENT_URL:-http://localhost:8134}"
+PAYLOAD="$(jq -n \
+  --arg runId "$RUN_ID" \
+  --arg userId "$USER_ID" \
+  '{
+    contractVersion: "2026-07-01",
+    mode: "live_llm_mock_tools",
+    runId: $runId,
+    userId: $userId,
+    currentDateTime: "2026-07-01T10:00:00.000Z",
+    turns: [
+      {
+        kind: "message",
+        messageId: ("wamid-" + $runId + "-1"),
+        text: ("Jakie wydarzenia mam jutro w kalendarzu? " + $runId),
+        timestamp: "2026-07-01T10:00:00.000Z"
+      }
+    ],
+    toolMocks: {
+      query_calendar_events: {
+        mode: "success",
+        result: {
+          status: "completed",
+          mode: "list",
+          count: 0,
+          events: []
+        }
+      }
+    }
+  }'
+)"
+
+HTTP_CODE="$(
+  curl -sS -o /tmp/intex-agent-test-conversation-response.json -w "%{http_code}" \
+  -H "content-type: application/json" \
+  -H "x-internal-auth: $INTEXURAOS_INTERNAL_AUTH_TOKEN" \
+  -X POST "${BASE_URL}/internal/intex-agent/test/conversation" \
+  --data "$PAYLOAD"
+)"
+
+test "$HTTP_CODE" = "200"
+jq -e '
+  .success == true
+  and .data.sideEffectBoundary == "mocked_tools_no_downstream_writes"
+  and (.data.turns[0].assistantReplies | length) >= 1
+  and (.data.toolCalls[] | select(.toolName == "query_calendar_events" and .status == "completed"))
+  and (.data.eventsBySessionId | tostring | contains("assistant_message"))
+' /tmp/intex-agent-test-conversation-response.json
+```
+
+Expected:
+
+- HTTP 200.
+- Response contains `turns[0].assistantReplies[0].message`.
+- Response contains a `toolCalls[]` entry for `query_calendar_events`.
+- Response declares `sideEffectBoundary: mocked_tools_no_downstream_writes`.
+- `eventsBySessionId` contains `user_message` and `assistant_message`.
+- Downstream side-effect isolation is proven by focused tests with throw-on-call downstream fakes; manual smoke does not prove provider absence by itself.
+
+## Self-Review Checklist
+
+- Spec coverage: OAuth bypass is handled by internal auth; UI bypass is handled by curl/API; domain preservation is handled by `handleIncomingMessage()` plus live LLM runner; tool side effects are replaced by `createTestToolExecutor()`.
+- Endpoint coverage: created, modified, removed, and unchanged endpoints are explicitly listed.
+- Auth coverage: route tests cover missing auth, wrong auth, unset internal token, no Pub/Sub `from` bypass, prod 404, non-test user rejection, and valid internal auth.
+- Side-effect coverage: tests assert captured replies, mock tool calls, mock-only preference tools, and throw-on-call downstream clients.
+- Redaction coverage: sanitizer tests prove raw `toolArgs`, raw tool results, source URLs, reply contexts, WhatsApp sender values, secret-like fields, and auth values are not returned or logged.
+- Documentation coverage: scenario spec and service docs include the endpoint and curl example.
+- Verification coverage: focused tests, workspace verification, full tracked CI, and local smoke test are specified.

--- a/docs/superpowers/specs/2026-06-24-intex-agent-dev-api-test-scenarios.md
+++ b/docs/superpowers/specs/2026-06-24-intex-agent-dev-api-test-scenarios.md
@@ -2,9 +2,17 @@
 
 ## Purpose
 
-These scenarios define the dev-environment behavioral checks for `intex-agent` once it is deployed to `https://dev.intexuraos.cloud`.
+These scenarios define behavioral checks for `intex-agent` in local/dev. They can run through the internal mocked-tool endpoint for conversation behavior or through the full dev flow for downstream resource persistence.
 
-The testing agent must drive the system through APIs and verify the user-facing behavior, session lifecycle, timeline events, and created resources. The validation must not be a raw JSON snapshot comparison. JSON from APIs is evidence, but the contract is what happens when the user types, what the assistant replies, what session state is produced, and whether the expected note or calendar event exists.
+The testing agent must drive the system through APIs and verify the user-facing behavior, session lifecycle, timeline events, and resource intent. The validation must not be a raw JSON snapshot comparison. JSON from APIs is evidence, but the contract is what happens when the user types, what the assistant replies, what session state is produced, and whether the expected tool/resource effect is represented.
+
+## Execution Modes
+
+`internal_mock_tools`: use `POST /internal/intex-agent/test/conversation` on local or dev host-local `intex-agent` with `X-Internal-Auth`. Set `mode: "live_llm_mock_tools"`, use a unique lowercase `runId`, and set `userId` to `test-intex-agent-<runId>`. This mode preserves session lifecycle, prompt preferences, classifier, runner, confirmations, fallback handling, and `handleIncomingMessage()`, but all tools are mocked. It verifies intended tool execution and assistant behavior, not downstream provider persistence.
+
+`full_dev_flow`: use the deployed dev WhatsApp ingress path and connected test account. This mode verifies provider resources such as created notes or calendar events.
+
+Current Intex Agent sessions remain `waiting_for_user` after completed, clarification, no-action, and unsupported outcomes. Treat completed/unsupported timeline events and user-facing replies as the outcome evidence; do not require session close events unless the scenario explicitly supersedes or expires a session.
 
 ## Test Harness Expectations
 
@@ -17,14 +25,23 @@ Use a dedicated dev test user with:
 
 Every user message should include a unique marker such as `INTEX-E2E-<timestamp>-<scenario>` so the testing agent can find related sessions, notes, and calendar events without relying on global ordering.
 
-The testing agent should use API calls against the deployed dev environment to:
+The testing agent should use API calls against the selected execution mode to:
 
-- Submit inbound WhatsApp Assistant messages to the deployed dev flow.
-- Read assistant replies through the dev-visible outbound message/session APIs.
-- Read `intex-agent` sessions.
-- Read session timeline events.
-- Verify created notes through notes APIs or the web-visible note read path.
-- Verify created calendar events through calendar APIs or Google Calendar-visible event read paths.
+- In `internal_mock_tools`, submit the complete conversation to
+  `POST /internal/intex-agent/test/conversation`.
+- In `internal_mock_tools`, read assistant replies from
+  `data.turns[].assistantReplies`, not from WhatsApp-facing outbound resources.
+- In `internal_mock_tools`, inspect `data.sessions`, `data.sessionTransitions`,
+  sanitized `data.eventsBySessionId`, `data.toolCalls`, and
+  `data.behavioralTranscript` from the response.
+- In `full_dev_flow`, submit inbound WhatsApp Assistant messages to the deployed
+  dev flow.
+- In `full_dev_flow`, read assistant replies through the dev-visible outbound
+  message/session APIs.
+- In `full_dev_flow`, read `intex-agent` sessions and session timeline events.
+- In `internal_mock_tools`, verify `toolCalls`, `behavioralTranscript`, and sanitized `eventsBySessionId`.
+- In `full_dev_flow`, verify created notes through notes APIs or the web-visible note read path.
+- In `full_dev_flow`, verify created calendar events through calendar APIs or Google Calendar-visible event read paths.
 
 Exact assistant wording may vary, but the reply must contain the required meaning. Session boundary phrases are required: the user must be told when a new session starts and when the previous session was closed, finished, expired, or superseded.
 
@@ -35,13 +52,25 @@ Each scenario is a conversation contract, not a response-body contract. The test
 For each scenario:
 
 1. Generate a marker in the form `INTEX-E2E-<runId>-<scenarioNumber>`.
-2. Send each "User types" message through the dev WhatsApp Assistant ingress. If the deployed system exposes the internal route directly to the test harness, use the `intex-agent` inbound message endpoint. If the test harness exercises the full WhatsApp adapter, submit the message through the WhatsApp webhook simulation path.
-3. Use the same dev user, WhatsApp sender, and channel identity for every turn in the same scenario.
-4. Poll assistant replies until a WhatsApp-facing assistant message is available for the turn. Do not treat an internal API success response as the assistant reply.
-5. Locate the session by user, marker, and recent timeline content. If the session list endpoint does not support marker filtering, list recent sessions for the user and inspect timeline events until the marker is found.
-6. Verify the session state and timeline events described by the scenario.
-7. Verify the resulting note or calendar event through the relevant dev API or connected provider read path.
-8. For negative scenarios, verify that no note or calendar event containing the marker was created after the user message.
+2. In `internal_mock_tools`, send one request containing the scenario `turns`,
+   `runId`, `userId: test-intex-agent-<runId>`, `currentDateTime`, and bounded
+   `toolMocks`. Treat the captured assistant replies in the response as the
+   user-visible replies for this mode.
+3. In `full_dev_flow`, send each "User types" message through the dev WhatsApp
+   Assistant ingress. If the harness exercises the full WhatsApp adapter, submit
+   the message through the WhatsApp webhook simulation path.
+4. In `full_dev_flow`, use the same dev user, WhatsApp sender, and channel
+   identity for every turn in the same scenario.
+5. In `full_dev_flow`, poll assistant replies until a WhatsApp-facing assistant
+   message is available for the turn.
+6. Locate the session by user, marker, and recent timeline content. In
+   `internal_mock_tools`, use the response's `sessions` and `eventsBySessionId`;
+   in `full_dev_flow`, list recent sessions for the user and inspect timeline
+   events until the marker is found.
+7. Verify the session state and timeline events described by the scenario.
+8. In `internal_mock_tools`, verify the expected mocked tool call and result summary.
+9. In `full_dev_flow`, verify the resulting note or calendar event through the relevant dev API or connected provider read path.
+10. For negative scenarios, verify that no mocked tool call happened in `internal_mock_tools` and that no note or calendar event containing the marker was created in `full_dev_flow`.
 
 The testing agent should report results as a behavioral transcript:
 
@@ -73,9 +102,9 @@ Expected session state:
 
 - One new session exists for the test user.
 - Session starts with `startReason: no_active_session` unless a prior session exists, in which case the assistant must acknowledge the prior session before starting this one.
-- Session final status is `completed`.
+- Session status remains `waiting_for_user` after the assistant reply; completion is proven by the completed tool event and reply.
 - Active or completed tool is `create_note`.
-- Timeline includes session start, user message, note tool call start, note tool call completion, assistant confirmation, and session close.
+- Timeline includes session start, user message, note tool completion, and assistant confirmation.
 
 Expected resource result:
 
@@ -100,9 +129,9 @@ Expected assistant behavior:
 
 Expected session state:
 
-- Session final status is `completed`.
+- Session status remains `waiting_for_user` after the assistant reply; completion is proven by the completed tool event and reply.
 - Active or completed tool is `create_calendar_event`.
-- Timeline includes session start, user message, calendar tool call start, calendar tool call completion, assistant confirmation, and session close.
+- Timeline includes session start, user message, calendar tool completion, and assistant confirmation.
 
 Expected resource result:
 
@@ -146,8 +175,8 @@ Expected assistant behavior after second message:
 
 Expected session state after second message:
 
-- The same session final status is `completed`.
-- Timeline includes the second user message, calendar tool call start, calendar tool call completion, assistant confirmation, and session close.
+- The same session remains `waiting_for_user` after the assistant reply; completion is proven by the completed tool event and reply.
+- Timeline includes the second user message, calendar tool completion, and assistant confirmation.
 
 Expected resource result:
 
@@ -191,7 +220,7 @@ Expected session state:
 - The original calendar clarification session final status is `superseded` or `cancelled`.
 - The original session end reason is user-driven superseding or cancellation.
 - A new session exists for the note request.
-- The new session final status is `completed`.
+- The new session remains `waiting_for_user` after the assistant reply; completion is proven by the completed tool event and reply.
 - The new session tool is `create_note`.
 
 Expected resource result:
@@ -199,7 +228,7 @@ Expected resource result:
 - No calendar event is created for `INTEX-E2E-004 dentist`.
 - A note exists with marker `INTEX-E2E-004` and code `9988`.
 
-## Scenario 5: Unsupported Request Closes As Unsupported
+## Scenario 5: Unsupported Request Returns An Unsupported Outcome
 
 User types:
 
@@ -212,25 +241,24 @@ Expected assistant behavior:
 - Replies in WhatsApp.
 - Says that a new session started.
 - Clearly says the request is not supported yet.
-- States that the currently supported capabilities are notes and calendar events.
+- Names supported Intex Agent capabilities instead of inventing an Uber booking flow.
 - Does not call a note or calendar tool.
 
 Expected session state:
 
-- Session final status is `unsupported`.
-- Session end reason is `unsupported_request`.
-- Timeline includes session start, user message, unsupported request event, assistant unsupported reply, and session close.
+- Session status remains `waiting_for_user` after the unsupported reply; the unsupported outcome is proven by the `unsupported_request` event.
+- Timeline includes session start, user message, unsupported request event, and assistant unsupported reply.
 
 Expected resource result:
 
 - No note is created for `INTEX-E2E-005`.
 - No calendar event is created for `INTEX-E2E-005`.
 
-## Scenario 6: New Message After Completed Session Starts A New Session
+## Scenario 6: New Message After Completed Outcome Continues The Open Session
 
 Precondition:
 
-- Scenario 1 or any other one-message successful session has completed.
+- Scenario 1 or any other one-message successful session has produced a completed tool outcome and is waiting for the user.
 
 User types:
 
@@ -241,16 +269,15 @@ Remember INTEX-E2E-006 parking is on level P3.
 Expected assistant behavior:
 
 - Replies in WhatsApp.
-- Says that the previous session finished.
-- Says that a new session started.
+- Continues the same open session.
+- Does not say that a new session started.
 - Confirms the note was saved.
 
 Expected session state:
 
-- A new session is created rather than reopening the completed session.
-- New session final status is `completed`.
-- Previous session remains `completed`.
-- Timeline for the new session starts with a session-started event whose reason reflects a previous completed session.
+- The existing `waiting_for_user` session is reused.
+- The session remains `waiting_for_user` after the assistant reply; completion is proven by the completed tool event and reply.
+- Timeline includes the new user message, the completed note tool outcome, and assistant confirmation.
 
 Expected resource result:
 
@@ -273,7 +300,7 @@ Expected assistant behavior:
 
 Expected session state:
 
-- Session final status is `completed`.
+- Session status remains `waiting_for_user` after the assistant reply; completion is proven by the completed tool event and reply.
 - Tool is `create_note`.
 - Timeline includes note tool execution and assistant confirmation.
 
@@ -315,7 +342,7 @@ Expected assistant behavior after second message:
 
 Expected session state after second message:
 
-- Same session final status is `completed`.
+- The same session remains `waiting_for_user` after the assistant reply; completion is proven by the completed tool event and reply.
 - Tool is `create_calendar_event`.
 
 Expected resource result:
@@ -336,12 +363,12 @@ Expected assistant behavior:
 
 - Closes any active or waiting session if one exists.
 - Says that a new session started.
-- Says the assistant can create notes and calendar events.
+- Says what supported Intex Agent jobs it can help with next.
 - Does not call any tool.
 
 Expected session state:
 
-- A new session exists with status `active` or another idle/open status chosen by the implementation.
+- A new session exists with status `waiting_for_user`.
 - Timeline includes session start and assistant message.
 - No tool call events exist for this session.
 
@@ -367,7 +394,7 @@ Expected assistant behavior:
 
 Expected session state:
 
-- Session final status is `completed`.
+- Session status remains `waiting_for_user` after the assistant reply; completion is proven by the completed tool event and reply.
 - Tool is `create_note`.
 - Timeline records that the source was voice or transcription, while still showing the transcript text as the user message content.
 
@@ -383,9 +410,9 @@ The implementation passes this scenario suite when all executed scenarios demons
 Failures include:
 
 - Starting a new product session silently.
-- Continuing a completed session without telling the user a new session started.
+- Continuing a superseded or expired session without telling the user a new session started.
 - Treating explicit `new session` as clarification text.
 - Creating a calendar event when required details are missing.
 - Creating notes or calendar events for unsupported requests.
-- Returning only machine-readable output without a WhatsApp-facing assistant message.
+- Returning only machine-readable output without a WhatsApp-facing assistant message or, in `internal_mock_tools`, a captured assistant reply.
 - Validating only raw response JSON without checking session timeline and created resources.

--- a/packages/infra-sentry/src/__tests__/fastify.test.ts
+++ b/packages/infra-sentry/src/__tests__/fastify.test.ts
@@ -133,6 +133,34 @@ describe('setupSentryErrorHandler', () => {
     expect(body.message).toBe('Rate limit exceeded');
   });
 
+  it('responds with 413 for Fastify body-limit parser errors without capturing to Sentry', async () => {
+    setupSentryErrorHandler(app);
+
+    app.addContentTypeParser(
+      'application/json',
+      { parseAs: 'string', bodyLimit: 8 },
+      (_request, body, done) => {
+        done(null, JSON.parse(body as string));
+      }
+    );
+    app.post('/test', async () => ({ ok: true }));
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/test',
+      headers: { 'content-type': 'application/json' },
+      payload: JSON.stringify({ value: 'too large' }),
+    });
+
+    expect(response.statusCode).toBe(413);
+    const body = JSON.parse(response.body) as {
+      error: { code: string; message: string };
+    };
+    expect(body.error.code).toBe('INVALID_REQUEST');
+    expect(body.error.message).toBe('Request body too large');
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+  });
+
   it('handles 404 routes without errors', async () => {
     setupSentryErrorHandler(app);
 

--- a/packages/infra-sentry/src/fastify.ts
+++ b/packages/infra-sentry/src/fastify.ts
@@ -67,6 +67,25 @@ export function setupSentryErrorHandler(app: FastifyInstance): void {
       return;
     }
 
+    if (fastifyError.code === 'FST_ERR_CTP_BODY_TOO_LARGE') {
+      request.log.info({ err: error }, 'Request body too large');
+      await reply.status(413).send({
+        success: false,
+        error: {
+          code: 'INVALID_REQUEST',
+          message: 'Request body too large',
+        },
+        diagnostics: {
+          requestId: 'requestId' in request ? request.requestId : '',
+          durationMs:
+            'startTime' in request && typeof request.startTime === 'number'
+              ? Date.now() - request.startTime
+              : 0,
+        },
+      });
+      return;
+    }
+
     // Handle validation errors
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (typeof error === 'object' && error !== null && 'validation' in error) {

--- a/scripts/__tests__/cleanup-intex-agent-test-conversations.test.ts
+++ b/scripts/__tests__/cleanup-intex-agent-test-conversations.test.ts
@@ -33,6 +33,35 @@ describe('cleanup-intex-agent-test-conversations', () => {
     });
   });
 
+  it('uses the last explicit cleanup mode flag', () => {
+    expect(
+      parseArgs([
+        '--user-id',
+        'test-intex-agent-run-1',
+        '--run-id',
+        'run-1',
+        '--execute',
+        '--dry-run',
+      ])
+    ).toMatchObject({
+      dryRun: true,
+      execute: false,
+    });
+    expect(
+      parseArgs([
+        '--user-id',
+        'test-intex-agent-run-1',
+        '--run-id',
+        'run-1',
+        '--dry-run',
+        '--execute',
+      ])
+    ).toMatchObject({
+      dryRun: false,
+      execute: true,
+    });
+  });
+
   it('rejects product users and test users that do not exactly match the run id', () => {
     expect(() => validateCleanupRequest({ userId: 'auth0|real-user', runId: 'real' })).toThrow(
       'outside the allowed test-intex-agent namespace'

--- a/scripts/__tests__/cleanup-intex-agent-test-conversations.test.ts
+++ b/scripts/__tests__/cleanup-intex-agent-test-conversations.test.ts
@@ -1,0 +1,71 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  parseArgs,
+  readServiceAccountInfo,
+  validateCleanupRequest,
+} from '../cleanup-intex-agent-test-conversations.mjs';
+
+describe('cleanup-intex-agent-test-conversations', () => {
+  const tempRoots: string[] = [];
+
+  afterEach(() => {
+    for (const root of tempRoots) {
+      rmSync(root, { recursive: true, force: true });
+    }
+    tempRoots.length = 0;
+  });
+
+  it('defaults to dry-run and parses explicit execute mode', () => {
+    expect(parseArgs(['--user-id', 'test-intex-agent-run-1', '--run-id', 'run-1'])).toMatchObject({
+      userId: 'test-intex-agent-run-1',
+      runId: 'run-1',
+      dryRun: true,
+      execute: false,
+    });
+    expect(
+      parseArgs(['--user-id', 'test-intex-agent-run-1', '--run-id', 'run-1', '--execute'])
+    ).toMatchObject({
+      dryRun: false,
+      execute: true,
+    });
+  });
+
+  it('rejects product users and test users that do not exactly match the run id', () => {
+    expect(() => validateCleanupRequest({ userId: 'auth0|real-user', runId: 'real' })).toThrow(
+      'outside the allowed test-intex-agent namespace'
+    );
+    expect(() =>
+      validateCleanupRequest({ userId: 'test-intex-agent-other', runId: 'run-1' })
+    ).toThrow('must equal test-intex-agent-<runId>');
+    expect(() =>
+      validateCleanupRequest({ userId: 'test-intex-agent-agent', runId: 'agent' })
+    ).not.toThrow();
+  });
+
+  it('requires service-account credentials', () => {
+    const root = mkdtempSync(join(tmpdir(), 'intex-cleanup-'));
+    tempRoots.push(root);
+    const credentialPath = join(root, 'credentials.json');
+    writeFileSync(credentialPath, JSON.stringify({ type: 'authorized_user' }));
+
+    expect(() => readServiceAccountInfo(credentialPath)).toThrow(
+      'requires a service_account credential file'
+    );
+
+    writeFileSync(
+      credentialPath,
+      JSON.stringify({
+        type: 'service_account',
+        client_email: 'test@example.iam.gserviceaccount.com',
+        project_id: 'intexuraos-dev-pbuchman',
+      })
+    );
+    expect(readServiceAccountInfo(credentialPath)).toMatchObject({
+      type: 'service_account',
+      project_id: 'intexuraos-dev-pbuchman',
+    });
+  });
+});

--- a/scripts/cleanup-intex-agent-test-conversations.mjs
+++ b/scripts/cleanup-intex-agent-test-conversations.mjs
@@ -47,6 +47,7 @@ export function parseArgs(argv) {
       parsed.execute = true;
       parsed.dryRun = false;
     } else if (arg === '--dry-run') {
+      parsed.execute = false;
       parsed.dryRun = true;
     } else {
       throw new Error(`Unknown or incomplete argument: ${String(arg)}`);

--- a/scripts/cleanup-intex-agent-test-conversations.mjs
+++ b/scripts/cleanup-intex-agent-test-conversations.mjs
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { cert, getApps, initializeApp } from 'firebase-admin/app';
+import { getFirestore } from 'firebase-admin/firestore';
+
+const COLLECTIONS = {
+  sessions: 'intex_agent_sessions',
+  events: 'intex_agent_session_events',
+  promptPreferences: 'intex_agent_prompt_preferences',
+  promptPreferenceVersions: 'intex_agent_prompt_preference_versions',
+};
+
+const TEST_USER_PATTERN = /^test-intex-agent-[a-z0-9._-]{1,96}$/u;
+const RUN_ID_PATTERN = /^[a-z0-9._-]{1,128}$/u;
+
+export function parseArgs(argv) {
+  const parsed = {
+    userId: '',
+    runId: '',
+    execute: false,
+    dryRun: true,
+    credentialsPath:
+      process.env.GOOGLE_APPLICATION_CREDENTIALS ??
+      resolve(homedir(), '.config/gcloud/sa-key.json'),
+    projectId: process.env.INTEXURAOS_GCP_PROJECT_ID ?? 'intexuraos-dev-pbuchman',
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = argv[index + 1];
+    if (arg === '--user-id' && next !== undefined) {
+      parsed.userId = next;
+      index += 1;
+    } else if (arg === '--run-id' && next !== undefined) {
+      parsed.runId = next;
+      index += 1;
+    } else if (arg === '--credentials' && next !== undefined) {
+      parsed.credentialsPath = next;
+      index += 1;
+    } else if (arg === '--project-id' && next !== undefined) {
+      parsed.projectId = next;
+      index += 1;
+    } else if (arg === '--execute') {
+      parsed.execute = true;
+      parsed.dryRun = false;
+    } else if (arg === '--dry-run') {
+      parsed.dryRun = true;
+    } else {
+      throw new Error(`Unknown or incomplete argument: ${String(arg)}`);
+    }
+  }
+
+  return parsed;
+}
+
+export function validateCleanupRequest(input) {
+  const normalizedRunId = input.runId.trim().toLowerCase();
+  if (!RUN_ID_PATTERN.test(normalizedRunId)) {
+    throw new Error(
+      'runId must be lowercase and contain only letters, numbers, dot, underscore, or dash'
+    );
+  }
+  if (!TEST_USER_PATTERN.test(input.userId)) {
+    throw new Error('user id is outside the allowed test-intex-agent namespace');
+  }
+  if (input.userId !== `test-intex-agent-${normalizedRunId}`) {
+    throw new Error('user id must equal test-intex-agent-<runId>');
+  }
+  return { ...input, runId: normalizedRunId };
+}
+
+export function readServiceAccountInfo(credentialsPath) {
+  if (!existsSync(credentialsPath)) {
+    throw new Error(`Service account credentials file does not exist: ${credentialsPath}`);
+  }
+  const parsed = JSON.parse(readFileSync(credentialsPath, 'utf8'));
+  if (parsed.type !== 'service_account') {
+    throw new Error('Firestore cleanup requires a service_account credential file');
+  }
+  return parsed;
+}
+
+export async function runCleanup(rawInput) {
+  const input = validateCleanupRequest(rawInput);
+  const serviceAccount = readServiceAccountInfo(input.credentialsPath);
+  const app =
+    getApps()[0] ??
+    initializeApp({
+      credential: cert(serviceAccount),
+      projectId: input.projectId,
+    });
+  const firestore = getFirestore(app);
+
+  const targets = await collectTargets(firestore, input.userId);
+  const total = Object.values(targets).reduce((sum, docs) => sum + docs.length, 0);
+
+  console.log(
+    JSON.stringify(
+      {
+        userId: input.userId,
+        runId: input.runId,
+        projectId: input.projectId,
+        mode: input.execute ? 'execute' : 'dry-run',
+        counts: Object.fromEntries(
+          Object.entries(targets).map(([key, docs]) => [key, docs.length])
+        ),
+        total,
+      },
+      null,
+      2
+    )
+  );
+
+  if (!input.execute) {
+    console.log('Dry run only. Re-run with --execute to delete matching test documents.');
+    return { deleted: 0, total };
+  }
+
+  for (const docs of Object.values(targets)) {
+    await Promise.all(docs.map(async (doc) => await doc.ref.delete()));
+  }
+  console.log(`Deleted ${String(total)} matching test documents.`);
+  return { deleted: total, total };
+}
+
+async function collectTargets(firestore, userId) {
+  const [sessions, events, versions, promptPreference] = await Promise.all([
+    firestore.collection(COLLECTIONS.sessions).where('userId', '==', userId).get(),
+    firestore.collection(COLLECTIONS.events).where('userId', '==', userId).get(),
+    firestore.collection(COLLECTIONS.promptPreferenceVersions).where('userId', '==', userId).get(),
+    firestore.collection(COLLECTIONS.promptPreferences).doc(userId).get(),
+  ]);
+
+  return {
+    sessions: sessions.docs,
+    events: events.docs,
+    promptPreferences: promptPreference.exists ? [promptPreference] : [],
+    promptPreferenceVersions: versions.docs,
+  };
+}
+
+async function main() {
+  try {
+    await runCleanup(parseArgs(process.argv.slice(2)));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  await main();
+}


### PR DESCRIPTION
## Summary

- Add local/dev-only internal Intex Agent test conversation endpoint with live LLM flow and mocked tool execution.
- Add sanitized transcript/tool summaries, strict request validation, cleanup tooling, and documentation.
- Cover domain runner, route behavior, sanitizer, service DI, cleanup script, and infra-sentry 413 handling.

## Verification

- `pnpm run ci:tracked`

## Linear

Linear: [INT-1826](https://linear.app/pbuchman/issue/INT-1826)
IntexuraOS Code Task: [View task](https://intexuraos.cloud/#/code-tasks/task_4974f353-4504-494a-85a5-e619d1ebd616)
Worker Type: `codex-xhigh`
Model: `default`
