### PR TITLE
[INT-1835] fix: prevent private WhatsApp direct chat splits

### DIFF
--- a/apps/whatsapp-service/src/__tests__/infra/privateWhatsAppRepository.test.ts
+++ b/apps/whatsapp-service/src/__tests__/infra/privateWhatsAppRepository.test.ts
@@ -1262,6 +1262,29 @@ describe('privateWhatsAppRepository', () => {
     expect(senderDay?.['messageCount']).toBe(1);
   });
 
+  it('returns the room chat id for a duplicate legacy message without a stored chat id', async () => {
+    const input = createStoreInput();
+    const messageId = deterministicId(input.sourceAccountId, input.message.matrixEventId);
+    await fakeFirestore.collection(PRIVATE_WHATSAPP_MESSAGES_COLLECTION).doc(messageId).set({
+      id: messageId,
+      sourceAccountId: input.sourceAccountId,
+      matrixRoomId: input.message.matrixRoomId,
+      matrixEventId: input.message.matrixEventId,
+      text: 'legacy duplicate',
+    });
+
+    const result = await repository.storeIncomingMessage(input);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(result.error.message);
+    expect(result.value).toEqual({
+      outcome: 'duplicate',
+      chatId: deterministicId(input.sourceAccountId, input.chat.matrixRoomId),
+      messageId,
+      matrixEventId: input.message.matrixEventId,
+    });
+  });
+
   it('increments one sender-day aggregate for multiple messages from the same sender and day', async () => {
     const first = await repository.storeIncomingMessage(createStoreInput());
     expect(first.ok).toBe(true);
@@ -1398,6 +1421,350 @@ describe('privateWhatsAppRepository', () => {
     const chat = fakeFirestore.getAllData().get(PRIVATE_WHATSAPP_CHATS_COLLECTION)?.get(chatId);
     expect(chat?.['displayName']).toBe('Alice Cooper');
     expect(chat?.['lastEventAt']).toBe('2026-06-22T10:05:00.000Z');
+  });
+
+  it('reuses an existing direct chat when the same phone sender appears in a new Matrix room', async () => {
+    const firstInput = createStoreInput({
+      chat: {
+        matrixRoomId: '!old-room:matrix.example',
+        type: 'direct',
+        displayName: 'Marcinek',
+      },
+      message: {
+        ...createStoreInput().message,
+        matrixRoomId: '!old-room:matrix.example',
+        matrixEventId: '$old-room-event',
+        matrixSenderId: '@whatsapp_48123456789:matrix.example',
+        senderDisplayName: 'Marcinek',
+        senderPhoneNumber: '+48123456789',
+        senderPhoneNumberNormalized: '48123456789',
+        senderKey: 'phone:+48123456789',
+        eventTimestamp: '2026-06-22T10:00:00.000Z',
+      },
+    });
+    const firstResult = await repository.storeIncomingMessage(firstInput);
+    expect(firstResult.ok).toBe(true);
+    if (!firstResult.ok) throw new Error(firstResult.error.message);
+
+    const secondInput = createStoreInput({
+      chat: {
+        matrixRoomId: '!new-room:matrix.example',
+        type: 'direct',
+        displayName: 'Pawel M (WA)',
+      },
+      message: {
+        ...createStoreInput().message,
+        matrixRoomId: '!new-room:matrix.example',
+        matrixEventId: '$new-room-event',
+        matrixSenderId: '@whatsapp_48123456789:matrix.example',
+        senderDisplayName: 'Pawel M (WA)',
+        senderPhoneNumber: '+48123456789',
+        senderPhoneNumberNormalized: '48123456789',
+        senderKey: 'phone:+48123456789',
+        eventTimestamp: '2026-06-22T10:05:00.000Z',
+      },
+    });
+    const secondResult = await repository.storeIncomingMessage(secondInput);
+
+    expect(secondResult.ok).toBe(true);
+    if (!secondResult.ok) throw new Error(secondResult.error.message);
+    expect(secondResult.value.chatId).toBe(firstResult.value.chatId);
+
+    const chats = fakeFirestore.getAllData().get(PRIVATE_WHATSAPP_CHATS_COLLECTION);
+    expect(chats?.size).toBe(1);
+    const chat = chats?.get(firstResult.value.chatId);
+    expect(chat).toMatchObject({
+      id: firstResult.value.chatId,
+      matrixRoomId: '!old-room:matrix.example',
+      matrixRoomIds: ['!old-room:matrix.example', '!new-room:matrix.example'],
+      displayName: 'Marcinek',
+      messageCount: 2,
+      participantKeys: ['phone:+48123456789'],
+    });
+  });
+
+  it('reuses a direct chat alias for outgoing messages from a linked Matrix room', async () => {
+    const oldRoomIncoming = await repository.storeIncomingMessage(
+      createStoreInput({
+        chat: {
+          matrixRoomId: '!old-room:matrix.example',
+          type: 'direct',
+          displayName: 'Marcinek',
+        },
+        message: {
+          ...createStoreInput().message,
+          matrixRoomId: '!old-room:matrix.example',
+          matrixEventId: '$old-room-incoming',
+          matrixSenderId: '@whatsapp_48123456789:matrix.example',
+          senderDisplayName: 'Marcinek',
+          senderKey: 'phone:+48123456789',
+          eventTimestamp: '2026-06-22T10:00:00.000Z',
+        },
+      })
+    );
+    expect(oldRoomIncoming.ok).toBe(true);
+    if (!oldRoomIncoming.ok) throw new Error(oldRoomIncoming.error.message);
+
+    const newRoomIncoming = await repository.storeIncomingMessage(
+      createStoreInput({
+        chat: {
+          matrixRoomId: '!new-room:matrix.example',
+          type: 'direct',
+          displayName: 'Pawel M (WA)',
+        },
+        message: {
+          ...createStoreInput().message,
+          matrixRoomId: '!new-room:matrix.example',
+          matrixEventId: '$new-room-incoming',
+          matrixSenderId: '@whatsapp_48123456789:matrix.example',
+          senderDisplayName: 'Pawel M (WA)',
+          senderKey: 'phone:+48123456789',
+          eventTimestamp: '2026-06-22T10:05:00.000Z',
+        },
+      })
+    );
+    expect(newRoomIncoming.ok).toBe(true);
+    if (!newRoomIncoming.ok) throw new Error(newRoomIncoming.error.message);
+
+    const {
+      senderPhoneNumber: _senderPhoneNumber,
+      senderPhoneNumberNormalized: _senderPhoneNumberNormalized,
+      ...outgoingMessageBase
+    } = createStoreInput().message;
+    const newRoomOutgoing = await repository.storeIncomingMessage(
+      createStoreInput({
+        chat: {
+          matrixRoomId: '!new-room:matrix.example',
+          type: 'direct',
+          displayName: 'Pawel M (WA)',
+        },
+        message: {
+          ...outgoingMessageBase,
+          matrixRoomId: '!new-room:matrix.example',
+          matrixEventId: '$new-room-outgoing',
+          matrixSenderId: '@pbuchman:matrix.example',
+          senderDisplayName: 'You',
+          senderKey: 'matrix:@pbuchman:matrix.example',
+          direction: 'outgoing',
+          text: 'reply from the new room',
+          eventTimestamp: '2026-06-22T10:06:00.000Z',
+        },
+      })
+    );
+
+    expect(newRoomOutgoing.ok).toBe(true);
+    if (!newRoomOutgoing.ok) throw new Error(newRoomOutgoing.error.message);
+    expect(newRoomOutgoing.value.chatId).toBe(oldRoomIncoming.value.chatId);
+
+    const chats = fakeFirestore.getAllData().get(PRIVATE_WHATSAPP_CHATS_COLLECTION);
+    expect(chats?.size).toBe(1);
+    expect(chats?.get(oldRoomIncoming.value.chatId)?.['messageCount']).toBe(3);
+  });
+
+  it('uses a room chat id for an outgoing direct message when no linked alias exists', async () => {
+    const {
+      senderPhoneNumber: _senderPhoneNumber,
+      senderPhoneNumberNormalized: _senderPhoneNumberNormalized,
+      ...outgoingMessageBase
+    } = createStoreInput().message;
+    const result = await repository.storeIncomingMessage(
+      createStoreInput({
+        chat: {
+          matrixRoomId: '!outgoing-only-room:matrix.example',
+          type: 'direct',
+          displayName: 'Pawel M (WA)',
+        },
+        message: {
+          ...outgoingMessageBase,
+          matrixRoomId: '!outgoing-only-room:matrix.example',
+          matrixEventId: '$outgoing-only-event',
+          matrixSenderId: '@pbuchman:matrix.example',
+          senderDisplayName: 'You',
+          senderKey: 'matrix:@pbuchman:matrix.example',
+          direction: 'outgoing',
+          text: 'reply before any incoming alias',
+          eventTimestamp: '2026-06-22T10:06:00.000Z',
+        },
+      })
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(result.error.message);
+    expect(result.value.chatId).toBe(
+      deterministicId('pbuchman-private-whatsapp', '!outgoing-only-room:matrix.example')
+    );
+    const chats = fakeFirestore.getAllData().get(PRIVATE_WHATSAPP_CHATS_COLLECTION);
+    expect(chats?.size).toBe(1);
+  });
+
+  it('chooses the strongest existing direct chat candidate for a repeated sender', async () => {
+    const sourceAccountId = 'pbuchman-private-whatsapp';
+    const senderKey = 'phone:+48123456789';
+    await fakeFirestore.collection(PRIVATE_WHATSAPP_CHATS_COLLECTION).doc('candidate-low').set({
+      id: 'candidate-low',
+      userId: 'user-123',
+      sourceAccountId,
+      matrixRoomId: '!low-room:matrix.example',
+      chatType: 'direct',
+      displayName: 'Low Candidate',
+      participantKeys: [senderKey],
+      participantCount: 1,
+      firstSeenAt: '2026-05-01T10:00:00.000Z',
+      lastEventAt: '2026-05-01T10:00:00.000Z',
+      schemaVersion: 2,
+    });
+    await fakeFirestore.collection(PRIVATE_WHATSAPP_CHATS_COLLECTION).doc('candidate-later').set({
+      id: 'candidate-later',
+      userId: 'user-123',
+      sourceAccountId,
+      matrixRoomId: '!later-room:matrix.example',
+      chatType: 'direct',
+      displayName: 'Later Candidate',
+      participantKeys: [senderKey],
+      participantCount: 1,
+      messageCount: 4,
+      firstSeenAt: '2026-06-01T10:00:00.000Z',
+      lastEventAt: '2026-06-01T10:00:00.000Z',
+      schemaVersion: 2,
+    });
+    await fakeFirestore.collection(PRIVATE_WHATSAPP_CHATS_COLLECTION).doc('candidate-earlier').set({
+      id: 'candidate-earlier',
+      userId: 'user-123',
+      sourceAccountId,
+      matrixRoomId: '!earlier-room:matrix.example',
+      chatType: 'direct',
+      displayName: 'Earlier Candidate',
+      participantKeys: [senderKey],
+      participantCount: 1,
+      messageCount: 4,
+      firstSeenAt: '2026-04-01T10:00:00.000Z',
+      lastEventAt: '2026-04-01T10:00:00.000Z',
+      schemaVersion: 2,
+    });
+
+    const result = await repository.storeIncomingMessage(
+      createStoreInput({
+        chat: {
+          matrixRoomId: '!fresh-room:matrix.example',
+          type: 'direct',
+          displayName: 'Fresh Sender (WA)',
+        },
+        message: {
+          ...createStoreInput().message,
+          matrixRoomId: '!fresh-room:matrix.example',
+          matrixEventId: '$fresh-repeated-sender-event',
+          matrixSenderId: '@whatsapp_48123456789:matrix.example',
+          senderDisplayName: 'Fresh Sender (WA)',
+          senderKey,
+          eventTimestamp: '2026-06-22T10:10:00.000Z',
+        },
+      })
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(result.error.message);
+    expect(result.value.chatId).toBe('candidate-earlier');
+    const chats = fakeFirestore.getAllData().get(PRIVATE_WHATSAPP_CHATS_COLLECTION);
+    expect(chats?.size).toBe(3);
+    expect(chats?.get('candidate-earlier')).toMatchObject({
+      displayName: 'Earlier Candidate',
+      matrixRoomIds: ['!earlier-room:matrix.example', '!fresh-room:matrix.example'],
+      messageCount: 5,
+    });
+  });
+
+  it('orders linked direct chat aliases when candidate metadata is sparse', async () => {
+    const sourceAccountId = 'pbuchman-private-whatsapp';
+    await fakeFirestore.collection(PRIVATE_WHATSAPP_CHATS_COLLECTION).doc('alias-a').set({
+      id: 'alias-a',
+      userId: 'user-123',
+      sourceAccountId,
+      matrixRoomId: '!primary-a:matrix.example',
+      matrixRoomIds: ['!alias-room:matrix.example'],
+      chatType: 'direct',
+      displayName: 'Alias A',
+      participantKeys: ['phone:+48123456789'],
+      participantCount: 1,
+      messageCount: 4,
+      lastEventAt: '2026-06-01T10:00:00.000Z',
+      schemaVersion: 2,
+    });
+    await fakeFirestore.collection(PRIVATE_WHATSAPP_CHATS_COLLECTION).doc('alias-b').set({
+      id: 'alias-b',
+      userId: 'user-123',
+      sourceAccountId,
+      matrixRoomId: '!primary-b:matrix.example',
+      matrixRoomIds: ['!alias-room:matrix.example'],
+      chatType: 'direct',
+      displayName: 'Alias B',
+      participantKeys: ['phone:+48123456789'],
+      participantCount: 1,
+      messageCount: 4,
+      firstSeenAt: '2026-04-01T10:00:00.000Z',
+      lastEventAt: '2026-06-01T10:00:00.000Z',
+      schemaVersion: 2,
+    });
+    await fakeFirestore.collection(PRIVATE_WHATSAPP_CHATS_COLLECTION).doc('alias-c').set({
+      id: 'alias-c',
+      userId: 'user-123',
+      sourceAccountId,
+      matrixRoomId: '!primary-c:matrix.example',
+      matrixRoomIds: ['!alias-room:matrix.example'],
+      chatType: 'direct',
+      displayName: 'Alias C',
+      participantKeys: ['phone:+48123456789'],
+      participantCount: 1,
+      firstSeenAt: '2026-03-01T10:00:00.000Z',
+      lastEventAt: '2026-06-01T10:00:00.000Z',
+      schemaVersion: 2,
+    });
+    await fakeFirestore.collection(PRIVATE_WHATSAPP_CHATS_COLLECTION).doc('alias-d').set({
+      id: 'alias-d',
+      userId: 'user-123',
+      sourceAccountId,
+      matrixRoomId: '!primary-d:matrix.example',
+      matrixRoomIds: ['!alias-room:matrix.example'],
+      chatType: 'direct',
+      displayName: 'Alias D',
+      participantKeys: ['phone:+48123456789'],
+      participantCount: 1,
+      messageCount: 4,
+      lastEventAt: '2026-06-01T10:00:00.000Z',
+      schemaVersion: 2,
+    });
+
+    const {
+      senderPhoneNumber: _senderPhoneNumber,
+      senderPhoneNumberNormalized: _senderPhoneNumberNormalized,
+      ...outgoingMessageBase
+    } = createStoreInput().message;
+    const result = await repository.storeIncomingMessage(
+      createStoreInput({
+        chat: {
+          matrixRoomId: '!alias-room:matrix.example',
+          type: 'direct',
+          displayName: 'Alias Room',
+        },
+        message: {
+          ...outgoingMessageBase,
+          matrixRoomId: '!alias-room:matrix.example',
+          matrixEventId: '$alias-room-outgoing',
+          matrixSenderId: '@pbuchman:matrix.example',
+          senderDisplayName: 'You',
+          senderKey: 'matrix:@pbuchman:matrix.example',
+          direction: 'outgoing',
+          text: 'reply in linked alias room',
+          eventTimestamp: '2026-06-22T10:12:00.000Z',
+        },
+      })
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(result.error.message);
+    expect(result.value.chatId).toBe('alias-a');
+    const chats = fakeFirestore.getAllData().get(PRIVATE_WHATSAPP_CHATS_COLLECTION);
+    expect(chats?.size).toBe(4);
+    expect(chats?.get('alias-a')?.['messageCount']).toBe(5);
   });
 
   it('keeps the newer chat timestamp and lowers firstSeenAt when an older backfill event arrives later', async () => {

--- a/apps/whatsapp-service/src/domain/whatsapp/models/PrivateWhatsApp.ts
+++ b/apps/whatsapp-service/src/domain/whatsapp/models/PrivateWhatsApp.ts
@@ -120,6 +120,7 @@ export interface PrivateWhatsAppChat {
   userId: string;
   sourceAccountId: string;
   matrixRoomId: string;
+  matrixRoomIds?: string[];
   chatType: PrivateWhatsAppChatType;
   displayName?: string;
   avatarMxcUri?: string;

--- a/apps/whatsapp-service/src/infra/firestore/privateWhatsAppRepository.ts
+++ b/apps/whatsapp-service/src/infra/firestore/privateWhatsAppRepository.ts
@@ -1,6 +1,11 @@
 import { createHash } from 'node:crypto';
 import { err, getErrorMessage, ok, type Result } from '@intexuraos/common-core';
-import { FieldPath, getFirestore, type Query } from '@intexuraos/infra-firestore';
+import {
+  FieldPath,
+  getFirestore,
+  type Query,
+  type QueryDocumentSnapshot,
+} from '@intexuraos/infra-firestore';
 import type { WhatsAppError } from '../../domain/whatsapp/index.js';
 import {
   createPrivateWhatsAppChatId,
@@ -56,6 +61,12 @@ const PRIVATE_WHATSAPP_MESSAGE_TYPES = new Set<PrivateWhatsAppMessage['messageTy
   'redaction',
   'unknown',
 ]);
+type FirestoreClient = ReturnType<typeof getFirestore>;
+type FirestoreTransaction = Parameters<Parameters<FirestoreClient['runTransaction']>[0]>[0];
+
+interface PrivateChatResolution {
+  chatId: string;
+}
 
 export {
   createPrivateWhatsAppChatId,
@@ -285,7 +296,6 @@ async function storeIncomingMessage(
 ): Promise<Result<PrivateWhatsAppIngestOutcome, WhatsAppError>> {
   try {
     const db = getFirestore();
-    const chatId = createPrivateWhatsAppChatId(input.sourceAccountId, input.chat.matrixRoomId);
     const messageId = createPrivateWhatsAppMessageId(
       input.sourceAccountId,
       input.message.matrixEventId
@@ -298,7 +308,6 @@ async function storeIncomingMessage(
       senderKey,
       eventDayKey
     );
-    const chatRef = db.collection(PRIVATE_WHATSAPP_CHATS_COLLECTION).doc(chatId);
     const messageRef = db.collection(PRIVATE_WHATSAPP_MESSAGES_COLLECTION).doc(messageId);
     const senderRef = db.collection(PRIVATE_WHATSAPP_SENDERS_COLLECTION).doc(senderId);
     const senderDayRef = db.collection(PRIVATE_WHATSAPP_SENDER_DAYS_COLLECTION).doc(senderDayId);
@@ -307,14 +316,22 @@ async function storeIncomingMessage(
     const outcome = await db.runTransaction(async (transaction) => {
       const existingMessage = await transaction.get(messageRef);
       if (existingMessage.exists) {
+        const existingData = existingMessage.data() as Partial<PrivateWhatsAppMessage> | undefined;
+        const existingChatId =
+          typeof existingData?.chatId === 'string'
+            ? existingData.chatId
+            : createPrivateWhatsAppChatId(input.sourceAccountId, input.chat.matrixRoomId);
         return {
           outcome: 'duplicate' as const,
-          chatId,
+          chatId: existingChatId,
           messageId,
           matrixEventId: input.message.matrixEventId,
         };
       }
 
+      const chatResolution = await resolveChatForStore(db, transaction, input, senderKey);
+      const chatId = chatResolution.chatId;
+      const chatRef = db.collection(PRIVATE_WHATSAPP_CHATS_COLLECTION).doc(chatId);
       const existingChat = await transaction.get(chatRef);
       const existingSender = await transaction.get(senderRef);
       const existingSenderDay = await transaction.get(senderDayRef);
@@ -366,6 +383,84 @@ async function storeIncomingMessage(
       message: `Failed to store private WhatsApp message: ${getErrorMessage(error, 'Unknown Firestore error')}`,
     });
   }
+}
+
+async function resolveChatForStore(
+  db: FirestoreClient,
+  transaction: FirestoreTransaction,
+  input: StorePrivateWhatsAppMessageInput,
+  senderKey: string
+): Promise<PrivateChatResolution> {
+  const roomChatId = createPrivateWhatsAppChatId(input.sourceAccountId, input.chat.matrixRoomId);
+  const roomChatRef = db.collection(PRIVATE_WHATSAPP_CHATS_COLLECTION).doc(roomChatId);
+  const roomChatDoc = await transaction.get(roomChatRef);
+  if (roomChatDoc.exists) {
+    return { chatId: roomChatId };
+  }
+
+  if (input.chat.type !== 'direct') {
+    return { chatId: roomChatId };
+  }
+
+  const aliasSnapshot = await transaction.get(
+    db
+      .collection(PRIVATE_WHATSAPP_CHATS_COLLECTION)
+      .where('sourceAccountId', '==', input.sourceAccountId)
+      .where('chatType', '==', 'direct')
+      .where('matrixRoomIds', 'array-contains', input.chat.matrixRoomId)
+      .limit(10)
+  );
+  const aliasChat = selectDirectChatCandidate(aliasSnapshot.docs);
+  if (aliasChat !== undefined) {
+    return { chatId: aliasChat.id };
+  }
+
+  if (input.message.direction !== 'incoming') {
+    return { chatId: roomChatId };
+  }
+
+  const senderSnapshot = await transaction.get(
+    db
+      .collection(PRIVATE_WHATSAPP_CHATS_COLLECTION)
+      .where('sourceAccountId', '==', input.sourceAccountId)
+      .where('chatType', '==', 'direct')
+      .where('participantKeys', 'array-contains', senderKey)
+      .limit(10)
+  );
+  const senderChat = selectDirectChatCandidate(senderSnapshot.docs);
+  if (senderChat !== undefined) {
+    return { chatId: senderChat.id };
+  }
+
+  return { chatId: roomChatId };
+}
+
+function selectDirectChatCandidate(
+  docs: QueryDocumentSnapshot[]
+): QueryDocumentSnapshot | undefined {
+  const candidates = [...docs].sort(compareDirectChatCandidates);
+  return candidates[0];
+}
+
+function compareDirectChatCandidates(
+  left: QueryDocumentSnapshot,
+  right: QueryDocumentSnapshot
+): number {
+  const leftData = left.data() as Partial<PrivateWhatsAppChat>;
+  const rightData = right.data() as Partial<PrivateWhatsAppChat>;
+  const messageCountDifference =
+    (readOptionalNumber(rightData.messageCount) ?? 0) -
+    (readOptionalNumber(leftData.messageCount) ?? 0);
+  if (messageCountDifference !== 0) {
+    return messageCountDifference;
+  }
+  const firstSeenComparison = (leftData.firstSeenAt ?? '').localeCompare(
+    rightData.firstSeenAt ?? ''
+  );
+  if (firstSeenComparison !== 0) {
+    return firstSeenComparison;
+  }
+  return left.id.localeCompare(right.id);
 }
 
 async function getMessageById(
@@ -944,12 +1039,12 @@ function buildChat(
   const shouldApplyIncomingChatMetadata = isSameOrNewerChatEvent(
     existingChat,
     input.message.eventTimestamp
-  );
+  ) && isPrimaryChatMatrixRoom(existingChat, input.chat.matrixRoomId);
   const chat: PrivateWhatsAppChat = {
     id: chatId,
     userId: input.userId,
     sourceAccountId: input.sourceAccountId,
-    matrixRoomId: input.chat.matrixRoomId,
+    matrixRoomId: existingChat?.matrixRoomId ?? input.chat.matrixRoomId,
     chatType: selectChatType(existingChat, input.chat.type, shouldApplyIncomingChatMetadata),
     messageCount: (existingChat?.messageCount ?? 0) + 1,
     firstSeenAt: oldestTimestamp(existingChat?.firstSeenAt, input.message.eventTimestamp),
@@ -960,6 +1055,7 @@ function buildChat(
   const participantKeys = appendUnique(existingChat?.participantKeys ?? [], getSenderKey(input));
   chat.participantKeys = participantKeys;
   chat.participantCount = participantKeys.length;
+  chat.matrixRoomIds = appendUnique(getChatMatrixRoomIds(existingChat), input.chat.matrixRoomId);
 
   if (
     input.chat.displayName !== undefined &&
@@ -1008,6 +1104,16 @@ function selectChatType(
     return existingChat.chatType;
   }
   return nextChatType;
+}
+
+function isPrimaryChatMatrixRoom(
+  existingChat: PrivateWhatsAppChat | undefined,
+  matrixRoomId: string
+): boolean {
+  if (existingChat === undefined || existingChat.matrixRoomId === '') {
+    return true;
+  }
+  return existingChat.matrixRoomId === matrixRoomId;
 }
 
 function buildSender(
@@ -1214,6 +1320,7 @@ function normalizeChat(id: string, data: Record<string, unknown> | undefined): P
   if (typeof chat?.avatarMxcUri === 'string') {
     projected.avatarMxcUri = chat.avatarMxcUri;
   }
+  projected.matrixRoomIds = getChatMatrixRoomIds(chat);
   if (typeof chat?.messageCount === 'number') {
     projected.messageCount = chat.messageCount;
   }
@@ -1320,6 +1427,20 @@ function appendUnique(values: string[], nextValue: string): string[] {
     return values;
   }
   return [...values, nextValue];
+}
+
+function getChatMatrixRoomIds(chat: Partial<PrivateWhatsAppChat> | undefined): string[] {
+  const matrixRoomIds = Array.isArray(chat?.matrixRoomIds)
+    ? chat.matrixRoomIds.filter((matrixRoomId): matrixRoomId is string => typeof matrixRoomId === 'string')
+    : [];
+  if (typeof chat?.matrixRoomId !== 'string' || chat.matrixRoomId === '') {
+    return matrixRoomIds;
+  }
+  return appendUnique(matrixRoomIds, chat.matrixRoomId);
+}
+
+function readOptionalNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
 }
 
 function selectLatestString(


### PR DESCRIPTION
## Summary
- Prevent private WhatsApp direct chats from splitting when the same sender appears through a new Matrix room.
- Preserve Matrix room aliases on the canonical chat and keep established direct chat labels.
- Add regression coverage for incoming and outgoing messages from linked room aliases.

## Verification
- `pnpm run ci:tracked`

## Linear
- Linear: [INT-1835](https://linear.app/pbuchman/issue/INT-1835)
- IntexuraOS Code Task: [View task](https://intexuraos.cloud/#/code-tasks/task_baba0e91-a579-4cda-9c26-78e53b143960)
- Worker Type: `codex-xhigh`
- Model: `default`
