### PR TITLE
[INT-1881] fix(web): hide technical Intex event payloads

### DIFF
--- a/apps/web/src/components/intex-agent/IntexSessionTimeline.tsx
+++ b/apps/web/src/components/intex-agent/IntexSessionTimeline.tsx
@@ -1,5 +1,12 @@
 import { Bot, CheckCircle2, MessageCircle, PlayCircle, Wrench } from 'lucide-react';
-import type { IntexAgentSession, IntexAgentSessionEvent } from '@/types';
+import type {
+  IntexAgentSession,
+  IntexAgentSessionEndReason,
+  IntexAgentSessionEvent,
+  IntexAgentSessionStartReason,
+  IntexAgentSessionStatus,
+  IntexAgentToolName,
+} from '@/types';
 import {
   formatSessionDateTimeCompact,
   formatSessionValue,
@@ -14,11 +21,99 @@ interface IntexSessionTimelineProps {
   loading: boolean;
 }
 
-function getPayloadString(payload: Record<string, unknown>, key: string): string | undefined {
+type IntexAgentFallbackReason =
+  | 'classifier_unsupported'
+  | 'runner_declared_unsupported'
+  | 'runner_output_malformed'
+  | 'tool_result_mismatch'
+  | 'llm_call_failed';
+
+type ConfirmationResolution = 'accepted' | 'rejected' | 'superseded';
+
+const SESSION_STATUSES = {
+  active: true,
+  waiting_for_user: true,
+  executing_tool: true,
+  completed: true,
+  unsupported: true,
+  expired: true,
+  cancelled: true,
+  superseded: true,
+} satisfies Record<IntexAgentSessionStatus, true>;
+
+const SESSION_START_REASONS = {
+  no_active_session: true,
+  previous_completed: true,
+  previous_expired: true,
+  user_requested_new_session: true,
+  previous_superseded: true,
+} satisfies Record<IntexAgentSessionStartReason, true>;
+
+const SESSION_END_REASONS = {
+  tool_completed: true,
+  tool_failed: true,
+  unsupported_request: true,
+  timeout: true,
+  cancelled_by_user: true,
+  superseded_by_user: true,
+} satisfies Record<IntexAgentSessionEndReason, true>;
+
+const TOOL_NAMES = {
+  create_note: true,
+  create_calendar_event: true,
+  query_calendar_events: true,
+  create_research: true,
+  create_link: true,
+  create_code_task: true,
+  save_external: true,
+  get_user_preferences: true,
+  add_user_preference: true,
+  update_user_preference: true,
+  delete_user_preference: true,
+} satisfies Record<IntexAgentToolName, true>;
+
+const FALLBACK_REASONS = {
+  classifier_unsupported: true,
+  runner_declared_unsupported: true,
+  runner_output_malformed: true,
+  tool_result_mismatch: true,
+  llm_call_failed: true,
+} satisfies Record<IntexAgentFallbackReason, true>;
+
+const CONFIRMATION_RESOLUTIONS = {
+  accepted: true,
+  rejected: true,
+  superseded: true,
+} satisfies Record<ConfirmationResolution, true>;
+
+function getCanonicalValue<T extends string>(
+  payload: Record<string, unknown>,
+  key: string,
+  values: Readonly<Record<T, true>>
+): T | undefined {
+  const value = payload[key];
+  if (typeof value !== 'string' || !Object.hasOwn(values, value)) {
+    return undefined;
+  }
+  return value as T;
+}
+
+function getDisplayString(payload: Record<string, unknown>, key: string): string | undefined {
   const value = payload[key];
   if (typeof value !== 'string' || value.trim() === '') {
     return undefined;
   }
+
+  const trimmed = value.trim();
+  try {
+    const parsed: unknown = JSON.parse(trimmed);
+    if (typeof parsed === 'object' && parsed !== null) {
+      return undefined;
+    }
+  } catch {
+    // Ordinary text is intentionally displayable.
+  }
+
   return value;
 }
 
@@ -40,39 +135,78 @@ function getEventTitle(event: IntexAgentSessionEvent): string {
       return 'Confirmation requested';
     case 'confirmation_resolved':
       return 'Confirmation resolved';
-    case 'tool_call_started':
-      return `${formatSessionValue(getPayloadString(event.payload, 'toolName'))} started`;
-    case 'tool_call_completed':
-      return `${formatSessionValue(getPayloadString(event.payload, 'toolName'))} completed`;
-    case 'tool_call_failed':
-      return `${formatSessionValue(getPayloadString(event.payload, 'toolName'))} failed`;
+    case 'tool_call_started': {
+      const toolName = getCanonicalValue(event.payload, 'toolName', TOOL_NAMES);
+      return toolName === undefined
+        ? 'Tool call started'
+        : `${formatSessionValue(toolName)} started`;
+    }
+    case 'tool_call_completed': {
+      const toolName = getCanonicalValue(event.payload, 'toolName', TOOL_NAMES);
+      return toolName === undefined
+        ? 'Tool call completed'
+        : `${formatSessionValue(toolName)} completed`;
+    }
+    case 'tool_call_failed': {
+      const toolName = getCanonicalValue(event.payload, 'toolName', TOOL_NAMES);
+      return toolName === undefined
+        ? 'Tool call failed'
+        : `${formatSessionValue(toolName)} failed`;
+    }
     case 'unsupported_request':
       return 'Unsupported request';
   }
 }
 
-function getEventBody(event: IntexAgentSessionEvent): string {
-  const text = getPayloadString(event.payload, 'text');
-  if (text !== undefined) return text;
-
-  const message = getPayloadString(event.payload, 'message');
-  if (message !== undefined) return message;
-
-  const reason = getPayloadString(event.payload, 'reason');
-  const status = getPayloadString(event.payload, 'status');
-  const toolName = getPayloadString(event.payload, 'toolName');
-  const parts = [
-    reason !== undefined ? `Reason: ${formatSessionValue(reason)}` : undefined,
-    status !== undefined ? `Status: ${formatSessionValue(status)}` : undefined,
-    toolName !== undefined ? `Tool: ${formatSessionValue(toolName)}` : undefined,
-    event.payload['explicit'] === true ? 'Explicitly announced to user' : undefined,
-  ].filter((part): part is string => part !== undefined);
-
-  if (parts.length > 0) {
-    return parts.join(' · ');
+function getEventBody(event: IntexAgentSessionEvent): string | undefined {
+  switch (event.type) {
+    case 'user_message':
+    case 'assistant_message':
+      return getDisplayString(event.payload, 'text');
+    case 'clarification_requested':
+    case 'confirmation_requested':
+    case 'unsupported_request':
+      return (
+        getDisplayString(event.payload, 'message') ?? getDisplayString(event.payload, 'text')
+      );
+    case 'session_started': {
+      const reason = getCanonicalValue(event.payload, 'reason', SESSION_START_REASONS);
+      const parts = [
+        reason !== undefined ? `Reason: ${formatSessionValue(reason)}` : undefined,
+        event.payload['explicit'] === true ? 'Explicitly announced to user' : undefined,
+      ].filter((part): part is string => part !== undefined);
+      return parts.length === 0 ? undefined : parts.join(' · ');
+    }
+    case 'session_closed': {
+      const reason = getCanonicalValue(event.payload, 'reason', SESSION_END_REASONS);
+      const status = getCanonicalValue(event.payload, 'status', SESSION_STATUSES);
+      const parts = [
+        reason !== undefined ? `Reason: ${formatSessionValue(reason)}` : undefined,
+        status !== undefined ? `Status: ${formatSessionValue(status)}` : undefined,
+      ].filter((part): part is string => part !== undefined);
+      return parts.length === 0 ? undefined : parts.join(' · ');
+    }
+    case 'tool_call_started':
+    case 'tool_call_completed':
+    case 'tool_call_failed': {
+      const toolName = getCanonicalValue(event.payload, 'toolName', TOOL_NAMES);
+      return toolName === undefined ? undefined : `Tool: ${formatSessionValue(toolName)}`;
+    }
+    case 'confirmation_resolved': {
+      const resolution = getCanonicalValue(
+        event.payload,
+        'resolution',
+        CONFIRMATION_RESOLUTIONS
+      );
+      return resolution === undefined
+        ? undefined
+        : `Resolution: ${formatSessionValue(resolution)}`;
+    }
+    case 'agent_fallback': {
+      const reason = getCanonicalValue(event.payload, 'reason', FALLBACK_REASONS);
+      return reason === undefined ? undefined : `Reason: ${formatSessionValue(reason)}`;
+    }
   }
-
-  return JSON.stringify(event.payload);
 }
 
 function EventIcon({ event }: { event: IntexAgentSessionEvent }): React.JSX.Element {
@@ -172,30 +306,35 @@ export function IntexSessionTimeline({
         ) : null}
 
         <div className="space-y-3">
-          {events.map((event) => (
-            <article
-              key={event.id}
-              className={`rounded-lg border px-4 py-3 ${getSessionEventClass(event.type)}`}
-            >
-              <div className="mb-2 flex flex-wrap items-center gap-2">
-                <span className="text-slate-500 dark:text-slate-400">
-                  <EventIcon event={event} />
-                </span>
-                <span className="text-sm font-semibold text-slate-950 dark:text-slate-50">
-                  {getEventTitle(event)}
-                </span>
-                <time
-                  dateTime={event.createdAt}
-                  className="text-xs font-medium text-slate-500 dark:text-slate-400"
-                >
-                  {formatSessionDateTimeCompact(event.createdAt)}
-                </time>
-              </div>
-              <p className="whitespace-pre-wrap break-words text-sm leading-6 text-slate-800 dark:text-slate-100">
-                {getEventBody(event)}
-              </p>
-            </article>
-          ))}
+          {events.map((event) => {
+            const body = getEventBody(event);
+            return (
+              <article
+                key={event.id}
+                className={`rounded-lg border px-4 py-3 ${getSessionEventClass(event.type)}`}
+              >
+                <div className="mb-2 flex flex-wrap items-center gap-2">
+                  <span className="text-slate-500 dark:text-slate-400">
+                    <EventIcon event={event} />
+                  </span>
+                  <span className="text-sm font-semibold text-slate-950 dark:text-slate-50">
+                    {getEventTitle(event)}
+                  </span>
+                  <time
+                    dateTime={event.createdAt}
+                    className="text-xs font-medium text-slate-500 dark:text-slate-400"
+                  >
+                    {formatSessionDateTimeCompact(event.createdAt)}
+                  </time>
+                </div>
+                {body !== undefined ? (
+                  <p className="whitespace-pre-wrap break-words text-sm leading-6 text-slate-800 dark:text-slate-100">
+                    {body}
+                  </p>
+                ) : null}
+              </article>
+            );
+          })}
         </div>
       </div>
     </section>

--- a/apps/web/src/components/intex-agent/__tests__/IntexSessionTimeline.test.tsx
+++ b/apps/web/src/components/intex-agent/__tests__/IntexSessionTimeline.test.tsx
@@ -1,6 +1,6 @@
 import { cleanup, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
-import type { IntexAgentSession } from '@/types';
+import type { IntexAgentSession, IntexAgentSessionEvent, IntexAgentToolName } from '@/types';
 import { formatDateTimeCompact } from '@/utils/dateFormat';
 import { IntexSessionTimeline } from '../IntexSessionTimeline.js';
 
@@ -21,6 +21,113 @@ function session(overrides: Partial<IntexAgentSession> = {}): IntexAgentSession 
     ...overrides,
   };
 }
+
+function event(overrides: Partial<IntexAgentSessionEvent> = {}): IntexAgentSessionEvent {
+  return {
+    id: 'event-1',
+    sessionId: 'session-1',
+    userId: 'user-1',
+    type: 'user_message',
+    payload: { text: 'Visible user text' },
+    createdAt: '2026-06-24T22:15:01.000Z',
+    ...overrides,
+  };
+}
+
+function getEventCard(title: string): HTMLElement {
+  const card = screen.getByText(title).closest('article');
+  if (!(card instanceof HTMLElement)) {
+    throw new Error('Expected event card');
+  }
+  return card;
+}
+
+interface EventBodyCase {
+  payload: Record<string, unknown>;
+  body: string;
+  omitted: string[];
+}
+
+const EVENT_BODY_CASES = {
+  session_started: {
+    payload: {
+      reason: 'no_active_session',
+      status: 'active',
+      explicit: true,
+      text: 'Ignored lifecycle text',
+    },
+    body: 'Reason: No Active Session · Explicitly announced to user',
+    omitted: ['Ignored lifecycle text'],
+  },
+  session_closed: {
+    payload: {
+      reason: 'tool_completed',
+      status: 'completed',
+      message: 'Ignored closed-session message',
+    },
+    body: 'Reason: Tool Completed · Status: Completed',
+    omitted: ['Ignored closed-session message'],
+  },
+  user_message: {
+    payload: { text: 'Visible matrix user text', message: 'Ignored user message' },
+    body: 'Visible matrix user text',
+    omitted: ['Ignored user message'],
+  },
+  assistant_message: {
+    payload: { text: 'Visible matrix assistant text', message: 'Ignored assistant message' },
+    body: 'Visible matrix assistant text',
+    omitted: ['Ignored assistant message'],
+  },
+  agent_fallback: {
+    payload: {
+      reason: 'runner_output_malformed',
+      status: 'waiting_for_user',
+      text: 'Ignored fallback text',
+    },
+    body: 'Reason: Runner Output Malformed',
+    omitted: ['Ignored fallback text'],
+  },
+  clarification_requested: {
+    payload: { message: 'Visible clarification', text: 'Ignored clarification fallback' },
+    body: 'Visible clarification',
+    omitted: ['Ignored clarification fallback'],
+  },
+  confirmation_requested: {
+    payload: {
+      message: '{"nestedTransport":"hidden"}',
+      text: 'Visible confirmation fallback',
+    },
+    body: 'Visible confirmation fallback',
+    omitted: ['{"nestedTransport":"hidden"}'],
+  },
+  confirmation_resolved: {
+    payload: { resolution: 'accepted', text: 'Ignored resolution text' },
+    body: 'Resolution: Accepted',
+    omitted: ['Ignored resolution text'],
+  },
+  tool_call_started: {
+    payload: { toolName: 'create_note', text: 'Ignored started-tool text' },
+    body: 'Tool: Create Note',
+    omitted: ['Ignored started-tool text'],
+  },
+  tool_call_completed: {
+    payload: { toolName: 'create_calendar_event', text: 'Ignored completed-tool text' },
+    body: 'Tool: Create Calendar Event',
+    omitted: ['Ignored completed-tool text'],
+  },
+  tool_call_failed: {
+    payload: { toolName: 'save_external', message: 'Ignored failed-tool message' },
+    body: 'Tool: Save External',
+    omitted: ['Ignored failed-tool message'],
+  },
+  unsupported_request: {
+    payload: { message: 'Visible unsupported message', text: 'Ignored unsupported fallback' },
+    body: 'Visible unsupported message',
+    omitted: ['Ignored unsupported fallback'],
+  },
+} satisfies Record<IntexAgentSessionEvent['type'], EventBodyCase>;
+
+const EVENT_BODY_TYPES = Object.keys(EVENT_BODY_CASES) as IntexAgentSessionEvent['type'][];
 
 describe('IntexSessionTimeline', () => {
   afterEach(() => {
@@ -50,5 +157,263 @@ describe('IntexSessionTimeline', () => {
     expect(screen.getByText('Started Unknown')).toBeInTheDocument();
     expect(screen.queryByText('End: Unknown')).not.toBeInTheDocument();
     expect(screen.queryByText('Tool: Unknown')).not.toBeInTheDocument();
+  });
+
+  it('keeps ordinary user and assistant text visible', () => {
+    render(
+      <IntexSessionTimeline
+        session={session()}
+        events={[
+          event(),
+          event({
+            id: 'event-2',
+            type: 'assistant_message',
+            payload: { text: 'Visible assistant text' },
+          }),
+        ]}
+        loading={false}
+      />
+    );
+
+    expect(screen.getByText('Visible user text')).toBeInTheDocument();
+    expect(screen.getByText('Visible assistant text')).toBeInTheDocument();
+  });
+
+  it.each(EVENT_BODY_TYPES)('renders only the allow-listed body for %s', (type) => {
+    const bodyCase = EVENT_BODY_CASES[type];
+    render(
+      <IntexSessionTimeline
+        session={session()}
+        events={[
+          event({
+            type,
+            payload: { ...bodyCase.payload, privateMetadata: 'Ignored technical marker' },
+          }),
+        ]}
+        loading={false}
+      />
+    );
+
+    expect(screen.getByText(bodyCase.body)).toBeInTheDocument();
+    expect(screen.queryByText('Ignored technical marker')).not.toBeInTheDocument();
+    for (const omitted of bodyCase.omitted) {
+      expect(screen.queryByText(omitted)).not.toBeInTheDocument();
+    }
+  });
+
+  it('omits serialized object and array message strings', () => {
+    render(
+      <IntexSessionTimeline
+        session={session()}
+        events={[
+          event({ payload: { text: '{"transportId":"hidden"}' } }),
+          event({
+            id: 'event-2',
+            type: 'assistant_message',
+            payload: { text: '[{"metadataToken":"hidden"}]' },
+          }),
+        ]}
+        loading={false}
+      />
+    );
+
+    expect(screen.queryByText(/transportId/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/metadataToken/)).not.toBeInTheDocument();
+    expect(getEventCard('User').querySelector('p')).toBeNull();
+    expect(getEventCard('IntexuraOS').querySelector('p')).toBeNull();
+  });
+
+  it.each([
+    ['accepted', 'Accepted'],
+    ['rejected', 'Rejected'],
+    ['superseded', 'Superseded'],
+  ])('renders only the normalized %s confirmation resolution', (resolution, label) => {
+    render(
+      <IntexSessionTimeline
+        session={session()}
+        events={[
+          event({
+            type: 'confirmation_resolved',
+            payload: {
+              resolution,
+              requestId: 'hidden',
+              metadata: { source: 'transport' },
+            },
+          }),
+        ]}
+        loading={false}
+      />
+    );
+
+    expect(screen.getByText(`Resolution: ${label}`)).toBeInTheDocument();
+    expect(screen.queryByText(/requestId|metadata|transport/)).not.toBeInTheDocument();
+  });
+
+  it('keeps a confirmation card with an unknown resolution but omits its body', () => {
+    const confirmation = event({
+      type: 'confirmation_resolved',
+      payload: { resolution: 'confirmed', requestId: 'hidden' },
+      createdAt: '2026-06-25T09:30:00.000Z',
+    });
+
+    render(
+      <IntexSessionTimeline
+        session={session()}
+        events={[confirmation]}
+        loading={false}
+      />
+    );
+
+    const card = getEventCard('Confirmation resolved');
+    expect(card).toHaveTextContent(formatDateTimeCompact(confirmation.createdAt));
+    expect(card.querySelector('p')).toBeNull();
+  });
+
+  it.each([
+    ['session_started', { reason: 'tool_completed' }, 'Session started'],
+    ['session_closed', { reason: 'no_active_session' }, 'Session closed'],
+    ['session_closed', { status: 'future_status' }, 'Session closed'],
+    ['agent_fallback', { reason: 'future_fallback' }, 'Agent fallback'],
+  ] satisfies [IntexAgentSessionEvent['type'], Record<string, unknown>, string][]) (
+    'omits an unknown canonical value for %s',
+    (type, payload, title) => {
+      render(
+        <IntexSessionTimeline
+          session={session()}
+          events={[event({ type, payload })]}
+          loading={false}
+        />
+      );
+
+      expect(getEventCard(title).querySelector('p')).toBeNull();
+    }
+  );
+
+  it.each([
+    ['session_started', 'Session started'],
+    ['agent_fallback', 'Agent fallback'],
+  ] satisfies [IntexAgentSessionEvent['type'], string][]) (
+    'omits status when it is not allow-listed for %s',
+    (type, title) => {
+      render(
+        <IntexSessionTimeline
+          session={session()}
+          events={[event({ type, payload: { status: 'active' } })]}
+          loading={false}
+        />
+      );
+
+      expect(getEventCard(title).querySelector('p')).toBeNull();
+    }
+  );
+
+  it.each([
+    ['tool_call_started', 'Tool call started'],
+    ['tool_call_completed', 'Tool call completed'],
+    ['tool_call_failed', 'Tool call failed'],
+  ] satisfies [IntexAgentSessionEvent['type'], string][]) (
+    'uses a safe title and no body for an unknown %s tool name',
+    (type, title) => {
+      render(
+        <IntexSessionTimeline
+          session={session()}
+          events={[event({ type, payload: { toolName: 'future_tool' } })]}
+          loading={false}
+        />
+      );
+
+      expect(getEventCard(title).querySelector('p')).toBeNull();
+      expect(screen.queryByText(/Future Tool/)).not.toBeInTheDocument();
+    }
+  );
+
+  it.each(['null', 'true', '42', '"visible-json-string"']) (
+    'keeps the JSON primitive %s as ordinary message text',
+    (text) => {
+      render(
+        <IntexSessionTimeline
+          session={session()}
+          events={[event({ payload: { text } })]}
+          loading={false}
+        />
+      );
+
+      expect(screen.getByText(text)).toBeInTheDocument();
+    }
+  );
+
+  it('keeps syntactically invalid JSON-like text visible', () => {
+    const text = '{not actually json';
+
+    render(
+      <IntexSessionTimeline
+        session={session()}
+        events={[event({ payload: { text } })]}
+        loading={false}
+      />
+    );
+
+    expect(screen.getByText(text)).toBeInTheDocument();
+  });
+
+  it.each([
+    ['tool_call_started', 'create_note', 'Create Note started'],
+    ['tool_call_completed', 'create_calendar_event', 'Create Calendar Event completed'],
+    ['tool_call_failed', 'save_external', 'Save External failed'],
+  ] satisfies [IntexAgentSessionEvent['type'], IntexAgentToolName, string][]) (
+    'renders the canonical title for %s with %s',
+    (type, toolName, title) => {
+      render(
+        <IntexSessionTimeline
+          session={session()}
+          events={[event({ type, payload: { toolName } })]}
+          loading={false}
+        />
+      );
+
+      expect(screen.getByText(title)).toBeInTheDocument();
+    }
+  );
+
+  it('renders only the normalized tool name for tool completion', () => {
+    render(
+      <IntexSessionTimeline
+        session={session()}
+        events={[
+          event({
+            type: 'tool_call_completed',
+            payload: {
+              toolName: 'create_note',
+              result: { reference: 'hidden' },
+              metadata: { transportId: 'hidden' },
+            },
+          }),
+        ]}
+        loading={false}
+      />
+    );
+
+    expect(screen.getByText('Tool: Create Note')).toBeInTheDocument();
+    expect(screen.queryByText(/result|reference|metadata|transportId/)).not.toBeInTheDocument();
+  });
+
+  it('keeps unsupported technical payload data out of the rendered card', () => {
+    const unsupported = event({
+      type: 'unsupported_request',
+      payload: {
+        transportId: 'hidden',
+        metadata: { requestId: 'hidden' },
+      },
+      createdAt: '2026-06-25T10:00:00.000Z',
+    });
+
+    render(
+      <IntexSessionTimeline session={session()} events={[unsupported]} loading={false} />
+    );
+
+    const card = getEventCard('Unsupported request');
+    expect(card).toHaveTextContent(formatDateTimeCompact(unsupported.createdAt));
+    expect(card.querySelector('p')).toBeNull();
+    expect(screen.queryByText(/transportId|metadata|requestId/)).not.toBeInTheDocument();
   });
 });

--- a/docs/superpowers/plans/2026-07-18-intex-agent-live-acceptance-fixes.md
+++ b/docs/superpowers/plans/2026-07-18-intex-agent-live-acceptance-fixes.md
@@ -627,6 +627,42 @@ The first authorized Matrix message and Chrome audit exposed additional defects 
 
 **Acceptance:** the isolated judge receives complete observable sanitized criteria for all three replies while closed technical facts remain authoritative for execution and supersession; every deterministic contract is unchanged, and the ordered shipping, focused, endpoint, full/Matrix, and browser gates remain fail closed.
 
+### Task 31: Keep technical event payloads out of the session timeline
+
+**Evidence:** the logged-in desktop/mobile Home Dev audit passed session selection,
+responsive ordering, focus restoration, refresh, preferences validation/history,
+settings rendering, console, and network checks. The selected timeline nevertheless
+contained four visible structured JSON bodies, including technical message and
+confirmation metadata. No payload value or private identifier is recorded here.
+
+- [x] Record the approved strict frontend allow-list design in
+  `docs/superpowers/specs/2026-07-19-intex-session-timeline-safe-presentation-design.md`.
+- [x] Add RED component tests proving ordinary conversation text remains visible,
+  structured JSON strings and unknown payloads remain absent, confirmation resolution
+  exposes only its safe state, and tool events ignore extra metadata.
+- [x] Replace the generic payload serialization with the event-specific allow-list and
+  omit the body paragraph when no safe display value exists.
+- [x] Preserve API/storage contracts, event title/timestamp/order, desktop/mobile layout,
+  search, refresh, accessibility, and every endpoint/Matrix invariant.
+- [ ] Close every independent-review finding, run focused web tests plus exact
+  `pnpm run ci:tracked`, and ship through a reviewed PR.
+- [ ] Verify the exact Home Dev deployment, then repeat the logged-in desktop/mobile
+  Chrome audit and require zero structured JSON bodies, zero console/network failures,
+  successful refresh/rapid selection, and no horizontal overflow.
+
+#### Endpoint Changes
+
+- **Modified:** none.
+- **Created:** none.
+- **Removed:** none.
+- **Unchanged:** the dev-only conversation endpoint, request/response schema, scenario
+  catalog, MiniMax M3 judge, mocked-tool boundary, cleanup, and Matrix gate.
+
+**Acceptance:** the authenticated session timeline never serializes arbitrary event
+payloads or displays noncanonical technical event fields, while established user-facing
+session summaries, safe human-readable event evidence, and all previously verified
+endpoint behavior remain intact.
+
 ### Deferred perfection (recorded, not implemented in this loop)
 
 - Dedicated portable WhatsApp integration accounts and cross-machine credential bootstrap.

--- a/docs/superpowers/plans/2026-07-19-intex-session-timeline-safe-presentation.md
+++ b/docs/superpowers/plans/2026-07-19-intex-session-timeline-safe-presentation.md
@@ -1,0 +1,142 @@
+# Intex Session Timeline Safe Presentation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent the authenticated Intex Agent session timeline from rendering arbitrary technical event payloads while preserving safe human-readable event evidence.
+
+**Architecture:** Keep the API and stored events unchanged. `IntexSessionTimeline` applies an event-type allow-list plus closed canonical value sets, rejects structured object/array JSON in message strings, safely titles tool events, and omits the body paragraph when no safe value exists.
+
+**Tech Stack:** React 19, TypeScript 5.8, Vitest 4, Testing Library, Home Dev, Chrome.
+
+## Global Constraints
+
+- Never render or log an entire event payload.
+- Never display a `text` or `message` value that parses to a JSON object or array.
+- Never format an enum-like payload string until it belongs to its canonical closed set.
+- Preserve event title, icon, timestamp, order, session metadata, API/storage contracts, responsive layout, search, refresh, endpoint evaluations, MiniMax M3, and Matrix ordering.
+- Keep the five user-owned untracked design files untouched and outside every commit.
+
+---
+
+### Task 1: Add the safe timeline body projection
+
+**Files:**
+- Modify: `apps/web/src/components/intex-agent/IntexSessionTimeline.tsx`
+- Test: `apps/web/src/components/intex-agent/__tests__/IntexSessionTimeline.test.tsx`
+- Modify: `docs/superpowers/plans/2026-07-18-intex-agent-live-acceptance-fixes.md`
+
+**Interfaces:**
+- Consumes: `IntexAgentSessionEvent` with `type` and `payload`.
+- Produces: internal `getEventBody(event): string | undefined`; `undefined` means render no body paragraph.
+
+- [x] **Step 1: Add RED component regressions**
+
+  Add an `event(overrides)` fixture and tests with exact assertions:
+
+  ```tsx
+  function event(overrides: Partial<IntexAgentSessionEvent> = {}): IntexAgentSessionEvent {
+    return {
+      id: 'event-1',
+      sessionId: 'session-1',
+      userId: 'user-1',
+      type: 'user_message',
+      payload: { text: 'Visible user text' },
+      createdAt: '2026-06-24T22:15:01.000Z',
+      ...overrides,
+    };
+  }
+  ```
+
+  Cover all twelve event types. Prove ordinary text, compatible `message`/`text`
+  fallback priority, syntactically invalid text, and JSON primitives remain visible;
+  serialized object and array strings are absent; `confirmation_resolved` accepts only
+  `accepted`, `rejected`, and `superseded`; a resolution-less confirmation card has no
+  `<p>`; all tool event variants accept only canonical tool names and ignore extra
+  `result`/`metadata`; lifecycle and fallback values use closed sets; unknown values and
+  unsupported technical payloads remain absent.
+
+- [x] **Step 2: Run the focused test and observe RED**
+
+  Run:
+
+  ```bash
+  pnpm --filter @intexuraos/web exec vitest run src/components/intex-agent/__tests__/IntexSessionTimeline.test.tsx
+  ```
+
+  Expected: new privacy assertions fail because structured message JSON or the generic
+  `JSON.stringify(event.payload)` output is still present.
+
+- [x] **Step 3: Implement the minimal allow-list**
+
+  Add a helper that trims message strings and rejects parsed objects/arrays:
+
+  ```ts
+  function getDisplayString(payload: Record<string, unknown>, key: string): string | undefined {
+    const value = payload[key];
+    if (typeof value !== 'string' || value.trim() === '') return undefined;
+    const trimmed = value.trim();
+    try {
+      const parsed: unknown = JSON.parse(trimmed);
+      if (typeof parsed === 'object' && parsed !== null) return undefined;
+    } catch {
+      // Ordinary text is intentionally displayable.
+    }
+    return value;
+  }
+  ```
+
+  Define readonly canonical sets for existing session statuses, start reasons, end
+  reasons, Intex Agent tool names, fallback reasons, and confirmation resolutions.
+  Switch on `event.type` to select only the fields defined in the design. The title and
+  body of tool events must share the same canonical tool resolver; an unknown name uses
+  `Tool call started`, `Tool call completed`, or `Tool call failed` and no body. Return
+  `undefined` for all unknown body data. Compute the body once per event and render
+  `<p>` only when it is defined. Do not introduce a redaction walker or backend change.
+
+- [x] **Step 4: Run focused GREEN and package checks**
+
+  Run:
+
+  ```bash
+  pnpm --filter @intexuraos/web exec vitest run src/components/intex-agent/__tests__/IntexSessionTimeline.test.tsx
+  pnpm --filter @intexuraos/web typecheck
+  pnpm --filter @intexuraos/web lint
+  ```
+
+  Expected: all commands exit `0`.
+
+- [ ] **Step 5: Review, verify, and record implementation evidence**
+
+  Request independent spec and code-quality reviews, resolve every Critical/Important
+  finding, run `git diff --check`, then run exact `pnpm run ci:tracked`. Mark only the
+  completed Task 31 implementation/review checkboxes in the active plan.
+
+### Task 2: Ship and repeat the live acceptance audit
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-07-18-intex-agent-live-acceptance-fixes.md`
+
+**Interfaces:**
+- Consumes: merged `development` revision containing Task 1.
+- Produces: exact Home Dev deployment evidence and privacy-safe Chrome acceptance evidence.
+
+- [ ] **Step 1: Ship through the repository workflow**
+
+  Commit only the intended design, plan, component, test, and active-plan files. Push a
+  `codex/` branch, create a reviewed PR to `development`, require every GitHub check to
+  pass, merge it, and verify Home Dev runs the exact merge SHA.
+
+- [ ] **Step 2: Repeat the logged-in Chrome audit**
+
+  On desktop and a narrow mobile breakpoint, verify session loading, rapid selection,
+  focus restoration, refresh, timeline/rail ordering, and no horizontal overflow.
+  Inspect only privacy-safe shapes: require zero body strings that parse to objects or
+  arrays, zero displayed technical key names from the observed regression, generic safe
+  titles for noncanonical tool names, zero console warnings/errors, and only successful
+  session list/event responses.
+
+- [ ] **Step 3: Record final evidence and close the loop**
+
+  Update Task 30 and Task 31 checkboxes/evidence without private content. Run the exact
+  commit gate again for the documentation-only evidence commit, ship it through a final
+  reviewed PR, and audit the complete user goal requirement by requirement.

--- a/docs/superpowers/specs/2026-07-19-intex-session-timeline-safe-presentation-design.md
+++ b/docs/superpowers/specs/2026-07-19-intex-session-timeline-safe-presentation-design.md
@@ -1,0 +1,94 @@
+# Intex Session Timeline Safe Presentation Design
+
+## Context
+
+The logged-in Home Dev UI audit found that the Intex Agent timeline can render an
+entire event payload through `JSON.stringify(payload)`. Live data proved that this
+can expose transport identifiers and other technical metadata. A message `text`
+value can also itself be serialized structured JSON, bypassing the generic payload
+fallback while producing the same unsafe result.
+
+## Decision
+
+Use a strict frontend allow-list for timeline titles and body text. The UI renders only
+fields that are intentionally meaningful for a specific event type. Enum-like values
+must belong to a closed canonical set before they are formatted. It never serializes
+an entire payload and never displays a `text` or `message` string that parses as a JSON
+object or array.
+
+This is preferred over recursively redacting arbitrary payloads because a deny-list
+cannot anticipate new nested identifiers. Moving display projection into the API is
+also unnecessary for this fix because the authenticated endpoint contract and stored
+events remain useful to other consumers and do not need to change.
+
+## Presentation Contract
+
+| Event type | Allowed timeline body |
+| --- | --- |
+| `user_message`, `assistant_message` | Non-empty, non-structured `text` |
+| `clarification_requested`, `confirmation_requested`, `unsupported_request` | Non-empty, non-structured `message`, with safe `text` as the existing compatible fallback |
+| `session_started` | A canonical session start reason and the existing explicit-announcement label |
+| `session_closed` | A canonical session end reason and session status |
+| `tool_call_started`, `tool_call_completed`, `tool_call_failed` | A canonical Intex Agent tool name only; an unknown name uses a fixed generic title and no body |
+| `confirmation_resolved` | Canonical `accepted`, `rejected`, or `superseded` resolution only |
+| `agent_fallback` | A canonical fallback reason only; arbitrary source outcomes remain hidden |
+| Missing or unrecognized display data | No body paragraph; title and timestamp remain visible |
+
+Structured JSON means a string that successfully parses to an object or array.
+JSON primitives remain ordinary text because they cannot contain nested transport
+metadata. A syntactically invalid string remains ordinary text; wrong field types and
+noncanonical enum-like values fail closed. The projection does not inspect, redact, or
+render unknown keys.
+
+The canonical sets are the existing frontend session status, start reason, end reason,
+and tool-name unions, plus fallback reasons `classifier_unsupported`,
+`runner_declared_unsupported`, `runner_output_malformed`, `tool_result_mismatch`, and
+`llm_call_failed`. The confirmation resolution set is `accepted`, `rejected`, and
+`superseded`.
+
+## Components and Data Flow
+
+`IntexSessionTimeline` owns the presentation projection. Small pure helpers validate
+canonical values, build a safe title, and select the safe body from an
+`IntexAgentSessionEvent` as `string | undefined`. Rendering omits the body paragraph
+when the helper returns `undefined`. Event icon, timestamp, ordering, session summary,
+session metadata, API responses, and persistence are unchanged. Session summaries are
+already user-facing content and are not arbitrary payload serialization; this task does
+not change their established presentation.
+
+## Error Handling
+
+Wrongly typed, noncanonical, or structured values fail closed to no body. JSON parsing
+is used only as a structural guard; syntactically invalid strings remain ordinary
+human-readable text. No parse error is surfaced to the user and no payload value is
+logged.
+
+## Testing
+
+Component regressions must prove:
+
+- all twelve event types use only their declared display fields;
+- ordinary user and assistant text, compatible message/text fallback priority, and JSON
+  primitives remain visible;
+- serialized object/array text and its technical key names are absent;
+- all three canonical confirmation resolutions render and an unknown one is absent;
+- confirmation events without an allowed value keep their card, title, and timestamp
+  but omit the body;
+- all tool event variants use canonical names, ignore extra result/metadata, and replace
+  an unknown name with a fixed generic title;
+- lifecycle and agent-fallback fields render only canonical values;
+- an unknown technical payload is never serialized;
+- existing metadata, responsive layout, search, and timeline projection tests remain
+  green.
+
+After unit and repository CI pass, deploy the exact merge to Home Dev and repeat the
+logged-in desktop/mobile audit. The live acceptance check requires zero JSON fallback
+bodies, no horizontal overflow, successful session refresh/selection, clean console,
+and only successful session API requests.
+
+## Out of Scope
+
+- Changing the Intex Agent session API or stored event schema.
+- Removing diagnostic data from authenticated API responses.
+- Implementing the deferred per-user Intex Agent model selector or language setting.
+- Changing endpoint evaluation, mocked tools, MiniMax M3 judging, or Matrix ordering.


### PR DESCRIPTION
## Summary
- replace arbitrary timeline payload serialization with an event-specific allow-list
- validate canonical lifecycle, tool, fallback, and confirmation values before rendering
- suppress structured object/array message strings and use safe generic tool titles for unknown names
- add a complete 12-event regression matrix and record Task 31 design/plan

## Verification
- focused timeline: 39/39
- web typecheck and lint: pass
- independent final review: 0 critical, 0 important, 0 minor
- pnpm run ci:tracked: 5,556 tests plus coverage, build, format, and bundle budget

No endpoint, stored-event, evaluator, Matrix, or mocked-tool contract changes.

Fixes INT-1881

## Code Task
- Linear: [INT-1881](https://linear.app/pbuchman/issue/INT-1881)
- IntexuraOS Code Task: [View task](https://intexuraos.cloud/#/code-tasks/task_33f57f43-eb87-41da-82d6-d832549e47fe)
- Worker Type: `codex-xhigh`
- Model: `default`