### PR TITLE
[INT-1874] test(intex-agent): expose redacted calendar previews

### DIFF
--- a/docs/superpowers/plans/2026-07-18-intex-agent-live-acceptance-fixes.md
+++ b/docs/superpowers/plans/2026-07-18-intex-agent-live-acceptance-fixes.md
@@ -513,6 +513,18 @@ The first authorized Matrix message and Chrome audit exposed additional defects 
 
 **Acceptance:** MiniMax does not infer passive aggression from brevity or direct confirmation syntax, but still rejects observable hostile or disrespectful tone; no scenario, deterministic assertion, payload, privacy boundary, model, provider, repair, Matrix, or cleanup contract is weakened.
 
+### Task 25: Make clarified calendar previews observable to the isolated judge
+
+**Evidence:** after PR `#2338` deployed exact merge `6c3225b81f5df994dde98403d80380a817fa58f7`, endpoint and Matrix tone calibrations passed neutral and explicitly hostile controls, and preflight passed 12/12. The first restarted scenario `008` run, `eval-469c0297-46a6-4b4b-94da-fcdfadf01a03`, again completed all three turns with zero deterministic failures, exactly one completed `create_calendar_event`, passing first/final replies, and cleanup `12/12`. MiniMax failed only the middle confirmation preview as `missing_information`/`unhelpful`. The runner builds that preview deterministically and the sanitizer exposes `Title: [redacted]`, `Start: [redacted]`, and `End: [redacted]`; unlike the eight confirmation cases already protected by the catalog invariant, clarified calendar scenarios `003` and `008` did not tell the isolated judge that those redacted labels are complete expected evidence.
+
+- [x] Extend the RED catalog invariant so the confirmation turns of scenarios `003` and `008` require the observable `Title`, `Start`, and `End` redacted labels plus the existing complete-evidence sentence.
+- [x] Replace inaccessible “clarified request” wording with an isolated-reply contract that judges the complete calendar action, reviewable sanitized preview, explicit confirmation, concise tone, and absence of another date/time request.
+- [x] Preserve every user message, turn count, exact deterministic date/time assertion, tool count, transition, timeline event, confirmation boundary, marker digest, cleanup contract, MiniMax model, and privacy boundary; regenerate only the intentional full-catalog digest.
+- [ ] Close every Critical/Important independent-review finding and run focused package checks plus `pnpm run ci:tracked` on the exact final diff.
+- [ ] Ship through a separate reviewed PR, verify exact Home Dev deployment and preflight, then restart the ordered 3x`008`, `006`, `010`, endpoint, full/Matrix, and Chrome gates.
+
+**Acceptance:** MiniMax judges the sanitized confirmation text it can actually observe and never treats intentionally redacted calendar values as missing; deterministic checks remain solely authoritative for exact dates, times, identifiers, and tool arguments.
+
 ### Deferred perfection (recorded, not implemented in this loop)
 
 - Dedicated portable WhatsApp integration accounts and cross-machine credential bootstrap.

--- a/tools/intex-agent-evals/scenarios/intex-eval-003.scenario.json
+++ b/tools/intex-agent-evals/scenarios/intex-eval-003.scenario.json
@@ -160,7 +160,9 @@
           {
             "replyIndex": 0,
             "semanticCriteria": [
-              "Correctly treats the clarified request as a complete calendar event and asks for explicit confirmation.",
+              "Correctly identifies a complete calendar-event request, presents a reviewable sanitized preview using observable redacted structured labels for Title, Start, and End, and asks for explicit confirmation in an appropriate, concise tone.",
+              "Expected complete sanitized confirmation evidence: `Title: [redacted]`, `Start: [redacted]`, and `End: [redacted]`.",
+              "The redacted values are complete expected evidence for the judge and are not missing information.",
               "Does not request the date again or expose raw argument content in the sanitized reply."
             ]
           }

--- a/tools/intex-agent-evals/scenarios/intex-eval-008.scenario.json
+++ b/tools/intex-agent-evals/scenarios/intex-eval-008.scenario.json
@@ -160,7 +160,9 @@
           {
             "replyIndex": 0,
             "semanticCriteria": [
-              "Correctly treats the clarified request as a complete calendar event and asks for explicit confirmation.",
+              "Correctly identifies a complete calendar-event request, presents a reviewable sanitized preview using observable redacted structured labels for Title, Start, and End, and asks for explicit confirmation in an appropriate, concise tone.",
+              "Expected complete sanitized confirmation evidence: `Title: [redacted]`, `Start: [redacted]`, and `End: [redacted]`.",
+              "The redacted values are complete expected evidence for the judge and are not missing information.",
               "Does not ask for the time again or expose raw argument content in the sanitized reply."
             ]
           }

--- a/tools/intex-agent-evals/src/__tests__/trackedScenarioCatalog.test.ts
+++ b/tools/intex-agent-evals/src/__tests__/trackedScenarioCatalog.test.ts
@@ -110,6 +110,11 @@ const REDACTED_CONFIRMATION_CASES = [
     labels: ['Title: [redacted]', 'Start: [redacted]', 'End: [redacted]', 'Location: [redacted]'],
   },
   {
+    scenarioId: 'intex-eval-003',
+    turnIndex: 1,
+    labels: ['Title: [redacted]', 'Start: [redacted]', 'End: [redacted]'],
+  },
+  {
     scenarioId: 'intex-eval-006',
     turnIndex: 0,
     labels: ['Title: [redacted]', 'Content: [redacted]'],
@@ -118,6 +123,11 @@ const REDACTED_CONFIRMATION_CASES = [
     scenarioId: 'intex-eval-006',
     turnIndex: 2,
     labels: ['Title: [redacted]', 'Content: [redacted]'],
+  },
+  {
+    scenarioId: 'intex-eval-008',
+    turnIndex: 1,
+    labels: ['Title: [redacted]', 'Start: [redacted]', 'End: [redacted]'],
   },
   {
     scenarioId: 'intex-eval-010',
@@ -1057,7 +1067,7 @@ describe('tracked scenario catalog', () => {
 
   it('matches the stable SHA-256 digest of the full canonical parsed catalog', () => {
     expect(fullCatalogDigest(scenarios)).toBe(
-      'a6f53a18a99e3bfefc14d84a7cf8be2986715df0487df6c1702d0f54229a1119'
+      '96de4db99eb1f367908838bdf233d976613207561e325846fbd0e72830d18416'
     );
   });
 });


### PR DESCRIPTION
## Summary
- make clarified calendar confirmation criteria observable to the isolated judge
- treat redacted Title, Start, and End labels as complete expected preview evidence in scenarios 003 and 008
- preserve all messages, deterministic arguments, tools, transitions, confirmations, markers, and cleanup contracts
- extend the tracked catalog invariant and record Task 25 live evidence

## Verification
- pnpm --filter @intexuraos/intex-agent-evals exec vitest run src/__tests__/trackedScenarioCatalog.test.ts
- pnpm --filter @intexuraos/intex-agent-evals test
- pnpm --filter @intexuraos/intex-agent-evals typecheck
- pnpm --filter @intexuraos/intex-agent-evals lint:local
- pnpm run ci:tracked (5553/5553)
- two independent reviews: APPROVED

Fixes INT-1874

Linear: [INT-1874](https://linear.app/pbuchman/issue/INT-1874)
IntexuraOS Code Task: [View task](https://intexuraos.cloud/#/code-tasks/task_f779a11d-4aa8-400c-bf5b-c712e1e86596)
Worker Type: `codex-xhigh`
Model: `default`

