### PR TITLE
[INT-1858] fix: harden production async reliability

### DIFF
--- a/apps/linear-agent/src/__tests__/domain/useCases/fullSyncUseCase.test.ts
+++ b/apps/linear-agent/src/__tests__/domain/useCases/fullSyncUseCase.test.ts
@@ -537,40 +537,7 @@ describe('fullSyncAllUsers', () => {
     }
   });
 
-  it('continues on individual user sync failure', async () => {
-    linearClient.seedIssue({
-      id: 'issue-1',
-      identifier: 'INT-1',
-      title: 'Test Issue',
-      description: 'Test description',
-      priority: 2,
-      state: { id: 'state-1', name: 'In Progress', type: 'started' },
-      url: 'https://linear.app/team/issue/INT-1',
-      createdAt: '2025-01-01T00:00:00.000Z',
-      updatedAt: '2025-01-02T00:00:00.000Z',
-      completedAt: null,
-      childCount: 0,
-      children: [],
-      labels: [],
-    });
-    linearClient.seedIssue({
-      id: 'issue-2',
-      identifier: 'INT-2',
-      title: 'Test Issue 2',
-      description: 'Test description 2',
-      priority: 2,
-      state: { id: 'state-1', name: 'In Progress', type: 'started' },
-      url: 'https://linear.app/team/issue/INT-2',
-      createdAt: '2025-01-01T00:00:00.000Z',
-      updatedAt: '2025-01-02T00:00:00.000Z',
-      completedAt: null,
-      childCount: 0,
-      children: [],
-      labels: [],
-    });
-
-    // Make first user fail by setting failure on getFullConnection
-    // Need to create a spy that fails only for user-1
+  it('returns an error after attempting every user when one sync fails', async () => {
     const originalGetFullConnection = connectionRepo.getFullConnection.bind(connectionRepo);
     const getFullConnectionSpy = vi.spyOn(connectionRepo, 'getFullConnection').mockImplementation(async (userId) => {
       if (userId === 'user-1') {
@@ -581,11 +548,54 @@ describe('fullSyncAllUsers', () => {
 
     const result = await fullSyncAllUsers(deps);
 
-    expect(result.ok).toBe(true);
-    if (result.ok) {
-      // Only user-2 should sync, getting 2 issues
-      expect(result.value.totalIssues).toBe(2);
-    }
+    expect(result).toEqual({
+      ok: false,
+      error: { code: 'NOT_CONNECTED', message: 'User not connected' },
+    });
+    expect(getFullConnectionSpy).toHaveBeenCalledWith('user-1');
+    expect(getFullConnectionSpy).toHaveBeenCalledWith('user-2');
+
+    getFullConnectionSpy.mockRestore();
+  });
+
+  it('prioritizes a transient failure after attempting every user', async () => {
+    deps.getAllConnectedUserIds = vi.fn().mockResolvedValue({
+      ok: true,
+      value: ['user-1', 'user-2', 'user-3'],
+    });
+    connectionRepo.seedConnection({
+      userId: 'user-3',
+      apiKey: 'test-api-key',
+      teamId: 'team-1',
+      teamName: 'Engineering',
+      connected: true,
+      createdAt: '2025-01-01T00:00:00.000Z',
+      updatedAt: '2025-01-01T00:00:00.000Z',
+    });
+    const originalGetFullConnection = connectionRepo.getFullConnection.bind(connectionRepo);
+    const getFullConnectionSpy = vi.spyOn(connectionRepo, 'getFullConnection').mockImplementation(async (userId) => {
+      if (userId === 'user-1') {
+        return err({ code: 'NOT_CONNECTED', message: 'User not connected' });
+      }
+      if (userId === 'user-2') {
+        return err({
+          code: 'UPSTREAM_UNAVAILABLE',
+          message: 'Linear API temporarily unavailable',
+        });
+      }
+      return originalGetFullConnection(userId);
+    });
+
+    const result = await fullSyncAllUsers(deps);
+
+    expect(result).toEqual({
+      ok: false,
+      error: {
+        code: 'UPSTREAM_UNAVAILABLE',
+        message: 'Linear API temporarily unavailable',
+      },
+    });
+    expect(getFullConnectionSpy).toHaveBeenCalledTimes(3);
 
     getFullConnectionSpy.mockRestore();
   });

--- a/apps/linear-agent/src/__tests__/routes/internalRoutes.test.ts
+++ b/apps/linear-agent/src/__tests__/routes/internalRoutes.test.ts
@@ -1,7 +1,8 @@
 /**
  * Tests for internal API routes.
  */
-import { describe, expect, it, beforeEach, afterEach, beforeAll, afterAll } from 'vitest';
+import { describe, expect, it, beforeEach, afterEach, beforeAll, afterAll, vi } from 'vitest';
+import { err } from '@intexuraos/common-core';
 import type { FastifyInstance } from 'fastify';
 import { buildServer } from '../../server.js';
 import type { LinearConnection, LinearIssueWithTeam } from '../../domain/models.js';
@@ -540,6 +541,17 @@ describe('internalRoutes', () => {
   });
 
   describe('POST /internal/linear/sync-all', () => {
+    it('documents the scheduler-retryable 503 response', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/openapi.json',
+      });
+
+      expect(response.statusCode).toBe(200);
+      const document = response.json();
+      expect(document.paths['/internal/linear/sync-all'].post.responses).toHaveProperty('503');
+    });
+
     it('returns 401 when no internal auth header provided', async () => {
       const response = await app.inject({
         method: 'POST',
@@ -616,6 +628,35 @@ describe('internalRoutes', () => {
       const body = response.json();
       expect(body.success).toBe(true);
       expect(body.data.userCount).toBe(2);
+    });
+
+    it('returns 503 after attempting all users when one sync is transiently unavailable', async () => {
+      seedConnection('user-1');
+      seedConnection('user-2');
+      const originalGetFullConnection = fakeConnectionRepo.getFullConnection.bind(fakeConnectionRepo);
+      const getFullConnectionSpy = vi
+        .spyOn(fakeConnectionRepo, 'getFullConnection')
+        .mockImplementation(async (userId) => {
+          if (userId === 'user-1') {
+            return err({
+              code: 'UPSTREAM_UNAVAILABLE',
+              message: 'Linear API temporarily unavailable',
+            });
+          }
+          return originalGetFullConnection(userId);
+        });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/internal/linear/sync-all',
+        headers: { 'x-internal-auth': INTERNAL_AUTH_TOKEN },
+      });
+
+      expect(response.statusCode).toBe(503);
+      expect(response.json().success).toBe(false);
+      expect(getFullConnectionSpy).toHaveBeenCalledTimes(2);
+
+      getFullConnectionSpy.mockRestore();
     });
 
     it('handles sync failure for all users', async () => {

--- a/apps/linear-agent/src/domain/useCases/fullSyncUseCase.ts
+++ b/apps/linear-agent/src/domain/useCases/fullSyncUseCase.ts
@@ -148,13 +148,28 @@ export async function fullSyncAllUsers(deps: FullSyncDeps & {
   logger.info({ userCount: userIds.length }, 'Starting full sync for all users');
 
   let totalIssues = 0;
+  let firstFailure: LinearError | null = null;
+  let transientFailure: LinearError | null = null;
+
   for (const userId of userIds) {
     const result = await fullSync(userId, deps);
     if (result.ok) {
       totalIssues += result.value.total;
-    } else {
-      logger.error({ userId, error: result.error }, 'Failed to sync user');
+      continue;
     }
+
+    logger.error({ userId, error: result.error }, 'Failed to sync user');
+    firstFailure ??= result.error;
+    if (result.error.code === 'UPSTREAM_UNAVAILABLE') {
+      transientFailure = result.error;
+    }
+  }
+
+  if (transientFailure !== null) {
+    return err(transientFailure);
+  }
+  if (firstFailure !== null) {
+    return err(firstFailure);
   }
 
   return ok({ userCount: userIds.length, totalIssues });

--- a/apps/linear-agent/src/routes/internalRoutes.ts
+++ b/apps/linear-agent/src/routes/internalRoutes.ts
@@ -467,6 +467,15 @@ export const internalRoutes: FastifyPluginCallback = (fastify, _opts, done) => {
               diagnostics: { $ref: 'Diagnostics#' },
             },
           },
+          503: {
+            description: 'Linear upstream temporarily unavailable',
+            type: 'object',
+            properties: {
+              success: { type: 'boolean', enum: [false] },
+              error: { $ref: 'ErrorBody#' },
+              diagnostics: { $ref: 'Diagnostics#' },
+            },
+          },
         },
       },
     },

--- a/docs/operations/hetzner-prod-runbook.md
+++ b/docs/operations/hetzner-prod-runbook.md
@@ -90,9 +90,9 @@ INTEXURAOS_ENVIRONMENT=prod bash scripts/hetzner/provision.sh --email ops@exampl
 ```
 
 Provisioning installs Node 22, PM2, Google Cloud CLI, nginx with Lua support,
-`lua-cjson`, certbot with the Cloudflare DNS plugin, loads secrets, installs
-certificates, and deploys the nginx config. A provisioned host must pass the
-nginx JWT Lua dependency check before nginx is reloaded:
+`lua-cjson`, logrotate, certbot with the Cloudflare DNS plugin, loads secrets,
+installs certificates, and deploys the nginx config. A provisioned host must
+pass the nginx JWT Lua dependency check before nginx is reloaded:
 
 ```bash
 lua5.1 <<'LUA'
@@ -149,6 +149,7 @@ secret allowlist and updates `/etc/intexuraos/internal-auth-token` for nginx.
 ```bash
 cd /opt/intexuraos
 sudo INTEXURAOS_ENVIRONMENT=prod bash scripts/hetzner/load-secrets.sh
+sudo INTEXURAOS_ENVIRONMENT=prod bash scripts/hetzner/install-pm2-logrotate.sh
 sudo -iu deploy bash -lc 'cd /opt/intexuraos && CI=true pnpm install --frozen-lockfile'
 sudo -iu deploy bash -lc 'cd /opt/intexuraos && INTEXURAOS_ENVIRONMENT=prod bash scripts/hetzner/deploy-web.sh'
 sudo -iu deploy bash -lc 'cd /opt/intexuraos && INTEXURAOS_ENVIRONMENT=prod bash scripts/hetzner/reload-pm2.sh'
@@ -163,7 +164,29 @@ Sentry values plus generated public API paths, so ignored local env files
 cannot leak backend secrets into Vite.
 `reload-pm2.sh` renders the CommonJS ecosystem config to a private JSON file
 before starting PM2, because PM2 treats `ecosystem.config.prod.cjs` as a plain
-script on the Hetzner host. `deploy-nginx.sh` verifies `cjson.safe` and
+script on the Hetzner host. It derives every local `/health` URL from the
+rendered app ports and requires three consecutive all-service passes before
+`pm2 save`. `PM2_HEALTH_URLS` remains an explicit override for controlled
+diagnostics; normal deployments must leave it unset.
+
+PM2 file logs are bounded by `/etc/logrotate.d/intexuraos-pm2`: daily rotation,
+early rotation at 100 MB per file, 14 retained rotations, compression with one
+rotation of delay, and `pm2 reloadLogs` after rotation. Validate the installed
+policy without rotating data:
+
+```bash
+sudo logrotate --debug /etc/logrotate.d/intexuraos-pm2
+sudo systemctl is-active alloy
+```
+
+A controlled forced rotation may be run with
+`sudo logrotate --force /etc/logrotate.d/intexuraos-pm2`; immediately verify
+`pm2 status`, new active log files owned by `deploy`, and active Grafana Alloy
+collection. Reinstalling the policy is idempotent. Rollback may restore the
+previous policy, but must preserve existing rotated log files until their
+documented retention expires.
+
+`deploy-nginx.sh` verifies `cjson.safe` and
 `resty.openidc`, then runs `nginx -t` before reload. If the VM is not available,
 validate an equivalent generated config in a container or staging VM that has
 nginx Lua/OpenResty modules installed, then record the command output in the
@@ -373,16 +396,13 @@ terraform -chdir=terraform/hetzner-prod apply
 
 ## Pre-Cutover Smoke Test
 
-Before changing DNS, every PM2 process must respond on localhost:
+Before changing DNS, reload through the production readiness gate. It derives
+the current app ports from `ecosystem.config.prod.cjs`, requires every PM2
+process to be online, and requires all health endpoints to pass three times:
 
 ```bash
-for port in \
-  8110 8112 8113 8114 8116 8117 8118 8119 8120 8121 8122 \
-  8123 8124 8125 8126 8127 8128 8129 8130 8131 8132 8133
-do
-  curl --fail --silent --show-error "http://127.0.0.1:${port}/health" >/dev/null
-done
-
+INTEXURAOS_ENVIRONMENT=prod PM2_HEALTH_CONSECUTIVE_SUCCESSES=3 \
+  bash scripts/hetzner/reload-pm2.sh
 curl --fail --silent --show-error http://127.0.0.1/healthz
 sudo nginx -t
 pm2 status

--- a/docs/operations/hetzner-prod-runbook.md
+++ b/docs/operations/hetzner-prod-runbook.md
@@ -7,6 +7,10 @@ This runbook covers the Hetzner host runtime owned by `scripts/hetzner/**` and
 Pub/Sub, Secret Manager, retained buckets, Cloud Functions, Artifact Registry,
 and the shared project `intexuraos-dev-pbuchman`.
 
+Dead-letter investigation and selected replay follow the
+[Pub/Sub DLQ runbook](./pubsub-dlq-runbook.md). Do not inspect or replay a DLQ
+with ad-hoc bulk commands.
+
 ## Runtime Layout
 
 | Path | Purpose |

--- a/docs/operations/pubsub-dlq-runbook.md
+++ b/docs/operations/pubsub-dlq-runbook.md
@@ -1,0 +1,113 @@
+# Pub/Sub Dead-Letter Queue Runbook
+
+Use this runbook when a production or retained development DLQ contains a
+message, or when Cloud Monitoring reports an unsuccessful dead-letter forward.
+DLQ inspection subscriptions retain unacknowledged messages for 31 days.
+
+## Safety Rules
+
+- Do not bulk replay. The same poison payload may appear many times after a
+  forwarding or acknowledgement failure.
+- Do not print decoded payloads in a terminal, ticket, pull request, or chat.
+- Work on one selected message at a time and record its source subscription.
+- Preserve the original correlation attributes when replaying a selected
+  message.
+- ACK a DLQ message only after its replay publish succeeds, or after an operator
+  explicitly records why the message is permanently non-replayable.
+- Use `gcloud` only for read, selected replay, and ACK operations. Persistent
+  topics, subscriptions, IAM, retention, and alerts are changed through
+  Terraform.
+
+## 1. Identify the Failure Mode
+
+Record the alert time, source subscription, DLQ inspection subscription, and
+the forwarding response code. Classify the incident before touching a message:
+
+1. permanent payload rejection;
+2. transient consumer dependency failure;
+3. consumer deployment outage;
+4. Pub/Sub forwarding or IAM failure.
+
+For a forwarding or IAM failure, verify that the Pub/Sub service agent has
+`roles/pubsub.publisher` on the DLQ topic and `roles/pubsub.subscriber` on the
+source subscription. Repair persistent IAM only in Terraform. A
+`permission_denied` forwarding result can create duplicate DLQ copies when the
+DLQ publish succeeds but the source ACK fails.
+
+## 2. Check Backlogs Without Pulling Payloads
+
+Use Cloud Monitoring or subscription descriptions to record source and DLQ
+backlogs. Confirm that the selected DLQ name ends in `-dlq-sub` or contains
+`-dlq-` and ends in `-inspect`. Do not use `--auto-ack` during investigation.
+
+If a pull is required, create a private temporary directory with mode `0700`,
+write the JSON response to a mode `0600` file, and arrange secure deletion when
+the incident is complete. The pull output contains private message data and
+must never be pasted into incident notes.
+
+Record only these metadata fields:
+
+- source and DLQ subscription names;
+- Pub/Sub message ID and publish time;
+- delivery attempt when present;
+- encoded payload size;
+- correlation ID and other non-sensitive routing attributes;
+- SHA-256 payload hash.
+
+Calculate payload size and the payload hash from the decoded bytes through a
+pipe so the content is never written to standard output. Use the payload hash
+with publish time and correlation metadata to identify repeated copies.
+
+## 3. Decide Whether Replay Is Safe
+
+Before replay, confirm all of the following:
+
+1. the consumer defect, dependency outage, deployment outage, or IAM defect is
+   fixed;
+2. the destination consumer is healthy;
+3. the consumer's idempotency behavior is understood for this event type;
+4. no successfully processed message already has the same correlation ID or
+   payload hash;
+5. replay cannot contact an unintended external recipient.
+
+Classify schema-invalid poison messages as non-replayable unless a reviewed
+payload migration exists. Record the reason and ACK only the selected copy.
+
+## 4. Replay One Selected Message
+
+Republish only the selected decoded bytes to the original source topic. Preserve
+the original correlation and routing attributes; add an operator replay marker
+and incident reference without changing the business payload. Capture the new
+Pub/Sub message ID as proof that publish succeeded.
+
+After the publish succeeds, verify consumer logs using the correlation ID. Then
+ACK the original DLQ message by its individual ACK ID. If publish or consumer
+verification fails, do not ACK; let the inspection lease expire so the message
+remains available inside the 31-day window.
+
+Repeated copies with the same payload hash are handled individually only after
+the first replay has been proven idempotent. Do not bulk replay or bulk ACK the
+remaining copies.
+
+## 5. Verify Recovery
+
+Confirm all of the following before closing the incident:
+
+- source subscription backlog is zero or falling normally;
+- DLQ backlog is zero after selected ACKs, or every remaining entry has an
+  owner and classification;
+- `dead_letter_message_count` reports `response_code="success"` for new
+  forwarding attempts;
+- there are no new unsuccessful forwarding response codes;
+- consumer logs show expected handling and no repeated external side effect;
+- the 31-day retention deadline is recorded for any deferred entry.
+
+## Synthetic Production Check
+
+After an infrastructure rollout, publish exactly one uniquely marked invalid
+WhatsApp event with no valid recipient and a new correlation ID. Record its
+message ID and payload hash, wait for it to reach the dedicated
+`intexuraos-whatsapp-send-prod-hetzner-dlq-sub` subscription, and verify the
+forwarding response is `success`. Inspect and ACK only that synthetic entry.
+Confirm afterward that both the source and DLQ backlogs are zero and that no
+WhatsApp message was sent.

--- a/docs/superpowers/plans/2026-07-13-hetzner-runtime-safety.md
+++ b/docs/superpowers/plans/2026-07-13-hetzner-runtime-safety.md
@@ -1,0 +1,244 @@
+# Hetzner Runtime Safety Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent production deployment from accepting an unhealthy PM2 service and bound local PM2 log growth without disrupting Grafana Alloy.
+
+**Architecture:** The PM2 reload script discovers health URLs from the rendered ecosystem config and requires consecutive all-green checks. A separate root-run installer owns an idempotent `/etc/logrotate.d` policy; provisioning and every production deployment invoke it before runtime readiness is declared.
+
+**Tech Stack:** Bash, embedded Node.js JSON parsing, PM2, curl, logrotate, Vitest runtime contract tests.
+
+## Global Constraints
+
+- Discover every rendered PM2 app with a numeric `PORT`; the current production config contains 18 such apps.
+- Retain an explicit `PM2_HEALTH_URLS` override for controlled tests.
+- Require three consecutive healthy passes by default before `pm2 save`.
+- Never print environment values or secrets in readiness failure output.
+- Rotate each `/home/deploy/.pm2/logs/*.log` daily or at 100 MB, retain 14 rotations, compress with delay, and reopen PM2 logs after rotation.
+- The logrotate installer must require `INTEXURAOS_ENVIRONMENT=prod`, root for installation, and successful policy validation.
+- Run `pnpm run ci:tracked` before every commit.
+
+---
+
+### Task 1: Discover and Stabilize All PM2 Health Checks
+
+**Files:**
+- Modify: `scripts/__tests__/hetzner-runtime.test.ts`
+- Modify: `scripts/hetzner/reload-pm2.sh`
+- Modify: `docs/operations/hetzner-prod-runbook.md`
+
+**Interfaces:**
+- Consumes: rendered JSON path `RENDERED_CONFIG` and optional space-delimited `PM2_HEALTH_URLS`.
+- Produces: derived `http://127.0.0.1:<PORT>/health` list and a readiness result after `PM2_HEALTH_CONSECUTIVE_SUCCESSES` all-green passes.
+
+- [ ] **Step 1: Write failing runtime contract assertions**
+
+Replace the two hard-coded URL assertions with:
+
+```ts
+expect(script).toContain('PM2_HEALTH_URLS="${PM2_HEALTH_URLS:-}"');
+expect(script).toContain('PM2_HEALTH_CONSECUTIVE_SUCCESSES="${PM2_HEALTH_CONSECUTIVE_SUCCESSES:-3}"');
+expect(script).toContain('derive_health_urls()');
+expect(script).toContain('config.apps');
+expect(script).toContain('app.env?.PORT');
+expect(script).toContain('http://127.0.0.1:${port}/health');
+expect(script).toContain('healthy_passes=$((healthy_passes + 1))');
+expect(script).toContain('healthy_passes=0');
+expect(script).toContain('PM2 health checks did not remain ready');
+expect(script).toMatch(/wait_for_http_health[\s\S]*pm2 save/);
+```
+
+Also parse `ecosystem.config.prod.cjs` in the test and assert all apps have unique numeric ports and the expected count is 18.
+
+- [ ] **Step 2: Run the runtime test and verify RED**
+
+Run: `PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm exec vitest run scripts/__tests__/hetzner-runtime.test.ts`
+
+Expected: FAIL because only two fixed URLs are configured and one successful pass returns immediately.
+
+- [ ] **Step 3: Derive URLs from rendered config**
+
+Set the defaults:
+
+```bash
+PM2_HEALTH_URLS="${PM2_HEALTH_URLS:-}"
+PM2_HEALTH_CONSECUTIVE_SUCCESSES="${PM2_HEALTH_CONSECUTIVE_SUCCESSES:-3}"
+```
+
+Add `derive_health_urls()` using embedded Node.js:
+
+```bash
+derive_health_urls() {
+  node - "${RENDERED_CONFIG}" <<'NODE'
+const { readFileSync } = require('node:fs');
+const config = JSON.parse(readFileSync(process.argv[2], 'utf8'));
+if (!config || !Array.isArray(config.apps)) {
+  throw new Error('Rendered PM2 config must contain apps');
+}
+const urls = config.apps.map((app) => {
+  const port = Number(app.env?.PORT);
+  if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+    throw new Error(`PM2 app ${app.name ?? 'unknown'} has invalid PORT`);
+  }
+  return `http://127.0.0.1:${port}/health`;
+});
+if (new Set(urls).size !== urls.length) {
+  throw new Error('Rendered PM2 config contains duplicate health ports');
+}
+process.stdout.write(urls.join(' '));
+NODE
+}
+```
+
+After installing `RENDERED_CONFIG`, populate `PM2_HEALTH_URLS` from this function only when the override is empty.
+
+- [ ] **Step 4: Require consecutive healthy passes**
+
+Validate `PM2_HEALTH_CONSECUTIVE_SUCCESSES` as a positive integer. In `wait_for_http_health`, initialize `healthy_passes=0`; increment it only when no URL failed, return only at the configured count, and reset it to zero after any failed URL. On timeout print the last failed URLs and `pm2 status`, without printing config or environment content.
+
+- [ ] **Step 5: Verify the runtime contract**
+
+Run:
+
+```bash
+bash -n scripts/hetzner/reload-pm2.sh
+PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm exec vitest run scripts/__tests__/hetzner-runtime.test.ts
+```
+
+Expected: PASS.
+
+### Task 2: Idempotent PM2 Log Rotation
+
+**Files:**
+- Create: `scripts/hetzner/install-pm2-logrotate.sh`
+- Modify: `scripts/hetzner/provision.sh`
+- Modify: `scripts/hetzner/github-actions-deploy.sh`
+- Modify: `scripts/__tests__/hetzner-runtime.test.ts`
+- Modify: `docs/operations/hetzner-prod-runbook.md`
+
+**Interfaces:**
+- Consumes: `DEPLOY_USER`, `PM2_HOME`, `PM2_BIN`, and optional `LOGROTATE_CONFIG_PATH`.
+- Produces: validated root-owned logrotate policy and PM2 descriptor reopen through `runuser`.
+
+- [ ] **Step 1: Add failing installer and integration tests**
+
+Add `spawnSync` to the child-process import and declare `installPm2LogrotatePath`. Assert a non-prod invocation fails:
+
+```ts
+const nonProd = spawnSync('bash', [installPm2LogrotatePath, '--render'], {
+  encoding: 'utf8',
+  env: Object.assign({}, process.env, {
+    INTEXURAOS_ENVIRONMENT: 'dev',
+    PM2_BIN: '/usr/bin/pm2',
+  }),
+});
+expect(nonProd.status).not.toBe(0);
+expect(nonProd.stderr).toContain('INTEXURAOS_ENVIRONMENT must be prod');
+```
+
+Render the policy without installing it:
+
+```ts
+const rendered = execFileSync('bash', [installPm2LogrotatePath, '--render'], {
+  encoding: 'utf8',
+  env: Object.assign({}, process.env, {
+    INTEXURAOS_ENVIRONMENT: 'prod',
+    PM2_BIN: '/usr/bin/pm2',
+  }),
+});
+for (const directive of [
+  '/home/deploy/.pm2/logs/*.log', 'daily', 'maxsize 100M', 'rotate 14',
+  'compress', 'delaycompress', 'missingok', 'notifempty', 'su deploy deploy',
+  'create 0640 deploy deploy', 'sharedscripts', 'reloadLogs',
+]) {
+  expect(rendered).toContain(directive);
+}
+```
+
+Assert the installer source contains `logrotate --debug`, `install -o root -g root -m 0644`, and cleanup traps. Assert both `provision.sh` and `github-actions-deploy.sh` invoke it with prod and root privileges.
+
+- [ ] **Step 2: Run the runtime test and verify RED**
+
+Run: `PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm exec vitest run scripts/__tests__/hetzner-runtime.test.ts`
+
+Expected: FAIL because the installer and integrations do not exist.
+
+- [ ] **Step 3: Implement the installer**
+
+Create a Bash script with `set -euo pipefail`, `--render` and install modes, prod guard, root guard for install mode, temporary-file cleanup, command checks, and this generated policy:
+
+```text
+/home/deploy/.pm2/logs/*.log {
+  daily
+  maxsize 100M
+  rotate 14
+  compress
+  delaycompress
+  missingok
+  notifempty
+  su deploy deploy
+  create 0640 deploy deploy
+  sharedscripts
+  postrotate
+    /usr/sbin/runuser -u deploy -- env PM2_HOME=/home/deploy/.pm2 /usr/bin/pm2 reloadLogs >/dev/null 2>&1 || true
+  endscript
+}
+```
+
+Substitute configured values while rendering. In install mode validate the temporary policy with `logrotate --debug`, then atomically install it to `/etc/logrotate.d/intexuraos-pm2` as `root:root` mode `0644`. Re-running the installer must replace the same file with identical content.
+
+- [ ] **Step 4: Integrate provisioning and deployment**
+
+Add `logrotate` to base packages. Add `install_pm2_logrotate()` to provisioning and call it after the deploy user and PM2 exist. In `deploy_runtime`, call:
+
+```bash
+run_remote 'sudo -n INTEXURAOS_ENVIRONMENT=prod bash scripts/hetzner/install-pm2-logrotate.sh'
+```
+
+Place it after Grafana Alloy installation and before dependency installation so a rotation-policy failure stops deployment early.
+
+- [ ] **Step 5: Document runtime operations**
+
+In `docs/operations/hetzner-prod-runbook.md`, document all-service readiness, the three-pass stability window, override use for controlled diagnostics, logrotate policy location, dry-run validation, forced-rotation verification, `pm2 reloadLogs`, Alloy-active verification, and rollback that preserves rotated logs.
+
+- [ ] **Step 6: Verify scripts and commit**
+
+Run:
+
+```bash
+bash -n scripts/hetzner/reload-pm2.sh
+bash -n scripts/hetzner/install-pm2-logrotate.sh
+bash -n scripts/hetzner/provision.sh
+bash -n scripts/hetzner/github-actions-deploy.sh
+PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm exec vitest run scripts/__tests__/hetzner-runtime.test.ts
+PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm run ci:tracked
+git add scripts/hetzner/reload-pm2.sh scripts/hetzner/install-pm2-logrotate.sh scripts/hetzner/provision.sh scripts/hetzner/github-actions-deploy.sh scripts/__tests__/hetzner-runtime.test.ts docs/operations/hetzner-prod-runbook.md
+git commit -m "fix: harden Hetzner runtime readiness"
+```
+
+Expected: syntax checks, tests, and full CI pass; the commit contains only runtime safety changes.
+
+### Task 3: Post-Merge Runtime Verification
+
+**Files:**
+- Verify: merged `development` deployment on home-dev and Hetzner production.
+
+**Interfaces:**
+- Consumes: merged commit and existing deployment workflows.
+- Produces: evidence that every service remains healthy, log rotation is installed, and Alloy continues collecting active logs.
+
+- [ ] **Step 1: Verify dev deployment**
+
+Confirm the home-dev checkout reaches the merged commit, all expected PM2 processes are online, and every dev health endpoint returns success.
+
+- [ ] **Step 2: Monitor production workflow**
+
+Wait for the GitHub Hetzner deployment triggered by the merge. Expected: installer validation succeeds, all 18 local health endpoints pass three consecutive checks, `pm2 save` occurs afterward, and public smoke checks pass.
+
+- [ ] **Step 3: Verify production host state**
+
+Confirm all 18 PM2 services are online with no deployment-time restart loop, `/etc/logrotate.d/intexuraos-pm2` matches the documented policy, `logrotate --debug` accepts it, Grafana Alloy is active, and PM2 active log files are open after a controlled rotation check.
+
+- [ ] **Step 4: Observe steady state**
+
+Review PM2, nginx, and Alloy logs after deployment. Expected: no new production 5xx, no all-service readiness failures, no logrotate errors, and local PM2 log growth is bounded by the 100 MB per-file threshold.

--- a/docs/superpowers/plans/2026-07-13-linear-scheduler-retries.md
+++ b/docs/superpowers/plans/2026-07-13-linear-scheduler-retries.md
@@ -1,0 +1,229 @@
+# Linear Scheduler Retries Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `/internal/linear/sync-all` return a scheduler-retryable error whenever any connected user was not synced, while still attempting every user.
+
+**Architecture:** The domain fan-out collects failures rather than swallowing them. After all users are attempted it returns `UPSTREAM_UNAVAILABLE` when any transient upstream failure occurred, otherwise the first domain failure; the existing HTTP error mapper turns the transient code into `503`.
+
+**Tech Stack:** TypeScript, Result types from `@intexuraos/common-core`, Fastify, Vitest.
+
+## Global Constraints
+
+- Keep processing connected users after an individual failure.
+- Return success only if every connected user sync succeeds.
+- Preserve an observed `UPSTREAM_UNAVAILABLE` error so Cloud Scheduler receives HTTP `503`.
+- Do not add or remove an endpoint; only modify `POST /internal/linear/sync-all` behavior and schema.
+- Preserve successful response fields `userCount` and `totalIssues`.
+- Keep 100% branch coverage and run `pnpm run ci:tracked` before commit.
+
+---
+
+### Task 1: Propagate Partial Fan-Out Failures
+
+**Files:**
+- Modify: `apps/linear-agent/src/__tests__/domain/useCases/fullSyncUseCase.test.ts`
+- Modify: `apps/linear-agent/src/domain/useCases/fullSyncUseCase.ts`
+
+**Interfaces:**
+- Consumes: `fullSync(userId, deps): Promise<Result<SyncStats, LinearError>>`.
+- Produces: unchanged `fullSyncAllUsers` signature with failure returned after the complete fan-out.
+
+- [ ] **Step 1: Replace the swallowed-failure expectation with a failing propagation test**
+
+Change the existing `continues on individual user sync failure` test so it verifies that both users are attempted and the aggregate fails:
+
+```ts
+it('returns an error after attempting every user when one sync fails', async () => {
+  const originalGetFullConnection = connectionRepo.getFullConnection.bind(connectionRepo);
+  const getFullConnectionSpy = vi
+    .spyOn(connectionRepo, 'getFullConnection')
+    .mockImplementation(async (userId) => {
+      if (userId === 'user-1') {
+        return err({ code: 'NOT_CONNECTED', message: 'User not connected' });
+      }
+      return await originalGetFullConnection(userId);
+    });
+
+  const result = await fullSyncAllUsers(deps);
+
+  expect(result).toEqual({
+    ok: false,
+    error: { code: 'NOT_CONNECTED', message: 'User not connected' },
+  });
+  expect(getFullConnectionSpy).toHaveBeenCalledWith('user-1');
+  expect(getFullConnectionSpy).toHaveBeenCalledWith('user-2');
+});
+```
+
+- [ ] **Step 2: Add a failing transient-priority test**
+
+```ts
+it('prioritizes a transient failure after attempting every user', async () => {
+  deps.getAllConnectedUserIds = vi
+    .fn()
+    .mockResolvedValue({ ok: true, value: ['user-1', 'user-2', 'user-3'] });
+  const originalGetFullConnection = connectionRepo.getFullConnection.bind(connectionRepo);
+  const getFullConnectionSpy = vi
+    .spyOn(connectionRepo, 'getFullConnection')
+    .mockImplementation(async (userId) => {
+      if (userId === 'user-1') {
+        return err({ code: 'NOT_CONNECTED', message: 'User not connected' });
+      }
+      if (userId === 'user-2') {
+        return err({ code: 'UPSTREAM_UNAVAILABLE', message: 'Linear API temporarily unavailable' });
+      }
+      return await originalGetFullConnection(userId);
+    });
+
+  const result = await fullSyncAllUsers(deps);
+
+  expect(result).toEqual({
+    ok: false,
+    error: {
+      code: 'UPSTREAM_UNAVAILABLE',
+      message: 'Linear API temporarily unavailable',
+    },
+  });
+  expect(getFullConnectionSpy).toHaveBeenCalledTimes(3);
+});
+```
+
+Seed `user-3` with the same valid connection shape as the existing two users before invoking the use case.
+
+- [ ] **Step 3: Run the domain tests and verify RED**
+
+Run: `PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm exec vitest run apps/linear-agent/src/__tests__/domain/useCases/fullSyncUseCase.test.ts`
+
+Expected: both new expectations fail because the current aggregate returns `ok`.
+
+- [ ] **Step 4: Implement minimal failure collection**
+
+In `fullSyncAllUsers`, retain the loop and add exact failure selection:
+
+```ts
+let totalIssues = 0;
+let firstFailure: LinearError | null = null;
+let transientFailure: LinearError | null = null;
+
+for (const userId of userIds) {
+  const result = await fullSync(userId, deps);
+  if (result.ok) {
+    totalIssues += result.value.total;
+    continue;
+  }
+
+  logger.error({ userId, error: result.error }, 'Failed to sync user');
+  firstFailure ??= result.error;
+  if (result.error.code === 'UPSTREAM_UNAVAILABLE') {
+    transientFailure ??= result.error;
+  }
+}
+
+if (transientFailure !== null) {
+  return err(transientFailure);
+}
+if (firstFailure !== null) {
+  return err(firstFailure);
+}
+
+return ok({ userCount: userIds.length, totalIssues });
+```
+
+- [ ] **Step 5: Run domain tests and verify GREEN**
+
+Run: `PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm exec vitest run apps/linear-agent/src/__tests__/domain/useCases/fullSyncUseCase.test.ts`
+
+Expected: PASS with complete branch coverage for failure selection.
+
+### Task 2: Expose Scheduler-Retryable HTTP Behavior
+
+**Files:**
+- Modify: `apps/linear-agent/src/__tests__/routes/internalRoutes.test.ts`
+- Modify: `apps/linear-agent/src/routes/internalRoutes.ts`
+
+**Interfaces:**
+- Consumes: `fullSyncAllUsers` domain result and existing `handleLinearError` mapping.
+- Produces: documented `503` response for `UPSTREAM_UNAVAILABLE`; unchanged `200` response for complete success.
+
+- [ ] **Step 1: Add a failing partial-transient route test**
+
+Seed two connected users, then use a per-user repository spy:
+
+```ts
+it('returns 503 after attempting all users when one sync is transiently unavailable', async () => {
+  const connectionOne: LinearConnection = {
+    userId: 'user-1', apiKey: 'key-1', teamId: 'team-1', teamName: 'Team 1',
+    webhookSecret: null, connected: true,
+    createdAt: '2025-01-15T00:00:00Z', updatedAt: '2025-01-15T00:00:00Z',
+  };
+  const connectionTwo: LinearConnection = {
+    userId: 'user-2', apiKey: 'key-2', teamId: 'team-2', teamName: 'Team 2',
+    webhookSecret: null, connected: true,
+    createdAt: '2025-01-15T00:00:00Z', updatedAt: '2025-01-15T00:00:00Z',
+  };
+  fakeConnectionRepo.seedConnection(connectionOne);
+  fakeConnectionRepo.seedConnection(connectionTwo);
+  const originalGetFullConnection = fakeConnectionRepo.getFullConnection.bind(fakeConnectionRepo);
+  const getFullConnectionSpy = vi
+    .spyOn(fakeConnectionRepo, 'getFullConnection')
+    .mockImplementation(async (userId) => userId === 'user-1'
+      ? err({ code: 'UPSTREAM_UNAVAILABLE', message: 'Linear API temporarily unavailable' })
+      : await originalGetFullConnection(userId));
+
+  const response = await app.inject({
+    method: 'POST',
+    url: '/internal/linear/sync-all',
+    headers: { 'x-internal-auth': INTERNAL_AUTH_TOKEN },
+  });
+
+  expect(response.statusCode).toBe(503);
+  expect(response.json().success).toBe(false);
+  expect(getFullConnectionSpy).toHaveBeenCalledTimes(2);
+});
+```
+
+- [ ] **Step 2: Run the route test and verify RED**
+
+Run: `PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm exec vitest run apps/linear-agent/src/__tests__/routes/internalRoutes.test.ts`
+
+Expected: FAIL until the domain change is present; if schema serialization rejects `503`, the response schema change remains necessary.
+
+- [ ] **Step 3: Add the explicit 503 response schema**
+
+Add a `503` schema next to `500`, using the same standard failure envelope:
+
+```ts
+503: {
+  description: 'Linear upstream temporarily unavailable',
+  type: 'object',
+  properties: {
+    success: { type: 'boolean', enum: [false] },
+    error: { $ref: 'ErrorBody#' },
+    diagnostics: { $ref: 'Diagnostics#' },
+  },
+},
+```
+
+Do not change the route handler: it already delegates failed results to `handleLinearError`, which maps `UPSTREAM_UNAVAILABLE` to `SERVICE_UNAVAILABLE`.
+
+- [ ] **Step 4: Verify targeted workspace quality**
+
+Run:
+
+```bash
+PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm exec vitest run apps/linear-agent/src/__tests__/domain/useCases/fullSyncUseCase.test.ts apps/linear-agent/src/__tests__/routes/internalRoutes.test.ts
+PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm run verify:workspace:tracked -- linear-agent
+```
+
+Expected: tests, types, lint, and 100% branch coverage pass.
+
+- [ ] **Step 5: Run full CI and commit**
+
+```bash
+PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm run ci:tracked
+git add apps/linear-agent/src/domain/useCases/fullSyncUseCase.ts apps/linear-agent/src/routes/internalRoutes.ts apps/linear-agent/src/__tests__/domain/useCases/fullSyncUseCase.test.ts apps/linear-agent/src/__tests__/routes/internalRoutes.test.ts
+git commit -m "fix: retry incomplete Linear scheduled syncs"
+```
+
+Expected: CI passes and the commit contains only the Linear behavior, schema, and tests.

--- a/docs/superpowers/plans/2026-07-13-production-dlq-infrastructure.md
+++ b/docs/superpowers/plans/2026-07-13-production-dlq-infrastructure.md
@@ -1,0 +1,286 @@
+# Production DLQ Infrastructure Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give every active dead-letter policy correct IAM, dedicated production DLQs, 31-day inspection retention, forwarding-failure alerts, and a safe replay runbook.
+
+**Architecture:** Terraform owns every persistent Pub/Sub and Cloud Monitoring change. The Hetzner production root creates DLQs from the existing subscription map, shared modules enforce the service-agent IAM contract, and the retained dev root repairs the explicit transcription subscription and monitoring.
+
+**Tech Stack:** Terraform, Google Pub/Sub, Google Cloud Monitoring, Vitest static infrastructure tests, Markdown runbook.
+
+## Global Constraints
+
+- Use project `intexuraos-dev-pbuchman`; the retained GCP project contains both dev and Hetzner production messaging resources.
+- Every inspection subscription uses `message_retention_duration = "2678400s"` and never expires.
+- Pub/Sub service agent is `service-${project_number}@gcp-sa-pubsub.iam.gserviceaccount.com`.
+- Never create, update, or delete persistent infrastructure with `gcloud`; Terraform is the only write path.
+- A production plan must not replace or delete any source subscription.
+- Do not replay DLQ payloads in bulk; ACK only after successful selected replay or explicit non-replayable classification.
+- Run `pnpm run ci:tracked` before every commit.
+
+---
+
+### Task 1: Dedicated Hetzner Production DLQs
+
+**Files:**
+- Modify: `scripts/__tests__/hetzner-runtime.test.ts`
+- Modify: `terraform/hetzner-prod/pubsub.tf`
+
+**Interfaces:**
+- Consumes: `local.hetzner_pubsub_push_subscriptions` with `subscription_name` and delivery settings.
+- Produces: `google_pubsub_topic.hetzner_push_dlq`, `google_pubsub_subscription.hetzner_push_dlq_inspect`, `google_pubsub_topic_iam_member.hetzner_push_dlq_publisher`, and `google_pubsub_subscription_iam_member.hetzner_push_dlq_subscriber`.
+
+- [ ] **Step 1: Write the failing production DLQ contract test**
+
+Add assertions to the existing `Hetzner async edge cutover` test:
+
+```ts
+expect(hetznerPubsub).toContain('resource "google_pubsub_topic" "hetzner_push_dlq"');
+expect(hetznerPubsub).toMatch(/name\s+=\s+"\$\{each\.value\.subscription_name\}-dlq"/);
+expect(hetznerPubsub).toContain('resource "google_pubsub_subscription" "hetzner_push_dlq_inspect"');
+expect(hetznerPubsub).toMatch(/name\s+=\s+"\$\{each\.value\.subscription_name\}-dlq-sub"/);
+expect(hetznerPubsub).toContain('message_retention_duration = "2678400s"');
+expect(hetznerPubsub).toContain('resource "google_pubsub_topic_iam_member" "hetzner_push_dlq_publisher"');
+expect(hetznerPubsub).toContain('resource "google_pubsub_subscription_iam_member" "hetzner_push_dlq_subscriber"');
+expect(hetznerPubsub).toContain('role         = "roles/pubsub.subscriber"');
+expect(hetznerPubsub).toContain('dead_letter_topic     = google_pubsub_topic.hetzner_push_dlq[each.key].id');
+expect(hetznerPubsub).not.toContain('data.google_pubsub_topic.hetzner_push_dlq');
+```
+
+- [ ] **Step 2: Run the test and verify RED**
+
+Run: `PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm exec vitest run scripts/__tests__/hetzner-runtime.test.ts`
+
+Expected: FAIL because dedicated production DLQ resources and subscriber IAM do not exist.
+
+- [ ] **Step 3: Create the production DLQ resources and repoint the source policy**
+
+In `terraform/hetzner-prod/pubsub.tf`, replace the dev-named DLQ data lookup with resources shaped as follows:
+
+```hcl
+resource "google_pubsub_topic" "hetzner_push_dlq" {
+  for_each = local.hetzner_pubsub_push_subscriptions
+
+  name    = "${each.value.subscription_name}-dlq"
+  project = var.project_id
+  labels  = local.common_labels
+}
+
+resource "google_pubsub_subscription" "hetzner_push_dlq_inspect" {
+  for_each = local.hetzner_pubsub_push_subscriptions
+
+  name                       = "${each.value.subscription_name}-dlq-sub"
+  topic                      = google_pubsub_topic.hetzner_push_dlq[each.key].id
+  project                    = var.project_id
+  labels                     = local.common_labels
+  ack_deadline_seconds       = 600
+  message_retention_duration = "2678400s"
+
+  expiration_policy {
+    ttl = ""
+  }
+}
+
+resource "google_pubsub_topic_iam_member" "hetzner_push_dlq_publisher" {
+  for_each = local.hetzner_pubsub_push_subscriptions
+
+  project = var.project_id
+  topic   = google_pubsub_topic.hetzner_push_dlq[each.key].name
+  role    = "roles/pubsub.publisher"
+  member  = "serviceAccount:service-${data.google_project.retained.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
+}
+
+resource "google_pubsub_subscription_iam_member" "hetzner_push_dlq_subscriber" {
+  for_each = local.hetzner_pubsub_push_subscriptions
+
+  project      = var.project_id
+  subscription = google_pubsub_subscription.hetzner_push[each.key].name
+  role         = "roles/pubsub.subscriber"
+  member       = "serviceAccount:service-${data.google_project.retained.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
+}
+```
+
+Set `dead_letter_topic` to `google_pubsub_topic.hetzner_push_dlq[each.key].id` and make the source subscription depend on the DLQ publisher grant. The subscriber grant already depends on the source subscription through its `subscription` reference; do not add a reverse dependency that would create a Terraform cycle.
+
+- [ ] **Step 4: Format and rerun the contract test**
+
+Run: `terraform fmt terraform/hetzner-prod/pubsub.tf && PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm exec vitest run scripts/__tests__/hetzner-runtime.test.ts`
+
+Expected: PASS.
+
+### Task 2: Shared Module and Retained Transcription Correctness
+
+**Files:**
+- Modify: `scripts/__tests__/hetzner-runtime.test.ts`
+- Modify: `terraform/modules/pubsub-push/main.tf`
+- Modify: `terraform/modules/pubsub/main.tf`
+- Modify: `terraform/environments/dev/main.tf`
+
+**Interfaces:**
+- Consumes: module variables `project_id`, `project_number`, and `enable_push_subscription`.
+- Produces: service-agent subscriber IAM adjacent to every module dead-letter policy and the explicit `audio_stored_push` policy.
+
+- [ ] **Step 1: Add failing module and transcription assertions**
+
+Declare paths for `terraform/modules/pubsub/main.tf` and `terraform/modules/monitoring/main.tf`, then assert:
+
+```ts
+for (const terraform of [
+  readRequired(terraformPubsubPushModuleMainPath),
+  readRequired(terraformPubsubModuleMainPath),
+]) {
+  expect(terraform).toContain('resource "google_pubsub_subscription_iam_member" "dlq_subscriber"');
+  expect(terraform).toContain('role         = "roles/pubsub.subscriber"');
+  expect(terraform).toContain('message_retention_duration = "2678400s"');
+}
+expect(devTerraform).toContain('resource "google_pubsub_subscription_iam_member" "pubsub_subscribes_audio_stored_push"');
+expect(devTerraform).toContain('subscription = google_pubsub_subscription.audio_stored_push.name');
+expect(devTerraform).toContain('message_retention_duration = "2678400s" # 31 days');
+```
+
+- [ ] **Step 2: Run the test and verify RED**
+
+Run: `PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm exec vitest run scripts/__tests__/hetzner-runtime.test.ts`
+
+Expected: FAIL on missing subscriber resources and seven-day retention.
+
+- [ ] **Step 3: Repair both shared modules**
+
+Add this resource to the push module, preserving the source subscription count:
+
+```hcl
+resource "google_pubsub_subscription_iam_member" "dlq_subscriber" {
+  count = var.enable_push_subscription ? 1 : 0
+
+  project      = var.project_id
+  subscription = google_pubsub_subscription.push[0].name
+  role         = "roles/pubsub.subscriber"
+  member       = "serviceAccount:service-${var.project_number}@gcp-sa-pubsub.iam.gserviceaccount.com"
+}
+```
+
+Add the equivalent resource to the pull module using `google_pubsub_subscription.main.name` without `count`. Change both DLQ inspection subscriptions to `2678400s`.
+
+- [ ] **Step 4: Repair explicit transcription resources**
+
+Change `google_pubsub_subscription.transcription_dlq_inspect` retention to `2678400s` and add:
+
+```hcl
+resource "google_pubsub_subscription_iam_member" "pubsub_subscribes_audio_stored_push" {
+  project      = var.project_id
+  subscription = google_pubsub_subscription.audio_stored_push.name
+  role         = "roles/pubsub.subscriber"
+  member       = "serviceAccount:service-${local.project_number}@gcp-sa-pubsub.iam.gserviceaccount.com"
+}
+```
+
+- [ ] **Step 5: Format and rerun the contract test**
+
+Run: `terraform fmt terraform/modules/pubsub-push/main.tf terraform/modules/pubsub/main.tf terraform/environments/dev/main.tf && PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm exec vitest run scripts/__tests__/hetzner-runtime.test.ts`
+
+Expected: PASS.
+
+### Task 3: Monitoring and DLQ Runbook
+
+**Files:**
+- Modify: `scripts/__tests__/hetzner-runtime.test.ts`
+- Modify: `terraform/modules/monitoring/main.tf`
+- Create: `docs/operations/pubsub-dlq-runbook.md`
+- Modify: `docs/operations/hetzner-prod-runbook.md`
+
+**Interfaces:**
+- Consumes: Pub/Sub backlog and `dead_letter_message_count` metrics, existing email notification channel.
+- Produces: alerts for retained and production DLQ names plus unsuccessful forwarding, and an operator-safe replay procedure.
+
+- [ ] **Step 1: Add failing alert and documentation assertions**
+
+```ts
+const monitoring = readRequired(terraformMonitoringMainPath);
+const dlqRunbook = readRequired(pubsubDlqRunbookPath);
+expect(monitoring).toContain('resource.label.subscription_id=has_substring("-dlq-")');
+expect(monitoring).toContain('pubsub.googleapis.com/subscription/dead_letter_message_count');
+expect(monitoring).toContain('metric.label.response_code!="success"');
+expect(monitoring).toContain('docs/operations/pubsub-dlq-runbook.md');
+expect(dlqRunbook).toContain('31 days');
+expect(dlqRunbook).toContain('payload hash');
+expect(dlqRunbook).toContain('Do not bulk replay');
+expect(dlqRunbook).toContain('ACK');
+expect(dlqRunbook).toContain('correlation');
+```
+
+- [ ] **Step 2: Run the test and verify RED**
+
+Run: `PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm exec vitest run scripts/__tests__/hetzner-runtime.test.ts`
+
+Expected: FAIL because the alert misses `-inspect`, forwarding failures are unmonitored, and the runbook is absent.
+
+- [ ] **Step 3: Expand backlog coverage and add forwarding failure alert**
+
+Change all dashboard and alert filters from `has_substring("-dlq-sub")` to `has_substring("-dlq-")`. Add an alert policy using:
+
+```hcl
+filter = <<-EOT
+  resource.type="pubsub_subscription"
+  metric.type="pubsub.googleapis.com/subscription/dead_letter_message_count"
+  metric.label.response_code!="success"
+EOT
+```
+
+Use `ALIGN_SUM`, `REDUCE_SUM`, threshold `0`, duration `60s`, the existing email channel, and documentation linking `docs/operations/pubsub-dlq-runbook.md`.
+
+- [ ] **Step 4: Write the operational runbook**
+
+Document exact read-only discovery, lease-safe pull, metadata capture, SHA-256 payload hashing without content output, failure classification, selected republish with original correlation attributes, ACK-after-publish semantics, duplicate detection, 31-day deadline, synthetic-test cleanup, and post-operation backlog/metric/log checks. Add the runbook link to `docs/operations/hetzner-prod-runbook.md`.
+
+- [ ] **Step 5: Format, test, and commit the infrastructure slice**
+
+Run:
+
+```bash
+terraform fmt terraform/modules/monitoring/main.tf
+PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm exec vitest run scripts/__tests__/hetzner-runtime.test.ts
+PATH="/opt/homebrew/opt/node@22/bin:$PATH" pnpm run ci:tracked
+git add scripts/__tests__/hetzner-runtime.test.ts terraform/hetzner-prod/pubsub.tf terraform/modules/pubsub-push/main.tf terraform/modules/pubsub/main.tf terraform/environments/dev/main.tf terraform/modules/monitoring/main.tf docs/operations/pubsub-dlq-runbook.md docs/operations/hetzner-prod-runbook.md
+git commit -m "fix: harden production dead letter queues"
+```
+
+Expected: all commands pass; the commit contains only DLQ infrastructure, monitoring, tests, and operations documentation.
+
+### Task 4: Terraform Plans and Post-Merge Apply
+
+**Files:**
+- Verify: `terraform/environments/dev`
+- Verify: `terraform/hetzner-prod`
+
+**Interfaces:**
+- Consumes: service-account key `$HOME/.config/gcloud/sa-key.json` and committed Terraform configuration.
+- Produces: reviewed plans, applied IAM/DLQ/monitoring resources, and zero remaining source/DLQ backlog after the synthetic test.
+
+- [ ] **Step 1: Initialize and validate both roots**
+
+Run with `GOOGLE_APPLICATION_CREDENTIALS="$HOME/.config/gcloud/sa-key.json"`, `CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE` set to the same path, and all Firestore/Pub/Sub emulator variables unset:
+
+```bash
+terraform -chdir=terraform/environments/dev init -upgrade
+terraform -chdir=terraform/environments/dev validate
+terraform -chdir=terraform/hetzner-prod init -upgrade
+terraform -chdir=terraform/hetzner-prod validate
+```
+
+Expected: both roots initialize and validate successfully.
+
+- [ ] **Step 2: Review plans before merge**
+
+Run `terraform plan` for each root with its existing checked-in/default variable inputs. Expected: additions and in-place updates only; no source subscription replacement or deletion. Save no plan file containing sensitive values in the repository.
+
+- [ ] **Step 3: Apply after PR merge**
+
+Re-run both plans against the merged `development` commit, then apply the reviewed plans. Stop if drift changes the resource actions or any source subscription would be replaced.
+
+- [ ] **Step 4: Verify IAM and synthetic dead lettering**
+
+Confirm all 11 `*-prod-hetzner` source subscriptions plus `intexuraos-audio-stored-dev-push` grant the Pub/Sub service agent `roles/pubsub.subscriber`. Publish one invalid WhatsApp event with a unique correlation ID, observe successful dead-letter forwarding to its dedicated production DLQ, inspect only that entry, and ACK only that synthetic entry.
+
+- [ ] **Step 5: Verify clean steady state**
+
+Expected: forwarding metric reports `response_code="success"`; all source and production DLQ backlogs are zero after cleanup; no synthetic payload reached a valid WhatsApp recipient.

--- a/docs/superpowers/specs/2026-07-13-production-async-reliability-design.md
+++ b/docs/superpowers/specs/2026-07-13-production-async-reliability-design.md
@@ -1,0 +1,311 @@
+# Production Async Reliability Design
+
+**Date:** 2026-07-13
+
+**Status:** Approved direction — dedicated production DLQs
+
+## Context
+
+The production investigation covered Hetzner PM2/nginx logs and the retained GCP
+Pub/Sub data plane. It established these facts:
+
+- The 11 Hetzner production push subscriptions and the retained
+  `intexuraos-audio-stored-dev-push` subscription have dead-letter policies, but
+  none grants the Pub/Sub service agent `roles/pubsub.subscriber` on the source
+  subscription.
+- The Pub/Sub service agent can publish to the current dead-letter topics. During
+  the WhatsApp incident, forwarding therefore published copies to the DLQ but
+  failed to acknowledge the source message, producing 1,445
+  `permission_denied` forwarding results and repeated deliveries.
+- Production currently points at dead-letter topics named `*-dev-dlq`. This is a
+  consequence of the retained single-project migration, but it makes production
+  ownership and incident response ambiguous.
+- The WhatsApp DLQ backlog fell from 1,446 to zero without pulls or ACKs. Its
+  messages expired under the seven-day subscription retention policy; the last
+  905 entries cannot be recovered.
+- The Matrix outbound adapter environment propagation defect was fixed and
+  deployed in PR #2318. The remaining deployment defect is that PM2 readiness
+  checks cover only two of 18 services and can accept a process before it has
+  remained healthy.
+- Two hourly Linear sync executions exhausted the existing Linear API retries.
+  `fullSyncAllUsers()` logged individual failures but returned success, so Cloud
+  Scheduler did not perform its configured retry.
+- One code-agent GitHub reconciliation timed out. The next one-minute scheduler
+  tick succeeded, so this is a bounded transient rather than a change target.
+- Production nginx emitted no 5xx responses in the current 72-hour window. The
+  observed 4xx/444 traffic is rejected internet scanning and requires no change.
+- Local PM2 logs occupy approximately 1.1 GB and no PM2 or system log rotation is
+  configured. Grafana Alloy forwards them, but does not bound local disk usage.
+
+Google Cloud requires the Pub/Sub service agent to have publisher permission on
+the dead-letter topic and subscriber permission on the source subscription so it
+can publish and acknowledge forwarded messages. Pub/Sub subscription retention
+can be configured up to 31 days.
+
+References:
+
+- <https://docs.cloud.google.com/pubsub/docs/dead-letter-topics>
+- <https://docs.cloud.google.com/pubsub/docs/subscription-properties>
+
+## Goals
+
+1. Make dead-letter forwarding correct for every active subscription with a
+   dead-letter policy.
+2. Separate production dead letters from retained development-named DLQs.
+3. Preserve failed messages long enough for controlled incident response.
+4. Alert on both DLQ backlog and failures in the forwarding mechanism itself.
+5. Make scheduled Linear syncs retry when any connected user was not synced.
+6. Prevent production deployment from succeeding while any PM2 service is
+   unhealthy or immediately crash-looping.
+7. Bound local PM2 log storage without interrupting Grafana Alloy collection.
+8. Deliver the changes through a PR to `development`, then verify dev, apply the
+   retained GCP infrastructure changes, and verify production.
+
+## Non-Goals
+
+- Recovering the expired 905 WhatsApp DLQ entries; GCP no longer retains them.
+- Replacing Pub/Sub with a different broker.
+- Adding a permanent BigQuery or Cloud Storage archive in this change. A 31-day
+  inspection window plus an explicit runbook is sufficient for the observed
+  traffic and avoids another data-retention surface.
+- Changing the public API or any Pub/Sub push endpoint.
+- Treating rejected scanner traffic or one self-healed GitHub timeout as product
+  failures.
+- Reworking WhatsApp delivery into exactly-once processing. Pub/Sub remains
+  at-least-once and consumers must retain their existing idempotency guarantees.
+
+## Chosen Approach
+
+Create dedicated production DLQ topics and inspection subscriptions for all 11
+Hetzner production push subscriptions. Fix the shared Terraform modules and the
+retained audio transcription subscription so the missing subscriber grant cannot
+recur elsewhere. Keep the existing development-named DLQs for their retained
+topics, but production subscriptions stop forwarding to them.
+
+This is preferred over repairing the current shared DLQs in place because it
+gives alerts, retention, ownership, and runbooks unambiguous production resource
+names. It is preferred over a permanent export archive because the current volume
+does not justify the extra storage pipeline and data-governance burden.
+
+## Architecture
+
+### 1. Dedicated Hetzner production DLQs
+
+For every entry in `local.hetzner_pubsub_push_subscriptions`, Terraform creates:
+
+- topic: `${subscription_name}-dlq`, for example
+  `intexuraos-whatsapp-send-prod-hetzner-dlq`;
+- inspection subscription: `${subscription_name}-dlq-sub`;
+- `message_retention_duration = "2678400s"` (31 days);
+- `expiration_policy { ttl = "" }`;
+- `roles/pubsub.publisher` on the DLQ topic for
+  `service-${project_number}@gcp-sa-pubsub.iam.gserviceaccount.com`;
+- `roles/pubsub.subscriber` on the source production subscription for the same
+  service agent.
+
+The source subscription's `dead_letter_policy.dead_letter_topic` points to the
+new production topic. The change is in place and does not replace the source
+subscription or change its push endpoint, filter, OIDC identity, retry policy, or
+delivery-attempt limit.
+
+### 2. Retained subscription and module correctness
+
+The explicit `google_pubsub_subscription.audio_stored_push` resource receives
+the same Pub/Sub service-agent subscriber grant. Its DLQ inspection subscription
+retention increases to 31 days.
+
+Both `terraform/modules/pubsub-push` and `terraform/modules/pubsub` gain the
+service-agent subscriber binding adjacent to their existing DLQ publisher
+binding. Their DLQ inspection subscriptions use 31-day retention. The push
+module's subscriber binding follows `enable_push_subscription`, so disabled
+retired Cloud Run consumers do not reference a missing subscription.
+
+The remaining retained development DLQ subscriptions also receive 31-day
+retention through the shared module. No development topic or subscription is
+renamed or removed.
+
+### 3. DLQ monitoring and operations
+
+Cloud Monitoring covers two distinct failure modes:
+
+1. A DLQ inspection subscription has undelivered messages.
+2. `pubsub.googleapis.com/subscription/dead_letter_message_count` records a
+   response code other than `success`.
+
+The backlog filter includes both `*-dlq-sub` and the retained
+`*-dlq-*-inspect` naming form. Alert documentation identifies the source
+subscription, states the 31-day deadline, and links to the operations runbook.
+The existing configured notification channels remain the delivery mechanism.
+
+The runbook defines a conservative workflow:
+
+1. Record source subscription, publish time, delivery count, payload size, and a
+   payload hash without printing private message content.
+2. Classify the failure as permanent payload rejection, transient dependency
+   failure, deployment outage, or forwarding/IAM failure.
+3. Confirm the consumer fix and its idempotency behavior before replay.
+4. Republish only selected messages with their original correlation metadata.
+5. ACK a DLQ message only after the replay publish succeeds or an operator
+   explicitly classifies it as non-replayable.
+6. Verify the source backlog, DLQ backlog, forwarding metric, and consumer logs.
+
+Blind bulk replay is forbidden because the expired incident contained repeated
+copies of the same poison message.
+
+### 4. Linear scheduled sync propagation
+
+`fullSyncAllUsers()` continues processing every connected user, but records each
+failed result. If any user fails, it returns an error after the loop instead of a
+successful aggregate. `UPSTREAM_UNAVAILABLE` is preserved when any failure is
+transient so the route returns `503` and Cloud Scheduler performs its configured
+retry. Other failures preserve their existing domain error mapping.
+
+A successful result still reports `userCount` and `totalIssues`. No partial
+success is advertised as a completed sync.
+
+### 5. Production deployment readiness
+
+`scripts/hetzner/reload-pm2.sh` derives health URLs from every rendered PM2 app
+with a numeric `PORT`, instead of defaulting to settings and user service only.
+The deploy waits for all 18 `/health` endpoints and requires consecutive healthy
+checks before saving the PM2 process list. A process that briefly reports
+`online` and then exits therefore fails the deployment.
+
+An explicit `PM2_HEALTH_URLS` override remains available for controlled tests.
+Failure output lists only unhealthy service URLs and the PM2 status; it does not
+print environment values.
+
+The GitHub deployment workflow keeps its existing public-origin smoke tests.
+Those checks run only after the all-service local readiness gate succeeds.
+
+### 6. PM2 log rotation
+
+A root-run installer provisions `/etc/logrotate.d/intexuraos-pm2` on every
+production deployment and during host provisioning. The policy is:
+
+- rotate daily;
+- rotate early when an individual log exceeds 100 MB;
+- retain 14 rotations;
+- compress old logs with delayed compression;
+- skip missing and empty files;
+- create files for the `deploy` user;
+- call `pm2 reloadLogs` after rotation so PM2 reopens file descriptors.
+
+Grafana Alloy already excludes compressed/backup files and continues forwarding
+the active logs. Installation is idempotent and validates the generated
+logrotate policy before returning success.
+
+## Error Handling
+
+- Terraform creates IAM bindings before production dead-letter behavior is
+  verified. A targeted plan must contain no source-subscription replacement or
+  deletion.
+- A failed Terraform apply stops delivery work; no direct `gcloud` resource
+  creation is used as a substitute.
+- A failed Linear user sync makes the scheduler request non-2xx only after the
+  remaining users have been attempted.
+- Any unhealthy PM2 service fails the production deployment before `pm2 save`.
+- Logrotate installation or validation failure fails the deployment rather than
+  leaving local retention unbounded.
+- Synthetic DLQ verification uses an invalid WhatsApp event with no valid
+  recipient and a unique test correlation ID. It cannot send a WhatsApp message.
+
+## Testing and Verification
+
+Implementation follows test-first development:
+
+- Static Terraform regression tests assert the production DLQ resource names,
+  publisher and subscriber IAM bindings, 31-day retention, and absence of
+  source-subscription replacement constructs.
+- Shared-module tests assert that every dead-letter policy has both required
+  service-agent roles.
+- Linear domain tests first demonstrate that an individual sync failure is
+  currently swallowed, then require an error after all users were attempted.
+- Linear route tests require `503` for a transient partial failure and `200` only
+  when every user succeeds.
+- Hetzner runtime tests require health discovery for all rendered PM2 apps and a
+  stability window.
+- Logrotate installer tests cover prod guard, generated policy, validation,
+  idempotent installation, and deployment/provision integration.
+
+Repository gates:
+
+1. Relevant workspace verification for `linear-agent` and scripts.
+2. Terraform formatting and validation after provider/module initialization.
+3. Targeted Terraform plans using the explicit service-account credential and
+   cleared emulator variables.
+4. `pnpm run ci:tracked` before every commit and again after rebasing onto the
+   latest `origin/development`.
+
+Post-merge delivery verification:
+
+1. Confirm the home-dev checkout reaches the merged commit and all dev PM2
+   services are online and healthy.
+2. Confirm the GitHub Hetzner production deployment succeeds and all 18 local
+   health endpoints plus public smoke checks pass.
+3. Apply the retained dev Terraform root for module, monitoring, and audio
+   subscription changes using the service-account key.
+4. Apply the Hetzner production Terraform root for dedicated production DLQs and
+   source-subscription IAM.
+5. Verify all 12 source subscriptions grant the service agent subscriber role.
+6. Publish one uniquely marked invalid WhatsApp event, wait for successful
+   forwarding, inspect only that DLQ entry, and ACK only that synthetic entry.
+7. Verify `dead_letter_message_count{response_code="success"}`, zero source
+   backlog, zero production DLQ backlog after cleanup, no production 5xx, active
+   Alloy and logrotate configuration, and bounded PM2 log files.
+
+## Endpoint Changes
+
+### Modified
+
+- `POST /internal/linear/sync-all`: returns the existing mapped non-2xx error
+  response when at least one connected user fails to sync; returns `200` only
+  when all connected users complete.
+
+### Created
+
+- None.
+
+### Removed
+
+- None.
+
+### Unchanged
+
+- All public API endpoints.
+- All Pub/Sub push endpoint paths and payload formats.
+- All Scheduler endpoint paths other than the error propagation behavior stated
+  above.
+
+## Delivery and Rollback
+
+The change is delivered from a feature branch in a PR targeting `development`.
+After required checks pass, the PR is merged and both deployment paths are
+monitored to completion.
+
+Infrastructure is applied only after merge. Rollback does not delete DLQ data:
+
+- application/script rollback uses the previous `development` commit through
+  the normal deployment workflow;
+- Terraform rollback may point source subscriptions back to the retained DLQ
+  topics, but dedicated production DLQ topics and subscriptions remain until
+  their retention window is empty and an explicit later cleanup is approved;
+- IAM subscriber grants are safe to retain and are not removed during an
+  incident rollback.
+
+## Acceptance Criteria
+
+1. Every active source subscription with a dead-letter policy has the service
+   agent publisher role on its DLQ topic and subscriber role on the source.
+2. All 11 Hetzner production subscriptions use dedicated `prod-hetzner` DLQs.
+3. Every inspection DLQ retains unacknowledged messages for 31 days.
+4. Monitoring alerts on DLQ backlog and unsuccessful forwarding responses.
+5. A transient per-user Linear sync failure produces a scheduler-retryable
+   response after all users have been attempted.
+6. Production deployment fails if any rendered PM2 service cannot remain
+   healthy.
+7. Production PM2 logs rotate under the documented bounded policy while Alloy
+   remains active.
+8. CI, Terraform plans, dev verification, production deployment, Terraform
+   applies, and the synthetic DLQ test all pass with no source or DLQ backlog
+   remaining.

--- a/scripts/__tests__/hetzner-runtime.test.ts
+++ b/scripts/__tests__/hetzner-runtime.test.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from 'node:child_process';
+import { execFileSync, spawnSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
@@ -10,11 +10,13 @@ const jwtVerifierPath = resolve(repoRoot, 'scripts/hetzner/nginx/jwt-verify.lua'
 const loadSecretsPath = resolve(repoRoot, 'scripts/hetzner/load-secrets.sh');
 const deployWebPath = resolve(repoRoot, 'scripts/hetzner/deploy-web.sh');
 const reloadPm2Path = resolve(repoRoot, 'scripts/hetzner/reload-pm2.sh');
+const prodEcosystemPath = resolve(repoRoot, 'ecosystem.config.prod.cjs');
 const cutoverEdgePath = resolve(repoRoot, 'scripts/hetzner/cutover-gcp-edge.sh');
 const pubsubPublishTestPath = resolve(repoRoot, 'scripts/pubsub-publish-test.mjs');
 const installNginxPath = resolve(repoRoot, 'scripts/hetzner/install-nginx-and-cert.sh');
 const provisionPath = resolve(repoRoot, 'scripts/hetzner/provision.sh');
 const githubActionsDeployPath = resolve(repoRoot, 'scripts/hetzner/github-actions-deploy.sh');
+const installPm2LogrotatePath = resolve(repoRoot, 'scripts/hetzner/install-pm2-logrotate.sh');
 const runbookPath = resolve(repoRoot, 'docs/operations/hetzner-prod-runbook.md');
 const pubsubDlqRunbookPath = resolve(repoRoot, 'docs/operations/pubsub-dlq-runbook.md');
 const migrationPlanPath = resolve(repoRoot, 'docs/operations/hetzner-prod-migration-plan.md');
@@ -430,17 +432,24 @@ describe('Hetzner web asset deployment', () => {
     expect(script).toContain('pm2 start "${RENDERED_CONFIG}" --update-env');
     expect(script).toContain('PM2_START_TIMEOUT_SECONDS');
     expect(script).toContain('PM2_SYSTEMD_SERVICE');
-    expect(script).toContain('PM2_HEALTH_URLS');
+    expect(script).toContain('PM2_HEALTH_URLS="${PM2_HEALTH_URLS:-}"');
+    expect(script).toContain(
+      'PM2_HEALTH_CONSECUTIVE_SUCCESSES="${PM2_HEALTH_CONSECUTIVE_SUCCESSES:-3}"'
+    );
+    expect(script).toContain('derive_health_urls()');
+    expect(script).toContain('config.apps');
+    expect(script).toContain('app.env?.PORT');
+    expect(script).toContain('http://127.0.0.1:${port}/health');
     expect(script).toContain('wait_for_pm2_online()');
     expect(script).toContain('wait_for_http_health()');
     expect(script).toContain('sync_pm2_systemd_service()');
     expect(script).toContain('pm2 jlist');
-    expect(script).toContain('http://127.0.0.1:8122/health');
-    expect(script).toContain('http://127.0.0.1:8110/health');
     expect(script).toContain("local IFS=' '");
+    expect(script).toContain('healthy_passes=$((healthy_passes + 1))');
+    expect(script).toContain('healthy_passes=0');
     expect(script).toContain('curl --fail --silent --show-error --max-time 5');
     expect(script).toContain('failed to reach online state');
-    expect(script).toContain('HTTP health checks did not become ready');
+    expect(script).toContain('PM2 health checks did not remain ready');
     expect(script).toContain('pm2 save');
     expect(script).toContain('systemctl start "${PM2_SYSTEMD_SERVICE}"');
     expect(script).toContain('systemctl is-active --quiet "${PM2_SYSTEMD_SERVICE}"');
@@ -458,7 +467,28 @@ describe('Hetzner web asset deployment', () => {
       reloadFlow.indexOf('pm2 save')
     );
     expect(runbook).toContain('scripts/hetzner/reload-pm2.sh');
+    expect(runbook).toContain('PM2_HEALTH_CONSECUTIVE_SUCCESSES=3');
+    expect(runbook).not.toContain('for port in');
     expect(plan).toContain('scripts/hetzner/reload-pm2.sh');
+
+    const renderedConfig = JSON.parse(
+      execFileSync(
+        process.execPath,
+        [
+          '-e',
+          'const config = require(process.argv[1]); process.stdout.write(JSON.stringify(config));',
+          prodEcosystemPath,
+        ],
+        {
+          encoding: 'utf8',
+          env: { ...process.env, INTEXURAOS_ENVIRONMENT: 'prod' },
+        }
+      )
+    ) as { apps: Array<{ env?: { PORT?: string } }> };
+    const ports = renderedConfig.apps.map((app) => Number(app.env?.PORT));
+    expect(ports).toHaveLength(18);
+    expect(ports.every((port) => Number.isInteger(port) && port > 0 && port <= 65535)).toBe(true);
+    expect(new Set(ports).size).toBe(18);
   });
 
   it('bootstraps Corepack when an existing Node 22 install does not provide it', () => {
@@ -603,6 +633,62 @@ describe('Hetzner web asset deployment', () => {
     expect(provisionFlow.indexOf('install_grafana_alloy_collector')).toBeGreaterThan(
       provisionFlow.indexOf('load-secrets.sh')
     );
+  });
+
+  it('installs validated bounded PM2 log rotation during provisioning and deploy', () => {
+    const nonProd = spawnSync('bash', [installPm2LogrotatePath, '--render'], {
+      encoding: 'utf8',
+      env: { ...process.env, INTEXURAOS_ENVIRONMENT: 'dev', PM2_BIN: '/usr/bin/pm2' },
+    });
+    expect(nonProd.status).not.toBe(0);
+    expect(nonProd.stderr).toContain('INTEXURAOS_ENVIRONMENT must be prod');
+
+    const rendered = execFileSync('bash', [installPm2LogrotatePath, '--render'], {
+      encoding: 'utf8',
+      env: { ...process.env, INTEXURAOS_ENVIRONMENT: 'prod', PM2_BIN: '/usr/bin/pm2' },
+    });
+    for (const directive of [
+      '/home/deploy/.pm2/logs/*.log',
+      'daily',
+      'maxsize 100M',
+      'rotate 14',
+      'compress',
+      'delaycompress',
+      'missingok',
+      'notifempty',
+      'su deploy deploy',
+      'create 0640 deploy deploy',
+      'sharedscripts',
+      'reloadLogs',
+    ]) {
+      expect(rendered).toContain(directive);
+    }
+
+    const installer = readRequired(installPm2LogrotatePath);
+    const provision = readRequired(provisionPath);
+    const deploy = readRequired(githubActionsDeployPath);
+    const runbook = readRequired(runbookPath);
+    expect(installer).toContain('logrotate --debug "${TEMP_CONFIG}"');
+    expect(installer).toContain(
+      'install -o root -g root -m 0644 "${TEMP_CONFIG}" "${LOGROTATE_CONFIG_PATH}"'
+    );
+    expect(installer).toContain('trap cleanup EXIT');
+    expect(provision).toContain('logrotate');
+    expect(provision).toContain('install_pm2_logrotate()');
+    expect(provision).toContain(
+      'INTEXURAOS_ENVIRONMENT=prod "${SCRIPT_DIR}/install-pm2-logrotate.sh"'
+    );
+    expect(deploy).toContain(
+      'sudo -n INTEXURAOS_ENVIRONMENT=prod bash scripts/hetzner/install-pm2-logrotate.sh'
+    );
+    expect(deploy.indexOf('scripts/hetzner/install-pm2-logrotate.sh')).toBeGreaterThan(
+      deploy.indexOf('scripts/observability/install-grafana-alloy.sh')
+    );
+    expect(deploy.indexOf('scripts/hetzner/install-pm2-logrotate.sh')).toBeLessThan(
+      deploy.indexOf('CI=true pnpm install --frozen-lockfile')
+    );
+    expect(runbook).toContain('/etc/logrotate.d/intexuraos-pm2');
+    expect(runbook).toContain('three consecutive');
   });
 });
 

--- a/scripts/__tests__/hetzner-runtime.test.ts
+++ b/scripts/__tests__/hetzner-runtime.test.ts
@@ -780,9 +780,11 @@ describe('Pub/Sub dead-letter reliability', () => {
     const monitoring = readRequired(terraformMonitoringMainPath);
     const dlqRunbook = readRequired(pubsubDlqRunbookPath);
 
-    expect(monitoring).toContain('resource.label.subscription_id=has_substring("-dlq-")');
+    expect(monitoring.match(/resource\.labels\.subscription_id=has_substring/g)).toHaveLength(3);
+    expect(monitoring).not.toMatch(/resource\.label\.subscription_id=has_substring/);
     expect(monitoring).toContain('pubsub.googleapis.com/subscription/dead_letter_message_count');
-    expect(monitoring).toContain('metric.label.response_code!="success"');
+    expect(monitoring).toContain('metric.labels.response_code!="success"');
+    expect(monitoring).not.toContain('metric.label.response_code!="success"');
     expect(monitoring).toContain('docs/operations/pubsub-dlq-runbook.md');
     expect(dlqRunbook).toContain('31 days');
     expect(dlqRunbook).toContain('payload hash');

--- a/scripts/__tests__/hetzner-runtime.test.ts
+++ b/scripts/__tests__/hetzner-runtime.test.ts
@@ -16,6 +16,7 @@ const installNginxPath = resolve(repoRoot, 'scripts/hetzner/install-nginx-and-ce
 const provisionPath = resolve(repoRoot, 'scripts/hetzner/provision.sh');
 const githubActionsDeployPath = resolve(repoRoot, 'scripts/hetzner/github-actions-deploy.sh');
 const runbookPath = resolve(repoRoot, 'docs/operations/hetzner-prod-runbook.md');
+const pubsubDlqRunbookPath = resolve(repoRoot, 'docs/operations/pubsub-dlq-runbook.md');
 const migrationPlanPath = resolve(repoRoot, 'docs/operations/hetzner-prod-migration-plan.md');
 const selfReviewPath = resolve(repoRoot, 'docs/operations/hetzner-prod-self-review.md');
 const deployWorkflowPath = resolve(repoRoot, '.github/workflows/deploy.yml');
@@ -34,6 +35,7 @@ const terraformPubsubPushModuleMainPath = resolve(
   repoRoot,
   'terraform/modules/pubsub-push/main.tf'
 );
+const terraformPubsubModuleMainPath = resolve(repoRoot, 'terraform/modules/pubsub/main.tf');
 const terraformPubsubPushModuleOutputsPath = resolve(
   repoRoot,
   'terraform/modules/pubsub-push/outputs.tf'
@@ -69,6 +71,7 @@ const terraformMonitoringCodeTaskAlertsPath = resolve(
   repoRoot,
   'terraform/modules/monitoring/code-task-alerts.tf'
 );
+const terraformMonitoringMainPath = resolve(repoRoot, 'terraform/modules/monitoring/main.tf');
 const terraformMonitoringOutputsPath = resolve(repoRoot, 'terraform/modules/monitoring/outputs.tf');
 const manifestPath = resolve(repoRoot, 'apps/web/service-manifest.json');
 const pnpmWorkspacePath = resolve(repoRoot, 'pnpm-workspace.yaml');
@@ -664,6 +667,45 @@ describe('Pub/Sub dev tooling', () => {
   });
 });
 
+describe('Pub/Sub dead-letter reliability', () => {
+  it('grants the Pub/Sub service agent both dead-letter roles with 31-day retention', () => {
+    const pushModule = readRequired(terraformPubsubPushModuleMainPath);
+    const pullModule = readRequired(terraformPubsubModuleMainPath);
+    const devTerraform = readRequired(terraformDevMainPath);
+
+    expect(pushModule).toMatch(
+      /resource "google_pubsub_subscription_iam_member" "dlq_subscriber" \{[\s\S]*?count\s+=\s+var\.enable_push_subscription \? 1 : 0[\s\S]*?subscription\s+=\s+google_pubsub_subscription\.push\[0\]\.name[\s\S]*?role\s+=\s+"roles\/pubsub\.subscriber"/
+    );
+    expect(pullModule).toMatch(
+      /resource "google_pubsub_subscription_iam_member" "dlq_subscriber" \{[\s\S]*?subscription\s+=\s+google_pubsub_subscription\.main\.name[\s\S]*?role\s+=\s+"roles\/pubsub\.subscriber"/
+    );
+    for (const terraform of [pushModule, pullModule]) {
+      expect(terraform).toContain('message_retention_duration = "2678400s"');
+    }
+    expect(devTerraform).toMatch(
+      /resource "google_pubsub_subscription_iam_member" "pubsub_subscribes_audio_stored_push" \{[\s\S]*?subscription\s+=\s+google_pubsub_subscription\.audio_stored_push\.name[\s\S]*?role\s+=\s+"roles\/pubsub\.subscriber"/
+    );
+    expect(devTerraform).toMatch(
+      /resource "google_pubsub_subscription" "transcription_dlq_inspect" \{[\s\S]*?message_retention_duration\s+=\s+"2678400s"/
+    );
+  });
+
+  it('alerts on every DLQ naming form and documents safe selected replay', () => {
+    const monitoring = readRequired(terraformMonitoringMainPath);
+    const dlqRunbook = readRequired(pubsubDlqRunbookPath);
+
+    expect(monitoring).toContain('resource.label.subscription_id=has_substring("-dlq-")');
+    expect(monitoring).toContain('pubsub.googleapis.com/subscription/dead_letter_message_count');
+    expect(monitoring).toContain('metric.label.response_code!="success"');
+    expect(monitoring).toContain('docs/operations/pubsub-dlq-runbook.md');
+    expect(dlqRunbook).toContain('31 days');
+    expect(dlqRunbook).toContain('payload hash');
+    expect(dlqRunbook).toContain('Do not bulk replay');
+    expect(dlqRunbook).toContain('ACK');
+    expect(dlqRunbook).toContain('correlation');
+  });
+});
+
 describe('Hetzner async edge cutover', () => {
   it('stages retained GCP Pub/Sub and Scheduler consumers in the Hetzner Terraform root', () => {
     const script = readRequired(cutoverEdgePath);
@@ -752,6 +794,24 @@ describe('Hetzner async edge cutover', () => {
     expect(hetznerMain).not.toContain(`"${retiredTodosPushPath}"`);
     expect(hetznerMain).not.toContain('"/internal/cron/tick"');
     expect(hetznerPubsub).toContain('google_pubsub_subscription" "hetzner_push"');
+    expect(hetznerPubsub).toContain('resource "google_pubsub_topic" "hetzner_push_dlq"');
+    expect(hetznerPubsub).toMatch(/name\s+=\s+"\$\{each\.value\.subscription_name\}-dlq"/);
+    expect(hetznerPubsub).toContain(
+      'resource "google_pubsub_subscription" "hetzner_push_dlq_inspect"'
+    );
+    expect(hetznerPubsub).toMatch(/name\s+=\s+"\$\{each\.value\.subscription_name\}-dlq-sub"/);
+    expect(hetznerPubsub).toContain('message_retention_duration = "2678400s"');
+    expect(hetznerPubsub).toContain(
+      'resource "google_pubsub_topic_iam_member" "hetzner_push_dlq_publisher"'
+    );
+    expect(hetznerPubsub).toContain(
+      'resource "google_pubsub_subscription_iam_member" "hetzner_push_dlq_subscriber"'
+    );
+    expect(hetznerPubsub).toContain('role         = "roles/pubsub.subscriber"');
+    expect(hetznerPubsub).toContain(
+      'dead_letter_topic     = google_pubsub_topic.hetzner_push_dlq[each.key].id'
+    );
+    expect(hetznerPubsub).not.toContain('data.google_pubsub_topic.hetzner_push_dlq');
     expect(hetznerPubsub).not.toContain(retiredUnderscored('todos', 'processing'));
     expect(hetznerPubsub).not.toContain(retiredTodosPushPath);
     expect(hetznerPubsub).toContain(

--- a/scripts/hetzner/github-actions-deploy.sh
+++ b/scripts/hetzner/github-actions-deploy.sh
@@ -133,6 +133,7 @@ run_remote_deploy_web() {
 deploy_runtime() {
   run_remote 'sudo -n INTEXURAOS_ENVIRONMENT=prod bash scripts/hetzner/load-secrets.sh'
   run_remote 'sudo -n INTEXURAOS_ENVIRONMENT=prod bash scripts/observability/install-grafana-alloy.sh'
+  run_remote 'sudo -n INTEXURAOS_ENVIRONMENT=prod bash scripts/hetzner/install-pm2-logrotate.sh'
   run_remote 'CI=true pnpm install --frozen-lockfile'
   run_remote_deploy_web
   run_remote 'INTEXURAOS_ENVIRONMENT=prod bash scripts/hetzner/reload-pm2.sh'

--- a/scripts/hetzner/install-pm2-logrotate.sh
+++ b/scripts/hetzner/install-pm2-logrotate.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+IFS=$'\n\t'
+
+DEPLOY_USER="${DEPLOY_USER:-deploy}"
+PM2_HOME="${PM2_HOME:-/home/${DEPLOY_USER}/.pm2}"
+PM2_BIN="${PM2_BIN:-}"
+RUNUSER_BIN="${RUNUSER_BIN:-/usr/sbin/runuser}"
+LOGROTATE_CONFIG_PATH="${LOGROTATE_CONFIG_PATH:-/etc/logrotate.d/intexuraos-pm2}"
+MODE="install"
+TEMP_CONFIG=""
+
+usage() {
+  printf 'Usage: INTEXURAOS_ENVIRONMENT=prod %s [--render]\n' "$(basename "$0")"
+}
+
+fail() {
+  printf 'ERROR: %s\n' "$1" >&2
+  exit 1
+}
+
+cleanup() {
+  if [[ -n "${TEMP_CONFIG:-}" ]]; then
+    rm -f "${TEMP_CONFIG}"
+  fi
+}
+
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --render)
+        MODE="render"
+        shift
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      *)
+        fail "Unknown argument: $1"
+        ;;
+    esac
+  done
+}
+
+require_prod() {
+  if [[ "${INTEXURAOS_ENVIRONMENT:-}" != "prod" ]]; then
+    fail "INTEXURAOS_ENVIRONMENT must be prod"
+  fi
+}
+
+require_root() {
+  if [[ "$(id -u)" -ne 0 ]]; then
+    fail "Run this script as root"
+  fi
+}
+
+resolve_pm2_bin() {
+  if [[ -z "${PM2_BIN}" ]]; then
+    PM2_BIN="$(command -v pm2 || true)"
+  fi
+  [[ -n "${PM2_BIN}" ]] || fail "pm2 is required"
+  [[ "${PM2_BIN}" == /* ]] || fail "PM2_BIN must be an absolute path"
+}
+
+validate_inputs() {
+  [[ "${DEPLOY_USER}" =~ ^[a-z_][a-z0-9_-]*$ ]] || fail "DEPLOY_USER is invalid"
+  [[ "${PM2_HOME}" == /* ]] || fail "PM2_HOME must be an absolute path"
+  [[ "${RUNUSER_BIN}" == /* ]] || fail "RUNUSER_BIN must be an absolute path"
+  [[ "${LOGROTATE_CONFIG_PATH}" == /* ]] || fail "LOGROTATE_CONFIG_PATH must be an absolute path"
+}
+
+render_policy() {
+  printf '%s\n' \
+    "${PM2_HOME}/logs/*.log {" \
+    '  daily' \
+    '  maxsize 100M' \
+    '  rotate 14' \
+    '  compress' \
+    '  delaycompress' \
+    '  missingok' \
+    '  notifempty' \
+    "  su ${DEPLOY_USER} ${DEPLOY_USER}" \
+    "  create 0640 ${DEPLOY_USER} ${DEPLOY_USER}" \
+    '  sharedscripts' \
+    '  postrotate' \
+    "    ${RUNUSER_BIN} -u ${DEPLOY_USER} -- env PM2_HOME=${PM2_HOME} ${PM2_BIN} reloadLogs >/dev/null 2>&1" \
+    '  endscript' \
+    '}'
+}
+
+install_policy() {
+  command -v install >/dev/null 2>&1 || fail "install is required"
+  command -v logrotate >/dev/null 2>&1 || fail "logrotate is required"
+  command -v mktemp >/dev/null 2>&1 || fail "mktemp is required"
+  [[ -x "${PM2_BIN}" ]] || fail "PM2_BIN is not executable: ${PM2_BIN}"
+  [[ -x "${RUNUSER_BIN}" ]] || fail "RUNUSER_BIN is not executable: ${RUNUSER_BIN}"
+
+  umask 077
+  TEMP_CONFIG="$(mktemp "${TMPDIR:-/tmp}/intexuraos-pm2-logrotate.XXXXXX")"
+  trap cleanup EXIT
+  render_policy > "${TEMP_CONFIG}"
+
+  logrotate --debug "${TEMP_CONFIG}" >/dev/null
+  install -d -o root -g root -m 0755 "$(dirname "${LOGROTATE_CONFIG_PATH}")"
+  install -o root -g root -m 0644 "${TEMP_CONFIG}" "${LOGROTATE_CONFIG_PATH}"
+  printf 'Installed PM2 logrotate policy at %s\n' "${LOGROTATE_CONFIG_PATH}"
+}
+
+main() {
+  parse_args "$@"
+  require_prod
+  resolve_pm2_bin
+  validate_inputs
+
+  if [[ "${MODE}" == "render" ]]; then
+    render_policy
+    return
+  fi
+
+  require_root
+  install_policy
+}
+
+main "$@"

--- a/scripts/hetzner/provision.sh
+++ b/scripts/hetzner/provision.sh
@@ -89,6 +89,7 @@ install_base_packages() {
     gnupg \
     jq \
     libnginx-mod-http-lua \
+    logrotate \
     lua5.1 \
     lua-cjson \
     nginx-extras \
@@ -245,6 +246,11 @@ install_grafana_alloy_collector() {
   INTEXURAOS_ENVIRONMENT=prod "${SCRIPT_DIR}/../observability/install-grafana-alloy.sh"
 }
 
+install_pm2_logrotate() {
+  printf 'Installing bounded PM2 log rotation\n'
+  INTEXURAOS_ENVIRONMENT=prod "${SCRIPT_DIR}/install-pm2-logrotate.sh"
+}
+
 main() {
   parse_args "$@"
   require_prod
@@ -255,6 +261,7 @@ main() {
   ensure_swap
   install_node_22
   prepare_user_and_directories
+  install_pm2_logrotate
   configure_firewall
   write_pm2_systemd_unit
 

--- a/scripts/hetzner/reload-pm2.sh
+++ b/scripts/hetzner/reload-pm2.sh
@@ -7,7 +7,8 @@ CONFIG_SOURCE="${CONFIG_SOURCE:-ecosystem.config.prod.cjs}"
 RENDERED_CONFIG="${RENDERED_CONFIG:-/home/deploy/.pm2/intexuraos-prod-ecosystem.json}"
 PM2_START_TIMEOUT_SECONDS="${PM2_START_TIMEOUT_SECONDS:-120}"
 PM2_SYSTEMD_SERVICE="${PM2_SYSTEMD_SERVICE:-pm2-deploy.service}"
-PM2_HEALTH_URLS="${PM2_HEALTH_URLS:-http://127.0.0.1:8122/health http://127.0.0.1:8110/health}"
+PM2_HEALTH_URLS="${PM2_HEALTH_URLS:-}"
+PM2_HEALTH_CONSECUTIVE_SUCCESSES="${PM2_HEALTH_CONSECUTIVE_SUCCESSES:-3}"
 TEMP_RENDERED_CONFIG=""
 
 usage() {
@@ -83,6 +84,34 @@ process.stdout.write(JSON.stringify(config, null, 2));
 NODE
 }
 
+derive_health_urls() {
+  node - "${RENDERED_CONFIG}" <<'NODE'
+const { readFileSync } = require('node:fs');
+
+const config = JSON.parse(readFileSync(process.argv[2], 'utf8'));
+if (!config || !Array.isArray(config.apps)) {
+  throw new Error('Rendered PM2 config must contain apps');
+}
+
+const urls = config.apps.map((app) => {
+  const port = Number(app.env?.PORT);
+  if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+    throw new Error(`PM2 app ${app.name ?? 'unknown'} has invalid PORT`);
+  }
+  return `http://127.0.0.1:${port}/health`;
+});
+
+if (urls.length === 0) {
+  throw new Error('Rendered PM2 config must contain at least one app');
+}
+if (new Set(urls).size !== urls.length) {
+  throw new Error('Rendered PM2 config contains duplicate health ports');
+}
+
+process.stdout.write(urls.join(' '));
+NODE
+}
+
 wait_for_pm2_online() {
   local deadline=$((SECONDS + PM2_START_TIMEOUT_SECONDS))
   local not_online=""
@@ -122,6 +151,7 @@ wait_for_http_health() {
   local deadline=$((SECONDS + PM2_START_TIMEOUT_SECONDS))
   local failed_urls=""
   local health_urls=()
+  local healthy_passes=0
   local url=""
   local IFS=' '
 
@@ -137,13 +167,19 @@ wait_for_http_health() {
     done
 
     if [[ -z "${failed_urls}" ]]; then
-      return 0
+      healthy_passes=$((healthy_passes + 1))
+      if ((healthy_passes >= PM2_HEALTH_CONSECUTIVE_SUCCESSES)); then
+        return 0
+      fi
+    else
+      healthy_passes=0
     fi
 
     sleep 5
   done
 
-  printf 'ERROR: HTTP health checks did not become ready:\n%s\n' "${failed_urls}" >&2
+  printf 'ERROR: PM2 health checks did not remain ready:\n%s\n' "${failed_urls}" >&2
+  pm2 status >&2 || true
   return 1
 }
 
@@ -162,6 +198,8 @@ main() {
   require_prod
 
   [[ "${PM2_START_TIMEOUT_SECONDS}" =~ ^[0-9]+$ ]] || fail "PM2_START_TIMEOUT_SECONDS must be an integer"
+  [[ "${PM2_HEALTH_CONSECUTIVE_SUCCESSES}" =~ ^[1-9][0-9]*$ ]] \
+    || fail "PM2_HEALTH_CONSECUTIVE_SUCCESSES must be a positive integer"
   command -v curl >/dev/null 2>&1 || fail "curl is required"
   command -v node >/dev/null 2>&1 || fail "node is required"
   command -v pm2 >/dev/null 2>&1 || fail "pm2 is required"
@@ -174,6 +212,9 @@ main() {
   render_config "${CONFIG_SOURCE}" "${TEMP_RENDERED_CONFIG}"
   install -d -m 700 "$(dirname "${RENDERED_CONFIG}")"
   install -m 600 "${TEMP_RENDERED_CONFIG}" "${RENDERED_CONFIG}"
+  if [[ -z "${PM2_HEALTH_URLS}" ]]; then
+    PM2_HEALTH_URLS="$(derive_health_urls)"
+  fi
 
   pm2 delete all || true
   pm2 start "${RENDERED_CONFIG}" --update-env

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -786,7 +786,7 @@ resource "google_pubsub_topic_iam_member" "transcription_publishes_dlq" {
   member  = "serviceAccount:${google_service_account.transcription_function.email}"
 }
 
-# DLQ inspection subscription — pull subscription with 7-day retention for
+# DLQ inspection subscription — pull subscription with 31-day retention for
 # manual / tooling-driven incident review. Per parent plan §5, this is the
 # anchor for a future BigQuery log sink.
 resource "google_pubsub_subscription" "transcription_dlq_inspect" {
@@ -796,7 +796,7 @@ resource "google_pubsub_subscription" "transcription_dlq_inspect" {
   labels  = local.common_labels
 
   ack_deadline_seconds       = 600
-  message_retention_duration = "604800s" # 7 days
+  message_retention_duration = "2678400s" # 31 days
 
   expiration_policy {
     ttl = ""
@@ -1409,7 +1409,7 @@ resource "google_pubsub_subscription" "transcription_completed_dlq" {
   labels  = local.common_labels
 
   ack_deadline_seconds       = 600
-  message_retention_duration = "604800s"
+  message_retention_duration = "2678400s"
 
   expiration_policy {
     ttl = ""
@@ -1528,6 +1528,15 @@ resource "google_pubsub_subscription" "audio_stored_push" {
     google_pubsub_topic.transcription_dlq,
     google_pubsub_topic_iam_member.pubsub_publishes_transcription_dlq,
   ]
+}
+
+# Pub/Sub must be able to ACK the source message after forwarding it to the
+# transcription DLQ.
+resource "google_pubsub_subscription_iam_member" "pubsub_subscribes_audio_stored_push" {
+  project      = var.project_id
+  subscription = google_pubsub_subscription.audio_stored_push.name
+  role         = "roles/pubsub.subscriber"
+  member       = "serviceAccount:service-${local.project_number}@gcp-sa-pubsub.iam.gserviceaccount.com"
 }
 
 # -----------------------------------------------------------------------------

--- a/terraform/hetzner-prod/pubsub.tf
+++ b/terraform/hetzner-prod/pubsub.tf
@@ -113,6 +113,38 @@ locals {
   }
 }
 
+resource "google_pubsub_topic" "hetzner_push_dlq" {
+  for_each = local.hetzner_pubsub_push_subscriptions
+
+  name    = "${each.value.subscription_name}-dlq"
+  project = var.project_id
+  labels  = local.common_labels
+}
+
+resource "google_pubsub_subscription" "hetzner_push_dlq_inspect" {
+  for_each = local.hetzner_pubsub_push_subscriptions
+
+  name                       = "${each.value.subscription_name}-dlq-sub"
+  topic                      = google_pubsub_topic.hetzner_push_dlq[each.key].id
+  project                    = var.project_id
+  labels                     = local.common_labels
+  ack_deadline_seconds       = 600
+  message_retention_duration = "2678400s"
+
+  expiration_policy {
+    ttl = ""
+  }
+}
+
+resource "google_pubsub_topic_iam_member" "hetzner_push_dlq_publisher" {
+  for_each = local.hetzner_pubsub_push_subscriptions
+
+  project = var.project_id
+  topic   = google_pubsub_topic.hetzner_push_dlq[each.key].name
+  role    = "roles/pubsub.publisher"
+  member  = "serviceAccount:service-${data.google_project.retained.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
+}
+
 resource "google_pubsub_subscription" "hetzner_push" {
   for_each = local.hetzner_pubsub_push_subscriptions
 
@@ -144,25 +176,29 @@ resource "google_pubsub_subscription" "hetzner_push" {
   }
 
   dead_letter_policy {
-    dead_letter_topic     = data.google_pubsub_topic.hetzner_push_dlq[each.key].id
+    dead_letter_topic     = google_pubsub_topic.hetzner_push_dlq[each.key].id
     max_delivery_attempts = each.value.max_delivery_attempts
   }
 
   expiration_policy {
     ttl = ""
   }
+
+  depends_on = [google_pubsub_topic_iam_member.hetzner_push_dlq_publisher]
+}
+
+resource "google_pubsub_subscription_iam_member" "hetzner_push_dlq_subscriber" {
+  for_each = local.hetzner_pubsub_push_subscriptions
+
+  project      = var.project_id
+  subscription = google_pubsub_subscription.hetzner_push[each.key].name
+  role         = "roles/pubsub.subscriber"
+  member       = "serviceAccount:service-${data.google_project.retained.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
 }
 
 data "google_pubsub_topic" "hetzner_push" {
   for_each = local.hetzner_pubsub_push_subscriptions
 
   name    = each.value.topic_name
-  project = var.project_id
-}
-
-data "google_pubsub_topic" "hetzner_push_dlq" {
-  for_each = local.hetzner_pubsub_push_subscriptions
-
-  name    = "${each.value.topic_name}-dlq"
   project = var.project_id
 }

--- a/terraform/modules/monitoring/main.tf
+++ b/terraform/modules/monitoring/main.tf
@@ -392,7 +392,7 @@ resource "google_monitoring_dashboard" "main" {
               dataSets = [{
                 timeSeriesQuery = {
                   timeSeriesFilter = {
-                    filter = "resource.type=\"pubsub_subscription\" metric.type=\"pubsub.googleapis.com/subscription/num_undelivered_messages\" resource.label.subscription_id=has_substring(\"-dlq-sub\")"
+                    filter = "resource.type=\"pubsub_subscription\" metric.type=\"pubsub.googleapis.com/subscription/num_undelivered_messages\" resource.label.subscription_id=has_substring(\"-dlq-\")"
                     aggregation = {
                       alignmentPeriod    = "60s"
                       perSeriesAligner   = "ALIGN_MEAN"
@@ -481,7 +481,7 @@ resource "google_monitoring_dashboard" "main" {
             scorecard = {
               timeSeriesQuery = {
                 timeSeriesFilter = {
-                  filter = "resource.type=\"pubsub_subscription\" metric.type=\"pubsub.googleapis.com/subscription/num_undelivered_messages\" resource.label.subscription_id=has_substring(\"-dlq-sub\")"
+                  filter = "resource.type=\"pubsub_subscription\" metric.type=\"pubsub.googleapis.com/subscription/num_undelivered_messages\" resource.label.subscription_id=has_substring(\"-dlq-\")"
                   aggregation = {
                     alignmentPeriod    = "60s"
                     perSeriesAligner   = "ALIGN_MEAN"
@@ -724,7 +724,7 @@ resource "google_monitoring_alert_policy" "dlq_messages" {
       filter          = <<-EOT
         resource.type="pubsub_subscription"
         metric.type="pubsub.googleapis.com/subscription/num_undelivered_messages"
-        resource.label.subscription_id=has_substring("-dlq-sub")
+        resource.label.subscription_id=has_substring("-dlq-")
       EOT
       comparison      = "COMPARISON_GT"
       threshold_value = 0
@@ -747,7 +747,50 @@ resource "google_monitoring_alert_policy" "dlq_messages" {
   }
 
   documentation {
-    content   = "Messages have failed processing and moved to DLQ. Investigate immediately - messages will expire after 7 days."
+    content   = "Messages have failed processing and moved to a DLQ. Investigate within the 31-day retention window using [the Pub/Sub DLQ runbook](https://github.com/pbuchman/intexuraos/blob/development/docs/operations/pubsub-dlq-runbook.md)."
+    mime_type = "text/markdown"
+  }
+}
+
+resource "google_monitoring_alert_policy" "dlq_forwarding_failures" {
+  count        = var.alert_email != null ? 1 : 0
+  display_name = "Dead Letter Queue Forwarding Failed"
+
+  combiner = "OR"
+  conditions {
+    display_name = "Pub/Sub could not forward or acknowledge a dead letter"
+    condition_threshold {
+      filter          = <<-EOT
+        resource.type="pubsub_subscription"
+        metric.type="pubsub.googleapis.com/subscription/dead_letter_message_count"
+        metric.label.response_code!="success"
+      EOT
+      comparison      = "COMPARISON_GT"
+      threshold_value = 0
+      duration        = "60s"
+      aggregations {
+        alignment_period     = "60s"
+        per_series_aligner   = "ALIGN_SUM"
+        cross_series_reducer = "REDUCE_SUM"
+        group_by_fields = [
+          "resource.label.subscription_id",
+          "metric.label.response_code",
+        ]
+      }
+      trigger {
+        count = 1
+      }
+    }
+  }
+
+  notification_channels = [google_monitoring_notification_channel.email[0].name]
+
+  alert_strategy {
+    auto_close = "3600s"
+  }
+
+  documentation {
+    content   = "Pub/Sub failed to forward a dead letter or ACK its source message. Check the source subscription IAM and follow [the Pub/Sub DLQ runbook](https://github.com/pbuchman/intexuraos/blob/development/docs/operations/pubsub-dlq-runbook.md)."
     mime_type = "text/markdown"
   }
 }

--- a/terraform/modules/monitoring/main.tf
+++ b/terraform/modules/monitoring/main.tf
@@ -392,7 +392,7 @@ resource "google_monitoring_dashboard" "main" {
               dataSets = [{
                 timeSeriesQuery = {
                   timeSeriesFilter = {
-                    filter = "resource.type=\"pubsub_subscription\" metric.type=\"pubsub.googleapis.com/subscription/num_undelivered_messages\" resource.label.subscription_id=has_substring(\"-dlq-\")"
+                    filter = "resource.type=\"pubsub_subscription\" metric.type=\"pubsub.googleapis.com/subscription/num_undelivered_messages\" resource.labels.subscription_id=has_substring(\"-dlq-\")"
                     aggregation = {
                       alignmentPeriod    = "60s"
                       perSeriesAligner   = "ALIGN_MEAN"
@@ -481,7 +481,7 @@ resource "google_monitoring_dashboard" "main" {
             scorecard = {
               timeSeriesQuery = {
                 timeSeriesFilter = {
-                  filter = "resource.type=\"pubsub_subscription\" metric.type=\"pubsub.googleapis.com/subscription/num_undelivered_messages\" resource.label.subscription_id=has_substring(\"-dlq-\")"
+                  filter = "resource.type=\"pubsub_subscription\" metric.type=\"pubsub.googleapis.com/subscription/num_undelivered_messages\" resource.labels.subscription_id=has_substring(\"-dlq-\")"
                   aggregation = {
                     alignmentPeriod    = "60s"
                     perSeriesAligner   = "ALIGN_MEAN"
@@ -724,7 +724,7 @@ resource "google_monitoring_alert_policy" "dlq_messages" {
       filter          = <<-EOT
         resource.type="pubsub_subscription"
         metric.type="pubsub.googleapis.com/subscription/num_undelivered_messages"
-        resource.label.subscription_id=has_substring("-dlq-")
+        resource.labels.subscription_id=has_substring("-dlq-")
       EOT
       comparison      = "COMPARISON_GT"
       threshold_value = 0
@@ -763,7 +763,7 @@ resource "google_monitoring_alert_policy" "dlq_forwarding_failures" {
       filter          = <<-EOT
         resource.type="pubsub_subscription"
         metric.type="pubsub.googleapis.com/subscription/dead_letter_message_count"
-        metric.label.response_code!="success"
+        metric.labels.response_code!="success"
       EOT
       comparison      = "COMPARISON_GT"
       threshold_value = 0

--- a/terraform/modules/pubsub-push/main.tf
+++ b/terraform/modules/pubsub-push/main.tf
@@ -61,6 +61,8 @@ resource "google_pubsub_subscription" "push" {
   expiration_policy {
     ttl = ""
   }
+
+  depends_on = [google_pubsub_topic_iam_member.dlq_publisher]
 }
 
 # DLQ subscription (for manual inspection)
@@ -73,8 +75,8 @@ resource "google_pubsub_subscription" "dlq" {
   # Longer ack deadline for manual processing
   ack_deadline_seconds = 600
 
-  # Retain messages for 7 days
-  message_retention_duration = "604800s"
+  # Retain messages for 31 days
+  message_retention_duration = "2678400s"
 
   # No retry policy - manual handling
   expiration_policy {
@@ -99,4 +101,15 @@ resource "google_pubsub_topic_iam_member" "dlq_publisher" {
   topic   = google_pubsub_topic.dlq.id
   role    = "roles/pubsub.publisher"
   member  = "serviceAccount:service-${var.project_number}@gcp-sa-pubsub.iam.gserviceaccount.com"
+}
+
+# Grant the Pub/Sub service agent permission to ACK the source subscription
+# after forwarding a message to the DLQ.
+resource "google_pubsub_subscription_iam_member" "dlq_subscriber" {
+  count = var.enable_push_subscription ? 1 : 0
+
+  project      = var.project_id
+  subscription = google_pubsub_subscription.push[0].name
+  role         = "roles/pubsub.subscriber"
+  member       = "serviceAccount:service-${var.project_number}@gcp-sa-pubsub.iam.gserviceaccount.com"
 }

--- a/terraform/modules/pubsub/main.tf
+++ b/terraform/modules/pubsub/main.tf
@@ -45,6 +45,8 @@ resource "google_pubsub_subscription" "main" {
   expiration_policy {
     ttl = ""
   }
+
+  depends_on = [google_pubsub_topic_iam_member.dlq_publisher]
 }
 
 # DLQ subscription (for manual inspection)
@@ -57,8 +59,8 @@ resource "google_pubsub_subscription" "dlq" {
   # Longer ack deadline for manual processing
   ack_deadline_seconds = 600
 
-  # Retain messages for 7 days
-  message_retention_duration = "604800s"
+  # Retain messages for 31 days
+  message_retention_duration = "2678400s"
 
   # No retry policy - manual handling
   expiration_policy {
@@ -95,3 +97,11 @@ resource "google_pubsub_topic_iam_member" "dlq_publisher" {
   member  = "serviceAccount:service-${var.project_number}@gcp-sa-pubsub.iam.gserviceaccount.com"
 }
 
+# Grant the Pub/Sub service agent permission to ACK the source subscription
+# after forwarding a message to the DLQ.
+resource "google_pubsub_subscription_iam_member" "dlq_subscriber" {
+  project      = var.project_id
+  subscription = google_pubsub_subscription.main.name
+  role         = "roles/pubsub.subscriber"
+  member       = "serviceAccount:service-${var.project_number}@gcp-sa-pubsub.iam.gserviceaccount.com"
+}


### PR DESCRIPTION
## Summary

- add dedicated production DLQ topics and inspection subscriptions for all 11 Hetzner push consumers, with the Pub/Sub service-agent IAM required for reliable forwarding
- retain DLQ messages for 31 days, cover every DLQ subscription in monitoring, and alert on unsuccessful forwarding
- make scheduled Linear synchronization return a retryable failure when any user sync is incomplete
- discover PM2 health checks from the rendered process configuration and install bounded log rotation during provisioning and deployment
- add operational runbooks for DLQ inspection, replay safety, readiness, and log rotation

## Endpoint changes

- Modified: `POST /internal/linear/sync-all` now returns non-2xx, including 503 for transient partial failures, so Cloud Scheduler retries incomplete runs
- Created: none
- Removed: none

## Infrastructure verification

- Terraform validation passed for `terraform/environments/dev` and `terraform/hetzner-prod`
- production source subscriptions remain in place with unchanged names
- full plans contain unrelated existing drift; rollout will use reviewed targeted plans for only the resources in this PR

## Testing

- `pnpm run ci:tracked` — 5307 tests passed, build and all validations passed
- targeted runtime, infrastructure, monitoring, and Linear tests passed
- shell syntax checks passed for all changed Hetzner scripts

## Linear

Fixes INT-1858.

## PR Description Update
- Linear: [INT-1858](https://linear.app/pbuchman/issue/INT-1858)
- IntexuraOS Code Task: [View task](https://intexuraos.cloud/#/code-tasks/task_e1258f47-384e-4863-b5bc-071345f12f6c)
- Worker Type: `codex-xhigh`
- Model: `default`

