### PR TITLE
[INT-1883] docs(intex-agent): close evaluation evidence loop

### DIFF
--- a/docs/superpowers/plans/2026-07-19-intex-session-timeline-safe-presentation.md
+++ b/docs/superpowers/plans/2026-07-19-intex-session-timeline-safe-presentation.md
@@ -145,8 +145,17 @@
   list plus one successful event response on refresh, no network failures, and no console
   warnings/errors.
 
-- [ ] **Step 3: Record final evidence and close the loop**
+- [x] **Step 3: Record final evidence and close the loop**
 
   Update Task 30 and Task 31 checkboxes/evidence without private content. Run the exact
   commit gate again for the documentation-only evidence commit, ship it through a final
   reviewed PR, and audit the complete user goal requirement by requirement.
+
+  **Closeout evidence:** PR [#2347](https://github.com/pbuchman/intexuraos/pull/2347)
+  merged as `7210fb225133ef2e13bd6c92e386abc883e4059c` after all 15 non-skipped
+  GitHub checks passed, including all eight required status checks. Its exact
+  documentation diff passed local
+  `pnpm run ci:tracked` with `5556/5556` tests, coverage, build, format, and bundle
+  budget; independent review reported zero Critical, Important, or Minor findings.
+  The committed evidence contains no private message content, identifiers, tool
+  arguments, or user-specific account data.


### PR DESCRIPTION
## Summary
- mark the final Task 31 evidence closeout step complete
- record the merged evidence PR SHA and verified GitHub check counts
- keep the closeout privacy-safe and documentation-only

## Verification
- pnpm run ci:tracked (5,556 tests; typecheck, lint, static validation, coverage, build, format, bundle budget)
- git diff --check
- independent review: 0 Critical, Important, or Minor findings

- Linear: [INT-1883](https://linear.app/pbuchman/issue/INT-1883)
- IntexuraOS Code Task: [View task](https://intexuraos.cloud/#/code-tasks/task_c493b6c2-91f1-4ebb-99ad-b3c40040984f)
- Worker Type: `codex-xhigh`
- Model: `default`