### PR TITLE
[INT-1856] fix: chunk Conversation Assistant transcripts

### DIFF
--- a/apps/whatsapp-service/src/__tests__/infra/conversationAssistantRepository.test.ts
+++ b/apps/whatsapp-service/src/__tests__/infra/conversationAssistantRepository.test.ts
@@ -3,7 +3,9 @@ import { createFakeFirestore, resetFirestore, setFirestore } from '@intexuraos/i
 import { DEFAULT_CONVERSATION_ASSISTANT_MODEL } from '@intexuraos/llm-contract';
 import {
   createConversationAssistantRepository,
+  TRANSCRIPT_CHUNK_MAX_BYTES,
   WHATSAPP_CONVERSATION_ASSISTANT_SESSIONS_COLLECTION,
+  WHATSAPP_CONVERSATION_ASSISTANT_TRANSCRIPT_CHUNKS_COLLECTION,
   WHATSAPP_CONVERSATION_ASSISTANT_TURNS_COLLECTION,
 } from '../../infra/firestore/conversationAssistantRepository.js';
 import type {
@@ -59,8 +61,9 @@ describe('conversationAssistantRepository', () => {
     resetFirestore();
   });
 
-  it('stores private transcript text on sessions and lists only the owning user sessions', async () => {
-    await repository.saveSession(makeSession());
+  it('stores private transcript text in chunks and lists only the owning user sessions', async () => {
+    const transcriptText = `${'a'.repeat(TRANSCRIPT_CHUNK_MAX_BYTES)}b`;
+    await repository.saveSession(makeSession({ transcriptText }));
     await repository.saveSession(
       makeSession({
         id: 'whatsapp_conv_session_other',
@@ -75,10 +78,34 @@ describe('conversationAssistantRepository', () => {
       .collection(WHATSAPP_CONVERSATION_ASSISTANT_SESSIONS_COLLECTION)
       .doc('whatsapp_conv_session_1')
       .get();
+    const firstChunk = await fakeFirestore
+      .collection(WHATSAPP_CONVERSATION_ASSISTANT_TRANSCRIPT_CHUNKS_COLLECTION)
+      .doc('whatsapp_conv_session_1_000000')
+      .get();
+    const secondChunk = await fakeFirestore
+      .collection(WHATSAPP_CONVERSATION_ASSISTANT_TRANSCRIPT_CHUNKS_COLLECTION)
+      .doc('whatsapp_conv_session_1_000001')
+      .get();
 
-    expect(loaded?.transcriptText).toContain('Alice: hello');
+    expect(loaded?.transcriptText).toBe(transcriptText);
     expect(listed.map((session) => session.id)).toEqual(['whatsapp_conv_session_1']);
-    expect(storedDoc.data()?.['transcriptText']).toContain('Alice: hello');
+    expect(storedDoc.data()?.['transcriptText']).toBeUndefined();
+    expect(storedDoc.data()?.['transcriptStorage']).toEqual({
+      type: 'chunks',
+      chunkCount: 2,
+      chunkSizeBytes: TRANSCRIPT_CHUNK_MAX_BYTES,
+      byteLength: TRANSCRIPT_CHUNK_MAX_BYTES + 1,
+    });
+    expect(firstChunk.data()).toMatchObject({
+      sessionId: 'whatsapp_conv_session_1',
+      chunkIndex: 0,
+      text: 'a'.repeat(TRANSCRIPT_CHUNK_MAX_BYTES),
+    });
+    expect(secondChunk.data()).toMatchObject({
+      sessionId: 'whatsapp_conv_session_1',
+      chunkIndex: 1,
+      text: 'b',
+    });
   });
 
   it('stores and lists turns chronologically by session', async () => {
@@ -96,8 +123,9 @@ describe('conversationAssistantRepository', () => {
     expect(storedDoc.data()?.['role']).toBe('assistant');
   });
 
-  it('loads a session snapshot with turns from one repository call', async () => {
-    await repository.saveSession(makeSession());
+  it('loads a session snapshot with hydrated transcript chunks and turns from one repository call', async () => {
+    const transcriptText = `${'x'.repeat(TRANSCRIPT_CHUNK_MAX_BYTES)}y`;
+    await repository.saveSession(makeSession({ transcriptText }));
     await repository.saveTurn(makeTurn({ id: 'turn-2', role: 'assistant', createdAt: '2026-06-30T10:02:00.000Z' }));
     await repository.saveTurn(makeTurn({ id: 'turn-1', role: 'user', createdAt: '2026-06-30T10:01:00.000Z' }));
     await repository.saveTurn(makeTurn({ id: 'foreign-turn', sessionId: 'other-session' }));
@@ -119,9 +147,127 @@ describe('conversationAssistantRepository', () => {
     });
 
     expect(snapshot?.session.id).toBe('whatsapp_conv_session_1');
+    expect(snapshot?.session.transcriptText).toBe(transcriptText);
     expect(snapshot?.turns.map((turn) => turn.id)).toEqual(['turn-1', 'turn-2']);
     expect(missing).toBeNull();
     expect(foreign).toBeNull();
+  });
+
+  it('hydrates legacy sessions that still store transcript text inline', async () => {
+    await fakeFirestore
+      .collection(WHATSAPP_CONVERSATION_ASSISTANT_SESSIONS_COLLECTION)
+      .doc('whatsapp_conv_session_legacy_inline')
+      .set(makeSession({ transcriptText: 'legacy inline transcript' }));
+
+    const loaded = await repository.getSessionById('whatsapp_conv_session_legacy_inline');
+
+    expect(loaded?.transcriptText).toBe('legacy inline transcript');
+  });
+
+  it('hydrates empty chunk storage without writing inline transcript text', async () => {
+    await repository.saveSession(
+      makeSession({ id: 'whatsapp_conv_session_empty_transcript', transcriptText: '' })
+    );
+
+    const loaded = await repository.getSessionById('whatsapp_conv_session_empty_transcript');
+    const storedDoc = await fakeFirestore
+      .collection(WHATSAPP_CONVERSATION_ASSISTANT_SESSIONS_COLLECTION)
+      .doc('whatsapp_conv_session_empty_transcript')
+      .get();
+    const firstChunk = await fakeFirestore
+      .collection(WHATSAPP_CONVERSATION_ASSISTANT_TRANSCRIPT_CHUNKS_COLLECTION)
+      .doc('whatsapp_conv_session_empty_transcript_000000')
+      .get();
+
+    expect(loaded?.transcriptText).toBe('');
+    expect(storedDoc.data()?.['transcriptText']).toBeUndefined();
+    expect(storedDoc.data()?.['transcriptStorage']).toEqual({
+      type: 'chunks',
+      chunkCount: 0,
+      chunkSizeBytes: TRANSCRIPT_CHUNK_MAX_BYTES,
+      byteLength: 0,
+    });
+    expect(firstChunk.exists).toBe(false);
+  });
+
+  it('falls back to inline transcript text when legacy storage metadata is malformed', async () => {
+    await fakeFirestore
+      .collection(WHATSAPP_CONVERSATION_ASSISTANT_SESSIONS_COLLECTION)
+      .doc('whatsapp_conv_session_wrong_storage_type')
+      .set({
+        ...makeSession({
+          id: 'whatsapp_conv_session_wrong_storage_type',
+          transcriptText: 'wrong storage type fallback',
+        }),
+        transcriptStorage: { type: 'inline' },
+      });
+    await fakeFirestore
+      .collection(WHATSAPP_CONVERSATION_ASSISTANT_SESSIONS_COLLECTION)
+      .doc('whatsapp_conv_session_invalid_storage_shape')
+      .set({
+        ...makeSession({
+          id: 'whatsapp_conv_session_invalid_storage_shape',
+          transcriptText: 'invalid storage shape fallback',
+        }),
+        transcriptStorage: {
+          type: 'chunks',
+          chunkCount: '1',
+          chunkSizeBytes: 0,
+          byteLength: -1,
+        },
+      });
+
+    const wrongType = await repository.getSessionById('whatsapp_conv_session_wrong_storage_type');
+    const invalidShape = await repository.getSessionById('whatsapp_conv_session_invalid_storage_shape');
+
+    expect(wrongType?.transcriptText).toBe('wrong storage type fallback');
+    expect(invalidShape?.transcriptText).toBe('invalid storage shape fallback');
+  });
+
+  it('throws a load error when chunked transcript metadata points to missing or invalid chunks', async () => {
+    const missingChunkSession = 'whatsapp_conv_session_missing_chunk';
+    const invalidChunkSession = 'whatsapp_conv_session_invalid_chunk';
+    const missingChunkDocument: Record<string, unknown> = {
+      ...makeSession({ id: missingChunkSession }),
+      transcriptStorage: {
+        type: 'chunks',
+        chunkCount: 1,
+        chunkSizeBytes: TRANSCRIPT_CHUNK_MAX_BYTES,
+        byteLength: 1,
+      },
+    };
+    const invalidChunkDocument: Record<string, unknown> = {
+      ...makeSession({ id: invalidChunkSession }),
+      transcriptStorage: {
+        type: 'chunks',
+        chunkCount: 1,
+        chunkSizeBytes: TRANSCRIPT_CHUNK_MAX_BYTES,
+        byteLength: 1,
+      },
+    };
+    Reflect.deleteProperty(missingChunkDocument, 'transcriptText');
+    Reflect.deleteProperty(invalidChunkDocument, 'transcriptText');
+    await fakeFirestore
+      .collection(WHATSAPP_CONVERSATION_ASSISTANT_SESSIONS_COLLECTION)
+      .doc(missingChunkSession)
+      .set(missingChunkDocument);
+    await fakeFirestore
+      .collection(WHATSAPP_CONVERSATION_ASSISTANT_SESSIONS_COLLECTION)
+      .doc(invalidChunkSession)
+      .set(invalidChunkDocument);
+    fakeFirestore.seedCollection(WHATSAPP_CONVERSATION_ASSISTANT_TRANSCRIPT_CHUNKS_COLLECTION, [
+      {
+        id: `${invalidChunkSession}_000000`,
+        data: null as unknown as Record<string, unknown>,
+      },
+    ]);
+
+    await expect(repository.getSessionById(missingChunkSession)).rejects.toThrow(
+      `Missing transcript chunk 0 for ${missingChunkSession}`
+    );
+    await expect(repository.getSessionById(invalidChunkSession)).rejects.toThrow(
+      `Invalid transcript chunk 0 for ${invalidChunkSession}`
+    );
   });
 
   it('returns null for missing sessions and hydrates defensive defaults', async () => {

--- a/apps/whatsapp-service/src/infra/firestore/conversationAssistantRepository.ts
+++ b/apps/whatsapp-service/src/infra/firestore/conversationAssistantRepository.ts
@@ -10,17 +10,46 @@ import { DEFAULT_CONVERSATION_ASSISTANT_ROLE_LABEL } from '../../domain/conversa
 
 export const WHATSAPP_CONVERSATION_ASSISTANT_SESSIONS_COLLECTION =
   'whatsapp_conversation_assistant_sessions';
+export const WHATSAPP_CONVERSATION_ASSISTANT_TRANSCRIPT_CHUNKS_COLLECTION =
+  'whatsapp_conversation_assistant_transcript_chunks';
 export const WHATSAPP_CONVERSATION_ASSISTANT_TURNS_COLLECTION =
   'whatsapp_conversation_assistant_turns';
+export const TRANSCRIPT_CHUNK_MAX_BYTES = 200_000;
+
+interface TranscriptChunkStorage {
+  type: 'chunks';
+  chunkCount: number;
+  chunkSizeBytes: number;
+  byteLength: number;
+}
 
 export function createConversationAssistantRepository(): ConversationAssistantRepository {
   return {
     async saveSession(session: ConversationAssistantSession): Promise<void> {
       try {
-        await getFirestore()
+        const db = getFirestore();
+        const chunks = splitTranscriptText(session.transcriptText);
+        const transcriptStorage: TranscriptChunkStorage = {
+          type: 'chunks',
+          chunkCount: chunks.length,
+          chunkSizeBytes: TRANSCRIPT_CHUNK_MAX_BYTES,
+          byteLength: Buffer.byteLength(session.transcriptText, 'utf8'),
+        };
+        const sessionRef = db
           .collection(WHATSAPP_CONVERSATION_ASSISTANT_SESSIONS_COLLECTION)
-          .doc(session.id)
-          .set(session);
+          .doc(session.id);
+        const chunkCollection = db.collection(
+          WHATSAPP_CONVERSATION_ASSISTANT_TRANSCRIPT_CHUNKS_COLLECTION
+        );
+
+        for (const [chunkIndex, text] of chunks.entries()) {
+          await chunkCollection.doc(toTranscriptChunkId(session.id, chunkIndex)).set({
+            sessionId: session.id,
+            chunkIndex,
+            text,
+          });
+        }
+        await sessionRef.set(toSessionDocument(session, transcriptStorage));
       } catch (error) {
         throw new Error(
           `Failed to save Conversation Assistant session: ${getErrorMessage(error)}`
@@ -30,14 +59,15 @@ export function createConversationAssistantRepository(): ConversationAssistantRe
 
     async getSessionById(sessionId: string): Promise<ConversationAssistantSession | null> {
       try {
-        const doc = await getFirestore()
+        const db = getFirestore();
+        const doc = await db
           .collection(WHATSAPP_CONVERSATION_ASSISTANT_SESSIONS_COLLECTION)
           .doc(sessionId)
           .get();
         if (!doc.exists) {
           return null;
         }
-        return toSession(doc.id, doc.data());
+        return await toHydratedSession(db, doc.id, doc.data());
       } catch (error) {
         throw new Error(
           `Failed to load Conversation Assistant session: ${getErrorMessage(error)}`
@@ -50,31 +80,29 @@ export function createConversationAssistantRepository(): ConversationAssistantRe
     ): Promise<{ session: ConversationAssistantSession; turns: ConversationAssistantTurn[] } | null> {
       try {
         const db = getFirestore();
-        const sessionRef = db
+        const sessionDoc = await db
           .collection(WHATSAPP_CONVERSATION_ASSISTANT_SESSIONS_COLLECTION)
-          .doc(input.sessionId);
-        return await db.runTransaction(async (transaction) => {
-          const sessionDoc = await transaction.get(sessionRef);
-          if (!sessionDoc.exists) {
-            return null;
-          }
-          const session = toSession(sessionDoc.id, sessionDoc.data());
-          if (session.userId !== input.userId) {
-            return null;
-          }
-          const turnsSnapshot = await transaction.get(
-            db
-              .collection(WHATSAPP_CONVERSATION_ASSISTANT_TURNS_COLLECTION)
-              .where('sessionId', '==', input.sessionId)
-              .where('userId', '==', input.userId)
-              .orderBy('createdAt', 'asc')
-              .orderBy(FieldPath.documentId(), 'asc')
-          );
-          return {
-            session,
-            turns: turnsSnapshot.docs.map((doc) => toTurn(doc.id, doc.data())),
-          };
-        });
+          .doc(input.sessionId)
+          .get();
+        if (!sessionDoc.exists) {
+          return null;
+        }
+        const sessionWithoutTranscript = toSession(sessionDoc.id, sessionDoc.data());
+        if (sessionWithoutTranscript.userId !== input.userId) {
+          return null;
+        }
+        const session = await toHydratedSession(db, sessionDoc.id, sessionDoc.data());
+        const turnsSnapshot = await db
+          .collection(WHATSAPP_CONVERSATION_ASSISTANT_TURNS_COLLECTION)
+          .where('sessionId', '==', input.sessionId)
+          .where('userId', '==', input.userId)
+          .orderBy('createdAt', 'asc')
+          .orderBy(FieldPath.documentId(), 'asc')
+          .get();
+        return {
+          session,
+          turns: turnsSnapshot.docs.map((doc) => toTurn(doc.id, doc.data())),
+        };
       } catch (error) {
         throw new Error(
           `Failed to load Conversation Assistant session snapshot: ${getErrorMessage(error)}`
@@ -125,9 +153,30 @@ export function createConversationAssistantRepository(): ConversationAssistantRe
   };
 }
 
-function toSession(
+function toSessionDocument(
+  session: ConversationAssistantSession,
+  transcriptStorage: TranscriptChunkStorage
+): Record<string, unknown> {
+  const document: Record<string, unknown> = {
+    ...session,
+    transcriptStorage,
+  };
+  Reflect.deleteProperty(document, 'transcriptText');
+  return document;
+}
+
+async function toHydratedSession(
+  db: ReturnType<typeof getFirestore>,
   id: string,
   data: Record<string, unknown> | undefined
+): Promise<ConversationAssistantSession> {
+  return toSession(id, data, await loadTranscriptText(db, id, data));
+}
+
+function toSession(
+  id: string,
+  data: Record<string, unknown> | undefined,
+  transcriptText?: string
 ): ConversationAssistantSession {
   const session = data as Partial<ConversationAssistantSession> | undefined;
   const range = session?.range ?? { from: '', to: '' };
@@ -144,7 +193,7 @@ function toSession(
         : DEFAULT_CONVERSATION_ASSISTANT_MODEL,
     transcriptSha256: session?.transcriptSha256 ?? '',
     transcriptMessageCount: session?.transcriptMessageCount ?? 0,
-    transcriptText: session?.transcriptText ?? '',
+    transcriptText: transcriptText ?? session?.transcriptText ?? '',
     assistantRoleLabel:
       typeof session?.assistantRoleLabel === 'string' && session.assistantRoleLabel.trim().length > 0
         ? session.assistantRoleLabel
@@ -167,6 +216,96 @@ function toSession(
     projected.lastTurnAt = session.lastTurnAt;
   }
   return projected;
+}
+
+async function loadTranscriptText(
+  db: ReturnType<typeof getFirestore>,
+  sessionId: string,
+  data: Record<string, unknown> | undefined
+): Promise<string> {
+  const storage = parseTranscriptStorage(data?.['transcriptStorage']);
+  if (storage === null) {
+    const inlineTranscriptText = data?.['transcriptText'];
+    return typeof inlineTranscriptText === 'string' ? inlineTranscriptText : '';
+  }
+
+  const chunkCollection = db.collection(
+    WHATSAPP_CONVERSATION_ASSISTANT_TRANSCRIPT_CHUNKS_COLLECTION
+  );
+  const chunks = await Promise.all(
+    Array.from({ length: storage.chunkCount }, async (_value, chunkIndex) => {
+      const chunkDoc = await chunkCollection
+        .doc(toTranscriptChunkId(sessionId, chunkIndex))
+        .get();
+      if (!chunkDoc.exists) {
+        throw new Error(`Missing transcript chunk ${String(chunkIndex)} for ${sessionId}`);
+      }
+      const chunkData: unknown = chunkDoc.data();
+      const text = isRecord(chunkData) ? chunkData['text'] : undefined;
+      if (typeof text !== 'string') {
+        throw new Error(`Invalid transcript chunk ${String(chunkIndex)} for ${sessionId}`);
+      }
+      return text;
+    })
+  );
+  return chunks.join('');
+}
+
+function parseTranscriptStorage(value: unknown): TranscriptChunkStorage | null {
+  if (!isRecord(value)) return null;
+  if (value['type'] !== 'chunks') return null;
+  const chunkCount = value['chunkCount'];
+  const chunkSizeBytes = value['chunkSizeBytes'];
+  const byteLength = value['byteLength'];
+  if (
+    !isInteger(chunkCount) ||
+    !isInteger(chunkSizeBytes) ||
+    !isInteger(byteLength) ||
+    chunkCount < 0 ||
+    chunkSizeBytes <= 0 ||
+    byteLength < 0
+  ) {
+    return null;
+  }
+  return {
+    type: 'chunks',
+    chunkCount,
+    chunkSizeBytes,
+    byteLength,
+  };
+}
+
+function splitTranscriptText(transcriptText: string): string[] {
+  const chunks: string[] = [];
+  let current = '';
+  let currentBytes = 0;
+  for (const char of transcriptText) {
+    const charBytes = Buffer.byteLength(char, 'utf8');
+    if (currentBytes + charBytes > TRANSCRIPT_CHUNK_MAX_BYTES && current.length > 0) {
+      chunks.push(current);
+      current = char;
+      currentBytes = charBytes;
+      continue;
+    }
+    current += char;
+    currentBytes += charBytes;
+  }
+  if (current.length > 0) {
+    chunks.push(current);
+  }
+  return chunks;
+}
+
+function toTranscriptChunkId(sessionId: string, chunkIndex: number): string {
+  return `${sessionId}_${String(chunkIndex).padStart(6, '0')}`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value);
 }
 
 function toTurn(id: string, data: Record<string, unknown> | undefined): ConversationAssistantTurn {

--- a/apps/whatsapp-service/src/infra/firestore/index.ts
+++ b/apps/whatsapp-service/src/infra/firestore/index.ts
@@ -62,7 +62,9 @@ export {
 } from './privateWhatsAppRepository.js';
 
 export {
+  TRANSCRIPT_CHUNK_MAX_BYTES,
   WHATSAPP_CONVERSATION_ASSISTANT_SESSIONS_COLLECTION,
+  WHATSAPP_CONVERSATION_ASSISTANT_TRANSCRIPT_CHUNKS_COLLECTION,
   WHATSAPP_CONVERSATION_ASSISTANT_TURNS_COLLECTION,
   createConversationAssistantRepository,
 } from './conversationAssistantRepository.js';

--- a/firestore-collections.json
+++ b/firestore-collections.json
@@ -62,6 +62,10 @@
       "owner": "whatsapp-service",
       "description": "Private WhatsApp Conversation Assistant sessions with frozen transcript snapshots and public metadata."
     },
+    "whatsapp_conversation_assistant_transcript_chunks": {
+      "owner": "whatsapp-service",
+      "description": "Chunked frozen transcript text for private WhatsApp Conversation Assistant sessions."
+    },
     "whatsapp_conversation_assistant_turns": {
       "owner": "whatsapp-service",
       "description": "Autosaved user and assistant turns for private WhatsApp Conversation Assistant sessions."


### PR DESCRIPTION
## Summary
- Store Conversation Assistant transcript snapshots in Firestore chunk documents instead of one session field.
- Hydrate transcript chunks for session, prompt, and PDF reads while keeping legacy inline sessions readable.
- Register the chunk collection owner.

## Verification
- `pnpm run ci:tracked`

## Linear
Linear: omitted by `$commit-push`; GitHub automation will create or link the Linear issue after PR creation.

- Linear: [INT-1856](https://linear.app/pbuchman/issue/INT-1856)
- IntexuraOS Code Task: [View task](https://intexuraos.cloud/#/code-tasks/task_5d3a62ba-7469-4da7-b89b-f76c535cc90c)
- Worker Type: `codex-xhigh`
- Model: `default`
