### PR TITLE
[INT-1824] Pin Speechmatics for transcription deploys

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1968,7 +1968,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/infra-sentry
       '@speechmatics/batch-client':
-        specifier: ^5.1.0
+        specifier: 5.1.0
         version: 5.1.0
       pino:
         specifier: 'catalog:'

--- a/scripts/__tests__/cloud-function-packaging.test.ts
+++ b/scripts/__tests__/cloud-function-packaging.test.ts
@@ -51,4 +51,12 @@ describe('Cloud Function production package generation', () => {
     expect(Object.values(pkg.dependencies ?? {})).not.toContain('catalog:');
     expect(pkg.dependencies?.pino).toBe(getCatalogVersion('pino'));
   });
+
+  it('pins Speechmatics for transcription Cloud Function deploys', () => {
+    buildWorker('@intexuraos/transcription');
+
+    const pkg = readBuiltPackageJson('workers/transcription/dist/package.json');
+
+    expect(pkg.dependencies?.['@speechmatics/batch-client']).toBe('5.1.0');
+  });
 });

--- a/workers/transcription/package.json
+++ b/workers/transcription/package.json
@@ -23,7 +23,7 @@
     "@intexuraos/common-core": "workspace:*",
     "@intexuraos/infra-pubsub": "workspace:*",
     "@intexuraos/infra-sentry": "workspace:*",
-    "@speechmatics/batch-client": "^5.1.0",
+    "@speechmatics/batch-client": "5.1.0",
     "pino": "catalog:"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- pin @speechmatics/batch-client to 5.1.0 for the transcription Cloud Function package
- keep pnpm lockfile specifier in sync for frozen CI installs
- add a packaging regression test so deploy artifacts cannot float Speechmatics again

## Verification
- pnpm install --frozen-lockfile
- pnpm run ci:tracked

- Linear: [INT-1824](https://linear.app/pbuchman/issue/INT-1824)
- IntexuraOS Code Task: [View task](https://intexuraos.cloud/#/code-tasks/task_6d243ecd-1001-4d7a-b517-6de01056b65e)
- Worker Type: `codex-xhigh`
- Model: `default`
