### PR TITLE
[INT-1833] Add private WhatsApp media player

### DIFF
--- a/apps/web/src/components/whatsapp/PrivateWhatsAppMediaPlayer.tsx
+++ b/apps/web/src/components/whatsapp/PrivateWhatsAppMediaPlayer.tsx
@@ -1,0 +1,93 @@
+import { useCallback, useEffect, useState } from 'react';
+import { AlertCircle, Loader2, Music, Video } from 'lucide-react';
+import { useAuth } from '@/context';
+import { getPrivateWhatsAppMessageMediaUrl } from '@/services/whatsappApi';
+import type { PrivateWhatsAppMessage } from '@/types';
+
+interface PrivateWhatsAppMediaPlayerProps {
+  message: PrivateWhatsAppMessage;
+}
+
+function getMediaName(message: PrivateWhatsAppMessage): string {
+  return message.media?.fileName ?? message.media?.mimeType ?? `${message.messageType} message`;
+}
+
+export function PrivateWhatsAppMediaPlayer({
+  message,
+}: PrivateWhatsAppMediaPlayerProps): React.JSX.Element {
+  const { getAccessToken } = useAuth();
+  const [mediaUrl, setMediaUrl] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+  const mediaName = getMediaName(message);
+  const isVideo = message.messageType === 'video';
+  const Icon = isVideo ? Video : Music;
+
+  const loadMedia = useCallback(async (): Promise<void> => {
+    setLoading(true);
+    setError(false);
+    try {
+      const token = await getAccessToken();
+      const response = await getPrivateWhatsAppMessageMediaUrl(token, message.id);
+      setMediaUrl(response.url);
+    } catch {
+      setMediaUrl(null);
+      setError(true);
+    } finally {
+      setLoading(false);
+    }
+  }, [getAccessToken, message.id]);
+
+  useEffect(() => {
+    void loadMedia();
+  }, [loadMedia]);
+
+  if (loading) {
+    return (
+      <div className="flex h-12 w-full max-w-md items-center justify-center rounded-lg bg-slate-100 dark:bg-slate-800">
+        <Loader2 className="h-5 w-5 animate-spin text-slate-400" />
+      </div>
+    );
+  }
+
+  if (error || mediaUrl === null) {
+    return (
+      <button
+        type="button"
+        onClick={(): void => {
+          void loadMedia();
+        }}
+        className="inline-flex max-w-full items-center gap-2 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-600 dark:border-red-900 dark:bg-red-950/30 dark:text-red-300"
+      >
+        <AlertCircle className="h-4 w-4 shrink-0" />
+        <span>Retry media</span>
+      </button>
+    );
+  }
+
+  return (
+    <div className="max-w-full space-y-2">
+      <span className="flex max-w-full items-center gap-2 text-xs text-slate-500 dark:text-slate-400">
+        <Icon className="h-3.5 w-3.5 shrink-0" />
+        <span className="truncate">{mediaName}</span>
+      </span>
+      {isVideo ? (
+        <video
+          aria-label={`Play ${mediaName}`}
+          className="max-h-96 w-auto max-w-full rounded-lg bg-slate-950"
+          controls
+          preload="metadata"
+          src={mediaUrl}
+        />
+      ) : (
+        <audio
+          aria-label={`Play ${mediaName}`}
+          className="w-full max-w-md"
+          controls
+          preload="metadata"
+          src={mediaUrl}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/pages/PrivateWhatsAppLogPage.tsx
+++ b/apps/web/src/pages/PrivateWhatsAppLogPage.tsx
@@ -14,6 +14,7 @@ import {
 } from 'lucide-react';
 import { Button, ErrorBanner, Layout } from '@/components';
 import { PrivateWhatsAppImagePreview } from '@/components/whatsapp/PrivateWhatsAppImagePreview';
+import { PrivateWhatsAppMediaPlayer } from '@/components/whatsapp/PrivateWhatsAppMediaPlayer';
 import { usePrivateWhatsAppLog } from '@/hooks/usePrivateWhatsAppLog';
 import { formatDateTimeCompact, formatRelative } from '@/utils/dateFormat';
 import type {
@@ -107,6 +108,14 @@ function hasStoredImage(message: PrivateWhatsAppMessage): boolean {
   );
 }
 
+function hasStoredPlayableMedia(message: PrivateWhatsAppMessage): boolean {
+  return (
+    (message.messageType === 'audio' || message.messageType === 'video') &&
+    message.media?.storageStatus === 'stored' &&
+    message.media.hasMedia === true
+  );
+}
+
 function MessageTranscription({ message }: { message: PrivateWhatsAppMessage }): React.JSX.Element | null {
   const transcription =
     message.messageType === 'audio' || message.messageType === 'video'
@@ -160,6 +169,20 @@ function MessageBody({ message }: { message: PrivateWhatsAppMessage }): React.JS
     return (
       <div className="space-y-3">
         <PrivateWhatsAppImagePreview message={message} />
+        {hasText ? (
+          <p className="whitespace-pre-wrap break-words text-sm leading-6 text-slate-900 dark:text-slate-100">
+            {message.text}
+          </p>
+        ) : null}
+        {transcription}
+      </div>
+    );
+  }
+
+  if (hasStoredPlayableMedia(message)) {
+    return (
+      <div className="space-y-3">
+        <PrivateWhatsAppMediaPlayer message={message} />
         {hasText ? (
           <p className="whitespace-pre-wrap break-words text-sm leading-6 text-slate-900 dark:text-slate-100">
             {message.text}

--- a/apps/web/src/pages/__tests__/PrivateWhatsAppLogPage.test.tsx
+++ b/apps/web/src/pages/__tests__/PrivateWhatsAppLogPage.test.tsx
@@ -3,16 +3,31 @@
  * @vitest-environment jsdom
  */
 
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { UsePrivateWhatsAppLogResult } from '@/hooks/usePrivateWhatsAppLog';
 
 const mockUsePrivateWhatsAppLog = vi.fn();
+const mockGetAccessToken = vi.fn<() => Promise<string>>();
+const mockGetPrivateWhatsAppMessageMediaUrl = vi.fn();
 
 vi.mock('@/hooks/usePrivateWhatsAppLog', () => ({
   usePrivateWhatsAppLog: (): UsePrivateWhatsAppLogResult => mockUsePrivateWhatsAppLog(),
+}));
+
+vi.mock('@/context', () => ({
+  useAuth: (): { getAccessToken: typeof mockGetAccessToken } => ({
+    getAccessToken: mockGetAccessToken,
+  }),
+}));
+
+vi.mock('@/services/whatsappApi', () => ({
+  getPrivateWhatsAppMessageMediaUrl: (
+    ...args: unknown[]
+  ): ReturnType<typeof mockGetPrivateWhatsAppMessageMediaUrl> =>
+    mockGetPrivateWhatsAppMessageMediaUrl(...args),
 }));
 
 vi.mock('@/components/whatsapp/PrivateWhatsAppImagePreview', () => ({
@@ -146,6 +161,13 @@ function createHookResult(
 
 describe('PrivateWhatsAppLogPage', () => {
   beforeEach(() => {
+    mockGetAccessToken.mockResolvedValue('access-token');
+    mockGetPrivateWhatsAppMessageMediaUrl.mockImplementation(
+      async (_token: string, messageId: string) => ({
+        url: `https://storage.example.com/${messageId}`,
+        expiresAt: '2026-06-22T09:30:00.000Z',
+      })
+    );
     mockUsePrivateWhatsAppLog.mockReturnValue(createHookResult());
   });
 
@@ -399,5 +421,90 @@ describe('PrivateWhatsAppLogPage', () => {
     expect(screen.getByText('Bring the documents tomorrow.')).toBeInTheDocument();
     expect(screen.getByText('Audio format was not supported')).toBeInTheDocument();
     expect(screen.getByText('The video says to bring the blue folder.')).toBeInTheDocument();
+  });
+
+  it('renders stored private audio and video players while preserving transcripts', async () => {
+    mockUsePrivateWhatsAppLog.mockReturnValueOnce(
+      createHookResult({
+        messages: [
+          {
+            id: 'audio-completed',
+            chatId: 'chat-group',
+            direction: 'incoming',
+            messageType: 'audio',
+            media: {
+              mxcUri: 'mxc://home-dev/audio-completed',
+              mimeType: 'audio/ogg',
+              fileName: 'voice.ogg',
+              storageStatus: 'stored',
+              hasMedia: true,
+            },
+            transcription: {
+              status: 'completed',
+              jobId: 'job-audio-completed',
+              text: 'Audio transcript stays visible.',
+              completedAt: '2026-06-22T09:03:00.000Z',
+            },
+            eventTimestamp: '2026-06-22T09:02:00.000Z',
+            eventDayKey: '2026-06-22',
+            receivedAt: '2026-06-22T09:02:02.000Z',
+            ingestedAt: '2026-06-22T09:02:03.000Z',
+            deliveryMode: 'live',
+          },
+          {
+            id: 'video-completed',
+            chatId: 'chat-group',
+            direction: 'incoming',
+            messageType: 'video',
+            media: {
+              mxcUri: 'mxc://home-dev/video-completed',
+              mimeType: 'video/mp4',
+              fileName: 'clip.mp4',
+              storageStatus: 'stored',
+              hasMedia: true,
+            },
+            transcription: {
+              status: 'completed',
+              jobId: 'job-video-completed',
+              text: 'Video transcript stays visible.',
+              completedAt: '2026-06-22T09:05:00.000Z',
+            },
+            eventTimestamp: '2026-06-22T09:05:00.000Z',
+            eventDayKey: '2026-06-22',
+            receivedAt: '2026-06-22T09:05:02.000Z',
+            ingestedAt: '2026-06-22T09:05:03.000Z',
+            deliveryMode: 'live',
+          },
+        ],
+      })
+    );
+
+    render(
+      <MemoryRouter>
+        <PrivateWhatsAppLogPage />
+      </MemoryRouter>
+    );
+
+    const audio = await screen.findByLabelText('Play voice.ogg');
+    const video = await screen.findByLabelText('Play clip.mp4');
+
+    expect(audio.tagName).toBe('AUDIO');
+    expect(audio).toHaveAttribute('controls');
+    expect(audio).toHaveAttribute('src', 'https://storage.example.com/audio-completed');
+    expect(video.tagName).toBe('VIDEO');
+    expect(video).toHaveAttribute('controls');
+    expect(video).toHaveAttribute('src', 'https://storage.example.com/video-completed');
+    expect(screen.getByText('Audio transcript stays visible.')).toBeInTheDocument();
+    expect(screen.getByText('Video transcript stays visible.')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(mockGetPrivateWhatsAppMessageMediaUrl).toHaveBeenCalledWith(
+        'access-token',
+        'audio-completed'
+      );
+      expect(mockGetPrivateWhatsAppMessageMediaUrl).toHaveBeenCalledWith(
+        'access-token',
+        'video-completed'
+      );
+    });
   });
 });

--- a/apps/whatsapp-service/src/__tests__/privateMediaRoutes.test.ts
+++ b/apps/whatsapp-service/src/__tests__/privateMediaRoutes.test.ts
@@ -616,6 +616,191 @@ describe('Private WhatsApp Media Routes', () => {
     expect(response.body).not.toContain('rawMatrixEvent');
   });
 
+  it('returns owner-checked signed URLs for private audio originals', async () => {
+    const token = await createToken({ sub: 'user-123' });
+    const stored = await ctx.privateWhatsAppRepository.storeIncomingMessage({
+      sourceAccountId: 'private-source-123',
+      userId: 'user-123',
+      deliveryMode: 'live',
+      receivedAt: '2026-06-26T10:00:01.000Z',
+      chat: { matrixRoomId: '!room:home-dev', type: 'direct' },
+      message: {
+        matrixRoomId: '!room:home-dev',
+        matrixEventId: '$stored-audio-original',
+        matrixSenderId: '@alice:home-dev',
+        senderKey: 'matrix:@alice:home-dev',
+        direction: 'incoming',
+        type: 'audio',
+        eventTimestamp: '2026-06-26T10:00:00.000Z',
+        rawMatrixEvent: {},
+        media: {
+          mxcUri: 'mxc://home-dev/audio-original',
+          mimeType: 'audio/ogg',
+          storageStatus: 'stored',
+          gcsPath: 'whatsapp/private/user-123/message/audio-original.ogg',
+        },
+      },
+    });
+    expect(stored.ok).toBe(true);
+    if (!stored.ok) {
+      throw new Error(stored.error.message);
+    }
+
+    const response = await ctx.app.inject({
+      method: 'GET',
+      url: `/private/messages/${stored.value.messageId}/media`,
+      headers: { authorization: `Bearer ${token}` },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body) as {
+      success: true;
+      data: { url: string; expiresAt: string };
+    };
+    expect(body.data).toStrictEqual({
+      url: expect.stringMatching(/^\/private\/media-access\?token=[A-Za-z0-9_-]+$/),
+      expiresAt: expect.any(String),
+    });
+    expect(Date.parse(body.data.expiresAt)).toBeGreaterThan(Date.now());
+    expect(body.data.url).not.toContain('whatsapp/private');
+    expect(body.data.url).not.toContain('audio-original.ogg');
+  });
+
+  it('redirects opaque public private video access tokens to storage signed URLs', async () => {
+    const token = await createToken({ sub: 'user-123' });
+    const stored = await ctx.privateWhatsAppRepository.storeIncomingMessage({
+      sourceAccountId: 'private-source-123',
+      userId: 'user-123',
+      deliveryMode: 'live',
+      receivedAt: '2026-06-26T10:00:01.000Z',
+      chat: { matrixRoomId: '!room:home-dev', type: 'direct' },
+      message: {
+        matrixRoomId: '!room:home-dev',
+        matrixEventId: '$stored-video-access-route',
+        matrixSenderId: '@alice:home-dev',
+        senderKey: 'matrix:@alice:home-dev',
+        direction: 'incoming',
+        type: 'video',
+        eventTimestamp: '2026-06-26T10:00:00.000Z',
+        rawMatrixEvent: {},
+        media: {
+          mxcUri: 'mxc://home-dev/video-access-route',
+          mimeType: 'video/mp4',
+          storageStatus: 'stored',
+          gcsPath: 'whatsapp/private/user-123/message/video-access-route.mp4',
+        },
+      },
+    });
+    expect(stored.ok).toBe(true);
+    if (!stored.ok) {
+      throw new Error(stored.error.message);
+    }
+
+    const publicResponse = await ctx.app.inject({
+      method: 'GET',
+      url: `/private/messages/${stored.value.messageId}/media`,
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(publicResponse.statusCode).toBe(200);
+    const publicBody = JSON.parse(publicResponse.body) as {
+      data: { url: string };
+    };
+
+    const accessResponse = await ctx.app.inject({
+      method: 'GET',
+      url: publicBody.data.url,
+    });
+
+    expect(accessResponse.statusCode).toBe(302);
+    expect(accessResponse.headers.location).toContain(
+      'whatsapp/private/user-123/message/video-access-route.mp4'
+    );
+  });
+
+  it('returns internal signed URLs for private audio and video originals after source account validation', async () => {
+    const audio = await ctx.privateWhatsAppRepository.storeIncomingMessage({
+      sourceAccountId: 'private-source-123',
+      userId: 'user-123',
+      deliveryMode: 'live',
+      receivedAt: '2026-06-26T10:00:01.000Z',
+      chat: { matrixRoomId: '!room:home-dev', type: 'direct' },
+      message: {
+        matrixRoomId: '!room:home-dev',
+        matrixEventId: '$stored-audio-internal',
+        matrixSenderId: '@alice:home-dev',
+        senderKey: 'matrix:@alice:home-dev',
+        direction: 'incoming',
+        type: 'audio',
+        eventTimestamp: '2026-06-26T10:00:00.000Z',
+        rawMatrixEvent: {},
+        media: {
+          mxcUri: 'mxc://home-dev/audio-internal',
+          mimeType: 'audio/ogg',
+          storageStatus: 'stored',
+          gcsPath: 'whatsapp/private/user-123/message/audio-internal.ogg',
+        },
+      },
+    });
+    const video = await ctx.privateWhatsAppRepository.storeIncomingMessage({
+      sourceAccountId: 'private-source-123',
+      userId: 'user-123',
+      deliveryMode: 'live',
+      receivedAt: '2026-06-26T10:00:02.000Z',
+      chat: { matrixRoomId: '!room:home-dev', type: 'direct' },
+      message: {
+        matrixRoomId: '!room:home-dev',
+        matrixEventId: '$stored-video-internal',
+        matrixSenderId: '@alice:home-dev',
+        senderKey: 'matrix:@alice:home-dev',
+        direction: 'incoming',
+        type: 'video',
+        eventTimestamp: '2026-06-26T10:00:01.000Z',
+        rawMatrixEvent: {},
+        media: {
+          mxcUri: 'mxc://home-dev/video-internal',
+          mimeType: 'video/mp4',
+          storageStatus: 'stored',
+          gcsPath: 'whatsapp/private/user-123/message/video-internal.mp4',
+        },
+      },
+    });
+    expect(audio.ok).toBe(true);
+    expect(video.ok).toBe(true);
+    if (!audio.ok || !video.ok) {
+      throw new Error('Failed to store private media messages');
+    }
+
+    const audioResponse = await ctx.app.inject({
+      method: 'GET',
+      url: `/internal/whatsapp/private/messages/${audio.value.messageId}/media?sourceAccountId=private-source-123`,
+      headers: { 'x-internal-auth': 'test-internal-token' },
+    });
+    const videoResponse = await ctx.app.inject({
+      method: 'GET',
+      url: `/internal/whatsapp/private/messages/${video.value.messageId}/media?sourceAccountId=private-source-123`,
+      headers: { 'x-internal-auth': 'test-internal-token' },
+    });
+
+    expect(audioResponse.statusCode).toBe(200);
+    expect(videoResponse.statusCode).toBe(200);
+    const audioBody = JSON.parse(audioResponse.body) as {
+      data: { url: string; media: { gcsPath: string; mimeType: string } };
+    };
+    const videoBody = JSON.parse(videoResponse.body) as {
+      data: { url: string; media: { gcsPath: string; mimeType: string } };
+    };
+    expect(audioBody.data.url).toContain('whatsapp/private/user-123/message/audio-internal.ogg');
+    expect(audioBody.data.media).toMatchObject({
+      gcsPath: 'whatsapp/private/user-123/message/audio-internal.ogg',
+      mimeType: 'audio/ogg',
+    });
+    expect(videoBody.data.url).toContain('whatsapp/private/user-123/message/video-internal.mp4');
+    expect(videoBody.data.media).toMatchObject({
+      gcsPath: 'whatsapp/private/user-123/message/video-internal.mp4',
+      mimeType: 'video/mp4',
+    });
+  });
+
   it('redirects opaque public private media access tokens to storage signed URLs', async () => {
     const token = await createToken({ sub: 'user-123' });
     const stored = await ctx.privateWhatsAppRepository.storeIncomingMessage({
@@ -826,6 +1011,44 @@ describe('Private WhatsApp Media Routes', () => {
         rawMatrixEvent: {},
         media: {
           mxcUri: 'mxc://home-dev/image-no-original',
+        },
+      },
+    });
+    expect(stored.ok).toBe(true);
+    if (!stored.ok) {
+      throw new Error(stored.error.message);
+    }
+
+    const response = await ctx.app.inject({
+      method: 'GET',
+      url: `/private/messages/${stored.value.messageId}/media`,
+      headers: { authorization: `Bearer ${token}` },
+    });
+
+    expect(response.statusCode).toBe(404);
+  });
+
+  it('returns 404 when stored private audio media has no MIME type', async () => {
+    const token = await createToken({ sub: 'user-123' });
+    const stored = await ctx.privateWhatsAppRepository.storeIncomingMessage({
+      sourceAccountId: 'private-source-123',
+      userId: 'user-123',
+      deliveryMode: 'live',
+      receivedAt: '2026-06-26T10:00:01.000Z',
+      chat: { matrixRoomId: '!room:home-dev', type: 'direct' },
+      message: {
+        matrixRoomId: '!room:home-dev',
+        matrixEventId: '$stored-audio-no-mime',
+        matrixSenderId: '@alice:home-dev',
+        senderKey: 'matrix:@alice:home-dev',
+        direction: 'incoming',
+        type: 'audio',
+        eventTimestamp: '2026-06-26T10:00:00.000Z',
+        rawMatrixEvent: {},
+        media: {
+          mxcUri: 'mxc://home-dev/audio-no-mime',
+          storageStatus: 'stored',
+          gcsPath: 'whatsapp/private/user-123/message/audio-no-mime.ogg',
         },
       },
     });

--- a/apps/whatsapp-service/src/routes/privateMediaRoutes.ts
+++ b/apps/whatsapp-service/src/routes/privateMediaRoutes.ts
@@ -85,6 +85,23 @@ function isPrivateImageMessage(message: PrivateWhatsAppMessage): boolean {
   return message.messageType === 'image';
 }
 
+function isPrivatePlayableOriginalMediaMessage(message: PrivateWhatsAppMessage): boolean {
+  const mimeType = message.media?.storedMimeType ?? message.media?.mimeType;
+  if (message.messageType === 'image') {
+    return true;
+  }
+  if (mimeType === undefined) {
+    return false;
+  }
+  if (message.messageType === 'audio') {
+    return isAudioMimeType(mimeType);
+  }
+  if (message.messageType === 'video') {
+    return isVideoMimeType(mimeType);
+  }
+  return false;
+}
+
 function getOriginalPath(message: PrivateWhatsAppMessage): string | undefined {
   return message.media?.gcsPath;
 }
@@ -204,15 +221,20 @@ async function getPrivateMessageForPublicUser(
   return message;
 }
 
-function getPrivateImageMediaPath(
+function getPrivateMediaPath(
   message: PrivateWhatsAppMessage,
   variant: 'original' | 'thumbnail'
 ): string | null {
-  if (!isPrivateImageMessage(message)) {
+  if (variant === 'thumbnail') {
+    if (!isPrivateImageMessage(message)) {
+      return null;
+    }
+    return getThumbnailPath(message) ?? null;
+  }
+  if (!isPrivatePlayableOriginalMediaMessage(message)) {
     return null;
   }
-  const gcsPath = variant === 'thumbnail' ? getThumbnailPath(message) : getOriginalPath(message);
-  return gcsPath ?? null;
+  return getOriginalPath(message) ?? null;
 }
 
 async function getSignedPrivateMediaUrlData(
@@ -223,7 +245,7 @@ async function getSignedPrivateMediaUrlData(
   | { ok: true; data: Record<string, unknown> }
   | { ok: false; errorCode: 'NOT_FOUND' | 'DOWNSTREAM_ERROR'; message: string }
 > {
-  const gcsPath = getPrivateImageMediaPath(message, variant);
+  const gcsPath = getPrivateMediaPath(message, variant);
   if (gcsPath === null) {
     return {
       ok: false,
@@ -509,7 +531,7 @@ export const privateMediaRoutes: FastifyPluginCallback = (fastify, _opts, done) 
           user.userId,
           reply
         );
-        if (message === null || getPrivateImageMediaPath(message, 'original') === null) {
+        if (message === null || getPrivateMediaPath(message, 'original') === null) {
           if (message !== null) {
             await reply.fail('NOT_FOUND', 'Private WhatsApp message not found');
           }
@@ -580,7 +602,7 @@ export const privateMediaRoutes: FastifyPluginCallback = (fastify, _opts, done) 
           user.userId,
           reply
         );
-        if (message === null || getPrivateImageMediaPath(message, 'thumbnail') === null) {
+        if (message === null || getPrivateMediaPath(message, 'thumbnail') === null) {
           if (message !== null) {
             await reply.fail('NOT_FOUND', 'Private WhatsApp message not found');
           }


### PR DESCRIPTION
## Summary

- Allow private WhatsApp signed media access for stored audio and video originals while keeping thumbnails image-only.
- Render audio/video controls in the private WhatsApp log and keep transcripts below the media.

## Verification

- `pnpm run ci:tracked`

## Linear

Linear: omitted by `$commit-push`; GitHub automation will create or link the Linear issue after PR creation.