### PR TITLE
[INT-1859] fix: unblock Intex Agent live acceptance

### DIFF
--- a/apps/intex-agent/src/__tests__/domain/testConversationSanitizer.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/testConversationSanitizer.test.ts
@@ -537,6 +537,32 @@ describe('test conversation sanitizer', () => {
     expect(sanitizeRecord({ textPreview: ' \n\t ', reason: 'kept' })).toEqual({ reason: 'kept' });
   });
 
+  it('omits event payload strings that normalize to empty values', () => {
+    const sanitized = sanitizeEventsBySessionId({
+      intex_session_1: [
+        {
+          id: 'event-1',
+          sessionId: 'intex_session_1',
+          userId: 'test-intex-agent-run',
+          type: 'user_message',
+          createdAt: '2026-07-01T10:00:00.000Z',
+          payload: { text: ' \n\t ', sourceType: ' \r\n ' },
+        },
+      ],
+    });
+
+    expect(sanitized).toEqual({
+      intex_session_1: [
+        {
+          id: 'event-1',
+          type: 'user_message',
+          createdAt: '2026-07-01T10:00:00.000Z',
+          payload: {},
+        },
+      ],
+    });
+  });
+
   it('redacts captured reply URLs, source lines, prompt lines, and CTA URLs', () => {
     const sanitized = sanitizeAssistantReplies([
       {

--- a/apps/intex-agent/src/__tests__/domain/testConversationSanitizer.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/testConversationSanitizer.test.ts
@@ -533,6 +533,10 @@ describe('test conversation sanitizer', () => {
     });
   });
 
+  it('omits strings that normalize to empty values', () => {
+    expect(sanitizeRecord({ textPreview: ' \n\t ', reason: 'kept' })).toEqual({ reason: 'kept' });
+  });
+
   it('redacts captured reply URLs, source lines, prompt lines, and CTA URLs', () => {
     const sanitized = sanitizeAssistantReplies([
       {

--- a/apps/intex-agent/src/domain/testConversation/testConversationSanitizer.ts
+++ b/apps/intex-agent/src/domain/testConversation/testConversationSanitizer.ts
@@ -405,7 +405,10 @@ function sanitizeEventPayload(event: IntexAgentSessionEvent): Record<string, unk
 
   const text = readFirstString(payload, ['text', 'message']);
   if (text !== undefined) {
-    sanitized['textPreview'] = previewText(redactSyntheticMarkers(text));
+    const textPreview = previewText(redactSyntheticMarkers(text));
+    if (textPreview !== '') {
+      sanitized['textPreview'] = textPreview;
+    }
   }
 
   if (event.type === 'tool_call_completed') {
@@ -442,7 +445,10 @@ function copyString(
 ): void {
   const value = source[key];
   if (typeof value === 'string' && !SECRET_FIELD_PATTERN.test(key)) {
-    target[key] = truncate(value);
+    const normalized = truncate(value);
+    if (normalized !== '') {
+      target[key] = normalized;
+    }
   }
 }
 

--- a/apps/intex-agent/src/domain/testConversation/testConversationSanitizer.ts
+++ b/apps/intex-agent/src/domain/testConversation/testConversationSanitizer.ts
@@ -500,7 +500,8 @@ function toolOutcomeForTurn(
 
 function sanitizeValue(value: unknown): unknown {
   if (typeof value === 'string') {
-    return truncate(value);
+    const normalized = truncate(value);
+    return normalized === '' ? undefined : normalized;
   }
   if (typeof value === 'number' || typeof value === 'boolean' || value === null) {
     return value;

--- a/docs/superpowers/plans/2026-07-18-intex-agent-live-acceptance-fixes.md
+++ b/docs/superpowers/plans/2026-07-18-intex-agent-live-acceptance-fixes.md
@@ -1,0 +1,123 @@
+# Intex Agent Live Acceptance Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the two infrastructure defects discovered during the first Home Dev acceptance run, redeploy the exact fixes, and complete `preflight` → `endpoint` → `full`.
+
+**Architecture:** Keep the approved evaluator contract unchanged. The Intex Agent sanitizer omits normalized-empty event values before they reach the strict evaluator wire schema. The shared OpenRouter client rejects malformed or in-band error completions as provider failures before MiniMax output parsing; MiniMax remains the sole judge in JSON-object mode with no fallback.
+
+**Tech Stack:** TypeScript 5.7, Node.js 22, pnpm 10, Vitest 4, Zod 3, Home Dev, OpenRouter, MiniMax M3.
+
+## Global Constraints
+
+- The only evaluation judge is `or:minimax/minimax-m3` (`minimax/minimax-m3` at the raw OpenRouter boundary).
+- Claude Sonnet is not used as judge, fallback, repair model, or retry model.
+- A MiniMax failure, invalid JSON, missing credential, or timeout is an infrastructure failure. It never silently passes or switches models.
+- Preserve JSON-object mode, temperature `0`, strict local Zod validation, and at most one same-model structured repair.
+- Product tools remain mocked in endpoint scenarios; every synthetic user is cleaned in `finally`.
+- Never log response content, provider error text, real user identifiers, Matrix identifiers, paths, tokens, or messages.
+- Do not implement strict JSON Schema routing, `provider.require_parameters`, a second model, or any deferred-perfection item in this fix.
+- Every production change follows RED → GREEN and receives an independent task review.
+
+---
+
+### Task 1: Omit normalized-empty sanitized event values
+
+**Files:**
+- Modify: `apps/intex-agent/src/domain/testConversation/testConversationSanitizer.ts`
+- Test: `apps/intex-agent/src/__tests__/domain/testConversationSanitizer.test.ts`
+
+**Interfaces:**
+- Consumes: `sanitizeRecord(record: Record<string, unknown>): Record<string, unknown>`.
+- Produces: the same public function, with string values omitted when normalization by the existing `truncate()` helper yields `''`.
+
+- [ ] **Step 1: Write the failing regression test**
+
+  Add one test using the real `sanitizeRecord()` implementation:
+
+  ```ts
+  expect(sanitizeRecord({ textPreview: ' \n\t ', reason: 'kept' })).toEqual({ reason: 'kept' });
+  ```
+
+  The test must also retain the existing coverage proving non-empty strings are normalized and kept.
+
+- [ ] **Step 2: Verify RED**
+
+  Run:
+
+  ```bash
+  pnpm exec vitest run apps/intex-agent/src/__tests__/domain/testConversationSanitizer.test.ts
+  ```
+
+  Expected: the new assertion fails because the current result contains `textPreview: ''`.
+
+- [ ] **Step 3: Implement the minimum fix**
+
+  In the string branch of `sanitizeValue()`, normalize once with `truncate(value)` and return `undefined` only when the normalized value is empty. Do not widen the evaluator wire schema and do not special-case `textPreview`.
+
+- [ ] **Step 4: Verify GREEN and commit**
+
+  Run the focused sanitizer test and `pnpm run ci:tracked`; both must pass with pristine test output. Commit only this task's source and test changes.
+
+**Acceptance:** whitespace-only sanitized payload values are absent; non-empty safe values and all other sanitizer behavior are unchanged.
+
+---
+
+### Task 2: Reject malformed OpenRouter success envelopes
+
+**Files:**
+- Modify: `packages/infra-openrouter/src/types.ts`
+- Modify: `packages/infra-openrouter/src/client.ts`
+- Test: `packages/infra-openrouter/src/__tests__/client.test.ts`
+
+**Interfaces:**
+- Consumes: OpenRouter's non-streaming chat-completion envelope.
+- Produces: `generate()` and `generateChat()` return an error `Result` for an absent first choice, `finish_reason: 'error'`, an in-band `choice.error`, or non-string assistant content.
+
+- [ ] **Step 1: Write failing HTTP-boundary regression tests**
+
+  Add complete Nock fixtures for:
+
+  1. HTTP 200 with `finish_reason: 'error'`, `choices[0].error`, and partial content;
+  2. HTTP 200 with `choices: []`;
+  3. HTTP 200 with `message.content: null`.
+
+  Assert that the public client returns an error `Result` and never exposes partial/empty content as success. Do not assert provider message text and do not add test-only production APIs. Update the two existing empty-choice success tests to the new failure contract.
+
+- [ ] **Step 2: Verify RED**
+
+  Run:
+
+  ```bash
+  pnpm exec vitest run packages/infra-openrouter/src/__tests__/client.test.ts
+  ```
+
+  Expected: the new assertions fail because the current client returns successful content for these envelopes.
+
+- [ ] **Step 3: Implement runtime validation**
+
+  Widen only the raw provider response type to reflect optional error metadata and unknown/null content. Before usage extraction and `ok(...)`, reject an absent choice, an in-band choice error, `finish_reason === 'error'`, and content whose runtime type is not `string`. Use a closed local error message; never forward the provider's error text. Preserve existing HTTP error mapping and retry behavior.
+
+- [ ] **Step 4: Verify GREEN and commit**
+
+  Run the focused OpenRouter test, evaluator MiniMax tests, and `pnpm run ci:tracked`; all must pass. Commit only this task's source and test changes.
+
+**Acceptance:** provider failures cannot be mislabeled downstream as valid chat output; valid string completions, usage accounting, JSON-object requests, and all existing model behavior remain unchanged.
+
+---
+
+### Task 3: Review, deliver, and repeat live acceptance
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-07-18-intex-agent-live-acceptance-fixes.md` only to record final evidence.
+
+- [ ] Independently review each task and the combined diff; close every Critical or Important finding.
+- [ ] Run focused suites and `pnpm run ci:tracked` on the exact final revision.
+- [ ] Push the branch, open and merge a PR into `development`, and wait until Home Dev contains the exact fix revision through the existing deployment path.
+- [ ] Verify Home Dev health and deployed-revision ancestry.
+- [ ] Run `scripts/run-intex-agent-evals-home-dev.sh preflight`.
+- [ ] Run `scripts/run-intex-agent-evals-home-dev.sh endpoint`; stop before Matrix on nonzero exit.
+- [ ] Only after endpoint exit `0`, run `scripts/run-intex-agent-evals-home-dev.sh full` exactly once.
+- [ ] Report the two artifact paths, MiniMax provider-reported USD, failed scenario IDs, and cleanup evidence without private content.
+
+**Final acceptance:** Home Dev `full` exits `0`; all 20 scenarios pass deterministic and MiniMax checks; one safe Matrix smoke passes; all reports are private and complete.

--- a/packages/infra-openrouter/src/__tests__/client.test.ts
+++ b/packages/infra-openrouter/src/__tests__/client.test.ts
@@ -826,7 +826,7 @@ describe('createOpenRouterClient', () => {
       expect(capturedBody).not.toHaveProperty('response_format');
     });
 
-    it('handles empty choices array in generate', async () => {
+    it('rejects an empty choices array in generate', async () => {
       nock(API_BASE_URL)
         .post('/chat/completions')
         .reply(200, {
@@ -848,10 +848,87 @@ describe('createOpenRouterClient', () => {
 
       const result = await client.generate('Write something', { promptType: 'test-prompt' });
 
-      // Should return empty content when choices is empty
-      expect(result.ok).toBe(true);
-      if (result.ok) {
-        expect(result.value.content).toBe('');
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe('API_ERROR');
+      }
+    });
+
+    it('rejects an in-band provider error instead of returning partial content', async () => {
+      nock(API_BASE_URL)
+        .post('/chat/completions')
+        .reply(200, {
+          id: 'test-id',
+          model: TEST_MODEL,
+          created: Date.now(),
+          object: 'chat.completion',
+          choices: [
+            {
+              index: 0,
+              message: { content: 'Partial response that must not escape', role: 'assistant' },
+              finish_reason: 'error',
+              error: {
+                code: 500,
+                message: 'Sensitive provider failure text',
+                metadata: { provider_name: 'test-provider' },
+              },
+            },
+          ],
+          usage: { prompt_tokens: 50, completion_tokens: 10, total_tokens: 60 },
+        });
+
+      const client = createOpenRouterClient({
+        apiKey: 'test-key',
+        model: TEST_MODEL,
+        userId: 'test-user',
+        logger: mockLogger,
+        usageSink: mockUsageSink,
+      });
+
+      const result = await client.generate('Write something', { promptType: 'test-prompt' });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe('API_ERROR');
+      }
+    });
+
+    it('rejects choice error metadata even when the finish reason is not error', async () => {
+      nock(API_BASE_URL)
+        .post('/chat/completions')
+        .reply(200, {
+          id: 'test-id',
+          model: TEST_MODEL,
+          created: Date.now(),
+          object: 'chat.completion',
+          choices: [
+            {
+              index: 0,
+              message: { content: 'Partial response that must not escape', role: 'assistant' },
+              finish_reason: 'stop',
+              error: {
+                code: 500,
+                message: 'Sensitive provider failure text',
+                metadata: { provider_name: 'test-provider' },
+              },
+            },
+          ],
+          usage: { prompt_tokens: 50, completion_tokens: 10, total_tokens: 60 },
+        });
+
+      const client = createOpenRouterClient({
+        apiKey: 'test-key',
+        model: TEST_MODEL,
+        userId: 'test-user',
+        logger: mockLogger,
+        usageSink: mockUsageSink,
+      });
+
+      const result = await client.generate('Write something', { promptType: 'test-prompt' });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe('API_ERROR');
       }
     });
   });
@@ -1316,7 +1393,7 @@ describe('createOpenRouterClient', () => {
       );
     });
 
-    it('returns empty content and zero usage when chat response choices are empty', async () => {
+    it('rejects a chat response with empty choices', async () => {
       nock(API_BASE_URL)
         .post('/chat/completions')
         .reply(200, {
@@ -1341,17 +1418,46 @@ describe('createOpenRouterClient', () => {
         { promptType: 'test-chat-prompt' }
       );
 
-      expect(result.ok).toBe(true);
-      if (result.ok) {
-        expect(result.value).toEqual({
-          content: '',
-          usage: {
-            inputTokens: 0,
-            outputTokens: 0,
-            totalTokens: 0,
-            costUsd: 0,
-          },
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe('API_ERROR');
+      }
+    });
+
+    it('rejects null assistant content', async () => {
+      nock(API_BASE_URL)
+        .post('/chat/completions')
+        .reply(200, {
+          id: 'test-id',
+          model: TEST_MODEL,
+          created: Date.now(),
+          object: 'chat.completion',
+          choices: [
+            {
+              index: 0,
+              message: { content: null, role: 'assistant' },
+              finish_reason: 'stop',
+            },
+          ],
+          usage: { prompt_tokens: 50, completion_tokens: 0, total_tokens: 50 },
         });
+
+      const client = createOpenRouterClient({
+        apiKey: 'test-key',
+        model: TEST_MODEL,
+        userId: 'test-user',
+        logger: mockLogger,
+        usageSink: mockUsageSink,
+      });
+
+      const result = await client.generateChat(
+        [{ role: 'user', content: 'What happened in this chat?' }],
+        { promptType: 'test-chat-prompt' }
+      );
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe('API_ERROR');
       }
     });
   });

--- a/packages/infra-openrouter/src/client.ts
+++ b/packages/infra-openrouter/src/client.ts
@@ -107,6 +107,7 @@ const DEFAULT_TIMEOUT_MS = 840_000;
 /** Application name sent to OpenRouter */
 const APP_TITLE = 'IntexuraOS';
 const RESEARCH_PROMPT_TYPE = 'research-web-search';
+const INVALID_COMPLETION_RESPONSE_MESSAGE = 'OpenRouter returned an invalid completion response';
 
 async function fetchWithTimeout(
   url: string,
@@ -327,7 +328,8 @@ export function createOpenRouterClient(config: OpenRouterConfig): OpenRouterClie
         }
 
         const data = (await response.json()) as OpenRouterResponse;
-        const content = data.choices[0]?.message.content ?? '';
+        const rawContent = data.choices[0]?.message.content;
+        const content = typeof rawContent === 'string' ? rawContent : '';
         const { normalized, providerReportedUsd } = extractUsage(data.usage);
 
         // Extract sources from annotations (OpenRouter returns web search citations as annotations)
@@ -524,13 +526,13 @@ export function createOpenRouterClient(config: OpenRouterConfig): OpenRouterClie
 
           const data = (await response.json()) as OpenRouterResponse;
           const firstChoice = data.choices[0];
-          // Handle case where choices array is empty (upstream API may return this)
-          if (firstChoice === undefined) {
-            return {
-              content: '',
-              normalized: { inputTokens: 0, outputTokens: 0, totalTokens: 0, costUsd: 0 },
-              providerReportedUsd: null,
-            };
+          if (
+            firstChoice === undefined ||
+            firstChoice.finish_reason === 'error' ||
+            firstChoice.error !== undefined ||
+            typeof firstChoice.message.content !== 'string'
+          ) {
+            throw new OpenRouterApiError(500, INVALID_COMPLETION_RESPONSE_MESSAGE);
           }
           const content = firstChoice.message.content;
           const { normalized, providerReportedUsd, cachedTokens, cacheWriteTokens } = extractUsage(

--- a/packages/infra-openrouter/src/types.ts
+++ b/packages/infra-openrouter/src/types.ts
@@ -150,10 +150,11 @@ export interface OpenRouterResponse {
   choices: {
     index: number;
     message: {
-      content: string;
+      content: unknown;
       role: string;
     };
     finish_reason: string;
+    error?: unknown;
   }[];
   usage?: OpenRouterUsage;
   annotations?: (string | { url?: string })[];


### PR DESCRIPTION
## Summary

- omit normalized-empty sanitized values on the actual evaluator event path
- reject malformed HTTP-200 OpenRouter completion envelopes as closed provider failures
- preserve MiniMax M3 JSON-object evaluation with no fallback or routing changes

## Verification

- public event-sanitizer regression reproduced RED, then 23/23 GREEN
- OpenRouter 57/57 and evaluator MiniMax 63/63
- `pnpm run ci:tracked`: 5,445 tests and every gate passed
- independent task reviews and follow-up review approved

## Live acceptance

The exact merged revision will be deployed through `development` to Home Dev, then verified with `preflight` → 20-scenario `endpoint` → `full` (including one safe Matrix smoke).

Fixes INT-1859

- Linear: [INT-1859](https://linear.app/pbuchman/issue/INT-1859)
- IntexuraOS Code Task: [View task](https://intexuraos.cloud/#/code-tasks/task_963693a6-6fe1-4e0d-abcb-da33ad12b9e4)
- Worker Type: `codex-xhigh`
- Model: `default`