### PR TITLE
[INT-1879] fix(intex-agent): require explicit Linear associations

### DIFF
--- a/apps/intex-agent/src/__tests__/domain/intexAgentRunner.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/intexAgentRunner.test.ts
@@ -112,7 +112,7 @@ describe('createIntexAgentRunner', () => {
     expect(client.calls[0]?.systemPrompt).toContain(
       'today: timeMin=2026-06-24T00:00:00.000+00:00; timeMax=2026-06-25T00:00:00.000+00:00'
     );
-    expect(INTEX_AGENT_SYSTEM_PROMPT.version).toBe('19.0.0');
+    expect(INTEX_AGENT_SYSTEM_PROMPT.version).toBe('20.0.0');
     expect(client.calls[0]?.systemPrompt).toContain('You are Intex in WhatsApp Assistant conversations.');
     expect(client.calls[0]?.systemPrompt).not.toContain('You are IntexuraOS');
     expect(client.calls[0]?.systemPrompt).toContain(
@@ -2364,7 +2364,7 @@ describe('createIntexAgentRunner', () => {
       reply: 'Do tej pory powiedziałeś, że chcesz zbierać fragmenty notatki.',
     });
 
-    expect(INTEX_AGENT_SYSTEM_PROMPT.version).toBe('19.0.0');
+    expect(INTEX_AGENT_SYSTEM_PROMPT.version).toBe('20.0.0');
     expect(client.calls[0]?.systemPrompt).toContain('You can use the current session transcript');
     expect(client.calls[0]?.systemPrompt).toContain('Do not claim you cannot review the current conversation');
     expect(client.calls[0]?.tools).toEqual([]);

--- a/apps/intex-agent/src/__tests__/domain/toolDefinitions.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/toolDefinitions.test.ts
@@ -156,16 +156,31 @@ describe('createIntexAgentToolDefinitions', () => {
     });
   });
 
-  it('allows a Linear issue only when the user explicitly supplied its identifier', () => {
+  it('allows a Linear issue only when the user explicitly associates an identifier with Linear', () => {
     const codeTaskTool = createIntexAgentToolDefinitions(createExecutor()).find(
       (tool) => tool.name === 'create_code_task'
     );
 
     expect(codeTaskTool?.parameters['required']).not.toContain('linearIssueId');
+    expect(codeTaskTool?.description).toContain(
+      'Set linearIssueId only when the user explicitly associates a supplied identifier with a Linear issue or ticket.'
+    );
+    expect(codeTaskTool?.description).toContain(
+      'An arbitrary opaque identifier, tracking marker, or evaluation marker is not enough'
+    );
     expect(codeTaskTool?.parameters['properties']).toMatchObject({
       linearIssueId: {
         type: 'string',
-        description: expect.stringMatching(/omit.*unless.*user explicitly supplies/iu),
+        description: expect.stringContaining(
+          'Set only when the user explicitly associates the supplied identifier with a Linear issue or ticket.'
+        ),
+      },
+    });
+    expect(codeTaskTool?.parameters['properties']).toMatchObject({
+      linearIssueId: {
+        description: expect.stringContaining(
+          'An arbitrary opaque identifier, tracking marker, or evaluation marker is not enough'
+        ),
       },
     });
   });

--- a/apps/intex-agent/src/domain/agent/toolDefinitions.ts
+++ b/apps/intex-agent/src/domain/agent/toolDefinitions.ts
@@ -357,15 +357,15 @@ export function createIntexAgentToolDefinitions(executor: IntexAgentToolExecutor
       description: toolDescription({
         purpose: 'Create an IntexuraOS code task.',
         useFor:
-          '"Create a code task to investigate auth bug", "Create code task execution for INT-123".',
+          '"Create a code task to investigate auth bug", "Create code task execution for Linear issue INT-123".',
         doNotUseFor:
           '"How do HTTP requests work?", "Can you code this right here?", "What parameters do code tasks need?", or general programming explanations.',
         requiredInput:
           'prompt is required. workerType, linearIssueId, and taskMode are optional. workerType is only codex, codex-xhigh, or minimax.',
         boundary:
-          'planning mode is default. Use execution mode only when explicitly requested or when the user says the task is in execution stage.',
+          'planning mode is default. Use execution mode only when explicitly requested or when the user says the task is in execution stage. Set linearIssueId only when the user explicitly associates a supplied identifier with a Linear issue or ticket. An arbitrary opaque identifier, tracking marker, or evaluation marker is not enough; keep it in the task prompt and omit linearIssueId.',
         examples:
-          'Positive: "Create a code task execution for INT-123." Negative: "Explain React hooks."',
+          'Positive: "Create a code task execution for Linear issue INT-123." Negative: "Explain React hooks."',
         result: 'Returns status, code task ID, and resource URL.',
         errors: 'Validation covers missing prompt, invalid worker type, invalid task mode, or invalid Linear issue ID.',
       }),
@@ -387,7 +387,7 @@ export function createIntexAgentToolDefinitions(executor: IntexAgentToolExecutor
           linearIssueId: {
             type: 'string',
             description:
-              'Optional Linear issue ID to associate with the task. Omit it unless the user explicitly supplies the identifier.',
+              'Optional Linear issue ID to associate with the task. Set only when the user explicitly associates the supplied identifier with a Linear issue or ticket. An arbitrary opaque identifier, tracking marker, or evaluation marker is not enough; keep it in the task prompt and omit linearIssueId.',
           },
           taskMode: {
             type: 'string',

--- a/docs/superpowers/plans/2026-07-18-intex-agent-live-acceptance-fixes.md
+++ b/docs/superpowers/plans/2026-07-18-intex-agent-live-acceptance-fixes.md
@@ -584,6 +584,26 @@ The first authorized Matrix message and Chrome audit exposed additional defects 
 
 **Acceptance:** private evaluator JSON and Markdown identify the exact schema-whitelisted deterministic assertion path without exposing compared values or payloads; multi-event timeline groups report the first assertion that deterministically eliminates all candidates; strict report validation rejects unknown, cross-kind, and locally/globally inconsistent paths.
 
+### Task 29: Keep synthetic markers out of Linear association
+
+**Evidence:** the focused scenario `014` retry identified privacy-safe deterministic paths `argsSummary.hasLinearIssueId` and `hasLinearIssueId`; the MiniMax judge also returned `unsupported_claim`. The existing prompt treated any user-supplied identifier as sufficient for `linearIssueId`, so synthetic tracking/evaluation markers could be incorrectly associated with Linear.
+
+- [x] Add RED prompt and tool-contract regressions requiring an explicit semantic Linear issue/ticket association and stating that arbitrary opaque identifiers or tracking/evaluation markers are insufficient.
+- [x] Preserve the existing no-invented-identifiers rule, bump `INTEX_AGENT_SYSTEM_PROMPT` to `20.0.0`, and align the `create_code_task` description, property, and positive example with the same boundary.
+- [x] Make scenario `014` state that its two existing synthetic markers belong only in the code-task prompt and are not Linear issue IDs; preserve its turn/tool/criterion structure, absent-Linear assertions, marker evidence, and marker digest, then regenerate only the intentional full-catalog digest.
+- [ ] Ship the reviewed change, verify the exact Home Dev deployment, and require the focused scenario `014` to pass once without retrying through a failure.
+- [ ] Require a fresh complete 20-scenario endpoint gate to exit `0`; only then run `full` exactly once and require its independently fresh endpoint corpus plus the authorized Matrix smoke to exit `0` with MiniMax M3.
+- [ ] Complete the logged-in desktop/mobile Chrome audit and record final privacy-safe evidence.
+
+#### Endpoint Changes
+
+- **Modified:** none.
+- **Created:** none.
+- **Removed:** none.
+- **Unchanged:** the existing dev-only conversation test endpoint, request/response schema, Home Dev wrapper commands, mocked-product-tool boundary, MiniMax M3 judge, cleanup contract, and Matrix ordering gate.
+
+**Acceptance:** scenario `014` preserves both synthetic markers in the created task prompt while omitting Linear association; focused prompt/tool/catalog regressions pass, and the ordered shipping, endpoint, Matrix, and browser gates remain fail closed.
+
 ### Deferred perfection (recorded, not implemented in this loop)
 
 - Dedicated portable WhatsApp integration accounts and cross-machine credential bootstrap.

--- a/packages/llm-prompts/src/intex-agent/__tests__/systemPrompt.test.ts
+++ b/packages/llm-prompts/src/intex-agent/__tests__/systemPrompt.test.ts
@@ -7,10 +7,10 @@ const TIME_ZONE = 'UTC';
 describe('buildIntexAgentSystemPrompt', () => {
   it('exposes prompt metadata with semver versions', () => {
     expect(INTEX_AGENT_SYSTEM_PROMPT.version).toMatch(/^\d+\.\d+\.\d+$/);
-    expect(INTEX_AGENT_SYSTEM_PROMPT.version).toBe('19.0.0');
+    expect(INTEX_AGENT_SYSTEM_PROMPT.version).toBe('20.0.0');
     expect(buildIntexAgentSystemPrompt.name).toBe('intex-agent-system-prompt');
     expect(buildIntexAgentSystemPrompt.version).toMatch(/^\d+\.\d+\.\d+$/);
-    expect(buildIntexAgentSystemPrompt.version).toBe('12.0.0');
+    expect(buildIntexAgentSystemPrompt.version).toBe('13.0.0');
   });
 
   it('builds the base prompt with the current date-time', () => {
@@ -91,7 +91,7 @@ describe('buildIntexAgentSystemPrompt', () => {
     expect(prompt).toContain('Current-date questions are answerable from Current date-time');
   });
 
-  it('requires an explicit calendar date and preserves exact identifiers across clarification', () => {
+  it('requires explicit semantic Linear association and preserves exact identifiers across clarification', () => {
     const prompt = buildIntexAgentSystemPrompt.build({
       currentDateTime: CURRENT_DATE_TIME,
       timeZone: TIME_ZONE,
@@ -108,7 +108,10 @@ describe('buildIntexAgentSystemPrompt', () => {
       'For a new explicit create or save request after a completed tool action, build the new mutating tool arguments from the current request and its unresolved active clarification chain only'
     );
     expect(prompt).toContain(
-      'Never invent an identifier or code that the user did not provide; omit linearIssueId unless the user explicitly supplies it'
+      'Never invent an identifier or code that the user did not provide; set linearIssueId only when the user explicitly associates a supplied identifier with a Linear issue or ticket'
+    );
+    expect(prompt).toContain(
+      'An arbitrary opaque identifier, tracking marker, or evaluation marker in the task prompt is not enough; preserve it in the task prompt and omit linearIssueId'
     );
   });
 

--- a/packages/llm-prompts/src/intex-agent/systemPrompt.ts
+++ b/packages/llm-prompts/src/intex-agent/systemPrompt.ts
@@ -1,7 +1,7 @@
 import type { PromptBuilder } from '../types.js';
 
 export const INTEX_AGENT_SYSTEM_PROMPT = {
-  version: '19.0.0',
+  version: '20.0.0',
   text: [
     'You are Intex in WhatsApp Assistant conversations.',
     'Default to the language of the last reasonable user message in the current session, unless an explicit current-turn instruction or allowed user preference says otherwise. Ignore bare links, image-only messages, attachments, and trivial greetings such as "hello" when selecting the language. For ambiguous simple messages, use the wider conversation context before falling back to English. If no specific language can be classified, reply in English. The JSON reply value must follow this language rule.',
@@ -31,7 +31,7 @@ export const INTEX_AGENT_SYSTEM_PROMPT = {
     'Never infer a missing calendar-event date from Current date-time or treat a bare time such as "at noon" as today. If the user gives a time without an explicit or unambiguous relative calendar date, ask a targeted clarification for the date before using create_calendar_event.',
     'Preserve every exact user-provided identifier, code, reference, and opaque token verbatim across clarification turns and in final tool arguments. Never normalize, translate, shorten, reformat, or drop these exact values.',
     'For a new explicit create or save request after a completed tool action, build the new mutating tool arguments from the current request and its unresolved active clarification chain only. Do not copy content or identifiers from an earlier completed action unless the user explicitly asks to combine or reuse them.',
-    'Never invent an identifier or code that the user did not provide; omit linearIssueId unless the user explicitly supplies it.',
+    'Never invent an identifier or code that the user did not provide; set linearIssueId only when the user explicitly associates a supplied identifier with a Linear issue or ticket. An arbitrary opaque identifier, tracking marker, or evaluation marker in the task prompt is not enough; preserve it in the task prompt and omit linearIssueId.',
     'Do not use create_calendar_event to list, inspect, search, summarize, or answer questions about existing calendar events.',
     'Use query_calendar_events only for read-only calendar questions that ask to list, show, check, count, search, or answer whether existing events are present in a time window.',
     'For availability questions such as free one-hour meeting slots, use query_calendar_events for the requested time range, infer free windows from returned events, propose a few options, and do not create the event until the user chooses a specific option and explicitly asks to schedule it.',
@@ -71,7 +71,7 @@ export const buildIntexAgentSystemPrompt: PromptBuilder<BuildIntexAgentSystemPro
   name: 'intex-agent-system-prompt',
   description:
     'Intex Agent system prompt with optional user preferences and DST-safe local calendar context',
-  version: '12.0.0',
+  version: '13.0.0',
   build(input: BuildIntexAgentSystemPromptInput): string {
     const lines: string[] = [INTEX_AGENT_SYSTEM_PROMPT.text];
     if (input.userPreferences !== null && input.userPreferences.trim() !== '') {

--- a/tools/intex-agent-evals/scenarios/intex-eval-014.scenario.json
+++ b/tools/intex-agent-evals/scenarios/intex-eval-014.scenario.json
@@ -8,7 +8,7 @@
   "turns": [
     {
       "kind": "message",
-      "text": "Create a MiniMax planning code task to investigate synthetic cache behavior INTEX-EVAL-014 INTEX-EVAL-014-F01.",
+      "text": "Create a MiniMax planning code task to investigate synthetic cache behavior. Keep both exact markers INTEX-EVAL-014 and INTEX-EVAL-014-F01 in the task prompt as synthetic test markers only. They are not Linear issue IDs, and the task must not be associated with Linear.",
       "sourceType": "whatsapp_text"
     },
     {

--- a/tools/intex-agent-evals/src/__tests__/trackedScenarioCatalog.test.ts
+++ b/tools/intex-agent-evals/src/__tests__/trackedScenarioCatalog.test.ts
@@ -988,6 +988,9 @@ describe('tracked scenario catalog', () => {
     const request = scenario.expected.turns[0];
     const execution = findRequiredToolCall(scenario, 'create_code_task');
 
+    expect(messageText(scenario, 0)).toBe(
+      'Create a MiniMax planning code task to investigate synthetic cache behavior. Keep both exact markers INTEX-EVAL-014 and INTEX-EVAL-014-F01 in the task prompt as synthetic test markers only. They are not Linear issue IDs, and the task must not be associated with Linear.'
+    );
     expect(
       request === undefined
         ? false
@@ -1102,7 +1105,7 @@ describe('tracked scenario catalog', () => {
 
   it('matches the stable SHA-256 digest of the full canonical parsed catalog', () => {
     expect(fullCatalogDigest(scenarios)).toBe(
-      'e6165511fd385be173d1ae3b8f28f5d1953073945acc363f5978c26c026c7957'
+      '6e69c02ec4d06d25d7934997d734486b46f27ab42828a3124f437b3e6bf1b9e8'
     );
   });
 });


### PR DESCRIPTION
## Summary
- require an explicit semantic Linear issue/ticket association before setting linearIssueId
- keep arbitrary opaque, tracking, and evaluation markers in the code-task prompt instead of associating them with Linear
- make scenario 014 unambiguous while preserving both markers, its absent-Linear assertions, worker, mode, and marker digest
- bump the affected base prompt and builder versions

## Verification
- focused prompt/tool/runner/catalog tests: 260 passed
- relevant typechecks and lints: pass
- independent review and re-review: 0 Critical, 0 Important, 0 Minor
- pnpm run ci:tracked: 5,556 tests plus coverage, build, format, and bundle budget pass

Fixes INT-1879.

## Code Task
- Linear: [INT-1879](https://linear.app/pbuchman/issue/INT-1879)
- IntexuraOS Code Task: [View task](https://intexuraos.cloud/#/code-tasks/task_7aefb20b-d78e-4eee-8672-be76c53c161a)
- Worker Type: `codex-xhigh`
- Model: `default`
