### PR TITLE
[INT-1877] fix(intex-agent): close final endpoint regressions

### DIFF
--- a/apps/intex-agent/src/__tests__/domain/handleIncomingMessage.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/handleIncomingMessage.test.ts
@@ -1,4 +1,8 @@
+import { ok } from '@intexuraos/common-core';
+import type { ToolCallingClient, ToolCallingResult } from '@intexuraos/llm-contract';
 import { describe, expect, it } from 'vitest';
+import { createIntexAgentRunner } from '../../domain/agent/intexAgentRunner.js';
+import type { IntexAgentToolExecutor } from '../../domain/agent/toolDefinitions.js';
 import type { IntexIncomingMessage } from '../../domain/ports/incomingMessageHandler.js';
 import type {
   SessionRepository,
@@ -274,6 +278,62 @@ describe('handleIncomingMessage', () => {
         correlationId: 'session-existing',
       },
     ]);
+  });
+
+  it('persists and executes canonical code-task confirmation arguments from the real runner', async () => {
+    const repo = new FakeSessionRepository();
+    const replies = new FakeReplyPublisher();
+    const createCodeTaskCalls: Record<string, unknown>[] = [];
+    const runner = createIntexAgentRunner({
+      client: forcedCodeTaskToolClient({
+        prompt: 'Investigate synthetic cache behavior.',
+        taskMode: 'execution',
+        workerType: 'codex-xhigh',
+      }),
+      intentClassifier: {
+        async classify() {
+          return { kind: 'tool', allowedToolNames: ['create_code_task'] as const };
+        },
+      },
+      toolExecutor: codeTaskCapturingExecutor(createCodeTaskCalls),
+    });
+
+    await handleIncomingMessage(
+      message({
+        messageId: 'wamid-code-task-request',
+        text: 'Create a MiniMax planning code task to investigate synthetic cache behavior.',
+      }),
+      deps(repo, runner, replies)
+    );
+
+    const canonicalArgs = {
+      prompt: 'Investigate synthetic cache behavior.',
+      taskMode: 'planning',
+      workerType: 'minimax',
+    };
+    expect(replies.messages[0]?.message).toContain('Mode: planning');
+    expect(replies.messages[0]?.message).toContain('Worker: minimax');
+    expect(eventPayloads(repo, 'confirmation_requested')[0]).toMatchObject({
+      toolName: 'create_code_task',
+      toolArgs: canonicalArgs,
+    });
+    expect(eventPayloads(repo, 'confirmation_requested')[0]?.['toolArgs']).toEqual(canonicalArgs);
+
+    await handleIncomingMessage(
+      message({
+        messageId: 'wamid-code-task-confirmation',
+        text: '',
+        sourceType: 'whatsapp_button',
+        buttonResponse: {
+          buttonId: 'intex_confirm:confirmation-3:yes',
+          buttonTitle: 'Yes',
+          replyToWamid: 'wamid-code-task-confirmation-message',
+        },
+      }),
+      deps(repo, runner, replies)
+    );
+
+    expect(createCodeTaskCalls).toEqual([canonicalArgs]);
   });
 
   it('records a failed confirmed execution and does not reinterpret the request', async () => {
@@ -1800,7 +1860,7 @@ describe('handleIncomingMessage', () => {
 
 function deps(
   sessionRepository: FakeSessionRepository,
-  runner: FakeRunner,
+  runner: IntexAgentRunner,
   replies: FakeReplyPublisher,
   clock: { now: () => string } = { now: () => NOW },
   resolveTimeZone: (userId: string) => Promise<string> = async () => 'UTC'
@@ -1817,6 +1877,48 @@ function deps(
       confirmationId: () => `confirmation-${String(sessionRepository.events.length + 1)}`,
     },
     sessionTimeoutMs: 30 * 60 * 1000,
+  };
+}
+
+function forcedCodeTaskToolClient(args: Record<string, unknown>): ToolCallingClient {
+  return {
+    async run(params): ReturnType<ToolCallingClient['run']> {
+      const tool = params.tools.find((candidate) => candidate.name === 'create_code_task');
+      if (tool === undefined) throw new Error('Missing create_code_task tool');
+      await tool.run(args);
+      return ok({
+        content: JSON.stringify({
+          outcome: 'completed',
+          reply: 'Ready.',
+          toolName: 'create_code_task',
+        }),
+        toolCallsMade: 1,
+        iterationCount: 2,
+        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2, costUsd: 0 },
+      } satisfies ToolCallingResult);
+    },
+  };
+}
+
+function codeTaskCapturingExecutor(
+  createCodeTaskCalls: Record<string, unknown>[]
+): IntexAgentToolExecutor {
+  const unsupported = async (): Promise<string> => JSON.stringify({ status: 'completed' });
+  return {
+    createNote: unsupported,
+    createCalendarEvent: unsupported,
+    queryCalendarEvents: unsupported,
+    createResearch: unsupported,
+    createLink: unsupported,
+    async createCodeTask(args): Promise<string> {
+      createCodeTaskCalls.push({ ...args });
+      return JSON.stringify({ status: 'completed', id: 'task-1' });
+    },
+    saveExternal: unsupported,
+    getUserPreferences: unsupported,
+    addUserPreference: unsupported,
+    updateUserPreference: unsupported,
+    deleteUserPreference: unsupported,
   };
 }
 

--- a/apps/intex-agent/src/__tests__/domain/handleIncomingMessage.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/handleIncomingMessage.test.ts
@@ -280,15 +280,14 @@ describe('handleIncomingMessage', () => {
     ]);
   });
 
-  it('persists and executes canonical code-task confirmation arguments from the real runner', async () => {
+  it('persists and executes typed code-task confirmation arguments from the real runner', async () => {
     const repo = new FakeSessionRepository();
     const replies = new FakeReplyPublisher();
     const createCodeTaskCalls: Record<string, unknown>[] = [];
     const runner = createIntexAgentRunner({
       client: forcedCodeTaskToolClient({
         prompt: 'Investigate synthetic cache behavior.',
-        taskMode: 'execution',
-        workerType: 'codex-xhigh',
+        workerType: 'minimax',
       }),
       intentClassifier: {
         async classify() {
@@ -301,7 +300,7 @@ describe('handleIncomingMessage', () => {
     await handleIncomingMessage(
       message({
         messageId: 'wamid-code-task-request',
-        text: 'Create a MiniMax planning code task to investigate synthetic cache behavior.',
+        text: 'Create a code task to investigate synthetic cache behavior.',
       }),
       deps(repo, runner, replies)
     );

--- a/apps/intex-agent/src/__tests__/domain/intexAgentRunner.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/intexAgentRunner.test.ts
@@ -478,6 +478,70 @@ describe('createIntexAgentRunner', () => {
     ).resolves.toMatchObject({ toolArgs: args });
   });
 
+  it.each([
+    {
+      message: 'Create a code task to fix a planning code task parsing bug.',
+      expectedArgs: { prompt: 'Investigate the parser.' },
+    },
+    {
+      message: 'Create a code task in planning mode or execution mode.',
+      expectedArgs: { prompt: 'Investigate the parser.' },
+    },
+    {
+      message: 'Create a MiniMax code task or a Codex code task.',
+      expectedArgs: { prompt: 'Investigate the parser.' },
+    },
+    {
+      message: 'Create a non-MiniMax code task.',
+      expectedArgs: { prompt: 'Investigate the parser.' },
+    },
+    {
+      message: 'Do not create a planning code task, create an execution code task.',
+      expectedArgs: { prompt: 'Investigate the parser.', taskMode: 'execution' },
+    },
+    {
+      message: 'Avoid MiniMax and pick execution mode for a code task.',
+      expectedArgs: { prompt: 'Investigate the parser.', taskMode: 'execution' },
+    },
+    {
+      message: 'Pick MiniMax for the code task.',
+      expectedArgs: { prompt: 'Investigate the parser.', workerType: 'minimax' },
+    },
+    {
+      message: 'Create a code task using MiniMax in planning mode.',
+      expectedArgs: {
+        prompt: 'Investigate the parser.',
+        workerType: 'minimax',
+        taskMode: 'planning',
+      },
+    },
+    {
+      message: 'Create a code task using MiniMax in execution mode.',
+      expectedArgs: {
+        prompt: 'Investigate the parser.',
+        workerType: 'minimax',
+        taskMode: 'execution',
+      },
+    },
+  ])('fails closed for clause-local code-task selections: $message', async ({ message, expectedArgs }) => {
+    const client = new ToolExecutingFakeToolCallingClient(
+      { toolName: 'create_code_task', args: { prompt: 'Investigate the parser.' } },
+      [ok(toolResult({ outcome: 'completed', reply: 'Ready.', toolName: 'create_code_task' }))]
+    );
+    const runner = createIntexAgentRunner({ client, toolExecutor: fakeToolExecutor() });
+
+    const result = await runner.run({
+      session: session(),
+      events: [],
+      message,
+      currentDateTime: CURRENT_DATE_TIME,
+    });
+
+    expect(result).toMatchObject({ outcome: 'needs_confirmation', toolName: 'create_code_task' });
+    if (result.outcome !== 'needs_confirmation') throw new Error('Expected confirmation');
+    expect(result.toolArgs).toEqual(expectedArgs);
+  });
+
   it('formats replied-message context as context-only user message content', async () => {
     const client = new FakeToolCallingClient([
       ok(toolResult({ outcome: 'no_action', reply: 'Jasne, sprawdzę.' })),

--- a/apps/intex-agent/src/__tests__/domain/intexAgentRunner.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/intexAgentRunner.test.ts
@@ -357,191 +357,6 @@ describe('createIntexAgentRunner', () => {
     ).resolves.toMatchObject({ toolArgs: args });
   });
 
-  it.each([
-    {
-      message: 'Create a MiniMax planning code task to investigate synthetic cache behavior.',
-      args: {
-        prompt: 'Investigate synthetic cache behavior.',
-        taskMode: 'execution',
-        workerType: 'codex-xhigh',
-        linearIssueId: 'LIN-123',
-      },
-      expectedArgs: {
-        prompt: 'Investigate synthetic cache behavior.',
-        taskMode: 'planning',
-        workerType: 'minimax',
-        linearIssueId: 'LIN-123',
-      },
-    },
-    {
-      message: 'Create a MiniMax planning code task to investigate synthetic cache behavior.',
-      args: {
-        prompt: 'Investigate synthetic cache behavior.',
-        workerType: 'minimax',
-      },
-      expectedArgs: {
-        prompt: 'Investigate synthetic cache behavior.',
-        taskMode: 'planning',
-        workerType: 'minimax',
-      },
-    },
-    {
-      message: 'Create a planning code task to investigate synthetic cache behavior.',
-      args: { prompt: 'Investigate synthetic cache behavior.' },
-      expectedArgs: {
-        prompt: 'Investigate synthetic cache behavior.',
-        taskMode: 'planning',
-      },
-    },
-    {
-      message: 'Create a MiniMax code task to investigate synthetic cache behavior.',
-      args: { prompt: 'Investigate synthetic cache behavior.' },
-      expectedArgs: {
-        prompt: 'Investigate synthetic cache behavior.',
-        workerType: 'minimax',
-      },
-    },
-    {
-      message: 'Create a code task in execution mode using MINIMAX.',
-      args: { prompt: 'Investigate the execution path.' },
-      expectedArgs: {
-        prompt: 'Investigate the execution path.',
-        taskMode: 'execution',
-        workerType: 'minimax',
-      },
-    },
-  ])(
-    'canonicalizes unique, explicit current-message code-task selections: $message',
-    async ({ message, args, expectedArgs }) => {
-      const client = new ToolExecutingFakeToolCallingClient(
-        { toolName: 'create_code_task', args },
-        [ok(toolResult({ outcome: 'completed', reply: 'Ready.', toolName: 'create_code_task' }))]
-      );
-      const runner = createIntexAgentRunner({ client, toolExecutor: fakeToolExecutor() });
-
-      const result = await runner.run({
-        session: session(),
-        events: [],
-        message,
-        currentDateTime: CURRENT_DATE_TIME,
-      });
-
-      expect(result).toMatchObject({
-        outcome: 'needs_confirmation',
-        toolName: 'create_code_task',
-      });
-      if (result.outcome !== 'needs_confirmation') throw new Error('Expected confirmation');
-      expect(result.toolArgs).toEqual(expectedArgs);
-    }
-  );
-
-  it.each([
-    'Create a code task about a MiniMax planning comparison.',
-    'Create a code task about using MiniMax.',
-    'Do not create a MiniMax execution code task.',
-    'Create a planning or execution code task.',
-    'Create a code task with MiniMax or codex.',
-    'Create a code task to investigate this issue.',
-  ])('does not infer code-task selections from non-explicit current-message text: %s', async (message) => {
-    const args = { prompt: 'Investigate this issue.', workerType: 'codex-xhigh' };
-    const client = new ToolExecutingFakeToolCallingClient(
-      { toolName: 'create_code_task', args },
-      [ok(toolResult({ outcome: 'completed', reply: 'Ready.', toolName: 'create_code_task' }))]
-    );
-    const runner = createIntexAgentRunner({ client, toolExecutor: fakeToolExecutor() });
-
-    await expect(
-      runner.run({
-        session: session(),
-        events: [],
-        message,
-        currentDateTime: CURRENT_DATE_TIME,
-      })
-    ).resolves.toMatchObject({ toolArgs: args });
-  });
-
-  it('does not infer code-task selections from a prior turn', async () => {
-    const args = { prompt: 'Investigate this issue.' };
-    const client = new ToolExecutingFakeToolCallingClient(
-      { toolName: 'create_code_task', args },
-      [ok(toolResult({ outcome: 'completed', reply: 'Ready.', toolName: 'create_code_task' }))]
-    );
-    const runner = createIntexAgentRunner({ client, toolExecutor: fakeToolExecutor() });
-
-    await expect(
-      runner.run({
-        session: session(),
-        events: [event('user_message', { text: 'Use MiniMax in planning mode.' })],
-        message: 'Create a code task to investigate this issue.',
-        currentDateTime: CURRENT_DATE_TIME,
-      })
-    ).resolves.toMatchObject({ toolArgs: args });
-  });
-
-  it.each([
-    {
-      message: 'Create a code task to fix a planning code task parsing bug.',
-      expectedArgs: { prompt: 'Investigate the parser.' },
-    },
-    {
-      message: 'Create a code task in planning mode or execution mode.',
-      expectedArgs: { prompt: 'Investigate the parser.' },
-    },
-    {
-      message: 'Create a MiniMax code task or a Codex code task.',
-      expectedArgs: { prompt: 'Investigate the parser.' },
-    },
-    {
-      message: 'Create a non-MiniMax code task.',
-      expectedArgs: { prompt: 'Investigate the parser.' },
-    },
-    {
-      message: 'Do not create a planning code task, create an execution code task.',
-      expectedArgs: { prompt: 'Investigate the parser.', taskMode: 'execution' },
-    },
-    {
-      message: 'Avoid MiniMax and pick execution mode for a code task.',
-      expectedArgs: { prompt: 'Investigate the parser.', taskMode: 'execution' },
-    },
-    {
-      message: 'Pick MiniMax for the code task.',
-      expectedArgs: { prompt: 'Investigate the parser.', workerType: 'minimax' },
-    },
-    {
-      message: 'Create a code task using MiniMax in planning mode.',
-      expectedArgs: {
-        prompt: 'Investigate the parser.',
-        workerType: 'minimax',
-        taskMode: 'planning',
-      },
-    },
-    {
-      message: 'Create a code task using MiniMax in execution mode.',
-      expectedArgs: {
-        prompt: 'Investigate the parser.',
-        workerType: 'minimax',
-        taskMode: 'execution',
-      },
-    },
-  ])('fails closed for clause-local code-task selections: $message', async ({ message, expectedArgs }) => {
-    const client = new ToolExecutingFakeToolCallingClient(
-      { toolName: 'create_code_task', args: { prompt: 'Investigate the parser.' } },
-      [ok(toolResult({ outcome: 'completed', reply: 'Ready.', toolName: 'create_code_task' }))]
-    );
-    const runner = createIntexAgentRunner({ client, toolExecutor: fakeToolExecutor() });
-
-    const result = await runner.run({
-      session: session(),
-      events: [],
-      message,
-      currentDateTime: CURRENT_DATE_TIME,
-    });
-
-    expect(result).toMatchObject({ outcome: 'needs_confirmation', toolName: 'create_code_task' });
-    if (result.outcome !== 'needs_confirmation') throw new Error('Expected confirmation');
-    expect(result.toolArgs).toEqual(expectedArgs);
-  });
-
   it('formats replied-message context as context-only user message content', async () => {
     const client = new FakeToolCallingClient([
       ok(toolResult({ outcome: 'no_action', reply: 'Jasne, sprawdzę.' })),
@@ -4194,10 +4009,10 @@ describe('createIntexAgentRunner', () => {
     expect(saveCalls).toBe(0);
   });
 
-  it('uses default planning mode when building a code task confirmation without explicit mode', async () => {
+  it('normalizes a missing code-task mode at the typed tool boundary', async () => {
     const client = new ToolExecutingFakeToolCallingClient({
       toolName: 'create_code_task',
-      args: { prompt: 'Investigate the webhook retry path.' },
+      args: { prompt: 'Investigate the webhook retry path.', workerType: 'minimax' },
     }, [
       ok(
         toolResult({
@@ -4219,9 +4034,43 @@ describe('createIntexAgentRunner', () => {
     ).resolves.toEqual({
       outcome: 'needs_confirmation',
       reply:
-        'Create this code task?\n\nPrompt: Investigate the webhook retry path.\nMode: planning',
+        'Create this code task?\n\nPrompt: Investigate the webhook retry path.\nMode: planning\nWorker: minimax',
       toolName: 'create_code_task',
-      toolArgs: { prompt: 'Investigate the webhook retry path.' },
+      toolArgs: {
+        prompt: 'Investigate the webhook retry path.',
+        taskMode: 'planning',
+        workerType: 'minimax',
+      },
+    });
+  });
+
+  it('preserves an explicit code-task execution mode without synthesizing optional fields', async () => {
+    const client = new ToolExecutingFakeToolCallingClient({
+      toolName: 'create_code_task',
+      args: { prompt: 'Execute the webhook retry fix.', taskMode: 'execution' },
+    }, [
+      ok(
+        toolResult({
+          outcome: 'completed',
+          reply: 'Done.',
+          toolName: 'create_code_task',
+        })
+      ),
+    ]);
+    const runner = createIntexAgentRunner({ client, toolExecutor: fakeToolExecutor() });
+
+    await expect(
+      runner.run({
+        session: session(),
+        events: [],
+        message: 'Create a code task to execute the webhook retry fix.',
+        currentDateTime: CURRENT_DATE_TIME,
+      })
+    ).resolves.toEqual({
+      outcome: 'needs_confirmation',
+      reply: 'Create this code task?\n\nPrompt: Execute the webhook retry fix.\nMode: execution',
+      toolName: 'create_code_task',
+      toolArgs: { prompt: 'Execute the webhook retry fix.', taskMode: 'execution' },
     });
   });
 

--- a/apps/intex-agent/src/__tests__/domain/intexAgentRunner.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/intexAgentRunner.test.ts
@@ -357,6 +357,127 @@ describe('createIntexAgentRunner', () => {
     ).resolves.toMatchObject({ toolArgs: args });
   });
 
+  it.each([
+    {
+      message: 'Create a MiniMax planning code task to investigate synthetic cache behavior.',
+      args: {
+        prompt: 'Investigate synthetic cache behavior.',
+        taskMode: 'execution',
+        workerType: 'codex-xhigh',
+        linearIssueId: 'LIN-123',
+      },
+      expectedArgs: {
+        prompt: 'Investigate synthetic cache behavior.',
+        taskMode: 'planning',
+        workerType: 'minimax',
+        linearIssueId: 'LIN-123',
+      },
+    },
+    {
+      message: 'Create a MiniMax planning code task to investigate synthetic cache behavior.',
+      args: {
+        prompt: 'Investigate synthetic cache behavior.',
+        workerType: 'minimax',
+      },
+      expectedArgs: {
+        prompt: 'Investigate synthetic cache behavior.',
+        taskMode: 'planning',
+        workerType: 'minimax',
+      },
+    },
+    {
+      message: 'Create a planning code task to investigate synthetic cache behavior.',
+      args: { prompt: 'Investigate synthetic cache behavior.' },
+      expectedArgs: {
+        prompt: 'Investigate synthetic cache behavior.',
+        taskMode: 'planning',
+      },
+    },
+    {
+      message: 'Create a MiniMax code task to investigate synthetic cache behavior.',
+      args: { prompt: 'Investigate synthetic cache behavior.' },
+      expectedArgs: {
+        prompt: 'Investigate synthetic cache behavior.',
+        workerType: 'minimax',
+      },
+    },
+    {
+      message: 'Create a code task in execution mode using MINIMAX.',
+      args: { prompt: 'Investigate the execution path.' },
+      expectedArgs: {
+        prompt: 'Investigate the execution path.',
+        taskMode: 'execution',
+        workerType: 'minimax',
+      },
+    },
+  ])(
+    'canonicalizes unique, explicit current-message code-task selections: $message',
+    async ({ message, args, expectedArgs }) => {
+      const client = new ToolExecutingFakeToolCallingClient(
+        { toolName: 'create_code_task', args },
+        [ok(toolResult({ outcome: 'completed', reply: 'Ready.', toolName: 'create_code_task' }))]
+      );
+      const runner = createIntexAgentRunner({ client, toolExecutor: fakeToolExecutor() });
+
+      const result = await runner.run({
+        session: session(),
+        events: [],
+        message,
+        currentDateTime: CURRENT_DATE_TIME,
+      });
+
+      expect(result).toMatchObject({
+        outcome: 'needs_confirmation',
+        toolName: 'create_code_task',
+      });
+      if (result.outcome !== 'needs_confirmation') throw new Error('Expected confirmation');
+      expect(result.toolArgs).toEqual(expectedArgs);
+    }
+  );
+
+  it.each([
+    'Create a code task about a MiniMax planning comparison.',
+    'Create a code task about using MiniMax.',
+    'Do not create a MiniMax execution code task.',
+    'Create a planning or execution code task.',
+    'Create a code task with MiniMax or codex.',
+    'Create a code task to investigate this issue.',
+  ])('does not infer code-task selections from non-explicit current-message text: %s', async (message) => {
+    const args = { prompt: 'Investigate this issue.', workerType: 'codex-xhigh' };
+    const client = new ToolExecutingFakeToolCallingClient(
+      { toolName: 'create_code_task', args },
+      [ok(toolResult({ outcome: 'completed', reply: 'Ready.', toolName: 'create_code_task' }))]
+    );
+    const runner = createIntexAgentRunner({ client, toolExecutor: fakeToolExecutor() });
+
+    await expect(
+      runner.run({
+        session: session(),
+        events: [],
+        message,
+        currentDateTime: CURRENT_DATE_TIME,
+      })
+    ).resolves.toMatchObject({ toolArgs: args });
+  });
+
+  it('does not infer code-task selections from a prior turn', async () => {
+    const args = { prompt: 'Investigate this issue.' };
+    const client = new ToolExecutingFakeToolCallingClient(
+      { toolName: 'create_code_task', args },
+      [ok(toolResult({ outcome: 'completed', reply: 'Ready.', toolName: 'create_code_task' }))]
+    );
+    const runner = createIntexAgentRunner({ client, toolExecutor: fakeToolExecutor() });
+
+    await expect(
+      runner.run({
+        session: session(),
+        events: [event('user_message', { text: 'Use MiniMax in planning mode.' })],
+        message: 'Create a code task to investigate this issue.',
+        currentDateTime: CURRENT_DATE_TIME,
+      })
+    ).resolves.toMatchObject({ toolArgs: args });
+  });
+
   it('formats replied-message context as context-only user message content', async () => {
     const client = new FakeToolCallingClient([
       ok(toolResult({ outcome: 'no_action', reply: 'Jasne, sprawdzę.' })),

--- a/apps/intex-agent/src/__tests__/domain/testToolMocks.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/testToolMocks.test.ts
@@ -300,7 +300,7 @@ describe('test tool mocks', () => {
     [
       'create_code_task',
       async (executor: TestToolExecutor): Promise<string> =>
-        await executor.createCodeTask({ prompt: 'Fix the prompt' }),
+        await executor.createCodeTask({ prompt: 'Fix the prompt', taskMode: 'planning' }),
     ],
     [
       'save_external',

--- a/apps/intex-agent/src/__tests__/domain/toolDefinitions.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/toolDefinitions.test.ts
@@ -478,7 +478,7 @@ describe('createIntexAgentToolDefinitions', () => {
     ]);
   });
 
-  it('omits code task mode by default so the executor can create planning tasks', async () => {
+  it('normalizes the default planning mode before delegating to the executor', async () => {
     const executor = createExecutor();
     const codeTaskTool = createIntexAgentToolDefinitions(executor).find(
       (tool) => tool.name === 'create_code_task'
@@ -487,7 +487,9 @@ describe('createIntexAgentToolDefinitions', () => {
     await expect(codeTaskTool?.run({ prompt: 'Plan the new import flow.' })).resolves.toBe(
       'code-task-created'
     );
-    expect(executor.codeTaskArgs).toEqual([{ prompt: 'Plan the new import flow.' }]);
+    expect(executor.codeTaskArgs).toEqual([
+      { prompt: 'Plan the new import flow.', taskMode: 'planning' },
+    ]);
   });
 
   it('delegates external save execution to the injected executor', async () => {

--- a/apps/intex-agent/src/__tests__/domain/toolDefinitions.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/toolDefinitions.test.ts
@@ -1,10 +1,21 @@
 import { describe, expect, it } from 'vitest';
 import {
   createIntexAgentToolDefinitions,
+  type CreateCodeTaskToolArgs,
   type IntexAgentToolExecutor,
 } from '../../domain/agent/toolDefinitions.js';
 
 describe('createIntexAgentToolDefinitions', () => {
+  it('requires task mode on normalized code-task arguments', () => {
+    const taskModeIsRequired: CreateCodeTaskToolArgs extends {
+      taskMode: 'planning' | 'execution';
+    }
+      ? true
+      : false = true;
+
+    expect(taskModeIsRequired).toBe(true);
+  });
+
   it('defines exactly the supported tools', () => {
     const tools = createIntexAgentToolDefinitions(createExecutor());
 

--- a/apps/intex-agent/src/__tests__/domain/toolExecutor.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/toolExecutor.test.ts
@@ -568,7 +568,7 @@ describe('createIntexAgentToolExecutor', () => {
     ).rejects.toThrow('Failed to create link: bookmarks-agent unavailable');
   });
 
-  it('creates planning code tasks by default without sending omitted worker types', async () => {
+  it('creates normalized planning code tasks without sending omitted worker types', async () => {
     const codeClient = new FakeCodeTaskClient();
     const executor = createIntexAgentToolExecutor(createExecutorDeps({
       codeClient,
@@ -577,6 +577,7 @@ describe('createIntexAgentToolExecutor', () => {
     const result = await executor.createCodeTask({
       prompt: 'Plan the new import flow.',
       linearIssueId: 'LIN-123',
+      taskMode: 'planning',
     });
 
     expect(codeClient.calls).toEqual([
@@ -604,6 +605,7 @@ describe('createIntexAgentToolExecutor', () => {
     await executor.createCodeTask({
       prompt: 'Plan the new import flow.',
       workerType: 'codex',
+      taskMode: 'planning',
     });
 
     expect(codeClient.calls).toEqual([
@@ -650,6 +652,7 @@ describe('createIntexAgentToolExecutor', () => {
     await expect(
       executor.createCodeTask({
         prompt: 'Plan the new import flow.',
+        taskMode: 'planning',
       })
     ).rejects.toThrow('Failed to create code task: Worker is not configured');
   });

--- a/apps/intex-agent/src/domain/agent/intexAgentRunner.ts
+++ b/apps/intex-agent/src/domain/agent/intexAgentRunner.ts
@@ -78,16 +78,50 @@ const OPAQUE_REFERENCE_PATTERN =
   /(?<![\p{L}\p{N}_-])(?=[\p{L}\p{N}_-]*\p{L})(?=[\p{L}\p{N}_-]*\p{N})[\p{L}\p{N}]+(?:[-_][\p{L}\p{N}]+)+(?![\p{L}\p{N}_-])/gu;
 const EXPLICIT_REFERENCE_EXCLUSION_PREFIX_PATTERN =
   /(?<!\p{L})(?:(?:do not|don['’]?t)\s+(?:include|copy|keep|repeat|save)|(?:omit|exclude|remove|without)|nie\s+(?:uwzględniaj|uwzgledniaj|dodawaj|kopiuj|zapisuj|powtarzaj)|(?:pomiń|pomin|wyklucz|usuń|usun|bez))\s*(?:(?:the|this|ten|tego|tę|ta)\s+)?(?:(?:code|reference|identifier|token|kod|referencję|referencje|identyfikator)\s*)?(?:[:=-]\s*)?$/iu;
-const EXPLICIT_CODE_TASK_MODE_PATTERN =
-  /\b(?:a\s+)?(planning|execution)\s+code\s+task\b|\bcode\s+task\s+(?:in|for)\s+(planning|execution)\s+mode\b/giu;
-const EXPLICIT_CODE_TASK_MINIMAX_PATTERN =
-  /\b(?:a\s+)?(minimax)\s+(?:(?:planning|execution)\s+)?code\s+task\b|\bcode\s+task\s+(?:in\s+(?:planning|execution)\s+mode\s+)?(?:with|using)\s+(?:the\s+)?(minimax)(?:\s+worker)?(?=\s*(?:[.!?]|$))/giu;
-const COMPETING_CODE_TASK_MODE_PATTERN =
-  /\b(?:planning|execution)\b\s*(?:or|and)\s*\b(?:planning|execution)\b/iu;
-const COMPETING_CODE_TASK_WORKER_PATTERN =
-  /\b(?:minimax|codex(?:-xhigh)?)\b\s*(?:or|and)\s*\b(?:minimax|codex(?:-xhigh)?)\b/iu;
-const EXPLICIT_CODE_TASK_NEGATION_PREFIX_PATTERN =
-  /\b(?:do\s+not|don['’]?t|avoid|exclude|without|not)\s+(?:(?:use|choose|select|create|run|make)\s+)?(?:a\s+|an\s+|the\s+)?$/iu;
+const EXPLICIT_CODE_TASK_MODE_PATTERNS = [
+  {
+    pattern:
+      /\b(?:(do\s+not|don['’]?t|avoid)\s+)?(?:create|make|start|open|add|build)\s+(?:a\s+|an\s+|the\s+)?(?:minimax\s+)?(planning|execution)\s+code\s+task\b/giu,
+    choiceIndex: 2,
+    negationIndex: 1,
+  },
+  {
+    pattern:
+      /\b(?:(do\s+not|don['’]?t|avoid)\s+)?(?:create|make|start|open|add|build)\s+(?:a\s+|an\s+|the\s+)?(?:minimax\s+)?code\s+task\s+in\s+(planning|execution)\s+mode\b/giu,
+    choiceIndex: 2,
+    negationIndex: 1,
+  },
+  {
+    pattern:
+      /\b(?:(do\s+not|don['’]?t|avoid)\s+)?(?:create|make|start|open|add|build)\s+(?:a\s+|an\s+|the\s+)?code\s+task\s+(?:with|using)\s+(?:the\s+)?minimax(?:\s+worker)?\s+in\s+(planning|execution)\s+mode\b/giu,
+    choiceIndex: 2,
+    negationIndex: 1,
+  },
+  {
+    pattern:
+      /\b(?:pick|choose|select)\s+(planning|execution)\s+mode\s+for\s+(?:a\s+|an\s+|the\s+)?code\s+task\b/giu,
+    choiceIndex: 1,
+  },
+] as const;
+const EXPLICIT_CODE_TASK_MINIMAX_PATTERNS = [
+  {
+    pattern:
+      /\b(?:(do\s+not|don['’]?t|avoid)\s+)?(?:create|make|start|open|add|build)\s+(?:a\s+|an\s+|the\s+)?(minimax)\s+(?:(?:planning|execution)\s+)?code\s+task\b/giu,
+    choiceIndex: 2,
+    negationIndex: 1,
+  },
+  {
+    pattern:
+      /\b(?:(do\s+not|don['’]?t|avoid)\s+)?(?:create|make|start|open|add|build)\s+(?:a\s+|an\s+|the\s+)?code\s+task\s+(?:in\s+(?:planning|execution)\s+mode\s+)?(?:with|using)\s+(?:the\s+)?(minimax)(?:\s+worker)?\b/giu,
+    choiceIndex: 2,
+    negationIndex: 1,
+  },
+  {
+    pattern:
+      /\b(?:pick|choose|select)\s+(minimax)\s+for\s+(?:a\s+|an\s+|the\s+)?code\s+task\b/giu,
+    choiceIndex: 1,
+  },
+] as const;
 
 type LocalizedText = Record<IntexAgentReplyLanguage, string>;
 interface ClassifierUnsupportedReplyMap {
@@ -787,7 +821,7 @@ async function parseRunnerContent(
   const parsed = await validateRunnerOutput(input);
   const toolExecution = getCompletedToolExecution(toolExecutions);
   if (toolExecution !== undefined && isMutatingToolName(toolExecution.toolName)) {
-    const confirmationArgs = preserveCurrentTurnOpaqueReferences(
+    const confirmationArgs = canonicalizeCurrentConfirmationArguments(
       toolExecution.toolName,
       toolExecution.args,
       input.currentMessage
@@ -886,7 +920,7 @@ async function parseRunnerContent(
   }
 }
 
-function preserveCurrentTurnOpaqueReferences(
+function canonicalizeCurrentConfirmationArguments(
   toolName: MutatingIntexAgentToolName,
   args: Record<string, unknown>,
   currentMessage: string
@@ -895,6 +929,14 @@ function preserveCurrentTurnOpaqueReferences(
     return canonicalizeCurrentCodeTaskSelections(args, currentMessage);
   }
   if (toolName !== 'create_note') return args;
+
+  return canonicalizeCurrentNoteOpaqueReferences(args, currentMessage);
+}
+
+function canonicalizeCurrentNoteOpaqueReferences(
+  args: Record<string, unknown>,
+  currentMessage: string
+): Record<string, unknown> {
 
   const currentReferences = extractRestorableOpaqueReferences(currentMessage);
   if (currentReferences.length === 0) return args;
@@ -916,12 +958,16 @@ function canonicalizeCurrentCodeTaskSelections(
   args: Record<string, unknown>,
   currentMessage: string
 ): Record<string, unknown> {
-  const taskMode = COMPETING_CODE_TASK_MODE_PATTERN.test(currentMessage)
-    ? undefined
-    : extractUniqueExplicitCodeTaskChoice(currentMessage, EXPLICIT_CODE_TASK_MODE_PATTERN);
-  const workerType = COMPETING_CODE_TASK_WORKER_PATTERN.test(currentMessage)
-    ? undefined
-    : extractUniqueExplicitCodeTaskChoice(currentMessage, EXPLICIT_CODE_TASK_MINIMAX_PATTERN);
+  const taskMode = extractUniqueExplicitCodeTaskChoice(
+    currentMessage,
+    EXPLICIT_CODE_TASK_MODE_PATTERNS,
+    'mode'
+  );
+  const workerType = extractUniqueExplicitCodeTaskChoice(
+    currentMessage,
+    EXPLICIT_CODE_TASK_MINIMAX_PATTERNS,
+    'worker'
+  );
 
   if (taskMode === undefined && workerType === undefined) return args;
   return {
@@ -931,24 +977,44 @@ function canonicalizeCurrentCodeTaskSelections(
   };
 }
 
-function extractUniqueExplicitCodeTaskChoice(value: string, pattern: RegExp): string | undefined {
+function extractUniqueExplicitCodeTaskChoice(
+  value: string,
+  patterns: readonly {
+    readonly pattern: RegExp;
+    readonly choiceIndex: number;
+    readonly negationIndex?: number;
+  }[],
+  choiceType: 'mode' | 'worker'
+): string | undefined {
   const choices = new Set<string>();
-  for (const match of value.matchAll(pattern)) {
-    const choice = match[1] ?? match[2];
-    const index = match.index;
-    if (choice !== undefined && !isNegatedExplicitCodeTaskChoice(value, index)) {
-      choices.add(choice.toLowerCase());
+  for (const { pattern, choiceIndex, negationIndex } of patterns) {
+    for (const match of value.matchAll(pattern)) {
+      const choice = match[choiceIndex];
+      if (
+        choice !== undefined &&
+        (negationIndex === undefined || match[negationIndex] === undefined) &&
+        !hasCodeTaskChoiceAlternative(value, match, choiceType)
+      ) {
+        choices.add(choice.toLowerCase());
+      }
     }
   }
   return choices.size === 1 ? [...choices][0] : undefined;
 }
 
-function isNegatedExplicitCodeTaskChoice(value: string, index: number): boolean {
-  const prefix = value.slice(Math.max(0, index - 80), index);
-  return (
-    EXPLICIT_CODE_TASK_NEGATION_PREFIX_PATTERN.test(prefix) ||
-    /\b(?:do\s+not|don['’]?t)\s+(?:create|make|run)\b[^.!?]{0,60}$/iu.test(prefix)
-  );
+function hasCodeTaskChoiceAlternative(
+  value: string,
+  match: RegExpMatchArray,
+  choiceType: 'mode' | 'worker'
+): boolean {
+  const index = match.index as number;
+  const suffix = value.slice(index + match[0].length, index + match[0].length + 80);
+  const alternative = choiceType === 'mode' ? '(?:planning|execution)' : '(?:minimax|codex(?:-xhigh)?)';
+  const taskContext = choiceType === 'mode' ? '(?:\\s+mode|\\s+code\\s+task)' : '(?:\\s+code\\s+task|\\s+worker)?';
+  return new RegExp(
+    `^\\s*(?:,\\s*)?(?:or|and)\\s+(?:a\\s+|an\\s+|the\\s+)?${alternative}${taskContext}\\b`,
+    'iu'
+  ).test(suffix);
 }
 
 function extractOpaqueReferences(value: string): string[] {

--- a/apps/intex-agent/src/domain/agent/intexAgentRunner.ts
+++ b/apps/intex-agent/src/domain/agent/intexAgentRunner.ts
@@ -78,6 +78,16 @@ const OPAQUE_REFERENCE_PATTERN =
   /(?<![\p{L}\p{N}_-])(?=[\p{L}\p{N}_-]*\p{L})(?=[\p{L}\p{N}_-]*\p{N})[\p{L}\p{N}]+(?:[-_][\p{L}\p{N}]+)+(?![\p{L}\p{N}_-])/gu;
 const EXPLICIT_REFERENCE_EXCLUSION_PREFIX_PATTERN =
   /(?<!\p{L})(?:(?:do not|don['’]?t)\s+(?:include|copy|keep|repeat|save)|(?:omit|exclude|remove|without)|nie\s+(?:uwzględniaj|uwzgledniaj|dodawaj|kopiuj|zapisuj|powtarzaj)|(?:pomiń|pomin|wyklucz|usuń|usun|bez))\s*(?:(?:the|this|ten|tego|tę|ta)\s+)?(?:(?:code|reference|identifier|token|kod|referencję|referencje|identyfikator)\s*)?(?:[:=-]\s*)?$/iu;
+const EXPLICIT_CODE_TASK_MODE_PATTERN =
+  /\b(?:a\s+)?(planning|execution)\s+code\s+task\b|\bcode\s+task\s+(?:in|for)\s+(planning|execution)\s+mode\b/giu;
+const EXPLICIT_CODE_TASK_MINIMAX_PATTERN =
+  /\b(?:a\s+)?(minimax)\s+(?:(?:planning|execution)\s+)?code\s+task\b|\bcode\s+task\s+(?:in\s+(?:planning|execution)\s+mode\s+)?(?:with|using)\s+(?:the\s+)?(minimax)(?:\s+worker)?(?=\s*(?:[.!?]|$))/giu;
+const COMPETING_CODE_TASK_MODE_PATTERN =
+  /\b(?:planning|execution)\b\s*(?:or|and)\s*\b(?:planning|execution)\b/iu;
+const COMPETING_CODE_TASK_WORKER_PATTERN =
+  /\b(?:minimax|codex(?:-xhigh)?)\b\s*(?:or|and)\s*\b(?:minimax|codex(?:-xhigh)?)\b/iu;
+const EXPLICIT_CODE_TASK_NEGATION_PREFIX_PATTERN =
+  /\b(?:do\s+not|don['’]?t|avoid|exclude|without|not)\s+(?:(?:use|choose|select|create|run|make)\s+)?(?:a\s+|an\s+|the\s+)?$/iu;
 
 type LocalizedText = Record<IntexAgentReplyLanguage, string>;
 interface ClassifierUnsupportedReplyMap {
@@ -881,6 +891,9 @@ function preserveCurrentTurnOpaqueReferences(
   args: Record<string, unknown>,
   currentMessage: string
 ): Record<string, unknown> {
+  if (toolName === 'create_code_task') {
+    return canonicalizeCurrentCodeTaskSelections(args, currentMessage);
+  }
   if (toolName !== 'create_note') return args;
 
   const currentReferences = extractRestorableOpaqueReferences(currentMessage);
@@ -897,6 +910,45 @@ function preserveCurrentTurnOpaqueReferences(
     ...args,
     content: [noteArgs.content, ...missingReferences].join(' '),
   };
+}
+
+function canonicalizeCurrentCodeTaskSelections(
+  args: Record<string, unknown>,
+  currentMessage: string
+): Record<string, unknown> {
+  const taskMode = COMPETING_CODE_TASK_MODE_PATTERN.test(currentMessage)
+    ? undefined
+    : extractUniqueExplicitCodeTaskChoice(currentMessage, EXPLICIT_CODE_TASK_MODE_PATTERN);
+  const workerType = COMPETING_CODE_TASK_WORKER_PATTERN.test(currentMessage)
+    ? undefined
+    : extractUniqueExplicitCodeTaskChoice(currentMessage, EXPLICIT_CODE_TASK_MINIMAX_PATTERN);
+
+  if (taskMode === undefined && workerType === undefined) return args;
+  return {
+    ...args,
+    ...(taskMode !== undefined ? { taskMode } : {}),
+    ...(workerType !== undefined ? { workerType } : {}),
+  };
+}
+
+function extractUniqueExplicitCodeTaskChoice(value: string, pattern: RegExp): string | undefined {
+  const choices = new Set<string>();
+  for (const match of value.matchAll(pattern)) {
+    const choice = match[1] ?? match[2];
+    const index = match.index;
+    if (choice !== undefined && !isNegatedExplicitCodeTaskChoice(value, index)) {
+      choices.add(choice.toLowerCase());
+    }
+  }
+  return choices.size === 1 ? [...choices][0] : undefined;
+}
+
+function isNegatedExplicitCodeTaskChoice(value: string, index: number): boolean {
+  const prefix = value.slice(Math.max(0, index - 80), index);
+  return (
+    EXPLICIT_CODE_TASK_NEGATION_PREFIX_PATTERN.test(prefix) ||
+    /\b(?:do\s+not|don['’]?t)\s+(?:create|make|run)\b[^.!?]{0,60}$/iu.test(prefix)
+  );
 }
 
 function extractOpaqueReferences(value: string): string[] {

--- a/apps/intex-agent/src/domain/agent/intexAgentRunner.ts
+++ b/apps/intex-agent/src/domain/agent/intexAgentRunner.ts
@@ -78,51 +78,6 @@ const OPAQUE_REFERENCE_PATTERN =
   /(?<![\p{L}\p{N}_-])(?=[\p{L}\p{N}_-]*\p{L})(?=[\p{L}\p{N}_-]*\p{N})[\p{L}\p{N}]+(?:[-_][\p{L}\p{N}]+)+(?![\p{L}\p{N}_-])/gu;
 const EXPLICIT_REFERENCE_EXCLUSION_PREFIX_PATTERN =
   /(?<!\p{L})(?:(?:do not|don['’]?t)\s+(?:include|copy|keep|repeat|save)|(?:omit|exclude|remove|without)|nie\s+(?:uwzględniaj|uwzgledniaj|dodawaj|kopiuj|zapisuj|powtarzaj)|(?:pomiń|pomin|wyklucz|usuń|usun|bez))\s*(?:(?:the|this|ten|tego|tę|ta)\s+)?(?:(?:code|reference|identifier|token|kod|referencję|referencje|identyfikator)\s*)?(?:[:=-]\s*)?$/iu;
-const EXPLICIT_CODE_TASK_MODE_PATTERNS = [
-  {
-    pattern:
-      /\b(?:(do\s+not|don['’]?t|avoid)\s+)?(?:create|make|start|open|add|build)\s+(?:a\s+|an\s+|the\s+)?(?:minimax\s+)?(planning|execution)\s+code\s+task\b/giu,
-    choiceIndex: 2,
-    negationIndex: 1,
-  },
-  {
-    pattern:
-      /\b(?:(do\s+not|don['’]?t|avoid)\s+)?(?:create|make|start|open|add|build)\s+(?:a\s+|an\s+|the\s+)?(?:minimax\s+)?code\s+task\s+in\s+(planning|execution)\s+mode\b/giu,
-    choiceIndex: 2,
-    negationIndex: 1,
-  },
-  {
-    pattern:
-      /\b(?:(do\s+not|don['’]?t|avoid)\s+)?(?:create|make|start|open|add|build)\s+(?:a\s+|an\s+|the\s+)?code\s+task\s+(?:with|using)\s+(?:the\s+)?minimax(?:\s+worker)?\s+in\s+(planning|execution)\s+mode\b/giu,
-    choiceIndex: 2,
-    negationIndex: 1,
-  },
-  {
-    pattern:
-      /\b(?:pick|choose|select)\s+(planning|execution)\s+mode\s+for\s+(?:a\s+|an\s+|the\s+)?code\s+task\b/giu,
-    choiceIndex: 1,
-  },
-] as const;
-const EXPLICIT_CODE_TASK_MINIMAX_PATTERNS = [
-  {
-    pattern:
-      /\b(?:(do\s+not|don['’]?t|avoid)\s+)?(?:create|make|start|open|add|build)\s+(?:a\s+|an\s+|the\s+)?(minimax)\s+(?:(?:planning|execution)\s+)?code\s+task\b/giu,
-    choiceIndex: 2,
-    negationIndex: 1,
-  },
-  {
-    pattern:
-      /\b(?:(do\s+not|don['’]?t|avoid)\s+)?(?:create|make|start|open|add|build)\s+(?:a\s+|an\s+|the\s+)?code\s+task\s+(?:in\s+(?:planning|execution)\s+mode\s+)?(?:with|using)\s+(?:the\s+)?(minimax)(?:\s+worker)?\b/giu,
-    choiceIndex: 2,
-    negationIndex: 1,
-  },
-  {
-    pattern:
-      /\b(?:pick|choose|select)\s+(minimax)\s+for\s+(?:a\s+|an\s+|the\s+)?code\s+task\b/giu,
-    choiceIndex: 1,
-  },
-] as const;
-
 type LocalizedText = Record<IntexAgentReplyLanguage, string>;
 interface ClassifierUnsupportedReplyMap {
   unsupported_capability: string;
@@ -821,7 +776,7 @@ async function parseRunnerContent(
   const parsed = await validateRunnerOutput(input);
   const toolExecution = getCompletedToolExecution(toolExecutions);
   if (toolExecution !== undefined && isMutatingToolName(toolExecution.toolName)) {
-    const confirmationArgs = canonicalizeCurrentConfirmationArguments(
+    const confirmationArgs = preserveCurrentTurnOpaqueReferences(
       toolExecution.toolName,
       toolExecution.args,
       input.currentMessage
@@ -920,24 +875,12 @@ async function parseRunnerContent(
   }
 }
 
-function canonicalizeCurrentConfirmationArguments(
+function preserveCurrentTurnOpaqueReferences(
   toolName: MutatingIntexAgentToolName,
   args: Record<string, unknown>,
   currentMessage: string
 ): Record<string, unknown> {
-  if (toolName === 'create_code_task') {
-    return canonicalizeCurrentCodeTaskSelections(args, currentMessage);
-  }
   if (toolName !== 'create_note') return args;
-
-  return canonicalizeCurrentNoteOpaqueReferences(args, currentMessage);
-}
-
-function canonicalizeCurrentNoteOpaqueReferences(
-  args: Record<string, unknown>,
-  currentMessage: string
-): Record<string, unknown> {
-
   const currentReferences = extractRestorableOpaqueReferences(currentMessage);
   if (currentReferences.length === 0) return args;
 
@@ -952,69 +895,6 @@ function canonicalizeCurrentNoteOpaqueReferences(
     ...args,
     content: [noteArgs.content, ...missingReferences].join(' '),
   };
-}
-
-function canonicalizeCurrentCodeTaskSelections(
-  args: Record<string, unknown>,
-  currentMessage: string
-): Record<string, unknown> {
-  const taskMode = extractUniqueExplicitCodeTaskChoice(
-    currentMessage,
-    EXPLICIT_CODE_TASK_MODE_PATTERNS,
-    'mode'
-  );
-  const workerType = extractUniqueExplicitCodeTaskChoice(
-    currentMessage,
-    EXPLICIT_CODE_TASK_MINIMAX_PATTERNS,
-    'worker'
-  );
-
-  if (taskMode === undefined && workerType === undefined) return args;
-  return {
-    ...args,
-    ...(taskMode !== undefined ? { taskMode } : {}),
-    ...(workerType !== undefined ? { workerType } : {}),
-  };
-}
-
-function extractUniqueExplicitCodeTaskChoice(
-  value: string,
-  patterns: readonly {
-    readonly pattern: RegExp;
-    readonly choiceIndex: number;
-    readonly negationIndex?: number;
-  }[],
-  choiceType: 'mode' | 'worker'
-): string | undefined {
-  const choices = new Set<string>();
-  for (const { pattern, choiceIndex, negationIndex } of patterns) {
-    for (const match of value.matchAll(pattern)) {
-      const choice = match[choiceIndex];
-      if (
-        choice !== undefined &&
-        (negationIndex === undefined || match[negationIndex] === undefined) &&
-        !hasCodeTaskChoiceAlternative(value, match, choiceType)
-      ) {
-        choices.add(choice.toLowerCase());
-      }
-    }
-  }
-  return choices.size === 1 ? [...choices][0] : undefined;
-}
-
-function hasCodeTaskChoiceAlternative(
-  value: string,
-  match: RegExpMatchArray,
-  choiceType: 'mode' | 'worker'
-): boolean {
-  const index = match.index as number;
-  const suffix = value.slice(index + match[0].length, index + match[0].length + 80);
-  const alternative = choiceType === 'mode' ? '(?:planning|execution)' : '(?:minimax|codex(?:-xhigh)?)';
-  const taskContext = choiceType === 'mode' ? '(?:\\s+mode|\\s+code\\s+task)' : '(?:\\s+code\\s+task|\\s+worker)?';
-  return new RegExp(
-    `^\\s*(?:,\\s*)?(?:or|and)\\s+(?:a\\s+|an\\s+|the\\s+)?${alternative}${taskContext}\\b`,
-    'iu'
-  ).test(suffix);
 }
 
 function extractOpaqueReferences(value: string): string[] {
@@ -1392,7 +1272,7 @@ function buildConfirmationReply(
     appendConfirmationLine(
       lines,
       CONFIRMATION_LABELS.mode[replyLanguage],
-      readRawString(args, 'taskMode') ?? 'planning'
+      readRawString(args, 'taskMode')
     );
     appendConfirmationLine(lines, CONFIRMATION_LABELS.worker[replyLanguage], readRawString(args, 'workerType'));
     appendConfirmationLine(lines, 'Linear', readRawString(args, 'linearIssueId'));

--- a/apps/intex-agent/src/domain/agent/toolDefinitions.ts
+++ b/apps/intex-agent/src/domain/agent/toolDefinitions.ts
@@ -46,7 +46,7 @@ export interface CreateCodeTaskToolArgs {
   prompt: string;
   workerType?: string;
   linearIssueId?: string;
-  taskMode?: 'planning' | 'execution';
+  taskMode: 'planning' | 'execution';
 }
 
 export interface SaveExternalToolArgs {

--- a/apps/intex-agent/src/domain/agent/toolDefinitions.ts
+++ b/apps/intex-agent/src/domain/agent/toolDefinitions.ts
@@ -657,13 +657,13 @@ function toCreateCodeTaskArgs(args: Record<string, unknown>): CreateCodeTaskTool
   const prompt = requiredString(args, 'prompt');
   const workerType = optionalString(args, 'workerType');
   const linearIssueId = optionalString(args, 'linearIssueId');
-  const taskMode = optionalTaskMode(args, 'taskMode');
+  const taskMode = optionalTaskMode(args, 'taskMode') ?? 'planning';
 
   return {
     prompt,
     ...(workerType !== undefined ? { workerType } : {}),
     ...(linearIssueId !== undefined ? { linearIssueId } : {}),
-    ...(taskMode !== undefined ? { taskMode } : {}),
+    taskMode,
   };
 }
 

--- a/apps/intex-agent/src/domain/agent/toolExecutor.ts
+++ b/apps/intex-agent/src/domain/agent/toolExecutor.ts
@@ -361,7 +361,7 @@ function toCodeTaskInput(args: CreateCodeTaskToolArgs, userId: string): CreateCo
     prompt: args.prompt,
     ...(args.workerType !== undefined ? { workerType: args.workerType } : {}),
     ...(args.linearIssueId !== undefined ? { linearIssueId: args.linearIssueId } : {}),
-    taskMode: args.taskMode ?? 'planning',
+    taskMode: args.taskMode,
   };
 }
 

--- a/docs/superpowers/plans/2026-07-18-intex-agent-live-acceptance-fixes.md
+++ b/docs/superpowers/plans/2026-07-18-intex-agent-live-acceptance-fixes.md
@@ -542,9 +542,35 @@ The first authorized Matrix message and Chrome audit exposed additional defects 
 
 **Review status:** two independent analyses approved the narrow `save_external` mapping over a general tool-action map, and final diff review found no Critical/Important issues. Focused evaluator checks passed (`783/783`), followed by exact tracked CI with `5554/5554` tests, coverage, build, format, and bundle budget green.
 
+### Task 27: Close the final observable-confirmation and explicit code-task regressions
+
+**Evidence:** PR `#2341` deployed exact merge `212fb2c4286e9262e8e217aacfe57ecda2c713dc`. The four-case external-save calibration kept all negative controls fail closed; the exact wrong-action failure taxonomy varied in the batched judge call, so batch-stable diagnostic taxonomy is recorded under Deferred perfection rather than weakening the binary semantic gate. Focused scenario `015` then passed. The next complete endpoint run, `eval-cc82cc9d-e2c9-49cf-a434-e8f696df811a`, completed 59 turns/replies and 19 tool calls with complete cleanup, but exited `1` at 17/20; `full` and Matrix remained closed.
+
+- Scenarios `001` and `007` each completed the expected `create_note` flow with zero deterministic failures and a passing final reply. MiniMax failed only the confirmation reply because their isolated criteria did not state that the sanitized `Content: [redacted]` preview is complete evidence and that `Title: [redacted]` is optional.
+- Scenario `014` selected `create_code_task` with `workerType=minimax`, but the LLM omitted raw `taskMode` because planning is the product default. The confirmation renderer displayed its own planning fallback while the persisted/executed arguments remained without `taskMode`, causing one timeline payload failure and one tool-argument failure for the same missing field.
+
+- [ ] Add RED catalog tests requiring scenarios `001` and `007` to expose `Content: [redacted]`, describe `Title: [redacted]` as optional, and mark those redacted values as complete judge evidence without exposing markers or raw arguments.
+- [ ] Update only those two semantic contracts and regenerate the intentional full-catalog digest; preserve all messages, turns, tool/timeline/cleanup assertions, marker evidence, and completion criteria.
+- [ ] Add RED runner tests proving that unique, unnegated, explicit current-message code-task choices are canonical: `planning`/`execution` map to `taskMode`, and an explicit MiniMax worker selection maps case-insensitively to `workerType=minimax`.
+- [ ] Keep canonicalization scoped to `create_code_task` and the current message. Do not infer a mode or worker from a topical mention, negated choice, multiple competing choices, prior turn, default, or absent selection; do not create or infer `linearIssueId`; preserve unrelated existing arguments. An explicit current choice overrides a conflicting LLM argument and the canonical payload is the one persisted for confirmation and later execution.
+- [ ] Close every Critical/Important independent-review finding, run focused evaluator and Intex Agent checks, and run exact `pnpm run ci:tracked` on the final diff.
+- [ ] Ship through a reviewed PR, verify exact Home Dev deployment, rerun the 12-check preflight, then require focused scenarios `001`, `007`, and `014` to pass once each without retrying through a failure.
+- [ ] Require a fresh complete 20-scenario endpoint gate to exit `0`; only then run `full` exactly once and require its independently fresh endpoint corpus plus the authorized Matrix smoke to exit `0` with MiniMax M3.
+- [ ] Complete the logged-in desktop/mobile Chrome audit of the Intex Agent session list/detail and affected settings, fix every production-readiness defect found through the same test-first/review/deploy loop, and record final privacy-safe evidence.
+
+#### Endpoint Changes
+
+- **Modified:** none.
+- **Created:** none.
+- **Removed:** none.
+- **Unchanged:** the existing dev-only conversation test endpoint, request/response schema, Home Dev wrapper commands, mocked-product-tool boundary, MiniMax M3 judge, cleanup contract, and Matrix ordering gate.
+
+**Acceptance:** both note confirmations are judged from complete observable sanitized evidence; explicit code-task worker/mode selections survive the LLM boundary in the persisted confirmation payload; focused regressions, the 20-scenario endpoint gate, the fresh full-plus-Matrix gate, and the production desktop/mobile UX audit all pass in order.
+
 ### Deferred perfection (recorded, not implemented in this loop)
 
 - Dedicated portable WhatsApp integration accounts and cross-machine credential bootstrap.
 - Automatic conversion of every debug-session request into a newly curated scenario and pull request.
 - Richer judge calibration fixtures, `failedSemanticCriterionIndexes`, and per-criterion diagnostics beyond the active closed failure-code mapping.
+- Batch-stable exact failure taxonomy for semantically rejected wrong-action controls. The binary gate is authoritative and remains fail closed; classification-label determinism is not required for current acceptance.
 - A per-user Intex Agent model selector matching the existing Default Model client contract. The current Home Dev UI exposes only the global default/fallback model and prompt preferences; implement the already frozen model-selection design separately after the evaluation baseline is stable.

--- a/docs/superpowers/plans/2026-07-18-intex-agent-live-acceptance-fixes.md
+++ b/docs/superpowers/plans/2026-07-18-intex-agent-live-acceptance-fixes.md
@@ -551,8 +551,8 @@ The first authorized Matrix message and Chrome audit exposed additional defects 
 
 - [ ] Add RED catalog tests requiring scenarios `001` and `007` to expose `Content: [redacted]`, describe `Title: [redacted]` as optional, and mark those redacted values as complete judge evidence without exposing markers or raw arguments.
 - [ ] Update only those two semantic contracts and regenerate the intentional full-catalog digest; preserve all messages, turns, tool/timeline/cleanup assertions, marker evidence, and completion criteria.
-- [ ] Add RED runner tests proving that unique, unnegated, explicit current-message code-task choices are canonical: `planning`/`execution` map to `taskMode`, and an explicit MiniMax worker selection maps case-insensitively to `workerType=minimax`.
-- [ ] Keep canonicalization scoped to `create_code_task` and the current message. Do not infer a mode or worker from a topical mention, negated choice, multiple competing choices, prior turn, default, or absent selection; do not create or infer `linearIssueId`; preserve unrelated existing arguments. An explicit current choice overrides a conflicting LLM argument and the canonical payload is the one persisted for confirmation and later execution.
+- [ ] Add RED runner and real message-handling regressions for the live typed tool payload `{ prompt, workerType: 'minimax' }`: normalize its omitted `taskMode` to the product default `planning`, preserve explicit `execution`, preserve the supplied worker, and never synthesize a worker or `linearIssueId`.
+- [ ] Normalize the product default exclusively in `toCreateCodeTaskArgs` at the typed `create_code_task` boundary, so the confirmation payload and accepted execution receive the same arguments. Do not parse the current message for code-task worker or mode selections: deterministic regex parsing was rejected because equivalent valid wording continually escaped its grammar and could overwrite an otherwise correct LLM selection. Keep opaque-reference restoration limited to note confirmation arguments.
 - [ ] Close every Critical/Important independent-review finding, run focused evaluator and Intex Agent checks, and run exact `pnpm run ci:tracked` on the final diff.
 - [ ] Ship through a reviewed PR, verify exact Home Dev deployment, rerun the 12-check preflight, then require focused scenarios `001`, `007`, and `014` to pass once each without retrying through a failure.
 - [ ] Require a fresh complete 20-scenario endpoint gate to exit `0`; only then run `full` exactly once and require its independently fresh endpoint corpus plus the authorized Matrix smoke to exit `0` with MiniMax M3.
@@ -565,7 +565,7 @@ The first authorized Matrix message and Chrome audit exposed additional defects 
 - **Removed:** none.
 - **Unchanged:** the existing dev-only conversation test endpoint, request/response schema, Home Dev wrapper commands, mocked-product-tool boundary, MiniMax M3 judge, cleanup contract, and Matrix ordering gate.
 
-**Acceptance:** both note confirmations are judged from complete observable sanitized evidence; explicit code-task worker/mode selections survive the LLM boundary in the persisted confirmation payload; focused regressions, the 20-scenario endpoint gate, the fresh full-plus-Matrix gate, and the production desktop/mobile UX audit all pass in order.
+**Acceptance:** both note confirmations are judged from complete observable sanitized evidence; typed code-task arguments normalize the planning default and preserve supplied worker/mode values through the persisted confirmation payload; focused regressions, the 20-scenario endpoint gate, the fresh full-plus-Matrix gate, and the production desktop/mobile UX audit all pass in order.
 
 ### Deferred perfection (recorded, not implemented in this loop)
 

--- a/tools/intex-agent-evals/scenarios/intex-eval-001.scenario.json
+++ b/tools/intex-agent-evals/scenarios/intex-eval-001.scenario.json
@@ -98,7 +98,9 @@
             "replyIndex": 0,
             "semanticCriteria": [
               "Correctly identifies a note-save request and asks for explicit confirmation in an appropriate, concise tone.",
-              "Does not claim the note already exists and does not expose raw argument content in the sanitized reply."
+              "Expected complete sanitized confirmation evidence: Content: [redacted]; an additional Title: [redacted] line is optional.",
+              "The redacted values are complete expected evidence for the judge and are not missing information.",
+              "Does not claim the note already exists or expose raw argument content in the sanitized reply."
             ]
           }
         ]

--- a/tools/intex-agent-evals/scenarios/intex-eval-007.scenario.json
+++ b/tools/intex-agent-evals/scenarios/intex-eval-007.scenario.json
@@ -97,7 +97,9 @@
           {
             "replyIndex": 0,
             "semanticCriteria": [
-              "Correctly identifies the request as a note-save action and asks for explicit confirmation.",
+              "Correctly identifies a note-save request and asks for explicit confirmation in an appropriate, concise tone.",
+              "Expected complete sanitized confirmation evidence: Content: [redacted]; an additional Title: [redacted] line is optional.",
+              "The redacted values are complete expected evidence for the judge and are not missing information.",
               "Does not classify the request as unsupported or expose raw argument content in the sanitized reply."
             ]
           }

--- a/tools/intex-agent-evals/src/__tests__/trackedScenarioCatalog.test.ts
+++ b/tools/intex-agent-evals/src/__tests__/trackedScenarioCatalog.test.ts
@@ -168,6 +168,11 @@ const OBSERVABLE_NOTE_CONFIRMATION_CRITERIA = [
   'Does not claim the note already exists or expose raw argument content in the sanitized reply.',
 ] as const;
 
+const OBSERVABLE_NOTE_CONFIRMATION_WITH_OPTIONAL_TITLE_CRITERIA = [
+  'Expected complete sanitized confirmation evidence: Content: [redacted]; an additional Title: [redacted] line is optional.',
+  COMPLETE_REDACTED_CONFIRMATION_EVIDENCE,
+] as const;
+
 const CONCISE_NOTE_COMPLETION_CRITERIA = [
   'Clearly communicates that the requested note was saved successfully.',
   'A concise completion-only reply is sufficient and should not restate details or invite another action.',
@@ -778,6 +783,36 @@ describe('tracked scenario catalog', () => {
     }
   });
 
+  it('keeps scenarios 001 and 007 note confirmations observable from complete redacted evidence', () => {
+    for (const testCase of [
+      {
+        scenarioId: 'intex-eval-001',
+        firstCriterion:
+          'Correctly identifies a note-save request and asks for explicit confirmation in an appropriate, concise tone.',
+        finalCriterion:
+          'Does not claim the note already exists or expose raw argument content in the sanitized reply.',
+      },
+      {
+        scenarioId: 'intex-eval-007',
+        firstCriterion:
+          'Correctly identifies a note-save request and asks for explicit confirmation in an appropriate, concise tone.',
+        finalCriterion:
+          'Does not classify the request as unsupported or expose raw argument content in the sanitized reply.',
+      },
+    ]) {
+      const scenario = findScenario(scenarios, testCase.scenarioId);
+      const criteria = scenario.expected.turns[0]?.replies[0]?.semanticCriteria;
+
+      expect(criteria).toEqual([
+        testCase.firstCriterion,
+        ...OBSERVABLE_NOTE_CONFIRMATION_WITH_OPTIONAL_TITLE_CRITERIA,
+        testCase.finalCriterion,
+      ]);
+      expect(criteria?.join(' ')).not.toMatch(SYNTHETIC_MARKER_PATTERN);
+      expect(criteria?.join(' ')).not.toContain(messageText(scenario, 0));
+    }
+  });
+
   it('keeps scenario 020 final confirmation and completion observable in isolation', () => {
     const scenario = findScenario(scenarios, 'intex-eval-020');
 
@@ -1067,7 +1102,7 @@ describe('tracked scenario catalog', () => {
 
   it('matches the stable SHA-256 digest of the full canonical parsed catalog', () => {
     expect(fullCatalogDigest(scenarios)).toBe(
-      '96de4db99eb1f367908838bdf233d976613207561e325846fbd0e72830d18416'
+      'e6165511fd385be173d1ae3b8f28f5d1953073945acc363f5978c26c026c7957'
     );
   });
 });


### PR DESCRIPTION
## Summary

- make note-confirmation evaluation criteria self-contained with complete redacted evidence
- normalize the default code-task planning mode once at the typed tool boundary
- verify identical typed arguments through confirmation rendering, persistence, acceptance, and execution

## Verification

- `pnpm run ci:tracked` — 5,556 tests plus coverage, build, format, and post-build checks
- evaluator validation — 784 tests
- independent final review — no Critical, Important, or Minor findings

## Linear

Fixes INT-1877

- Linear: [INT-1877](https://linear.app/pbuchman/issue/INT-1877)
- IntexuraOS Code Task: [View task](https://intexuraos.cloud/#/code-tasks/task_c2ed5560-06a4-4464-a083-0909ae78c0b7)
- Worker Type: `codex-xhigh`
- Model: `default`