### PR TITLE
[INT-1837] Consolidate Conversation Assistant PDF export

### DIFF
--- a/apps/web/src/components/ui/ErrorBanner.tsx
+++ b/apps/web/src/components/ui/ErrorBanner.tsx
@@ -6,7 +6,10 @@ interface ErrorBannerProps {
 export function ErrorBanner({ message, className = '' }: ErrorBannerProps): React.JSX.Element | null {
   if (message === null || message === '') return null;
   return (
-    <div className={`rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-800 dark:bg-red-900/30 dark:text-red-400 ${className}`}>
+    <div
+      role="alert"
+      className={`rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-800 dark:bg-red-900/30 dark:text-red-400 ${className}`}
+    >
       {message}
     </div>
   );

--- a/apps/web/src/hooks/__tests__/useWhatsAppConversationAssistant.test.tsx
+++ b/apps/web/src/hooks/__tests__/useWhatsAppConversationAssistant.test.tsx
@@ -5,7 +5,7 @@
 
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { MemoryRouter, useLocation, useNavigate } from 'react-router-dom';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type {
   ConversationAssistantSession,
   ConversationAssistantTurn,
@@ -18,6 +18,7 @@ const mocks = vi.hoisted(() => ({
   listConversationAssistantSessions: vi.fn(),
   checkConversationAssistantContext: vi.fn(),
   createConversationAssistantSession: vi.fn(),
+  exportConversationAssistantSessionPdf: vi.fn(),
   getConversationAssistantSession: vi.fn(),
   listConversationAssistantTurns: vi.fn(),
   streamConversationAssistantTurn: vi.fn(),
@@ -37,6 +38,7 @@ vi.mock('@/services/conversationAssistantApi', () => ({
   listConversationAssistantSessions: mocks.listConversationAssistantSessions,
   checkConversationAssistantContext: mocks.checkConversationAssistantContext,
   createConversationAssistantSession: mocks.createConversationAssistantSession,
+  exportConversationAssistantSessionPdf: mocks.exportConversationAssistantSessionPdf,
   getConversationAssistantSession: mocks.getConversationAssistantSession,
   listConversationAssistantTurns: mocks.listConversationAssistantTurns,
   streamConversationAssistantTurn: mocks.streamConversationAssistantTurn,
@@ -153,7 +155,33 @@ function createDeferred<T>(): Deferred<T> {
   return { promise, resolve, reject };
 }
 
+function mockBrowserDownloadApis(): {
+  createObjectURL: ReturnType<typeof vi.fn>;
+  revokeObjectURL: ReturnType<typeof vi.fn>;
+  anchorClickSpy: ReturnType<typeof vi.spyOn>;
+} {
+  const createObjectURL = vi.fn(() => 'blob:session-1');
+  const revokeObjectURL = vi.fn();
+  vi.stubGlobal(
+    'URL',
+    class extends URL {
+      static createObjectURL = createObjectURL;
+      static revokeObjectURL = revokeObjectURL;
+    }
+  );
+  const anchorClickSpy = vi
+    .spyOn(HTMLAnchorElement.prototype, 'click')
+    .mockImplementation((): void => undefined);
+
+  return { createObjectURL, revokeObjectURL, anchorClickSpy };
+}
+
 describe('useWhatsAppConversationAssistant', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.getAccessToken.mockResolvedValue('tok');
@@ -167,6 +195,10 @@ describe('useWhatsAppConversationAssistant', () => {
     mocks.getConversationAssistantSession.mockResolvedValue(session);
     mocks.listConversationAssistantTurns.mockResolvedValue({ turns });
     mocks.createConversationAssistantSession.mockResolvedValue(session);
+    mocks.exportConversationAssistantSessionPdf.mockResolvedValue({
+      blob: new Blob(['pdf-bytes'], { type: 'application/pdf' }),
+      filename: 'alice-context.pdf',
+    });
     mocks.streamConversationAssistantTurn.mockImplementation(
       async (
         _token: string,
@@ -1263,5 +1295,112 @@ describe('useWhatsAppConversationAssistant', () => {
     expect(result.current.directChats).toEqual([latestChat]);
     expect(result.current.sessions).toEqual([latestSession]);
     expect(result.current.error).toBeNull();
+  });
+
+  it('exports selected session PDF through the service helper and browser download flow', async () => {
+    const { createObjectURL, revokeObjectURL, anchorClickSpy } = mockBrowserDownloadApis();
+    const createElementSpy = vi.spyOn(document, 'createElement');
+
+    const { result } = renderHook(() => useWhatsAppConversationAssistant(), {
+      wrapper: createWrapper('/whatsapp/conversation-assistant?session=session-1'),
+    });
+
+    await waitFor(() => {
+      expect(result.current.selectedSession?.id).toBe(session.id);
+    });
+
+    expect(result.current.exporting).toBe(false);
+
+    await act(async () => {
+      await result.current.exportSelectedSessionPdf();
+    });
+
+    expect(mocks.exportConversationAssistantSessionPdf).toHaveBeenCalledWith('tok', session.id);
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+    expect(anchorClickSpy).toHaveBeenCalledTimes(1);
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:session-1');
+
+    const anchor = createElementSpy.mock.results.find(
+      (entry) => entry.type === 'return' && entry.value instanceof HTMLAnchorElement
+    )?.value as HTMLAnchorElement | undefined;
+    expect(anchor).toBeDefined();
+    expect(anchor?.download).toBe('alice-context.pdf');
+    expect(anchor?.href).toBe('blob:session-1');
+    expect(document.body.contains(anchor ?? null)).toBe(false);
+    expect(result.current.exporting).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('does not export without a selected session and reports a helpful error', async () => {
+    const { result } = renderHook(() => useWhatsAppConversationAssistant(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.directChats).toEqual([directChat]);
+    });
+
+    await act(async () => {
+      await result.current.exportSelectedSessionPdf();
+    });
+
+    expect(mocks.exportConversationAssistantSessionPdf).not.toHaveBeenCalled();
+    expect(result.current.error).toBe('Select an assistant session before exporting.');
+    expect(result.current.exporting).toBe(false);
+  });
+
+  it('prevents duplicate exports while an export is already in flight', async () => {
+    mockBrowserDownloadApis();
+    const exportRequest = createDeferred<{ blob: Blob; filename: string }>();
+    mocks.exportConversationAssistantSessionPdf.mockReturnValue(exportRequest.promise);
+
+    const { result } = renderHook(() => useWhatsAppConversationAssistant(), {
+      wrapper: createWrapper('/whatsapp/conversation-assistant?session=session-1'),
+    });
+
+    await waitFor(() => {
+      expect(result.current.selectedSession?.id).toBe(session.id);
+    });
+
+    let firstExport!: Promise<void>;
+    let secondExport!: Promise<void>;
+    act(() => {
+      firstExport = result.current.exportSelectedSessionPdf();
+      secondExport = result.current.exportSelectedSessionPdf();
+    });
+
+    await waitFor(() => {
+      expect(result.current.exporting).toBe(true);
+    });
+    expect(mocks.exportConversationAssistantSessionPdf).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      exportRequest.resolve({
+        blob: new Blob(['pdf-bytes'], { type: 'application/pdf' }),
+        filename: 'alice-context.pdf',
+      });
+      await Promise.all([firstExport, secondExport]);
+    });
+
+    expect(result.current.exporting).toBe(false);
+  });
+
+  it('clears exporting and surfaces API failures when PDF export fails', async () => {
+    mocks.exportConversationAssistantSessionPdf.mockRejectedValue(new Error('export failed'));
+
+    const { result } = renderHook(() => useWhatsAppConversationAssistant(), {
+      wrapper: createWrapper('/whatsapp/conversation-assistant?session=session-1'),
+    });
+
+    await waitFor(() => {
+      expect(result.current.selectedSession?.id).toBe(session.id);
+    });
+
+    await act(async () => {
+      await result.current.exportSelectedSessionPdf();
+    });
+
+    expect(result.current.exporting).toBe(false);
+    expect(result.current.error).toBe('export failed');
   });
 });

--- a/apps/web/src/hooks/useWhatsAppConversationAssistant.ts
+++ b/apps/web/src/hooks/useWhatsAppConversationAssistant.ts
@@ -5,6 +5,7 @@ import { useAuth } from '@/context';
 import {
   checkConversationAssistantContext,
   createConversationAssistantSession,
+  exportConversationAssistantSessionPdf,
   getConversationAssistantSession,
   listConversationAssistantSessions,
   listConversationAssistantTurns,
@@ -63,6 +64,7 @@ export interface UseWhatsAppConversationAssistantResult {
   creating: boolean;
   checkingContext: boolean;
   sending: boolean;
+  exporting: boolean;
   error: string | null;
   largeContextWarning: ConversationAssistantContextCheckResponse | null;
   selectSession: (sessionId: string) => void;
@@ -75,6 +77,7 @@ export interface UseWhatsAppConversationAssistantResult {
   confirmLargeContextCreate: () => Promise<void>;
   dismissLargeContextWarning: () => void;
   sendFollowUp: () => Promise<void>;
+  exportSelectedSessionPdf: () => Promise<void>;
   refresh: () => Promise<void>;
 }
 
@@ -107,6 +110,7 @@ export function useWhatsAppConversationAssistant(): UseWhatsAppConversationAssis
   const sessionListRequestIdRef = useRef(0);
   const sendRequestIdRef = useRef(0);
   const sendInFlightRef = useRef(false);
+  const exportInFlightRef = useRef(false);
   const turnsRequestIdRef = useRef(0);
   const skipNextSelectedSessionLoadRef = useRef<string | undefined>(undefined);
 
@@ -130,6 +134,7 @@ export function useWhatsAppConversationAssistant(): UseWhatsAppConversationAssis
   const [creating, setCreating] = useState(false);
   const [checkingContext, setCheckingContext] = useState(false);
   const [sending, setSending] = useState(false);
+  const [exporting, setExporting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [pendingLargeContext, setPendingLargeContext] =
     useState<PendingLargeContextCreate | null>(null);
@@ -578,6 +583,41 @@ export function useWhatsAppConversationAssistant(): UseWhatsAppConversationAssis
     }
   }, [followUpQuestion, getAccessToken, streamQuestionIntoSession]);
 
+  const exportSelectedSessionPdf = useCallback(async (): Promise<void> => {
+    if (exportInFlightRef.current) return;
+
+    const session = selectedSession;
+    if (session === undefined) {
+      setError('Select an assistant session before exporting.');
+      return;
+    }
+
+    exportInFlightRef.current = true;
+    setExporting(true);
+    setError(null);
+
+    try {
+      const token = await getAccessToken();
+      const download = await exportConversationAssistantSessionPdf(token, session.id);
+      const url = URL.createObjectURL(download.blob);
+      const anchor = document.createElement('a');
+      anchor.href = url;
+      anchor.download = download.filename;
+      document.body.append(anchor);
+      try {
+        anchor.click();
+      } finally {
+        anchor.remove();
+        URL.revokeObjectURL(url);
+      }
+    } catch (err) {
+      setError(getErrorMessage(err, 'Failed to export assistant session'));
+    } finally {
+      exportInFlightRef.current = false;
+      setExporting(false);
+    }
+  }, [getAccessToken, selectedSession]);
+
   return {
     sessions,
     selectedSessionId,
@@ -594,6 +634,7 @@ export function useWhatsAppConversationAssistant(): UseWhatsAppConversationAssis
     creating,
     checkingContext,
     sending,
+    exporting,
     error,
     largeContextWarning: pendingLargeContext?.check ?? null,
     selectSession,
@@ -606,6 +647,7 @@ export function useWhatsAppConversationAssistant(): UseWhatsAppConversationAssis
     confirmLargeContextCreate,
     dismissLargeContextWarning,
     sendFollowUp,
+    exportSelectedSessionPdf,
     refresh,
   };
 }

--- a/apps/web/src/pages/WhatsAppConversationAssistantPage.tsx
+++ b/apps/web/src/pages/WhatsAppConversationAssistantPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef } from 'react';
-import { Bot, RefreshCw } from 'lucide-react';
+import { Bot, Download, RefreshCw } from 'lucide-react';
 import { Button, ErrorBanner, Layout, MarkdownContent } from '@/components';
 import { ConversationAssistantComposer } from '@/components/whatsapp/ConversationAssistantComposer';
 import { ConversationAssistantSessionRail } from '@/components/whatsapp/ConversationAssistantSessionRail';
@@ -64,6 +64,11 @@ function SessionMetadata({
 
 export function WhatsAppConversationAssistantPage(): React.JSX.Element {
   const assistant = useWhatsAppConversationAssistant();
+  const canExportSelectedSession =
+    assistant.selectedSession !== undefined &&
+    assistant.turns.length > 0 &&
+    !assistant.sending &&
+    !assistant.exporting;
   const selectedSessionId = assistant.selectedSessionId;
   const turnsScrollRef = useRef<HTMLDivElement | null>(null);
   const followTurnsRef = useRef(true);
@@ -112,18 +117,33 @@ export function WhatsAppConversationAssistantPage(): React.JSX.Element {
               Analyze a frozen private direct-chat range and continue autosaved assistant sessions.
             </p>
           </div>
-          <Button
-            variant="secondary"
-            size="sm"
-            onClick={(): void => {
-              void assistant.refresh();
-            }}
-            isLoading={assistant.loading}
-            loadingText="Refreshing"
-          >
-            <RefreshCw className="mr-2 h-4 w-4" />
-            Refresh
-          </Button>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={(): void => {
+                void assistant.exportSelectedSessionPdf();
+              }}
+              isLoading={assistant.exporting}
+              loadingText="Exporting"
+              disabled={!canExportSelectedSession}
+            >
+              <Download className="mr-2 h-4 w-4" />
+              Export PDF
+            </Button>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={(): void => {
+                void assistant.refresh();
+              }}
+              isLoading={assistant.loading}
+              loadingText="Refreshing"
+            >
+              <RefreshCw className="mr-2 h-4 w-4" />
+              Refresh
+            </Button>
+          </div>
         </header>
 
         <ErrorBanner message={assistant.error} />

--- a/apps/web/src/pages/__tests__/WhatsAppConversationAssistantPage.test.tsx
+++ b/apps/web/src/pages/__tests__/WhatsAppConversationAssistantPage.test.tsx
@@ -78,6 +78,7 @@ function createHookResult(
     creating: false,
     checkingContext: false,
     sending: false,
+    exporting: false,
     error: null,
     largeContextWarning: null,
     selectSession: vi.fn(),
@@ -90,6 +91,7 @@ function createHookResult(
     confirmLargeContextCreate: vi.fn(),
     dismissLargeContextWarning: vi.fn(),
     sendFollowUp: vi.fn(),
+    exportSelectedSessionPdf: vi.fn(),
     refresh: vi.fn(),
     ...overrides,
   };
@@ -226,6 +228,95 @@ describe('WhatsAppConversationAssistantPage', () => {
 
     expect(createSession).toHaveBeenCalledTimes(1);
     expect(sendFollowUp).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables Export PDF when no selected session is loaded', () => {
+    render(<WhatsAppConversationAssistantPage />);
+
+    expect(screen.getByRole('button', { name: 'Export PDF' })).toBeDisabled();
+  });
+
+  it('disables Export PDF until the selected session has completed turns', () => {
+    const result = createHookResult();
+    mockUseAssistant.mockReturnValue(
+      createHookResult({
+        selectedSession: result.sessions[0],
+        turns: [],
+      })
+    );
+
+    render(<WhatsAppConversationAssistantPage />);
+
+    expect(screen.getByRole('button', { name: 'Export PDF' })).toBeDisabled();
+  });
+
+  it('disables Export PDF while a follow-up send is in progress', () => {
+    const result = createHookResult();
+    mockUseAssistant.mockReturnValue(
+      createHookResult({
+        selectedSession: result.sessions[0],
+        sending: true,
+        turns: [
+          {
+            id: 'turn-user',
+            sessionId: 'session-1',
+            userId: 'user-1',
+            role: 'user',
+            text: 'What did we agree?',
+            createdAt: '2026-06-21T11:01:00.000Z',
+          },
+        ],
+      })
+    );
+
+    render(<WhatsAppConversationAssistantPage />);
+
+    expect(screen.getByRole('button', { name: 'Export PDF' })).toBeDisabled();
+  });
+
+  it('exports selected session through the hook action', async () => {
+    const user = userEvent.setup();
+    const exportSelectedSessionPdf = vi.fn();
+    const result = createHookResult();
+    mockUseAssistant.mockReturnValue(
+      createHookResult({
+        selectedSession: result.sessions[0],
+        turns: [
+          {
+            id: 'turn-user',
+            sessionId: 'session-1',
+            userId: 'user-1',
+            role: 'user',
+            text: 'What did we agree?',
+            createdAt: '2026-06-21T11:01:00.000Z',
+          },
+        ],
+        exportSelectedSessionPdf,
+      })
+    );
+
+    render(<WhatsAppConversationAssistantPage />);
+
+    const exportButton = screen.getByRole('button', { name: 'Export PDF' });
+    expect(exportButton).toBeEnabled();
+
+    await user.click(exportButton);
+
+    expect(exportSelectedSessionPdf).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows Exporting state while a PDF export is in flight', () => {
+    const result = createHookResult();
+    mockUseAssistant.mockReturnValue(
+      createHookResult({
+        selectedSession: result.sessions[0],
+        exporting: true,
+      })
+    );
+
+    render(<WhatsAppConversationAssistantPage />);
+
+    expect(screen.getByRole('button', { name: 'Exporting' })).toBeDisabled();
   });
 
   it('renders large-context confirmation actions', async () => {

--- a/apps/web/src/services/__tests__/conversationAssistantApi.test.ts
+++ b/apps/web/src/services/__tests__/conversationAssistantApi.test.ts
@@ -2,16 +2,22 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   checkConversationAssistantContext,
   createConversationAssistantSession,
+  exportConversationAssistantSessionPdf,
   getConversationAssistantSession,
   listConversationAssistantSessions,
   listConversationAssistantTurns,
   sendConversationAssistantTurn,
   streamConversationAssistantTurn,
 } from '../conversationAssistantApi.js';
+import { ApiError } from '../apiClient.js';
 
-vi.mock('../apiClient.js', () => ({
-  apiRequest: vi.fn(),
-}));
+vi.mock('../apiClient.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../apiClient.js')>();
+  return {
+    ...actual,
+    apiRequest: vi.fn(),
+  };
+});
 
 vi.mock('../../config', () => ({
   config: {
@@ -197,5 +203,94 @@ describe('conversationAssistantApi', () => {
       'assistant_delta',
       'done',
     ]);
+  });
+
+  it('exports conversation assistant PDF with filename from content disposition', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response('pdf-bytes', {
+          status: 200,
+          headers: {
+            'Content-Disposition': 'attachment; filename="alice-context.pdf"',
+            'Content-Type': 'application/pdf',
+          },
+        })
+      )
+    );
+
+    const result = await exportConversationAssistantSessionPdf(TOKEN, 'session/with spaces?');
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://wa.test/conversation-assistant/sessions/session%2Fwith%20spaces%3F/export.pdf',
+      expect.objectContaining({
+        method: 'GET',
+        cache: 'no-store',
+        headers: expect.objectContaining({
+          Authorization: `Bearer ${TOKEN}`,
+        }),
+      })
+    );
+    expect(result.filename).toBe('alice-context.pdf');
+    expect(result.blob.type).toBe('application/pdf');
+    await expect(result.blob.text()).resolves.toBe('pdf-bytes');
+  });
+
+  it('exports conversation assistant PDF and throws ApiError for API envelopes', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            error: {
+              code: 'FORBIDDEN',
+              message: 'No export access',
+              details: { reason: 'policy' },
+            },
+          }),
+          {
+            status: 403,
+            headers: { 'Content-Type': 'application/json' },
+          }
+        )
+      )
+    );
+
+    await expect(
+      exportConversationAssistantSessionPdf(TOKEN, 'session-1')
+    ).rejects.toMatchObject<ApiError>({
+      code: 'FORBIDDEN',
+      message: 'No export access',
+      status: 403,
+      details: { reason: 'policy' },
+    });
+  });
+
+  it('exports conversation assistant PDF with UTF-8 filename and fallback when missing', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn()
+        .mockResolvedValueOnce(
+          new Response(new Blob(['pdf-bytes'], { type: 'application/pdf' }), {
+            status: 200,
+            headers: {
+              'Content-Disposition':
+                "attachment; filename*=UTF-8''alice%20context%20%E2%82%AC.pdf",
+            },
+          })
+        )
+        .mockResolvedValueOnce(
+          new Response(new Blob(['pdf-bytes'], { type: 'application/pdf' }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/pdf' },
+          })
+        )
+    );
+
+    const utf8Result = await exportConversationAssistantSessionPdf(TOKEN, 'session-utf8');
+    const fallbackResult = await exportConversationAssistantSessionPdf(TOKEN, 'session-1');
+
+    expect(utf8Result.filename).toBe('alice context €.pdf');
+    expect(fallbackResult.filename).toBe('conversation-assistant-session-1.pdf');
   });
 });

--- a/apps/web/src/services/conversationAssistantApi.ts
+++ b/apps/web/src/services/conversationAssistantApi.ts
@@ -2,6 +2,7 @@ import { config } from '@/config';
 import type {
   ConversationAssistantContextCheckRequest,
   ConversationAssistantContextCheckResponse,
+  ConversationAssistantPdfDownload,
   ConversationAssistantSession,
   ConversationAssistantStreamEvent,
   ConversationAssistantTurn,
@@ -27,6 +28,23 @@ interface CreateConversationAssistantSessionResponse {
 
 function getSessionPath(sessionId: string): string {
   return `${CONVERSATION_ASSISTANT_SESSIONS_PATH}/${encodeURIComponent(sessionId)}`;
+}
+
+function parseAttachmentFilename(contentDisposition: string | null): string | null {
+  if (contentDisposition === null) return null;
+
+  const utf8Match = /filename\*=UTF-8''([^;]+)/i.exec(contentDisposition);
+  if (utf8Match?.[1] !== undefined) {
+    try {
+      return decodeURIComponent(utf8Match[1]);
+    } catch {
+      return utf8Match[1];
+    }
+  }
+
+  const filenameMatch = /filename="([^"]+)"|filename=([^;]+)/i.exec(contentDisposition);
+  const filename = filenameMatch?.[1] ?? filenameMatch?.[2]?.trim();
+  return filename === undefined || filename === '' ? null : filename;
 }
 
 export async function listConversationAssistantSessions(
@@ -91,6 +109,34 @@ export async function listConversationAssistantTurns(
     `${getSessionPath(sessionId)}/turns`,
     accessToken
   );
+}
+
+export async function exportConversationAssistantSessionPdf(
+  accessToken: string,
+  sessionId: string
+): Promise<ConversationAssistantPdfDownload> {
+  const response = await fetch(
+    `${config.whatsappServiceUrl}${getSessionPath(sessionId)}/export.pdf`,
+    {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'X-Request-Id': newRequestId(),
+      },
+      cache: 'no-store',
+    }
+  );
+
+  if (!response.ok) {
+    throw await toApiError(response);
+  }
+
+  return {
+    blob: await response.blob(),
+    filename:
+      parseAttachmentFilename(response.headers.get('Content-Disposition')) ??
+      `conversation-assistant-${sessionId}.pdf`,
+  };
 }
 
 export async function streamConversationAssistantTurn(

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -396,6 +396,11 @@ export interface ConversationAssistantTurnsResponse {
   turns: ConversationAssistantTurn[];
 }
 
+export interface ConversationAssistantPdfDownload {
+  blob: Blob;
+  filename: string;
+}
+
 export interface ConversationAssistantContextCheckRequest {
   chatId: string;
   from: string;

--- a/apps/whatsapp-service/package.json
+++ b/apps/whatsapp-service/package.json
@@ -25,6 +25,7 @@
     "@intexuraos/http-contracts": "workspace:*",
     "@intexuraos/http-server": "workspace:*",
     "@intexuraos/infra-firestore": "workspace:*",
+    "@intexuraos/infra-pdf-export": "workspace:*",
     "@intexuraos/infra-pubsub": "workspace:*",
     "@intexuraos/infra-sentry": "workspace:*",
     "@intexuraos/infra-whatsapp": "workspace:*",

--- a/apps/whatsapp-service/src/__tests__/conversationAssistantRoutes.test.ts
+++ b/apps/whatsapp-service/src/__tests__/conversationAssistantRoutes.test.ts
@@ -127,6 +127,161 @@ describe('Conversation Assistant routes', () => {
     expect(JSON.parse(turns.body).data.turns).toHaveLength(2);
   });
 
+  it('does not require the PDF exporter for non-export Conversation Assistant routes', async () => {
+    const token = await seed();
+    const { pdfConversationExporter: _pdfConversationExporter, ...servicesWithoutPdfExporter } =
+      getServices();
+    setServices(servicesWithoutPdfExporter);
+
+    const response = await ctx.app.inject({
+      method: 'GET',
+      url: '/conversation-assistant/sessions',
+      headers: { authorization: `Bearer ${token}` },
+    });
+
+    expect(response.statusCode).toBe(200);
+  });
+
+  it('exports a PDF snapshot with binary headers and a session-scoped filename', async () => {
+    const token = await seed();
+
+    const created = await ctx.app.inject({
+      method: 'POST',
+      url: '/conversation-assistant/sessions',
+      headers: { authorization: `Bearer ${token}` },
+      payload: {
+        chatId: CHAT_ID,
+        from: '2026-06-30T00:00:00.000Z',
+        to: '2026-07-01T00:00:00.000Z',
+        question: 'What was agreed?',
+      },
+    });
+    expect(created.statusCode).toBe(201);
+    const createdBody = JSON.parse(created.body) as { data: { session: { id: string } } };
+
+    const response = await ctx.app.inject({
+      method: 'GET',
+      url: `/conversation-assistant/sessions/${createdBody.data.session.id}/export.pdf`,
+      headers: { authorization: `Bearer ${token}` },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers['content-type']).toBe('application/pdf');
+    expect(response.headers['cache-control']).toBe('no-store');
+    expect(response.headers['content-disposition']).toBe(
+      `attachment; filename="alice-context-${createdBody.data.session.id}.pdf"`
+    );
+    expect(response.body).toBe('%PDF-test');
+    expect(ctx.pdfConversationExporter.calls).toHaveLength(1);
+    expect(ctx.pdfConversationExporter.calls[0]?.messages.map((message) => message.role)).toEqual([
+      'user',
+      'assistant',
+    ]);
+    expect(ctx.pdfConversationExporter.calls[0]?.messageCounts).toEqual({
+      included: 1,
+      excluded: 0,
+    });
+  });
+
+  it('rejects unauthenticated, missing, and foreign PDF export requests', async () => {
+    const token = await seed();
+    const created = await ctx.app.inject({
+      method: 'POST',
+      url: '/conversation-assistant/sessions',
+      headers: { authorization: `Bearer ${token}` },
+      payload: {
+        chatId: CHAT_ID,
+        from: '2026-06-30T00:00:00.000Z',
+        to: '2026-07-01T00:00:00.000Z',
+        question: 'What was agreed?',
+      },
+    });
+    expect(created.statusCode).toBe(201);
+    const createdBody = JSON.parse(created.body) as { data: { session: { id: string } } };
+
+    const unauthenticated = await ctx.app.inject({
+      method: 'GET',
+      url: `/conversation-assistant/sessions/${createdBody.data.session.id}/export.pdf`,
+    });
+    const missing = await ctx.app.inject({
+      method: 'GET',
+      url: '/conversation-assistant/sessions/whatsapp_conv_session_missing/export.pdf',
+      headers: { authorization: `Bearer ${token}` },
+    });
+    const foreignToken = await createToken({ sub: 'other-user' });
+    const foreign = await ctx.app.inject({
+      method: 'GET',
+      url: `/conversation-assistant/sessions/${createdBody.data.session.id}/export.pdf`,
+      headers: { authorization: `Bearer ${foreignToken}` },
+    });
+
+    expect(unauthenticated.statusCode).toBe(401);
+    expect(missing.statusCode).toBe(404);
+    expect(foreign.statusCode).toBe(404);
+  });
+
+  it('maps PDF exporter failures to internal errors', async () => {
+    const token = await seed();
+    const created = await ctx.app.inject({
+      method: 'POST',
+      url: '/conversation-assistant/sessions',
+      headers: { authorization: `Bearer ${token}` },
+      payload: {
+        chatId: CHAT_ID,
+        from: '2026-06-30T00:00:00.000Z',
+        to: '2026-07-01T00:00:00.000Z',
+        question: 'What was agreed?',
+      },
+    });
+    expect(created.statusCode).toBe(201);
+    const createdBody = JSON.parse(created.body) as { data: { session: { id: string } } };
+    ctx.pdfConversationExporter.failNext('pdf render failed');
+
+    const response = await ctx.app.inject({
+      method: 'GET',
+      url: `/conversation-assistant/sessions/${createdBody.data.session.id}/export.pdf`,
+      headers: { authorization: `Bearer ${token}` },
+    });
+
+    expect(response.statusCode).toBe(500);
+    expect(JSON.parse(response.body).error).toMatchObject({
+      code: 'INTERNAL_ERROR',
+      message: 'pdf render failed',
+    });
+  });
+
+  it('requires the PDF exporter for PDF export requests', async () => {
+    const token = await seed();
+    const created = await ctx.app.inject({
+      method: 'POST',
+      url: '/conversation-assistant/sessions',
+      headers: { authorization: `Bearer ${token}` },
+      payload: {
+        chatId: CHAT_ID,
+        from: '2026-06-30T00:00:00.000Z',
+        to: '2026-07-01T00:00:00.000Z',
+        question: 'What was agreed?',
+      },
+    });
+    expect(created.statusCode).toBe(201);
+    const createdBody = JSON.parse(created.body) as { data: { session: { id: string } } };
+    const { pdfConversationExporter: _pdfConversationExporter, ...servicesWithoutPdfExporter } =
+      getServices();
+    setServices(servicesWithoutPdfExporter);
+
+    const response = await ctx.app.inject({
+      method: 'GET',
+      url: `/conversation-assistant/sessions/${createdBody.data.session.id}/export.pdf`,
+      headers: { authorization: `Bearer ${token}` },
+    });
+
+    expect(response.statusCode).toBe(500);
+    expect(JSON.parse(response.body).error).toMatchObject({
+      code: 'INTERNAL_ERROR',
+      message: 'Conversation Assistant services are not configured',
+    });
+  });
+
   it('checks selected context size before creating a session', async () => {
     const token = await seed();
 
@@ -353,6 +508,7 @@ describe('Conversation Assistant routes', () => {
       { method: 'POST' as const, url: '/conversation-assistant/sessions', payload: {} },
       { method: 'POST' as const, url: '/conversation-assistant/context/check', payload: {} },
       { method: 'GET' as const, url: '/conversation-assistant/sessions/missing' },
+      { method: 'GET' as const, url: '/conversation-assistant/sessions/missing/export.pdf' },
       { method: 'GET' as const, url: '/conversation-assistant/sessions/missing/turns' },
       {
         method: 'POST' as const,
@@ -393,6 +549,7 @@ describe('Conversation Assistant routes', () => {
         },
       },
       { method: 'GET' as const, url: '/conversation-assistant/sessions/missing' },
+      { method: 'GET' as const, url: '/conversation-assistant/sessions/missing/export.pdf' },
       { method: 'GET' as const, url: '/conversation-assistant/sessions/missing/turns' },
       {
         method: 'POST' as const,
@@ -421,6 +578,8 @@ describe('Conversation Assistant routes', () => {
       saveSession: (session) => ctx.conversationAssistantRepository.saveSession(session),
       getSessionById: (sessionId) =>
         ctx.conversationAssistantRepository.getSessionById(sessionId),
+      getSessionSnapshotById: (input) =>
+        ctx.conversationAssistantRepository.getSessionSnapshotById(input),
       listSessionsByUserId: () => {
         throw new Error('list failed');
       },

--- a/apps/whatsapp-service/src/__tests__/domain/conversation-assistant/sessionUseCases.test.ts
+++ b/apps/whatsapp-service/src/__tests__/domain/conversation-assistant/sessionUseCases.test.ts
@@ -9,13 +9,22 @@ import {
 import {
   checkConversationAssistantContext,
   createConversationAssistantSession,
+  exportConversationAssistantSessionPdf,
   getConversationAssistantSession,
   listConversationAssistantTurns,
   sendConversationAssistantTurn,
   streamConversationAssistantTurn,
 } from '../../../domain/conversation-assistant/sessionUseCases.js';
-import type { ConversationAssistantDeps } from '../../../domain/conversation-assistant/ports.js';
-import type { ConversationAssistantStreamEvent } from '../../../domain/conversation-assistant/types.js';
+import type {
+  ConversationAssistantDeps,
+  ConversationAssistantPdfExporter,
+  ConversationAssistantPdfExportError,
+  ConversationAssistantPdfExportInput,
+} from '../../../domain/conversation-assistant/ports.js';
+import type {
+  ConversationAssistantStreamEvent,
+  ExportConversationAssistantPdfResult,
+} from '../../../domain/conversation-assistant/types.js';
 import type {
   PrivateWhatsAppMessage,
   PrivateConversationContextMessageQueryInput,
@@ -31,11 +40,13 @@ function makeDeps(): {
   conversationRepository: FakeConversationAssistantRepository;
   privateRepository: FakePrivateWhatsAppRepository;
   llmClient: FakeLlmGenerateClient;
+  pdfExporter: FakePdfConversationExporter;
   llmFactoryUserIds: string[];
 } {
   const conversationRepository = new FakeConversationAssistantRepository();
   const privateRepository = new FakePrivateWhatsAppRepository();
   const llmClient = new FakeLlmGenerateClient();
+  const pdfExporter = new FakePdfConversationExporter();
   const llmFactoryUserIds: string[] = [];
   const clock = { now: (): string => '2026-06-30T12:00:00.000Z' };
   const ids = {
@@ -60,6 +71,7 @@ function makeDeps(): {
           return Promise.resolve(ok(llmClient));
         },
       },
+      pdfExporter,
       model: 'or:google/gemini-3.5-flash',
       clock,
       ids,
@@ -67,8 +79,45 @@ function makeDeps(): {
     conversationRepository,
     privateRepository,
     llmClient,
+    pdfExporter,
     llmFactoryUserIds,
   };
+}
+
+class FakePdfConversationExporter implements ConversationAssistantPdfExporter {
+  readonly calls: ConversationAssistantPdfExportInput[] = [];
+  private nextResult: import('@intexuraos/common-core').Result<
+    ExportConversationAssistantPdfResult,
+    ConversationAssistantPdfExportError
+  > = ok({
+    bytes: Buffer.from('%PDF-test'),
+    fileName: 'alice-context.pdf',
+    contentType: 'application/pdf',
+  });
+
+  exportConversation(
+    input: ConversationAssistantPdfExportInput
+  ): Promise<
+    import('@intexuraos/common-core').Result<
+      ExportConversationAssistantPdfResult,
+      ConversationAssistantPdfExportError
+    >
+  > {
+    this.calls.push(input);
+    return Promise.resolve(this.nextResult);
+  }
+
+  failNext(message = 'render failed'): void {
+    this.nextResult = err({ message });
+  }
+
+  setFileName(fileName: string): void {
+    this.nextResult = ok({
+      bytes: Buffer.from('%PDF-test'),
+      fileName,
+      contentType: 'application/pdf',
+    });
+  }
 }
 
 async function seedDirectMessage(
@@ -508,6 +557,326 @@ describe('Conversation Assistant session use cases', () => {
       code: 'LLM_ERROR',
       message: 'stream broke',
     });
+  });
+
+  it('exports an owned session PDF with mapped counts and chronological turns', async () => {
+    const { deps, conversationRepository, pdfExporter } = makeDeps();
+    await conversationRepository.saveSession({
+      id: 'whatsapp_conv_session_test',
+      userId: USER_ID,
+      chatId: CHAT_ID,
+      status: 'active',
+      range: {
+        from: '2026-06-30T00:00:00.000Z',
+        to: '2026-07-01T00:00:00.000Z',
+      },
+      model: 'or:google/gemini-3.5-flash',
+      transcriptSha256: 'abc123',
+      transcriptMessageCount: 7,
+      transcriptText: 'frozen transcript',
+      omitted: {
+        mediaOnly: 2,
+        failedTranscriptions: 1,
+        pendingTranscriptions: 3,
+        nonText: 4,
+        overLimit: 5,
+      },
+      title: 'Alice context',
+      createdAt: '2026-06-30T12:00:00.000Z',
+      updatedAt: '2026-06-30T12:00:00.000Z',
+    });
+    await conversationRepository.saveTurn({
+      id: 'turn-b',
+      sessionId: 'whatsapp_conv_session_test',
+      userId: USER_ID,
+      role: 'assistant',
+      text: 'assistant answer',
+      createdAt: '2026-06-30T12:02:00.000Z',
+    });
+    await conversationRepository.saveTurn({
+      id: 'turn-a',
+      sessionId: 'whatsapp_conv_session_test',
+      userId: USER_ID,
+      role: 'user',
+      text: 'user question',
+      createdAt: '2026-06-30T12:01:00.000Z',
+    });
+
+    const result = await exportConversationAssistantSessionPdf(
+      { userId: USER_ID, sessionId: 'whatsapp_conv_session_test' },
+      deps
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.contentType).toBe('application/pdf');
+    expect(result.value.bytes.toString()).toBe('%PDF-test');
+    expect(result.value.fileName).toBe('alice-context-whatsapp_conv_session_test.pdf');
+    expect(pdfExporter.calls).toEqual([
+      {
+        title: 'Alice context',
+        modelName: 'or:google/gemini-3.5-flash',
+        initialPrompt: 'user question',
+        generatedAt: '2026-06-30T12:00:00.000Z',
+        sourceRange: {
+          from: '2026-06-30T00:00:00.000Z',
+          to: '2026-07-01T00:00:00.000Z',
+        },
+        messageCounts: { included: 7, excluded: 15 },
+        omittedBreakdown: {
+          mediaOnly: 2,
+          failedTranscriptions: 1,
+          pendingTranscriptions: 3,
+          nonText: 4,
+          overLimit: 5,
+        },
+        messages: [
+          {
+            role: 'user',
+            createdAt: '2026-06-30T12:01:00.000Z',
+            text: 'user question',
+          },
+          {
+            role: 'assistant',
+            createdAt: '2026-06-30T12:02:00.000Z',
+            text: 'assistant answer',
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('orders equal-timestamp PDF export turns by conversation role and same-role id', async () => {
+    const { deps, conversationRepository, pdfExporter } = makeDeps();
+    pdfExporter.setFileName('custom-base');
+    await conversationRepository.saveSession({
+      id: 'whatsapp_conv_session_test',
+      userId: USER_ID,
+      chatId: CHAT_ID,
+      status: 'active',
+      range: {
+        from: '2026-06-30T00:00:00.000Z',
+        to: '2026-07-01T00:00:00.000Z',
+      },
+      model: 'or:google/gemini-3.5-flash',
+      transcriptSha256: 'abc123',
+      transcriptMessageCount: 4,
+      transcriptText: 'frozen transcript',
+      omitted: {
+        mediaOnly: 0,
+        failedTranscriptions: 0,
+        pendingTranscriptions: 0,
+        nonText: 0,
+        overLimit: 0,
+      },
+      title: 'Alice context',
+      createdAt: '2026-06-30T12:00:00.000Z',
+      updatedAt: '2026-06-30T12:00:00.000Z',
+    });
+    for (const turn of [
+      { id: 'turn-z', role: 'assistant' as const, text: 'assistant same time' },
+      { id: 'turn-b', role: 'user' as const, text: 'user b' },
+      { id: 'turn-a', role: 'user' as const, text: 'user a' },
+      { id: 'turn-future', role: 'assistant' as const, text: 'assistant future' },
+    ]) {
+      await conversationRepository.saveTurn({
+        id: turn.id,
+        sessionId: 'whatsapp_conv_session_test',
+        userId: USER_ID,
+        role: turn.role,
+        text: turn.text,
+        createdAt:
+          turn.id === 'turn-future'
+            ? '2026-06-30T12:01:00.000Z'
+            : '2026-06-30T12:00:00.000Z',
+      });
+    }
+
+    const result = await exportConversationAssistantSessionPdf(
+      { userId: USER_ID, sessionId: 'whatsapp_conv_session_test' },
+      deps
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.fileName).toBe('custom-base-whatsapp_conv_session_test.pdf');
+    expect(pdfExporter.calls[0]?.messages.map((message) => message.text)).toEqual([
+      'user a',
+      'user b',
+      'assistant same time',
+      'assistant future',
+    ]);
+
+    pdfExporter.setFileName('   ');
+    const fallback = await exportConversationAssistantSessionPdf(
+      { userId: USER_ID, sessionId: 'whatsapp_conv_session_test' },
+      deps
+    );
+    expect(fallback.ok).toBe(true);
+    if (fallback.ok) {
+      expect(fallback.value.fileName).toBe(
+        'conversation-assistant-export-whatsapp_conv_session_test.pdf'
+      );
+    }
+  });
+
+  it('rejects missing and foreign PDF export sessions without calling the exporter', async () => {
+    const { deps, conversationRepository, pdfExporter } = makeDeps();
+    await conversationRepository.saveSession({
+      id: 'whatsapp_conv_session_test',
+      userId: USER_ID,
+      chatId: CHAT_ID,
+      status: 'active',
+      range: {
+        from: '2026-06-30T00:00:00.000Z',
+        to: '2026-07-01T00:00:00.000Z',
+      },
+      model: 'or:google/gemini-3.5-flash',
+      transcriptSha256: 'abc123',
+      transcriptMessageCount: 1,
+      transcriptText: 'frozen transcript',
+      omitted: {
+        mediaOnly: 0,
+        failedTranscriptions: 0,
+        pendingTranscriptions: 0,
+        nonText: 0,
+        overLimit: 0,
+      },
+      title: 'Alice context',
+      createdAt: '2026-06-30T12:00:00.000Z',
+      updatedAt: '2026-06-30T12:00:00.000Z',
+    });
+
+    const missing = await exportConversationAssistantSessionPdf(
+      { userId: USER_ID, sessionId: 'missing' },
+      deps
+    );
+    const foreign = await exportConversationAssistantSessionPdf(
+      { userId: 'other-user', sessionId: 'whatsapp_conv_session_test' },
+      deps
+    );
+
+    expect(missing.ok).toBe(false);
+    if (!missing.ok) expect(missing.error.code).toBe('NOT_FOUND');
+    expect(foreign.ok).toBe(false);
+    if (!foreign.ok) expect(foreign.error.code).toBe('NOT_FOUND');
+    expect(pdfExporter.calls).toEqual([]);
+    expect(conversationRepository.snapshotRequests).toEqual([
+      { sessionId: 'missing', userId: USER_ID },
+      { sessionId: 'whatsapp_conv_session_test', userId: 'other-user' },
+    ]);
+  });
+
+  it('rejects PDF export when the session has no initial user prompt', async () => {
+    const { deps, conversationRepository, pdfExporter } = makeDeps();
+    await conversationRepository.saveSession({
+      id: 'whatsapp_conv_session_test',
+      userId: USER_ID,
+      chatId: CHAT_ID,
+      status: 'active',
+      range: {
+        from: '2026-06-30T00:00:00.000Z',
+        to: '2026-07-01T00:00:00.000Z',
+      },
+      model: 'or:google/gemini-3.5-flash',
+      transcriptSha256: 'abc123',
+      transcriptMessageCount: 1,
+      transcriptText: 'frozen transcript',
+      omitted: {
+        mediaOnly: 0,
+        failedTranscriptions: 0,
+        pendingTranscriptions: 0,
+        nonText: 0,
+        overLimit: 0,
+      },
+      title: 'Alice context',
+      createdAt: '2026-06-30T12:00:00.000Z',
+      updatedAt: '2026-06-30T12:00:00.000Z',
+    });
+    await conversationRepository.saveTurn({
+      id: 'turn-assistant',
+      sessionId: 'whatsapp_conv_session_test',
+      userId: USER_ID,
+      role: 'assistant',
+      text: 'assistant answer',
+      createdAt: '2026-06-30T12:02:00.000Z',
+    });
+
+    const result = await exportConversationAssistantSessionPdf(
+      { userId: USER_ID, sessionId: 'whatsapp_conv_session_test' },
+      deps
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('EMPTY_TRANSCRIPT');
+    }
+    expect(pdfExporter.calls).toEqual([]);
+  });
+
+  it('rejects PDF export when the exporter dependency is missing', async () => {
+    const { deps } = makeDeps();
+    const { pdfExporter: _pdfExporter, ...depsWithoutPdfExporter } = deps;
+
+    const result = await exportConversationAssistantSessionPdf(
+      { userId: USER_ID, sessionId: 'whatsapp_conv_session_test' },
+      depsWithoutPdfExporter
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toEqual({
+        code: 'INTERNAL_ERROR',
+        message: 'Conversation Assistant PDF exporter is not configured',
+      });
+    }
+  });
+
+  it('maps PDF rendering failures to internal errors', async () => {
+    const { deps, conversationRepository, pdfExporter } = makeDeps();
+    pdfExporter.failNext('pdf failed');
+    await conversationRepository.saveSession({
+      id: 'whatsapp_conv_session_test',
+      userId: USER_ID,
+      chatId: CHAT_ID,
+      status: 'active',
+      range: {
+        from: '2026-06-30T00:00:00.000Z',
+        to: '2026-07-01T00:00:00.000Z',
+      },
+      model: 'or:google/gemini-3.5-flash',
+      transcriptSha256: 'abc123',
+      transcriptMessageCount: 1,
+      transcriptText: 'frozen transcript',
+      omitted: {
+        mediaOnly: 0,
+        failedTranscriptions: 0,
+        pendingTranscriptions: 0,
+        nonText: 0,
+        overLimit: 0,
+      },
+      title: 'Alice context',
+      createdAt: '2026-06-30T12:00:00.000Z',
+      updatedAt: '2026-06-30T12:00:00.000Z',
+    });
+    await conversationRepository.saveTurn({
+      id: 'turn-user',
+      sessionId: 'whatsapp_conv_session_test',
+      userId: USER_ID,
+      role: 'user',
+      text: 'user question',
+      createdAt: '2026-06-30T12:01:00.000Z',
+    });
+
+    const result = await exportConversationAssistantSessionPdf(
+      { userId: USER_ID, sessionId: 'whatsapp_conv_session_test' },
+      deps
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toEqual({ code: 'INTERNAL_ERROR', message: 'pdf failed' });
+    }
   });
 
   it('persists streaming assistant errors when the user LLM key is unavailable', async () => {

--- a/apps/whatsapp-service/src/__tests__/fakes.ts
+++ b/apps/whatsapp-service/src/__tests__/fakes.ts
@@ -95,6 +95,7 @@ import { randomUUID } from 'node:crypto';
 export class FakeConversationAssistantRepository implements ConversationAssistantRepository {
   private readonly sessions = new Map<string, ConversationAssistantSession>();
   private readonly turns = new Map<string, ConversationAssistantTurn>();
+  readonly snapshotRequests: { sessionId: string; userId: string }[] = [];
 
   saveSession(session: ConversationAssistantSession): Promise<void> {
     this.sessions.set(session.id, { ...session });
@@ -104,6 +105,20 @@ export class FakeConversationAssistantRepository implements ConversationAssistan
   getSessionById(sessionId: string): Promise<ConversationAssistantSession | null> {
     const session = this.sessions.get(sessionId);
     return Promise.resolve(session === undefined ? null : { ...session });
+  }
+
+  getSessionSnapshotById(
+    input: { sessionId: string; userId: string }
+  ): Promise<{ session: ConversationAssistantSession; turns: ConversationAssistantTurn[] } | null> {
+    this.snapshotRequests.push(input);
+    const session = this.sessions.get(input.sessionId);
+    if (session === undefined || session.userId !== input.userId) {
+      return Promise.resolve(null);
+    }
+    return Promise.resolve({
+      session: { ...session },
+      turns: this.listTurnsForSnapshot(input.sessionId, input.userId),
+    });
   }
 
   listSessionsByUserId(userId: string): Promise<ConversationAssistantSession[]> {
@@ -123,14 +138,22 @@ export class FakeConversationAssistantRepository implements ConversationAssistan
   }
 
   listTurnsBySessionId(sessionId: string): Promise<ConversationAssistantTurn[]> {
+    return Promise.resolve(this.listTurnsForSnapshot(sessionId));
+  }
+
+  private listTurnsForSnapshot(
+    sessionId: string,
+    userId?: string
+  ): ConversationAssistantTurn[] {
     const turns = Array.from(this.turns.values())
       .filter((turn) => turn.sessionId === sessionId)
+      .filter((turn) => userId === undefined || turn.userId === userId)
       .sort((a, b) => {
         const createdComparison = a.createdAt.localeCompare(b.createdAt);
         return createdComparison === 0 ? a.id.localeCompare(b.id) : createdComparison;
       })
       .map((turn) => ({ ...turn }));
-    return Promise.resolve(turns);
+    return turns;
   }
 
   getAllSessions(): ConversationAssistantSession[] {

--- a/apps/whatsapp-service/src/__tests__/infra/conversationAssistantRepository.test.ts
+++ b/apps/whatsapp-service/src/__tests__/infra/conversationAssistantRepository.test.ts
@@ -93,6 +93,34 @@ describe('conversationAssistantRepository', () => {
     expect(storedDoc.data()?.['role']).toBe('assistant');
   });
 
+  it('loads a session snapshot with turns from one repository call', async () => {
+    await repository.saveSession(makeSession());
+    await repository.saveTurn(makeTurn({ id: 'turn-2', role: 'assistant', createdAt: '2026-06-30T10:02:00.000Z' }));
+    await repository.saveTurn(makeTurn({ id: 'turn-1', role: 'user', createdAt: '2026-06-30T10:01:00.000Z' }));
+    await repository.saveTurn(makeTurn({ id: 'foreign-turn', sessionId: 'other-session' }));
+    await repository.saveTurn(
+      makeTurn({ id: 'foreign-user-turn', userId: 'other-user', createdAt: '2026-06-30T10:03:00.000Z' })
+    );
+
+    const snapshot = await repository.getSessionSnapshotById({
+      sessionId: 'whatsapp_conv_session_1',
+      userId: 'user-123',
+    });
+    const missing = await repository.getSessionSnapshotById({
+      sessionId: 'missing',
+      userId: 'user-123',
+    });
+    const foreign = await repository.getSessionSnapshotById({
+      sessionId: 'whatsapp_conv_session_1',
+      userId: 'other-user',
+    });
+
+    expect(snapshot?.session.id).toBe('whatsapp_conv_session_1');
+    expect(snapshot?.turns.map((turn) => turn.id)).toEqual(['turn-1', 'turn-2']);
+    expect(missing).toBeNull();
+    expect(foreign).toBeNull();
+  });
+
   it('returns null for missing sessions and hydrates defensive defaults', async () => {
     const missing = await repository.getSessionById('whatsapp_conv_session_missing');
     expect(missing).toBeNull();

--- a/apps/whatsapp-service/src/__tests__/testUtils.ts
+++ b/apps/whatsapp-service/src/__tests__/testUtils.ts
@@ -9,6 +9,12 @@ import { buildServer } from '../server.js';
 import { resetServices, setServices } from '../services.js';
 import { clearJwksCache } from '@intexuraos/common-http';
 import { ok } from '@intexuraos/common-core';
+import type {
+  ConversationAssistantPdfExporter,
+  ConversationAssistantPdfExportError,
+  ConversationAssistantPdfExportInput,
+} from '../domain/conversation-assistant/ports.js';
+import type { ExportConversationAssistantPdfResult } from '../domain/conversation-assistant/types.js';
 import {
   FakeConversationAssistantRepository,
   FakeEventPublisher,
@@ -116,6 +122,45 @@ export const testConfig: Config = {
   port: 8080,
   host: '0.0.0.0',
 };
+
+export class FakePdfConversationExporter implements ConversationAssistantPdfExporter {
+  readonly calls: ConversationAssistantPdfExportInput[] = [];
+  private nextResult: import('@intexuraos/common-core').Result<
+    ExportConversationAssistantPdfResult,
+    ConversationAssistantPdfExportError
+  > = ok({
+    bytes: Buffer.from('%PDF-test'),
+    fileName: 'alice-context.pdf',
+    contentType: 'application/pdf',
+  });
+
+  exportConversation(
+    input: ConversationAssistantPdfExportInput
+  ): Promise<
+    import('@intexuraos/common-core').Result<
+      ExportConversationAssistantPdfResult,
+      ConversationAssistantPdfExportError
+    >
+  > {
+    this.calls.push(input);
+    return Promise.resolve(this.nextResult);
+  }
+
+  failNext(message = 'render failed'): void {
+    this.nextResult = {
+      ok: false,
+      error: { message },
+    };
+  }
+
+  setFileName(fileName: string): void {
+    this.nextResult = ok({
+      bytes: Buffer.from('%PDF-test'),
+      fileName,
+      contentType: 'application/pdf',
+    });
+  }
+}
 
 /**
  * Create a valid HMAC-SHA256 signature for a payload.
@@ -529,6 +574,7 @@ export interface TestContext {
   linkPreviewFetcher: FakeLinkPreviewFetcherPort;
   conversationAssistantRepository: FakeConversationAssistantRepository;
   llmClient: FakeLlmGenerateClient;
+  pdfConversationExporter: FakePdfConversationExporter;
 }
 
 /**
@@ -552,6 +598,7 @@ export function setupTestContext(): TestContext {
     linkPreviewFetcher: null as unknown as FakeLinkPreviewFetcherPort,
     conversationAssistantRepository: null as unknown as FakeConversationAssistantRepository,
     llmClient: null as unknown as FakeLlmGenerateClient,
+    pdfConversationExporter: null as unknown as FakePdfConversationExporter,
   };
 
   beforeAll(async () => {
@@ -577,6 +624,7 @@ export function setupTestContext(): TestContext {
     context.linkPreviewFetcher = new FakeLinkPreviewFetcherPort();
     context.conversationAssistantRepository = new FakeConversationAssistantRepository();
     context.llmClient = new FakeLlmGenerateClient();
+    context.pdfConversationExporter = new FakePdfConversationExporter();
 
     setServices({
       webhookEventRepository: context.webhookEventRepository,
@@ -596,6 +644,7 @@ export function setupTestContext(): TestContext {
       llmClientFactory: {
         createLlmClientForUser: () => Promise.resolve(ok(context.llmClient)),
       },
+      pdfConversationExporter: context.pdfConversationExporter,
       conversationAssistantModel: 'or:minimax/minimax-m2.7',
     });
 

--- a/apps/whatsapp-service/src/domain/conversation-assistant/ports.ts
+++ b/apps/whatsapp-service/src/domain/conversation-assistant/ports.ts
@@ -1,13 +1,19 @@
 import type { LlmGenerateClient } from '@intexuraos/llm-factory';
+import type { Result } from '@intexuraos/common-core';
 import type {
   ConversationAssistantResult,
   ConversationAssistantSession,
   ConversationAssistantTurn,
+  ConversationAssistantTurnRole,
+  ExportConversationAssistantPdfResult,
 } from './types.js';
 
 export interface ConversationAssistantRepository {
   saveSession(session: ConversationAssistantSession): Promise<void>;
   getSessionById(sessionId: string): Promise<ConversationAssistantSession | null>;
+  getSessionSnapshotById(
+    input: { sessionId: string; userId: string }
+  ): Promise<{ session: ConversationAssistantSession; turns: ConversationAssistantTurn[] } | null>;
   listSessionsByUserId(userId: string): Promise<ConversationAssistantSession[]>;
   saveTurn(turn: ConversationAssistantTurn): Promise<void>;
   listTurnsBySessionId(sessionId: string): Promise<ConversationAssistantTurn[]>;
@@ -26,10 +32,36 @@ export interface ConversationAssistantLlmClientFactory {
   createLlmClientForUser(userId: string): Promise<ConversationAssistantResult<LlmGenerateClient>>;
 }
 
+export interface ConversationAssistantPdfExportInput {
+  title: string;
+  modelName: string;
+  initialPrompt: string;
+  generatedAt: string;
+  sourceRange: { from: string; to: string };
+  messageCounts: { included: number; excluded: number };
+  omittedBreakdown?: Record<string, number>;
+  messages: {
+    role: ConversationAssistantTurnRole;
+    createdAt: string;
+    text: string;
+  }[];
+}
+
+export interface ConversationAssistantPdfExportError {
+  message: string;
+}
+
+export interface ConversationAssistantPdfExporter {
+  exportConversation(
+    input: ConversationAssistantPdfExportInput
+  ): Promise<Result<ExportConversationAssistantPdfResult, ConversationAssistantPdfExportError>>;
+}
+
 export interface ConversationAssistantDeps {
   repository: ConversationAssistantRepository;
   privateWhatsAppRepository: import('../whatsapp/index.js').PrivateWhatsAppRepository;
   llmClientFactory: ConversationAssistantLlmClientFactory;
+  pdfExporter?: ConversationAssistantPdfExporter;
   model: string;
   clock: ConversationAssistantClock;
   ids: ConversationAssistantIdGenerator;

--- a/apps/whatsapp-service/src/domain/conversation-assistant/sessionUseCases.ts
+++ b/apps/whatsapp-service/src/domain/conversation-assistant/sessionUseCases.ts
@@ -19,6 +19,8 @@ import type {
   ConversationAssistantTurn,
   CreateConversationAssistantSessionInput,
   CreateConversationAssistantSessionResult,
+  ExportConversationAssistantPdfInput,
+  ExportConversationAssistantPdfResult,
   SendConversationAssistantTurnInput,
 } from './types.js';
 import {
@@ -239,6 +241,78 @@ export async function listConversationAssistantTurns(
     return err({ code: 'NOT_FOUND', message: 'Conversation Assistant session not found' });
   }
   return ok(await deps.repository.listTurnsBySessionId(input.sessionId));
+}
+
+export async function exportConversationAssistantSessionPdf(
+  input: ExportConversationAssistantPdfInput,
+  deps: ConversationAssistantDeps
+): Promise<ConversationAssistantResult<ExportConversationAssistantPdfResult>> {
+  if (deps.pdfExporter === undefined) {
+    return err({
+      code: 'INTERNAL_ERROR',
+      message: 'Conversation Assistant PDF exporter is not configured',
+    });
+  }
+
+  const snapshot = await deps.repository.getSessionSnapshotById({
+    sessionId: input.sessionId,
+    userId: input.userId,
+  });
+  if (snapshot === null) {
+    return err({ code: 'NOT_FOUND', message: 'Conversation Assistant session not found' });
+  }
+  const session = snapshot.session;
+
+  const turns = snapshot.turns;
+  const orderedTurns = [...turns].sort((a, b) => {
+    const createdComparison = a.createdAt.localeCompare(b.createdAt);
+    if (createdComparison !== 0) {
+      return createdComparison;
+    }
+    const roleComparison = turnRoleSortValue(a.role) - turnRoleSortValue(b.role);
+    return roleComparison === 0 ? a.id.localeCompare(b.id) : roleComparison;
+  });
+  const omittedBreakdown = session.omitted;
+  const excluded =
+    omittedBreakdown.mediaOnly +
+    omittedBreakdown.failedTranscriptions +
+    omittedBreakdown.pendingTranscriptions +
+    omittedBreakdown.nonText +
+    omittedBreakdown.overLimit;
+  const initialPrompt = orderedTurns.find((turn) => turn.role === 'user')?.text;
+  if (initialPrompt === undefined || initialPrompt.trim().length === 0) {
+    return err({
+      code: 'EMPTY_TRANSCRIPT',
+      message: 'Conversation Assistant session has no initial user prompt',
+    });
+  }
+
+  const exportResult = await deps.pdfExporter.exportConversation({
+    title: session.title,
+    modelName: session.model,
+    initialPrompt,
+    generatedAt: deps.clock.now(),
+    sourceRange: session.range,
+    messageCounts: {
+      included: session.transcriptMessageCount,
+      excluded,
+    },
+    omittedBreakdown: { ...omittedBreakdown },
+    messages: orderedTurns.map((turn) => ({
+      role: turn.role,
+      createdAt: turn.createdAt,
+      text: turn.text,
+    })),
+  });
+
+  if (!exportResult.ok) {
+    return err({ code: 'INTERNAL_ERROR', message: exportResult.error.message });
+  }
+
+  return ok({
+    ...exportResult.value,
+    fileName: appendSessionIdToPdfFileName(exportResult.value.fileName, session.id),
+  });
 }
 
 async function appendQuestionAndAssistantTurn(
@@ -484,4 +558,14 @@ function isOwnedSession(
   userId: string
 ): session is ConversationAssistantSession {
   return session !== null && session.userId === userId;
+}
+
+function appendSessionIdToPdfFileName(fileName: string, sessionId: string): string {
+  const baseName = fileName.endsWith('.pdf') ? fileName.slice(0, -4) : fileName;
+  const normalizedBaseName = baseName.trim().length > 0 ? baseName.trim() : 'conversation-assistant-export';
+  return `${normalizedBaseName}-${sessionId}.pdf`;
+}
+
+function turnRoleSortValue(role: ConversationAssistantTurn['role']): number {
+  return role === 'user' ? 0 : 1;
 }

--- a/apps/whatsapp-service/src/domain/conversation-assistant/types.ts
+++ b/apps/whatsapp-service/src/domain/conversation-assistant/types.ts
@@ -69,10 +69,21 @@ export interface SendConversationAssistantTurnInput {
   question: string;
 }
 
+export interface ExportConversationAssistantPdfInput {
+  userId: string;
+  sessionId: string;
+}
+
 export interface CreateConversationAssistantSessionResult {
   session: ConversationAssistantSession;
   turns: ConversationAssistantTurn[];
   context: PrivateConversationContextResponse;
+}
+
+export interface ExportConversationAssistantPdfResult {
+  bytes: Buffer;
+  fileName: string;
+  contentType: 'application/pdf';
 }
 
 export interface ConversationAssistantError {

--- a/apps/whatsapp-service/src/infra/firestore/conversationAssistantRepository.ts
+++ b/apps/whatsapp-service/src/infra/firestore/conversationAssistantRepository.ts
@@ -43,6 +43,43 @@ export function createConversationAssistantRepository(): ConversationAssistantRe
       }
     },
 
+    async getSessionSnapshotById(
+      input: { sessionId: string; userId: string }
+    ): Promise<{ session: ConversationAssistantSession; turns: ConversationAssistantTurn[] } | null> {
+      try {
+        const db = getFirestore();
+        const sessionRef = db
+          .collection(WHATSAPP_CONVERSATION_ASSISTANT_SESSIONS_COLLECTION)
+          .doc(input.sessionId);
+        return await db.runTransaction(async (transaction) => {
+          const sessionDoc = await transaction.get(sessionRef);
+          if (!sessionDoc.exists) {
+            return null;
+          }
+          const session = toSession(sessionDoc.id, sessionDoc.data());
+          if (session.userId !== input.userId) {
+            return null;
+          }
+          const turnsSnapshot = await transaction.get(
+            db
+              .collection(WHATSAPP_CONVERSATION_ASSISTANT_TURNS_COLLECTION)
+              .where('sessionId', '==', input.sessionId)
+              .where('userId', '==', input.userId)
+              .orderBy('createdAt', 'asc')
+              .orderBy(FieldPath.documentId(), 'asc')
+          );
+          return {
+            session,
+            turns: turnsSnapshot.docs.map((doc) => toTurn(doc.id, doc.data())),
+          };
+        });
+      } catch (error) {
+        throw new Error(
+          `Failed to load Conversation Assistant session snapshot: ${getErrorMessage(error)}`
+        );
+      }
+    },
+
     async listSessionsByUserId(userId: string): Promise<ConversationAssistantSession[]> {
       try {
         const snapshot = await getFirestore()

--- a/apps/whatsapp-service/src/routes/conversationAssistantRoutes.ts
+++ b/apps/whatsapp-service/src/routes/conversationAssistantRoutes.ts
@@ -7,6 +7,7 @@ import {
   conversationAssistantRandomIds,
   conversationAssistantSystemClock,
   createConversationAssistantSession,
+  exportConversationAssistantSessionPdf,
   getConversationAssistantSession,
   listConversationAssistantSessions,
   listConversationAssistantTurns,
@@ -215,6 +216,46 @@ export const conversationAssistantRoutes: FastifyPluginCallback = (fastify, _opt
   );
 
   fastify.get<{ Params: SessionParams }>(
+    '/conversation-assistant/sessions/:sessionId/export.pdf',
+    {
+      schema: {
+        operationId: 'exportWhatsAppConversationAssistantSessionPdf',
+        tags: ['whatsapp'],
+        response: pdfExportResponseSchema(),
+      },
+    },
+    async (request, reply) => {
+      logIncomingRequest(request, {
+        message:
+          'Received request to GET /whatsapp/conversation-assistant/sessions/:sessionId/export.pdf',
+        bodyPreviewLength: 0,
+        additionalFields: { route: 'whatsapp_conversation_assistant_export_pdf' },
+      });
+      const user = await requireAuth(request, reply);
+      if (user === null) return;
+      const deps = await getConversationAssistantExportDeps(reply);
+      if (deps === null) return;
+
+      const result = await safeCall(() =>
+        exportConversationAssistantSessionPdf(
+          { userId: user.userId, sessionId: request.params.sessionId },
+          deps
+        )
+      );
+      if (!result.ok) {
+        return await sendConversationAssistantError(reply, result.error);
+      }
+
+      reply
+        .header('Content-Type', result.value.contentType)
+        .header('Content-Disposition', `attachment; filename="${result.value.fileName}"`)
+        .header('Cache-Control', 'no-store');
+      // @allow-raw-send: Conversation Assistant PDF export returns binary PDF bytes
+      return await reply.send(result.value.bytes);
+    }
+  );
+
+  fastify.get<{ Params: SessionParams }>(
     '/conversation-assistant/sessions/:sessionId/turns',
     {
       schema: {
@@ -371,7 +412,7 @@ async function getConversationAssistantDeps(
     await reply.fail('INTERNAL_ERROR', 'Conversation Assistant services are not configured');
     return null;
   }
-  return {
+  const deps: ConversationAssistantDeps = {
     repository: services.conversationAssistantRepository,
     privateWhatsAppRepository: services.privateWhatsAppRepository,
     llmClientFactory: services.llmClientFactory,
@@ -379,6 +420,24 @@ async function getConversationAssistantDeps(
     clock: conversationAssistantSystemClock,
     ids: conversationAssistantRandomIds,
   };
+  if (services.pdfConversationExporter !== undefined) {
+    deps.pdfExporter = services.pdfConversationExporter;
+  }
+  return deps;
+}
+
+async function getConversationAssistantExportDeps(
+  reply: FastifyReply
+): Promise<ConversationAssistantDeps | null> {
+  const deps = await getConversationAssistantDeps(reply);
+  if (deps === null) {
+    return null;
+  }
+  if (deps.pdfExporter === undefined) {
+    await reply.fail('INTERNAL_ERROR', 'Conversation Assistant services are not configured');
+    return null;
+  }
+  return deps;
 }
 
 function toPublicSession(
@@ -444,6 +503,23 @@ function streamResponseSchema(): Record<number, Record<string, unknown>> {
     },
     400: errorResponse('Invalid request'),
     401: errorResponse('Unauthorized'),
+    500: errorResponse('Internal error'),
+  };
+}
+
+function pdfExportResponseSchema(): Record<number, Record<string, unknown>> {
+  return {
+    200: {
+      description: 'Conversation Assistant PDF export',
+      type: 'string',
+      content: {
+        'application/pdf': {
+          schema: { type: 'string', format: 'binary' },
+        },
+      },
+    },
+    401: errorResponse('Unauthorized'),
+    404: errorResponse('Not found'),
     500: errorResponse('Internal error'),
   };
 }

--- a/apps/whatsapp-service/src/services.ts
+++ b/apps/whatsapp-service/src/services.ts
@@ -18,6 +18,7 @@ import { createWebAgentLinkPreviewClient } from './infra/linkpreview/webAgentLin
 import { createLlmClient } from '@intexuraos/llm-factory';
 import { createUserServiceClient } from '@intexuraos/internal-clients';
 import { HttpInternalAuthUsageSink } from '@intexuraos/llm-pricing';
+import { createPdfConversationExporter } from '@intexuraos/infra-pdf-export';
 import { err, ok } from '@intexuraos/common-core';
 import type {
   EventPublisherPort,
@@ -36,6 +37,7 @@ import type {
 } from './domain/whatsapp/index.js';
 import type {
   ConversationAssistantLlmClientFactory,
+  ConversationAssistantPdfExporter,
   ConversationAssistantRepository,
 } from './domain/conversation-assistant/ports.js';
 import { createOutboundMessageRepository } from './infra/firestore/outboundMessageRepository.js';
@@ -95,6 +97,7 @@ export interface ServiceContainer {
   linkPreviewFetcher: LinkPreviewFetcherPort;
   conversationAssistantRepository?: ConversationAssistantRepository;
   llmClientFactory?: ConversationAssistantLlmClientFactory;
+  pdfConversationExporter?: ConversationAssistantPdfExporter;
   conversationAssistantModel?: string;
 }
 
@@ -145,6 +148,7 @@ export function getServices(): ServiceContainer {
     }),
     conversationAssistantRepository: createConversationAssistantRepository(),
     llmClientFactory: createConversationAssistantLlmClientFactory(serviceConfig),
+    pdfConversationExporter: createConversationAssistantPdfExporter(),
     conversationAssistantModel: serviceConfig.conversationAssistantModel,
   };
   return container;
@@ -189,6 +193,21 @@ export function createConversationAssistantLlmClientFactory(
         usageSink,
         ownerType: 'user',
       }));
+    },
+  };
+}
+
+export function createConversationAssistantPdfExporter(): ConversationAssistantPdfExporter {
+  const exporter = createPdfConversationExporter();
+  return {
+    async exportConversation(
+      input
+    ): ReturnType<ConversationAssistantPdfExporter['exportConversation']> {
+      const result = await exporter.exportConversation(input);
+      if (!result.ok) {
+        return err({ message: result.error.message });
+      }
+      return ok(result.value);
     },
   };
 }

--- a/docs/packages/infra-pdf-export/README.md
+++ b/docs/packages/infra-pdf-export/README.md
@@ -1,56 +1,138 @@
 # @intexuraos/infra-pdf-export
 
-Reusable server-side PDF export for conversation transcripts.
+`@intexuraos/infra-pdf-export` renders already-authorized, already-redacted conversation snapshots into PDF files.
 
-## Purpose
+Consumers provide the title, model name, initial prompt, source range, message counts, optional omitted-message breakdown, and chronological user/assistant messages. The package returns PDF bytes, an `application/pdf` content type, and a sanitized full filename including the `.pdf` extension.
 
-This package owns PDF rendering only. It accepts already-selected transcript data and returns a binary PDF plus a deterministic base filename.
-The filename is an ASCII slug derived from the title, falling back to `conversation-export.pdf` when the title has no ASCII slug characters.
 It embeds Noto Sans TTF fonts from `@expo-google-fonts/noto-sans` so multilingual conversation text is not rendered with PDF standard font glyph limits.
 
-## Public Surface
+## Exported API
 
 ```ts
-import type { Result } from '@intexuraos/common-core';
+import { createPdfConversationExporter } from '@intexuraos/infra-pdf-export';
+import type {
+  PdfConversationExporter,
+  PdfConversationExportInput,
+  PdfConversationExportResult,
+  PdfExportError,
+} from '@intexuraos/infra-pdf-export';
+```
 
-export type PdfConversationMessageRole = 'user' | 'assistant';
+`createPdfConversationExporter()` returns a `PdfConversationExporter`:
 
-export interface PdfConversationExportInput {
-  title: string;
-  generatedAt: string;
-  sourceRange: { from: string; to: string };
-  messageCounts: { included: number; excluded: number };
-  omittedBreakdown?: Record<string, number>;
-  messages: Array<{
-    role: PdfConversationMessageRole;
-    createdAt: string;
-    text: string;
-  }>;
-}
-
-export interface PdfConversationExportResult {
-  bytes: Buffer;
-  fileName: string;
-  contentType: 'application/pdf';
-}
-
-export interface PdfExportError {
-  code: 'INVALID_INPUT' | 'RENDER_FAILED';
-  message: string;
-}
-
-export interface PdfConversationExporter {
+```ts
+interface PdfConversationExporter {
   exportConversation(
     input: PdfConversationExportInput
   ): Promise<Result<PdfConversationExportResult, PdfExportError>>;
 }
-
-export function createPdfConversationExporter(): PdfConversationExporter;
 ```
+
+## Input Contract
+
+`PdfConversationExportInput` is the full persisted conversation snapshot to render. Callers must perform authorization and redaction before passing data to the exporter.
+
+```ts
+interface PdfConversationExportInput {
+  title: string;
+  modelName: string;
+  initialPrompt: string;
+  generatedAt: string;
+  sourceRange: { from: string; to: string };
+  messageCounts: { included: number; excluded: number };
+  omittedBreakdown?: Record<string, number>;
+  messages: {
+    role: 'user' | 'assistant';
+    createdAt: string;
+    text: string;
+  }[];
+}
+```
+
+- `title`, `modelName`, `initialPrompt`, `generatedAt`, `sourceRange.from`, and `sourceRange.to` must be non-empty after trimming.
+- `messageCounts.included` and `messageCounts.excluded` must be zero or positive.
+- Each message must have non-empty `text`; empty transcripts should be filtered or represented by the caller before export.
+- `messages` must be in the display order the PDF should use.
+- `omittedBreakdown` accepts any consumer-owned omitted-message keys and renders them as readable labels.
+- Common Markdown markers in titles, prompts, and messages are rendered as readable plain text in the PDF, including headings, emphasis, links, images, list markers, task-list markers, fenced-code markers, blockquotes, and table separators.
+
+## Output Contract
+
+On success, `exportConversation()` returns:
+
+```ts
+interface PdfConversationExportResult {
+  bytes: Buffer;
+  fileName: string;
+  contentType: 'application/pdf';
+}
+```
+
+`bytes` contains the rendered PDF. `fileName` is a sanitized lowercase filename derived from `title`, includes the `.pdf` extension, is capped to the exporter filename limit, and falls back to `conversation-export.pdf` when the sanitized title is empty.
+
+## Errors
+
+Failures are returned as `Result` errors instead of thrown exceptions:
+
+```ts
+interface PdfExportError {
+  code: 'INVALID_INPUT' | 'RENDER_FAILED';
+  message: string;
+}
+```
+
+- `INVALID_INPUT` means the input contract was not satisfied.
+- `RENDER_FAILED` means PDF rendering failed after validation.
 
 ## Ownership Boundary
 
 - The consumer owns authentication and authorization.
 - The consumer owns transcript selection and omitted-message accounting.
-- The consumer owns redaction and any privacy filtering.
+- The consumer owns redaction and privacy filtering.
 - This package only renders the provided conversation payload into a PDF.
+
+## Usage
+
+```ts
+const exporter = createPdfConversationExporter();
+const result = await exporter.exportConversation({
+  title: 'Conversation with Alice',
+  modelName: 'openrouter/minimax-m2.7',
+  initialPrompt: 'Please summarize the appointment thread.',
+  generatedAt: new Date().toISOString(),
+  sourceRange: {
+    from: '2026-07-01T00:00:00.000Z',
+    to: '2026-07-03T23:59:59.999Z',
+  },
+  messageCounts: { included: 12, excluded: 3 },
+  omittedBreakdown: {
+    mediaOnly: 1,
+    failedTranscriptions: 0,
+    pendingTranscriptions: 0,
+    nonText: 2,
+    overLimit: 0,
+  },
+  messages: [
+    {
+      role: 'user',
+      createdAt: '2026-07-03T16:01:00.000Z',
+      text: 'Please summarize the appointment thread.',
+    },
+    {
+      role: 'assistant',
+      createdAt: '2026-07-03T16:02:00.000Z',
+      text: 'The appointment is confirmed for Friday afternoon.',
+    },
+  ],
+});
+
+if (!result.ok) {
+  return result;
+}
+
+return {
+  bytes: result.value.bytes,
+  contentType: result.value.contentType,
+  fileName: result.value.fileName,
+};
+```

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -2078,6 +2078,28 @@
           "order": "ASCENDING"
         }
       ]
+    },
+    {
+      "collectionGroup": "whatsapp_conversation_assistant_turns",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "sessionId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "userId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "__name__",
+          "order": "ASCENDING"
+        }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/migrations/119_private-whatsapp-reaction-target-index.mjs
+++ b/migrations/119_private-whatsapp-reaction-target-index.mjs
@@ -1,13 +1,14 @@
 /**
- * Migration 119: Private WhatsApp reaction target index.
+ * Migration 119: Pending WhatsApp indexes.
  *
  * Required by whatsapp-service private message reads to load reactions by target message id.
+ * Also supports owner-filtered Conversation Assistant turn snapshots.
  */
 
 export const metadata = {
   id: '119',
   name: 'private-whatsapp-reaction-target-index',
-  description: 'Private WhatsApp reaction lookup by target message id',
+  description: 'Private WhatsApp reaction lookup and Conversation Assistant turn snapshots',
   createdAt: '2026-07-03',
 };
 
@@ -58,9 +59,19 @@ export const indexes = [
       { fieldPath: '__name__', order: 'ASCENDING' },
     ],
   },
+  {
+    collectionGroup: 'whatsapp_conversation_assistant_turns',
+    queryScope: 'COLLECTION',
+    fields: [
+      { fieldPath: 'sessionId', order: 'ASCENDING' },
+      { fieldPath: 'userId', order: 'ASCENDING' },
+      { fieldPath: 'createdAt', order: 'ASCENDING' },
+      { fieldPath: '__name__', order: 'ASCENDING' },
+    ],
+  },
 ];
 
 export async function up(context) {
-  console.log('  Deploying private WhatsApp reaction target indexes...');
+  console.log('  Deploying pending WhatsApp indexes...');
   await context.deployIndexes();
 }

--- a/migrations/__tests__/119-private-whatsapp-reaction-target-index.test.ts
+++ b/migrations/__tests__/119-private-whatsapp-reaction-target-index.test.ts
@@ -7,12 +7,12 @@ describe('migration 119 - private WhatsApp reaction target index', () => {
     expect(metadata).toMatchObject({
       id: '119',
       name: 'private-whatsapp-reaction-target-index',
-      description: 'Private WhatsApp reaction lookup by target message id',
+      description: 'Private WhatsApp reaction lookup and Conversation Assistant turn snapshots',
       createdAt: '2026-07-03',
     });
   });
 
-  it('defines normalized private WhatsApp reaction lookup indexes', () => {
+  it('defines normalized private WhatsApp reaction lookup and assistant turn indexes', () => {
     expect(indexes).toEqual([
       {
         collectionGroup: 'whatsapp_private_messages',
@@ -57,6 +57,16 @@ describe('migration 119 - private WhatsApp reaction target index', () => {
           { fieldPath: 'messageType', order: 'ASCENDING' },
           { fieldPath: 'rawMatrixEvent.content.`m.relates_to`.event_id', order: 'ASCENDING' },
           { fieldPath: 'eventTimestamp', order: 'ASCENDING' },
+          { fieldPath: '__name__', order: 'ASCENDING' },
+        ],
+      },
+      {
+        collectionGroup: 'whatsapp_conversation_assistant_turns',
+        queryScope: 'COLLECTION',
+        fields: [
+          { fieldPath: 'sessionId', order: 'ASCENDING' },
+          { fieldPath: 'userId', order: 'ASCENDING' },
+          { fieldPath: 'createdAt', order: 'ASCENDING' },
           { fieldPath: '__name__', order: 'ASCENDING' },
         ],
       },

--- a/packages/infra-pdf-export/README.md
+++ b/packages/infra-pdf-export/README.md
@@ -6,7 +6,7 @@ Server-side PDF export helpers for conversation-style transcripts.
 
 - **Layer:** infra-wrapper
 - **Dependencies:** `@intexuraos/common-core`, `@expo-google-fonts/noto-sans`, `pdfkit`
-- **Exports:** `./src/index.ts` (source-exports; no `dist/` package output)
+- **Exports:** `./src/index.ts` (source exports; no `dist/` package output)
 
 ## Usage
 
@@ -18,4 +18,4 @@ For full API documentation, see [`docs/packages/infra-pdf-export/README.md`](../
 
 ## Authorization And Redaction
 
-This package renders the text it is given. Authorization, transcript selection, and redaction remain the responsibility of the consumer before calling the exporter.
+This package renders the text it is given. Authorization, transcript selection, omitted-message accounting, and redaction remain the responsibility of the consumer before calling the exporter.

--- a/packages/infra-pdf-export/src/__tests__/conversationPdfExporter.test.ts
+++ b/packages/infra-pdf-export/src/__tests__/conversationPdfExporter.test.ts
@@ -1,5 +1,33 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createPdfConversationExporter } from '../conversationPdfExporter.js';
+import type { PdfConversationExportInput } from '../types.js';
+
+const validInput: PdfConversationExportInput = {
+  title: 'Alice context',
+  modelName: 'openrouter/minimax-m2.7',
+  initialPrompt: 'What happened?',
+  generatedAt: '2026-07-03T16:00:00.000Z',
+  sourceRange: {
+    from: '2026-06-30T00:00:00.000Z',
+    to: '2026-07-01T00:00:00.000Z',
+  },
+  messageCounts: { included: 47, excluded: 23 },
+  omittedBreakdown: {
+    mediaOnly: 2,
+    failedTranscriptions: 1,
+    pendingTranscriptions: 0,
+    nonText: 3,
+    overLimit: 0,
+  },
+  messages: [
+    { role: 'user', createdAt: '2026-07-03T16:01:00.000Z', text: 'User line '.repeat(120) },
+    {
+      role: 'assistant',
+      createdAt: '2026-07-03T16:02:00.000Z',
+      text: 'Assistant answer with\nmultiple lines.',
+    },
+  ],
+};
 
 afterEach(() => {
   vi.resetModules();
@@ -9,32 +37,8 @@ afterEach(() => {
 describe('createPdfConversationExporter', () => {
   it('renders an A4 PDF conversation snapshot without truncating messages', async () => {
     const exporter = createPdfConversationExporter();
-    const longUserText = 'User line '.repeat(120);
 
-    const result = await exporter.exportConversation({
-      title: 'Alice context',
-      generatedAt: '2026-07-03T16:00:00.000Z',
-      sourceRange: {
-        from: '2026-06-30T00:00:00.000Z',
-        to: '2026-07-01T00:00:00.000Z',
-      },
-      messageCounts: { included: 47, excluded: 23 },
-      omittedBreakdown: {
-        mediaOnly: 2,
-        failedTranscriptions: 1,
-        pendingTranscriptions: 0,
-        nonText: 3,
-        overLimit: 0,
-      },
-      messages: [
-        { role: 'user', createdAt: '2026-07-03T16:01:00.000Z', text: longUserText },
-        {
-          role: 'assistant',
-          createdAt: '2026-07-03T16:02:00.000Z',
-          text: 'Assistant answer with\nmultiple lines.',
-        },
-      ],
-    });
+    const result = await exporter.exportConversation(validInput);
 
     expect(result.ok).toBe(true);
     if (!result.ok) {
@@ -57,60 +61,35 @@ describe('createPdfConversationExporter', () => {
     expect(readablePdfText).toContain('Media Only');
     expect(readablePdfText).toContain('Failed Transcriptions');
     expect(normalizedPdfText).toContain(normalizePdfText('Assistant answer with\nmultiple lines.'));
-    expect(normalizedPdfText).toContain(normalizePdfText(longUserText));
+    expect(normalizedPdfText).toContain(normalizePdfText(validInput.messages[0]?.text ?? ''));
   });
 
-  it('rejects empty titles and empty message text', async () => {
+  it('rejects invalid input before rendering', async () => {
     const exporter = createPdfConversationExporter();
+    const firstMessage = validInput.messages[0] ?? {
+      role: 'user' as const,
+      createdAt: '2026-07-03T16:01:00.000Z',
+      text: 'fallback',
+    };
 
-    const emptyTitleResult = await exporter.exportConversation({
-      title: ' ',
-      generatedAt: '2026-07-03T16:00:00.000Z',
-      sourceRange: {
-        from: '2026-06-30T00:00:00.000Z',
-        to: '2026-07-01T00:00:00.000Z',
-      },
-      messageCounts: { included: 0, excluded: 0 },
-      messages: [{ role: 'user', createdAt: '2026-07-03T16:01:00.000Z', text: '' }],
-    });
+    const invalidInputs: PdfConversationExportInput[] = [
+      { ...validInput, title: '   ' },
+      { ...validInput, modelName: '   ' },
+      { ...validInput, initialPrompt: '   ' },
+      { ...validInput, generatedAt: '   ' },
+      { ...validInput, sourceRange: { from: '', to: validInput.sourceRange.to } },
+      { ...validInput, sourceRange: { from: validInput.sourceRange.from, to: '' } },
+      { ...validInput, messageCounts: { included: -1, excluded: 0 } },
+      { ...validInput, messageCounts: { included: 0, excluded: -1 } },
+      { ...validInput, messages: [{ ...firstMessage, text: '' }] },
+    ];
 
-    expect(emptyTitleResult.ok).toBe(false);
-    if (!emptyTitleResult.ok) {
-      expect(emptyTitleResult.error.code).toBe('INVALID_INPUT');
-      expect(emptyTitleResult.error.message).toContain('title cannot be empty');
-    }
-
-    const emptyMessageResult = await exporter.exportConversation({
-      title: 'Alice context',
-      generatedAt: '2026-07-03T16:00:00.000Z',
-      sourceRange: {
-        from: '2026-06-30T00:00:00.000Z',
-        to: '2026-07-01T00:00:00.000Z',
-      },
-      messageCounts: { included: 1, excluded: 0 },
-      messages: [{ role: 'user', createdAt: '2026-07-03T16:01:00.000Z', text: '' }],
-    });
-
-    expect(emptyMessageResult.ok).toBe(false);
-    if (!emptyMessageResult.ok) {
-      expect(emptyMessageResult.error.code).toBe('INVALID_INPUT');
-      expect(emptyMessageResult.error.message).toContain('empty text');
-    }
-
-    const symbolTitleResult = await exporter.exportConversation({
-      title: '!!!',
-      generatedAt: '2026-07-03T16:00:00.000Z',
-      sourceRange: {
-        from: '2026-06-30T00:00:00.000Z',
-        to: '2026-07-01T00:00:00.000Z',
-      },
-      messageCounts: { included: 1, excluded: 0 },
-      messages: [{ role: 'user', createdAt: '2026-07-03T16:01:00.000Z', text: 'hello' }],
-    });
-
-    expect(symbolTitleResult.ok).toBe(true);
-    if (symbolTitleResult.ok) {
-      expect(symbolTitleResult.value.fileName).toBe('conversation-export.pdf');
+    for (const input of invalidInputs) {
+      const result = await exporter.exportConversation(input);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe('INVALID_INPUT');
+      }
     }
   });
 
@@ -118,13 +97,8 @@ describe('createPdfConversationExporter', () => {
     const exporter = createPdfConversationExporter();
 
     const result = await exporter.exportConversation({
+      ...validInput,
       title: 'Что решили?',
-      generatedAt: '2026-07-03T16:00:00.000Z',
-      sourceRange: {
-        from: '2026-06-30T00:00:00.000Z',
-        to: '2026-07-01T00:00:00.000Z',
-      },
-      messageCounts: { included: 1, excluded: 0 },
       messages: [{ role: 'user', createdAt: '2026-07-03T16:01:00.000Z', text: 'hello' }],
     });
 
@@ -137,26 +111,111 @@ describe('createPdfConversationExporter', () => {
     expect(result.value.bytes.toString('latin1')).toContain('NotoSans');
   });
 
+  it('uses the fallback title when markdown cleanup removes the provided title', async () => {
+    const exporter = createPdfConversationExporter();
+
+    const result = await exporter.exportConversation({
+      ...validInput,
+      title: '```',
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+
+    expect(result.value.fileName).toBe('conversation-export.pdf');
+    expect(toReadablePdfText(extractPdfText(result.value.bytes))).toContain('conversation-export');
+  });
+
+  it('renders model attribution, initial prompt, and markdown answers as plain text', async () => {
+    const exporter = createPdfConversationExporter();
+    const input = {
+      ...validInput,
+      title: '# Decision **summary**',
+      modelName: 'openrouter/minimax-m2.7',
+      initialPrompt: '- Please decide what to include.',
+      messages: [
+        {
+          role: 'user' as const,
+          createdAt: '2026-07-03T16:01:00.000Z',
+          text: 'Please decide what to include.',
+        },
+        {
+          role: 'assistant' as const,
+          createdAt: '2026-07-03T16:02:00.000Z',
+          text: [
+            '# Decision',
+            '',
+            '**Include** the timeline and [evidence](https://example.test/evidence).',
+            '',
+            '- First action',
+            '- [ ] Follow up',
+            '| Owner | Task |',
+            '| --- | --- |',
+            '| Alice | Prepare docs |',
+            '![chart](https://example.test/chart.png)',
+            '',
+            '```text',
+            'Keep this raw line',
+            '```',
+          ].join('\n'),
+        },
+      ],
+    } as PdfConversationExportInput;
+
+    const result = await exporter.exportConversation(input);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+
+    const readablePdfText = toReadablePdfText(extractPdfText(result.value.bytes));
+    const normalizedPdfText = normalizePdfText(readablePdfText);
+    expect(readablePdfText).toContain('Decision summary');
+    expect(readablePdfText).toContain('LLM model: openrouter/minimax-m2.7');
+    expect(readablePdfText).toContain('Initial prompt: Please decide what to include.');
+    expect(readablePdfText).toContain('LLM response (openrouter/minimax-m2.7)');
+    expect(readablePdfText).toContain('Decision');
+    expect(readablePdfText).toContain(
+      'Include the timeline and evidence (https://example.test/evidence).'
+    );
+    expect(readablePdfText).toContain('First action');
+    expect(readablePdfText).toContain('Follow up');
+    expect(normalizedPdfText).toContain(normalizePdfText('Owner Task\nAlice Prepare docs'));
+    expect(readablePdfText).toContain('chart (https://example.test/chart.png)');
+    expect(readablePdfText).toContain('Keep this raw line');
+    expect(readablePdfText).not.toContain('# Decision **summary**');
+    expect(readablePdfText).not.toContain('# Decision');
+    expect(readablePdfText).not.toContain('**Include**');
+    expect(readablePdfText).not.toContain('- First action');
+    expect(readablePdfText).not.toContain('- [ ] Follow up');
+    expect(readablePdfText).not.toContain('| --- | --- |');
+    expect(readablePdfText).not.toContain('![chart]');
+    expect(readablePdfText).not.toContain('[evidence]');
+    expect(readablePdfText).not.toContain('```');
+  });
+
   it('renders page breaks without an omitted breakdown', async () => {
     const exporter = createPdfConversationExporter();
     const finalMessageText = 'Final page message survives pagination.';
 
     const result = await exporter.exportConversation({
-      title: 'Paged context',
-      generatedAt: '2026-07-03T16:00:00.000Z',
-      sourceRange: {
-        from: '2026-06-30T00:00:00.000Z',
-        to: '2026-07-01T00:00:00.000Z',
-      },
+      title: validInput.title,
+      modelName: validInput.modelName,
+      initialPrompt: validInput.initialPrompt,
+      generatedAt: validInput.generatedAt,
+      sourceRange: validInput.sourceRange,
       messageCounts: { included: 81, excluded: 0 },
       messages: [
         ...Array.from({ length: 80 }, (_, index) => ({
           role: index % 2 === 0 ? ('user' as const) : ('assistant' as const),
           createdAt: `2026-07-03T16:${String(index).padStart(2, '0')}:00.000Z`,
-          text: `Message ${index} `.repeat(40),
+          text: `Message ${String(index)} `.repeat(40),
         })),
         {
-          role: 'assistant',
+          role: 'assistant' as const,
           createdAt: '2026-07-03T17:30:00.000Z',
           text: finalMessageText,
         },
@@ -178,13 +237,8 @@ describe('createPdfConversationExporter', () => {
     const multilingualText = 'Zażółć gęślą jaźń. Árvíztűrő tükörfúrógép. Кириллица.';
 
     const result = await exporter.exportConversation({
+      ...validInput,
       title: 'Łódź context',
-      generatedAt: '2026-07-03T16:00:00.000Z',
-      sourceRange: {
-        from: '2026-06-30T00:00:00.000Z',
-        to: '2026-07-01T00:00:00.000Z',
-      },
-      messageCounts: { included: 1, excluded: 0 },
       messages: [{ role: 'user', createdAt: '2026-07-03T16:01:00.000Z', text: multilingualText }],
     });
 
@@ -209,26 +263,12 @@ describe('createPdfConversationExporter', () => {
       await import('../conversationPdfExporter.js');
     const exporter = createBrokenExporter();
 
-    const result = await exporter.exportConversation({
-      title: 'Alice context',
-      generatedAt: '2026-07-03T16:00:00.000Z',
-      sourceRange: {
-        from: '2026-06-30T00:00:00.000Z',
-        to: '2026-07-01T00:00:00.000Z',
-      },
-      messageCounts: { included: 1, excluded: 0 },
-      messages: [
-        {
-          role: 'user',
-          createdAt: '2026-07-03T16:01:00.000Z',
-          text: 'hello',
-        },
-      ],
-    });
+    const result = await exporter.exportConversation(validInput);
 
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.error.code).toBe('RENDER_FAILED');
+      expect(result.error.message).toBe('render broke');
     }
   });
 
@@ -244,22 +284,7 @@ describe('createPdfConversationExporter', () => {
       await import('../conversationPdfExporter.js');
     const exporter = createBrokenExporter();
 
-    const result = await exporter.exportConversation({
-      title: 'Alice context',
-      generatedAt: '2026-07-03T16:00:00.000Z',
-      sourceRange: {
-        from: '2026-06-30T00:00:00.000Z',
-        to: '2026-07-01T00:00:00.000Z',
-      },
-      messageCounts: { included: 1, excluded: 0 },
-      messages: [
-        {
-          role: 'user',
-          createdAt: '2026-07-03T16:01:00.000Z',
-          text: 'hello',
-        },
-      ],
-    });
+    const result = await exporter.exportConversation(validInput);
 
     expect(result.ok).toBe(false);
     if (!result.ok) {

--- a/packages/infra-pdf-export/src/conversationPdfExporter.ts
+++ b/packages/infra-pdf-export/src/conversationPdfExporter.ts
@@ -16,6 +16,7 @@ const STANDARD_REGULAR_FONT = 'Helvetica';
 const STANDARD_BOLD_FONT = 'Helvetica-Bold';
 const UNICODE_REGULAR_FONT = 'NotoSansRegular';
 const UNICODE_BOLD_FONT = 'NotoSansBold';
+const FALLBACK_FILE_NAME = 'conversation-export';
 const require = createRequire(import.meta.url);
 const REGULAR_FONT_PATH =
   require.resolve('@expo-google-fonts/noto-sans/400Regular/NotoSans_400Regular.ttf');
@@ -51,6 +52,41 @@ function validateInput(input: PdfConversationExportInput): PdfExportError | null
     return {
       code: 'INVALID_INPUT',
       message: 'Conversation export title cannot be empty',
+    };
+  }
+
+  if (input.modelName.trim().length === 0) {
+    return {
+      code: 'INVALID_INPUT',
+      message: 'Conversation export modelName cannot be empty',
+    };
+  }
+
+  if (input.initialPrompt.trim().length === 0) {
+    return {
+      code: 'INVALID_INPUT',
+      message: 'Conversation export initialPrompt cannot be empty',
+    };
+  }
+
+  if (input.generatedAt.trim().length === 0) {
+    return {
+      code: 'INVALID_INPUT',
+      message: 'Conversation export generatedAt cannot be empty',
+    };
+  }
+
+  if (input.sourceRange.from.trim().length === 0 || input.sourceRange.to.trim().length === 0) {
+    return {
+      code: 'INVALID_INPUT',
+      message: 'Conversation export source range cannot be empty',
+    };
+  }
+
+  if (input.messageCounts.included < 0 || input.messageCounts.excluded < 0) {
+    return {
+      code: 'INVALID_INPUT',
+      message: 'Conversation export message counts cannot be negative',
     };
   }
 
@@ -95,10 +131,11 @@ function registerConversationFonts(doc: PDFKit.PDFDocument): void {
 
 function drawConversation(doc: PDFKit.PDFDocument, input: PdfConversationExportInput): void {
   const contentWidth = getContentWidth(doc);
+  const titleText = toPlainPdfText(input.title) || FALLBACK_FILE_NAME;
 
-  doc.info.Title = input.title;
-  doc.font(fontForText(input.title, 'bold')).fontSize(20).fillColor('#111827');
-  doc.text(input.title, {
+  doc.info.Title = titleText;
+  doc.font(fontForText(titleText, 'bold')).fontSize(20).fillColor('#111827');
+  doc.text(titleText, {
     width: contentWidth,
     align: 'left',
   });
@@ -110,6 +147,10 @@ function drawConversation(doc: PDFKit.PDFDocument, input: PdfConversationExportI
     width: contentWidth,
     align: 'left',
   });
+
+  doc.moveDown(0.35);
+  drawMetadataLine(doc, contentWidth, 'LLM model', input.modelName);
+  drawMetadataLine(doc, contentWidth, 'Initial prompt', toPlainPdfText(input.initialPrompt));
 
   doc.moveDown(0.9);
   drawDivider(doc, contentWidth);
@@ -141,7 +182,7 @@ function drawConversation(doc: PDFKit.PDFDocument, input: PdfConversationExportI
   doc.moveDown(0.9);
 
   for (const message of input.messages) {
-    drawMessage(doc, contentWidth, message.role, message.createdAt, message.text);
+    drawMessage(doc, contentWidth, message.role, message.createdAt, message.text, input.modelName);
   }
 }
 
@@ -182,16 +223,18 @@ function drawMessage(
   contentWidth: number,
   role: 'user' | 'assistant',
   createdAt: string,
-  text: string
+  text: string,
+  modelName: string
 ): void {
-  const roleLabel = role === 'user' ? 'User' : 'Assistant';
+  const roleLabel = getMessageRoleLabel(role, modelName);
   const headerText = `${roleLabel}  ${createdAt}`;
+  const plainText = toPlainPdfText(text);
   const headerFont = fontForText(headerText, 'bold');
-  const textFont = fontForText(text, 'regular');
+  const textFont = fontForText(plainText, 'regular');
   doc.font(headerFont).fontSize(11);
   const headerHeight = doc.heightOfString(headerText, { width: contentWidth });
   doc.font(textFont).fontSize(10.5);
-  const textHeight = doc.heightOfString(text, { width: contentWidth });
+  const textHeight = doc.heightOfString(plainText, { width: contentWidth });
   const minimumHeight = headerHeight + textHeight + SECTION_GAP;
   ensureSpace(doc, minimumHeight);
 
@@ -206,12 +249,63 @@ function drawMessage(
 
   doc.moveDown(0.2);
   doc.font(textFont).fontSize(10.5).fillColor('#111827');
-  doc.text(text, {
+  doc.text(plainText, {
     width: contentWidth,
     lineGap: 2,
   });
 
   doc.moveDown(0.8);
+}
+
+function getMessageRoleLabel(role: 'user' | 'assistant', modelName: string): string {
+  return role === 'assistant' ? `LLM response (${modelName})` : 'User';
+}
+
+function toPlainPdfText(text: string): string {
+  const inlineCleaned = text
+    .replace(/\r\n/g, '\n')
+    .replace(/^```[A-Za-z0-9_-]*\s*$/gm, '')
+    .replace(/!\[([^\]]*)\]\(([^)]+)\)/g, '$1 ($2)')
+    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '$1 ($2)')
+    .replace(/`([^`]+)`/g, '$1')
+    .replace(/\*\*([^*]+)\*\*/g, '$1')
+    .replace(/__([^_]+)__/g, '$1')
+    .replace(/\*([^*\n]+)\*/g, '$1')
+    .replace(/_([^_\n]+)_/g, '$1')
+    .replace(/~~([^~]+)~~/g, '$1');
+
+  return inlineCleaned
+    .split('\n')
+    .map(cleanMarkdownLine)
+    .filter((line) => line !== null)
+    .join('\n')
+    .replace(/[ \t]+\n/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+function cleanMarkdownLine(line: string): string | null {
+  const trimmed = line.trim();
+  if (/^\|?\s*:?-{3,}:?\s*(\|\s*:?-{3,}:?\s*)+\|?$/.test(trimmed)) {
+    return null;
+  }
+
+  if (/^\|?.+\|.+\|?$/.test(trimmed)) {
+    return trimmed
+      .replace(/^\|/, '')
+      .replace(/\|$/, '')
+      .split('|')
+      .map((cell) => cell.trim())
+      .filter((cell) => cell.length > 0)
+      .join(' ');
+  }
+
+  return line
+    .replace(/^#{1,6}\s+/, '')
+    .replace(/^>\s?/, '')
+    .replace(/^\s{0,3}[-*+]\s+\[[ xX]\]\s+/, '')
+    .replace(/^\s{0,3}[-*+]\s+/, '')
+    .replace(/^\s{0,3}\d+[.)]\s+/, '');
 }
 
 function drawDivider(doc: PDFKit.PDFDocument, contentWidth: number): void {
@@ -255,8 +349,8 @@ function fontForText(text: string, weight: 'regular' | 'bold'): string {
 }
 
 function createBaseFileName(title: string): string {
-  const sanitizedTitle = sanitizeTitle(title);
-  return sanitizedTitle.length > 0 ? sanitizedTitle : 'conversation-export';
+  const sanitizedTitle = sanitizeTitle(toPlainPdfText(title));
+  return sanitizedTitle.length > 0 ? sanitizedTitle : FALLBACK_FILE_NAME;
 }
 
 function sanitizeTitle(title: string): string {
@@ -264,7 +358,9 @@ function sanitizeTitle(title: string): string {
     .trim()
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 80)
+    .replace(/-+$/g, '');
 }
 
 function formatBreakdownLabel(key: string): string {

--- a/packages/infra-pdf-export/src/index.ts
+++ b/packages/infra-pdf-export/src/index.ts
@@ -2,7 +2,7 @@ export type {
   PdfConversationMessageRole,
   PdfConversationExportInput,
   PdfConversationExportResult,
-  PdfExportError,
   PdfConversationExporter,
+  PdfExportError,
 } from './types.js';
 export { createPdfConversationExporter } from './conversationPdfExporter.js';

--- a/packages/infra-pdf-export/src/types.ts
+++ b/packages/infra-pdf-export/src/types.ts
@@ -4,6 +4,8 @@ export type PdfConversationMessageRole = 'user' | 'assistant';
 
 export interface PdfConversationExportInput {
   title: string;
+  modelName: string;
+  initialPrompt: string;
   generatedAt: string;
   sourceRange: { from: string; to: string };
   messageCounts: { included: number; excluded: number };
@@ -17,6 +19,7 @@ export interface PdfConversationExportInput {
 
 export interface PdfConversationExportResult {
   bytes: Buffer;
+  /** Sanitized full filename including the `.pdf` extension. */
   fileName: string;
   contentType: 'application/pdf';
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1313,6 +1313,9 @@ importers:
       '@intexuraos/infra-firestore':
         specifier: workspace:*
         version: link:../../packages/infra-firestore
+      '@intexuraos/infra-pdf-export':
+        specifier: workspace:*
+        version: link:../../packages/infra-pdf-export
       '@intexuraos/infra-pubsub':
         specifier: workspace:*
         version: link:../../packages/infra-pubsub
@@ -5146,6 +5149,20 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
+  '@noble/ciphers@1.3.0':
+    resolution:
+      {
+        integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==,
+      }
+    engines: { node: ^14.21.3 || >=16 }
+
+  '@noble/hashes@1.8.0':
+    resolution:
+      {
+        integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==,
+      }
+    engines: { node: ^14.21.3 || >=16 }
+
   '@notionhq/client@2.3.0':
     resolution:
       {
@@ -6719,6 +6736,12 @@ packages:
         integrity: sha512-lR8q/9W7hZpMWweNiAKU7NQerBnzQQLvi8qnTDU/fxItPhtZVMbPV3lbCwjhIlNBe9Bbr5V+KHshvWmVSG9cxQ==,
       }
 
+  '@swc/helpers@0.5.23':
+    resolution:
+      {
+        integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==,
+      }
+
   '@tailwindcss/node@4.1.18':
     resolution:
       {
@@ -7138,6 +7161,12 @@ packages:
     resolution:
       {
         integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==,
+      }
+
+  '@types/pdfkit@0.17.6':
+    resolution:
+      {
+        integrity: sha512-tIwzxk2uWKp0Cq9JIluQXJid77lYhF52EsIOwhsMF4iWLA6YneoBR1xVKYYdAysHuepUB0OX4tdwMiUDdGKmig==,
       }
 
   '@types/pg-pool@2.0.6':
@@ -7957,6 +7986,13 @@ packages:
       bare-abort-controller:
         optional: true
 
+  base64-js@0.0.8:
+    resolution:
+      {
+        integrity: sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==,
+      }
+    engines: { node: '>= 0.4' }
+
   base64-js@1.5.1:
     resolution:
       {
@@ -8093,10 +8129,22 @@ packages:
       }
     engines: { node: '>=8' }
 
+  brotli@1.3.3:
+    resolution:
+      {
+        integrity: sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==,
+      }
+
   browser-tabs-lock@1.3.0:
     resolution:
       {
         integrity: sha512-g6nHaobTiT0eMZ7jh16YpD2kcjAp+PInbiVq3M1x6KKaEIVhT4v9oURNIpZLOZ3LQbQ3XYfNhMAb/9hzNLIWrw==,
+      }
+
+  browserify-zlib@0.2.0:
+    resolution:
+      {
+        integrity: sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==,
       }
 
   browserslist@4.28.1:
@@ -8423,6 +8471,13 @@ packages:
     resolution:
       {
         integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==,
+      }
+    engines: { node: '>=0.8' }
+
+  clone@2.1.2:
+    resolution:
+      {
+        integrity: sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==,
       }
     engines: { node: '>=0.8' }
 
@@ -9001,6 +9056,12 @@ packages:
     resolution:
       {
         integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==,
+      }
+
+  dfa@1.2.0:
+    resolution:
+      {
+        integrity: sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==,
       }
 
   diff@4.0.2:
@@ -9911,6 +9972,12 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
+
+  fontkit@2.0.4:
+    resolution:
+      {
+        integrity: sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==,
+      }
 
   for-each@0.3.5:
     resolution:
@@ -11386,6 +11453,12 @@ packages:
         integrity: sha512-+E5ZH/HeRnoc/LW0AmAyhU+mNcWBzAKE+30+IDMLSLbbK+Tdt02AdkOKq9u15rlJsDEGFqtgckc8ZM59LhhiUA==,
       }
 
+  js-md5@0.8.3:
+    resolution:
+      {
+        integrity: sha512-qR0HB5uP6wCuRMrWPTrkMaev7MJZwJuuw4fnwAzRgP4J4/F8RwtodOKpGp4XpqsLBFzzgqIO42efFAyz2Et6KQ==,
+      }
+
   js-tokens@4.0.0:
     resolution:
       {
@@ -11745,6 +11818,12 @@ packages:
     resolution:
       {
         integrity: sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA==,
+      }
+
+  linebreak@1.1.0:
+    resolution:
+      {
+        integrity: sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==,
       }
 
   lines-and-columns@1.2.4:
@@ -13064,6 +13143,12 @@ packages:
         integrity: sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==,
       }
 
+  pako@1.0.11:
+    resolution:
+      {
+        integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==,
+      }
+
   parent-module@1.0.1:
     resolution:
       {
@@ -13203,6 +13288,12 @@ packages:
         integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==,
       }
     engines: { node: '>= 14.16' }
+
+  pdfkit@0.19.1:
+    resolution:
+      {
+        integrity: sha512-6Gzk+wDwTs4VSxsR5rCMTnIl5nlmkye1oWB0l2hDB1EX6ZNSIBroKQEv+2+fPPn+stVjyqzmsqRJVDfB9fo5DA==,
+      }
 
   pg-cloudflare@1.2.7:
     resolution:
@@ -13395,6 +13486,12 @@ packages:
       }
     engines: { node: '>=16.0.0' }
     hasBin: true
+
+  png-js@1.1.0:
+    resolution:
+      {
+        integrity: sha512-PM/uYGzGdNSzqeOgly68+6wKQDL1SY0a/N+OEa/+br6LnHWOAJB0Npiamnodfq3jd2LS/i2fMeOKSAILjA+m5Q==,
+      }
 
   point-in-polygon@1.1.0:
     resolution:
@@ -14139,6 +14236,12 @@ packages:
         integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==,
       }
     engines: { node: '>=8' }
+
+  restructure@3.0.2:
+    resolution:
+      {
+        integrity: sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==,
+      }
 
   ret@0.1.15:
     resolution:
@@ -15064,6 +15167,12 @@ packages:
         integrity: sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==,
       }
 
+  tiny-inflate@1.0.3:
+    resolution:
+      {
+        integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==,
+      }
+
   tinybench@2.9.0:
     resolution:
       {
@@ -15474,12 +15583,24 @@ packages:
       }
     engines: { node: '>=4' }
 
+  unicode-properties@1.4.1:
+    resolution:
+      {
+        integrity: sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==,
+      }
+
   unicode-property-aliases-ecmascript@2.2.0:
     resolution:
       {
         integrity: sha512-hpbDzxUY9BFwX+UeBnxv3Sh1q7HFxj48DTmXchNgRa46lO8uj3/1iEn3MiNUYTg1g9ctIqXCCERn8gYZhHC5lQ==,
       }
     engines: { node: '>=4' }
+
+  unicode-trie@2.0.0:
+    resolution:
+      {
+        integrity: sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==,
+      }
 
   unified@11.0.5:
     resolution:
@@ -16485,199 +16606,7 @@ packages:
         integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==,
       }
 
-  '@noble/ciphers@1.3.0':
-    resolution:
-      {
-        integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==,
-      }
-    engines: { node: ^14.21.3 || >=16 }
-
-  '@noble/hashes@1.8.0':
-    resolution:
-      {
-        integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==,
-      }
-    engines: { node: ^14.21.3 || >=16 }
-
-  '@swc/helpers@0.5.23':
-    resolution:
-      {
-        integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==,
-      }
-
-  '@types/pdfkit@0.17.6':
-    resolution:
-      {
-        integrity: sha512-tIwzxk2uWKp0Cq9JIluQXJid77lYhF52EsIOwhsMF4iWLA6YneoBR1xVKYYdAysHuepUB0OX4tdwMiUDdGKmig==,
-      }
-
-  base64-js@0.0.8:
-    resolution:
-      {
-        integrity: sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==,
-      }
-    engines: { node: '>= 0.4' }
-
-  brotli@1.3.3:
-    resolution:
-      {
-        integrity: sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==,
-      }
-
-  browserify-zlib@0.2.0:
-    resolution:
-      {
-        integrity: sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==,
-      }
-
-  clone@2.1.2:
-    resolution:
-      {
-        integrity: sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==,
-      }
-    engines: { node: '>=0.8' }
-
-  dfa@1.2.0:
-    resolution:
-      {
-        integrity: sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==,
-      }
-
-  fontkit@2.0.4:
-    resolution:
-      {
-        integrity: sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==,
-      }
-
-  js-md5@0.8.3:
-    resolution:
-      {
-        integrity: sha512-qR0HB5uP6wCuRMrWPTrkMaev7MJZwJuuw4fnwAzRgP4J4/F8RwtodOKpGp4XpqsLBFzzgqIO42efFAyz2Et6KQ==,
-      }
-
-  linebreak@1.1.0:
-    resolution:
-      {
-        integrity: sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==,
-      }
-
-  pako@1.0.11:
-    resolution:
-      {
-        integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==,
-      }
-
-  pdfkit@0.19.1:
-    resolution:
-      {
-        integrity: sha512-6Gzk+wDwTs4VSxsR5rCMTnIl5nlmkye1oWB0l2hDB1EX6ZNSIBroKQEv+2+fPPn+stVjyqzmsqRJVDfB9fo5DA==,
-      }
-
-  png-js@1.1.0:
-    resolution:
-      {
-        integrity: sha512-PM/uYGzGdNSzqeOgly68+6wKQDL1SY0a/N+OEa/+br6LnHWOAJB0Npiamnodfq3jd2LS/i2fMeOKSAILjA+m5Q==,
-      }
-
-  restructure@3.0.2:
-    resolution:
-      {
-        integrity: sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==,
-      }
-
-  tiny-inflate@1.0.3:
-    resolution:
-      {
-        integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==,
-      }
-
-  unicode-properties@1.4.1:
-    resolution:
-      {
-        integrity: sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==,
-      }
-
-  unicode-trie@2.0.0:
-    resolution:
-      {
-        integrity: sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==,
-      }
-
 snapshots:
-  '@noble/ciphers@1.3.0': {}
-
-  '@noble/hashes@1.8.0': {}
-
-  '@swc/helpers@0.5.23':
-    dependencies:
-      tslib: 2.8.1
-
-  '@types/pdfkit@0.17.6':
-    dependencies:
-      '@types/node': 22.19.5
-
-  base64-js@0.0.8: {}
-
-  brotli@1.3.3:
-    dependencies:
-      base64-js: 1.5.1
-
-  browserify-zlib@0.2.0:
-    dependencies:
-      pako: 1.0.11
-
-  clone@2.1.2: {}
-
-  dfa@1.2.0: {}
-
-  fontkit@2.0.4:
-    dependencies:
-      '@swc/helpers': 0.5.23
-      brotli: 1.3.3
-      clone: 2.1.2
-      dfa: 1.2.0
-      fast-deep-equal: 3.1.3
-      restructure: 3.0.2
-      tiny-inflate: 1.0.3
-      unicode-properties: 1.4.1
-      unicode-trie: 2.0.0
-
-  js-md5@0.8.3: {}
-
-  linebreak@1.1.0:
-    dependencies:
-      base64-js: 0.0.8
-      unicode-trie: 2.0.0
-
-  pako@1.0.11: {}
-
-  pdfkit@0.19.1:
-    dependencies:
-      '@noble/ciphers': 1.3.0
-      '@noble/hashes': 1.8.0
-      fontkit: 2.0.4
-      js-md5: 0.8.3
-      linebreak: 1.1.0
-      png-js: 1.1.0
-
-  png-js@1.1.0:
-    dependencies:
-      browserify-zlib: 0.2.0
-
-  restructure@3.0.2: {}
-
-  tiny-inflate@1.0.3: {}
-
-  unicode-properties@1.4.1:
-    dependencies:
-      base64-js: 1.5.1
-      unicode-trie: 2.0.0
-
-  unicode-trie@2.0.0:
-    dependencies:
-      pako: 0.2.9
-      tiny-inflate: 1.0.3
-
   '@adobe/css-tools@4.4.4': {}
 
   '@anthropic-ai/sdk@0.52.0': {}
@@ -18864,6 +18793,10 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
+  '@noble/ciphers@1.3.0': {}
+
+  '@noble/hashes@1.8.0': {}
+
   '@notionhq/client@2.3.0(encoding@0.1.13)':
     dependencies:
       '@types/node-fetch': 2.6.13
@@ -19851,6 +19784,10 @@ snapshots:
       magic-string: 0.25.9
       string.prototype.matchall: 4.0.12
 
+  '@swc/helpers@0.5.23':
+    dependencies:
+      tslib: 2.8.1
+
   '@tailwindcss/node@4.1.18':
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -20097,6 +20034,10 @@ snapshots:
       undici-types: 6.21.0
 
   '@types/normalize-package-data@2.4.4': {}
+
+  '@types/pdfkit@0.17.6':
+    dependencies:
+      '@types/node': 22.19.5
 
   '@types/pg-pool@2.0.6':
     dependencies:
@@ -20671,6 +20612,8 @@ snapshots:
 
   bare-events@2.8.2: {}
 
+  base64-js@0.0.8: {}
+
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.9.14: {}
@@ -20766,9 +20709,17 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
+  brotli@1.3.3:
+    dependencies:
+      base64-js: 1.5.1
+
   browser-tabs-lock@1.3.0:
     dependencies:
       lodash: 4.17.21
+
+  browserify-zlib@0.2.0:
+    dependencies:
+      pako: 1.0.11
 
   browserslist@4.28.1:
     dependencies:
@@ -20971,6 +20922,8 @@ snapshots:
       wrap-ansi: 7.0.0
 
   clone@1.0.4: {}
+
+  clone@2.1.2: {}
 
   cloudevents@8.0.3:
     dependencies:
@@ -21271,6 +21224,8 @@ snapshots:
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
+
+  dfa@1.2.0: {}
 
   diff@4.0.2: {}
 
@@ -22154,6 +22109,18 @@ snapshots:
   follow-redirects@1.15.11(debug@4.3.1):
     optionalDependencies:
       debug: 4.3.1
+
+  fontkit@2.0.4:
+    dependencies:
+      '@swc/helpers': 0.5.23
+      brotli: 1.3.3
+      clone: 2.1.2
+      dfa: 1.2.0
+      fast-deep-equal: 3.1.3
+      restructure: 3.0.2
+      tiny-inflate: 1.0.3
+      unicode-properties: 1.4.1
+      unicode-trie: 2.0.0
 
   for-each@0.3.5:
     dependencies:
@@ -23125,6 +23092,8 @@ snapshots:
       git-sha1: 0.1.2
       pako: 0.2.9
 
+  js-md5@0.8.3: {}
+
   js-tokens@4.0.0: {}
 
   js-tokens@9.0.1: {}
@@ -23355,6 +23324,11 @@ snapshots:
       lightningcss-win32-x64-msvc: 1.30.2
 
   limiter@1.1.5: {}
+
+  linebreak@1.1.0:
+    dependencies:
+      base64-js: 0.0.8
+      unicode-trie: 2.0.0
 
   lines-and-columns@1.2.4: {}
 
@@ -24346,6 +24320,8 @@ snapshots:
 
   pako@0.2.9: {}
 
+  pako@1.0.11: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -24421,6 +24397,15 @@ snapshots:
   pathe@2.0.3: {}
 
   pathval@2.0.1: {}
+
+  pdfkit@0.19.1:
+    dependencies:
+      '@noble/ciphers': 1.3.0
+      '@noble/hashes': 1.8.0
+      fontkit: 2.0.4
+      js-md5: 0.8.3
+      linebreak: 1.1.0
+      png-js: 1.1.0
 
   pg-cloudflare@1.2.7:
     optional: true
@@ -24607,6 +24592,10 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
+
+  png-js@1.1.0:
+    dependencies:
+      browserify-zlib: 0.2.0
 
   point-in-polygon@1.1.0: {}
 
@@ -25167,6 +25156,8 @@ snapshots:
     dependencies:
       onetime: 5.1.2
       signal-exit: 3.0.7
+
+  restructure@3.0.2: {}
 
   ret@0.1.15: {}
 
@@ -25841,6 +25832,8 @@ snapshots:
       readable-stream: 2.3.8
       xtend: 4.0.2
 
+  tiny-inflate@1.0.3: {}
+
   tinybench@2.9.0: {}
 
   tinyexec@0.3.2: {}
@@ -26057,7 +26050,17 @@ snapshots:
 
   unicode-match-property-value-ecmascript@2.2.1: {}
 
+  unicode-properties@1.4.1:
+    dependencies:
+      base64-js: 1.5.1
+      unicode-trie: 2.0.0
+
   unicode-property-aliases-ecmascript@2.2.0: {}
+
+  unicode-trie@2.0.0:
+    dependencies:
+      pako: 0.2.9
+      tiny-inflate: 1.0.3
 
   unified@11.0.5:
     dependencies:


### PR DESCRIPTION
## Summary

- Consolidates the Conversation Assistant PDF export UI, API client, service route, domain use case, and reusable PDF package integration.
- Requires and renders the LLM model plus initial user prompt in exports, strips common Markdown for PDF-safe text, and hardens empty-session/exporter error handling.
- Adds owner-filtering for turn snapshots and includes the required Firestore composite index in the single pending migration 119.
- Supersedes child PRs #2289 and #2290 while preserving the already-merged reusable package foundation from INT-1838.

## Verification

- `pnpm run ci:tracked`

Fixes INT-1837
Refs INT-1839
Refs INT-1840
Supersedes #2289
Supersedes #2290


Linear: [INT-1837](https://linear.app/pbuchman/issue/INT-1837)
IntexuraOS Code Task: [View task](https://intexuraos.cloud/#/code-tasks/task_db2eb288-afa3-4d8e-8c61-ae4bd52d6c7a)
Worker Type: `codex-xhigh`
Model: `default`
