### PR TITLE
[INT-1868] fix(intex-agent): harden live calendar evaluations

### DIFF
--- a/apps/intex-agent/src/__tests__/domain/intexAgentRunner.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/intexAgentRunner.test.ts
@@ -112,7 +112,7 @@ describe('createIntexAgentRunner', () => {
     expect(client.calls[0]?.systemPrompt).toContain(
       'today: timeMin=2026-06-24T00:00:00.000+00:00; timeMax=2026-06-25T00:00:00.000+00:00'
     );
-    expect(INTEX_AGENT_SYSTEM_PROMPT.version).toBe('17.0.0');
+    expect(INTEX_AGENT_SYSTEM_PROMPT.version).toBe('18.0.0');
     expect(client.calls[0]?.systemPrompt).toContain('You are Intex in WhatsApp Assistant conversations.');
     expect(client.calls[0]?.systemPrompt).not.toContain('You are IntexuraOS');
     expect(client.calls[0]?.systemPrompt).toContain(
@@ -346,6 +346,342 @@ describe('createIntexAgentRunner', () => {
       suggestedNextStep: 'Ask for the missing date.',
     });
   });
+
+  it.each([
+    {
+      message: 'Add lunch with Marta at noon for one hour.',
+      events: [],
+      expectedReply: 'Which day or date should I use for this calendar event?',
+      expectedNextStep: 'Provide the day or date for the calendar event.',
+    },
+    {
+      message: 'Dodaj lunch z Martą o 12:00 na godzinę.',
+      events: [],
+      expectedReply: 'Którego dnia lub na jaką datę mam dodać to wydarzenie?',
+      expectedNextStep: 'Podaj dzień lub datę wydarzenia w kalendarzu.',
+    },
+    {
+      message: 'Add lunch with Marta at noon.',
+      events: [event('assistant_message', { text: 'What should I add?' }), event('user_message', { text: 123 })],
+      expectedReply: 'Which day or date should I use for this calendar event?',
+      expectedNextStep: 'Provide the day or date for the calendar event.',
+    },
+    {
+      message: 'Add lunch with Marta at noon.',
+      events: [
+        event('user_message', { text: 'Show my calendar events tomorrow.' }),
+        event('assistant_message', { text: 'There are no events tomorrow.' }),
+      ],
+      expectedReply: 'Which day or date should I use for this calendar event?',
+      expectedNextStep: 'Provide the day or date for the calendar event.',
+    },
+    {
+      message: 'May I schedule lunch with Marta at noon?',
+      events: [],
+      expectedReply: 'Which day or date should I use for this calendar event?',
+      expectedNextStep: 'Provide the day or date for the calendar event.',
+    },
+    {
+      message: 'Add the 2nd planning session at noon.',
+      events: [],
+      expectedReply: 'Which day or date should I use for this calendar event?',
+      expectedNextStep: 'Provide the day or date for the calendar event.',
+    },
+    {
+      message: 'Schedule the site inspection on the 2nd floor at noon.',
+      events: [],
+      expectedReply: 'Which day or date should I use for this calendar event?',
+      expectedNextStep: 'Provide the day or date for the calendar event.',
+    },
+    {
+      message: 'Schedule the site inspection in May at noon.',
+      events: [],
+      expectedReply: 'Which day or date should I use for this calendar event?',
+      expectedNextStep: 'Provide the day or date for the calendar event.',
+    },
+    {
+      message: 'Add dentist at noon.',
+      events: [
+        event('user_message', { text: 'Add lunch with Marta next Tuesday.' }),
+        event('clarification_requested', {
+          message: 'What time should I use?',
+          missingFields: ['time'],
+          candidateIntents: ['create_calendar_event'],
+        }),
+        event('assistant_message', { text: 'What time should I use?' }),
+        event('user_message', { text: 'Actually, show me my notes.' }),
+        event('assistant_message', { text: 'Here are your notes.' }),
+      ],
+      expectedReply: 'Which day or date should I use for this calendar event?',
+      expectedNextStep: 'Provide the day or date for the calendar event.',
+    },
+    {
+      message: 'At noon for one hour.',
+      events: [
+        event('clarification_requested', {
+          message: 'Which date should I use?',
+          missingFields: ['date'],
+        }),
+        event('assistant_message', { text: 'Which date should I use?' }),
+      ],
+      expectedReply: 'Which day or date should I use for this calendar event?',
+      expectedNextStep: 'Provide the day or date for the calendar event.',
+    },
+    {
+      message: 'Add dentist at noon.',
+      events: [
+        event('user_message', { text: 'Create a note.' }),
+        event('clarification_requested', {
+          message: 'What should the note contain?',
+          missingFields: ['content'],
+          candidateIntents: ['create_note'],
+        }),
+        event('assistant_message', { text: 'What should the note contain?' }),
+      ],
+      expectedReply: 'Which day or date should I use for this calendar event?',
+      expectedNextStep: 'Provide the day or date for the calendar event.',
+    },
+    {
+      message: 'At noon for one hour.',
+      events: [
+        event('user_message', { text: 'Add lunch with Marta next Tuesday.' }),
+        event('clarification_requested', {
+          message: 'What time should I use?',
+          missingFields: ['time'],
+          candidateIntents: ['create_calendar_event'],
+        }),
+        event('clarification_requested', {
+          message: 'Where should I add it?',
+          missingFields: ['location'],
+          candidateIntents: ['create_calendar_event'],
+        }),
+        event('assistant_message', { text: 'Where should I add it?' }),
+      ],
+      expectedReply: 'Which day or date should I use for this calendar event?',
+      expectedNextStep: 'Provide the day or date for the calendar event.',
+    },
+    {
+      message: 'At noon for one hour.',
+      events: [
+        event('user_message', { text: 'Add lunch with Marta next Tuesday.' }),
+        event('clarification_requested', {
+          message: 'What time should I use?',
+          missingFields: ['time'],
+          candidateIntents: ['create_calendar_event'],
+        }),
+        event('assistant_message', { text: 'What time should I use?' }),
+        event('user_message', { text: 'Actually, cancel that.' }),
+        event('assistant_message', { text: 'Okay.' }),
+        event('user_message', { text: 'Add dentist.' }),
+        event('clarification_requested', {
+          message: 'What time should I use?',
+          missingFields: ['time'],
+          candidateIntents: ['create_calendar_event'],
+        }),
+        event('assistant_message', { text: 'What time should I use?' }),
+      ],
+      expectedReply: 'Which day or date should I use for this calendar event?',
+      expectedNextStep: 'Provide the day or date for the calendar event.',
+    },
+    {
+      message: 'At Building A.',
+      events: [
+        event('user_message', { text: 'Create a note.' }),
+        event('clarification_requested', {
+          message: 'What should the note contain?',
+          missingFields: ['content'],
+          candidateIntents: ['create_note'],
+        }),
+        event('assistant_message', { text: 'What should the note contain?' }),
+        event('user_message', { text: 'Add dentist at noon.' }),
+        event('clarification_requested', {
+          message: 'Where should I add it?',
+          missingFields: ['location'],
+          candidateIntents: ['create_calendar_event'],
+        }),
+        event('assistant_message', { text: 'Where should I add it?' }),
+      ],
+      expectedReply: 'Which day or date should I use for this calendar event?',
+      expectedNextStep: 'Provide the day or date for the calendar event.',
+    },
+    {
+      message: 'At noon for one hour.',
+      events: [
+        event('user_message', { text: 'Add lunch with Marta.' }),
+        undefined,
+        event('assistant_message', { text: 'Let me clarify that request.' }),
+        event('clarification_requested', {
+          message: 'What time should I use?',
+          missingFields: ['time'],
+          candidateIntents: ['create_calendar_event'],
+        }),
+        event('assistant_message', { text: 'What time should I use?' }),
+      ] as unknown as IntexAgentSessionEvent[],
+      expectedReply: 'Which day or date should I use for this calendar event?',
+      expectedNextStep: 'Provide the day or date for the calendar event.',
+    },
+  ])(
+    'deterministically asks for a missing calendar date before calling the runner LLM: $message',
+    async ({ events, expectedNextStep, expectedReply, message }) => {
+      const client = new FakeToolCallingClient([]);
+      let createCalendarEventCalls = 0;
+      const runner = createIntexAgentRunner({
+        client,
+        intentClassifier: toolIntentClassifier(['create_calendar_event']),
+        toolExecutor: fakeToolExecutor({
+          createCalendarEvent: async () => {
+            createCalendarEventCalls += 1;
+            return 'event-1';
+          },
+        }),
+      });
+
+      await expect(
+        runner.run({
+          session: session(),
+          events,
+          message,
+          currentDateTime: CURRENT_DATE_TIME,
+        })
+      ).resolves.toEqual({
+        outcome: 'needs_clarification',
+        reply: expectedReply,
+        clarification: expectedReply,
+        blockerReason: 'missing_required_details',
+        missingFields: ['date'],
+        candidateIntents: ['create_calendar_event'],
+        suggestedNextStep: expectedNextStep,
+      });
+      expect(client.calls).toHaveLength(0);
+      expect(createCalendarEventCalls).toBe(0);
+    }
+  );
+
+  it.each([
+    {
+      message: 'Add lunch with Marta next Tuesday at noon for one hour.',
+      events: [],
+      replyContext: undefined,
+    },
+    {
+      message: 'At noon for one hour.',
+      events: [
+        event('user_message', { text: 'Add lunch with Marta next Tuesday.' }),
+        event('clarification_requested', {
+          message: 'What time should I use?',
+          missingFields: ['time'],
+          candidateIntents: ['create_calendar_event'],
+        }),
+        event('assistant_message', { text: 'What time should I use?' }),
+      ],
+      replyContext: undefined,
+    },
+    {
+      message: 'At noon for one hour.',
+      events: [
+        event('user_message', {
+          text: 'Schedule the quoted appointment.',
+          replyContext: {
+            replyToWamid: 'wamid-prior-calendar-source',
+            source: 'inbound_user_message',
+            text: 'Dentist next Tuesday',
+            truncated: false,
+          },
+        }),
+        event('clarification_requested', {
+          message: 'What time should I use?',
+          missingFields: ['time'],
+          candidateIntents: ['create_calendar_event'],
+        }),
+        event('assistant_message', { text: 'What time should I use?' }),
+      ],
+      replyContext: undefined,
+    },
+    {
+      message: 'At Building A.',
+      events: [
+        event('user_message', { text: 'Add lunch with Marta next Tuesday.' }),
+        event('clarification_requested', {
+          message: 'What time should I use?',
+          missingFields: ['time'],
+          candidateIntents: ['create_calendar_event'],
+        }),
+        event('assistant_message', { text: 'What time should I use?' }),
+        event('user_message', { text: 'At noon.' }),
+        event('clarification_requested', {
+          message: 'Where should I add it?',
+          missingFields: ['location'],
+          candidateIntents: ['create_calendar_event'],
+        }),
+        event('assistant_message', { text: 'Where should I add it?' }),
+      ],
+      replyContext: undefined,
+    },
+    {
+      message: 'Add lunch with Marta on 2026-07-21 at noon.',
+      events: [],
+      replyContext: undefined,
+    },
+    {
+      message: 'Schedule the site inspection on the 2nd at noon.',
+      events: [],
+      replyContext: undefined,
+    },
+    {
+      message: 'Dodaj lunch z Martą 21 lipca o 12:00.',
+      events: [],
+      replyContext: undefined,
+    },
+    {
+      message: 'Schedule this at noon.',
+      events: [],
+      replyContext: {
+        replyToWamid: 'wamid-calendar-source',
+        source: 'inbound_user_message' as const,
+        text: 'Dentist next Tuesday',
+        truncated: false,
+      },
+    },
+  ])(
+    'allows calendar confirmation when an explicit date signal exists: $message',
+    async ({ events, message, replyContext }) => {
+      const client = new ToolExecutingFakeToolCallingClient({
+        toolName: 'create_calendar_event',
+        args: {
+          summary: 'Lunch with Marta',
+          start: '2026-07-21T12:00:00+02:00',
+          end: '2026-07-21T13:00:00+02:00',
+        },
+      }, [
+        ok(
+          toolResult({
+            outcome: 'completed',
+            reply: 'Ready for confirmation.',
+            toolName: 'create_calendar_event',
+          })
+        ),
+      ]);
+      const runner = createIntexAgentRunner({
+        client,
+        intentClassifier: toolIntentClassifier(['create_calendar_event']),
+        toolExecutor: fakeToolExecutor(),
+      });
+
+      const result = await runner.run({
+        session: session(),
+        events,
+        message,
+        ...(replyContext !== undefined ? { replyContext } : {}),
+        currentDateTime: CURRENT_DATE_TIME,
+      });
+
+      expect(result).toMatchObject({
+        outcome: 'needs_confirmation',
+        toolName: 'create_calendar_event',
+      });
+      expect(client.calls).toHaveLength(1);
+    }
+  );
 
   it('uses an injected intent classifier to expose context-derived tools', async () => {
     const client = new ToolExecutingFakeToolCallingClient({
@@ -1821,7 +2157,7 @@ describe('createIntexAgentRunner', () => {
       reply: 'Do tej pory powiedziałeś, że chcesz zbierać fragmenty notatki.',
     });
 
-    expect(INTEX_AGENT_SYSTEM_PROMPT.version).toBe('17.0.0');
+    expect(INTEX_AGENT_SYSTEM_PROMPT.version).toBe('18.0.0');
     expect(client.calls[0]?.systemPrompt).toContain('You can use the current session transcript');
     expect(client.calls[0]?.systemPrompt).toContain('Do not claim you cannot review the current conversation');
     expect(client.calls[0]?.tools).toEqual([]);

--- a/apps/intex-agent/src/__tests__/domain/toolDefinitions.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/toolDefinitions.test.ts
@@ -145,6 +145,20 @@ describe('createIntexAgentToolDefinitions', () => {
     });
   });
 
+  it('allows a Linear issue only when the user explicitly supplied its identifier', () => {
+    const codeTaskTool = createIntexAgentToolDefinitions(createExecutor()).find(
+      (tool) => tool.name === 'create_code_task'
+    );
+
+    expect(codeTaskTool?.parameters['required']).not.toContain('linearIssueId');
+    expect(codeTaskTool?.parameters['properties']).toMatchObject({
+      linearIssueId: {
+        type: 'string',
+        description: expect.stringMatching(/omit.*unless.*user explicitly supplies/iu),
+      },
+    });
+  });
+
   it('describes external save forwarding without inspecting URLs', () => {
     const externalSaveTool = createIntexAgentToolDefinitions(createExecutor()).find(
       (tool) => tool.name === 'save_external'

--- a/apps/intex-agent/src/domain/agent/intexAgentRunner.ts
+++ b/apps/intex-agent/src/domain/agent/intexAgentRunner.ts
@@ -117,6 +117,25 @@ const RETAIN_ONLY_REPLIES: LocalizedText = {
   pl: 'Zachowuję to tylko w tej sesji. Nie utworzono notatki ani innego zasobu.',
 };
 
+const CALENDAR_DATE_CLARIFICATION_REPLIES: LocalizedText = {
+  en: 'Which day or date should I use for this calendar event?',
+  pl: 'Którego dnia lub na jaką datę mam dodać to wydarzenie?',
+};
+
+const CALENDAR_DATE_CLARIFICATION_NEXT_STEPS: LocalizedText = {
+  en: 'Provide the day or date for the calendar event.',
+  pl: 'Podaj dzień lub datę wydarzenia w kalendarzu.',
+};
+
+const CALENDAR_DIRECT_DATE_SIGNAL_PATTERN =
+  /(?<![\p{L}\p{N}])(?:\d{4}-\d{1,2}-\d{1,2}|\d{1,2}[./]\d{1,2}(?:[./]\d{2,4})?|monday|tuesday|wednesday|thursday|friday|saturday|sunday|poniedział(?:ek|ku)|wtorek|wtorku|środ(?:a|ę|y)|czwart(?:ek|ku)|pią(?:tek|tku)|sobot(?:a|ę|y)|niedziel(?:a|ę|i)|today|tomorrow|tonight|day\s+after\s+tomorrow|dzisiaj|dziś|jutro|pojutrze|(?:in|za)\s+(?:\d+|one|two|three|jeden|jedną|dwa|dwie|trzy)\s+(?:days?|dni|dzień))(?=$|[^\p{L}\p{N}])/iu;
+
+const CALENDAR_ORDINAL_DATE_SIGNAL_PATTERN =
+  /(?<![\p{L}\p{N}])on\s+(?:the\s+)?\d{1,2}(?:st|nd|rd|th)(?=\s*(?:$|[,.;!?]|(?:at|from|between|until|for)\b))/iu;
+
+const CALENDAR_CONTEXTUAL_MONTH_SIGNAL_PATTERN =
+  /(?<![\p{L}\p{N}])(?:\d{1,2}(?:st|nd|rd|th)?\s+(?:january|february|march|april|may|june|july|august|september|october|november|december|stycznia|lutego|marca|kwietnia|maja|czerwca|lipca|sierpnia|września|października|listopada|grudnia)|(?:january|february|march|april|may|june|july|august|september|october|november|december)\s+\d{1,2}(?:st|nd|rd|th)?)(?=$|[^\p{L}\p{N}])/iu;
+
 const CLASSIFIER_UNSUPPORTED_REPLIES: Record<
   IntexAgentReplyLanguage,
   ClassifierUnsupportedReplyMap
@@ -362,6 +381,23 @@ export function createIntexAgentRunner(config: IntexAgentRunnerConfig): IntexAge
         }
       }
 
+      if (
+        intent.kind === 'tool' &&
+        intent.allowedToolNames.includes('create_calendar_event') &&
+        !hasCalendarDateSignal(input.message, input.events, input.replyContext)
+      ) {
+        const clarification = CALENDAR_DATE_CLARIFICATION_REPLIES[replyLanguage];
+        return {
+          outcome: 'needs_clarification',
+          reply: clarification,
+          clarification,
+          blockerReason: 'missing_required_details',
+          missingFields: ['date'],
+          candidateIntents: ['create_calendar_event'],
+          suggestedNextStep: CALENDAR_DATE_CLARIFICATION_NEXT_STEPS[replyLanguage],
+        };
+      }
+
       const toolExecutions: IntexAgentToolExecution[] = [];
       const tools = createIntexAgentToolDefinitions(
         createTrackingToolExecutor(createConfirmationPreviewExecutor(config.toolExecutor), toolExecutions)
@@ -405,6 +441,86 @@ export function createIntexAgentRunner(config: IntexAgentRunnerConfig): IntexAge
       );
     },
   };
+}
+
+function hasCalendarDateSignal(
+  message: string,
+  events: readonly IntexAgentSessionEvent[],
+  replyContext: IntexIncomingMessageReplyContext | undefined
+): boolean {
+  if (containsCalendarDateSignal(message)) return true;
+  if (
+    replyContext?.source === 'inbound_user_message' &&
+    containsCalendarDateSignal(replyContext.text)
+  ) {
+    return true;
+  }
+
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const event = events[index];
+    if (event?.type === 'user_message') return false;
+    if (event?.type !== 'clarification_requested') continue;
+    if (!isCalendarClarification(event)) return false;
+    return activeCalendarClarificationChainContainsDate(events, index);
+  }
+
+  return false;
+}
+
+function activeCalendarClarificationChainContainsDate(
+  events: readonly IntexAgentSessionEvent[],
+  latestClarificationIndex: number
+): boolean {
+  let expectsUserMessage = true;
+
+  for (let index = latestClarificationIndex - 1; index >= 0; index -= 1) {
+    const event = events[index];
+    if (event === undefined) continue;
+
+    if (expectsUserMessage) {
+      if (event.type === 'clarification_requested') return false;
+      if (event.type !== 'user_message') continue;
+
+      const priorMessage = event.payload['text'];
+      if (typeof priorMessage === 'string' && containsCalendarDateSignal(priorMessage)) {
+        return true;
+      }
+      const priorReplyContext = parseIncomingReplyContext(event.payload['replyContext']);
+      if (
+        priorReplyContext?.source === 'inbound_user_message' &&
+        containsCalendarDateSignal(priorReplyContext.text)
+      ) {
+        return true;
+      }
+      expectsUserMessage = false;
+      continue;
+    }
+
+    if (event.type === 'user_message') return false;
+    if (event.type !== 'clarification_requested') continue;
+    if (!isCalendarClarification(event)) return false;
+    expectsUserMessage = true;
+  }
+
+  return false;
+}
+
+function containsCalendarDateSignal(message: string): boolean {
+  const normalized = message.normalize('NFKC');
+  return (
+    CALENDAR_DIRECT_DATE_SIGNAL_PATTERN.test(normalized) ||
+    CALENDAR_ORDINAL_DATE_SIGNAL_PATTERN.test(normalized) ||
+    CALENDAR_CONTEXTUAL_MONTH_SIGNAL_PATTERN.test(normalized)
+  );
+}
+
+function isCalendarClarification(event: IntexAgentSessionEvent): boolean {
+  const candidateIntents = event.payload['candidateIntents'];
+  const missingFields = event.payload['missingFields'];
+  return (
+    (Array.isArray(candidateIntents) && candidateIntents.includes('create_calendar_event')) ||
+    (Array.isArray(missingFields) && missingFields.includes('date'))
+  );
 }
 
 function detectRetainOnlyLanguage(message: string): IntexAgentReplyLanguage | null {

--- a/apps/intex-agent/src/domain/agent/toolDefinitions.ts
+++ b/apps/intex-agent/src/domain/agent/toolDefinitions.ts
@@ -386,7 +386,8 @@ export function createIntexAgentToolDefinitions(executor: IntexAgentToolExecutor
           },
           linearIssueId: {
             type: 'string',
-            description: 'Optional Linear issue ID to associate with the task.',
+            description:
+              'Optional Linear issue ID to associate with the task. Omit it unless the user explicitly supplies the identifier.',
           },
           taskMode: {
             type: 'string',

--- a/docs/superpowers/plans/2026-07-18-intex-agent-live-acceptance-fixes.md
+++ b/docs/superpowers/plans/2026-07-18-intex-agent-live-acceptance-fixes.md
@@ -415,13 +415,30 @@ The first authorized Matrix message and Chrome audit exposed additional defects 
 - [x] Propagate the user's IANA time zone into the runner and define exact `mode=list` whole-day bounds for `today`/`tomorrow`, including DST-skipped midnights and fully skipped civil dates; make scenario `011` assert the exact Warsaw `+02:00` bounds and bump every affected prompt version.
 - [x] Bound the production time-zone lookup to 1000 ms with transport abort, safe UTC fallback, and reason-only logs; preserve the `2026-07-01` endpoint contract by defaulting omitted `timeZone` to UTC while rejecting a supplied invalid IANA zone.
 - [x] Close every Critical/Important combined-review finding, then run `pnpm run ci:tracked` on the exact final diff (`5518/5518` tests, coverage, build, format, and bundle budget passed).
-- [ ] Commit, push, merge, and wait for Home Dev to contain the exact revision; rerun preflight and the 20-scenario endpoint gate.
+- [x] Commit, push, merge PR `#2332`, wait for Home Dev to contain exact merge `ebf1f133df901bf93bf4b7bd20038081391da2c2`, and rerun the green preflight plus 20-scenario endpoint gate.
 - [ ] Only after endpoint exit `0`, run `full` once and require its fresh endpoint corpus plus authorized Matrix smoke to exit `0`.
 - [ ] Complete the logged-in desktop/mobile Chrome audit and record final privacy-safe evidence.
 
 **Acceptance:** the real 20-scenario endpoint corpus exits `0`, the independently executed full gate exits `0` with MiniMax M3 and one Matrix smoke, no product tool writes escape the mock boundary, and the browser audit confirms the deployed session UI.
 
-**Review status:** independent combined and time-zone/operations re-reviews approved the final implementation diff after verifying mixed-intent routing, exact scenario `011` bounds, skipped-midnight/date behavior, cancellable privacy-safe lookup, and legacy endpoint compatibility. Full tracked CI passed on the exact final diff with `5518/5518` tests; deployed/live checkboxes remain deliberately open below until fresh evidence exists.
+**Review status:** independent combined and time-zone/operations re-reviews approved the final implementation diff after verifying mixed-intent routing, exact scenario `011` bounds, skipped-midnight/date behavior, cancellable privacy-safe lookup, and legacy endpoint compatibility. Full tracked CI passed on the exact final diff with `5518/5518` tests, PR `#2332` merged with every GitHub check green, and Home Dev ran the exact merge. The fresh endpoint corpus fixed `011` and `020` but exposed the separate Task 19 regressions below, so Matrix/full correctly remained closed.
+
+### Task 19: Close missing-date and code-task judge regressions from the exact deployed corpus
+
+**Evidence:** deployed endpoint run `eval-c89c1373-af10-4e19-96a3-417c261a44b6` completed all 20 scenarios; scenarios `001`–`002`, `004`–`013`, and `015`–`020` passed, including the two Task 18 targets. Scenario `003` inferred the missing event date from `Current date-time`, requested confirmation before clarification, superseded that invalid confirmation after the user supplied Tuesday, and lost one exact synthetic identifier before the completed mocked tool call. Scenario `014` had zero deterministic failures, one correct completed `create_code_task`, and cleanup `9/9`, but one MiniMax verdict treated the intentionally redacted planning/worker confirmation as unclear; independent repeats passed the identical shape `3/4` times. Cleanup for both failures was `22/22`; the endpoint exited `1`, so Matrix/full was not run.
+
+- [x] Add a RED runner test proving that a false-positive `create_calendar_event` classification cannot reach the runner LLM or tool preview when no date signal exists in the current request or relevant session history.
+- [x] Add a deterministic pre-LLM missing-date gate with localized EN/PL clarification, explicit date-signal coverage, and paired pass-through tests for weekdays, ISO dates, Polish month dates, and prior-turn dates.
+- [x] Strengthen the versioned runner prompt so a bare time never defaults to today and every exact identifier/code/reference survives clarification into final tool arguments.
+- [x] Make scenario `014` treat its literal redacted confirmation labels as complete judge evidence and deterministically assert `workerType=minimax` plus `taskMode=planning` in both confirmation and execution evidence.
+- [x] Close every Critical/Important independent-review finding and run `pnpm run ci:tracked` on the exact final source/test/evaluation diff (`5542/5542` tests, coverage, build, format, and bundle budget passed).
+- [ ] Commit, push, merge, wait for exact Home Dev deployment, rerun preflight, and require focused live scenarios `003` and `014` to pass before the complete endpoint corpus.
+- [ ] Require the 20-scenario endpoint gate to exit `0`; only then run `full` once and require its fresh endpoint corpus plus authorized Matrix smoke to exit `0`.
+- [ ] Complete the logged-in desktop/mobile Chrome audit and record final privacy-safe evidence.
+
+**Acceptance:** the deterministic date gate prevents invented event dates without reducing valid calendar routing, exact identifiers survive clarification, scenario `014` is judged only from observable privacy-safe evidence, the real endpoint and full gates exit `0`, and Matrix remains strictly downstream of endpoint success.
+
+**Review status:** independent calendar-chain and scenario-`014` re-reviews approved the final implementation after verifying topic boundaries, multi-clarification continuity, inbound quoted context, ordinal/month false positives, omitted Linear identifiers, closed sanitization paths, and 100% branch coverage of the new runner gate. No Critical or Important findings remain.
 
 ### Deferred perfection (recorded, not implemented in this loop)
 

--- a/packages/llm-prompts/src/intex-agent/__tests__/systemPrompt.test.ts
+++ b/packages/llm-prompts/src/intex-agent/__tests__/systemPrompt.test.ts
@@ -7,10 +7,10 @@ const TIME_ZONE = 'UTC';
 describe('buildIntexAgentSystemPrompt', () => {
   it('exposes prompt metadata with semver versions', () => {
     expect(INTEX_AGENT_SYSTEM_PROMPT.version).toMatch(/^\d+\.\d+\.\d+$/);
-    expect(INTEX_AGENT_SYSTEM_PROMPT.version).toBe('17.0.0');
+    expect(INTEX_AGENT_SYSTEM_PROMPT.version).toBe('18.0.0');
     expect(buildIntexAgentSystemPrompt.name).toBe('intex-agent-system-prompt');
     expect(buildIntexAgentSystemPrompt.version).toMatch(/^\d+\.\d+\.\d+$/);
-    expect(buildIntexAgentSystemPrompt.version).toBe('10.0.0');
+    expect(buildIntexAgentSystemPrompt.version).toBe('11.0.0');
   });
 
   it('builds the base prompt with the current date-time', () => {
@@ -89,6 +89,24 @@ describe('buildIntexAgentSystemPrompt', () => {
     expect(prompt).toContain('show every event candidate you can identify');
     expect(prompt).toContain('create only one calendar event per confirmed tool call');
     expect(prompt).toContain('Current-date questions are answerable from Current date-time');
+  });
+
+  it('requires an explicit calendar date and preserves exact identifiers across clarification', () => {
+    const prompt = buildIntexAgentSystemPrompt.build({
+      currentDateTime: CURRENT_DATE_TIME,
+      timeZone: TIME_ZONE,
+      userPreferences: null,
+    });
+
+    expect(prompt).toContain(
+      'Never infer a missing calendar-event date from Current date-time or treat a bare time such as "at noon" as today'
+    );
+    expect(prompt).toContain(
+      'Preserve every exact user-provided identifier, code, reference, and opaque token verbatim across clarification turns and in final tool arguments'
+    );
+    expect(prompt).toContain(
+      'Never invent an identifier or code that the user did not provide; omit linearIssueId unless the user explicitly supplies it'
+    );
   });
 
   it('acknowledges current-session context retention without echoing fragment details', () => {

--- a/packages/llm-prompts/src/intex-agent/systemPrompt.ts
+++ b/packages/llm-prompts/src/intex-agent/systemPrompt.ts
@@ -1,7 +1,7 @@
 import type { PromptBuilder } from '../types.js';
 
 export const INTEX_AGENT_SYSTEM_PROMPT = {
-  version: '17.0.0',
+  version: '18.0.0',
   text: [
     'You are Intex in WhatsApp Assistant conversations.',
     'Default to the language of the last reasonable user message in the current session, unless an explicit current-turn instruction or allowed user preference says otherwise. Ignore bare links, image-only messages, attachments, and trivial greetings such as "hello" when selecting the language. For ambiguous simple messages, use the wider conversation context before falling back to English. If no specific language can be classified, reply in English. The JSON reply value must follow this language rule.',
@@ -28,6 +28,9 @@ export const INTEX_AGENT_SYSTEM_PROMPT = {
     'Use create_note only when the user explicitly asks to create, save, note, remember, or write down a note or specific information.',
     'Use create_calendar_event only when the user explicitly asks to create, add, schedule, or plan a meeting, appointment, scheduled block, or calendar item.',
     'For calendar events, ask a clarification before using the tool if title, date, time, start, or end is missing or ambiguous.',
+    'Never infer a missing calendar-event date from Current date-time or treat a bare time such as "at noon" as today. If the user gives a time without an explicit or unambiguous relative calendar date, ask a targeted clarification for the date before using create_calendar_event.',
+    'Preserve every exact user-provided identifier, code, reference, and opaque token verbatim across clarification turns and in final tool arguments. Never normalize, translate, shorten, reformat, or drop these exact values.',
+    'Never invent an identifier or code that the user did not provide; omit linearIssueId unless the user explicitly supplies it.',
     'Do not use create_calendar_event to list, inspect, search, summarize, or answer questions about existing calendar events.',
     'Use query_calendar_events only for read-only calendar questions that ask to list, show, check, count, search, or answer whether existing events are present in a time window.',
     'For availability questions such as free one-hour meeting slots, use query_calendar_events for the requested time range, infer free windows from returned events, propose a few options, and do not create the event until the user chooses a specific option and explicitly asks to schedule it.',
@@ -67,7 +70,7 @@ export const buildIntexAgentSystemPrompt: PromptBuilder<BuildIntexAgentSystemPro
   name: 'intex-agent-system-prompt',
   description:
     'Intex Agent system prompt with optional user preferences and DST-safe local calendar context',
-  version: '10.0.0',
+  version: '11.0.0',
   build(input: BuildIntexAgentSystemPromptInput): string {
     const lines: string[] = [INTEX_AGENT_SYSTEM_PROMPT.text];
     if (input.userPreferences !== null && input.userPreferences.trim() !== '') {

--- a/tools/intex-agent-evals/scenarios/intex-eval-014.scenario.json
+++ b/tools/intex-agent-evals/scenarios/intex-eval-014.scenario.json
@@ -80,6 +80,20 @@
                   "value": "create_code_task"
                 },
                 {
+                  "path": "argsSummary.workerType",
+                  "operator": "equals",
+                  "value": "minimax"
+                },
+                {
+                  "path": "argsSummary.taskMode",
+                  "operator": "equals",
+                  "value": "planning"
+                },
+                {
+                  "path": "argsSummary.hasLinearIssueId",
+                  "operator": "absent"
+                },
+                {
                   "path": "argsSummary.syntheticMarkerCount",
                   "operator": "equals",
                   "value": 2
@@ -98,6 +112,8 @@
             "replyIndex": 0,
             "semanticCriteria": [
               "Correctly identifies a planning code-task request for the selected worker and asks for explicit confirmation.",
+              "Expected complete sanitized confirmation evidence: `Prompt: [redacted]`, `Mode: [redacted]`, and `Worker: [redacted]`.",
+              "The redacted values are complete expected evidence for the judge and are not missing information.",
               "Does not claim the task already exists or expose raw argument content in the sanitized reply."
             ]
           }
@@ -123,6 +139,10 @@
                 "path": "taskMode",
                 "operator": "equals",
                 "value": "planning"
+              },
+              {
+                "path": "hasLinearIssueId",
+                "operator": "absent"
               },
               {
                 "path": "syntheticMarkerCount",

--- a/tools/intex-agent-evals/src/__tests__/deterministicEvaluator.test.ts
+++ b/tools/intex-agent-evals/src/__tests__/deterministicEvaluator.test.ts
@@ -457,6 +457,38 @@ describe('deterministic evaluator', () => {
     ]);
   });
 
+  it('enforces exact sanitized code-task worker and mode confirmation evidence', () => {
+    const scenario = scenarioFor((expected) => {
+      expected.timeline.payloadAssertions = [
+        {
+          eventType: 'confirmation_requested',
+          assertions: [
+            { path: 'argsSummary.workerType', operator: 'equals', value: 'minimax' },
+            { path: 'argsSummary.taskMode', operator: 'equals', value: 'planning' },
+            { path: 'argsSummary.hasLinearIssueId', operator: 'absent' },
+          ],
+        },
+      ];
+    });
+    const response = responseFor(scenario);
+    const confirmation = requiredItem(response.turns, 0).timelineEvents.find(
+      (candidate) => candidate.type === 'confirmation_requested'
+    );
+    if (confirmation === undefined) throw new Error('Expected confirmation event');
+    confirmation.payload = {
+      argsSummary: { workerType: 'minimax', taskMode: 'planning' },
+    };
+
+    expect(evaluateDeterministically(scenario, response).failures).toEqual([]);
+
+    confirmation.payload = {
+      argsSummary: { workerType: 'minimax', taskMode: 'execution', hasLinearIssueId: true },
+    };
+    expect(evaluateDeterministically(scenario, response).failures).toContainEqual(
+      expect.objectContaining({ code: 'timeline_payload_assertion_failed' })
+    );
+  });
+
   it.each([
     ['passed', true, true],
     ['failed', true, false],

--- a/tools/intex-agent-evals/src/__tests__/scenarioSchema.test.ts
+++ b/tools/intex-agent-evals/src/__tests__/scenarioSchema.test.ts
@@ -548,7 +548,10 @@ describe('IntexEvalScenarioSchema', () => {
   it.each([
     ['argsSummary.syntheticMarkerCount', 2],
     ['argsSummary.syntheticMarkerDigest', 'digest'],
-  ])('accepts nested timeline marker evidence path %s', (path, value) => {
+    ['argsSummary.workerType', 'minimax'],
+    ['argsSummary.taskMode', 'planning'],
+    ['argsSummary.hasLinearIssueId', true],
+  ])('accepts nested sanitized timeline argument evidence path %s', (path, value) => {
     const scenario = createScenario();
     setTimelineAssertion(scenario, { path, operator: 'equals', value });
     expectScenarioValid(scenario);

--- a/tools/intex-agent-evals/src/__tests__/trackedScenarioCatalog.test.ts
+++ b/tools/intex-agent-evals/src/__tests__/trackedScenarioCatalog.test.ts
@@ -125,6 +125,11 @@ const REDACTED_CONFIRMATION_CASES = [
     labels: ['Title: [redacted]', 'Prompt: [redacted]'],
   },
   {
+    scenarioId: 'intex-eval-014',
+    turnIndex: 0,
+    labels: ['Prompt: [redacted]', 'Mode: [redacted]', 'Worker: [redacted]'],
+  },
+  {
     scenarioId: 'intex-eval-018',
     turnIndex: 0,
     labels: ['Entry: [redacted]', 'After: [redacted]'],
@@ -918,6 +923,54 @@ describe('tracked scenario catalog', () => {
     }
   });
 
+  it('pins scenario 014 planning worker in both confirmation preview and executed arguments', () => {
+    const scenario = findScenario(scenarios, 'intex-eval-014');
+    const request = scenario.expected.turns[0];
+    const execution = findRequiredToolCall(scenario, 'create_code_task');
+
+    expect(
+      request === undefined
+        ? false
+        : hasEqualsPayloadAssertion(
+            request,
+            'confirmation_requested',
+            'argsSummary.workerType',
+            'minimax'
+          )
+    ).toBe(true);
+    expect(
+      request === undefined
+        ? false
+        : hasEqualsPayloadAssertion(
+            request,
+            'confirmation_requested',
+            'argsSummary.taskMode',
+            'planning'
+          )
+    ).toBe(true);
+    expect(
+      request === undefined
+        ? false
+        : request.timeline.payloadAssertions.some(
+            (payload) =>
+              payload.eventType === 'confirmation_requested' &&
+              payload.assertions.some(
+                (assertion) =>
+                  assertion.path === 'argsSummary.hasLinearIssueId' &&
+                  assertion.operator === 'absent'
+              )
+          )
+    ).toBe(true);
+    expect(execution.argumentAssertions).toEqual(
+      expect.arrayContaining([
+        { path: 'workerType', operator: 'equals', value: 'minimax' },
+        { path: 'taskMode', operator: 'equals', value: 'planning' },
+        { path: 'hasLinearIssueId', operator: 'absent' },
+      ])
+    );
+    expect(semanticCriteriaFor(scenario, 0)).not.toContain('Linear: [redacted]');
+  });
+
   it('uses exactly the base marker plus F01 through F18 for scenario 020', () => {
     const scenario = findScenario(scenarios, 'intex-eval-020');
     const markers = new Set(
@@ -989,7 +1042,7 @@ describe('tracked scenario catalog', () => {
 
   it('matches the stable SHA-256 digest of the full canonical parsed catalog', () => {
     expect(fullCatalogDigest(scenarios)).toBe(
-      '8da3890c2982192fd75438ede4b0c27d91839d8d826309674077029e219aa935'
+      '7f0e0a4a46e6bafcb52d9c1a11b5b392e8bbb9f32de6c9cde49aba77da64f718'
     );
   });
 });

--- a/tools/intex-agent-evals/src/types.ts
+++ b/tools/intex-agent-evals/src/types.ts
@@ -185,6 +185,9 @@ export const TIMELINE_PAYLOAD_PATH_METADATA = {
   textPreview: 'string',
   'argsSummary.syntheticMarkerCount': 'number',
   'argsSummary.syntheticMarkerDigest': 'string',
+  'argsSummary.workerType': 'string',
+  'argsSummary.taskMode': 'string',
+  'argsSummary.hasLinearIssueId': 'boolean',
 } as const satisfies AssertionPathMetadata;
 
 export const TIMELINE_PAYLOAD_PATHS = Object.keys(TIMELINE_PAYLOAD_PATH_METADATA);


### PR DESCRIPTION
## Summary
- require explicit calendar dates before the runner LLM can preview a mutating event
- preserve exact identifiers through clarification and harden the versioned prompt/tool contract
- make scenario 014 verify MiniMax planning mode from privacy-safe deterministic evidence without accepting invented Linear IDs
- record Task 19 review and CI evidence in the live-acceptance plan

## Verification
- pnpm run ci:tracked: 5542/5542 tests, coverage, build, format, and bundle budget passed
- independent exact-diff reviews: approved, no Critical or Important findings
- focused runner branch coverage for the new gate: 100%

- Linear: [INT-1868](https://linear.app/pbuchman/issue/INT-1868)
- IntexuraOS Code Task: [View task](https://intexuraos.cloud/#/code-tasks/task_380ac228-3e88-4550-a4b4-b5983878b6fc)
- Worker Type: `codex-xhigh`
- Model: `default`