### PR TITLE
[INT-1824] Allow private WhatsApp media backfill edge auth

### DIFF
--- a/docs/operations/hetzner-prod-runbook.md
+++ b/docs/operations/hetzner-prod-runbook.md
@@ -406,7 +406,9 @@ service account.
 Private WhatsApp sync uses the same edge-auth path. The external bridge machine
 must call both
 `POST https://intexuraos.cloud/internal/whatsapp/private/events` and
-`POST https://intexuraos.cloud/internal/whatsapp/private/media` with a Google
+`POST https://intexuraos.cloud/internal/whatsapp/private/media`, and may call
+`POST https://intexuraos.cloud/internal/whatsapp/private/media/backfill` for
+stored-media repairs, with a Google
 OIDC bearer token whose audience is `https://intexuraos.cloud` and whose email
 claim is
 `intexuraos-wa-private-sync-dev@intexuraos-dev-pbuchman.iam.gserviceaccount.com`.

--- a/scripts/__tests__/hetzner-runtime.test.ts
+++ b/scripts/__tests__/hetzner-runtime.test.ts
@@ -298,6 +298,7 @@ describe('Hetzner nginx runtime config', () => {
     );
     expect(routeAllowlist).toContain('["/internal/whatsapp/private/events"]');
     expect(routeAllowlist).toContain('["/internal/whatsapp/private/media"]');
+    expect(routeAllowlist).toContain('["/internal/whatsapp/private/media/backfill"]');
     expect(routeAllowlist).toContain(
       'intexuraos-wa-private-sync-dev@intexuraos-dev-pbuchman.iam.gserviceaccount.com'
     );
@@ -307,9 +308,13 @@ describe('Hetzner nginx runtime config', () => {
     );
     expect(hetznerMain).toContain('"/internal/whatsapp/private/events"');
     expect(hetznerMain).toContain('"/internal/whatsapp/private/media"');
+    expect(hetznerMain).toContain('"/internal/whatsapp/private/media/backfill"');
     expect(hetznerMain).toContain('"/internal/users/"');
     expect(runbook).toContain('POST https://intexuraos.cloud/internal/whatsapp/private/events');
     expect(runbook).toContain('POST https://intexuraos.cloud/internal/whatsapp/private/media');
+    expect(runbook).toContain(
+      'POST https://intexuraos.cloud/internal/whatsapp/private/media/backfill'
+    );
 
     const allowFunction = verifier.slice(
       verifier.indexOf('local function is_service_account_allowed'),

--- a/scripts/hetzner/nginx/jwt-verify.lua
+++ b/scripts/hetzner/nginx/jwt-verify.lua
@@ -21,6 +21,9 @@ local ROUTE_ALLOWED_SERVICE_ACCOUNTS = {
   ["/internal/whatsapp/private/media"] = {
     ["intexuraos-wa-private-sync-dev@intexuraos-dev-pbuchman.iam.gserviceaccount.com"] = true,
   },
+  ["/internal/whatsapp/private/media/backfill"] = {
+    ["intexuraos-wa-private-sync-dev@intexuraos-dev-pbuchman.iam.gserviceaccount.com"] = true,
+  },
 }
 
 local ROUTE_PREFIX_ALLOWED_SERVICE_ACCOUNTS = {

--- a/terraform/hetzner-prod/main.tf
+++ b/terraform/hetzner-prod/main.tf
@@ -73,6 +73,7 @@ locals {
     "/internal/users/"                                  = "user-service"
     "/internal/whatsapp/private/events"                 = "whatsapp-service"
     "/internal/whatsapp/private/media"                  = "whatsapp-service"
+    "/internal/whatsapp/private/media/backfill"         = "whatsapp-service"
     "/internal/whatsapp/pubsub/media-cleanup"           = "whatsapp-service"
     "/internal/whatsapp/pubsub/process-webhook"         = "whatsapp-service"
     "/internal/whatsapp/pubsub/send-message"            = "whatsapp-service"


### PR DESCRIPTION
Fixes INT-1824

### Summary
- Allows the private WhatsApp sync service account to call the media backfill endpoint through Hetzner edge JWT verification.
- Adds runtime-test coverage for the new route allowance.
- Documents the route in the Hetzner route inventory and runbook.

### Verification
- pnpm run ci:tracked

Linear: [INT-1824](https://linear.app/pbuchman/issue/INT-1824)
IntexuraOS Code Task: [View task](https://intexuraos.cloud/#/code-tasks/task_9b2bdbfc-c3f2-47e6-a88c-661f010e3546)
Worker Type: `codex-xhigh`
Model: `default`
