### PR TITLE
[INT-1863] fix(evals): report unavailable confirmations behaviorally

### DIFF
--- a/apps/intex-agent/src/__tests__/domain/runTestConversation.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/runTestConversation.test.ts
@@ -724,35 +724,52 @@ describe('test conversation contract', () => {
     }
   });
 
-  it('fails fast when a semantic confirmation cannot find a captured button', async () => {
+  it('stops with the executed prefix when a semantic confirmation button is unavailable', async () => {
     const repository = new MemorySessionRepository();
+    const runner = new ScriptedRunner([
+      { outcome: 'no_action', reply: 'Odpowiedź bez przycisków.' },
+      { outcome: 'no_action', reply: 'Ta tura nie może się wykonać.' },
+    ]);
 
-    await expect(
-      runTestConversation(
-        {
-          contractVersion: '2026-07-01',
-          mode: 'live_llm_mock_tools',
-          userId: 'test-intex-agent-intex-e2e-missing-button',
-          runId: 'intex-e2e-missing-button',
-          currentDateTime: '2026-07-01T10:00:00.000Z',
-          turns: [
-            {
-              kind: 'message',
-              text: 'Tylko odpowiedz tekstem. intex-e2e-missing-button',
-            },
-            { kind: 'confirmation_button', previousTurnIndex: 0, decision: 'accept' },
-          ],
-        },
-        {
-          sessionRepository: repository,
-          runner: new ScriptedRunner([{ outcome: 'no_action', reply: 'Odpowiedź bez przycisków.' }]),
-          sessionTimeoutMs: 30 * 60 * 1000,
-          ids: fixedTestIds(),
-          toolCalls: [],
-          logger: silentLogger(),
-        }
-      )
-    ).rejects.toThrow('confirmation_button could not resolve a captured confirmation button');
+    const result = await runTestConversation(
+      {
+        contractVersion: '2026-07-01',
+        mode: 'live_llm_mock_tools',
+        userId: 'test-intex-agent-intex-e2e-missing-button',
+        runId: 'intex-e2e-missing-button',
+        currentDateTime: '2026-07-01T10:00:00.000Z',
+        turns: [
+          {
+            kind: 'message',
+            text: 'Tylko odpowiedz tekstem. intex-e2e-missing-button',
+          },
+          { kind: 'confirmation_button', previousTurnIndex: 0, decision: 'accept' },
+          { kind: 'message', text: 'Ta tura nie może się wykonać.' },
+        ],
+      },
+      {
+        sessionRepository: repository,
+        runner,
+        sessionTimeoutMs: 30 * 60 * 1000,
+        ids: fixedTestIds(),
+        toolCalls: [],
+        logger: silentLogger(),
+      }
+    );
+
+    expect(result).toMatchObject({
+      finalSessionId: 'intex_session_test_1',
+      stoppedBeforeTurn: { turnIndex: 1, reason: 'confirmation_button_unavailable' },
+    });
+    expect(result.turns).toHaveLength(1);
+    expect(result.sessionTransitions).toHaveLength(1);
+    expect(result.behavioralTranscript.turns).toHaveLength(1);
+    expect(result.sessions).toHaveLength(1);
+    expect(runner.calls).toHaveLength(1);
+    expect(runner.executeConfirmedCalls).toEqual([]);
+    expect(repository.events.every((event) => event.sessionId === 'intex_session_test_1')).toBe(
+      true
+    );
   });
 
   it('fails fast when a semantic confirmation references an unexecuted turn', async () => {
@@ -775,7 +792,48 @@ describe('test conversation contract', () => {
           logger: silentLogger(),
         }
       )
-    ).rejects.toThrow('confirmation_button previousTurnIndex does not reference an executed turn');
+    ).rejects.toThrow(
+      'confirmation_button previousTurnIndex does not reference an executed message turn'
+    );
+  });
+
+  it('fails fast when a semantic confirmation references an executed confirmation turn', async () => {
+    await expect(
+      runTestConversation(
+        {
+          contractVersion: '2026-07-01',
+          mode: 'live_llm_mock_tools',
+          userId: 'test-intex-agent-intex-e2e-confirm-target',
+          runId: 'intex-e2e-confirm-target',
+          currentDateTime: '2026-07-01T10:00:00.000Z',
+          turns: [
+            { kind: 'message', text: 'Dodaj notatkę.' },
+            { kind: 'confirmation_button', previousTurnIndex: 0, decision: 'accept' },
+            { kind: 'confirmation_button', previousTurnIndex: 1, decision: 'accept' },
+          ],
+        },
+        {
+          sessionRepository: new MemorySessionRepository(),
+          runner: new ScriptedRunner(
+            [
+              {
+                outcome: 'needs_confirmation',
+                reply: 'Czy dodać notatkę?',
+                toolName: 'create_note',
+                toolArgs: { content: 'notatka' },
+              },
+            ],
+            [{ outcome: 'completed', reply: 'Notatka dodana.', toolName: 'create_note' }]
+          ),
+          sessionTimeoutMs: 30 * 60 * 1000,
+          ids: fixedTestIds(),
+          toolCalls: [],
+          logger: silentLogger(),
+        }
+      )
+    ).rejects.toThrow(
+      'confirmation_button previousTurnIndex does not reference an executed message turn'
+    );
   });
 });
 

--- a/apps/intex-agent/src/domain/testConversation/runTestConversation.ts
+++ b/apps/intex-agent/src/domain/testConversation/runTestConversation.ts
@@ -62,8 +62,15 @@ export async function runTestConversation(
   const touchedSessionIds = new Set<string>();
   const turnEventsByTurnIndex: Record<number, readonly IntexAgentSessionEvent[]> = {};
   const toolCallsByTurnIndex: Record<number, readonly CapturedToolCall[]> = {};
+  let stoppedBeforeTurn: TestConversationResponse['stoppedBeforeTurn'];
 
   for (const [index, turn] of input.turns.entries()) {
+    const turnNow = turn.timestamp ?? timestampForTurn(input.currentDateTime, index);
+    const message = buildIncomingMessage(input, turn, index, turns, turnNow);
+    if (message === null) {
+      stoppedBeforeTurn = { turnIndex: index, reason: 'confirmation_button_unavailable' };
+      break;
+    }
     const beforeSession = await deps.sessionRepository.findContinuableSession(input.userId);
     const eventBaselines = new Map<string, number>();
     if (beforeSession !== null) {
@@ -72,8 +79,6 @@ export async function runTestConversation(
     }
     const beforeReplyCount = replies.length;
     const beforeToolCallCount = deps.toolCalls.length;
-    const turnNow = turn.timestamp ?? timestampForTurn(input.currentDateTime, index);
-    const message = buildIncomingMessage(input, turn, index, turns, turnNow);
     const result = await handleIncomingMessage(message, {
       sessionRepository: deps.sessionRepository,
       runner: deps.runner,
@@ -134,6 +139,7 @@ export async function runTestConversation(
     ...(input.scenarioId !== undefined ? { scenarioId: input.scenarioId } : {}),
     userId: input.userId,
     finalSessionId,
+    ...(stoppedBeforeTurn !== undefined ? { stoppedBeforeTurn } : {}),
     turns,
     toolCalls: sanitizedToolCalls,
     sessions: sanitizeSessions(sessions),
@@ -168,15 +174,17 @@ function buildIncomingMessage(
   index: number,
   previousTurns: readonly TestConversationTurnResult[],
   timestamp: string
-): IntexIncomingMessage {
+): IntexIncomingMessage | null {
   if (turn.kind === 'confirmation_button') {
     const previous = previousTurns[turn.previousTurnIndex];
-    if (previous === undefined) {
-      throw new Error('confirmation_button previousTurnIndex does not reference an executed turn');
+    if (previous?.kind !== 'message') {
+      throw new Error(
+        'confirmation_button previousTurnIndex does not reference an executed message turn'
+      );
     }
     const button = findConfirmationButton(previous, turn.decision);
     if (button === null) {
-      throw new Error('confirmation_button could not resolve a captured confirmation button');
+      return null;
     }
     return {
       type: 'intex.message.ingest',

--- a/apps/intex-agent/src/domain/testConversation/testConversationTypes.ts
+++ b/apps/intex-agent/src/domain/testConversation/testConversationTypes.ts
@@ -208,6 +208,10 @@ export interface TestConversationResponse {
   scenarioId?: string;
   userId: string;
   finalSessionId: string | null;
+  stoppedBeforeTurn?: {
+    turnIndex: number;
+    reason: 'confirmation_button_unavailable';
+  };
   turns: TestConversationTurnResult[];
   toolCalls: SanitizedToolCall[];
   sessions: SanitizedTestConversationSession[];

--- a/docs/superpowers/plans/2026-07-14-intex-agent-quality-program-implementation.md
+++ b/docs/superpowers/plans/2026-07-14-intex-agent-quality-program-implementation.md
@@ -2,9 +2,9 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` to implement this plan task-by-task. Every production change follows RED → GREEN → review.
 
-**Goal:** Provide one repository command that runs every tracked Intex Agent scenario on Home Dev, verifies tool/session behavior deterministically, evaluates every assistant response with MiniMax M3, performs one safe Matrix round-trip, and writes a complete report.
+**Goal:** Provide one repository command that runs every tracked Intex Agent scenario on Home Dev, verifies tool/session behavior deterministically, evaluates every assistant response with MiniMax M3, performs one safe Matrix round-trip only after its endpoint corpus passes, and writes a complete report.
 
-**Architecture:** A small evaluator under `tools/intex-agent-evals` runs on Home Dev and calls the existing local/dev-only `POST /internal/intex-agent/test/conversation` endpoint. The endpoint keeps the real Intex Agent LLM flow and mocked product tools, and additively exposes sanitized per-turn evidence already computed by the domain runner. Deterministic assertions remain authoritative; MiniMax M3 evaluates response semantics. The same command finishes with one real Matrix smoke whose prompt forbids product-tool side effects.
+**Architecture:** A small evaluator under `tools/intex-agent-evals` runs on Home Dev and calls the existing local/dev-only `POST /internal/intex-agent/test/conversation` endpoint. The endpoint keeps the real Intex Agent LLM flow and mocked product tools, and additively exposes sanitized per-turn evidence already computed by the domain runner. Deterministic assertions remain authoritative; MiniMax M3 evaluates response semantics. Only after its endpoint corpus passes, the same command finishes with one real Matrix smoke whose prompt forbids product-tool side effects.
 
 **Tech Stack:** TypeScript 5.7, Node.js 22, pnpm 10, Vitest 4, Zod 3, the existing Intex Agent test endpoint, the existing OpenRouter client, MiniMax M3, SSH, Matrix/Synapse on Home Dev.
 
@@ -21,9 +21,9 @@ The ten narrative scenarios in [`2026-06-24-intex-agent-dev-api-test-scenarios.m
 - Tasks 1–8 are implemented, independently reviewed, and green in `pnpm run ci:tracked`.
 - Delivered commits through Task 8: `deada8c2d` (20-turn endpoint), `839a9dda6` + `6acb58c64` (strict evaluator contract), `f2eed4d60` + `fb656ce44` + `c15b0c2fe` (20-scenario corpus), `52680fd04` + `56b24fe21` (secure Home Dev configuration and preflight), `c2d673683` + `6cd0dd44e` + `3033e438f` (scenario lifecycle), `4382f9223` + `f40dda449` (MiniMax M3 judge), `e75bc6f3a` (safe Matrix smoke), and `6f1fbb351` (CLI, reports, and Home Dev wrapper).
 - The offline completion audit is implemented and independently approved: every correlated assistant reply is judged, scenarios 001–010 enforce their source lifecycle semantics, tool/error evidence is closed and privacy-safe, setup is non-echoing, and the Home Dev wrapper accepts only one private framed CLI stream with selector/status validation. A fresh `pnpm run ci:tracked` passed on 2026-07-17.
-- The user explicitly authorized the Task 9 live lane. The implementation and the first two acceptance fixes were delivered through `development`; Home Dev health, deployed revision, account, Firebase, Matrix identity, and delivery readiness were verified.
-- Real preflight and endpoint evaluation calls have been executed. Preflight reached exit `0` after the prompt-only experiment, but the endpoint run stopped on scenario 001 when MiniMax returned invalid judge output both initially and after the one allowed repair; deterministic endpoint execution and cleanup succeeded. No Matrix message has been sent.
-- The remaining executable work is to deliver the self-contained verdict prompt and verified three-host routing contract, then repeat `preflight` → `endpoint` → `full`. Offline/unit/contract success is not final acceptance.
+- The user explicitly authorized the Task 9 live lane. The implementation and MiniMax contract fixes were delivered through `development`; Home Dev health, deployed revision, account, Firebase, Matrix identity, and delivery readiness were verified.
+- Real preflight and endpoint evaluation calls have been executed. The self-contained verdict contract produced 15 schema-valid MiniMax verdicts without repair across scenarios 001–006; those scenarios completed with real behavioral findings, zero deterministic failures, and complete cleanup. Scenario 007 then exposed a separate runner defect: a stochastic missing confirmation button became endpoint HTTP 500 instead of a behavioral stop. A later isolated 007 run completed as a behavioral result, confirming that transport and tool execution are healthy. No Matrix message has been sent.
+- The remaining executable work is to represent an unavailable dependent confirmation as a correlated partial response, then repeat `preflight` → `endpoint` → `full`. Offline/unit/contract success is not final acceptance.
 - The “Deferred perfection backlog” remains intentionally frozen and must not be implemented as part of this plan.
 
 ### Live contract correction — 2026-07-18
@@ -33,6 +33,8 @@ The ten narrative scenarios in [`2026-06-24-intex-agent-dev-api-test-scenarios.m
 - Two otherwise identical probes with `response_format` plus `provider.require_parameters: true` returned the expected final string while keeping reasoning separate. The evaluator therefore preserves JSON-object mode and requires OpenRouter to route only to endpoints that support every requested parameter.
 - A real endpoint retry then proved two remaining defects. The judge and repair prompts referred to “documented failure enums” without listing the six allowed values, so three parameter-compatible MiniMax M3 hosts returned valid JSON that failed only at `failures[]`; the repair repeated the same error. The same privacy-safe provider matrix also found one host returning `content: null` and another rate-limited.
 - The final contract uses one canonical failure-code tuple in Zod and every judge prompt, makes repair self-contained, and orders the three verified string-content MiniMax M3 hosts with fallback outside that list disabled. It does not parse `message.reasoning`, change the judge model, add a second model, or weaken local `JSON.parse` plus strict Zod validation. All privacy, fail-closed, cost-accounting, temperature, model, and repair constraints remain authoritative.
+- A scenario turn that depends on an assistant-generated confirmation button must not turn a missing button into HTTP 500. The endpoint returns the fully correlated executed prefix plus a closed `stoppedBeforeTurn` reason; deterministic evaluation records one behavioral stop and does not invent evidence for unexecuted turns.
+- The `full` command must enforce the same hard Matrix gate internally: it sends the one safe Matrix prompt only when its own endpoint corpus has `effectiveKind === 'passed'`. A behavioral or infrastructure endpoint result skips Matrix.
 
 ## Global constraints
 
@@ -43,12 +45,14 @@ The ten narrative scenarios in [`2026-06-24-intex-agent-dev-api-test-scenarios.m
 - The system under test uses the currently deployed Intex Agent model. Product model selection is outside this plan.
 - The endpoint accepts from 1 through exactly 20 product turns. The independent provider tool-loop limit remains unchanged.
 - Product tools stay mocked in the endpoint scenario suite.
+- A missing assistant-generated confirmation button stops the scenario before that dependent turn and is a deterministic behavioral failure, not an infrastructure failure or fabricated user action.
+- Matrix smoke is never attempted after a non-passing endpoint corpus, including inside the combined `full` command.
 - Every synthetic test user is removed through the existing cleanup utility in a `finally` path; cleanup failure is exit `2`.
 - All tracked scenario content is synthetic. No real e-mail, Auth0 user ID, phone number, Matrix room ID, message, or token enters Git.
 - Home Dev is fixed: SSH alias `home-dev`, repository `~/deploy/intexuraos`, Intex Agent port `8134`, WhatsApp Service port `8113`, Matrix adapter port `8099`.
 - Machine-specific account data and Matrix paths live only in `~/.config/intexuraos/intex-agent-evals.json` on Home Dev with mode `0600`.
 - The workstation wrapper passes its exact implementation commit as a required ancestor; Home Dev refuses the run until `~/deploy/intexuraos` contains that revision.
-- `full` runs the endpoint corpus and one safe Matrix smoke. `endpoint` exists for a run with no real message.
+- `full` runs the endpoint corpus and, only when that corpus passes, one safe Matrix smoke. `endpoint` exists for a run with no real message.
 - The Matrix smoke is safe with respect to product tools, but it is not storage-free: it creates one real outbound Matrix/WhatsApp prompt and one real Intex Agent session on the configured operator account. Synthetic endpoint cleanup must not delete those operator-owned records; dedicated-account lifecycle cleanup remains deferred.
 - No evaluation gateway, new cloud service, Terraform, WIF, GitHub Actions, dedicated account, or production rollout work belongs to this plan.
 - Reports are written below ignored `.artifacts/intex-agent-evals/` and are never committed.
@@ -59,7 +63,7 @@ The ten narrative scenarios in [`2026-06-24-intex-agent-dev-api-test-scenarios.m
 
 ### Modified
 
-- `POST /internal/intex-agent/test/conversation`: increase from 5 to 20 turns, confirmation reference maximum from 4 to 19, request body limit from 64 KiB to 256 KiB, and additive sanitized per-turn `toolCalls`, `sessionAfterTurn`, and `timelineEvents` evidence. Sanitized `user_message` event payloads also retain `sourceType`.
+- `POST /internal/intex-agent/test/conversation`: increase from 5 to 20 turns, confirmation reference maximum from 4 to 19, request body limit from 64 KiB to 256 KiB, and additive sanitized per-turn `toolCalls`, `sessionAfterTurn`, and `timelineEvents` evidence. Sanitized `user_message` event payloads also retain `sourceType`. When a dependent confirmation button is unavailable, the existing endpoint additionally returns the correlated executed prefix and optional closed `stoppedBeforeTurn` marker instead of HTTP 500.
 
 ### Created
 
@@ -71,7 +75,7 @@ The ten narrative scenarios in [`2026-06-24-intex-agent-dev-api-test-scenarios.m
 
 ### Unchanged
 
-- Internal authentication, local/dev-only availability, `live_llm_mock_tools` mode, exact `test-intex-agent-<runId>` namespace, every existing response field, production `404`, and the independent provider tool-loop limit.
+- Endpoint path, request contract, internal authentication, local/dev-only availability, `live_llm_mock_tools` mode, exact `test-intex-agent-<runId>` namespace, every existing response field, full-response behavior without a stop marker, production `404`, and the independent provider tool-loop limit.
 
 ## Canonical operator contract
 
@@ -105,7 +109,7 @@ Future-agent interpretation:
 - “Odpal scenariusz …” means `scenario <id>`.
 - “Odpal test Matrix” means `matrix-smoke`.
 
-The phrase “odpal testy” is the explicit authorization for the one safe Matrix message included in `full`. Merely inspecting status or editing code is not.
+The phrase “odpal testy” is the explicit authorization for the one safe Matrix message conditionally included in `full`; the message is still skipped unless that invocation's endpoint corpus passes. Merely inspecting status or editing code is not.
 
 ## Success criteria
 
@@ -117,7 +121,7 @@ The phrase “odpal testy” is the explicit authorization for the one safe Matr
 6. Failures identify scenario, turn, deterministic mismatch, and judge criterion without secrets.
 7. JSON and Markdown reports exist for every run.
 8. Preflight identifies endpoints, environment, judge, scenario count, and configured account alias without real identifiers.
-9. Full mode verifies one Matrix → WhatsApp → Intex Agent → Matrix response from the WhatsApp puppet without authorizing any product-tool side effect. This smoke proves transport and reply semantics; deterministic tool behavior is proven by the endpoint corpus.
+9. After its endpoint corpus passes, full mode verifies one Matrix → WhatsApp → Intex Agent → Matrix response from the WhatsApp puppet without authorizing any product-tool side effect. This smoke proves transport and reply semantics; deterministic tool behavior is proven by the endpoint corpus.
 10. A new Codex session can run everything from the repository runbook without rediscovering paths, ports, or commands.
 
 ## Locked file map
@@ -382,7 +386,7 @@ const MiniMaxJudgeVerdictSchema = z.object({
 - [x] Write `.artifacts/intex-agent-evals/<runId>/report.json` and `report.md` atomically through a restrictive temporary directory plus rename, with totals, tool/turn summaries, judge verdicts, provider-reported cost, duration, and safe failure codes. Evaluation commands produce reports; `setup` and `preflight` print safe summaries only.
 - [x] Ignore the artifact root in Git.
 - [x] Add root scripts `eval:intex-agent:setup`, `eval:intex-agent:preflight`, `eval:intex-agent:endpoint`, `eval:intex-agent`, and `eval:intex-agent:matrix-smoke`.
-- [x] Continue corpus and the authorized Matrix smoke after behavioral failures so the report is complete; stop before later scenarios or Matrix only after infrastructure, cleanup, judge-protocol, or reporting failure. Exit precedence is `2` over `1` over `0`, while preserving all earlier verdicts.
+- [x] Continue the endpoint corpus after behavioral failures so its report is complete. Run the authorized Matrix smoke only when the corpus executed by that same `full` invocation passes; any behavioral or infrastructure endpoint result stops before Matrix. Stop later endpoint scenarios only after infrastructure, cleanup, judge-protocol, or reporting failure. Exit precedence is `2` over `1` over `0`, while preserving all earlier verdicts.
 - [x] Implement the wrapper with a closed selector set and fixed `home-dev` / `~/deploy/intexuraos`.
 - [x] Execute remotely through `zsh -lic` and `direnv exec .`. Never forward secrets as SSH arguments.
 - [x] Resolve the local implementation SHA, pass it only as the revision proof, and require remote `git merge-base --is-ancestor <requiredSha> HEAD` before preflight or tests.
@@ -408,7 +412,7 @@ const MiniMaxJudgeVerdictSchema = z.object({
 - [x] Judge the first new assistant text through the dedicated MiniMax M3 Matrix seam; return/report only the closed verdict fields and usage, never rationale or message text.
 - [x] Retain no token, room/user/event ID, phone, or room history in reports.
 
-**Acceptance:** `endpoint` never sends a real message. `full` and `matrix-smoke` each send exactly one safe outbound prompt and may persist its real bridge/message metadata plus one real Intex Agent session on the configured operator account. The prompt never authorizes a product side effect, and synthetic cleanup never targets these records. This Matrix smoke does not claim hidden tool-call auditing; deterministic tool selection is covered by the endpoint corpus.
+**Acceptance:** `endpoint` never sends a real message. `full` sends exactly one safe outbound prompt only after its endpoint corpus passes; `matrix-smoke` sends exactly one when explicitly selected. Either Matrix path may persist real bridge/message metadata plus one real Intex Agent session on the configured operator account. The prompt never authorizes a product side effect, and synthetic cleanup never targets these records. This Matrix smoke does not claim hidden tool-call auditing; deterministic tool selection is covered by the endpoint corpus.
 
 ## Task 9: Write the runbook and prove the workflow
 
@@ -439,6 +443,7 @@ The following would make the system more comprehensive or portable, but is inten
 - a verified DeepSeek product-model identifier and DeepSeek-specific exact-20 evidence;
 - mechanical 95% capability coverage and a large generated catalog;
 - repetitions, statistical flake policy, baselines, drift alerts, nightly CI, and protected releases;
+- atomic semantic criteria with closed `failedSemanticCriterionIndexes`, enforced failure-code/boolean coherence, and calibration fixtures that distinguish judge instability from product instability;
 - a restricted evaluation gateway, separate evaluation credential, budgets, IAM, WIF, and attestation;
 - automatic debug-session → privacy-safe regression draft → review → promotion;
 - authoring/verifying skill teams for regression scenarios;

--- a/docs/superpowers/plans/2026-07-18-intex-agent-live-acceptance-fixes.md
+++ b/docs/superpowers/plans/2026-07-18-intex-agent-live-acceptance-fixes.md
@@ -4,7 +4,7 @@
 
 **Goal:** Remove the infrastructure defects discovered during Home Dev acceptance, redeploy the exact fixes, and complete `preflight` → `endpoint` → `full`.
 
-**Architecture:** The Intex Agent sanitizer omits normalized-empty event values before they reach the strict evaluator wire schema. The shared OpenRouter client rejects malformed or in-band error completions as provider failures before MiniMax output parsing. MiniMax remains the sole judge in JSON-object mode; its dedicated client uses an evidence-based three-host order, and one canonical verdict contract drives Zod plus the initial, Matrix, and repair prompts.
+**Architecture:** The Intex Agent sanitizer omits normalized-empty event values before they reach the strict evaluator wire schema. The endpoint returns a correlated executed prefix when a later turn depends on a confirmation button the model did not produce, allowing deterministic evaluation to classify the stop behaviorally. The combined runner admits Matrix only after its own endpoint corpus passes. The shared OpenRouter client and self-contained MiniMax prompt keep provider and judge failures closed.
 
 **Tech Stack:** TypeScript 5.7, Node.js 22, pnpm 10, Vitest 4, Zod 3, Home Dev, OpenRouter, MiniMax M3.
 
@@ -19,6 +19,24 @@
 - Do not implement strict JSON Schema routing, a second model, or any deferred-perfection item in this fix. The required-parameter flag and ordered provider restriction are required only on the dedicated MiniMax evaluator client.
 - Every production change follows RED → GREEN and receives an independent task review.
 
+## Endpoint Changes
+
+### Modified
+
+- `POST /internal/intex-agent/test/conversation`: when a requested dependent confirmation button is unavailable, return the strictly correlated executed prefix plus optional `stoppedBeforeTurn: { turnIndex, reason: 'confirmation_button_unavailable' }` instead of HTTP 500.
+
+### Created
+
+- None.
+
+### Removed
+
+- None.
+
+### Unchanged
+
+- Endpoint path, request contract, internal authentication, local/dev-only availability, production `404`, every existing response field, and full-response behavior when no stop marker is present.
+
 ## Live Contract Amendment — 2026-07-18
 
 - Two consecutive deployed preflights passed every local/account/Matrix check and failed only the MiniMax provider probe. A privacy-safe A/B request proved that default routing selected a path returning `content: null` for JSON mode.
@@ -27,6 +45,9 @@
 - The next real endpoint run still failed scenario 001 after one repair. Privacy-safe structural diagnostics proved the exact schema issue: GMICloud, direct MiniMax, and Morph returned valid JSON with only `failures[]:invalid_enum_value`; the prompt never listed the allowed enum values, so repair repeated the same error. Parasail returned `content: null`, and Together returned `429` in the same matrix.
 - Before delivery, the replacement self-contained prompt was exercised against the same synthetic scenario: GMICloud, direct MiniMax, and Morph each returned schema-valid verdict JSON on the initial call, while endpoint determinism and cleanup again passed. No response content was printed or persisted.
 - Keep MiniMax M3, temperature `0`, strict `JSON.parse` plus Zod, one repair, and closed errors. Make the prompt contract self-contained and route in the verified order GMICloud, direct MiniMax, then Morph, with no fallback outside that list. Do not parse chain-of-thought, add JSON Schema routing, switch models, or weaken the non-string response guard.
+- After that fix was deployed, scenarios 001–006 completed with 15 schema-valid MiniMax verdicts and complete cleanup. Scenario 007 twice returned endpoint HTTP 500, while a first-turn probe, a direct full runner call, and a later full endpoint call all completed. The stochastic difference is whether the model emits the expected confirmation button; the current runner throws when it cannot materialize the dependent input turn.
+- Treat that absence as product behavior. Return the exact executed prefix plus `stoppedBeforeTurn: { turnIndex, reason: 'confirmation_button_unavailable' }`, require strict correlation, and record one deterministic behavioral failure. Never fabricate or retry the missing user confirmation.
+- The audit also found that `full` currently runs Matrix after an endpoint `behavioral_failure`. Tighten this to `effectiveKind === 'passed'`; a separate preceding endpoint pass is not sufficient because `full` executes a fresh corpus whose stochastic result must gate its own real message.
 
 ---
 
@@ -40,7 +61,7 @@
 - Consumes: `sanitizeRecord(record)` and the public `sanitizeEventsBySessionId(eventsBySessionId)` path.
 - Produces: sanitized generic records and event payloads with string values omitted when normalization yields `''`.
 
-- [ ] **Step 1: Write the failing regression test**
+- [x] **Step 1: Write the failing regression test**
 
   Add one test using the real `sanitizeRecord()` implementation and one regression through public `sanitizeEventsBySessionId()`:
 
@@ -50,7 +71,7 @@
 
   The public-path test must prove whitespace-only `text`/`message` does not emit `textPreview` and a whitespace-only copied payload field is also omitted. Retain existing coverage proving non-empty strings are normalized and kept.
 
-- [ ] **Step 2: Verify RED**
+- [x] **Step 2: Verify RED**
 
   Run:
 
@@ -60,11 +81,11 @@
 
   Expected: the tests fail because the generic record and live event path contain normalized-empty values.
 
-- [ ] **Step 3: Implement the minimum fix**
+- [x] **Step 3: Implement the minimum fix**
 
   In the string branch of `sanitizeValue()`, normalize once and omit an empty result. Apply the same rule to the actual event payload copy path and `textPreview` assignment. Do not widen the evaluator wire schema.
 
-- [ ] **Step 4: Verify GREEN and commit**
+- [x] **Step 4: Verify GREEN and commit**
 
   Run the focused sanitizer test and `pnpm run ci:tracked`; both must pass with pristine test output. Commit only this task's source and test changes.
 
@@ -83,7 +104,7 @@
 - Consumes: OpenRouter's non-streaming chat-completion envelope.
 - Produces: `generate()` and `generateChat()` return an error `Result` for an absent first choice, `finish_reason: 'error'`, an in-band `choice.error`, or non-string assistant content.
 
-- [ ] **Step 1: Write failing HTTP-boundary regression tests**
+- [x] **Step 1: Write failing HTTP-boundary regression tests**
 
   Add complete Nock fixtures for:
 
@@ -93,7 +114,7 @@
 
   Assert that the public client returns an error `Result` and never exposes partial/empty content as success. Do not assert provider message text and do not add test-only production APIs. Update the two existing empty-choice success tests to the new failure contract.
 
-- [ ] **Step 2: Verify RED**
+- [x] **Step 2: Verify RED**
 
   Run:
 
@@ -103,11 +124,11 @@
 
   Expected: the new assertions fail because the current client returns successful content for these envelopes.
 
-- [ ] **Step 3: Implement runtime validation**
+- [x] **Step 3: Implement runtime validation**
 
   Widen only the raw provider response type to reflect optional error metadata and unknown/null content. Before usage extraction and `ok(...)`, reject an absent choice, an in-band choice error, `finish_reason === 'error'`, and content whose runtime type is not `string`. Use a closed local error message; never forward the provider's error text. Preserve existing HTTP error mapping and retry behavior.
 
-- [ ] **Step 4: Verify GREEN and commit**
+- [x] **Step 4: Verify GREEN and commit**
 
   Run the focused OpenRouter test, evaluator MiniMax tests, and `pnpm run ci:tracked`; all must pass. Commit only this task's source and test changes.
 
@@ -181,13 +202,76 @@
 
 ---
 
-### Task 5: Review, deliver, and repeat live acceptance
+### Task 5: Convert an unavailable dependent confirmation into a behavioral stop
+
+**Files:**
+- Modify: `apps/intex-agent/src/domain/testConversation/testConversationTypes.ts`
+- Modify: `apps/intex-agent/src/domain/testConversation/runTestConversation.ts`
+- Test: `apps/intex-agent/src/__tests__/domain/runTestConversation.test.ts`
+- Modify: `tools/intex-agent-evals/src/endpointClient.ts`
+- Test: `tools/intex-agent-evals/src/__tests__/endpointClient.test.ts`
+- Modify: `tools/intex-agent-evals/src/deterministicEvaluator.ts`
+- Test: `tools/intex-agent-evals/src/__tests__/deterministicEvaluator.test.ts`
+- Modify: `tools/intex-agent-evals/src/reportWriter.ts`
+- Test: `tools/intex-agent-evals/src/__tests__/reportWriter.test.ts`
+- Modify: `docs/testing/intex-agent-evals.md`
+- Test: `tools/intex-agent-evals/src/__tests__/documentation.test.ts`
+
+**Interfaces:**
+- Consumes: a scenario `confirmation_button` turn whose requested button is absent from the executed prior turn.
+- Produces: a strict correlated prefix with `stoppedBeforeTurn.reason = 'confirmation_button_unavailable'` and one closed deterministic failure of the same meaning.
+
+- [x] **Step 1: Write failing prefix, correlation, evaluator, and report tests**
+
+  Prove the domain runner stops before the unavailable turn without mutation, the client accepts only an exact bounded confirmation-turn prefix, the deterministic evaluator judges executed replies and emits one stop failure without cascaded evidence for unexecuted turns, and the report schema accepts the closed code. Prove malformed or forged partial responses remain infrastructure failures.
+
+- [x] **Step 2: Verify RED**
+
+  Run the four focused suites. The new assertions must fail against the deployed throwing/full-length-only behavior while all existing tests remain green.
+
+- [x] **Step 3: Implement the additive partial-stop contract**
+
+  Return the executed prefix and marker only for an absent requested confirmation button. Keep invalid request references as errors. Tighten endpoint correlation around the stop index and request turn kind; never fabricate a button or retry the LLM. Skip deterministic expectations at and after the stop while preserving all real prefix failures and judge inputs.
+
+- [x] **Step 4: Verify GREEN and review**
+
+  Run all focused suites, package typecheck/lint, and `pnpm run ci:tracked` on the exact diff. Require independent review before delivery.
+
+**Acceptance:** an agent decision not to request confirmation is reported as a behavioral regression with intact prefix evidence and cleanup; it can no longer abort the corpus as endpoint infrastructure failure.
+
+---
+
+### Task 6: Enforce the Matrix gate inside `full`
+
+**Files:**
+- Modify: `tools/intex-agent-evals/src/cli.ts`
+- Test: `tools/intex-agent-evals/src/__tests__/cli.test.ts`
+- Modify: `tools/intex-agent-evals/src/reportWriter.ts`
+- Test: `tools/intex-agent-evals/src/__tests__/reportWriter.test.ts`
+
+**Interfaces:**
+- Consumes: the `effectiveKind` of the endpoint corpus executed by the same `full` invocation.
+- Produces: exactly one Matrix smoke only for `passed`; no Matrix call for `behavioral_failure`, `infrastructure_failure`, or missing endpoint evidence.
+
+- [x] **Step 1: Write and verify the failing behavioral-gate test**
+
+  Replace the old expectation that `full` continues after endpoint behavior with a proof that Matrix is not called and the private partial report records only the endpoint behavioral result.
+
+- [x] **Step 2: Implement the strict gate and verify GREEN**
+
+  Require `endpoint.result.effectiveKind === 'passed'` before `runMatrixSmoke()`. Preserve explicit `matrix-smoke` behavior and the one-call guarantee for a passing `full` run.
+
+**Acceptance:** no real Matrix prompt can be sent by `full` unless all endpoint scenarios in that same invocation pass.
+
+---
+
+### Task 7: Review, deliver, and repeat live acceptance
 
 **Files:**
 - Modify: `docs/superpowers/plans/2026-07-18-intex-agent-live-acceptance-fixes.md` only to record final evidence.
 
-- [ ] Independently review each task and the combined diff; close every Critical or Important finding.
-- [ ] Run focused suites and `pnpm run ci:tracked` on the exact final revision.
+- [x] Independently review each task and the combined diff; close every Critical or Important finding.
+- [x] Run focused suites and `pnpm run ci:tracked` on the exact final revision.
 - [ ] Push the branch, open and merge a PR into `development`, and wait until Home Dev contains the exact fix revision through the existing deployment path.
 - [ ] Verify Home Dev health and deployed-revision ancestry.
 - [ ] Run `scripts/run-intex-agent-evals-home-dev.sh preflight`.

--- a/docs/testing/intex-agent-evals.md
+++ b/docs/testing/intex-agent-evals.md
@@ -13,11 +13,12 @@ exactly 20 product turns. `or:minimax/minimax-m3` is the only semantic judge.
 Missing credentials, a timeout, invalid output, or provider failure is an
 infrastructure failure with exit `2`; there is no fallback judge.
 
-`endpoint` and `scenario` send no real Matrix message. `matrix-smoke` and `full`
-each send one safe operator-owned Matrix/WhatsApp prompt and can leave one real
-Intex Agent session plus bridge metadata. The documented final acceptance runs
-`full`, not a preceding standalone `matrix-smoke`. During that acceptance, full
-sends exactly one safe message.
+`endpoint` and `scenario` send no real Matrix message. `matrix-smoke` sends one
+safe operator-owned Matrix/WhatsApp prompt. `full` sends that one prompt only when
+the endpoint corpus executed by the same invocation passes; otherwise it stops
+before Matrix. A sent prompt can leave one real Intex Agent session plus bridge
+metadata. The documented final acceptance runs `full`, not a preceding standalone
+`matrix-smoke`, and therefore sends at most one safe message.
 
 Preparation commands never run the wrapper. Every wrapper command below is
 **LIVE** and requires the explicit instruction “odpal testy” or equally explicit
@@ -121,7 +122,9 @@ Normal operator acceptance is `preflight` → `endpoint` → `full`. If prefligh
 returns `CONFIG_NOT_FOUND`, obtain the operator's values through one interactive
 `setup`, then rerun preflight. Stop on a nonzero endpoint result before sending a
 real message. After endpoint exit `0`, run `full` once and do not also run
-`matrix-smoke`.
+`matrix-smoke`. The fresh endpoint corpus inside `full` independently gates its
+Matrix stage, so a behavioral or infrastructure result there also sends no
+message.
 
 ## Exit codes and triage
 
@@ -137,6 +140,7 @@ tokens, or protected paths.
 
 `revision_mismatch` means the reviewed revision has not reached the existing Home
 Dev deployment. Wait for deployment; do not use remote `git pull`, `rsync`, `scp`,
-service restarts, or a wrapper bypass. A missing configuration requires the
-operator's interactive values; never infer them from e-mail or adapter legacy
-fields.
+or a wrapper bypass. After the reviewed merge is an ancestor of deployed `HEAD`,
+restart only the Home Dev `intex-agent` PM2 process and verify health on all three
+fixed ports before preflight. A missing configuration requires the operator's
+interactive values; never infer them from e-mail or adapter legacy fields.

--- a/tools/intex-agent-evals/src/__tests__/cli.test.ts
+++ b/tools/intex-agent-evals/src/__tests__/cli.test.ts
@@ -687,7 +687,7 @@ describe('runCli evaluation orchestration and projection', () => {
     ]);
   });
 
-  it('continues full to exactly one Matrix smoke after endpoint behavior', async () => {
+  it('stops full before Matrix after endpoint behavioral failure and preserves the report', async () => {
     const endpointResults = [
       lifecycleFor(SCENARIOS[0], 'behavioral_failure'),
       lifecycleFor(SCENARIOS[1], 'passed'),
@@ -710,16 +710,16 @@ describe('runCli evaluation orchestration and projection', () => {
 
     await expect(runCli(['full'], harness.dependencies)).resolves.toBe(1);
 
-    expect(harness.runMatrixSmoke).toHaveBeenCalledOnce();
+    expect(harness.runMatrixSmoke).not.toHaveBeenCalled();
     const report = requiredItem(reports, 0);
     expect(EvaluationReportV1Schema.parse(report)).toEqual(report);
     expect(report).toMatchObject({
       status: 'behavioral_failure',
       exitCode: 1,
       scenarios: [{ status: 'behavioral_failure' }, { status: 'passed' }],
-      matrixSmoke: { status: 'passed', exitCode: 0 },
     });
-    expect(harness.stdout.mock.calls).toContainEqual(['matrix-smoke PASS']);
+    expect(report).not.toHaveProperty('matrixSmoke');
+    expect(harness.stdout.mock.calls).not.toContainEqual(['matrix-smoke PASS']);
     expect(harness.stdout.mock.calls).toContainEqual([
       'evaluation result BEHAVIORAL_FAILURE exit 1',
     ]);
@@ -911,9 +911,9 @@ describe('runCli evaluation orchestration and projection', () => {
     expect(harness.outputText()).not.toContain('private-endpoint-runner-error-sentinel');
   });
 
-  it('applies infrastructure over behavior and retains both endpoint and Matrix evidence', async () => {
+  it('runs Matrix after a passed endpoint corpus and reports Matrix infrastructure failure', async () => {
     const endpointResults = [
-      lifecycleFor(SCENARIOS[0], 'behavioral_failure'),
+      lifecycleFor(SCENARIOS[0], 'passed'),
       lifecycleFor(SCENARIOS[1], 'passed'),
     ];
     const matrixResult = matrixResultFor('infrastructure_failure');
@@ -940,7 +940,7 @@ describe('runCli evaluation orchestration and projection', () => {
     expect(report).toMatchObject({
       status: 'infrastructure_failure',
       exitCode: 2,
-      scenarios: [{ status: 'behavioral_failure' }, { status: 'passed' }],
+      scenarios: [{ status: 'passed' }, { status: 'passed' }],
       matrixSmoke: { status: 'infrastructure_failure', exitCode: 2 },
     });
     expect(report.failures).toContainEqual({

--- a/tools/intex-agent-evals/src/__tests__/deterministicEvaluator.test.ts
+++ b/tools/intex-agent-evals/src/__tests__/deterministicEvaluator.test.ts
@@ -7,12 +7,48 @@ import type {
 } from '../endpointClient.js';
 import { IntexEvalScenarioSchema, type IntexEvalScenario } from '../scenarioSchema.js';
 import {
+  createConfirmationScenario,
   createScenario,
   type ExpectationFixture,
   type ScenarioFixture,
 } from './scenarioFixtures.js';
 
 describe('deterministic evaluator', () => {
+  it('reports a stopped confirmation without cascading failures beyond the executed prefix', () => {
+    const scenario = IntexEvalScenarioSchema.parse(createConfirmationScenario());
+    const response = responseFor(scenario);
+    requiredItem(response.turns, 0).toolCalls = [];
+    response.turns = response.turns.slice(0, 1);
+    response.sessionTransitions = response.sessionTransitions.slice(0, 1);
+    Object.assign(response, {
+      stoppedBeforeTurn: { turnIndex: 1, reason: 'confirmation_button_unavailable' },
+    });
+
+    const evaluation = evaluateDeterministically(scenario, response);
+
+    expect(evaluation.passed).toBe(false);
+    expect(evaluation.failures).toEqual([
+      {
+        code: 'required_tool_count_mismatch',
+        scenarioId: scenario.id,
+        turnIndex: 0,
+        expected: 1,
+        actual: 0,
+      },
+      {
+        code: 'confirmation_button_unavailable',
+        scenarioId: scenario.id,
+        turnIndex: 1,
+      },
+    ]);
+    expect(evaluation.repliesForJudge).toHaveLength(1);
+    expect(evaluation.repliesForJudge[0]).toMatchObject({
+      turnIndex: 0,
+      assistantText: 'Sanitized assistant reply.',
+      technicalFacts: { failureCodes: ['required_tool_count_mismatch'] },
+    });
+  });
+
   it('passes every evidence class and freezes the exact judge technical facts', () => {
     const scenario = scenarioFor((expected) => {
       expected.requiredToolCalls = [

--- a/tools/intex-agent-evals/src/__tests__/documentation.test.ts
+++ b/tools/intex-agent-evals/src/__tests__/documentation.test.ts
@@ -90,7 +90,11 @@ describe('Intex Agent evaluation documentation', () => {
     ]) {
       expect(runbook).toContain(fact);
     }
-    expect(runbook).toMatch(/full\s+sends exactly one safe\s+message/u);
+    expect(runbook).toContain('`full` sends that one prompt only when');
+    expect(runbook).toContain(
+      'the endpoint corpus executed by the same invocation passes; otherwise it stops'
+    );
+    expect(runbook).toContain('The fresh endpoint corpus inside `full` independently gates its');
 
     for (const field of CONFIG_FIELDS) {
       expect(runbook).toContain(`"${field}"`);

--- a/tools/intex-agent-evals/src/__tests__/endpointClient.test.ts
+++ b/tools/intex-agent-evals/src/__tests__/endpointClient.test.ts
@@ -419,6 +419,113 @@ describe('endpoint client transport and strict parsing', () => {
 });
 
 describe('endpoint client correlation', () => {
+  it('preserves the existing full-response correlation contract without a stop marker', async () => {
+    const scenario = parsedScenario();
+    const identity = fixedIdentity();
+    const response = validResponse(scenario, identity);
+    const aggregateToolCall = response.toolCalls[0];
+    const aggregateEvent = response.eventsBySessionId['intex_session_synthetic']?.[0];
+    if (aggregateToolCall === undefined || aggregateEvent === undefined) {
+      throw new Error('Expected full response aggregate fixtures');
+    }
+    response.toolCalls.push(structuredClone(aggregateToolCall));
+    response.behavioralTranscript.turns.push({
+      turnIndex: 9,
+      assistantReplyPreviews: ['Additional sanitized preview.'],
+      sessionAction: 'continued',
+    });
+    response.eventsBySessionId['intex_session_synthetic']?.push(structuredClone(aggregateEvent));
+
+    await expect(
+      clientForBody({ success: true, data: response }).runScenario(scenario, identity)
+    ).resolves.toMatchObject({ runId: identity.runId });
+  });
+
+  it.each(['accept', 'reject'] as const)(
+    'accepts an exact executed prefix stopped before an unavailable %s confirmation button',
+    async (decision) => {
+      const scenario = parsedConfirmationScenario(decision);
+      const identity = fixedIdentity();
+      const response = validResponse(scenario, identity);
+      materializeStoppedConfirmationPrefix(response as unknown as Record<string, unknown>);
+
+      const result = await clientForBody({ success: true, data: response }).runScenario(
+        scenario,
+        identity
+      );
+
+      expect(result).toMatchObject({
+        turns: [{ turnIndex: 0, kind: 'message' }],
+        stoppedBeforeTurn: { turnIndex: 1, reason: 'confirmation_button_unavailable' },
+      });
+    }
+  );
+
+  it('rejects a stop marker that points at a message request turn', async () => {
+    const scenario = IntexEvalScenarioSchema.parse(createScenario(2));
+    const identity = fixedIdentity();
+    const response = validResponse(scenario, identity);
+    materializeStoppedConfirmationPrefix(response as unknown as Record<string, unknown>);
+
+    await expectFailure(
+      clientForBody({ success: true, data: response }).runScenario(scenario, identity),
+      { code: 'endpoint_correlation_failed' }
+    );
+  });
+
+  it('accepts exact multi-session evidence in a stopped superseding prefix', async () => {
+    const scenario = parsedConfirmationScenario();
+    const identity = fixedIdentity();
+    const response = validResponse(scenario, identity);
+    const data = response as unknown as Record<string, unknown>;
+    materializeStoppedConfirmationPrefix(data);
+    const sessions = asArray(data['sessions']);
+    const currentSession = asRecord(sessions[0]);
+    const previousSession = {
+      ...structuredClone(currentSession),
+      id: 'intex_session_previous',
+      status: 'completed',
+      endedAt: scenario.currentDateTime,
+      endReason: 'cancelled_by_user',
+    };
+    sessions.unshift(previousSession);
+    const turn = asRecord(asArray(data['turns'])[0]);
+    const timelineEvents = asArray(turn['timelineEvents']);
+    const previousEvent = {
+      ...structuredClone(asRecord(timelineEvents[0])),
+      sessionId: 'intex_session_previous',
+      id: 'event-previous-session',
+    };
+    timelineEvents.unshift(previousEvent);
+    const { sessionId: _sessionId, ...aggregatePreviousEvent } = previousEvent;
+    asRecord(data['eventsBySessionId'])['intex_session_previous'] = [aggregatePreviousEvent];
+    const transition = asRecord(asArray(data['sessionTransitions'])[0]);
+    transition['action'] = 'superseded_previous';
+    transition['previousSessionId'] = 'intex_session_previous';
+    transition['previousEndReason'] = 'cancelled_by_user';
+    asRecord(asArray(asRecord(data['behavioralTranscript'])['turns'])[0])['sessionAction'] =
+      'superseded_previous';
+
+    await expect(
+      clientForBody({ success: true, data: response }).runScenario(scenario, identity)
+    ).resolves.toMatchObject({
+      stoppedBeforeTurn: { turnIndex: 1, reason: 'confirmation_button_unavailable' },
+    });
+  });
+
+  it('rejects a stopped reject turn when the requested no button is present', async () => {
+    const scenario = parsedConfirmationScenario('reject');
+    const identity = fixedIdentity();
+    const response = validResponse(scenario, identity);
+    materializeStoppedConfirmationPrefix(response as unknown as Record<string, unknown>);
+    const envelope = { success: true, data: response };
+    asRecord(firstReplyButton(envelope)['reply'])['id'] = 'confirmation-synthetic:no';
+
+    await expectFailure(clientForBody(envelope).runScenario(scenario, identity), {
+      code: 'endpoint_correlation_failed',
+    });
+  });
+
   it.each([
     [
       'contract version',
@@ -522,6 +629,115 @@ describe('endpoint client correlation', () => {
         data['finalSessionId'] = 'private-final-session-sentinel';
       },
     ],
+    [
+      'full response stop marker',
+      (data: Record<string, unknown>): void => {
+        data['stoppedBeforeTurn'] = {
+          turnIndex: 1,
+          reason: 'confirmation_button_unavailable',
+        };
+      },
+    ],
+    [
+      'partial stop marker turn index',
+      (data: Record<string, unknown>): void => {
+        materializeStoppedConfirmationPrefix(data);
+        asRecord(data['stoppedBeforeTurn'])['turnIndex'] = 0;
+      },
+    ],
+    [
+      'partial stop marker request bound',
+      (data: Record<string, unknown>): void => {
+        materializeStoppedConfirmationPrefix(data);
+        asRecord(data['stoppedBeforeTurn'])['turnIndex'] = 2;
+      },
+    ],
+    [
+      'partial transition count',
+      (data: Record<string, unknown>): void => {
+        materializeStoppedConfirmationPrefix(data);
+        asArray(data['sessionTransitions']).push({
+          turnIndex: 1,
+          action: 'continued',
+          sessionId: 'intex_session_synthetic',
+        });
+      },
+    ],
+    [
+      'partial behavioral transcript count',
+      (data: Record<string, unknown>): void => {
+        materializeStoppedConfirmationPrefix(data);
+        asArray(asRecord(data['behavioralTranscript'])['turns']).push({
+          turnIndex: 1,
+          assistantReplyPreviews: ['Unexecuted preview.'],
+          sessionAction: 'continued',
+        });
+      },
+    ],
+    [
+      'partial aggregate tool calls',
+      (data: Record<string, unknown>): void => {
+        materializeStoppedConfirmationPrefix(data);
+        asArray(data['toolCalls']).push(structuredClone(firstToolCall({ data })));
+      },
+    ],
+    [
+      'partial aggregate events',
+      (data: Record<string, unknown>): void => {
+        materializeStoppedConfirmationPrefix(data);
+        const events = asArray(asRecord(data['eventsBySessionId'])['intex_session_synthetic']);
+        events.push(structuredClone(events[0]));
+      },
+    ],
+    [
+      'partial stop marker with requested button present',
+      (data: Record<string, unknown>): void => {
+        materializeStoppedConfirmationPrefix(data);
+        asRecord(firstReplyButton({ data })['reply'])['id'] = 'confirmation-synthetic:yes';
+      },
+    ],
+    [
+      'partial duplicate session',
+      (data: Record<string, unknown>): void => {
+        materializeStoppedConfirmationPrefix(data);
+        const sessions = asArray(data['sessions']);
+        sessions.push(structuredClone(sessions[0]));
+      },
+    ],
+    [
+      'partial missing session',
+      (data: Record<string, unknown>): void => {
+        materializeStoppedConfirmationPrefix(data);
+        data['sessions'] = [];
+      },
+    ],
+    [
+      'partial session user',
+      (data: Record<string, unknown>): void => {
+        materializeStoppedConfirmationPrefix(data);
+        asRecord(asArray(data['sessions'])[0])['userId'] = 'test-intex-agent-wrong-user';
+      },
+    ],
+    [
+      'partial warning',
+      (data: Record<string, unknown>): void => {
+        materializeStoppedConfirmationPrefix(data);
+        data['warnings'] = ['safe warning'];
+      },
+    ],
+    [
+      'zero-turn partial',
+      (data: Record<string, unknown>): void => {
+        materializeStoppedConfirmationPrefix(data);
+        data['turns'] = [];
+        data['toolCalls'] = [];
+        data['sessionTransitions'] = [];
+        asRecord(data['behavioralTranscript'])['turns'] = [];
+        data['eventsBySessionId'] = {};
+        data['finalSessionId'] = null;
+        asRecord(data['stoppedBeforeTurn'])['turnIndex'] = 0;
+      },
+    ],
   ])('rejects %s mismatch without leaking correlated values', async (_label, mutate) => {
     const scenario = parsedConfirmationScenario();
     const identity = fixedIdentity();
@@ -546,10 +762,12 @@ function parsedScenario(): IntexEvalScenario {
   return IntexEvalScenarioSchema.parse(createScenario());
 }
 
-function parsedConfirmationScenario(): IntexEvalScenario {
+function parsedConfirmationScenario(decision: 'accept' | 'reject' = 'accept'): IntexEvalScenario {
   const fixture = createConfirmationScenario();
   const first = fixture.turns[0];
   if (first !== undefined) first.sourceType = 'whatsapp_audio_transcript';
+  const confirmation = fixture.turns[1];
+  if (confirmation !== undefined) confirmation.decision = decision;
   return IntexEvalScenarioSchema.parse(fixture);
 }
 
@@ -662,6 +880,31 @@ function validResponse(
     },
     sideEffectBoundary: 'mocked_tools_no_downstream_writes',
     warnings: [],
+  };
+}
+
+function materializeStoppedConfirmationPrefix(data: Record<string, unknown>): void {
+  const prefixTurns = asArray(data['turns']).slice(0, 1);
+  const firstPrefixTurn = asRecord(prefixTurns[0]);
+  const sessionId = String(firstPrefixTurn['sessionId']);
+  data['turns'] = prefixTurns;
+  data['toolCalls'] = prefixTurns.flatMap((turn) => asArray(asRecord(turn)['toolCalls']));
+  data['sessionTransitions'] = asArray(data['sessionTransitions']).slice(0, 1);
+  const transcript = asRecord(data['behavioralTranscript']);
+  transcript['turns'] = asArray(transcript['turns']).slice(0, 1);
+  data['eventsBySessionId'] = {
+    [sessionId]: prefixTurns.flatMap((turn) =>
+      asArray(asRecord(turn)['timelineEvents']).map((event) => {
+        const aggregateEvent = { ...asRecord(event) };
+        delete aggregateEvent['sessionId'];
+        return aggregateEvent;
+      })
+    ),
+  };
+  data['finalSessionId'] = sessionId;
+  data['stoppedBeforeTurn'] = {
+    turnIndex: 1,
+    reason: 'confirmation_button_unavailable',
   };
 }
 

--- a/tools/intex-agent-evals/src/__tests__/reportWriter.test.ts
+++ b/tools/intex-agent-evals/src/__tests__/reportWriter.test.ts
@@ -212,6 +212,28 @@ function behavioralReport(): EvaluationReportV1 {
   };
 }
 
+function stoppedConfirmationReport(): Record<string, unknown> {
+  const report = cloneReport(passReport());
+  report['status'] = 'behavioral_failure';
+  report['exitCode'] = 1;
+  const totals = report['totals'] as Record<string, unknown>;
+  totals['scenarioPassed'] = 0;
+  totals['scenarioBehavioralFailed'] = 1;
+  const scenario = first(report['scenarios'] as Record<string, unknown>[]);
+  scenario['status'] = 'behavioral_failure';
+  scenario['exitCode'] = 1;
+  scenario['deterministicFailures'] = [{ code: 'confirmation_button_unavailable', turnIndex: 2 }];
+  report['failures'] = [
+    {
+      stage: 'deterministic',
+      code: 'confirmation_button_unavailable',
+      scenarioId: 'intex-eval-001',
+      turnIndex: 2,
+    },
+  ];
+  return report;
+}
+
 function preflightFailureReport(): EvaluationReportV1 {
   return {
     schemaVersion: 1,
@@ -854,6 +876,61 @@ describe('EvaluationReportV1Schema', () => {
     }
   });
 
+  it('accepts the closed stopped-confirmation failure at the executed-prefix boundary', () => {
+    const report = stoppedConfirmationReport();
+
+    const parsed = EvaluationReportV1Schema.safeParse(report);
+
+    expect(parsed.success).toBe(true);
+    expect(JSON.stringify(parsed)).not.toMatch(/assistantText|rationale|rawResponse/u);
+  });
+
+  it.each([
+    [
+      'missing turn index',
+      (failure: Record<string, unknown>): void => {
+        delete failure['turnIndex'];
+      },
+    ],
+    [
+      'reply index',
+      (failure: Record<string, unknown>): void => {
+        failure['replyIndex'] = 0;
+      },
+    ],
+    [
+      'turn before prefix boundary',
+      (failure: Record<string, unknown>): void => {
+        failure['turnIndex'] = 1;
+      },
+    ],
+    [
+      'turn after prefix boundary',
+      (failure: Record<string, unknown>): void => {
+        failure['turnIndex'] = 3;
+      },
+    ],
+  ])('rejects stopped-confirmation evidence with %s', (_label, mutate) => {
+    const report = stoppedConfirmationReport();
+    const scenario = first(report['scenarios'] as Record<string, unknown>[]);
+    const scenarioFailure = first(scenario['deterministicFailures'] as Record<string, unknown>[]);
+    const globalFailure = first(report['failures'] as Record<string, unknown>[]);
+    mutate(scenarioFailure);
+    mutate(globalFailure);
+
+    expect(EvaluationReportV1Schema.safeParse(report).success).toBe(false);
+  });
+
+  it('keeps the executed-turn upper bound exclusive for every other deterministic code', () => {
+    const report = stoppedConfirmationReport();
+    const scenario = first(report['scenarios'] as Record<string, unknown>[]);
+    first(scenario['deterministicFailures'] as Record<string, unknown>[])['code'] =
+      'forbidden_tool_called';
+    first(report['failures'] as Record<string, unknown>[])['code'] = 'forbidden_tool_called';
+
+    expect(EvaluationReportV1Schema.safeParse(report).success).toBe(false);
+  });
+
   it.each([
     ['passed', 1],
     ['behavioral_failure', 0],
@@ -933,7 +1010,7 @@ describe('EvaluationReportV1Schema', () => {
     }
   );
 
-  it('requires the authorized Matrix stage after successful preflight unless full stopped on endpoint infrastructure', () => {
+  it('requires the authorized Matrix stage only after a fully passing endpoint corpus', () => {
     const matrixOnlyWithoutMatrix: EvaluationReportV1 = {
       ...preflightFailureReport(),
       command: 'matrix-smoke',
@@ -948,6 +1025,13 @@ describe('EvaluationReportV1Schema', () => {
     );
     expect(
       EvaluationReportV1Schema.safeParse({ ...behavioralReport(), command: 'full' }).success
+    ).toBe(true);
+    expect(
+      EvaluationReportV1Schema.safeParse({
+        ...behavioralReport(),
+        command: 'full',
+        matrixSmoke: passedMatrixReport().matrixSmoke,
+      }).success
     ).toBe(false);
     expect(
       EvaluationReportV1Schema.safeParse({ ...failedJudgeReport(), command: 'full' }).success

--- a/tools/intex-agent-evals/src/cli.ts
+++ b/tools/intex-agent-evals/src/cli.ts
@@ -459,9 +459,7 @@ async function runEvaluationCommand(
 
     const endpointAllowsMatrix =
       command.kind === 'matrix-smoke' ||
-      (command.kind === 'full' &&
-        endpoint !== undefined &&
-        endpoint.result.effectiveKind !== 'infrastructure_failure');
+      (command.kind === 'full' && endpoint?.result.effectiveKind === 'passed');
     if (endpointAllowsMatrix) {
       try {
         matrixSmoke = await dependencies.runMatrixSmoke();

--- a/tools/intex-agent-evals/src/deterministicEvaluator.ts
+++ b/tools/intex-agent-evals/src/deterministicEvaluator.ts
@@ -30,7 +30,8 @@ export type DeterministicFailureCode =
   | 'forbidden_timeline_event_present'
   | 'timeline_payload_assertion_failed'
   | 'assistant_reply_missing'
-  | 'assistant_reply_unexpected';
+  | 'assistant_reply_unexpected'
+  | 'confirmation_button_unavailable';
 
 export interface DeterministicFailure {
   code: DeterministicFailureCode;
@@ -133,8 +134,12 @@ export function evaluateDeterministically(
   const repliesForJudge: ReplyEvaluationInput[] = [];
   const turnsByIndex = groupByTurnIndex(response.turns);
   const transitionsByIndex = groupByTurnIndex(response.sessionTransitions);
+  const stoppedBeforeTurnIndex = response.stoppedBeforeTurn?.turnIndex;
 
   for (const expectation of scenario.expected.turns) {
+    if (stoppedBeforeTurnIndex !== undefined && expectation.turnIndex >= stoppedBeforeTurnIndex) {
+      continue;
+    }
     const turnStart = failures.length;
     const actualTurns = turnsByIndex.get(expectation.turnIndex) ?? [];
     const actualTurn = actualTurns.length === 1 ? actualTurns[0] : undefined;
@@ -201,6 +206,14 @@ export function evaluateDeterministically(
         technicalFacts,
       });
     }
+  }
+
+  if (stoppedBeforeTurnIndex !== undefined) {
+    failures.push({
+      code: 'confirmation_button_unavailable',
+      scenarioId: scenario.id,
+      turnIndex: stoppedBeforeTurnIndex,
+    });
   }
 
   return { passed: failures.length === 0, failures, repliesForJudge };

--- a/tools/intex-agent-evals/src/endpointClient.ts
+++ b/tools/intex-agent-evals/src/endpointClient.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { performance } from 'node:perf_hooks';
+import { isDeepStrictEqual } from 'node:util';
 import { z } from 'zod';
 import {
   IntexAgentSessionEndReasonSchema,
@@ -282,6 +283,13 @@ const BehavioralTranscriptTurnSchema = z
   })
   .strict();
 
+const StoppedBeforeTurnSchema = z
+  .object({
+    turnIndex: z.number().int().nonnegative().max(19),
+    reason: z.literal('confirmation_button_unavailable'),
+  })
+  .strict();
+
 const EndpointConversationResponseSchema = z
   .object({
     contractVersion: z.literal('2026-07-01'),
@@ -290,6 +298,7 @@ const EndpointConversationResponseSchema = z
     scenarioId: BoundedIdentifierSchema.optional(),
     userId: z.string().regex(USER_ID_PATTERN),
     finalSessionId: BoundedIdentifierSchema.nullable(),
+    stoppedBeforeTurn: StoppedBeforeTurnSchema.optional(),
     turns: z.array(EndpointTurnResultSchema).max(20),
     toolCalls: z.array(EndpointToolCallSchema),
     sessions: z.array(EndpointSessionSchema),
@@ -320,6 +329,10 @@ export interface EndpointConversationResponse {
   scenarioId?: string;
   userId: string;
   finalSessionId: string | null;
+  stoppedBeforeTurn?: {
+    turnIndex: number;
+    reason: 'confirmation_button_unavailable';
+  };
   turns: EndpointTurnResult[];
   toolCalls: EndpointToolCall[];
   sessions: {
@@ -570,11 +583,29 @@ function isCorrelated(
     response.runId !== request.runId ||
     response.scenarioId !== request.scenarioId ||
     response.userId !== request.userId ||
-    response.sideEffectBoundary !== 'mocked_tools_no_downstream_writes' ||
-    response.turns.length !== request.turns.length ||
-    response.sessionTransitions.length !== request.turns.length
+    response.sideEffectBoundary !== 'mocked_tools_no_downstream_writes'
   ) {
     return false;
+  }
+
+  const executedTurnCount = response.turns.length;
+  if (response.sessionTransitions.length !== executedTurnCount) return false;
+  if (response.stoppedBeforeTurn === undefined) {
+    if (executedTurnCount !== request.turns.length) return false;
+  } else {
+    const stoppedRequestTurn = request.turns[response.stoppedBeforeTurn.turnIndex];
+    if (
+      executedTurnCount === 0 ||
+      response.stoppedBeforeTurn.turnIndex !== executedTurnCount ||
+      response.stoppedBeforeTurn.turnIndex >= request.turns.length ||
+      stoppedRequestTurn?.kind !== 'confirmation_button' ||
+      stoppedRequestTurn.previousTurnIndex >= executedTurnCount ||
+      response.turns[stoppedRequestTurn.previousTurnIndex] === undefined ||
+      hasRequestedConfirmationButton(response, stoppedRequestTurn)
+    ) {
+      return false;
+    }
+    if (!hasExactPartialEvidence(response)) return false;
   }
 
   const seenTurnIndexes = new Set<number>();
@@ -597,7 +628,78 @@ function isCorrelated(
     if (matchingTransitions.length !== 1 || matchingTransitions[0]?.sessionId !== turn.sessionId) {
       return false;
     }
+    if (response.stoppedBeforeTurn !== undefined) {
+      const transcriptTurn = response.behavioralTranscript.turns[index];
+      if (
+        transcriptTurn?.turnIndex !== index ||
+        transcriptTurn.sessionAction !== matchingTransitions[0].action
+      ) {
+        return false;
+      }
+    }
   }
 
-  return response.finalSessionId === response.turns.at(-1)?.sessionId;
+  return (
+    (response.stoppedBeforeTurn === undefined ||
+      response.behavioralTranscript.turns.length === executedTurnCount) &&
+    response.finalSessionId === response.turns.at(-1)?.sessionId
+  );
+}
+
+function hasRequestedConfirmationButton(
+  response: CorrelatableEndpointConversationResponse,
+  turn: Extract<EndpointConversationTurnRequest, { kind: 'confirmation_button' }>
+): boolean {
+  const suffix = turn.decision === 'accept' ? ':yes' : ':no';
+  const referencedTurn = response.turns[turn.previousTurnIndex];
+  return (
+    referencedTurn?.assistantReplies.some(
+      (reply) => reply.buttons?.some((button) => button.reply.id.endsWith(suffix)) === true
+    ) === true
+  );
+}
+
+function hasExactPartialEvidence(response: CorrelatableEndpointConversationResponse): boolean {
+  if (response.warnings.length !== 0 || !hasExactPartialSessions(response)) return false;
+
+  const expectedToolCalls = response.turns.flatMap((turn) => turn.toolCalls);
+  if (!isDeepStrictEqual(response.toolCalls, expectedToolCalls)) return false;
+
+  const expectedEventsBySessionId: Record<string, Omit<EndpointTimelineEvent, 'sessionId'>[]> = {};
+  for (const turn of response.turns) {
+    for (const event of turn.timelineEvents) {
+      const { sessionId, ...aggregateEvent } = event;
+      const events = expectedEventsBySessionId[sessionId] ?? [];
+      events.push(aggregateEvent);
+      expectedEventsBySessionId[sessionId] = events;
+    }
+  }
+  return isDeepStrictEqual(response.eventsBySessionId, expectedEventsBySessionId);
+}
+
+function hasExactPartialSessions(response: CorrelatableEndpointConversationResponse): boolean {
+  const expectedSessionIds = new Set<string>();
+  for (const turn of response.turns) {
+    expectedSessionIds.add(turn.sessionId);
+    for (const event of turn.timelineEvents) expectedSessionIds.add(event.sessionId);
+  }
+  for (const transition of response.sessionTransitions) {
+    if (transition.previousSessionId !== undefined) {
+      expectedSessionIds.add(transition.previousSessionId);
+    }
+  }
+
+  if (response.sessions.length !== expectedSessionIds.size) return false;
+  const observedSessionIds = new Set<string>();
+  for (const session of response.sessions) {
+    if (
+      session.userId !== response.userId ||
+      !expectedSessionIds.has(session.id) ||
+      observedSessionIds.has(session.id)
+    ) {
+      return false;
+    }
+    observedSessionIds.add(session.id);
+  }
+  return observedSessionIds.size === expectedSessionIds.size;
 }

--- a/tools/intex-agent-evals/src/reportWriter.ts
+++ b/tools/intex-agent-evals/src/reportWriter.ts
@@ -140,6 +140,7 @@ const DETERMINISTIC_FAILURE_CODES = defineExhaustiveCodes<DeterministicFailureCo
   'timeline_payload_assertion_failed',
   'assistant_reply_missing',
   'assistant_reply_unexpected',
+  'confirmation_button_unavailable',
 ] as const satisfies readonly DeterministicFailureCode[]);
 
 const DETERMINISTIC_REPORT_FAILURE_CODES = defineExhaustiveCodes<DeterministicReportFailureCode>()([
@@ -483,7 +484,19 @@ export const ScenarioReportV1Schema = z
       verdictReferences.add(reference);
     }
     for (const [index, failure] of scenario.deterministicFailures.entries()) {
-      if (failure.turnIndex !== undefined && failure.turnIndex >= scenario.turnCount) {
+      if (failure.code === 'confirmation_button_unavailable') {
+        if (
+          scenario.turnCount === 0 ||
+          failure.turnIndex !== scenario.turnCount ||
+          failure.replyIndex !== undefined
+        ) {
+          addCustomIssue(
+            context,
+            ['deterministicFailures', index],
+            'Stopped confirmation reference is incoherent'
+          );
+        }
+      } else if (failure.turnIndex !== undefined && failure.turnIndex >= scenario.turnCount) {
         addCustomIssue(
           context,
           ['deterministicFailures', index, 'turnIndex'],
@@ -707,6 +720,9 @@ export const EvaluationReportV1Schema = z
     const hasEndpointInterruption =
       hasGlobalEndpointInterruption ||
       report.scenarios.some((scenario) => scenario.status === 'infrastructure_failure');
+    const hasEndpointBehavioralFailure = report.scenarios.some(
+      (scenario) => scenario.status === 'behavioral_failure'
+    );
 
     if (report.preflight.status === 'failed') {
       if (report.scenarios.length !== 0 || report.matrixSmoke !== undefined) {
@@ -752,7 +768,8 @@ export const EvaluationReportV1Schema = z
       report.preflight.status === 'passed' &&
       report.command === 'full' &&
       report.matrixSmoke === undefined &&
-      !hasEndpointInterruption
+      !hasEndpointInterruption &&
+      !hasEndpointBehavioralFailure
     ) {
       addCustomIssue(
         context,
@@ -760,8 +777,12 @@ export const EvaluationReportV1Schema = z
         'Full command is missing its authorized Matrix result'
       );
     }
-    if (report.command === 'full' && hasEndpointInterruption && report.matrixSmoke !== undefined) {
-      addCustomIssue(context, ['matrixSmoke'], 'Endpoint infrastructure must stop before Matrix');
+    if (
+      report.command === 'full' &&
+      (hasEndpointInterruption || hasEndpointBehavioralFailure) &&
+      report.matrixSmoke !== undefined
+    ) {
+      addCustomIssue(context, ['matrixSmoke'], 'Endpoint failure must stop before Matrix');
     }
     if (
       report.command === 'matrix-smoke' &&
@@ -836,7 +857,19 @@ function validateFailureEvidence(
       addCustomIssue(context, ['failures', index, 'scenarioId'], 'Scenario reference is missing');
     }
     if (scenario !== undefined) {
-      if (failure.turnIndex !== undefined && failure.turnIndex >= scenario.turnCount) {
+      if (failure.code === 'confirmation_button_unavailable') {
+        if (
+          scenario.turnCount === 0 ||
+          failure.turnIndex !== scenario.turnCount ||
+          failure.replyIndex !== undefined
+        ) {
+          addCustomIssue(
+            context,
+            ['failures', index],
+            'Stopped confirmation reference is incoherent'
+          );
+        }
+      } else if (failure.turnIndex !== undefined && failure.turnIndex >= scenario.turnCount) {
         addCustomIssue(context, ['failures', index, 'turnIndex'], 'Turn reference is out of range');
       }
       if (failure.replyIndex !== undefined && failure.replyIndex >= scenario.replyCount) {


### PR DESCRIPTION
## Summary
- return a strict executed prefix when an expected confirmation button is unavailable instead of turning product behavior into endpoint HTTP 500
- classify the stop with the closed `confirmation_button_unavailable` deterministic/report code without cascaded evidence
- hard-gate Matrix inside `full` on the same invocation endpoint corpus passing
- update the implementation plan and Home Dev runbook with the live findings and deferred judge-attribution work

## Verification
- TDD RED reproduced the throwing endpoint and unsafe Matrix gate
- focused GREEN: 401/401 contract and wrapper tests
- package GREEN: Intex Agent 588/588; evaluator 749/749
- `pnpm run ci:tracked`: PASS before and after integration with current `development`
- independent exact-diff review: APPROVED with all P2 findings closed

## Live evidence motivating the fix
Home Dev preflight passed. Scenarios 001-006 completed with 15 schema-valid MiniMax verdicts, zero deterministic failures, and complete cleanup. Scenario 007 showed that a stochastic missing confirmation button was incorrectly projected as endpoint infrastructure failure; an isolated retry completed behaviorally. No Matrix message has been sent.

- Linear: [INT-1863](https://linear.app/pbuchman/issue/INT-1863)
- IntexuraOS Code Task: [View task](https://intexuraos.cloud/#/code-tasks/task_a816626c-fd98-4085-a83b-4473736061a9)
- Worker Type: `codex-xhigh`
- Model: `default`