### PR TITLE
[INT-1866] Calibrate Intex Agent long-session evaluations

### DIFF
--- a/apps/intex-agent/src/__tests__/domain/intexAgentRunner.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/intexAgentRunner.test.ts
@@ -93,7 +93,7 @@ describe('createIntexAgentRunner', () => {
     expect(client.calls[0]?.systemPrompt).toBe(
       `${INTEX_AGENT_SYSTEM_PROMPT.text}\n\nCurrent date-time: ${CURRENT_DATE_TIME}`
     );
-    expect(INTEX_AGENT_SYSTEM_PROMPT.version).toBe('14.0.0');
+    expect(INTEX_AGENT_SYSTEM_PROMPT.version).toBe('15.0.0');
     expect(client.calls[0]?.systemPrompt).toContain('You are Intex in WhatsApp Assistant conversations.');
     expect(client.calls[0]?.systemPrompt).not.toContain('You are IntexuraOS');
     expect(client.calls[0]?.systemPrompt).toContain(
@@ -1550,7 +1550,7 @@ describe('createIntexAgentRunner', () => {
       reply: 'Do tej pory powiedziałeś, że chcesz zbierać fragmenty notatki.',
     });
 
-    expect(INTEX_AGENT_SYSTEM_PROMPT.version).toBe('14.0.0');
+    expect(INTEX_AGENT_SYSTEM_PROMPT.version).toBe('15.0.0');
     expect(client.calls[0]?.systemPrompt).toContain('You can use the current session transcript');
     expect(client.calls[0]?.systemPrompt).toContain('Do not claim you cannot review the current conversation');
     expect(client.calls[0]?.tools).toEqual([]);

--- a/docs/superpowers/plans/2026-07-18-intex-agent-live-acceptance-fixes.md
+++ b/docs/superpowers/plans/2026-07-18-intex-agent-live-acceptance-fixes.md
@@ -393,6 +393,17 @@ The first authorized Matrix message and Chrome audit exposed additional defects 
 
 **Acceptance:** no line belonging to a redacted structured confirmation value can reach endpoint output, judge input, reports, or diagnostics, including scenario `020`'s accumulated multiline note.
 
+### Task 17: Calibrate privacy-safe isolated judging and long-session acknowledgements
+
+**Evidence:** the deployed post-fix corpus improved from `6/20` to `15/20`, with scenarios `016` and `017` now passing and zero deterministic failures. The remaining five failures were MiniMax-only. Safe endpoint-only reruns proved the confirmation replies contained their expected structured labels followed by `[redacted]`, while the 20-turn run exposed one incorrect paraphrase of a retained fragment even though the final deterministic note arguments still contained all 18 markers. Passing `submittedTextPreview` to the external judge was rejected because it would unnecessarily widen the user-text privacy boundary.
+
+- [x] Add RED catalog invariants that treat literal structured `…: [redacted]` fields as complete confirmation evidence and prohibit isolated criteria from requiring unavailable raw values or earlier conversation state.
+- [x] Calibrate scenarios `002`, `006`, `012`, `018`, and `020` without changing messages, turn counts, transitions, tools, payload assertions, cleanup, or the MiniMax M3 judge.
+- [x] Instruct Intex Agent to answer explicit retain-only, do-not-save turns with a short neutral current-session acknowledgement that does not paraphrase, enumerate, count, infer, or claim durable storage; lock the behavior with a RED prompt test and required version bump.
+- [ ] Rerun the deployed 20-scenario endpoint gate; only after exit `0`, run the full endpoint-plus-Matrix gate once.
+
+**Acceptance:** MiniMax evaluates only observable privacy-safe evidence, long context-retention turns cannot invent or repeat fragment details, all deterministic assertions remain authoritative, and Matrix remains gated behind a green endpoint corpus.
+
 ### Deferred perfection (recorded, not implemented in this loop)
 
 - Dedicated portable WhatsApp integration accounts and cross-machine credential bootstrap.

--- a/packages/llm-prompts/src/intex-agent/__tests__/systemPrompt.test.ts
+++ b/packages/llm-prompts/src/intex-agent/__tests__/systemPrompt.test.ts
@@ -6,10 +6,10 @@ const CURRENT_DATE_TIME = '2026-06-24T10:00:00.000Z';
 describe('buildIntexAgentSystemPrompt', () => {
   it('exposes prompt metadata with semver versions', () => {
     expect(INTEX_AGENT_SYSTEM_PROMPT.version).toMatch(/^\d+\.\d+\.\d+$/);
-    expect(INTEX_AGENT_SYSTEM_PROMPT.version).toBe('14.0.0');
+    expect(INTEX_AGENT_SYSTEM_PROMPT.version).toBe('15.0.0');
     expect(buildIntexAgentSystemPrompt.name).toBe('intex-agent-system-prompt');
     expect(buildIntexAgentSystemPrompt.version).toMatch(/^\d+\.\d+\.\d+$/);
-    expect(buildIntexAgentSystemPrompt.version).toBe('7.0.0');
+    expect(buildIntexAgentSystemPrompt.version).toBe('8.0.0');
   });
 
   it('builds the base prompt with the current date-time', () => {
@@ -75,6 +75,17 @@ describe('buildIntexAgentSystemPrompt', () => {
     expect(prompt).toContain('show every event candidate you can identify');
     expect(prompt).toContain('create only one calendar event per confirmed tool call');
     expect(prompt).toContain('Current-date questions are answerable from Current date-time');
+  });
+
+  it('acknowledges current-session context retention without echoing fragment details', () => {
+    const prompt = buildIntexAgentSystemPrompt.build({
+      currentDateTime: CURRENT_DATE_TIME,
+      userPreferences: null,
+    });
+
+    expect(prompt).toContain(
+      'When the current user message explicitly asks you only to retain or hold provided context and not save it yet, reply with a short neutral acknowledgement. Do not paraphrase, restate, enumerate, count, or infer the provided fragment details, and do not claim durable storage; the context exists only in the current session.'
+    );
   });
 
   it('keeps direct answers and explicit tool requests out of generic protocol fallback', () => {

--- a/packages/llm-prompts/src/intex-agent/systemPrompt.ts
+++ b/packages/llm-prompts/src/intex-agent/systemPrompt.ts
@@ -1,7 +1,7 @@
 import type { PromptBuilder } from '../types.js';
 
 export const INTEX_AGENT_SYSTEM_PROMPT = {
-  version: '14.0.0',
+  version: '15.0.0',
   text: [
     'You are Intex in WhatsApp Assistant conversations.',
     'Default to the language of the last reasonable user message in the current session, unless an explicit current-turn instruction or allowed user preference says otherwise. Ignore bare links, image-only messages, attachments, and trivial greetings such as "hello" when selecting the language. For ambiguous simple messages, use the wider conversation context before falling back to English. If no specific language can be classified, reply in English. The JSON reply value must follow this language rule.',
@@ -11,6 +11,7 @@ export const INTEX_AGENT_SYSTEM_PROMPT = {
     'If the user asks you to answer, explain, summarize, compare, reason, or reply directly, answer in the reply field with outcome no_action unless a matching read tool is required.',
     'Do as much useful work as possible before naming a blocker. If the final requested action is unavailable or needs confirmation, still analyze, extract, classify, count, summarize, draft, or list what you can from the current session and provided content.',
     'Use the full current session history to understand topic shifts and references. The latest user message is important, but it is not the only context. Distinguish completed preference-management turns from a new calendar, note, research, or general conversation topic.',
+    'When the current user message explicitly asks you only to retain or hold provided context and not save it yet, reply with a short neutral acknowledgement. Do not paraphrase, restate, enumerate, count, or infer the provided fragment details, and do not claim durable storage; the context exists only in the current session.',
     'Current-date questions are answerable from Current date-time. General knowledge questions are answerable from your model knowledge when they do not require unavailable private or live external data. For current weather or other live facts, use a matching exposed tool if one is available; if no data or tool is available, say exactly that and still answer any stable part you can.',
     'When the user provides a list of possible calendar events, questions, agenda items, or raw event-like text, first analyze the list without a tool; show every event candidate you can identify, where you found it, extracted title/date/time/location/details, confidence, and missing fields. Only ask to create calendar events after that analysis or when the user explicitly asks to add a specific event.',
     'If the user wants multiple calendar events created, explain that you can create only one calendar event per confirmed tool call and each calendar creation requires confirmation. Offer to start with the first complete event or show which event candidates need more details.',
@@ -64,7 +65,7 @@ export const buildIntexAgentSystemPrompt: PromptBuilder<BuildIntexAgentSystemPro
   name: 'intex-agent-system-prompt',
   description:
     'Intex Agent system prompt with optional user preferences block and current date-time suffix',
-  version: '7.0.0',
+  version: '8.0.0',
   build(input: BuildIntexAgentSystemPromptInput): string {
     const lines: string[] = [INTEX_AGENT_SYSTEM_PROMPT.text];
     if (input.userPreferences !== null && input.userPreferences.trim() !== '') {

--- a/tools/intex-agent-evals/scenarios/intex-eval-002.scenario.json
+++ b/tools/intex-agent-evals/scenarios/intex-eval-002.scenario.json
@@ -98,6 +98,8 @@
             "replyIndex": 0,
             "semanticCriteria": [
               "Correctly identifies a fully specified calendar-event request, presents a reviewable sanitized preview using observable redacted structured labels for Title, Start, and End, and asks for explicit confirmation in an appropriate, concise tone.",
+              "Expected complete sanitized confirmation evidence: `Title: [redacted]`, `Start: [redacted]`, `End: [redacted]`, and `Location: [redacted]`.",
+              "The redacted values are complete expected evidence for the judge and are not missing information.",
               "Does not request already supplied details or expose raw argument content in the sanitized reply."
             ]
           }

--- a/tools/intex-agent-evals/scenarios/intex-eval-006.scenario.json
+++ b/tools/intex-agent-evals/scenarios/intex-eval-006.scenario.json
@@ -107,7 +107,9 @@
           {
             "replyIndex": 0,
             "semanticCriteria": [
-              "Correctly identifies the first note-save request and asks for explicit confirmation in an appropriate, concise tone.",
+              "Correctly identifies a note-save request and asks for explicit confirmation in an appropriate, concise tone.",
+              "Expected complete sanitized confirmation evidence: `Title: [redacted]` and `Content: [redacted]`.",
+              "The redacted values are complete expected evidence for the judge and are not missing information.",
               "Does not claim the note already exists or expose raw argument content in the sanitized reply."
             ]
           }
@@ -200,8 +202,8 @@
           {
             "replyIndex": 0,
             "semanticCriteria": [
-              "Clearly communicates that the first requested note was saved successfully.",
-              "Leaves the interaction open for a coherent follow-up."
+              "Clearly communicates that the requested note was saved successfully.",
+              "A concise completion-only reply is sufficient and should not restate details or invite another action."
             ]
           }
         ]
@@ -270,8 +272,10 @@
           {
             "replyIndex": 0,
             "semanticCriteria": [
-              "Correctly identifies the follow-up as a second note-save request and asks for explicit confirmation.",
-              "Does not claim the note exists or expose raw argument content in the sanitized reply."
+              "Correctly identifies a note-save request and asks for explicit confirmation in an appropriate, concise tone.",
+              "Expected complete sanitized confirmation evidence: `Title: [redacted]` and `Content: [redacted]`.",
+              "The redacted values are complete expected evidence for the judge and are not missing information.",
+              "Does not claim the note already exists or expose raw argument content in the sanitized reply."
             ]
           }
         ]
@@ -363,8 +367,8 @@
           {
             "replyIndex": 0,
             "semanticCriteria": [
-              "Clearly communicates that the follow-up note was saved successfully.",
-              "Remains coherent with the prior successful action in the same session."
+              "Clearly communicates that the requested note was saved successfully.",
+              "A concise completion-only reply is sufficient and should not restate details or invite another action."
             ]
           }
         ]

--- a/tools/intex-agent-evals/scenarios/intex-eval-012.scenario.json
+++ b/tools/intex-agent-evals/scenarios/intex-eval-012.scenario.json
@@ -98,6 +98,8 @@
             "replyIndex": 0,
             "semanticCriteria": [
               "Correctly identifies a research-draft request and asks for explicit confirmation in an appropriate tone.",
+              "Expected complete sanitized confirmation evidence: `Title: [redacted]` and `Prompt: [redacted]`.",
+              "The redacted values are complete expected evidence for the judge and are not missing information.",
               "Does not claim the draft already exists or expose raw argument content in the sanitized reply."
             ]
           }

--- a/tools/intex-agent-evals/scenarios/intex-eval-018.scenario.json
+++ b/tools/intex-agent-evals/scenarios/intex-eval-018.scenario.json
@@ -98,6 +98,8 @@
             "replyIndex": 0,
             "semanticCriteria": [
               "Correctly identifies an exact preference-update request and asks for explicit confirmation.",
+              "Expected complete sanitized confirmation evidence: `Entry: [redacted]` and `After: [redacted]`.",
+              "The redacted values are complete expected evidence for the judge and are not missing information.",
               "Does not claim the preference already changed or expose raw argument content in the sanitized reply."
             ]
           }

--- a/tools/intex-agent-evals/scenarios/intex-eval-020.scenario.json
+++ b/tools/intex-agent-evals/scenarios/intex-eval-020.scenario.json
@@ -162,8 +162,8 @@
           {
             "replyIndex": 0,
             "semanticCriteria": [
-              "Acknowledges or appropriately retains the supplied synthetic context without claiming it was saved.",
-              "Honors the explicit no-save instruction and does not ask for action confirmation."
+              "A brief generic acknowledgement that the context is retained only in the current session is sufficient and preferred.",
+              "Must not claim a durable save, ask for confirmation, or restate, enumerate, count, or infer any fragment details."
             ]
           }
         ]
@@ -211,8 +211,8 @@
           {
             "replyIndex": 0,
             "semanticCriteria": [
-              "Acknowledges or appropriately retains the supplied synthetic context without claiming it was saved.",
-              "Honors the explicit no-save instruction and does not ask for action confirmation."
+              "A brief generic acknowledgement that the context is retained only in the current session is sufficient and preferred.",
+              "Must not claim a durable save, ask for confirmation, or restate, enumerate, count, or infer any fragment details."
             ]
           }
         ]
@@ -260,8 +260,8 @@
           {
             "replyIndex": 0,
             "semanticCriteria": [
-              "Acknowledges or appropriately retains the supplied synthetic context without claiming it was saved.",
-              "Honors the explicit no-save instruction and does not ask for action confirmation."
+              "A brief generic acknowledgement that the context is retained only in the current session is sufficient and preferred.",
+              "Must not claim a durable save, ask for confirmation, or restate, enumerate, count, or infer any fragment details."
             ]
           }
         ]
@@ -309,8 +309,8 @@
           {
             "replyIndex": 0,
             "semanticCriteria": [
-              "Acknowledges or appropriately retains the supplied synthetic context without claiming it was saved.",
-              "Honors the explicit no-save instruction and does not ask for action confirmation."
+              "A brief generic acknowledgement that the context is retained only in the current session is sufficient and preferred.",
+              "Must not claim a durable save, ask for confirmation, or restate, enumerate, count, or infer any fragment details."
             ]
           }
         ]
@@ -358,8 +358,8 @@
           {
             "replyIndex": 0,
             "semanticCriteria": [
-              "Acknowledges or appropriately retains the supplied synthetic context without claiming it was saved.",
-              "Honors the explicit no-save instruction and does not ask for action confirmation."
+              "A brief generic acknowledgement that the context is retained only in the current session is sufficient and preferred.",
+              "Must not claim a durable save, ask for confirmation, or restate, enumerate, count, or infer any fragment details."
             ]
           }
         ]
@@ -407,8 +407,8 @@
           {
             "replyIndex": 0,
             "semanticCriteria": [
-              "Acknowledges or appropriately retains the supplied synthetic context without claiming it was saved.",
-              "Honors the explicit no-save instruction and does not ask for action confirmation."
+              "A brief generic acknowledgement that the context is retained only in the current session is sufficient and preferred.",
+              "Must not claim a durable save, ask for confirmation, or restate, enumerate, count, or infer any fragment details."
             ]
           }
         ]
@@ -456,8 +456,8 @@
           {
             "replyIndex": 0,
             "semanticCriteria": [
-              "Acknowledges or appropriately retains the supplied synthetic context without claiming it was saved.",
-              "Honors the explicit no-save instruction and does not ask for action confirmation."
+              "A brief generic acknowledgement that the context is retained only in the current session is sufficient and preferred.",
+              "Must not claim a durable save, ask for confirmation, or restate, enumerate, count, or infer any fragment details."
             ]
           }
         ]
@@ -505,8 +505,8 @@
           {
             "replyIndex": 0,
             "semanticCriteria": [
-              "Acknowledges or appropriately retains the supplied synthetic context without claiming it was saved.",
-              "Honors the explicit no-save instruction and does not ask for action confirmation."
+              "A brief generic acknowledgement that the context is retained only in the current session is sufficient and preferred.",
+              "Must not claim a durable save, ask for confirmation, or restate, enumerate, count, or infer any fragment details."
             ]
           }
         ]
@@ -554,8 +554,8 @@
           {
             "replyIndex": 0,
             "semanticCriteria": [
-              "Acknowledges or appropriately retains the supplied synthetic context without claiming it was saved.",
-              "Honors the explicit no-save instruction and does not ask for action confirmation."
+              "A brief generic acknowledgement that the context is retained only in the current session is sufficient and preferred.",
+              "Must not claim a durable save, ask for confirmation, or restate, enumerate, count, or infer any fragment details."
             ]
           }
         ]
@@ -603,8 +603,8 @@
           {
             "replyIndex": 0,
             "semanticCriteria": [
-              "Acknowledges or appropriately retains the supplied synthetic context without claiming it was saved.",
-              "Honors the explicit no-save instruction and does not ask for action confirmation."
+              "A brief generic acknowledgement that the context is retained only in the current session is sufficient and preferred.",
+              "Must not claim a durable save, ask for confirmation, or restate, enumerate, count, or infer any fragment details."
             ]
           }
         ]
@@ -652,8 +652,8 @@
           {
             "replyIndex": 0,
             "semanticCriteria": [
-              "Acknowledges or appropriately retains the supplied synthetic context without claiming it was saved.",
-              "Honors the explicit no-save instruction and does not ask for action confirmation."
+              "A brief generic acknowledgement that the context is retained only in the current session is sufficient and preferred.",
+              "Must not claim a durable save, ask for confirmation, or restate, enumerate, count, or infer any fragment details."
             ]
           }
         ]
@@ -701,8 +701,8 @@
           {
             "replyIndex": 0,
             "semanticCriteria": [
-              "Acknowledges or appropriately retains the supplied synthetic context without claiming it was saved.",
-              "Honors the explicit no-save instruction and does not ask for action confirmation."
+              "A brief generic acknowledgement that the context is retained only in the current session is sufficient and preferred.",
+              "Must not claim a durable save, ask for confirmation, or restate, enumerate, count, or infer any fragment details."
             ]
           }
         ]
@@ -750,8 +750,8 @@
           {
             "replyIndex": 0,
             "semanticCriteria": [
-              "Acknowledges or appropriately retains the supplied synthetic context without claiming it was saved.",
-              "Honors the explicit no-save instruction and does not ask for action confirmation."
+              "A brief generic acknowledgement that the context is retained only in the current session is sufficient and preferred.",
+              "Must not claim a durable save, ask for confirmation, or restate, enumerate, count, or infer any fragment details."
             ]
           }
         ]
@@ -799,8 +799,8 @@
           {
             "replyIndex": 0,
             "semanticCriteria": [
-              "Acknowledges or appropriately retains the supplied synthetic context without claiming it was saved.",
-              "Honors the explicit no-save instruction and does not ask for action confirmation."
+              "A brief generic acknowledgement that the context is retained only in the current session is sufficient and preferred.",
+              "Must not claim a durable save, ask for confirmation, or restate, enumerate, count, or infer any fragment details."
             ]
           }
         ]
@@ -848,8 +848,8 @@
           {
             "replyIndex": 0,
             "semanticCriteria": [
-              "Acknowledges or appropriately retains the supplied synthetic context without claiming it was saved.",
-              "Honors the explicit no-save instruction and does not ask for action confirmation."
+              "A brief generic acknowledgement that the context is retained only in the current session is sufficient and preferred.",
+              "Must not claim a durable save, ask for confirmation, or restate, enumerate, count, or infer any fragment details."
             ]
           }
         ]
@@ -897,8 +897,8 @@
           {
             "replyIndex": 0,
             "semanticCriteria": [
-              "Acknowledges or appropriately retains the supplied synthetic context without claiming it was saved.",
-              "Honors the explicit no-save instruction and does not ask for action confirmation."
+              "A brief generic acknowledgement that the context is retained only in the current session is sufficient and preferred.",
+              "Must not claim a durable save, ask for confirmation, or restate, enumerate, count, or infer any fragment details."
             ]
           }
         ]
@@ -946,8 +946,8 @@
           {
             "replyIndex": 0,
             "semanticCriteria": [
-              "Acknowledges or appropriately retains the supplied synthetic context without claiming it was saved.",
-              "Honors the explicit no-save instruction and does not ask for action confirmation."
+              "A brief generic acknowledgement that the context is retained only in the current session is sufficient and preferred.",
+              "Must not claim a durable save, ask for confirmation, or restate, enumerate, count, or infer any fragment details."
             ]
           }
         ]
@@ -995,8 +995,8 @@
           {
             "replyIndex": 0,
             "semanticCriteria": [
-              "Acknowledges or appropriately retains the supplied synthetic context without claiming it was saved.",
-              "Honors the explicit no-save instruction and does not ask for action confirmation."
+              "A brief generic acknowledgement that the context is retained only in the current session is sufficient and preferred.",
+              "Must not claim a durable save, ask for confirmation, or restate, enumerate, count, or infer any fragment details."
             ]
           }
         ]
@@ -1065,8 +1065,10 @@
           {
             "replyIndex": 0,
             "semanticCriteria": [
-              "Correctly identifies the accumulated context as one note-save request and asks for explicit confirmation in an appropriate tone.",
-              "Does not claim the note exists, ask for the context again, or expose raw argument content in the sanitized reply."
+              "Correctly identifies a note-save request and asks for explicit confirmation in an appropriate, concise tone.",
+              "Expected complete sanitized confirmation evidence: `Title: [redacted]` and `Content: [redacted]`.",
+              "The redacted values are complete expected evidence for the judge and are not missing information.",
+              "Does not claim the note already exists or expose raw argument content in the sanitized reply."
             ]
           }
         ]
@@ -1162,8 +1164,8 @@
           {
             "replyIndex": 0,
             "semanticCriteria": [
-              "Clearly communicates that the accumulated note was saved successfully.",
-              "Does not ask for the context again or request another confirmation."
+              "Clearly communicates that the requested note was saved successfully.",
+              "A concise completion-only reply is sufficient and should not restate details or invite another action."
             ]
           }
         ]

--- a/tools/intex-agent-evals/src/__tests__/trackedScenarioCatalog.test.ts
+++ b/tools/intex-agent-evals/src/__tests__/trackedScenarioCatalog.test.ts
@@ -100,6 +100,59 @@ const SYNTHETIC_MARKER_PATTERN = /(?<![A-Z0-9-])INTEX-EVAL-[0-9]{3}(?:-F[0-9]{2}
 const SESSION_LIFECYCLE_NARRATION_PATTERN =
   /\b(?:(?:new|another|previous) (?:Intex Agent )?session|session (?:has |was )?(?:started|closed|superseded)|session (?:start|closure|supersession|lifecycle))\b/iu;
 
+const COMPLETE_REDACTED_CONFIRMATION_EVIDENCE =
+  'The redacted values are complete expected evidence for the judge and are not missing information.';
+
+const REDACTED_CONFIRMATION_CASES = [
+  {
+    scenarioId: 'intex-eval-002',
+    turnIndex: 0,
+    labels: ['Title: [redacted]', 'Start: [redacted]', 'End: [redacted]', 'Location: [redacted]'],
+  },
+  {
+    scenarioId: 'intex-eval-006',
+    turnIndex: 0,
+    labels: ['Title: [redacted]', 'Content: [redacted]'],
+  },
+  {
+    scenarioId: 'intex-eval-006',
+    turnIndex: 2,
+    labels: ['Title: [redacted]', 'Content: [redacted]'],
+  },
+  {
+    scenarioId: 'intex-eval-012',
+    turnIndex: 0,
+    labels: ['Title: [redacted]', 'Prompt: [redacted]'],
+  },
+  {
+    scenarioId: 'intex-eval-018',
+    turnIndex: 0,
+    labels: ['Entry: [redacted]', 'After: [redacted]'],
+  },
+  {
+    scenarioId: 'intex-eval-020',
+    turnIndex: 18,
+    labels: ['Title: [redacted]', 'Content: [redacted]'],
+  },
+] as const;
+
+const SCENARIO_020_ISOLATED_REPLY_CRITERIA = [
+  'A brief generic acknowledgement that the context is retained only in the current session is sufficient and preferred.',
+  'Must not claim a durable save, ask for confirmation, or restate, enumerate, count, or infer any fragment details.',
+] as const;
+
+const OBSERVABLE_NOTE_CONFIRMATION_CRITERIA = [
+  'Correctly identifies a note-save request and asks for explicit confirmation in an appropriate, concise tone.',
+  'Expected complete sanitized confirmation evidence: `Title: [redacted]` and `Content: [redacted]`.',
+  COMPLETE_REDACTED_CONFIRMATION_EVIDENCE,
+  'Does not claim the note already exists or expose raw argument content in the sanitized reply.',
+] as const;
+
+const CONCISE_NOTE_COMPLETION_CRITERIA = [
+  'Clearly communicates that the requested note was saved successfully.',
+  'A concise completion-only reply is sufficient and should not restate details or invite another action.',
+] as const;
+
 function markerCase(
   scenarioId: string,
   requestTurnIndex: number,
@@ -637,6 +690,59 @@ describe('tracked scenario catalog', () => {
     expect(completionCriteria).not.toMatch(duplicatedExactValue);
   });
 
+  it('treats literal redacted confirmation labels as complete judge evidence', () => {
+    for (const testCase of REDACTED_CONFIRMATION_CASES) {
+      const criteria = semanticCriteriaFor(
+        findScenario(scenarios, testCase.scenarioId),
+        testCase.turnIndex
+      );
+
+      for (const label of testCase.labels) expect(criteria).toContain(label);
+      expect(criteria).toContain(COMPLETE_REDACTED_CONFIRMATION_EVIDENCE);
+      expect(markersIn(criteria)).toEqual([]);
+    }
+  });
+
+  it('uses a privacy-safe isolated-reply contract for scenario 020 context turns', () => {
+    const scenario = findScenario(scenarios, 'intex-eval-020');
+
+    for (let turnIndex = 0; turnIndex < 18; turnIndex += 1) {
+      expect(scenario.expected.turns[turnIndex]?.replies[0]?.semanticCriteria).toEqual(
+        SCENARIO_020_ISOLATED_REPLY_CRITERIA
+      );
+    }
+  });
+
+  it('keeps scenario 006 confirmation and completion criteria isolated from prior turns', () => {
+    const scenario = findScenario(scenarios, 'intex-eval-006');
+    const inaccessiblePriorStatePattern = /\b(?:first|second|follow-up|prior|previous)\b/iu;
+
+    for (const turnIndex of [0, 2]) {
+      expect(scenario.expected.turns[turnIndex]?.replies[0]?.semanticCriteria).toEqual(
+        OBSERVABLE_NOTE_CONFIRMATION_CRITERIA
+      );
+    }
+    for (const turnIndex of [1, 3]) {
+      expect(scenario.expected.turns[turnIndex]?.replies[0]?.semanticCriteria).toEqual(
+        CONCISE_NOTE_COMPLETION_CRITERIA
+      );
+    }
+    for (let turnIndex = 0; turnIndex < 4; turnIndex += 1) {
+      expect(semanticCriteriaFor(scenario, turnIndex)).not.toMatch(inaccessiblePriorStatePattern);
+    }
+  });
+
+  it('keeps scenario 020 final confirmation and completion observable in isolation', () => {
+    const scenario = findScenario(scenarios, 'intex-eval-020');
+
+    expect(scenario.expected.turns[18]?.replies[0]?.semanticCriteria).toEqual(
+      OBSERVABLE_NOTE_CONFIRMATION_CRITERIA
+    );
+    expect(scenario.expected.turns[19]?.replies[0]?.semanticCriteria).toEqual(
+      CONCISE_NOTE_COMPLETION_CRITERIA
+    );
+  });
+
   it('uses endpoint-observable exact calendar ranges without requiring a tool timezone', () => {
     const calendar002 = findRequiredToolCall(
       findScenario(scenarios, 'intex-eval-002'),
@@ -859,7 +965,7 @@ describe('tracked scenario catalog', () => {
 
   it('matches the stable SHA-256 digest of the full canonical parsed catalog', () => {
     expect(fullCatalogDigest(scenarios)).toBe(
-      '9b20c9b8e96e9e61322eff382d2473360648028fe4601c0b4efcc69032b0f5e1'
+      'e1e03fcbaafa900bde373446cc7904384f2bf646832a61dad2e963fe76b885e7'
     );
   });
 });


### PR DESCRIPTION
## Summary

- treat structured `[redacted]` confirmation labels as complete MiniMax judge evidence without exposing raw values
- keep isolated scenario criteria independent from unavailable earlier conversation state
- make retain-only, do-not-save turns use a short neutral current-session acknowledgement without paraphrasing or counting fragment details
- record the 15/20 live corpus evidence and privacy decision in the acceptance plan

## Verification

- `pnpm run ci:tracked` — 5,477 tests passed; typecheck, lint, static validation, coverage, web build, format, and bundle budget passed
- targeted evaluator package — 772/772 passed
- prompt package — 727/727 passed; runner fixture — 129/129 passed
- independent Task 17 review — approved with no Critical, Important, or Minor findings

## Linear

- Linear: [INT-1866](https://linear.app/pbuchman/issue/INT-1866)
- IntexuraOS Code Task: [View task](https://intexuraos.cloud/#/code-tasks/task_3d9f7aaa-b7c0-41f8-8074-4f2f9e3966b5)
- Worker Type: `codex-xhigh`
- Model: `default`
