### PR TITLE
[INT-1853] Infer Conversation Assistant assistant role labels

### DIFF
--- a/apps/web/src/components/whatsapp/ConversationAssistantSessionRail.tsx
+++ b/apps/web/src/components/whatsapp/ConversationAssistantSessionRail.tsx
@@ -74,7 +74,9 @@ export function ConversationAssistantSessionRail({
               </span>
               <span className="mt-1 flex min-w-0 items-center gap-1 text-xs text-slate-500 dark:text-slate-400">
                 <Bot className="h-3.5 w-3.5 shrink-0" />
-                <span className="truncate">{session.modelDisplayName}</span>
+                <span className="truncate">
+                  {session.assistantRoleLabel} · {session.modelDisplayName}
+                </span>
               </span>
               {session.lastTurnAt !== undefined ? (
                 <span className="mt-1 block text-xs text-slate-400 dark:text-slate-500">

--- a/apps/web/src/hooks/__tests__/useWhatsAppConversationAssistant.test.tsx
+++ b/apps/web/src/hooks/__tests__/useWhatsAppConversationAssistant.test.tsx
@@ -261,7 +261,7 @@ describe('useWhatsAppConversationAssistant', () => {
     expect(mocks.listConversationAssistantTurns).toHaveBeenCalledWith('tok', session.id);
   });
 
-  it('creates a new session and streams the optional first question', async () => {
+  it('creates a new session with the optional first question for role inference', async () => {
     const createdSession: ConversationAssistantSession = {
       ...session,
       id: 'session-created',
@@ -269,9 +269,30 @@ describe('useWhatsAppConversationAssistant', () => {
       createdAt: '2026-06-21T12:00:00.000Z',
       updatedAt: '2026-06-21T12:00:00.000Z',
     };
+    const createdTurns: ConversationAssistantTurn[] = [
+      {
+        id: 'turn-created-user',
+        sessionId: createdSession.id,
+        userId: 'user-1',
+        role: 'user',
+        text: 'What changed?',
+        createdAt: '2026-06-21T12:01:00.000Z',
+      },
+      {
+        id: 'turn-created-assistant',
+        sessionId: createdSession.id,
+        userId: 'user-1',
+        role: 'assistant',
+        text: 'Created answer.',
+        createdAt: '2026-06-21T12:02:00.000Z',
+      },
+    ];
     mocks.createConversationAssistantSession.mockResolvedValue(createdSession);
     mocks.getConversationAssistantSession.mockImplementation((_token: string, sessionId: string) =>
       Promise.resolve(sessionId === createdSession.id ? createdSession : session)
+    );
+    mocks.listConversationAssistantTurns.mockImplementation((_token: string, sessionId: string) =>
+      Promise.resolve({ turns: sessionId === createdSession.id ? createdTurns : turns })
     );
 
     const { result } = renderHook(() => useWhatsAppConversationAssistant(), {
@@ -303,16 +324,15 @@ describe('useWhatsAppConversationAssistant', () => {
       from: new Date('2026-06-20T09:00').toISOString(),
       to: new Date('2026-06-21T10:00').toISOString(),
       model: DEFAULT_CONVERSATION_ASSISTANT_MODEL,
+      question: 'What changed?',
     });
-    expect(mocks.streamConversationAssistantTurn).toHaveBeenCalledWith(
-      'tok',
-      createdSession.id,
-      { question: 'What changed?' },
-      expect.any(Function)
-    );
+    expect(mocks.streamConversationAssistantTurn).not.toHaveBeenCalled();
     expect(result.current.sessions[0]).toEqual(createdSession);
     expect(result.current.selectedSession?.id).toBe(createdSession.id);
     expect(result.current.firstQuestion).toBe('');
+    await waitFor(() => {
+      expect(result.current.turns).toEqual(createdTurns);
+    });
   });
 
   it('sends the selected model when creating a session', async () => {
@@ -355,7 +375,7 @@ describe('useWhatsAppConversationAssistant', () => {
     });
   });
 
-  it('keeps first-question streamed turns by suppressing the selected-session loader', async () => {
+  it('loads create-time first-question turns without streaming a duplicate follow-up', async () => {
     const createdSession: ConversationAssistantSession = {
       ...session,
       id: 'session-created',
@@ -363,25 +383,30 @@ describe('useWhatsAppConversationAssistant', () => {
       createdAt: '2026-06-21T12:00:00.000Z',
       updatedAt: '2026-06-21T12:00:00.000Z',
     };
-    const streamRequest = createDeferred<undefined>();
-    let streamEventHandler: ((event: unknown) => void) | undefined;
+    const createdTurns: ConversationAssistantTurn[] = [
+      {
+        id: 'turn-created-user',
+        sessionId: createdSession.id,
+        userId: 'user-1',
+        role: 'user',
+        text: 'What changed?',
+        createdAt: '2026-06-21T12:01:00.000Z',
+      },
+      {
+        id: 'turn-created-assistant',
+        sessionId: createdSession.id,
+        userId: 'user-1',
+        role: 'assistant',
+        text: 'Created answer.',
+        createdAt: '2026-06-21T12:02:00.000Z',
+      },
+    ];
     mocks.createConversationAssistantSession.mockResolvedValue(createdSession);
     mocks.getConversationAssistantSession.mockImplementation((_token: string, sessionId: string) =>
       Promise.resolve(sessionId === createdSession.id ? createdSession : session)
     );
     mocks.listConversationAssistantTurns.mockImplementation((_token: string, sessionId: string) =>
-      Promise.resolve({ turns: sessionId === createdSession.id ? [] : turns })
-    );
-    mocks.streamConversationAssistantTurn.mockImplementation(
-      async (
-        _token: string,
-        _streamSessionId: string,
-        _request: { question: string },
-        onEvent: (event: unknown) => void
-      ) => {
-        streamEventHandler = onEvent;
-        return await streamRequest.promise;
-      }
+      Promise.resolve({ turns: sessionId === createdSession.id ? createdTurns : turns })
     );
 
     const { result } = renderHook(() => useWhatsAppConversationAssistant(), {
@@ -397,65 +422,27 @@ describe('useWhatsAppConversationAssistant', () => {
       result.current.setFirstQuestion('What changed?');
     });
 
-    let createPromise!: Promise<void>;
-    act(() => {
-      createPromise = result.current.createSession();
-    });
-
-    await waitFor(() => {
-      expect(mocks.streamConversationAssistantTurn).toHaveBeenCalledWith(
-        'tok',
-        createdSession.id,
-        { question: 'What changed?' },
-        expect.any(Function)
-      );
-    });
-
     await act(async () => {
-      streamEventHandler?.({
-        type: 'user_turn',
-        turn: {
-          id: 'turn-created-user',
-          sessionId: createdSession.id,
-          userId: 'user-1',
-          role: 'user',
-          text: 'What changed?',
-          createdAt: '2026-06-21T12:01:00.000Z',
-        },
-      });
-      streamEventHandler?.({
-        type: 'assistant_turn',
-        turn: {
-          id: 'turn-created-assistant',
-          sessionId: createdSession.id,
-          userId: 'user-1',
-          role: 'assistant',
-          text: 'Created streamed answer.',
-          createdAt: '2026-06-21T12:02:00.000Z',
-        },
-      });
+      await result.current.createSession();
     });
 
+    expect(mocks.createConversationAssistantSession).toHaveBeenCalledWith('tok', {
+      chatId: directChat.id,
+      from: expect.any(String),
+      to: expect.any(String),
+      model: DEFAULT_CONVERSATION_ASSISTANT_MODEL,
+      question: 'What changed?',
+    });
+    expect(mocks.streamConversationAssistantTurn).not.toHaveBeenCalled();
     await waitFor(() => {
-      expect(result.current.turns.map((turn) => turn.id)).toEqual([
-        'turn-created-user',
-        'turn-created-assistant',
-      ]);
+      expect(mocks.listConversationAssistantTurns).toHaveBeenCalledWith('tok', createdSession.id);
     });
-    expect(mocks.listConversationAssistantTurns).not.toHaveBeenCalledWith('tok', createdSession.id);
-    expect(result.current.turns.map((turn) => turn.id)).toEqual([
-      'turn-created-user',
-      'turn-created-assistant',
-    ]);
-
-    await act(async () => {
-      streamRequest.resolve(undefined);
-      await streamRequest.promise;
-      await createPromise;
+    await waitFor(() => {
+      expect(result.current.turns).toEqual(createdTurns);
     });
   });
 
-  it('clears previous session turns before streaming a first question into a new session', async () => {
+  it('clears previous session turns before loading first-question turns for a new session', async () => {
     const createdSession: ConversationAssistantSession = {
       ...session,
       id: 'session-created',
@@ -463,24 +450,35 @@ describe('useWhatsAppConversationAssistant', () => {
       createdAt: '2026-06-21T12:00:00.000Z',
       updatedAt: '2026-06-21T12:00:00.000Z',
     };
-    const streamRequest = createDeferred<undefined>();
-    let streamEventHandler: ((event: unknown) => void) | undefined;
+    const createdTurns: ConversationAssistantTurn[] = [
+      {
+        id: 'turn-created-user',
+        sessionId: createdSession.id,
+        userId: 'user-1',
+        role: 'user',
+        text: 'Start a new created session',
+        createdAt: '2026-06-21T12:01:00.000Z',
+      },
+      {
+        id: 'turn-created-assistant',
+        sessionId: createdSession.id,
+        userId: 'user-1',
+        role: 'assistant',
+        text: 'Created answer.',
+        createdAt: '2026-06-21T12:02:00.000Z',
+      },
+    ];
+    const createdTurnsRequest = createDeferred<{ turns: ConversationAssistantTurn[] }>();
     mocks.createConversationAssistantSession.mockResolvedValue(createdSession);
     mocks.getConversationAssistantSession.mockImplementation((_token: string, sessionId: string) =>
       Promise.resolve(sessionId === createdSession.id ? createdSession : session)
     );
-    mocks.listConversationAssistantTurns.mockImplementation((_token: string, sessionId: string) =>
-      Promise.resolve({ turns: sessionId === createdSession.id ? [] : turns })
-    );
-    mocks.streamConversationAssistantTurn.mockImplementation(
-      async (
-        _token: string,
-        _streamSessionId: string,
-        _request: { question: string },
-        onEvent: (event: unknown) => void
-      ) => {
-        streamEventHandler = onEvent;
-        return await streamRequest.promise;
+    mocks.listConversationAssistantTurns.mockImplementation(
+      (_token: string, sessionId: string): Promise<{ turns: ConversationAssistantTurn[] }> => {
+        if (sessionId === createdSession.id) {
+          return createdTurnsRequest.promise;
+        }
+        return Promise.resolve({ turns });
       }
     );
 
@@ -494,63 +492,29 @@ describe('useWhatsAppConversationAssistant', () => {
 
     act(() => {
       result.current.selectChat(directChat.id);
-      result.current.setFirstQuestion('Start a new streamed session');
-    });
-
-    let createPromise!: Promise<void>;
-    act(() => {
-      createPromise = result.current.createSession();
-    });
-
-    await waitFor(() => {
-      expect(mocks.streamConversationAssistantTurn).toHaveBeenCalledWith(
-        'tok',
-        createdSession.id,
-        { question: 'Start a new streamed session' },
-        expect.any(Function)
-      );
+      result.current.setFirstQuestion('Start a new created session');
     });
 
     await act(async () => {
-      streamEventHandler?.({
-        type: 'user_turn',
-        turn: {
-          id: 'turn-created-user',
-          sessionId: createdSession.id,
-          userId: 'user-1',
-          role: 'user',
-          text: 'Start a new streamed session',
-          createdAt: '2026-06-21T12:01:00.000Z',
-        },
-      });
-      streamEventHandler?.({
-        type: 'assistant_turn',
-        turn: {
-          id: 'turn-created-assistant',
-          sessionId: createdSession.id,
-          userId: 'user-1',
-          role: 'assistant',
-          text: 'Created streamed answer.',
-          createdAt: '2026-06-21T12:02:00.000Z',
-        },
-      });
+      await result.current.createSession();
     });
 
     await waitFor(() => {
-      expect(result.current.turns.map((turn) => turn.id)).toEqual([
-        'turn-created-user',
-        'turn-created-assistant',
-      ]);
+      expect(mocks.listConversationAssistantTurns).toHaveBeenCalledWith('tok', createdSession.id);
+    });
+    expect(mocks.streamConversationAssistantTurn).not.toHaveBeenCalled();
+    expect(result.current.turns).toEqual([]);
+
+    await act(async () => {
+      createdTurnsRequest.resolve({ turns: createdTurns });
+      await createdTurnsRequest.promise;
+    });
+
+    await waitFor(() => {
+      expect(result.current.turns).toEqual(createdTurns);
     });
     expect(result.current.turns).not.toContainEqual(turns[0]);
     expect(result.current.turns).not.toContainEqual(turns[1]);
-    expect(mocks.listConversationAssistantTurns).not.toHaveBeenCalledWith('tok', createdSession.id);
-
-    await act(async () => {
-      streamRequest.resolve(undefined);
-      await streamRequest.promise;
-      await createPromise;
-    });
   });
 
   it('requires confirmation before creating a session with a large context', async () => {

--- a/apps/web/src/hooks/__tests__/useWhatsAppConversationAssistant.test.tsx
+++ b/apps/web/src/hooks/__tests__/useWhatsAppConversationAssistant.test.tsx
@@ -541,6 +541,10 @@ describe('useWhatsAppConversationAssistant', () => {
       expect(result.current.selectedChatId).toBe(directChat.id);
     });
 
+    act(() => {
+      result.current.setFirstQuestion('  Please summarize the legal risk.  ');
+    });
+
     await act(async () => {
       await result.current.createSession();
     });
@@ -557,6 +561,13 @@ describe('useWhatsAppConversationAssistant', () => {
     });
 
     expect(mocks.createConversationAssistantSession).toHaveBeenCalledTimes(1);
+    expect(mocks.createConversationAssistantSession).toHaveBeenCalledWith('tok', {
+      chatId: directChat.id,
+      from: expect.any(String),
+      to: expect.any(String),
+      model: DEFAULT_CONVERSATION_ASSISTANT_MODEL,
+      question: 'Please summarize the legal risk.',
+    });
     expect(result.current.largeContextWarning).toBeNull();
     await waitFor(() => {
       expect(result.current.selectedSession?.id).toBe(createdSession.id);

--- a/apps/web/src/hooks/useWhatsAppConversationAssistant.ts
+++ b/apps/web/src/hooks/useWhatsAppConversationAssistant.ts
@@ -441,11 +441,14 @@ export function useWhatsAppConversationAssistant(): UseWhatsAppConversationAssis
     async (
       token: string,
       request: CreateConversationAssistantSessionRequest,
-      firstQuestionToStream: string,
+      firstQuestionForCreate: string,
       requestId: number,
       originatingSessionId: string | undefined
     ): Promise<void> => {
-      const session = await createConversationAssistantSession(token, request);
+      const session = await createConversationAssistantSession(token, {
+        ...request,
+        ...(firstQuestionForCreate !== '' ? { question: firstQuestionForCreate } : {}),
+      });
       if (
         createRequestIdRef.current !== requestId ||
         selectedSessionIdRef.current !== originatingSessionId
@@ -461,18 +464,12 @@ export function useWhatsAppConversationAssistant(): UseWhatsAppConversationAssis
       setError(null);
       turnsRequestIdRef.current += 1;
       selectedSessionIdRef.current = session.id;
-      if (firstQuestionToStream !== '') {
-        skipNextSelectedSessionLoadRef.current = session.id;
+      if (firstQuestionForCreate !== '') {
         setTurns([]);
       }
       setSessionParam(session.id);
-      if (firstQuestionToStream !== '') {
-        await streamQuestionIntoSession(token, session.id, firstQuestionToStream, () => {
-          setFirstQuestionState('');
-        }, undefined, false);
-      }
     },
-    [setSessionParam, streamQuestionIntoSession]
+    [setSessionParam]
   );
 
   const createSession = useCallback(async (): Promise<void> => {

--- a/apps/web/src/hooks/useWhatsAppConversationAssistant.ts
+++ b/apps/web/src/hooks/useWhatsAppConversationAssistant.ts
@@ -118,7 +118,6 @@ export function useWhatsAppConversationAssistant(): UseWhatsAppConversationAssis
   const sendInFlightRef = useRef(false);
   const exportInFlightRef = useRef(false);
   const turnsRequestIdRef = useRef(0);
-  const skipNextSelectedSessionLoadRef = useRef<string | undefined>(undefined);
 
   const defaultRange = useMemo(() => getDefaultRange(), []);
   const [sessions, setSessions] = useState<ConversationAssistantSession[]>([]);
@@ -149,13 +148,9 @@ export function useWhatsAppConversationAssistant(): UseWhatsAppConversationAssis
     useState<PendingLargeContextCreate | null>(null);
 
   useEffect(() => {
-    const skipSelectedSessionLoad =
-      selectedSessionId !== undefined && skipNextSelectedSessionLoadRef.current === selectedSessionId;
     selectedSessionIdRef.current = selectedSessionId;
-    if (!skipSelectedSessionLoad) {
-      setSelectedSessionOverride(undefined);
-      setTurns([]);
-    }
+    setSelectedSessionOverride(undefined);
+    setTurns([]);
     setFollowUpQuestion('');
     sendInFlightRef.current = false;
     setSending(false);
@@ -164,8 +159,6 @@ export function useWhatsAppConversationAssistant(): UseWhatsAppConversationAssis
     setPendingLargeContext(null);
     setInvalidSelectedSessionId(undefined);
     if (selectedSessionId === undefined) {
-      setLoadingTurns(false);
-    } else if (skipSelectedSessionLoad) {
       setLoadingTurns(false);
     }
   }, [selectedSessionId]);
@@ -229,14 +222,6 @@ export function useWhatsAppConversationAssistant(): UseWhatsAppConversationAssis
       turnsRequestIdRef.current += 1;
       setSelectedSessionOverride(undefined);
       setTurns([]);
-      setLoadingTurns(false);
-      return;
-    }
-
-    if (skipNextSelectedSessionLoadRef.current === selectedSessionId) {
-      skipNextSelectedSessionLoadRef.current = undefined;
-      turnsRequestIdRef.current += 1;
-      setInvalidSelectedSessionId(undefined);
       setLoadingTurns(false);
       return;
     }

--- a/apps/web/src/pages/WhatsAppConversationAssistantPage.tsx
+++ b/apps/web/src/pages/WhatsAppConversationAssistantPage.tsx
@@ -25,7 +25,7 @@ function SessionMetadata({
 }): React.JSX.Element {
   if (session === undefined) {
     return (
-      <div className="grid grid-cols-1 gap-2 text-sm text-slate-500 dark:text-slate-400 sm:grid-cols-2 xl:grid-cols-5">
+      <div className="grid grid-cols-1 gap-2 text-sm text-slate-500 dark:text-slate-400 sm:grid-cols-2 xl:grid-cols-6">
         <div className="rounded-md border border-slate-200 px-3 py-2 dark:border-slate-800">
           No information range
         </div>
@@ -35,12 +35,13 @@ function SessionMetadata({
         <div className="rounded-md border border-slate-200 px-3 py-2 dark:border-slate-800">No transcript</div>
         <div className="rounded-md border border-slate-200 px-3 py-2 dark:border-slate-800">No omissions</div>
         <div className="rounded-md border border-slate-200 px-3 py-2 dark:border-slate-800">No model</div>
+        <div className="rounded-md border border-slate-200 px-3 py-2 dark:border-slate-800">No role</div>
       </div>
     );
   }
 
   return (
-    <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 xl:grid-cols-5">
+    <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 xl:grid-cols-6">
       <div className="rounded-md border border-slate-200 px-3 py-2 dark:border-slate-800">
         <div className="text-xs font-semibold uppercase text-slate-500 dark:text-slate-400">
           Information range
@@ -81,6 +82,12 @@ function SessionMetadata({
           {session.modelDisplayName}
         </div>
       </div>
+      <div className="rounded-md border border-slate-200 px-3 py-2 dark:border-slate-800">
+        <div className="text-xs font-semibold uppercase text-slate-500 dark:text-slate-400">Role</div>
+        <div className="mt-1 text-sm text-slate-950 dark:text-slate-50">
+          {session.assistantRoleLabel}
+        </div>
+      </div>
     </div>
   );
 }
@@ -92,6 +99,7 @@ export function WhatsAppConversationAssistantPage(): React.JSX.Element {
     assistant.turns.length > 0 &&
     !assistant.sending &&
     !assistant.exporting;
+  const assistantRoleLabel = assistant.selectedSession?.assistantRoleLabel ?? 'Assistant';
   const selectedSessionId = assistant.selectedSessionId;
   const turnsScrollRef = useRef<HTMLDivElement | null>(null);
   const followTurnsRef = useRef(true);
@@ -342,7 +350,7 @@ export function WhatsAppConversationAssistantPage(): React.JSX.Element {
                     }`}
                   >
                     <div className="mb-1 flex items-center justify-between gap-3 text-xs font-semibold uppercase text-slate-500 dark:text-slate-400">
-                      <span>{isUser ? 'You' : 'Assistant'}</span>
+                      <span>{isUser ? 'You' : assistantRoleLabel}</span>
                       <span>{formatDateTimeCompact(turn.createdAt)}</span>
                     </div>
                     {isUser ? (

--- a/apps/web/src/pages/WhatsAppConversationAssistantPage.tsx
+++ b/apps/web/src/pages/WhatsAppConversationAssistantPage.tsx
@@ -349,9 +349,11 @@ export function WhatsAppConversationAssistantPage(): React.JSX.Element {
                         : 'mr-auto border-slate-200 bg-white dark:border-slate-800 dark:bg-slate-900'
                     }`}
                   >
-                    <div className="mb-1 flex items-center justify-between gap-3 text-xs font-semibold uppercase text-slate-500 dark:text-slate-400">
-                      <span>{isUser ? 'You' : assistantRoleLabel}</span>
-                      <span>{formatDateTimeCompact(turn.createdAt)}</span>
+                    <div className="mb-1 flex flex-wrap items-start justify-between gap-x-3 gap-y-1 text-xs font-semibold uppercase text-slate-500 dark:text-slate-400">
+                      <span className="min-w-0 flex-1 break-words">
+                        {isUser ? 'You' : assistantRoleLabel}
+                      </span>
+                      <span className="shrink-0">{formatDateTimeCompact(turn.createdAt)}</span>
                     </div>
                     {isUser ? (
                       <p className="whitespace-pre-wrap break-words text-sm leading-6 text-slate-950 dark:text-slate-50">

--- a/apps/web/src/pages/__tests__/WhatsAppConversationAssistantPage.test.tsx
+++ b/apps/web/src/pages/__tests__/WhatsAppConversationAssistantPage.test.tsx
@@ -45,6 +45,7 @@ function createHookResult(
     },
     model: 'or:google/gemini-3.5-flash',
     modelDisplayName: 'Gemini 3.5 Flash Thinking',
+    assistantRoleLabel: 'Psychologist',
     transcriptSha256: 'abc123',
     transcriptMessageCount: 9,
     omitted: {
@@ -128,6 +129,7 @@ describe('WhatsAppConversationAssistantPage', () => {
     expect(screen.getByLabelText('From')).toHaveValue('2026-06-20T09:00');
     expect(screen.getByLabelText('To')).toHaveValue('2026-06-21T10:00');
     expect(screen.getByRole('button', { name: 'Send' })).toBeDisabled();
+    expect(screen.getByText('No role')).toBeInTheDocument();
   });
 
   it('updates the selected model through the creation selector', async () => {
@@ -175,6 +177,8 @@ describe('WhatsAppConversationAssistantPage', () => {
     expect(screen.getByText('Bring docs')).toBeInTheDocument();
     expect(screen.getByText('9 messages')).toBeInTheDocument();
     expect(screen.getAllByText('Gemini 3.5 Flash Thinking').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Psychologist').length).toBeGreaterThan(0);
+    expect(screen.queryByText('Assistant')).not.toBeInTheDocument();
     expect(screen.getByText('6 omitted')).toBeInTheDocument();
     expect(screen.getByText(/non-text 3/i)).toBeInTheDocument();
     expect(screen.getByText(/over limit 0/i)).toBeInTheDocument();

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -368,6 +368,7 @@ export interface ConversationAssistantSession {
   effectiveRange: ConversationAssistantDateRange;
   model: ConversationAssistantModel | string;
   modelDisplayName: string;
+  assistantRoleLabel: string;
   transcriptSha256: string;
   transcriptMessageCount: number;
   omitted: ConversationAssistantOmittedCounts;

--- a/apps/whatsapp-service/package.json
+++ b/apps/whatsapp-service/package.json
@@ -34,6 +34,7 @@
     "@intexuraos/llm-factory": "workspace:*",
     "@intexuraos/llm-pricing": "workspace:*",
     "@intexuraos/llm-prompts": "workspace:*",
+    "@intexuraos/llm-utils": "workspace:*",
     "fastify": "catalog:",
     "libphonenumber-js": "^1.12.33",
     "pino": "catalog:",

--- a/apps/whatsapp-service/src/__tests__/conversationAssistantRoutes.test.ts
+++ b/apps/whatsapp-service/src/__tests__/conversationAssistantRoutes.test.ts
@@ -100,6 +100,7 @@ describe('Conversation Assistant routes', () => {
           id: string;
           effectiveRange: ConversationAssistantDateRange;
           transcriptText?: string;
+          assistantRoleLabel: string;
           model: string;
           modelDisplayName: string;
         };
@@ -107,6 +108,7 @@ describe('Conversation Assistant routes', () => {
       };
     };
     expect(body.data.session.transcriptText).toBeUndefined();
+    expect(body.data.session.assistantRoleLabel).toBe('Assistant');
     expect(body.data.session.effectiveRange).toEqual({
       from: '2026-06-30T10:00:00.000Z',
       to: '2026-06-30T10:00:00.000Z',
@@ -114,6 +116,7 @@ describe('Conversation Assistant routes', () => {
     expect(body.data.session.model).toBe(DEFAULT_CONVERSATION_ASSISTANT_MODEL);
     expect(body.data.session.modelDisplayName).toBe('MiniMax M3');
     expect(JSON.stringify(body)).not.toContain('We agreed to meet');
+    expect(JSON.stringify(body)).not.toContain('transcriptText');
     expect(body.data.turns).toEqual([]);
   });
 
@@ -154,6 +157,10 @@ describe('Conversation Assistant routes', () => {
 
   it('creates first turns, lists sessions, and lists turns', async () => {
     const token = await seed();
+    ctx.llmClient.queueGenerateResponse({
+      content:
+        '{"roleLabel":"lawyer","confidence":0.92,"rationale":"Conversation asks for legal interpretation."}',
+    });
     await storeMessage({
       eventTimestamp: '2026-06-30T10:05:00.000Z',
       matrixEventId: '$event-2',
@@ -169,7 +176,7 @@ describe('Conversation Assistant routes', () => {
         from: '2026-06-30T00:00:00.000Z',
         to: '2026-07-01T00:00:00.000Z',
         maxMessages: 1,
-        question: 'What was agreed?',
+        question: 'Can a lawyer explain what these messages mean for my lease dispute?',
       },
     });
 
@@ -180,16 +187,19 @@ describe('Conversation Assistant routes', () => {
           id: string;
           effectiveRange: ConversationAssistantDateRange;
           transcriptText?: string;
+          assistantRoleLabel: string;
         };
         turns: { role: string }[];
       };
     };
     expect(createdBody.data.turns.map((turn) => turn.role)).toEqual(['user', 'assistant']);
+    expect(createdBody.data.session.assistantRoleLabel).toBe('Lawyer');
     expect(createdBody.data.session.effectiveRange).toEqual({
       from: '2026-06-30T10:00:00.000Z',
       to: '2026-06-30T10:00:00.000Z',
     });
     expect(createdBody.data.session.transcriptText).toBeUndefined();
+    expect(JSON.stringify(createdBody)).not.toContain('transcriptText');
     expect(ctx.llmClient.chatCalls[0]?.options.sessionId).toBe(createdBody.data.session.id);
 
     const listed = await ctx.app.inject({
@@ -216,12 +226,14 @@ describe('Conversation Assistant routes', () => {
       to: '2026-06-30T10:00:00.000Z',
     });
     expect(JSON.parse(listed.body).data.sessions[0].transcriptText).toBeUndefined();
+    expect(JSON.parse(listed.body).data.sessions[0].assistantRoleLabel).toBe('Lawyer');
     expect(JSON.stringify(JSON.parse(listed.body).data.sessions)).not.toContain('We agreed to meet');
     expect(JSON.parse(fetched.body).data.session.effectiveRange).toEqual({
       from: '2026-06-30T10:00:00.000Z',
       to: '2026-06-30T10:00:00.000Z',
     });
     expect(JSON.parse(fetched.body).data.session.transcriptText).toBeUndefined();
+    expect(JSON.parse(fetched.body).data.session.assistantRoleLabel).toBe('Lawyer');
     expect(JSON.parse(turns.body).data.turns).toHaveLength(2);
   });
 

--- a/apps/whatsapp-service/src/__tests__/domain/conversation-assistant/roleInference.test.ts
+++ b/apps/whatsapp-service/src/__tests__/domain/conversation-assistant/roleInference.test.ts
@@ -1,0 +1,159 @@
+import { err, ok } from '@intexuraos/common-core';
+import type { LlmGenerateClient, LLMError } from '@intexuraos/llm-factory';
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_CONVERSATION_ASSISTANT_ROLE_LABEL,
+  inferConversationAssistantRoleLabel,
+  normalizeConversationAssistantRoleLabel,
+} from '../../../domain/conversation-assistant/roleInference.js';
+
+const zeroUsage = { inputTokens: 0, outputTokens: 0, totalTokens: 0, costUsd: 0 };
+
+class FakeGenerateClient implements LlmGenerateClient {
+  readonly prompts: string[] = [];
+
+  constructor(
+    private readonly responses: ReturnType<LlmGenerateClient['generate']>[]
+  ) {}
+
+  async generate(
+    prompt: string,
+    options: { promptType: string }
+  ): Promise<ReturnType<LlmGenerateClient['generate']> extends Promise<infer T> ? T : never> {
+    this.prompts.push(`${options.promptType}\n${prompt}`);
+    return await (
+      this.responses.shift() ??
+      Promise.resolve(
+        ok({
+          content: '{"roleLabel":"Assistant","confidence":0.1,"rationale":"fallback"}',
+          usage: zeroUsage,
+        })
+      )
+    );
+  }
+}
+
+describe('inferConversationAssistantRoleLabel', () => {
+  it('returns Assistant without calling the LLM when the initial question is blank', async () => {
+    const client = new FakeGenerateClient([]);
+
+    const label = await inferConversationAssistantRoleLabel({
+      initialQuestion: '  ',
+      client,
+      sessionId: 'session-1',
+    });
+
+    expect(label).toBe(DEFAULT_CONVERSATION_ASSISTANT_ROLE_LABEL);
+    expect(client.prompts).toHaveLength(0);
+  });
+
+  it('accepts a high-confidence profession that is not from a fixed enum', async () => {
+    const client = new FakeGenerateClient([
+      Promise.resolve(
+        ok({
+          content:
+            '{"roleLabel":"marine surveyor","confidence":0.93,"rationale":"The user asks about a boat inspection."}',
+          usage: zeroUsage,
+        })
+      ),
+    ]);
+
+    const label = await inferConversationAssistantRoleLabel({
+      initialQuestion: 'Can you review this boat survey before I buy it?',
+      client,
+      sessionId: 'session-1',
+    });
+
+    expect(label).toBe('Marine Surveyor');
+  });
+
+  it('falls back to Assistant on API failure', async () => {
+    const client = new FakeGenerateClient([
+      Promise.resolve(err({ code: 'API_ERROR', message: 'down' } as LLMError)),
+    ]);
+
+    await expect(
+      inferConversationAssistantRoleLabel({
+        initialQuestion: 'Can I sue my employer?',
+        client,
+        sessionId: 'session-1',
+      })
+    ).resolves.toBe(DEFAULT_CONVERSATION_ASSISTANT_ROLE_LABEL);
+  });
+
+  it('falls back to Assistant on low-confidence classifications', async () => {
+    const client = new FakeGenerateClient([
+      Promise.resolve(
+        ok({
+          content:
+            '{"roleLabel":"lawyer","confidence":0.59,"rationale":"The user may be asking about legal options."}',
+          usage: zeroUsage,
+        })
+      ),
+    ]);
+
+    await expect(
+      inferConversationAssistantRoleLabel({
+        initialQuestion: 'Can I sue my employer?',
+        client,
+        sessionId: 'session-1',
+      })
+    ).resolves.toBe(DEFAULT_CONVERSATION_ASSISTANT_ROLE_LABEL);
+  });
+
+  it('falls back to Assistant after malformed JSON and failed repair', async () => {
+    const client = new FakeGenerateClient([
+      Promise.resolve(ok({ content: 'not json', usage: zeroUsage })),
+      Promise.resolve(ok({ content: '{"roleLabel":"","confidence":2,"rationale":""}', usage: zeroUsage })),
+    ]);
+
+    await expect(
+      inferConversationAssistantRoleLabel({
+        initialQuestion: 'What does this MRI note mean?',
+        client,
+        sessionId: 'session-1',
+      })
+    ).resolves.toBe(DEFAULT_CONVERSATION_ASSISTANT_ROLE_LABEL);
+    expect(client.prompts).toHaveLength(2);
+  });
+
+  it('normalizes and rejects unsafe labels', () => {
+    expect(normalizeConversationAssistantRoleLabel('  software engineer  ')).toBe(
+      'Software Engineer'
+    );
+    expect(normalizeConversationAssistantRoleLabel('Employment Lawyer')).toBe(
+      'Employment Lawyer'
+    );
+    expect(normalizeConversationAssistantRoleLabel('Marine Surveyor')).toBe('Marine Surveyor');
+    expect(normalizeConversationAssistantRoleLabel('Data Scientist')).toBe('Data Scientist');
+    expect(normalizeConversationAssistantRoleLabel('Tax Advisor')).toBe('Tax Advisor');
+    expect(normalizeConversationAssistantRoleLabel('Business Strategist')).toBe(
+      'Business Strategist'
+    );
+    expect(normalizeConversationAssistantRoleLabel('Security Analyst')).toBe('Security Analyst');
+    expect(normalizeConversationAssistantRoleLabel('Marketing Consultant')).toBe(
+      'Marketing Consultant'
+    );
+    expect(normalizeConversationAssistantRoleLabel('Policy Advisor')).toBe('Policy Advisor');
+    expect(normalizeConversationAssistantRoleLabel('Support Engineer')).toBe('Support Engineer');
+    expect(normalizeConversationAssistantRoleLabel('Systems Analyst')).toBe('Systems Analyst');
+    expect(normalizeConversationAssistantRoleLabel('Solutions Architect')).toBe(
+      'Solutions Architect'
+    );
+    expect(normalizeConversationAssistantRoleLabel('Alice Smith')).toBe('Assistant');
+    expect(normalizeConversationAssistantRoleLabel('Dr. Alice Smith')).toBe('Assistant');
+    expect(normalizeConversationAssistantRoleLabel('Dr.Alice')).toBe('Assistant');
+    expect(normalizeConversationAssistantRoleLabel('Advisor Dr. Smith')).toBe('Assistant');
+    expect(normalizeConversationAssistantRoleLabel('123')).toBe('Assistant');
+    expect(normalizeConversationAssistantRoleLabel('Acme Legal Group')).toBe('Assistant');
+    expect(normalizeConversationAssistantRoleLabel('Amazon Strategist')).toBe('Assistant');
+    expect(normalizeConversationAssistantRoleLabel('Meta Analyst')).toBe('Assistant');
+    expect(normalizeConversationAssistantRoleLabel('Contoso Advisor')).toBe('Assistant');
+    expect(normalizeConversationAssistantRoleLabel('Intexuraos Strategist')).toBe('Assistant');
+    expect(normalizeConversationAssistantRoleLabel('Licensed Psychologist')).toBe('Assistant');
+    expect(normalizeConversationAssistantRoleLabel('Certified Tax Advisor')).toBe('Assistant');
+    expect(normalizeConversationAssistantRoleLabel('Jane Doe, PhD')).toBe('Assistant');
+    expect(normalizeConversationAssistantRoleLabel('**Lawyer**')).toBe('Assistant');
+    expect(normalizeConversationAssistantRoleLabel('Assistant')).toBe('Assistant');
+  });
+});

--- a/apps/whatsapp-service/src/__tests__/domain/conversation-assistant/roleInference.test.ts
+++ b/apps/whatsapp-service/src/__tests__/domain/conversation-assistant/roleInference.test.ts
@@ -161,6 +161,9 @@ describe('inferConversationAssistantRoleLabel', () => {
     expect(normalizeConversationAssistantRoleLabel('Certified Tax Advisor')).toBe('Assistant');
     expect(normalizeConversationAssistantRoleLabel('Jane Doe, PhD')).toBe('Assistant');
     expect(normalizeConversationAssistantRoleLabel('**Lawyer**')).toBe('Assistant');
+    expect(normalizeConversationAssistantRoleLabel('Customer Success Support Engineer')).toBe(
+      'Assistant'
+    );
     expect(normalizeConversationAssistantRoleLabel('Assistant')).toBe('Assistant');
   });
 });

--- a/apps/whatsapp-service/src/__tests__/domain/conversation-assistant/roleInference.test.ts
+++ b/apps/whatsapp-service/src/__tests__/domain/conversation-assistant/roleInference.test.ts
@@ -135,6 +135,9 @@ describe('inferConversationAssistantRoleLabel', () => {
       'Marketing Consultant'
     );
     expect(normalizeConversationAssistantRoleLabel('Policy Advisor')).toBe('Policy Advisor');
+    expect(normalizeConversationAssistantRoleLabel('driver')).toBe('Driver');
+    expect(normalizeConversationAssistantRoleLabel('Drone Engineer')).toBe('Drone Engineer');
+    expect(normalizeConversationAssistantRoleLabel('Drama Teacher')).toBe('Drama Teacher');
     expect(normalizeConversationAssistantRoleLabel('tax advisor/consultant')).toBe(
       'Tax Advisor/Consultant'
     );

--- a/apps/whatsapp-service/src/__tests__/domain/conversation-assistant/roleInference.test.ts
+++ b/apps/whatsapp-service/src/__tests__/domain/conversation-assistant/roleInference.test.ts
@@ -135,6 +135,13 @@ describe('inferConversationAssistantRoleLabel', () => {
       'Marketing Consultant'
     );
     expect(normalizeConversationAssistantRoleLabel('Policy Advisor')).toBe('Policy Advisor');
+    expect(normalizeConversationAssistantRoleLabel('tax advisor/consultant')).toBe(
+      'Tax Advisor/Consultant'
+    );
+    expect(normalizeConversationAssistantRoleLabel('career-coach')).toBe('Career-Coach');
+    expect(normalizeConversationAssistantRoleLabel('strategy & planning advisor')).toBe(
+      'Strategy & Planning Advisor'
+    );
     expect(normalizeConversationAssistantRoleLabel('Support Engineer')).toBe('Support Engineer');
     expect(normalizeConversationAssistantRoleLabel('Systems Analyst')).toBe('Systems Analyst');
     expect(normalizeConversationAssistantRoleLabel('Solutions Architect')).toBe(

--- a/apps/whatsapp-service/src/__tests__/domain/conversation-assistant/sessionUseCases.test.ts
+++ b/apps/whatsapp-service/src/__tests__/domain/conversation-assistant/sessionUseCases.test.ts
@@ -532,6 +532,7 @@ describe('Conversation Assistant session use cases', () => {
     expect(conversationRepository.getAllTurns()).toHaveLength(2);
     expect(llmFactoryCalls).toEqual([
       { userId: USER_ID, model: 'or:google/gemini-3.5-flash' },
+      { userId: USER_ID, model: 'or:google/gemini-3.5-flash' },
     ]);
     expect(llmClient.chatCalls[0]?.options.sessionId).toBe('whatsapp_conv_session_test');
     expect(llmClient.chatCalls[0]?.options.reasoning).toEqual({ enabled: true });
@@ -616,10 +617,59 @@ describe('Conversation Assistant session use cases', () => {
     expect(llmFactoryCalls).toEqual([
       { userId: USER_ID, model: 'or:anthropic/claude-sonnet-5' },
       { userId: USER_ID, model: 'or:anthropic/claude-sonnet-5' },
+      { userId: USER_ID, model: 'or:anthropic/claude-sonnet-5' },
     ]);
     expect(JSON.stringify(llmClient.chatCalls[0]?.messages[1])).toBe(
       JSON.stringify(llmClient.chatCalls[1]?.messages[1])
     );
+  });
+
+  it('stores an inferred assistant role label from the initial question', async () => {
+    const { deps, llmClient } = makeDeps();
+    await seedDirectMessage(deps.privateWhatsAppRepository as FakePrivateWhatsAppRepository);
+    llmClient.queueGenerateResponse({
+      content:
+        '{"roleLabel":"psychologist","confidence":0.88,"rationale":"The user asks about anxiety."}',
+    });
+    llmClient.queueChatResponse('The selected context shows...');
+
+    const result = await createConversationAssistantSession(
+      {
+        userId: USER_ID,
+        chatId: CHAT_ID,
+        from: '2026-06-30T00:00:00.000Z',
+        to: '2026-07-01T00:00:00.000Z',
+        question: 'Why do I keep feeling anxious after these messages?',
+      },
+      deps
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.session.assistantRoleLabel).toBe('Psychologist');
+  });
+
+  it('falls back to Assistant when role classification returns invalid content', async () => {
+    const { deps, llmClient } = makeDeps();
+    await seedDirectMessage(deps.privateWhatsAppRepository as FakePrivateWhatsAppRepository);
+    llmClient.queueGenerateResponse({ content: 'not json' });
+    llmClient.queueGenerateResponse({ content: '{"roleLabel":"","confidence":2,"rationale":""}' });
+    llmClient.queueChatResponse('The selected context shows...');
+
+    const result = await createConversationAssistantSession(
+      {
+        userId: USER_ID,
+        chatId: CHAT_ID,
+        from: '2026-06-30T00:00:00.000Z',
+        to: '2026-07-01T00:00:00.000Z',
+        question: 'Do I need a doctor?',
+      },
+      deps
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.session.assistantRoleLabel).toBe('Assistant');
   });
 
   it('streams follow-up turns and persists the final assistant turn', async () => {
@@ -726,6 +776,7 @@ describe('Conversation Assistant session use cases', () => {
       transcriptSha256: 'abc123',
       transcriptMessageCount: 7,
       transcriptText: 'frozen transcript',
+      assistantRoleLabel: 'Assistant',
       omitted: {
         mediaOnly: 2,
         failedTranscriptions: 1,
@@ -822,6 +873,7 @@ describe('Conversation Assistant session use cases', () => {
       transcriptSha256: 'abc123',
       transcriptMessageCount: 4,
       transcriptText: 'frozen transcript',
+      assistantRoleLabel: 'Assistant',
       omitted: {
         mediaOnly: 0,
         failedTranscriptions: 0,
@@ -907,6 +959,7 @@ describe('Conversation Assistant session use cases', () => {
       transcriptSha256: 'abc123',
       transcriptMessageCount: 1,
       transcriptText: 'frozen transcript',
+      assistantRoleLabel: 'Assistant',
       omitted: {
         mediaOnly: 0,
         failedTranscriptions: 0,
@@ -958,6 +1011,7 @@ describe('Conversation Assistant session use cases', () => {
       transcriptSha256: 'abc123',
       transcriptMessageCount: 1,
       transcriptText: 'frozen transcript',
+      assistantRoleLabel: 'Assistant',
       omitted: {
         mediaOnly: 0,
         failedTranscriptions: 0,
@@ -1028,6 +1082,7 @@ describe('Conversation Assistant session use cases', () => {
       transcriptSha256: 'abc123',
       transcriptMessageCount: 1,
       transcriptText: 'frozen transcript',
+      assistantRoleLabel: 'Assistant',
       omitted: {
         mediaOnly: 0,
         failedTranscriptions: 0,

--- a/apps/whatsapp-service/src/__tests__/domain/conversation-assistant/sessionUseCases.test.ts
+++ b/apps/whatsapp-service/src/__tests__/domain/conversation-assistant/sessionUseCases.test.ts
@@ -776,7 +776,7 @@ describe('Conversation Assistant session use cases', () => {
       transcriptSha256: 'abc123',
       transcriptMessageCount: 7,
       transcriptText: 'frozen transcript',
-      assistantRoleLabel: 'Assistant',
+      assistantRoleLabel: 'Psychologist',
       omitted: {
         mediaOnly: 2,
         failedTranscriptions: 1,
@@ -819,6 +819,7 @@ describe('Conversation Assistant session use cases', () => {
       {
         title: 'Alice context',
         modelName: 'Gemini 3.5 Flash Thinking',
+        assistantRoleLabel: 'Psychologist',
         initialPrompt: 'user question',
         generatedAt: '2026-06-30T12:00:00.000Z',
         sourceRange: {
@@ -851,6 +852,7 @@ describe('Conversation Assistant session use cases', () => {
         ],
       },
     ]);
+    expect(pdfExporter.calls[0]?.assistantRoleLabel).toBe('Psychologist');
   });
 
   it('orders equal-timestamp PDF export turns by conversation role and same-role id', async () => {

--- a/apps/whatsapp-service/src/__tests__/fakes.ts
+++ b/apps/whatsapp-service/src/__tests__/fakes.ts
@@ -10,6 +10,7 @@
 import type { Result } from '@intexuraos/common-core';
 import { err, ok } from '@intexuraos/common-core';
 import type {
+  GenerateOptions,
   GenerateChatOptions,
   GenerateChatResult,
   GenerateChatStreamEvent,
@@ -206,6 +207,8 @@ export class FakeMatrixOutboundGateway implements MatrixOutboundGateway {
 }
 
 export class FakeLlmGenerateClient implements LlmGenerateClient {
+  private readonly generateResponses: Result<GenerateResult, LLMError>[] = [];
+  private readonly chatResponses: Result<GenerateChatResult, LLMError>[] = [];
   private nextChatResult: Result<GenerateChatResult, LLMError> = ok({
     content: 'assistant answer',
     usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15, costUsd: 0.001 },
@@ -218,7 +221,14 @@ export class FakeLlmGenerateClient implements LlmGenerateClient {
   readonly chatCalls: { messages: LlmChatMessage[]; options: GenerateChatOptions }[] = [];
   readonly streamChatCalls: { messages: LlmChatMessage[]; options: GenerateChatOptions }[] = [];
 
-  generate(): Promise<Result<GenerateResult, LLMError>> {
+  generate(
+    _prompt?: string,
+    _options?: GenerateOptions
+  ): Promise<Result<GenerateResult, LLMError>> {
+    const queued = this.generateResponses.shift();
+    if (queued !== undefined) {
+      return Promise.resolve(queued);
+    }
     return Promise.resolve(
       ok({
         content: 'assistant answer',
@@ -232,6 +242,10 @@ export class FakeLlmGenerateClient implements LlmGenerateClient {
     options: GenerateChatOptions
   ): Promise<Result<GenerateChatResult, LLMError>> {
     this.chatCalls.push({ messages, options });
+    const queued = this.chatResponses.shift();
+    if (queued !== undefined) {
+      return Promise.resolve(queued);
+    }
     return Promise.resolve(this.nextChatResult);
   }
 
@@ -249,6 +263,36 @@ export class FakeLlmGenerateClient implements LlmGenerateClient {
 
   setNextStreamEvents(events: GenerateChatStreamEvent[]): void {
     this.nextStreamEvents = events;
+  }
+
+  queueGenerateResponse(
+    response: Partial<GenerateResult> & Pick<GenerateResult, 'content'>
+  ): void {
+    this.generateResponses.push(
+      ok({
+        content: response.content,
+        usage: response.usage ?? {
+          inputTokens: 1,
+          outputTokens: 1,
+          totalTokens: 2,
+          costUsd: 0,
+        },
+      })
+    );
+  }
+
+  queueChatResponse(content: string, usage?: GenerateChatResult['usage']): void {
+    this.chatResponses.push(
+      ok({
+        content,
+        usage: usage ?? {
+          inputTokens: 10,
+          outputTokens: 5,
+          totalTokens: 15,
+          costUsd: 0.001,
+        },
+      })
+    );
   }
 
   failNextChat(message = 'model failed'): void {

--- a/apps/whatsapp-service/src/__tests__/infra/conversationAssistantRepository.test.ts
+++ b/apps/whatsapp-service/src/__tests__/infra/conversationAssistantRepository.test.ts
@@ -24,6 +24,7 @@ function makeSession(overrides: Partial<ConversationAssistantSession> = {}): Con
     transcriptSha256: 'hash',
     transcriptMessageCount: 1,
     transcriptText: '[2026-06-30T10:00:00.000Z] Alice: hello',
+    assistantRoleLabel: 'Doctor',
     omitted: { mediaOnly: 0, failedTranscriptions: 0, pendingTranscriptions: 0, nonText: 0, overLimit: 0 },
     title: 'Question',
     createdAt: '2026-06-30T10:00:00.000Z',
@@ -155,6 +156,7 @@ describe('conversationAssistantRepository', () => {
       transcriptSha256: '',
       transcriptMessageCount: 0,
       transcriptText: '',
+      assistantRoleLabel: 'Assistant',
       omitted: { mediaOnly: 0, failedTranscriptions: 0, pendingTranscriptions: 0, nonText: 0, overLimit: 0 },
       title: '',
       createdAt: '',
@@ -162,6 +164,7 @@ describe('conversationAssistantRepository', () => {
       chatDisplayName: 'Alice',
       lastTurnAt: '2026-06-30T10:03:00.000Z',
     });
+    expect(empty?.assistantRoleLabel).toBe('Assistant');
   });
 
   it('preserves unknown legacy models while defaulting missing model values', async () => {

--- a/apps/whatsapp-service/src/domain/conversation-assistant/ports.ts
+++ b/apps/whatsapp-service/src/domain/conversation-assistant/ports.ts
@@ -39,6 +39,7 @@ export interface ConversationAssistantLlmClientFactory {
 export interface ConversationAssistantPdfExportInput {
   title: string;
   modelName: string;
+  assistantRoleLabel: string;
   initialPrompt: string;
   generatedAt: string;
   sourceRange: ConversationAssistantDateRange;

--- a/apps/whatsapp-service/src/domain/conversation-assistant/roleInference.ts
+++ b/apps/whatsapp-service/src/domain/conversation-assistant/roleInference.ts
@@ -11,7 +11,7 @@ export const DEFAULT_CONVERSATION_ASSISTANT_ROLE_LABEL = 'Assistant';
 const MIN_ROLE_CONFIDENCE = 0.6;
 const ROLE_LABEL_PATTERN = /^[\p{L}\p{N}][\p{L}\p{N} .&'/-]{0,38}[\p{L}\p{N}]$/u;
 const HAS_LETTER_PATTERN = /\p{L}/u;
-const PERSONAL_TITLE_PATTERN = /\b(?:dr|mr|mrs|ms|prof)\.?\s*\p{L}/iu;
+const PERSONAL_TITLE_PATTERN = /\b(?:dr|mr|mrs|ms|prof)(?:\.|\s+)\s*\p{L}/iu;
 const COMMON_PERSON_NAME_PATTERN =
   /^(?:alex|alice|anna|ben|charles|david|emma|jane|john|julia|maria|michael|natalie|oliver|piotr|priya|robert|sarah|sophia|thomas|william)\s+\p{L}[\p{L}'-]*$/iu;
 const ORGANIZATION_PATTERN =

--- a/apps/whatsapp-service/src/domain/conversation-assistant/roleInference.ts
+++ b/apps/whatsapp-service/src/domain/conversation-assistant/roleInference.ts
@@ -17,6 +17,7 @@ const COMMON_PERSON_NAME_PATTERN =
 const ORGANIZATION_PATTERN =
   /(?:\b(?:acme|amazon|apple|contoso|google|intexuraos|meta|microsoft|openai|stripe|tesla)\b|\b(?:inc|llc|ltd|corp(?:oration)?|company|group|clinic|hospital|firm|partners|associates|team)\b$)/iu;
 const CREDENTIAL_PATTERN = /\b(?:licensed|certified|registered|accredited|phd|m\.?d\.?|esq\.?)\b/iu;
+const ROLE_LABEL_WORD_PATTERN = /\p{L}[\p{L}\p{N}]*/gu;
 
 export interface InferConversationAssistantRoleLabelInput {
   initialQuestion: string | undefined;
@@ -66,8 +67,8 @@ export function normalizeConversationAssistantRoleLabel(label: string): string {
     return DEFAULT_CONVERSATION_ASSISTANT_ROLE_LABEL;
   }
 
-  return collapsed
-    .split(' ')
-    .map((part) => `${part.slice(0, 1).toUpperCase()}${part.slice(1).toLowerCase()}`)
-    .join(' ');
+  return collapsed.replace(
+    ROLE_LABEL_WORD_PATTERN,
+    (word) => `${word.slice(0, 1).toUpperCase()}${word.slice(1).toLowerCase()}`
+  );
 }

--- a/apps/whatsapp-service/src/domain/conversation-assistant/roleInference.ts
+++ b/apps/whatsapp-service/src/domain/conversation-assistant/roleInference.ts
@@ -1,0 +1,73 @@
+import { generateStructured, type StructuredClient } from '@intexuraos/llm-utils';
+import {
+  CONVERSATION_ASSISTANT_ROLE_CLASSIFIER_PROMPT,
+  buildConversationAssistantRoleClassifierPrompt,
+  buildConversationAssistantRoleClassifierRepairPrompt,
+  conversationAssistantRoleClassificationSchema,
+} from '@intexuraos/llm-prompts';
+
+export const DEFAULT_CONVERSATION_ASSISTANT_ROLE_LABEL = 'Assistant';
+
+const MIN_ROLE_CONFIDENCE = 0.6;
+const ROLE_LABEL_PATTERN = /^[\p{L}\p{N}][\p{L}\p{N} .&'/-]{0,38}[\p{L}\p{N}]$/u;
+const HAS_LETTER_PATTERN = /\p{L}/u;
+const PERSONAL_TITLE_PATTERN = /\b(?:dr|mr|mrs|ms|prof)\.?\s*\p{L}/iu;
+const COMMON_PERSON_NAME_PATTERN =
+  /^(?:alex|alice|anna|ben|charles|david|emma|jane|john|julia|maria|michael|natalie|oliver|piotr|priya|robert|sarah|sophia|thomas|william)\s+\p{L}[\p{L}'-]*$/iu;
+const ORGANIZATION_PATTERN =
+  /(?:\b(?:acme|amazon|apple|contoso|google|intexuraos|meta|microsoft|openai|stripe|tesla)\b|\b(?:inc|llc|ltd|corp(?:oration)?|company|group|clinic|hospital|firm|partners|associates|team)\b$)/iu;
+const CREDENTIAL_PATTERN = /\b(?:licensed|certified|registered|accredited|phd|m\.?d\.?|esq\.?)\b/iu;
+
+export interface InferConversationAssistantRoleLabelInput {
+  initialQuestion: string | undefined;
+  client: StructuredClient;
+  sessionId: string;
+}
+
+export async function inferConversationAssistantRoleLabel(
+  input: InferConversationAssistantRoleLabelInput
+): Promise<string> {
+  const question = input.initialQuestion?.trim();
+  if (question === undefined || question.length === 0) {
+    return DEFAULT_CONVERSATION_ASSISTANT_ROLE_LABEL;
+  }
+
+  const result = await generateStructured({
+    client: input.client,
+    prompt: buildConversationAssistantRoleClassifierPrompt({ initialQuestion: question }),
+    schema: conversationAssistantRoleClassificationSchema,
+    promptType: CONVERSATION_ASSISTANT_ROLE_CLASSIFIER_PROMPT.promptType,
+    repairBuilder: buildConversationAssistantRoleClassifierRepairPrompt,
+    maxRepairAttempts: 1,
+    options: { correlation: { sessionId: input.sessionId } },
+  });
+
+  if (!result.ok || result.value.data.confidence < MIN_ROLE_CONFIDENCE) {
+    return DEFAULT_CONVERSATION_ASSISTANT_ROLE_LABEL;
+  }
+
+  return normalizeConversationAssistantRoleLabel(result.value.data.roleLabel);
+}
+
+export function normalizeConversationAssistantRoleLabel(label: string): string {
+  const collapsed = label.trim().replace(/\s+/g, ' ');
+  if (collapsed === DEFAULT_CONVERSATION_ASSISTANT_ROLE_LABEL) {
+    return DEFAULT_CONVERSATION_ASSISTANT_ROLE_LABEL;
+  }
+
+  if (
+    !ROLE_LABEL_PATTERN.test(collapsed) ||
+    !HAS_LETTER_PATTERN.test(collapsed) ||
+    PERSONAL_TITLE_PATTERN.test(collapsed) ||
+    COMMON_PERSON_NAME_PATTERN.test(collapsed) ||
+    ORGANIZATION_PATTERN.test(collapsed) ||
+    CREDENTIAL_PATTERN.test(collapsed)
+  ) {
+    return DEFAULT_CONVERSATION_ASSISTANT_ROLE_LABEL;
+  }
+
+  return collapsed
+    .split(' ')
+    .map((part) => `${part.slice(0, 1).toUpperCase()}${part.slice(1).toLowerCase()}`)
+    .join(' ');
+}

--- a/apps/whatsapp-service/src/domain/conversation-assistant/roleInference.ts
+++ b/apps/whatsapp-service/src/domain/conversation-assistant/roleInference.ts
@@ -18,6 +18,7 @@ const ORGANIZATION_PATTERN =
   /(?:\b(?:acme|amazon|apple|contoso|google|intexuraos|meta|microsoft|openai|stripe|tesla)\b|\b(?:inc|llc|ltd|corp(?:oration)?|company|group|clinic|hospital|firm|partners|associates|team)\b$)/iu;
 const CREDENTIAL_PATTERN = /\b(?:licensed|certified|registered|accredited|phd|m\.?d\.?|esq\.?)\b/iu;
 const ROLE_LABEL_WORD_PATTERN = /\p{L}[\p{L}\p{N}]*/gu;
+const ROLE_LABEL_MAX_WORDS = 3;
 
 export interface InferConversationAssistantRoleLabelInput {
   initialQuestion: string | undefined;
@@ -59,6 +60,7 @@ export function normalizeConversationAssistantRoleLabel(label: string): string {
   if (
     !ROLE_LABEL_PATTERN.test(collapsed) ||
     !HAS_LETTER_PATTERN.test(collapsed) ||
+    countRoleLabelWords(collapsed) > ROLE_LABEL_MAX_WORDS ||
     PERSONAL_TITLE_PATTERN.test(collapsed) ||
     COMMON_PERSON_NAME_PATTERN.test(collapsed) ||
     ORGANIZATION_PATTERN.test(collapsed) ||
@@ -71,4 +73,8 @@ export function normalizeConversationAssistantRoleLabel(label: string): string {
     ROLE_LABEL_WORD_PATTERN,
     (word) => `${word.slice(0, 1).toUpperCase()}${word.slice(1).toLowerCase()}`
   );
+}
+
+function countRoleLabelWords(label: string): number {
+  return Array.from(label.matchAll(ROLE_LABEL_WORD_PATTERN)).length;
 }

--- a/apps/whatsapp-service/src/domain/conversation-assistant/sessionUseCases.ts
+++ b/apps/whatsapp-service/src/domain/conversation-assistant/sessionUseCases.ts
@@ -335,6 +335,7 @@ export async function exportConversationAssistantSessionPdf(
   const exportResult = await deps.pdfExporter.exportConversation({
     title: session.title,
     modelName: getConversationAssistantModelDisplayName(session.model),
+    assistantRoleLabel: session.assistantRoleLabel,
     initialPrompt,
     generatedAt: deps.clock.now(),
     sourceRange: session.range,

--- a/apps/whatsapp-service/src/domain/conversation-assistant/sessionUseCases.ts
+++ b/apps/whatsapp-service/src/domain/conversation-assistant/sessionUseCases.ts
@@ -4,11 +4,16 @@ import type { GenerateChatResult, LLMError } from '@intexuraos/llm-factory';
 import {
   getConversationAssistantModelDisplayName,
   isConversationAssistantModel,
+  type ConversationAssistantModel,
 } from '@intexuraos/llm-contract';
 import {
   WHATSAPP_CONVERSATION_ASSISTANT_PROMPT,
   buildWhatsAppConversationAssistantMessages,
 } from '@intexuraos/llm-prompts';
+import {
+  DEFAULT_CONVERSATION_ASSISTANT_ROLE_LABEL,
+  inferConversationAssistantRoleLabel,
+} from './roleInference.js';
 import {
   buildPrivateConversationTranscriptText,
   projectPrivateConversationContext,
@@ -110,8 +115,18 @@ export async function createConversationAssistantSession(
   }
 
   const now = deps.clock.now();
+  const sessionId = deps.ids.sessionId();
+  const assistantRoleLabel = await inferRoleLabelForInitialQuestion(
+    {
+      userId: input.userId,
+      model: selectedModel,
+      sessionId,
+      question: input.question,
+    },
+    deps
+  );
   const session: ConversationAssistantSession = {
-    id: deps.ids.sessionId(),
+    id: sessionId,
     userId: input.userId,
     chatId: input.chatId,
     status: 'active',
@@ -124,6 +139,7 @@ export async function createConversationAssistantSession(
     transcriptSha256: context.transcriptSha256,
     transcriptMessageCount: context.messageCount,
     transcriptText: buildPrivateConversationTranscriptText(context.messages),
+    assistantRoleLabel,
     omitted: context.omitted,
     title: deriveTitle(chatLoadResult.value.chat.displayName, input.from, input.to, input.question),
     createdAt: now,
@@ -364,6 +380,35 @@ async function appendQuestionAndAssistantTurn(
   await persistAssistantTurnAndTouchSession(input.session, assistantTurn, deps);
 
   return { turns: [userTurn, assistantTurn] };
+}
+
+async function inferRoleLabelForInitialQuestion(
+  input: {
+    userId: string;
+    model: ConversationAssistantModel | string;
+    sessionId: string;
+    question: string | undefined;
+  },
+  deps: ConversationAssistantDeps
+): Promise<string> {
+  const question = input.question?.trim();
+  if (question === undefined || question.length === 0) {
+    return DEFAULT_CONVERSATION_ASSISTANT_ROLE_LABEL;
+  }
+
+  try {
+    const clientResult = await deps.llmClientFactory.createLlmClientForUser(input.userId, input.model);
+    if (!clientResult.ok) {
+      return DEFAULT_CONVERSATION_ASSISTANT_ROLE_LABEL;
+    }
+    return await inferConversationAssistantRoleLabel({
+      initialQuestion: question,
+      client: clientResult.value,
+      sessionId: input.sessionId,
+    });
+  } catch {
+    return DEFAULT_CONVERSATION_ASSISTANT_ROLE_LABEL;
+  }
 }
 
 async function loadOwnedDirectChat(

--- a/apps/whatsapp-service/src/domain/conversation-assistant/types.ts
+++ b/apps/whatsapp-service/src/domain/conversation-assistant/types.ts
@@ -4,6 +4,9 @@ import type {
   PrivateConversationContextOmittedCounts,
   PrivateConversationContextResponse,
 } from '../whatsapp/models/PrivateWhatsApp.js';
+import { DEFAULT_CONVERSATION_ASSISTANT_ROLE_LABEL } from './roleInference.js';
+
+export { DEFAULT_CONVERSATION_ASSISTANT_ROLE_LABEL };
 
 export type ConversationAssistantSessionStatus = 'active' | 'archived';
 export type ConversationAssistantTurnRole = 'user' | 'assistant';
@@ -20,6 +23,7 @@ export interface ConversationAssistantSession {
   transcriptSha256: string;
   transcriptMessageCount: number;
   transcriptText: string;
+  assistantRoleLabel: string;
   omitted: PrivateConversationContextOmittedCounts;
   title: string;
   createdAt: string;

--- a/apps/whatsapp-service/src/infra/firestore/conversationAssistantRepository.ts
+++ b/apps/whatsapp-service/src/infra/firestore/conversationAssistantRepository.ts
@@ -6,6 +6,7 @@ import type {
   ConversationAssistantSession,
   ConversationAssistantTurn,
 } from '../../domain/conversation-assistant/types.js';
+import { DEFAULT_CONVERSATION_ASSISTANT_ROLE_LABEL } from '../../domain/conversation-assistant/roleInference.js';
 
 export const WHATSAPP_CONVERSATION_ASSISTANT_SESSIONS_COLLECTION =
   'whatsapp_conversation_assistant_sessions';
@@ -144,6 +145,10 @@ function toSession(
     transcriptSha256: session?.transcriptSha256 ?? '',
     transcriptMessageCount: session?.transcriptMessageCount ?? 0,
     transcriptText: session?.transcriptText ?? '',
+    assistantRoleLabel:
+      typeof session?.assistantRoleLabel === 'string' && session.assistantRoleLabel.trim().length > 0
+        ? session.assistantRoleLabel
+        : DEFAULT_CONVERSATION_ASSISTANT_ROLE_LABEL,
     omitted: session?.omitted ?? {
       mediaOnly: 0,
       failedTranscriptions: 0,

--- a/packages/infra-pdf-export/src/__tests__/conversationPdfExporter.test.ts
+++ b/packages/infra-pdf-export/src/__tests__/conversationPdfExporter.test.ts
@@ -5,6 +5,7 @@ import type { PdfConversationExportInput } from '../types.js';
 const validInput: PdfConversationExportInput = {
   title: 'Alice context',
   modelName: 'MiniMax M3',
+  assistantRoleLabel: 'Psychologist',
   initialPrompt: 'What happened?',
   generatedAt: '2026-07-03T16:00:00.000Z',
   sourceRange: {
@@ -59,6 +60,7 @@ describe('createPdfConversationExporter', () => {
     const normalizedPdfText = normalizePdfText(readablePdfText);
     expect(readablePdfText).toContain('Alice context');
     expect(readablePdfText).toContain('Generated at 2026-07-03T16:00:00.000Z');
+    expect(readablePdfText).toContain('Assistant role: Psychologist');
     expect(readablePdfText).toContain(
       'Information range: 2026-06-30T00:00:00.000Z to 2026-07-01T00:00:00.000Z'
     );
@@ -69,6 +71,7 @@ describe('createPdfConversationExporter', () => {
     expect(readablePdfText).toContain('Messages excluded: 23');
     expect(readablePdfText).toContain('Media Only');
     expect(readablePdfText).toContain('Failed Transcriptions');
+    expect(readablePdfText).toContain('Psychologist (MiniMax M3)');
     expect(normalizedPdfText).toContain(normalizePdfText('Assistant answer with\nmultiple lines.'));
     expect(normalizedPdfText).toContain(normalizePdfText(validInput.messages[0]?.text ?? ''));
   });
@@ -84,6 +87,7 @@ describe('createPdfConversationExporter', () => {
     const invalidInputs: PdfConversationExportInput[] = [
       { ...validInput, title: '   ' },
       { ...validInput, modelName: '   ' },
+      { ...validInput, assistantRoleLabel: '   ' },
       { ...validInput, initialPrompt: '   ' },
       { ...validInput, generatedAt: '   ' },
       { ...validInput, sourceRange: { from: '', to: validInput.sourceRange.to } },
@@ -186,8 +190,9 @@ describe('createPdfConversationExporter', () => {
     const normalizedPdfText = normalizePdfText(readablePdfText);
     expect(readablePdfText).toContain('Decision summary');
     expect(readablePdfText).toContain('LLM model: Claude Sonnet 5');
+    expect(readablePdfText).toContain('Assistant role: Psychologist');
     expect(readablePdfText).toContain('Initial prompt: Please decide what to include.');
-    expect(readablePdfText).toContain('LLM response (Claude Sonnet 5)');
+    expect(readablePdfText).toContain('Psychologist (Claude Sonnet 5)');
     expect(readablePdfText).toContain('Decision');
     expect(readablePdfText).toContain(
       'Include the timeline and evidence (https://example.test/evidence).'
@@ -215,6 +220,7 @@ describe('createPdfConversationExporter', () => {
     const result = await exporter.exportConversation({
       title: validInput.title,
       modelName: validInput.modelName,
+      assistantRoleLabel: validInput.assistantRoleLabel,
       initialPrompt: validInput.initialPrompt,
       generatedAt: validInput.generatedAt,
       sourceRange: validInput.sourceRange,

--- a/packages/infra-pdf-export/src/conversationPdfExporter.ts
+++ b/packages/infra-pdf-export/src/conversationPdfExporter.ts
@@ -62,6 +62,13 @@ function validateInput(input: PdfConversationExportInput): PdfExportError | null
     };
   }
 
+  if (input.assistantRoleLabel.trim().length === 0) {
+    return {
+      code: 'INVALID_INPUT',
+      message: 'Conversation export assistantRoleLabel cannot be empty',
+    };
+  }
+
   if (input.initialPrompt.trim().length === 0) {
     return {
       code: 'INVALID_INPUT',
@@ -160,6 +167,7 @@ function drawConversation(doc: PDFKit.PDFDocument, input: PdfConversationExportI
 
   doc.moveDown(0.35);
   drawMetadataLine(doc, contentWidth, 'LLM model', input.modelName);
+  drawMetadataLine(doc, contentWidth, 'Assistant role', input.assistantRoleLabel);
   drawMetadataLine(doc, contentWidth, 'Initial prompt', toPlainPdfText(input.initialPrompt));
 
   doc.moveDown(0.9);
@@ -198,7 +206,15 @@ function drawConversation(doc: PDFKit.PDFDocument, input: PdfConversationExportI
   doc.moveDown(0.9);
 
   for (const message of input.messages) {
-    drawMessage(doc, contentWidth, message.role, message.createdAt, message.text, input.modelName);
+    drawMessage(
+      doc,
+      contentWidth,
+      message.role,
+      message.createdAt,
+      message.text,
+      input.modelName,
+      input.assistantRoleLabel
+    );
   }
 }
 
@@ -240,9 +256,10 @@ function drawMessage(
   role: 'user' | 'assistant',
   createdAt: string,
   text: string,
-  modelName: string
+  modelName: string,
+  assistantRoleLabel: string
 ): void {
-  const roleLabel = getMessageRoleLabel(role, modelName);
+  const roleLabel = getMessageRoleLabel(role, modelName, assistantRoleLabel);
   const headerText = `${roleLabel}  ${createdAt}`;
   const plainText = toPlainPdfText(text);
   const headerFont = fontForText(headerText, 'bold');
@@ -273,8 +290,12 @@ function drawMessage(
   doc.moveDown(0.8);
 }
 
-function getMessageRoleLabel(role: 'user' | 'assistant', modelName: string): string {
-  return role === 'assistant' ? `LLM response (${modelName})` : 'User';
+function getMessageRoleLabel(
+  role: 'user' | 'assistant',
+  modelName: string,
+  assistantRoleLabel: string
+): string {
+  return role === 'assistant' ? `${assistantRoleLabel} (${modelName})` : 'User';
 }
 
 function toPlainPdfText(text: string): string {

--- a/packages/infra-pdf-export/src/types.ts
+++ b/packages/infra-pdf-export/src/types.ts
@@ -6,6 +6,7 @@ export type PdfConversationMessageRole = 'user' | 'assistant';
 export interface PdfConversationExportInput {
   title: string;
   modelName: string;
+  assistantRoleLabel: string;
   initialPrompt: string;
   generatedAt: string;
   sourceRange: ConversationAssistantDateRange;

--- a/packages/llm-prompts/src/whatsapp-conversation-assistant/__tests__/roleClassifierPrompt.test.ts
+++ b/packages/llm-prompts/src/whatsapp-conversation-assistant/__tests__/roleClassifierPrompt.test.ts
@@ -8,7 +8,7 @@ import {
 
 describe('conversation assistant role classifier prompt', () => {
   it('exposes semver prompt metadata and a dedicated prompt type', () => {
-    expect(CONVERSATION_ASSISTANT_ROLE_CLASSIFIER_PROMPT.version).toBe('1.0.0');
+    expect(CONVERSATION_ASSISTANT_ROLE_CLASSIFIER_PROMPT.version).toBe('1.1.0');
     expect(CONVERSATION_ASSISTANT_ROLE_CLASSIFIER_PROMPT.promptType).toBe(
       'whatsapp-conversation-assistant-role-classifier'
     );
@@ -57,6 +57,41 @@ describe('conversation assistant role classifier prompt', () => {
       confidence: 0.91,
       rationale: 'The user asks about primary care.',
     });
+    const validSupportEngineer = conversationAssistantRoleClassificationSchema.safeParse({
+      roleLabel: 'Support Engineer',
+      confidence: 0.91,
+      rationale: 'The user asks about technical support.',
+    });
+    const validSystemsAnalyst = conversationAssistantRoleClassificationSchema.safeParse({
+      roleLabel: 'Systems Analyst',
+      confidence: 0.91,
+      rationale: 'The user asks about technical systems.',
+    });
+    const validSolutionsArchitect = conversationAssistantRoleClassificationSchema.safeParse({
+      roleLabel: 'Solutions Architect',
+      confidence: 0.91,
+      rationale: 'The user asks about solution design.',
+    });
+    const validBusinessStrategist = conversationAssistantRoleClassificationSchema.safeParse({
+      roleLabel: 'Business Strategist',
+      confidence: 0.91,
+      rationale: 'The user asks about business strategy.',
+    });
+    const validSecurityAnalyst = conversationAssistantRoleClassificationSchema.safeParse({
+      roleLabel: 'Security Analyst',
+      confidence: 0.91,
+      rationale: 'The user asks about security analysis.',
+    });
+    const validMarketingConsultant = conversationAssistantRoleClassificationSchema.safeParse({
+      roleLabel: 'Marketing Consultant',
+      confidence: 0.91,
+      rationale: 'The user asks about marketing.',
+    });
+    const validPolicyAdvisor = conversationAssistantRoleClassificationSchema.safeParse({
+      roleLabel: 'Policy Advisor',
+      confidence: 0.91,
+      rationale: 'The user asks about policy.',
+    });
     const invalid = conversationAssistantRoleClassificationSchema.safeParse({
       roleLabel: 'Employment Lawyer',
       confidence: 0.91,
@@ -70,6 +105,16 @@ describe('conversation assistant role classifier prompt', () => {
     });
     const personalTitle = conversationAssistantRoleClassificationSchema.safeParse({
       roleLabel: 'Dr. Alice',
+      confidence: 0.91,
+      rationale: 'The user asks about a health concern.',
+    });
+    const embeddedPersonalTitle = conversationAssistantRoleClassificationSchema.safeParse({
+      roleLabel: 'Advisor Dr. Smith',
+      confidence: 0.91,
+      rationale: 'The user asks about advice.',
+    });
+    const compactPersonalTitle = conversationAssistantRoleClassificationSchema.safeParse({
+      roleLabel: 'Dr.Alice',
       confidence: 0.91,
       rationale: 'The user asks about a health concern.',
     });
@@ -102,6 +147,26 @@ describe('conversation assistant role classifier prompt', () => {
       roleLabel: 'Microsoft Advisor',
       confidence: 0.91,
       rationale: 'The user asks about account access.',
+    });
+    const organizationStrategist = conversationAssistantRoleClassificationSchema.safeParse({
+      roleLabel: 'Amazon Strategist',
+      confidence: 0.91,
+      rationale: 'The user asks about marketplace strategy.',
+    });
+    const organizationAnalyst = conversationAssistantRoleClassificationSchema.safeParse({
+      roleLabel: 'Meta Analyst',
+      confidence: 0.91,
+      rationale: 'The user asks about an ad account.',
+    });
+    const organizationAdvisor = conversationAssistantRoleClassificationSchema.safeParse({
+      roleLabel: 'Contoso Advisor',
+      confidence: 0.91,
+      rationale: 'The user asks about an account.',
+    });
+    const organizationStrategistName = conversationAssistantRoleClassificationSchema.safeParse({
+      roleLabel: 'Intexuraos Strategist',
+      confidence: 0.91,
+      rationale: 'The user asks about an organization.',
     });
     const genericBrandSupport = conversationAssistantRoleClassificationSchema.safeParse({
       roleLabel: 'Stripe Support',
@@ -139,15 +204,28 @@ describe('conversation assistant role classifier prompt', () => {
     expect(validGroupRole.success).toBe(true);
     expect(validSocialWorker.success).toBe(true);
     expect(validFamilyPhysician.success).toBe(true);
+    expect(validSupportEngineer.success).toBe(true);
+    expect(validSystemsAnalyst.success).toBe(true);
+    expect(validSolutionsArchitect.success).toBe(true);
+    expect(validBusinessStrategist.success).toBe(true);
+    expect(validSecurityAnalyst.success).toBe(true);
+    expect(validMarketingConsultant.success).toBe(true);
+    expect(validPolicyAdvisor.success).toBe(true);
     expect(invalid.success).toBe(false);
     expect(markdown.success).toBe(false);
     expect(personalTitle.success).toBe(false);
+    expect(embeddedPersonalTitle.success).toBe(false);
+    expect(compactPersonalTitle.success).toBe(false);
     expect(credentialClaim.success).toBe(false);
     expect(singlePersonName.success).toBe(false);
     expect(organization.success).toBe(false);
     expect(organizationBrand.success).toBe(false);
     expect(reviewerOrganization.success).toBe(false);
     expect(secondReviewerOrganization.success).toBe(false);
+    expect(organizationStrategist.success).toBe(false);
+    expect(organizationAnalyst.success).toBe(false);
+    expect(organizationAdvisor.success).toBe(false);
+    expect(organizationStrategistName.success).toBe(false);
     expect(genericBrandSupport.success).toBe(false);
     expect(genericOrganizationTeam.success).toBe(false);
     expect(numericOnly.success).toBe(false);

--- a/packages/llm-prompts/src/whatsapp-conversation-assistant/__tests__/roleClassifierPrompt.test.ts
+++ b/packages/llm-prompts/src/whatsapp-conversation-assistant/__tests__/roleClassifierPrompt.test.ts
@@ -8,7 +8,7 @@ import {
 
 describe('conversation assistant role classifier prompt', () => {
   it('exposes semver prompt metadata and a dedicated prompt type', () => {
-    expect(CONVERSATION_ASSISTANT_ROLE_CLASSIFIER_PROMPT.version).toBe('1.1.0');
+    expect(CONVERSATION_ASSISTANT_ROLE_CLASSIFIER_PROMPT.version).toBe('1.1.1');
     expect(CONVERSATION_ASSISTANT_ROLE_CLASSIFIER_PROMPT.promptType).toBe(
       'whatsapp-conversation-assistant-role-classifier'
     );
@@ -91,6 +91,21 @@ describe('conversation assistant role classifier prompt', () => {
       roleLabel: 'Policy Advisor',
       confidence: 0.91,
       rationale: 'The user asks about policy.',
+    });
+    const validDriver = conversationAssistantRoleClassificationSchema.safeParse({
+      roleLabel: 'Driver',
+      confidence: 0.91,
+      rationale: 'The user asks about professional driving.',
+    });
+    const validDroneEngineer = conversationAssistantRoleClassificationSchema.safeParse({
+      roleLabel: 'Drone Engineer',
+      confidence: 0.91,
+      rationale: 'The user asks about drone engineering.',
+    });
+    const validDramaTeacher = conversationAssistantRoleClassificationSchema.safeParse({
+      roleLabel: 'Drama Teacher',
+      confidence: 0.91,
+      rationale: 'The user asks about drama instruction.',
     });
     const invalid = conversationAssistantRoleClassificationSchema.safeParse({
       roleLabel: 'Employment Lawyer',
@@ -216,6 +231,9 @@ describe('conversation assistant role classifier prompt', () => {
     expect(validSecurityAnalyst.success).toBe(true);
     expect(validMarketingConsultant.success).toBe(true);
     expect(validPolicyAdvisor.success).toBe(true);
+    expect(validDriver.success).toBe(true);
+    expect(validDroneEngineer.success).toBe(true);
+    expect(validDramaTeacher.success).toBe(true);
     expect(invalid.success).toBe(false);
     expect(markdown.success).toBe(false);
     expect(personalTitle.success).toBe(false);

--- a/packages/llm-prompts/src/whatsapp-conversation-assistant/__tests__/roleClassifierPrompt.test.ts
+++ b/packages/llm-prompts/src/whatsapp-conversation-assistant/__tests__/roleClassifierPrompt.test.ts
@@ -198,6 +198,11 @@ describe('conversation assistant role classifier prompt', () => {
       confidence: 0.91,
       rationale: 'The user asks about legal options.',
     });
+    const tooManyWords = conversationAssistantRoleClassificationSchema.safeParse({
+      roleLabel: 'Customer Success Support Engineer',
+      confidence: 0.91,
+      rationale: 'The user asks about technical customer support.',
+    });
 
     expect(valid.success).toBe(true);
     expect(validClinicRole.success).toBe(true);
@@ -232,6 +237,7 @@ describe('conversation assistant role classifier prompt', () => {
     expect(repeatedSlashes.success).toBe(false);
     expect(repeatedHyphens.success).toBe(false);
     expect(trailingPunctuation.success).toBe(false);
+    expect(tooManyWords.success).toBe(false);
   });
 
   it('builds a repair prompt from invalid raw output and schema details', () => {

--- a/packages/llm-prompts/src/whatsapp-conversation-assistant/__tests__/roleClassifierPrompt.test.ts
+++ b/packages/llm-prompts/src/whatsapp-conversation-assistant/__tests__/roleClassifierPrompt.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CONVERSATION_ASSISTANT_ROLE_CLASSIFIER_PROMPT,
+  buildConversationAssistantRoleClassifierPrompt,
+  buildConversationAssistantRoleClassifierRepairPrompt,
+  conversationAssistantRoleClassificationSchema,
+} from '../roleClassifierPrompt.js';
+
+describe('conversation assistant role classifier prompt', () => {
+  it('exposes semver prompt metadata and a dedicated prompt type', () => {
+    expect(CONVERSATION_ASSISTANT_ROLE_CLASSIFIER_PROMPT.version).toBe('1.0.0');
+    expect(CONVERSATION_ASSISTANT_ROLE_CLASSIFIER_PROMPT.promptType).toBe(
+      'whatsapp-conversation-assistant-role-classifier'
+    );
+  });
+
+  it('asks for an unrestricted professional role label as strict JSON', () => {
+    const prompt = buildConversationAssistantRoleClassifierPrompt({
+      initialQuestion: 'My employer is threatening me. What are my options?',
+    });
+
+    expect(prompt).toContain('Return only JSON');
+    expect(prompt).toContain('roleLabel');
+    expect(prompt).toContain('confidence');
+    expect(prompt).toContain('not a fixed enum');
+    expect(prompt).toContain('Assistant');
+    expect(prompt).toContain('lawyer');
+    expect(prompt).toContain('maximum three words');
+    expect(prompt).toContain('personal title');
+    expect(prompt).toContain('punctuation-heavy');
+    expect(prompt).not.toContain('Transcript follows');
+  });
+
+  it('validates the expected schema and rejects extra fields and unsafe labels', () => {
+    const valid = conversationAssistantRoleClassificationSchema.safeParse({
+      roleLabel: 'Employment Lawyer',
+      confidence: 0.91,
+      rationale: 'The user asks about employment legal options.',
+    });
+    const validClinicRole = conversationAssistantRoleClassificationSchema.safeParse({
+      roleLabel: 'Clinic Psychologist',
+      confidence: 0.91,
+      rationale: 'The user asks about clinical mental health support.',
+    });
+    const validGroupRole = conversationAssistantRoleClassificationSchema.safeParse({
+      roleLabel: 'Group Therapist',
+      confidence: 0.91,
+      rationale: 'The user asks about group therapy.',
+    });
+    const validSocialWorker = conversationAssistantRoleClassificationSchema.safeParse({
+      roleLabel: 'Social Worker',
+      confidence: 0.91,
+      rationale: 'The user asks about social support.',
+    });
+    const validFamilyPhysician = conversationAssistantRoleClassificationSchema.safeParse({
+      roleLabel: 'Family Physician',
+      confidence: 0.91,
+      rationale: 'The user asks about primary care.',
+    });
+    const invalid = conversationAssistantRoleClassificationSchema.safeParse({
+      roleLabel: 'Employment Lawyer',
+      confidence: 0.91,
+      rationale: 'The user asks about employment legal options.',
+      extra: true,
+    });
+    const markdown = conversationAssistantRoleClassificationSchema.safeParse({
+      roleLabel: '**Lawyer**',
+      confidence: 0.91,
+      rationale: 'The user asks about employment legal options.',
+    });
+    const personalTitle = conversationAssistantRoleClassificationSchema.safeParse({
+      roleLabel: 'Dr. Alice',
+      confidence: 0.91,
+      rationale: 'The user asks about a health concern.',
+    });
+    const credentialClaim = conversationAssistantRoleClassificationSchema.safeParse({
+      roleLabel: 'Certified Tax Advisor',
+      confidence: 0.91,
+      rationale: 'The user asks about tax filing.',
+    });
+    const singlePersonName = conversationAssistantRoleClassificationSchema.safeParse({
+      roleLabel: 'Alice',
+      confidence: 0.91,
+      rationale: 'The user asks about a health concern.',
+    });
+    const organization = conversationAssistantRoleClassificationSchema.safeParse({
+      roleLabel: 'Acme Legal Group',
+      confidence: 0.91,
+      rationale: 'The user asks about legal options.',
+    });
+    const organizationBrand = conversationAssistantRoleClassificationSchema.safeParse({
+      roleLabel: 'Google Support',
+      confidence: 0.91,
+      rationale: 'The user asks about account access.',
+    });
+    const reviewerOrganization = conversationAssistantRoleClassificationSchema.safeParse({
+      roleLabel: 'OpenAI Support',
+      confidence: 0.91,
+      rationale: 'The user asks about account access.',
+    });
+    const secondReviewerOrganization = conversationAssistantRoleClassificationSchema.safeParse({
+      roleLabel: 'Microsoft Advisor',
+      confidence: 0.91,
+      rationale: 'The user asks about account access.',
+    });
+    const genericBrandSupport = conversationAssistantRoleClassificationSchema.safeParse({
+      roleLabel: 'Stripe Support',
+      confidence: 0.91,
+      rationale: 'The user asks about account access.',
+    });
+    const genericOrganizationTeam = conversationAssistantRoleClassificationSchema.safeParse({
+      roleLabel: 'Beta Team',
+      confidence: 0.91,
+      rationale: 'The user asks about account access.',
+    });
+    const numericOnly = conversationAssistantRoleClassificationSchema.safeParse({
+      roleLabel: '123',
+      confidence: 0.91,
+      rationale: 'The user asks a numeric question.',
+    });
+    const repeatedSlashes = conversationAssistantRoleClassificationSchema.safeParse({
+      roleLabel: 'Lawyer///Coach',
+      confidence: 0.91,
+      rationale: 'The user asks about legal and coaching support.',
+    });
+    const repeatedHyphens = conversationAssistantRoleClassificationSchema.safeParse({
+      roleLabel: 'Tax---Advisor',
+      confidence: 0.91,
+      rationale: 'The user asks about tax filing.',
+    });
+    const trailingPunctuation = conversationAssistantRoleClassificationSchema.safeParse({
+      roleLabel: 'Lawyer!',
+      confidence: 0.91,
+      rationale: 'The user asks about legal options.',
+    });
+
+    expect(valid.success).toBe(true);
+    expect(validClinicRole.success).toBe(true);
+    expect(validGroupRole.success).toBe(true);
+    expect(validSocialWorker.success).toBe(true);
+    expect(validFamilyPhysician.success).toBe(true);
+    expect(invalid.success).toBe(false);
+    expect(markdown.success).toBe(false);
+    expect(personalTitle.success).toBe(false);
+    expect(credentialClaim.success).toBe(false);
+    expect(singlePersonName.success).toBe(false);
+    expect(organization.success).toBe(false);
+    expect(organizationBrand.success).toBe(false);
+    expect(reviewerOrganization.success).toBe(false);
+    expect(secondReviewerOrganization.success).toBe(false);
+    expect(genericBrandSupport.success).toBe(false);
+    expect(genericOrganizationTeam.success).toBe(false);
+    expect(numericOnly.success).toBe(false);
+    expect(repeatedSlashes.success).toBe(false);
+    expect(repeatedHyphens.success).toBe(false);
+    expect(trailingPunctuation.success).toBe(false);
+  });
+
+  it('builds a repair prompt from invalid raw output and schema details', () => {
+    const parsed = conversationAssistantRoleClassificationSchema.safeParse({ roleLabel: '' });
+    expect(parsed.success).toBe(false);
+    if (parsed.success) return;
+
+    const repair = buildConversationAssistantRoleClassifierRepairPrompt('not json', parsed.error);
+
+    expect(repair).toContain('not json');
+    expect(repair).toContain('Return only valid JSON');
+    expect(repair).toContain('roleLabel');
+  });
+});

--- a/packages/llm-prompts/src/whatsapp-conversation-assistant/index.ts
+++ b/packages/llm-prompts/src/whatsapp-conversation-assistant/index.ts
@@ -3,3 +3,11 @@ export {
   buildWhatsAppConversationAssistantMessages,
   type WhatsAppConversationAssistantPromptInput,
 } from './conversationAssistantPrompt.js';
+export {
+  CONVERSATION_ASSISTANT_ROLE_CLASSIFIER_PROMPT,
+  buildConversationAssistantRoleClassifierPrompt,
+  buildConversationAssistantRoleClassifierRepairPrompt,
+  conversationAssistantRoleClassificationSchema,
+  type ConversationAssistantRoleClassification,
+  type ConversationAssistantRoleClassifierPromptInput,
+} from './roleClassifierPrompt.js';

--- a/packages/llm-prompts/src/whatsapp-conversation-assistant/roleClassifierPrompt.ts
+++ b/packages/llm-prompts/src/whatsapp-conversation-assistant/roleClassifierPrompt.ts
@@ -10,6 +10,8 @@ export const CONVERSATION_ASSISTANT_ROLE_CLASSIFIER_PROMPT = {
 const ROLE_LABEL_SAFE_CHARACTERS_PATTERN = /^[\p{L}\p{N}][\p{L}\p{N} .&'/-]{0,38}[\p{L}\p{N}]$/u;
 const ROLE_LABEL_HAS_LETTER_PATTERN = /\p{L}/u;
 const ROLE_LABEL_REPEATED_PUNCTUATION_PATTERN = /[.&'/-]{2,}/u;
+const ROLE_LABEL_WORD_PATTERN = /\p{L}[\p{L}\p{N}]*/gu;
+const ROLE_LABEL_MAX_WORDS = 3;
 const ROLE_LABEL_PERSONAL_TITLE_PATTERN = /\b(?:dr|mr|mrs|ms|prof)\.?\s*\p{L}/iu;
 const ROLE_LABEL_COMMON_SINGLE_NAME_PATTERN =
   /^(?:alex|alice|anna|ben|charles|david|emma|jane|john|julia|maria|michael|natalie|oliver|piotr|priya|robert|sarah|sophia|thomas|william)$/iu;
@@ -17,6 +19,10 @@ const ROLE_LABEL_ORGANIZATION_PATTERN =
   /(?:\b(?:acme|amazon|apple|contoso|google|intexuraos|meta|microsoft|openai|stripe|tesla)\b|\b(?:inc|llc|ltd|corp(?:oration)?|company|group|clinic|hospital|firm|partners|associates|team)\b$)/iu;
 const ROLE_LABEL_CREDENTIAL_PATTERN =
   /\b(?:licensed|certified|registered|accredited|phd|m\.?d\.?|esq\.?)\b/iu;
+
+function countRoleLabelWords(label: string): number {
+  return Array.from(label.matchAll(ROLE_LABEL_WORD_PATTERN)).length;
+}
 
 export const conversationAssistantRoleClassificationSchema = z
   .object({
@@ -34,6 +40,9 @@ export const conversationAssistantRoleClassificationSchema = z
       })
       .refine((label) => !ROLE_LABEL_REPEATED_PUNCTUATION_PATTERN.test(label), {
         message: 'roleLabel must not be punctuation-heavy',
+      })
+      .refine((label) => countRoleLabelWords(label) <= ROLE_LABEL_MAX_WORDS, {
+        message: 'roleLabel must be at most three words',
       })
       .refine((label) => !ROLE_LABEL_PERSONAL_TITLE_PATTERN.test(label), {
         message: 'roleLabel must not contain a personal title',

--- a/packages/llm-prompts/src/whatsapp-conversation-assistant/roleClassifierPrompt.ts
+++ b/packages/llm-prompts/src/whatsapp-conversation-assistant/roleClassifierPrompt.ts
@@ -3,19 +3,20 @@ import { z } from 'zod';
 import type { PromptBuilder } from '../shared/types.js';
 
 export const CONVERSATION_ASSISTANT_ROLE_CLASSIFIER_PROMPT = {
-  version: '1.0.0',
+  version: '1.1.0',
   promptType: 'whatsapp-conversation-assistant-role-classifier',
 } as const;
 
 const ROLE_LABEL_SAFE_CHARACTERS_PATTERN = /^[\p{L}\p{N}][\p{L}\p{N} .&'/-]{0,38}[\p{L}\p{N}]$/u;
 const ROLE_LABEL_HAS_LETTER_PATTERN = /\p{L}/u;
 const ROLE_LABEL_REPEATED_PUNCTUATION_PATTERN = /[.&'/-]{2,}/u;
-const ROLE_LABEL_PERSONAL_TITLE_PATTERN = /^(?:dr|mr|mrs|ms|prof)\.?\s+\p{L}/iu;
+const ROLE_LABEL_PERSONAL_TITLE_PATTERN = /\b(?:dr|mr|mrs|ms|prof)\.?\s*\p{L}/iu;
 const ROLE_LABEL_COMMON_SINGLE_NAME_PATTERN =
   /^(?:alex|alice|anna|ben|charles|david|emma|jane|john|julia|maria|michael|natalie|oliver|piotr|priya|robert|sarah|sophia|thomas|william)$/iu;
 const ROLE_LABEL_ORGANIZATION_PATTERN =
-  /(?:\b(?:acme|google|microsoft|openai)\b|\b(?:inc|llc|ltd|corp(?:oration)?|company|group|clinic|hospital|firm|partners|associates|support|team|services?|labs|systems|technologies|solutions)\b$)/iu;
-const ROLE_LABEL_CREDENTIAL_PATTERN = /\b(?:licensed|certified|registered|accredited|phd|m\.?d\.?|esq\.?)\b/iu;
+  /(?:\b(?:acme|amazon|apple|contoso|google|intexuraos|meta|microsoft|openai|stripe|tesla)\b|\b(?:inc|llc|ltd|corp(?:oration)?|company|group|clinic|hospital|firm|partners|associates|team)\b$)/iu;
+const ROLE_LABEL_CREDENTIAL_PATTERN =
+  /\b(?:licensed|certified|registered|accredited|phd|m\.?d\.?|esq\.?)\b/iu;
 
 export const conversationAssistantRoleClassificationSchema = z
   .object({
@@ -35,7 +36,7 @@ export const conversationAssistantRoleClassificationSchema = z
         message: 'roleLabel must not be punctuation-heavy',
       })
       .refine((label) => !ROLE_LABEL_PERSONAL_TITLE_PATTERN.test(label), {
-        message: 'roleLabel must not start with a personal title',
+        message: 'roleLabel must not contain a personal title',
       })
       .refine((label) => !ROLE_LABEL_COMMON_SINGLE_NAME_PATTERN.test(label), {
         message: 'roleLabel must not be a person name',
@@ -63,7 +64,7 @@ export const conversationAssistantRoleClassifierPrompt: PromptBuilder<Conversati
   {
     name: 'whatsapp-conversation-assistant-role-classifier',
     description: 'Infers the expert role label to display for a WhatsApp assistant session',
-    version: '1.0.0',
+    version: '1.1.0',
     build(input: ConversationAssistantRoleClassifierPromptInput): string {
       return [
         'Infer the professional or expert role label that should be displayed for an assistant session.',
@@ -89,7 +90,7 @@ export const conversationAssistantRoleClassifierRepairPrompt: PromptBuilder<Conv
   {
     name: 'whatsapp-conversation-assistant-role-classifier-repair',
     description: 'Repairs invalid role-classification JSON for WhatsApp assistant sessions',
-    version: '1.0.0',
+    version: '1.1.0',
     build(input: ConversationAssistantRoleClassifierRepairPromptInput): string {
       return [
         'The previous role-classification response was invalid.',

--- a/packages/llm-prompts/src/whatsapp-conversation-assistant/roleClassifierPrompt.ts
+++ b/packages/llm-prompts/src/whatsapp-conversation-assistant/roleClassifierPrompt.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import type { PromptBuilder } from '../shared/types.js';
 
 export const CONVERSATION_ASSISTANT_ROLE_CLASSIFIER_PROMPT = {
-  version: '1.1.0',
+  version: '1.1.1',
   promptType: 'whatsapp-conversation-assistant-role-classifier',
 } as const;
 
@@ -12,7 +12,7 @@ const ROLE_LABEL_HAS_LETTER_PATTERN = /\p{L}/u;
 const ROLE_LABEL_REPEATED_PUNCTUATION_PATTERN = /[.&'/-]{2,}/u;
 const ROLE_LABEL_WORD_PATTERN = /\p{L}[\p{L}\p{N}]*/gu;
 const ROLE_LABEL_MAX_WORDS = 3;
-const ROLE_LABEL_PERSONAL_TITLE_PATTERN = /\b(?:dr|mr|mrs|ms|prof)\.?\s*\p{L}/iu;
+const ROLE_LABEL_PERSONAL_TITLE_PATTERN = /\b(?:dr|mr|mrs|ms|prof)(?:\.|\s+)\s*\p{L}/iu;
 const ROLE_LABEL_COMMON_SINGLE_NAME_PATTERN =
   /^(?:alex|alice|anna|ben|charles|david|emma|jane|john|julia|maria|michael|natalie|oliver|piotr|priya|robert|sarah|sophia|thomas|william)$/iu;
 const ROLE_LABEL_ORGANIZATION_PATTERN =
@@ -73,7 +73,7 @@ export const conversationAssistantRoleClassifierPrompt: PromptBuilder<Conversati
   {
     name: 'whatsapp-conversation-assistant-role-classifier',
     description: 'Infers the expert role label to display for a WhatsApp assistant session',
-    version: '1.1.0',
+    version: '1.1.1',
     build(input: ConversationAssistantRoleClassifierPromptInput): string {
       return [
         'Infer the professional or expert role label that should be displayed for an assistant session.',

--- a/packages/llm-prompts/src/whatsapp-conversation-assistant/roleClassifierPrompt.ts
+++ b/packages/llm-prompts/src/whatsapp-conversation-assistant/roleClassifierPrompt.ts
@@ -1,0 +1,113 @@
+import { formatZodErrors } from '@intexuraos/llm-utils';
+import { z } from 'zod';
+import type { PromptBuilder } from '../shared/types.js';
+
+export const CONVERSATION_ASSISTANT_ROLE_CLASSIFIER_PROMPT = {
+  version: '1.0.0',
+  promptType: 'whatsapp-conversation-assistant-role-classifier',
+} as const;
+
+const ROLE_LABEL_SAFE_CHARACTERS_PATTERN = /^[\p{L}\p{N}][\p{L}\p{N} .&'/-]{0,38}[\p{L}\p{N}]$/u;
+const ROLE_LABEL_HAS_LETTER_PATTERN = /\p{L}/u;
+const ROLE_LABEL_REPEATED_PUNCTUATION_PATTERN = /[.&'/-]{2,}/u;
+const ROLE_LABEL_PERSONAL_TITLE_PATTERN = /^(?:dr|mr|mrs|ms|prof)\.?\s+\p{L}/iu;
+const ROLE_LABEL_COMMON_SINGLE_NAME_PATTERN =
+  /^(?:alex|alice|anna|ben|charles|david|emma|jane|john|julia|maria|michael|natalie|oliver|piotr|priya|robert|sarah|sophia|thomas|william)$/iu;
+const ROLE_LABEL_ORGANIZATION_PATTERN =
+  /(?:\b(?:acme|google|microsoft|openai)\b|\b(?:inc|llc|ltd|corp(?:oration)?|company|group|clinic|hospital|firm|partners|associates|support|team|services?|labs|systems|technologies|solutions)\b$)/iu;
+const ROLE_LABEL_CREDENTIAL_PATTERN = /\b(?:licensed|certified|registered|accredited|phd|m\.?d\.?|esq\.?)\b/iu;
+
+export const conversationAssistantRoleClassificationSchema = z
+  .object({
+    roleLabel: z
+      .string()
+      .trim()
+      .min(2)
+      .max(40)
+      .refine((label) => ROLE_LABEL_HAS_LETTER_PATTERN.test(label), {
+        message: 'roleLabel must contain at least one letter',
+      })
+      .refine((label) => ROLE_LABEL_SAFE_CHARACTERS_PATTERN.test(label), {
+        message:
+          'roleLabel may only contain letters, numbers, spaces, apostrophes, hyphens, slashes, ampersands, and periods; it must not end with punctuation',
+      })
+      .refine((label) => !ROLE_LABEL_REPEATED_PUNCTUATION_PATTERN.test(label), {
+        message: 'roleLabel must not be punctuation-heavy',
+      })
+      .refine((label) => !ROLE_LABEL_PERSONAL_TITLE_PATTERN.test(label), {
+        message: 'roleLabel must not start with a personal title',
+      })
+      .refine((label) => !ROLE_LABEL_COMMON_SINGLE_NAME_PATTERN.test(label), {
+        message: 'roleLabel must not be a person name',
+      })
+      .refine((label) => !ROLE_LABEL_ORGANIZATION_PATTERN.test(label), {
+        message: 'roleLabel must not be an organization name',
+      })
+      .refine((label) => !ROLE_LABEL_CREDENTIAL_PATTERN.test(label), {
+        message: 'roleLabel must not contain credential claims',
+      }),
+    confidence: z.number().min(0).max(1),
+    rationale: z.string().trim().max(240),
+  })
+  .strict();
+
+export type ConversationAssistantRoleClassification = z.infer<
+  typeof conversationAssistantRoleClassificationSchema
+>;
+
+export interface ConversationAssistantRoleClassifierPromptInput {
+  initialQuestion: string;
+}
+
+export const conversationAssistantRoleClassifierPrompt: PromptBuilder<ConversationAssistantRoleClassifierPromptInput> =
+  {
+    name: 'whatsapp-conversation-assistant-role-classifier',
+    description: 'Infers the expert role label to display for a WhatsApp assistant session',
+    version: '1.0.0',
+    build(input: ConversationAssistantRoleClassifierPromptInput): string {
+      return [
+        'Infer the professional or expert role label that should be displayed for an assistant session.',
+        'Use only the initial user question. Do not use or request the private WhatsApp transcript.',
+        'The role label is not a fixed enum: allow any real profession or expert role when strongly implied.',
+        'Examples include doctor, psychologist, lawyer, software engineer, tax advisor, teacher, mediator, mechanic, career coach, and other professions.',
+        'If the question is generic, unclear, casual, or not profession-specific, use roleLabel "Assistant" with confidence below 0.6.',
+        'Return one concise display label, maximum three words and 40 characters.',
+        'Do not output a person name, personal title such as Dr. or Prof., company/organization name, credentials, markdown, punctuation-heavy label, explanations outside JSON, or claims like licensed/certified.',
+        'Return only JSON matching this shape: {"roleLabel":"string","confidence":0.0,"rationale":"string"}.',
+        '',
+        `Initial question:\n${input.initialQuestion.trim()}`,
+      ].join('\n');
+    },
+  };
+
+export interface ConversationAssistantRoleClassifierRepairPromptInput {
+  raw: string;
+  error: z.ZodError;
+}
+
+export const conversationAssistantRoleClassifierRepairPrompt: PromptBuilder<ConversationAssistantRoleClassifierRepairPromptInput> =
+  {
+    name: 'whatsapp-conversation-assistant-role-classifier-repair',
+    description: 'Repairs invalid role-classification JSON for WhatsApp assistant sessions',
+    version: '1.0.0',
+    build(input: ConversationAssistantRoleClassifierRepairPromptInput): string {
+      return [
+        'The previous role-classification response was invalid.',
+        `Validation errors: ${formatZodErrors(input.error)}`,
+        'Return only valid JSON with roleLabel, confidence, and rationale.',
+        'Use roleLabel "Assistant" with low confidence when the initial question does not clearly imply a profession.',
+        '',
+        'Invalid response:',
+        input.raw,
+      ].join('\n');
+    },
+  };
+
+export const buildConversationAssistantRoleClassifierPrompt = (
+  input: ConversationAssistantRoleClassifierPromptInput
+): string => conversationAssistantRoleClassifierPrompt.build(input);
+
+export const buildConversationAssistantRoleClassifierRepairPrompt = (
+  raw: string,
+  error: z.ZodError
+): string => conversationAssistantRoleClassifierRepairPrompt.build({ raw, error });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -535,6 +535,9 @@ importers:
       '@intexuraos/llm-prompts':
         specifier: workspace:*
         version: link:../../packages/llm-prompts
+      '@intexuraos/llm-utils':
+        specifier: workspace:*
+        version: link:../../packages/llm-utils
       fastify:
         specifier: 'catalog:'
         version: 5.6.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -535,9 +535,6 @@ importers:
       '@intexuraos/llm-prompts':
         specifier: workspace:*
         version: link:../../packages/llm-prompts
-      '@intexuraos/llm-utils':
-        specifier: workspace:*
-        version: link:../../packages/llm-utils
       fastify:
         specifier: 'catalog:'
         version: 5.6.2
@@ -1343,6 +1340,9 @@ importers:
       '@intexuraos/llm-prompts':
         specifier: workspace:*
         version: link:../../packages/llm-prompts
+      '@intexuraos/llm-utils':
+        specifier: workspace:*
+        version: link:../../packages/llm-utils
       fastify:
         specifier: 'catalog:'
         version: 5.6.2


### PR DESCRIPTION
## Summary

- Add a versioned Conversation Assistant role-classifier prompt and role-label inference in whatsapp-service
- Surface assistantRoleLabel through the Conversation Assistant API, PDF export, and web UI
- Recover and complete the failed CodeTask task_e994bf36-2095-4d49-8561-00c2bdb71176 after TASK_INACTIVITY_RESTART_FAILED

## Verification

- `pnpm run verify:workspace:tracked llm-prompts`
- `pnpm run verify:workspace:tracked whatsapp-service`
- `pnpm run verify:workspace:tracked infra-pdf-export`
- `pnpm run verify:workspace:tracked web`
- `pnpm run ci:tracked`

Fixes INT-1853

- Linear: [INT-1853](https://linear.app/pbuchman/issue/INT-1853)
- IntexuraOS Code Task: [View task](https://intexuraos.cloud/#/code-tasks/task_852b1368-8350-4a36-8262-244e893eb465)
- Worker Type: `codex-xhigh`
- Model: `default`


