### PR TITLE
[INT-1836] Fix private WhatsApp contact label downgrades

### DIFF
--- a/apps/whatsapp-service/src/__tests__/infra/privateWhatsAppRepository.test.ts
+++ b/apps/whatsapp-service/src/__tests__/infra/privateWhatsAppRepository.test.ts
@@ -1461,7 +1461,8 @@ describe('privateWhatsAppRepository', () => {
         senderPhoneNumber: '+48123456789',
         senderPhoneNumberNormalized: '48123456789',
         senderKey: 'phone:+48123456789',
-        eventTimestamp: '2026-06-22T10:05:00.000Z',
+        eventTimestamp: '2026-06-23T10:05:00.000Z',
+        eventDayKey: '2026-06-23',
       },
     });
     const secondResult = await repository.storeIncomingMessage(secondInput);
@@ -1481,6 +1482,149 @@ describe('privateWhatsAppRepository', () => {
       messageCount: 2,
       participantKeys: ['phone:+48123456789'],
     });
+
+    const data = fakeFirestore.getAllData();
+    const senderId = deterministicId('pbuchman-private-whatsapp', 'phone:+48123456789');
+    const senderDayId = deterministicId(
+      'pbuchman-private-whatsapp',
+      `phone:+48123456789\0${'2026-06-23'}`
+    );
+    const sender = data.get(PRIVATE_WHATSAPP_SENDERS_COLLECTION)?.get(senderId);
+    const senderDay = data.get(PRIVATE_WHATSAPP_SENDER_DAYS_COLLECTION)?.get(senderDayId);
+    expect(sender?.['senderDisplayName']).toBe('Marcinek');
+    expect(senderDay?.['senderDisplayName']).toBe('Marcinek');
+    const newRoomMessageId = deterministicId('pbuchman-private-whatsapp', '$new-room-event');
+    const newRoomMessage = data.get(PRIVATE_WHATSAPP_MESSAGES_COLLECTION)?.get(newRoomMessageId);
+    expect(newRoomMessage?.['senderDisplayName']).toBe('Marcinek');
+    expect(newRoomMessage?.['chatDisplayName']).toBe('Marcinek');
+  });
+
+  it('keeps a canonical direct sender label when a later alias uses a phone label', async () => {
+    const firstResult = await repository.storeIncomingMessage(
+      createStoreInput({
+        chat: {
+          matrixRoomId: '!old-karolina-room:matrix.example',
+          type: 'direct',
+          displayName: 'Karolina Buchman',
+        },
+        message: {
+          ...createStoreInput().message,
+          matrixRoomId: '!old-karolina-room:matrix.example',
+          matrixEventId: '$old-karolina-event',
+          matrixSenderId: '@whatsapp_48000000002:matrix.example',
+          senderDisplayName: 'Karolina Buchman',
+          senderPhoneNumber: '+48000000002',
+          senderPhoneNumberNormalized: '48000000002',
+          senderKey: 'phone:+48000000002',
+          eventTimestamp: '2026-06-22T10:00:00.000Z',
+        },
+      })
+    );
+    expect(firstResult.ok).toBe(true);
+    if (!firstResult.ok) throw new Error(firstResult.error.message);
+
+    const secondResult = await repository.storeIncomingMessage(
+      createStoreInput({
+        chat: {
+          matrixRoomId: '!new-karolina-room:matrix.example',
+          type: 'direct',
+          displayName: '+48000000002',
+        },
+        message: {
+          ...createStoreInput().message,
+          matrixRoomId: '!new-karolina-room:matrix.example',
+          matrixEventId: '$new-karolina-event',
+          matrixSenderId: '@whatsapp_48000000002:matrix.example',
+          senderDisplayName: '+48000000002',
+          senderPhoneNumber: '+48000000002',
+          senderPhoneNumberNormalized: '48000000002',
+          senderKey: 'phone:+48000000002',
+          eventTimestamp: '2026-06-23T10:05:00.000Z',
+          eventDayKey: '2026-06-23',
+        },
+      })
+    );
+
+    expect(secondResult.ok).toBe(true);
+    if (!secondResult.ok) throw new Error(secondResult.error.message);
+    expect(secondResult.value.chatId).toBe(firstResult.value.chatId);
+
+    const data = fakeFirestore.getAllData();
+    const senderId = deterministicId('pbuchman-private-whatsapp', 'phone:+48000000002');
+    const senderDayId = deterministicId(
+      'pbuchman-private-whatsapp',
+      `phone:+48000000002\0${'2026-06-23'}`
+    );
+    const messageId = deterministicId('pbuchman-private-whatsapp', '$new-karolina-event');
+    expect(data.get(PRIVATE_WHATSAPP_SENDERS_COLLECTION)?.get(senderId)?.['senderDisplayName']).toBe(
+      'Karolina Buchman'
+    );
+    expect(
+      data.get(PRIVATE_WHATSAPP_SENDER_DAYS_COLLECTION)?.get(senderDayId)?.['senderDisplayName']
+    ).toBe('Karolina Buchman');
+    expect(
+      data.get(PRIVATE_WHATSAPP_MESSAGES_COLLECTION)?.get(messageId)?.['senderDisplayName']
+    ).toBe('Karolina Buchman');
+  });
+
+  it('keeps a stable group sender label when a later member label is bridge-generated', async () => {
+    const firstResult = await repository.storeIncomingMessage(
+      createStoreInput({
+        chat: {
+          matrixRoomId: '!group-room:matrix.example',
+          type: 'group',
+          displayName: 'Fishing Crew',
+        },
+        message: {
+          ...createStoreInput().message,
+          matrixRoomId: '!group-room:matrix.example',
+          matrixEventId: '$old-group-member-event',
+          matrixSenderId: '@whatsapp_48000000003:matrix.example',
+          senderDisplayName: 'Piotrek',
+          senderPhoneNumber: '+48000000003',
+          senderPhoneNumberNormalized: '48000000003',
+          senderKey: 'phone:+48000000003',
+          eventTimestamp: '2026-06-22T10:00:00.000Z',
+        },
+      })
+    );
+    expect(firstResult.ok).toBe(true);
+    if (!firstResult.ok) throw new Error(firstResult.error.message);
+
+    const secondResult = await repository.storeIncomingMessage(
+      createStoreInput({
+        chat: {
+          matrixRoomId: '!group-room:matrix.example',
+          type: 'group',
+          displayName: 'Fishing Crew',
+        },
+        message: {
+          ...createStoreInput().message,
+          matrixRoomId: '!group-room:matrix.example',
+          matrixEventId: '$new-group-member-event',
+          matrixSenderId: '@whatsapp_48000000003:matrix.example',
+          senderDisplayName: 'Piotrek (WA)',
+          senderPhoneNumber: '+48000000003',
+          senderPhoneNumberNormalized: '48000000003',
+          senderKey: 'phone:+48000000003',
+          eventTimestamp: '2026-06-23T10:05:00.000Z',
+          eventDayKey: '2026-06-23',
+        },
+      })
+    );
+
+    expect(secondResult.ok).toBe(true);
+    if (!secondResult.ok) throw new Error(secondResult.error.message);
+
+    const data = fakeFirestore.getAllData();
+    const senderId = deterministicId('pbuchman-private-whatsapp', 'phone:+48000000003');
+    const messageId = deterministicId('pbuchman-private-whatsapp', '$new-group-member-event');
+    expect(data.get(PRIVATE_WHATSAPP_SENDERS_COLLECTION)?.get(senderId)?.['senderDisplayName']).toBe(
+      'Piotrek'
+    );
+    expect(
+      data.get(PRIVATE_WHATSAPP_MESSAGES_COLLECTION)?.get(messageId)?.['senderDisplayName']
+    ).toBe('Piotrek');
   });
 
   it('reuses a direct chat alias for outgoing messages from a linked Matrix room', async () => {

--- a/apps/whatsapp-service/src/infra/firestore/privateWhatsAppRepository.ts
+++ b/apps/whatsapp-service/src/infra/firestore/privateWhatsAppRepository.ts
@@ -68,6 +68,11 @@ interface PrivateChatResolution {
   chatId: string;
 }
 
+interface PrivateWhatsAppMessageDisplayNames {
+  senderDisplayName?: string;
+  chatDisplayName?: string;
+}
+
 export {
   createPrivateWhatsAppChatId,
   createPrivateWhatsAppMessageId,
@@ -337,19 +342,28 @@ async function storeIncomingMessage(
       const existingSenderDay = await transaction.get(senderDayRef);
       const existingAccount = await transaction.get(accountRef);
       const chat = buildChat(input, chatId, existingChat.data() as PrivateWhatsAppChat | undefined);
-      const message = buildMessage(input, chatId, messageId);
       const sender = buildSender(
         input,
         senderId,
         chatId,
-        existingSender.data() as PrivateWhatsAppSender | undefined
+        existingSender.data() as PrivateWhatsAppSender | undefined,
+        getDirectChatDisplayName(chat)
       );
       const senderDay = buildSenderDay(
         input,
         senderDayId,
         chatId,
-        existingSenderDay.data() as PrivateWhatsAppSenderDay | undefined
+        existingSenderDay.data() as PrivateWhatsAppSenderDay | undefined,
+        sender.senderDisplayName
       );
+      const messageDisplayNames: PrivateWhatsAppMessageDisplayNames = {};
+      if (sender.senderDisplayName !== undefined) {
+        messageDisplayNames.senderDisplayName = sender.senderDisplayName;
+      }
+      if (chat.displayName !== undefined) {
+        messageDisplayNames.chatDisplayName = chat.displayName;
+      }
+      const message = buildMessage(input, chatId, messageId, messageDisplayNames);
 
       transaction.set(chatRef, chat, { merge: true });
       transaction.set(messageRef, message);
@@ -970,10 +984,17 @@ async function rebuildAggregates(
         eventDayKey
       );
 
-      senders.set(senderId, buildSender(storeInput, senderId, chatId, senders.get(senderId)));
+      const sender = buildSender(storeInput, senderId, chatId, senders.get(senderId));
+      senders.set(senderId, sender);
       senderDays.set(
         senderDayId,
-        buildSenderDay(storeInput, senderDayId, chatId, senderDays.get(senderDayId))
+        buildSenderDay(
+          storeInput,
+          senderDayId,
+          chatId,
+          senderDays.get(senderDayId),
+          sender.senderDisplayName
+        )
       );
 
       const upgradeFields = buildMessageUpgradeFields(message, storeInput);
@@ -1116,11 +1137,16 @@ function isPrimaryChatMatrixRoom(
   return existingChat.matrixRoomId === matrixRoomId;
 }
 
+function getDirectChatDisplayName(chat: PrivateWhatsAppChat): string | undefined {
+  return chat.chatType === 'direct' ? chat.displayName : undefined;
+}
+
 function buildSender(
   input: StorePrivateWhatsAppMessageInput,
   senderId: string,
   chatId: string,
-  existingSender: PrivateWhatsAppSender | undefined
+  existingSender: PrivateWhatsAppSender | undefined,
+  canonicalDisplayName?: string
 ): PrivateWhatsAppSender {
   const now = new Date().toISOString();
   const senderKey = getSenderKey(input);
@@ -1137,11 +1163,12 @@ function buildSender(
     schemaVersion: PRIVATE_WHATSAPP_SCHEMA_VERSION,
   };
 
-  const senderDisplayName = selectLatestString(
+  const senderDisplayName = selectContactDisplayName(
     existingSender?.senderDisplayName,
     input.message.senderDisplayName,
     existingSender?.lastEventAt,
-    input.message.eventTimestamp
+    input.message.eventTimestamp,
+    canonicalDisplayName
   );
   if (senderDisplayName !== undefined) {
     sender.senderDisplayName = senderDisplayName;
@@ -1165,7 +1192,8 @@ function buildSenderDay(
   input: StorePrivateWhatsAppMessageInput,
   senderDayId: string,
   chatId: string,
-  existingSenderDay: PrivateWhatsAppSenderDay | undefined
+  existingSenderDay: PrivateWhatsAppSenderDay | undefined,
+  canonicalDisplayName?: string
 ): PrivateWhatsAppSenderDay {
   const now = new Date().toISOString();
   const senderDay: PrivateWhatsAppSenderDay = {
@@ -1189,11 +1217,12 @@ function buildSenderDay(
     schemaVersion: PRIVATE_WHATSAPP_SCHEMA_VERSION,
   };
 
-  const senderDisplayName = selectLatestString(
+  const senderDisplayName = selectContactDisplayName(
     existingSenderDay?.senderDisplayName,
     input.message.senderDisplayName,
     existingSenderDay?.lastEventAt,
-    input.message.eventTimestamp
+    input.message.eventTimestamp,
+    canonicalDisplayName
   );
   if (senderDisplayName !== undefined) {
     senderDay.senderDisplayName = senderDisplayName;
@@ -1461,6 +1490,45 @@ function selectLatestString(
   return isSameOrNewerTimestamp(existingTimestamp, nextTimestamp) ? nextValue : existingValue;
 }
 
+function selectContactDisplayName(
+  existingValue: string | undefined,
+  nextValue: string | undefined,
+  existingTimestamp: string | undefined,
+  nextTimestamp: string,
+  canonicalDisplayName?: string
+): string | undefined {
+  const latestValue = selectLatestString(existingValue, nextValue, existingTimestamp, nextTimestamp);
+  const stableCanonical = isStableContactDisplayName(canonicalDisplayName)
+    ? canonicalDisplayName
+    : undefined;
+  if (latestValue === undefined) {
+    return stableCanonical;
+  }
+  if (isBridgeGeneratedContactLabel(latestValue)) {
+    if (stableCanonical !== undefined) {
+      return stableCanonical;
+    }
+    if (isStableContactDisplayName(existingValue)) {
+      return existingValue;
+    }
+  }
+  return latestValue;
+}
+
+function isStableContactDisplayName(value: string | undefined): value is string {
+  return value !== undefined && value.trim() !== '' && !isBridgeGeneratedContactLabel(value);
+}
+
+function isBridgeGeneratedContactLabel(value: string): boolean {
+  const trimmed = value.trim();
+  return trimmed.endsWith(' (WA)') || isPhoneLikeContactLabel(trimmed);
+}
+
+function isPhoneLikeContactLabel(value: string): boolean {
+  const digitCount = value.replace(/\D/g, '').length;
+  return digitCount >= 6 && /^[+\d\s().-]+$/.test(value);
+}
+
 function isSameOrNewerTimestamp(existingTimestamp: string, nextTimestamp: string): boolean {
   const existingMs = Date.parse(existingTimestamp);
   const nextMs = Date.parse(nextTimestamp);
@@ -1562,7 +1630,8 @@ function isSameOrNewerChatEvent(
 function buildMessage(
   input: StorePrivateWhatsAppMessageInput,
   chatId: string,
-  messageId: string
+  messageId: string,
+  displayNames: PrivateWhatsAppMessageDisplayNames = {}
 ): PrivateWhatsAppMessage {
   const message: PrivateWhatsAppMessage = {
     id: messageId,
@@ -1586,8 +1655,9 @@ function buildMessage(
     schemaVersion: PRIVATE_WHATSAPP_SCHEMA_VERSION,
   };
 
-  if (input.message.senderDisplayName !== undefined) {
-    message.senderDisplayName = input.message.senderDisplayName;
+  const senderDisplayName = displayNames.senderDisplayName ?? input.message.senderDisplayName;
+  if (senderDisplayName !== undefined) {
+    message.senderDisplayName = senderDisplayName;
   }
   if (input.message.senderPhoneNumber !== undefined) {
     message.senderPhoneNumber = input.message.senderPhoneNumber;
@@ -1596,8 +1666,9 @@ function buildMessage(
   if (senderPhoneNumberNormalized !== undefined) {
     message.senderPhoneNumberNormalized = senderPhoneNumberNormalized;
   }
-  if (input.chat.displayName !== undefined) {
-    message.chatDisplayName = input.chat.displayName;
+  const chatDisplayName = displayNames.chatDisplayName ?? input.chat.displayName;
+  if (chatDisplayName !== undefined) {
+    message.chatDisplayName = chatDisplayName;
   }
   if (input.message.text !== undefined) {
     message.text = input.message.text;


### PR DESCRIPTION
## Summary
- Preserve canonical private WhatsApp contact labels when later Matrix/WhatsApp bridge labels look generated, such as `Pawel M (WA)` or a phone-shaped label.
- Apply the normalized sender/chat labels to new message docs as well as sender and sender-day aggregates.
- Extend repository tests for direct alias rooms, phone-shaped aliases, and group member bridge labels.

## Evidence
- Production dry-run for the five pasted mappings found only aggregate/message label repairs remaining: 4 sender docs, 29 sender-day docs, 272 message docs, 0 chat docs.
- Dry-run source account: `private-wa-d475181cf78906fbf99f26b1`.

## Verification
- `pnpm --filter whatsapp-service exec vitest run src/__tests__/infra/privateWhatsAppRepository.test.ts`
- `pnpm run ci:tracked`


- Linear: [INT-1836](https://linear.app/pbuchman/issue/INT-1836)
- IntexuraOS Code Task: [View task](https://intexuraos.cloud/#/code-tasks/task_1890d793-16ab-4ccb-b5c6-f1bf184edbfb)
- Worker Type: `codex-xhigh`
- Model: `default`
