### PR TITLE
[INT-1860] fix(evals): make MiniMax M3 judge compatible with live routing

### DIFF
--- a/docs/superpowers/plans/2026-07-14-intex-agent-quality-program-implementation.md
+++ b/docs/superpowers/plans/2026-07-14-intex-agent-quality-program-implementation.md
@@ -25,12 +25,18 @@ The ten narrative scenarios in [`2026-06-24-intex-agent-dev-api-test-scenarios.m
 - No real endpoint corpus, MiniMax M3 judge run, or Matrix message has been executed yet. Offline/unit/contract success is not final acceptance.
 - The “Deferred perfection backlog” remains intentionally frozen and must not be implemented as part of this plan.
 
+### Live contract correction — 2026-07-18
+
+- Home Dev A/B evidence showed that OpenRouter's mixed MiniMax M3 endpoint pool can ignore `response_format: { type: 'json_object' }`; the affected path returned `finish_reason: 'stop'` with `message.content: null`, while the otherwise identical prompt-only request returned the expected final string and kept reasoning separate.
+- The evaluator therefore uses prompt-enforced strict JSON, `JSON.parse`, strict local Zod validation, and at most one same-model repair. It does not send `response_format`, parse `message.reasoning`, add `provider.require_parameters`, change the judge model, or add a fallback.
+- This is a narrow evidence-based correction to the original JSON-object-mode constraint. All privacy, fail-closed, cost-accounting, temperature, model, and repair constraints remain authoritative.
+
 ## Global constraints
 
 - The only evaluation judge is `or:minimax/minimax-m3` (`minimax/minimax-m3` at the raw OpenRouter boundary).
 - Claude Sonnet is not used as judge, fallback, repair model, or retry model.
 - A MiniMax failure, invalid JSON, missing credential, or timeout is an infrastructure failure. It never silently passes or switches models.
-- The judge uses OpenRouter JSON-object mode, strict local Zod validation, temperature `0`, and at most one structured repair.
+- The judge uses prompt-enforced strict JSON, strict local Zod validation, temperature `0`, and at most one structured repair. It does not parse reasoning as the answer.
 - The system under test uses the currently deployed Intex Agent model. Product model selection is outside this plan.
 - The endpoint accepts from 1 through exactly 20 product turns. The independent provider tool-loop limit remains unchanged.
 - Product tools stay mocked in the endpoint scenario suite.
@@ -301,7 +307,7 @@ The real values exist only in the mode-`0600` Home Dev file. Existing `INTEXURAO
 - [x] Check `127.0.0.1:8134/health`, `127.0.0.1:8113/health`, `127.0.0.1:8099/health`, and WhatsApp `matrix-delivery-status/:userId`.
 - [x] Check the configured Firebase UID with the existing Admin SDK and require `disabled !== true`; do not fetch or print profile fields.
 - [x] Verify Matrix state `running`, direct Matrix `/account/whoami` equality with the configured Matrix identity, and delivery `ready`.
-- [x] Define and orchestrate one `MiniMaxProbePort` call as the final preflight check. Task 6 supplies its only production implementation: one minimal MiniMax M3 JSON-object request with strict Zod parsing, no fallback, and no alternative model.
+- [x] Define and orchestrate one `MiniMaxProbePort` call as the final preflight check. Task 6 supplies its only production implementation: one minimal MiniMax M3 prompt-enforced JSON request with strict Zod parsing, no fallback, and no alternative model.
 - [x] Return only closed safe results containing host, fixed ports, readiness, judge model, scenario count, and `accountAlias`. Task 7 owns printing those results and cannot print arbitrary exception text.
 
 **Acceptance:** offline Task 4 tests prove secure config handling and the full readiness orchestration through injected fakes. A real command-level preflight is not complete until Tasks 6 and 7 provide the production MiniMax adapter and CLI. Never print token, e-mail, real user ID, room ID, phone, secret path, or private message. WhatsApp delivery readiness here is configuration readiness; the one Task 8 send is the end-to-end delivery proof.
@@ -352,7 +358,7 @@ const MiniMaxJudgeVerdictSchema = z.object({
 }).strict();
 ```
 
-- [x] Test exact MiniMax model selection, JSON-object mode, temperature 0, one repair, and absence of alternative models.
+- [x] Test exact MiniMax model selection, prompt-enforced strict JSON without `responseFormat`, temperature 0, one repair, and absence of alternative models.
 - [x] Use `createOpenRouterClient` directly with raw model `minimax/minimax-m3`; do not widen the Intex tool-calling allowlist.
 - [x] Use versioned `PromptBuilder` prompts and call `generateChat`; do not use the generic structured helper, strip Markdown fences, or confuse one structured repair with the client's same-model transient transport retries.
 - [x] Judge each reply independently from synthetic scenario criteria plus sanitized technical facts.

--- a/docs/superpowers/plans/2026-07-18-intex-agent-live-acceptance-fixes.md
+++ b/docs/superpowers/plans/2026-07-18-intex-agent-live-acceptance-fixes.md
@@ -4,7 +4,7 @@
 
 **Goal:** Remove the two infrastructure defects discovered during the first Home Dev acceptance run, redeploy the exact fixes, and complete `preflight` → `endpoint` → `full`.
 
-**Architecture:** Keep the approved evaluator contract unchanged. The Intex Agent sanitizer omits normalized-empty event values before they reach the strict evaluator wire schema. The shared OpenRouter client rejects malformed or in-band error completions as provider failures before MiniMax output parsing; MiniMax remains the sole judge in JSON-object mode with no fallback.
+**Architecture:** The Intex Agent sanitizer omits normalized-empty event values before they reach the strict evaluator wire schema. The shared OpenRouter client rejects malformed or in-band error completions as provider failures before MiniMax output parsing. MiniMax remains the sole judge with prompt-enforced strict JSON, local `JSON.parse` plus Zod validation, one same-model repair, and no fallback.
 
 **Tech Stack:** TypeScript 5.7, Node.js 22, pnpm 10, Vitest 4, Zod 3, Home Dev, OpenRouter, MiniMax M3.
 
@@ -13,11 +13,18 @@
 - The only evaluation judge is `or:minimax/minimax-m3` (`minimax/minimax-m3` at the raw OpenRouter boundary).
 - Claude Sonnet is not used as judge, fallback, repair model, or retry model.
 - A MiniMax failure, invalid JSON, missing credential, or timeout is an infrastructure failure. It never silently passes or switches models.
-- Preserve JSON-object mode, temperature `0`, strict local Zod validation, and at most one same-model structured repair.
+- Preserve temperature `0`, prompt-enforced strict JSON, strict local Zod validation, and at most one same-model structured repair. Do not parse reasoning as the answer.
 - Product tools remain mocked in endpoint scenarios; every synthetic user is cleaned in `finally`.
 - Never log response content, provider error text, real user identifiers, Matrix identifiers, paths, tokens, or messages.
 - Do not implement strict JSON Schema routing, `provider.require_parameters`, a second model, or any deferred-perfection item in this fix.
 - Every production change follows RED → GREEN and receives an independent task review.
+
+## Live Contract Amendment — 2026-07-18
+
+- Two consecutive deployed preflights passed every local/account/Matrix check and failed only the MiniMax provider probe.
+- A privacy-safe Home Dev A/B request proved the cause: with `response_format: { type: 'json_object' }`, the selected MiniMax M3 path returned `finish_reason: 'stop'` and `message.content: null`; without that parameter, the otherwise identical request returned the expected final string and a separate reasoning field.
+- OpenRouter documents that unsupported parameters may be ignored, and its MiniMax M3 endpoint pool has mixed `response_format` support. The evaluator therefore omits only `responseFormat`; it keeps MiniMax M3, temperature `0`, strict prompts, `JSON.parse`, Zod, one repair, closed errors, and no fallback.
+- Do not solve this by parsing chain-of-thought, adding JSON Schema routing, setting `provider.require_parameters`, switching providers/models, or weakening the non-string response guard.
 
 ---
 
@@ -28,18 +35,18 @@
 - Test: `apps/intex-agent/src/__tests__/domain/testConversationSanitizer.test.ts`
 
 **Interfaces:**
-- Consumes: `sanitizeRecord(record: Record<string, unknown>): Record<string, unknown>`.
-- Produces: the same public function, with string values omitted when normalization by the existing `truncate()` helper yields `''`.
+- Consumes: `sanitizeRecord(record)` and the public `sanitizeEventsBySessionId(eventsBySessionId)` path.
+- Produces: sanitized generic records and event payloads with string values omitted when normalization yields `''`.
 
 - [ ] **Step 1: Write the failing regression test**
 
-  Add one test using the real `sanitizeRecord()` implementation:
+  Add one test using the real `sanitizeRecord()` implementation and one regression through public `sanitizeEventsBySessionId()`:
 
   ```ts
   expect(sanitizeRecord({ textPreview: ' \n\t ', reason: 'kept' })).toEqual({ reason: 'kept' });
   ```
 
-  The test must also retain the existing coverage proving non-empty strings are normalized and kept.
+  The public-path test must prove whitespace-only `text`/`message` does not emit `textPreview` and a whitespace-only copied payload field is also omitted. Retain existing coverage proving non-empty strings are normalized and kept.
 
 - [ ] **Step 2: Verify RED**
 
@@ -49,11 +56,11 @@
   pnpm exec vitest run apps/intex-agent/src/__tests__/domain/testConversationSanitizer.test.ts
   ```
 
-  Expected: the new assertion fails because the current result contains `textPreview: ''`.
+  Expected: the tests fail because the generic record and live event path contain normalized-empty values.
 
 - [ ] **Step 3: Implement the minimum fix**
 
-  In the string branch of `sanitizeValue()`, normalize once with `truncate(value)` and return `undefined` only when the normalized value is empty. Do not widen the evaluator wire schema and do not special-case `textPreview`.
+  In the string branch of `sanitizeValue()`, normalize once and omit an empty result. Apply the same rule to the actual event payload copy path and `textPreview` assignment. Do not widen the evaluator wire schema.
 
 - [ ] **Step 4: Verify GREEN and commit**
 
@@ -102,7 +109,7 @@
 
   Run the focused OpenRouter test, evaluator MiniMax tests, and `pnpm run ci:tracked`; all must pass. Commit only this task's source and test changes.
 
-**Acceptance:** provider failures cannot be mislabeled downstream as valid chat output; valid string completions, usage accounting, JSON-object requests, and all existing model behavior remain unchanged.
+**Acceptance:** provider failures cannot be mislabeled downstream as valid chat output; valid string completions, usage accounting, and all existing model behavior remain unchanged.
 
 ---
 

--- a/tools/intex-agent-evals/src/__tests__/minimaxJudge.test.ts
+++ b/tools/intex-agent-evals/src/__tests__/minimaxJudge.test.ts
@@ -285,7 +285,6 @@ describe('MiniMax judge happy path', () => {
       ],
       {
         promptType: 'intex-agent-eval-minimax-judge',
-        responseFormat: { type: 'json_object' },
         temperature: 0,
       }
     );
@@ -379,7 +378,6 @@ describe('MiniMax judge strict parsing and one repair', () => {
     expect(repairCall?.[1]).toEqual(initialCall?.[1]);
     expect(repairCall?.[1]).toEqual({
       promptType: 'intex-agent-eval-minimax-judge',
-      responseFormat: { type: 'json_object' },
       temperature: 0,
     });
     expect(repairCall?.[0]).toEqual([
@@ -1063,7 +1061,6 @@ describe('MiniMax Matrix-smoke judge seam', () => {
       ],
       {
         promptType: 'intex-agent-eval-minimax-judge',
-        responseFormat: { type: 'json_object' },
         temperature: 0,
       },
     ]);
@@ -1264,7 +1261,6 @@ describe('MiniMax production preflight probe', () => {
       ],
       {
         promptType: 'intex-agent-eval-minimax-probe',
-        responseFormat: { type: 'json_object' },
         temperature: 0,
       },
     ]);

--- a/tools/intex-agent-evals/src/minimaxJudge.ts
+++ b/tools/intex-agent-evals/src/minimaxJudge.ts
@@ -365,7 +365,6 @@ export function createMiniMaxEvaluator(config: {
     try {
       response = await client.generateChat(messages, {
         promptType: MINIMAX_JUDGE_PROMPT_TYPE,
-        responseFormat: { type: 'json_object' },
         temperature: 0,
       });
     } catch {
@@ -562,7 +561,6 @@ export function createMiniMaxEvaluator(config: {
           ],
           {
             promptType: MINIMAX_PROBE_PROMPT_TYPE,
-            responseFormat: { type: 'json_object' },
             temperature: 0,
           }
         );


### PR DESCRIPTION
## Summary

- remove only the unsupported `responseFormat` option from MiniMax evaluator requests
- keep MiniMax M3, temperature 0, strict prompts, JSON.parse, strict Zod, one repair, and fail-closed behavior
- record the Home Dev A/B evidence and explicit contract amendment in both implementation plans

## Root cause

OpenRouter routes MiniMax M3 across endpoints with mixed `response_format` support. The deployed request returned `finish_reason: stop` with `message.content: null`; the otherwise identical prompt-only request returned the expected final string and kept reasoning separate. We do not parse reasoning or add a fallback.

## Verification

- TDD RED: 4/63 contract tests failed (judge, repair, Matrix, probe)
- GREEN: 63/63
- independent review: Approved
- `pnpm run ci:tracked`: 5,445 tests and every gate passed

- Linear: [INT-1860](https://linear.app/pbuchman/issue/INT-1860)
- IntexuraOS Code Task: [View task](https://intexuraos.cloud/#/code-tasks/task_4e6a623b-e0e9-4c34-99a6-31ef0e9c5cc0)
- Worker Type: `codex-xhigh`
- Model: `default`