### PR TITLE
[INT-1861] fix(evals): route MiniMax to JSON-capable providers

### DIFF
--- a/docs/superpowers/plans/2026-07-14-intex-agent-quality-program-implementation.md
+++ b/docs/superpowers/plans/2026-07-14-intex-agent-quality-program-implementation.md
@@ -16,27 +16,29 @@ It supersedes the previous four-plan implementation graph for evaluation infrast
 
 The ten narrative scenarios in [`2026-06-24-intex-agent-dev-api-test-scenarios.md`](../specs/2026-06-24-intex-agent-dev-api-test-scenarios.md) are the behavioral source for the initial executable corpus. The completed endpoint plan in [`2026-07-01-intex-agent-internal-test-conversation-endpoint.md`](./2026-07-01-intex-agent-internal-test-conversation-endpoint.md) is historical context, not work to repeat.
 
-### Current implementation status — 2026-07-17
+### Current implementation status — 2026-07-18
 
 - Tasks 1–8 are implemented, independently reviewed, and green in `pnpm run ci:tracked`.
 - Delivered commits through Task 8: `deada8c2d` (20-turn endpoint), `839a9dda6` + `6acb58c64` (strict evaluator contract), `f2eed4d60` + `fb656ce44` + `c15b0c2fe` (20-scenario corpus), `52680fd04` + `56b24fe21` (secure Home Dev configuration and preflight), `c2d673683` + `6cd0dd44e` + `3033e438f` (scenario lifecycle), `4382f9223` + `f40dda449` (MiniMax M3 judge), `e75bc6f3a` (safe Matrix smoke), and `6f1fbb351` (CLI, reports, and Home Dev wrapper).
 - The offline completion audit is implemented and independently approved: every correlated assistant reply is judged, scenarios 001–010 enforce their source lifecycle semantics, tool/error evidence is closed and privacy-safe, setup is non-echoing, and the Home Dev wrapper accepts only one private framed CLI stream with selector/status validation. A fresh `pnpm run ci:tracked` passed on 2026-07-17.
-- The only remaining executable work is the Task 9 live lane: deliver the implementation through `development`, prove Home Dev health and deployed revision, then run `preflight` → `endpoint` → `full`. It remains gated on the user's explicit “odpal testy” instruction.
-- No real endpoint corpus, MiniMax M3 judge run, or Matrix message has been executed yet. Offline/unit/contract success is not final acceptance.
+- The user explicitly authorized the Task 9 live lane. The implementation and the first two acceptance fixes were delivered through `development`; Home Dev health, deployed revision, account, Firebase, Matrix identity, and delivery readiness were verified.
+- Real preflight and endpoint evaluation calls have been executed. Preflight reached exit `0` after the prompt-only experiment, but the endpoint run stopped on scenario 001 when MiniMax returned invalid judge output both initially and after the one allowed repair; deterministic endpoint execution and cleanup succeeded. No Matrix message has been sent.
+- The remaining executable work is to deliver the final parameter-compatible routing fix, then repeat `preflight` → `endpoint` → `full`. Offline/unit/contract success is not final acceptance.
 - The “Deferred perfection backlog” remains intentionally frozen and must not be implemented as part of this plan.
 
 ### Live contract correction — 2026-07-18
 
-- Home Dev A/B evidence showed that OpenRouter's mixed MiniMax M3 endpoint pool can ignore `response_format: { type: 'json_object' }`; the affected path returned `finish_reason: 'stop'` with `message.content: null`, while the otherwise identical prompt-only request returned the expected final string and kept reasoning separate.
-- The evaluator therefore uses prompt-enforced strict JSON, `JSON.parse`, strict local Zod validation, and at most one same-model repair. It does not send `response_format`, parse `message.reasoning`, add `provider.require_parameters`, change the judge model, or add a fallback.
-- This is a narrow evidence-based correction to the original JSON-object-mode constraint. All privacy, fail-closed, cost-accounting, temperature, model, and repair constraints remain authoritative.
+- Home Dev A/B evidence showed that OpenRouter's mixed MiniMax M3 endpoint pool can send `response_format: { type: 'json_object' }` to an endpoint that does not support it; the affected path returned `finish_reason: 'stop'` with `message.content: null`.
+- Removing `response_format` restored string content, but the first real scenario then failed strict parsing after the one allowed repair. Prompt-only JSON is therefore not reliable enough for the judge contract.
+- Two otherwise identical probes with `response_format` plus `provider.require_parameters: true` returned the expected final string while keeping reasoning separate. The evaluator therefore preserves JSON-object mode and requires OpenRouter to route only to endpoints that support every requested parameter.
+- It does not parse `message.reasoning`, change the judge model, add a fallback, or weaken local `JSON.parse` plus strict Zod validation. All privacy, fail-closed, cost-accounting, temperature, model, and repair constraints remain authoritative.
 
 ## Global constraints
 
 - The only evaluation judge is `or:minimax/minimax-m3` (`minimax/minimax-m3` at the raw OpenRouter boundary).
 - Claude Sonnet is not used as judge, fallback, repair model, or retry model.
 - A MiniMax failure, invalid JSON, missing credential, or timeout is an infrastructure failure. It never silently passes or switches models.
-- The judge uses prompt-enforced strict JSON, strict local Zod validation, temperature `0`, and at most one structured repair. It does not parse reasoning as the answer.
+- The judge uses OpenRouter JSON-object mode with `provider.require_parameters: true`, strict local Zod validation, temperature `0`, and at most one structured repair. It does not parse reasoning as the answer.
 - The system under test uses the currently deployed Intex Agent model. Product model selection is outside this plan.
 - The endpoint accepts from 1 through exactly 20 product turns. The independent provider tool-loop limit remains unchanged.
 - Product tools stay mocked in the endpoint scenario suite.
@@ -307,7 +309,7 @@ The real values exist only in the mode-`0600` Home Dev file. Existing `INTEXURAO
 - [x] Check `127.0.0.1:8134/health`, `127.0.0.1:8113/health`, `127.0.0.1:8099/health`, and WhatsApp `matrix-delivery-status/:userId`.
 - [x] Check the configured Firebase UID with the existing Admin SDK and require `disabled !== true`; do not fetch or print profile fields.
 - [x] Verify Matrix state `running`, direct Matrix `/account/whoami` equality with the configured Matrix identity, and delivery `ready`.
-- [x] Define and orchestrate one `MiniMaxProbePort` call as the final preflight check. Task 6 supplies its only production implementation: one minimal MiniMax M3 prompt-enforced JSON request with strict Zod parsing, no fallback, and no alternative model.
+- [x] Define and orchestrate one `MiniMaxProbePort` call as the final preflight check. Task 6 supplies its only production implementation: one minimal MiniMax M3 JSON-object request routed only to parameter-compatible endpoints, with strict Zod parsing, no fallback, and no alternative model.
 - [x] Return only closed safe results containing host, fixed ports, readiness, judge model, scenario count, and `accountAlias`. Task 7 owns printing those results and cannot print arbitrary exception text.
 
 **Acceptance:** offline Task 4 tests prove secure config handling and the full readiness orchestration through injected fakes. A real command-level preflight is not complete until Tasks 6 and 7 provide the production MiniMax adapter and CLI. Never print token, e-mail, real user ID, room ID, phone, secret path, or private message. WhatsApp delivery readiness here is configuration readiness; the one Task 8 send is the end-to-end delivery proof.
@@ -358,7 +360,7 @@ const MiniMaxJudgeVerdictSchema = z.object({
 }).strict();
 ```
 
-- [x] Test exact MiniMax model selection, prompt-enforced strict JSON without `responseFormat`, temperature 0, one repair, and absence of alternative models.
+- [x] Test exact MiniMax model selection, JSON-object mode, required parameter-compatible routing, temperature 0, one repair, and absence of alternative models.
 - [x] Use `createOpenRouterClient` directly with raw model `minimax/minimax-m3`; do not widen the Intex tool-calling allowlist.
 - [x] Use versioned `PromptBuilder` prompts and call `generateChat`; do not use the generic structured helper, strip Markdown fences, or confuse one structured repair with the client's same-model transient transport retries.
 - [x] Judge each reply independently from synthetic scenario criteria plus sanitized technical facts.

--- a/docs/superpowers/plans/2026-07-18-intex-agent-live-acceptance-fixes.md
+++ b/docs/superpowers/plans/2026-07-18-intex-agent-live-acceptance-fixes.md
@@ -2,9 +2,9 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Remove the two infrastructure defects discovered during the first Home Dev acceptance run, redeploy the exact fixes, and complete `preflight` → `endpoint` → `full`.
+**Goal:** Remove the infrastructure defects discovered during Home Dev acceptance, redeploy the exact fixes, and complete `preflight` → `endpoint` → `full`.
 
-**Architecture:** The Intex Agent sanitizer omits normalized-empty event values before they reach the strict evaluator wire schema. The shared OpenRouter client rejects malformed or in-band error completions as provider failures before MiniMax output parsing. MiniMax remains the sole judge with prompt-enforced strict JSON, local `JSON.parse` plus Zod validation, one same-model repair, and no fallback.
+**Architecture:** The Intex Agent sanitizer omits normalized-empty event values before they reach the strict evaluator wire schema. The shared OpenRouter client rejects malformed or in-band error completions as provider failures before MiniMax output parsing. MiniMax remains the sole judge in JSON-object mode; its dedicated client requires parameter-compatible OpenRouter routing, followed by local `JSON.parse`, strict Zod validation, one same-model repair, and no fallback.
 
 **Tech Stack:** TypeScript 5.7, Node.js 22, pnpm 10, Vitest 4, Zod 3, Home Dev, OpenRouter, MiniMax M3.
 
@@ -13,18 +13,18 @@
 - The only evaluation judge is `or:minimax/minimax-m3` (`minimax/minimax-m3` at the raw OpenRouter boundary).
 - Claude Sonnet is not used as judge, fallback, repair model, or retry model.
 - A MiniMax failure, invalid JSON, missing credential, or timeout is an infrastructure failure. It never silently passes or switches models.
-- Preserve temperature `0`, prompt-enforced strict JSON, strict local Zod validation, and at most one same-model structured repair. Do not parse reasoning as the answer.
+- Preserve JSON-object mode, `provider.require_parameters: true`, temperature `0`, strict local Zod validation, and at most one same-model structured repair. Do not parse reasoning as the answer.
 - Product tools remain mocked in endpoint scenarios; every synthetic user is cleaned in `finally`.
 - Never log response content, provider error text, real user identifiers, Matrix identifiers, paths, tokens, or messages.
-- Do not implement strict JSON Schema routing, `provider.require_parameters`, a second model, or any deferred-perfection item in this fix.
+- Do not implement strict JSON Schema routing, provider pinning, a second model, or any deferred-perfection item in this fix. `provider.require_parameters: true` is required only on the dedicated MiniMax evaluator client.
 - Every production change follows RED → GREEN and receives an independent task review.
 
 ## Live Contract Amendment — 2026-07-18
 
-- Two consecutive deployed preflights passed every local/account/Matrix check and failed only the MiniMax provider probe.
-- A privacy-safe Home Dev A/B request proved the cause: with `response_format: { type: 'json_object' }`, the selected MiniMax M3 path returned `finish_reason: 'stop'` and `message.content: null`; without that parameter, the otherwise identical request returned the expected final string and a separate reasoning field.
-- OpenRouter documents that unsupported parameters may be ignored, and its MiniMax M3 endpoint pool has mixed `response_format` support. The evaluator therefore omits only `responseFormat`; it keeps MiniMax M3, temperature `0`, strict prompts, `JSON.parse`, Zod, one repair, closed errors, and no fallback.
-- Do not solve this by parsing chain-of-thought, adding JSON Schema routing, setting `provider.require_parameters`, switching providers/models, or weakening the non-string response guard.
+- Two consecutive deployed preflights passed every local/account/Matrix check and failed only the MiniMax provider probe. A privacy-safe A/B request proved that default routing selected a path returning `content: null` for JSON mode.
+- Removing `response_format` restored string content and made preflight pass, but scenario 001 then produced invalid judge output both initially and after the one repair. Prompt-only JSON is not accepted as the final contract.
+- OpenRouter documents mixed MiniMax M3 endpoint support. Two probes with `response_format` plus `provider.require_parameters: true` returned valid string content and separate reasoning, so the evaluator preserves JSON mode and constrains routing by capability rather than provider name.
+- Keep MiniMax M3, temperature `0`, strict prompts, `JSON.parse`, Zod, one repair, closed errors, and no fallback. Do not parse chain-of-thought, add JSON Schema routing, pin a provider, switch models, or weaken the non-string response guard.
 
 ---
 
@@ -109,11 +109,44 @@
 
   Run the focused OpenRouter test, evaluator MiniMax tests, and `pnpm run ci:tracked`; all must pass. Commit only this task's source and test changes.
 
-**Acceptance:** provider failures cannot be mislabeled downstream as valid chat output; valid string completions, usage accounting, and all existing model behavior remain unchanged.
+**Acceptance:** provider failures cannot be mislabeled downstream as valid chat output; valid string completions, usage accounting, JSON-object requests, and all existing model behavior remain unchanged.
 
 ---
 
-### Task 3: Review, deliver, and repeat live acceptance
+### Task 3: Route MiniMax JSON requests only to parameter-compatible endpoints
+
+**Files:**
+- Modify: `packages/infra-openrouter/src/types.ts`
+- Modify: `packages/infra-openrouter/src/client.ts`
+- Test: `packages/infra-openrouter/src/__tests__/client.test.ts`
+- Modify: `tools/intex-agent-evals/src/minimaxJudge.ts`
+- Test: `tools/intex-agent-evals/src/__tests__/minimaxJudge.test.ts`
+
+**Interfaces:**
+- Consumes: optional `OpenRouterConfig.providerRouting.requireParameters` on the shared client and the dedicated MiniMax evaluator client configuration.
+- Produces: OpenRouter request field `provider: { require_parameters: true }` only when explicitly enabled; the MiniMax judge and probe combine it with `response_format: { type: 'json_object' }`.
+
+- [x] **Step 1: Write failing routing-contract tests**
+
+  Prove that the shared client omits `provider` by default and serializes the exact snake-case request for `generate()`, `generateChat()`, and `generateChatStream()`. Prove that the MiniMax evaluator enables the option and uses JSON-object mode for initial judge, same-model repair, Matrix judge, and production probe.
+
+- [x] **Step 2: Verify RED**
+
+  Run the focused OpenRouter and MiniMax evaluator suites. Expected and observed: eight new assertions fail while all pre-existing assertions pass.
+
+- [x] **Step 3: Implement the minimum routing constraint**
+
+  Add the optional typed client configuration and conditionally serialize `provider.require_parameters`. Enable it only in the dedicated MiniMax evaluator client and restore JSON-object mode through the common judge invocation and probe. Do not pin a provider, parse reasoning, change models, add fallback, or weaken strict parsing.
+
+- [x] **Step 4: Verify GREEN and review**
+
+  Run both focused suites and `pnpm run ci:tracked` on the combined code diff. Require an independent review of the implementation and plan before delivery.
+
+**Acceptance:** MiniMax JSON requests are routed by declared parameter capability, every default OpenRouter caller is unchanged, all four evaluator paths retain JSON-object mode, and invalid provider output still fails closed.
+
+---
+
+### Task 4: Review, deliver, and repeat live acceptance
 
 **Files:**
 - Modify: `docs/superpowers/plans/2026-07-18-intex-agent-live-acceptance-fixes.md` only to record final evidence.

--- a/packages/infra-openrouter/src/__tests__/client.test.ts
+++ b/packages/infra-openrouter/src/__tests__/client.test.ts
@@ -780,6 +780,7 @@ describe('createOpenRouterClient', () => {
         userId: 'test-user',
         logger: mockLogger,
         usageSink: mockUsageSink,
+        providerRouting: { requireParameters: true },
       });
 
       await client.generate('Return JSON', {
@@ -788,6 +789,7 @@ describe('createOpenRouterClient', () => {
       });
 
       expect(capturedBody).toHaveProperty('response_format', { type: 'json_object' });
+      expect(capturedBody).toHaveProperty('provider', { require_parameters: true });
     });
 
     it('does NOT include response_format in request body when no options are provided', async () => {
@@ -824,6 +826,7 @@ describe('createOpenRouterClient', () => {
       await client.generate('Write something', { promptType: 'test-prompt' });
 
       expect(capturedBody).not.toHaveProperty('response_format');
+      expect(capturedBody).not.toHaveProperty('provider');
     });
 
     it('rejects an empty choices array in generate', async () => {
@@ -935,8 +938,13 @@ describe('createOpenRouterClient', () => {
 
   describe('generateChat', () => {
     it('returns provider-reported USD separately from normalized chat cost', async () => {
+      let capturedBody: Record<string, unknown> | undefined;
+
       nock(API_BASE_URL)
-        .post('/chat/completions')
+        .post('/chat/completions', (body) => {
+          capturedBody = body as Record<string, unknown>;
+          return true;
+        })
         .reply(200, {
           id: 'test-id',
           model: TEST_MODEL,
@@ -982,6 +990,7 @@ describe('createOpenRouterClient', () => {
       expect(mockUsageLoggerLog).toHaveBeenCalledWith(
         expect.objectContaining({ providerReportedUsd: 0.0042 })
       );
+      expect(capturedBody).not.toHaveProperty('provider');
     });
 
     it('forwards reasoning options to OpenRouter chat completions', async () => {
@@ -1013,6 +1022,7 @@ describe('createOpenRouterClient', () => {
         userId: 'test-user',
         logger: mockLogger,
         usageSink: mockUsageSink,
+        providerRouting: { requireParameters: true },
       });
 
       const result = await client.generateChat([{ role: 'user', content: 'hello' }], {
@@ -1032,6 +1042,7 @@ describe('createOpenRouterClient', () => {
         max_tokens: 2048,
         exclude: true,
       });
+      expect(capturedBody?.['provider']).toEqual({ require_parameters: true });
     });
 
     it('streams chat completion deltas and final usage', async () => {
@@ -1063,6 +1074,7 @@ describe('createOpenRouterClient', () => {
         userId: 'test-user',
         logger: mockLogger,
         usageSink: mockUsageSink,
+        providerRouting: { requireParameters: true },
       });
       const events: unknown[] = [];
 
@@ -1083,6 +1095,7 @@ describe('createOpenRouterClient', () => {
       expect(capturedBody).toMatchObject({
         session_id: 'session-123',
         response_format: { type: 'json_object' },
+        provider: { require_parameters: true },
       });
       expect(events).toContainEqual({ type: 'delta', text: 'Hel' });
       expect(events).toContainEqual({ type: 'delta', text: 'lo' });
@@ -1104,8 +1117,13 @@ describe('createOpenRouterClient', () => {
     });
 
     it('ignores streaming comments and buffers incomplete SSE frames', async () => {
+      let capturedBody: Record<string, unknown> | undefined;
+
       nock(API_BASE_URL)
-        .post('/chat/completions')
+        .post('/chat/completions', (body) => {
+          capturedBody = body as Record<string, unknown>;
+          return true;
+        })
         .reply(
           200,
           ': keep-alive\n\nevent: completion\n\ndata: {"choices":[{"delta":{"content":"Hi"}}]}\n\ndata: [DONE]\n\n',
@@ -1130,6 +1148,7 @@ describe('createOpenRouterClient', () => {
       if (result.ok) {
         expect(result.value.content).toBe('Hi');
       }
+      expect(capturedBody).not.toHaveProperty('provider');
     });
 
     it('maps non-ok streaming responses and empty stream bodies to errors', async () => {

--- a/packages/infra-openrouter/src/client.ts
+++ b/packages/infra-openrouter/src/client.ts
@@ -174,9 +174,12 @@ export function createOpenRouterClient(config: OpenRouterConfig): OpenRouterClie
     logger,
     usageSink,
     ownerType,
+    providerRouting,
   } = config;
 
   const usageLogger = createUsageLogger({ logger, sink: usageSink });
+  const providerRequest =
+    providerRouting?.requireParameters === true ? { require_parameters: true } : undefined;
 
   function trackUsage(
     callType: CallType,
@@ -497,6 +500,7 @@ export function createOpenRouterClient(config: OpenRouterConfig): OpenRouterClie
             ...(options.responseFormat !== undefined && {
               response_format: options.responseFormat,
             }),
+            ...(providerRequest !== undefined && { provider: providerRequest }),
             ...(toOpenRouterReasoning(options.reasoning) !== undefined && {
               reasoning: toOpenRouterReasoning(options.reasoning),
             }),
@@ -601,6 +605,7 @@ export function createOpenRouterClient(config: OpenRouterConfig): OpenRouterClie
         ...(options.responseFormat !== undefined && {
           response_format: options.responseFormat,
         }),
+        ...(providerRequest !== undefined && { provider: providerRequest }),
         ...(toOpenRouterReasoning(options.reasoning) !== undefined && {
           reasoning: toOpenRouterReasoning(options.reasoning),
         }),

--- a/packages/infra-openrouter/src/types.ts
+++ b/packages/infra-openrouter/src/types.ts
@@ -93,6 +93,11 @@ export interface OpenRouterConfig {
   usageSink: UsageSink;
   /** Owner scope of the call. When omitted, the usage sink defaults to 'system'. */
   ownerType?: OwnerType;
+  /** OpenRouter-specific provider routing constraints. */
+  providerRouting?: {
+    /** Route only to providers that support every supplied request parameter. */
+    requireParameters?: boolean;
+  };
 }
 
 /**

--- a/tools/intex-agent-evals/src/__tests__/minimaxJudge.test.ts
+++ b/tools/intex-agent-evals/src/__tests__/minimaxJudge.test.ts
@@ -232,6 +232,7 @@ describe('MiniMax judge happy path', () => {
       userId: 'test-intex-agent-evals-judge',
       timeoutMs: 30_000,
       ownerType: 'system',
+      providerRouting: { requireParameters: true },
       logger: {
         debug: expect.any(Function),
         info: expect.any(Function),
@@ -285,6 +286,7 @@ describe('MiniMax judge happy path', () => {
       ],
       {
         promptType: 'intex-agent-eval-minimax-judge',
+        responseFormat: { type: 'json_object' },
         temperature: 0,
       }
     );
@@ -378,6 +380,7 @@ describe('MiniMax judge strict parsing and one repair', () => {
     expect(repairCall?.[1]).toEqual(initialCall?.[1]);
     expect(repairCall?.[1]).toEqual({
       promptType: 'intex-agent-eval-minimax-judge',
+      responseFormat: { type: 'json_object' },
       temperature: 0,
     });
     expect(repairCall?.[0]).toEqual([
@@ -1061,6 +1064,7 @@ describe('MiniMax Matrix-smoke judge seam', () => {
       ],
       {
         promptType: 'intex-agent-eval-minimax-judge',
+        responseFormat: { type: 'json_object' },
         temperature: 0,
       },
     ]);
@@ -1261,6 +1265,7 @@ describe('MiniMax production preflight probe', () => {
       ],
       {
         promptType: 'intex-agent-eval-minimax-probe',
+        responseFormat: { type: 'json_object' },
         temperature: 0,
       },
     ]);

--- a/tools/intex-agent-evals/src/minimaxJudge.ts
+++ b/tools/intex-agent-evals/src/minimaxJudge.ts
@@ -309,6 +309,7 @@ export function createMiniMaxEvaluator(config: {
           logger: SAFE_NOOP_LOGGER,
           usageSink: new NoopUsageSink(),
           ownerType: 'system',
+          providerRouting: { requireParameters: true },
         });
       } catch {
         cachedClient = undefined;
@@ -365,6 +366,7 @@ export function createMiniMaxEvaluator(config: {
     try {
       response = await client.generateChat(messages, {
         promptType: MINIMAX_JUDGE_PROMPT_TYPE,
+        responseFormat: { type: 'json_object' },
         temperature: 0,
       });
     } catch {
@@ -561,6 +563,7 @@ export function createMiniMaxEvaluator(config: {
           ],
           {
             promptType: MINIMAX_PROBE_PROMPT_TYPE,
+            responseFormat: { type: 'json_object' },
             temperature: 0,
           }
         );


### PR DESCRIPTION
## Summary
- add an opt-in OpenRouter routing constraint for providers supporting every request parameter
- use it only for the MiniMax M3 evaluator and restore JSON-object mode for judge, repair, Matrix, and probe
- update the live-acceptance plans with the observed Home Dev evidence and final delivery task

## Verification
- focused OpenRouter and MiniMax suites: 120/120
- pnpm run ci:tracked: 5445/5445 tests plus typecheck, lint, static validation, build, and bundle checks
- independent review: approved

## Live evidence
Default mixed routing returned null content for JSON mode. Prompt-only JSON passed preflight but failed scenario 001 after the one allowed repair. Two safe probes combining JSON-object mode with required-parameter routing returned valid string content. No provider is pinned and no fallback is added.

## Tracking

Fixes INT-1861

- Linear: [INT-1861](https://linear.app/pbuchman/issue/INT-1861)
- IntexuraOS Code Task: [View task](https://intexuraos.cloud/#/code-tasks/task_7d48d63d-d44f-437a-bcb8-4aa746bf722b)
- Worker Type: `codex-xhigh`
- Model: `default`
