### PR TITLE
[INT-1884] Fix private WhatsApp literal reaction index

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -2216,6 +2216,36 @@
           "order": "ASCENDING"
         }
       ]
+    },
+    {
+      "collectionGroup": "whatsapp_private_messages",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "chatId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "messageType",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "rawMatrixEvent.content.`\\`m`.`relates_to\\``.event_id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "sourceAccountId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "eventTimestamp",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "__name__",
+          "order": "ASCENDING"
+        }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/migrations/123_private-whatsapp-literal-reaction-index.mjs
+++ b/migrations/123_private-whatsapp-literal-reaction-index.mjs
@@ -1,0 +1,37 @@
+/**
+ * Migration 123: Private WhatsApp literal legacy-reaction field index.
+ *
+ * Required by the private chat reaction query. Firestore requested the literal
+ * escaped field path below, which is distinct from the normalized
+ * rawMatrixEvent.content.`m.relates_to`.event_id index declared by migration 121.
+ */
+
+export const metadata = {
+  id: '123',
+  name: 'private-whatsapp-literal-reaction-index',
+  description: 'Composite index required by private WhatsApp legacy reaction reads',
+  createdAt: '2026-07-19',
+};
+
+export const indexes = [
+  {
+    collectionGroup: 'whatsapp_private_messages',
+    queryScope: 'COLLECTION',
+    fields: [
+      { fieldPath: 'chatId', order: 'ASCENDING' },
+      { fieldPath: 'messageType', order: 'ASCENDING' },
+      {
+        fieldPath: 'rawMatrixEvent.content.`\\`m`.`relates_to\\``.event_id',
+        order: 'ASCENDING',
+      },
+      { fieldPath: 'sourceAccountId', order: 'ASCENDING' },
+      { fieldPath: 'eventTimestamp', order: 'ASCENDING' },
+      { fieldPath: '__name__', order: 'ASCENDING' },
+    ],
+  },
+];
+
+export async function up(context) {
+  console.log('  Deploying private WhatsApp literal legacy-reaction index...');
+  await context.deployIndexes();
+}

--- a/migrations/__tests__/123-private-whatsapp-literal-reaction-index.test.ts
+++ b/migrations/__tests__/123-private-whatsapp-literal-reaction-index.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { indexes, metadata, up } from '../123_private-whatsapp-literal-reaction-index.mjs'; // @allow-missing-js -- .mjs import
+
+describe('migration 123 - private WhatsApp literal reaction index', () => {
+  it('exports the expected metadata', () => {
+    expect(metadata).toEqual({
+      id: '123',
+      name: 'private-whatsapp-literal-reaction-index',
+      description: 'Composite index required by private WhatsApp legacy reaction reads',
+      createdAt: '2026-07-19',
+    });
+  });
+
+  it('defines the exact composite index requested by Firestore', () => {
+    expect(indexes).toEqual([
+      {
+        collectionGroup: 'whatsapp_private_messages',
+        queryScope: 'COLLECTION',
+        fields: [
+          { fieldPath: 'chatId', order: 'ASCENDING' },
+          { fieldPath: 'messageType', order: 'ASCENDING' },
+          {
+            fieldPath: 'rawMatrixEvent.content.`\\`m`.`relates_to\\``.event_id',
+            order: 'ASCENDING',
+          },
+          { fieldPath: 'sourceAccountId', order: 'ASCENDING' },
+          { fieldPath: 'eventTimestamp', order: 'ASCENDING' },
+          { fieldPath: '__name__', order: 'ASCENDING' },
+        ],
+      },
+    ]);
+  });
+
+  it('deploys indexes in up()', async () => {
+    const deployIndexes = vi.fn().mockResolvedValue(undefined);
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    await up({ deployIndexes });
+
+    expect(deployIndexes).toHaveBeenCalledOnce();
+    consoleSpy.mockRestore();
+  });
+
+  it('propagates deployIndexes failures from up()', async () => {
+    const deployIndexes = vi.fn().mockRejectedValue(new Error('deploy failed'));
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    await expect(up({ deployIndexes })).rejects.toThrow('deploy failed');
+
+    expect(deployIndexes).toHaveBeenCalledOnce();
+    consoleSpy.mockRestore();
+  });
+});

--- a/migrations/manifest.json
+++ b/migrations/manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastReservedId": "122",
+  "lastReservedId": "123",
   "entries": [
     {
       "id": "001",
@@ -610,6 +610,11 @@
       "id": "122",
       "name": "whatsapp-conversation-assistant-snapshot-index-redeploy",
       "checksum": "sha256:c1f73e696596487913e8731a254618e7032e5cc855f303757686309b9d192e61"
+    },
+    {
+      "id": "123",
+      "name": "private-whatsapp-literal-reaction-index",
+      "checksum": "sha256:8be6dd007e1e298d5f44f8694f25c369afb4fc29ecec131b100ff576492a3ac3"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Add migration 123 for the exact composite index requested by the private WhatsApp reaction query.
- Regenerate the committed Firestore index artifact and migration manifest.
- Cover the migration metadata, exact field order, deployment, and failure propagation.

## Verification

- `pnpm run verify:workspace:tracked whatsapp-service`
- `pnpm run ci:tracked`

## Linear

Linear: omitted by `$commit-push`; GitHub automation will create or link the Linear issue after PR creation.

- Linear: [INT-1884](https://linear.app/pbuchman/issue/INT-1884)
- IntexuraOS Code Task: [View task](https://intexuraos.cloud/#/code-tasks/task_4cf98c58-e9cb-4f04-b2cd-4737254a0574)
- Worker Type: `codex-xhigh`
- Model: `default`
