### PR TITLE
[INT-1886] feat: improve Conversation Assistant deletion and send status

### DIFF
--- a/apps/web/src/components/whatsapp/ConversationAssistantActionsMenu.tsx
+++ b/apps/web/src/components/whatsapp/ConversationAssistantActionsMenu.tsx
@@ -1,0 +1,103 @@
+import { EllipsisVertical, Trash2 } from 'lucide-react';
+import { useEffect, useId, useRef, useState } from 'react';
+
+export function ConversationAssistantActionsMenu({
+  title,
+  deleteLabel = 'Delete analysis',
+  onDelete,
+}: {
+  title: string;
+  deleteLabel?: string;
+  onDelete: (trigger: HTMLButtonElement) => void;
+}): React.JSX.Element {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const deleteItemRef = useRef<HTMLButtonElement | null>(null);
+  const menuId = useId();
+
+  useEffect(() => {
+    if (!open) return;
+    const focusTimer = window.setTimeout(() => {
+      deleteItemRef.current?.focus();
+    }, 0);
+    const closeOnOutsideClick = (event: MouseEvent): void => {
+      if (containerRef.current?.contains(event.target as Node) !== true) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', closeOnOutsideClick);
+    return (): void => {
+      window.clearTimeout(focusTimer);
+      document.removeEventListener('mousedown', closeOnOutsideClick);
+    };
+  }, [open]);
+
+  return (
+    <div
+      ref={containerRef}
+      onBlurCapture={(event): void => {
+        if (
+          open &&
+          (event.relatedTarget === null ||
+            !event.currentTarget.contains(event.relatedTarget as Node))
+        ) {
+          setOpen(false);
+        }
+      }}
+      className="relative shrink-0"
+    >
+      <button
+        ref={triggerRef}
+        type="button"
+        aria-label={`Actions for ${title}`}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-controls={open ? menuId : undefined}
+        onClick={(): void => {
+          setOpen((current) => !current);
+        }}
+        className="inline-flex min-h-11 min-w-11 items-center justify-center rounded-lg text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-900 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-slate-100"
+      >
+        <EllipsisVertical className="h-5 w-5" />
+      </button>
+      {open ? (
+        <div
+          id={menuId}
+          role="menu"
+          onKeyDown={(event): void => {
+            if (event.key === 'Escape') {
+              event.preventDefault();
+              setOpen(false);
+              triggerRef.current?.focus();
+              return;
+            }
+            if (event.key === 'Tab') {
+              setOpen(false);
+              if (event.shiftKey) {
+                event.preventDefault();
+                triggerRef.current?.focus();
+              }
+            }
+          }}
+          className="absolute right-0 top-full z-20 mt-1 w-44 rounded-lg border border-slate-200 bg-white py-1 shadow-lg dark:border-slate-700 dark:bg-slate-800"
+        >
+          <button
+            ref={deleteItemRef}
+            type="button"
+            role="menuitem"
+            onClick={(): void => {
+              setOpen(false);
+              const trigger = triggerRef.current;
+              if (trigger !== null) onDelete(trigger);
+            }}
+            className="flex min-h-11 w-full items-center gap-2 px-3 py-2 text-left text-sm font-medium text-red-600 transition-colors hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-red-500 dark:text-red-400 dark:hover:bg-red-950/40"
+          >
+            <Trash2 className="h-4 w-4" />
+            {deleteLabel}
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/whatsapp/ConversationAssistantComposer.tsx
+++ b/apps/web/src/components/whatsapp/ConversationAssistantComposer.tsx
@@ -1,17 +1,18 @@
 import { Send } from 'lucide-react';
 import { Button } from '@/components';
+import type { ConversationAssistantTurnPhase } from '@/hooks/useWhatsAppConversationAssistant';
 
 export function ConversationAssistantComposer({
   value,
   disabled,
-  sending,
+  turnPhase,
   mode,
   onChange,
   onSend,
 }: {
   value: string;
   disabled: boolean;
-  sending: boolean;
+  turnPhase: ConversationAssistantTurnPhase;
   mode: 'first-question' | 'follow-up';
   onChange: (value: string) => void;
   onSend: () => Promise<void>;
@@ -24,7 +25,7 @@ export function ConversationAssistantComposer({
 
   return (
     <form
-      className="flex flex-col gap-2 border-t border-slate-200 bg-white p-3 dark:border-slate-800 dark:bg-slate-900 sm:flex-row"
+      className="flex flex-row items-end gap-2 border-t border-slate-200 bg-white p-3 dark:border-slate-800 dark:bg-slate-900"
       onSubmit={(event): void => {
         event.preventDefault();
         void onSend();
@@ -39,21 +40,21 @@ export function ConversationAssistantComposer({
         onChange={(event): void => {
           onChange(event.target.value);
         }}
-        disabled={disabled || sending}
+        disabled={disabled || turnPhase === 'submitting'}
         rows={2}
-        className="min-h-12 flex-1 resize-none rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-950 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:bg-slate-100 disabled:text-slate-500 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-50 dark:disabled:bg-slate-800"
+        className="min-h-12 min-w-0 flex-1 resize-none rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-950 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:bg-slate-100 disabled:text-slate-500 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-50 dark:disabled:bg-slate-800"
         placeholder={placeholder}
       />
       <Button
         type="submit"
         size="sm"
-        isLoading={sending}
-        loadingText="Sending"
-        disabled={disabled || sending || value.trim() === ''}
-        className="h-10 self-end"
+        isLoading={turnPhase === 'submitting'}
+        loadingText="Sending…"
+        disabled={disabled || turnPhase !== 'idle' || value.trim() === ''}
+        className={`h-12 shrink-0 px-3 ${turnPhase === 'submitting' ? 'w-auto' : 'w-12 sm:w-auto'}`}
       >
-        <Send className="mr-2 h-4 w-4" />
-        Send
+        <Send className="h-4 w-4 sm:mr-2" />
+        <span className="sr-only sm:not-sr-only">Send</span>
       </Button>
     </form>
   );

--- a/apps/web/src/components/whatsapp/ConversationAssistantDeleteDialog.tsx
+++ b/apps/web/src/components/whatsapp/ConversationAssistantDeleteDialog.tsx
@@ -1,0 +1,97 @@
+import { AlertTriangle, ShieldCheck } from 'lucide-react';
+import { Button } from '@/components/ui/Button';
+import { Modal } from '@/components/ui/Modal';
+
+export function ConversationAssistantDeleteDialog({
+  open,
+  title,
+  deleting,
+  error,
+  resumePending = false,
+  returnFocusTo,
+  onOpenChange,
+  onConfirm,
+}: {
+  open: boolean;
+  title: string;
+  deleting: boolean;
+  error: string | null;
+  resumePending?: boolean;
+  returnFocusTo: HTMLButtonElement | null;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => Promise<void>;
+}): React.JSX.Element {
+  const closeAndRestoreFocus = (): void => {
+    onOpenChange(false);
+    window.setTimeout(() => {
+      if (returnFocusTo?.isConnected === true) returnFocusTo.focus();
+    }, 0);
+  };
+
+  return (
+    <Modal
+      open={open}
+      onOpenChange={(nextOpen): void => {
+        if (deleting) return;
+        if (nextOpen) {
+          onOpenChange(true);
+          return;
+        }
+        closeAndRestoreFocus();
+      }}
+      title={resumePending ? 'Finish deletion?' : 'Delete analysis?'}
+      description={
+        resumePending
+          ? `The previous deletion of “${title}” was interrupted. Finish removing its remaining analysis data.`
+          : `This permanently removes “${title}”, its frozen context, questions and answers.`
+      }
+      size="sm"
+    >
+      <div
+        role="note"
+        aria-label="WhatsApp data safety"
+        className="mt-4 flex items-start gap-2 rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-800 dark:border-emerald-900 dark:bg-emerald-950/40 dark:text-emerald-300"
+      >
+        <ShieldCheck className="mt-0.5 h-4 w-4 shrink-0" />
+        <span>Original WhatsApp conversation stays untouched.</span>
+      </div>
+      <p className="mt-3 text-sm font-medium text-slate-700 dark:text-slate-300">
+        This action cannot be undone.
+      </p>
+      {error !== null ? (
+        <div
+          role="alert"
+          className="mt-4 flex items-start gap-2 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-900 dark:bg-red-950/40 dark:text-red-300"
+        >
+          <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+          <span>{error}</span>
+        </div>
+      ) : null}
+      <div className="mt-6 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+        <Button
+          type="button"
+          variant="secondary"
+          className="min-h-11"
+          disabled={deleting}
+          onClick={(): void => {
+            closeAndRestoreFocus();
+          }}
+        >
+          Cancel
+        </Button>
+        <Button
+          type="button"
+          variant="danger"
+          className="min-h-11"
+          isLoading={deleting}
+          loadingText={resumePending ? 'Finishing…' : 'Deleting…'}
+          onClick={(): void => {
+            void onConfirm();
+          }}
+        >
+          {resumePending ? 'Finish deletion' : 'Delete analysis'}
+        </Button>
+      </div>
+    </Modal>
+  );
+}

--- a/apps/web/src/hooks/__tests__/useWhatsAppConversationAssistant.test.tsx
+++ b/apps/web/src/hooks/__tests__/useWhatsAppConversationAssistant.test.tsx
@@ -12,6 +12,7 @@ import { MemoryRouter, useLocation, useNavigate } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type {
   ConversationAssistantSession,
+  ConversationAssistantStreamEvent,
   ConversationAssistantTurn,
   PrivateWhatsAppChat,
 } from '@/types';
@@ -22,6 +23,7 @@ const mocks = vi.hoisted(() => ({
   listConversationAssistantSessions: vi.fn(),
   checkConversationAssistantContext: vi.fn(),
   createConversationAssistantSession: vi.fn(),
+  deleteConversationAssistantSession: vi.fn(),
   exportConversationAssistantSessionPdf: vi.fn(),
   getConversationAssistantContext: vi.fn(),
   getConversationAssistantSession: vi.fn(),
@@ -45,6 +47,7 @@ vi.mock('@/services/conversationAssistantApi', () => ({
   listConversationAssistantSessions: mocks.listConversationAssistantSessions,
   checkConversationAssistantContext: mocks.checkConversationAssistantContext,
   createConversationAssistantSession: mocks.createConversationAssistantSession,
+  deleteConversationAssistantSession: mocks.deleteConversationAssistantSession,
   exportConversationAssistantSessionPdf: mocks.exportConversationAssistantSessionPdf,
   getConversationAssistantContext: mocks.getConversationAssistantContext,
   getConversationAssistantSession: mocks.getConversationAssistantSession,
@@ -80,6 +83,7 @@ const groupChat: PrivateWhatsAppChat = {
 
 const session: ConversationAssistantSession = {
   id: 'session-1',
+  deletionToken: 'deletion-token-session-1',
   userId: 'user-1',
   chatId: directChat.id,
   chatDisplayName: directChat.displayName,
@@ -224,6 +228,7 @@ describe('useWhatsAppConversationAssistant', () => {
     mocks.getConversationAssistantSessionByRequest.mockRejectedValue(new Error('Not found'));
     mocks.listConversationAssistantTurns.mockResolvedValue({ turns });
     mocks.createConversationAssistantSession.mockResolvedValue(session);
+    mocks.deleteConversationAssistantSession.mockResolvedValue(undefined);
     mocks.retryConversationAssistantPreparation.mockResolvedValue(session);
     mocks.exportConversationAssistantSessionPdf.mockResolvedValue({
       blob: new Blob(['pdf-bytes'], { type: 'application/pdf' }),
@@ -301,6 +306,244 @@ describe('useWhatsAppConversationAssistant', () => {
     expect(mocks.listPrivateWhatsAppChats).toHaveBeenCalledWith('tok', { limit: 100 });
     expect(mocks.getConversationAssistantSession).toHaveBeenCalledWith('tok', session.id);
     expect(mocks.listConversationAssistantTurns).toHaveBeenCalledWith('tok', session.id);
+  });
+
+  it('deletes one session, blocks duplicate deletion, and removes it from local state', async () => {
+    const deletion = createDeferred<undefined>();
+    mocks.deleteConversationAssistantSession.mockReturnValue(deletion.promise);
+    const { result } = renderHook(
+      () => useWhatsAppConversationAssistant({ loadChats: false, loadSessions: true }),
+      { wrapper: createWrapper() }
+    );
+    await waitFor(() => {
+      expect(result.current.sessions).toEqual([session]);
+    });
+
+    let first!: Promise<boolean>;
+    let second!: Promise<boolean>;
+    act(() => {
+      first = result.current.deleteSession(session.id, session.deletionToken);
+      second = result.current.deleteSession(session.id, session.deletionToken);
+    });
+    await waitFor(() => {
+      expect(result.current.deletingSessionId).toBe(session.id);
+    });
+    expect(mocks.deleteConversationAssistantSession).toHaveBeenCalledTimes(1);
+    expect(mocks.deleteConversationAssistantSession).toHaveBeenCalledWith(
+      'tok',
+      session.id,
+      session.deletionToken
+    );
+
+    await act(async () => {
+      deletion.resolve(undefined);
+      await deletion.promise;
+    });
+    await expect(first).resolves.toBe(true);
+    await expect(second).resolves.toBe(false);
+    expect(result.current.sessions).toEqual([]);
+    expect(result.current.deletingSessionId).toBeUndefined();
+    expect(result.current.deleteError).toBeNull();
+  });
+
+  it('keeps a session visible and exposes a retryable error when deletion fails', async () => {
+    mocks.deleteConversationAssistantSession.mockRejectedValue(new Error('Delete failed'));
+    const { result } = renderHook(
+      () => useWhatsAppConversationAssistant({ loadChats: false, loadSessions: true }),
+      { wrapper: createWrapper() }
+    );
+    await waitFor(() => {
+      expect(result.current.sessions).toEqual([session]);
+    });
+
+    await act(async () => {
+      await expect(
+        result.current.deleteSession(session.id, session.deletionToken)
+      ).resolves.toBe(false);
+    });
+
+    expect(result.current.sessions).toEqual([session]);
+    expect(result.current.deleteError).toBe('Delete failed');
+    act(() => {
+      result.current.clearDeleteError();
+    });
+    expect(result.current.deleteError).toBeNull();
+  });
+
+  it('bounds best-effort deletion reconciliation when the refresh never answers', async () => {
+    const hangingRefresh = createDeferred<{ sessions: ConversationAssistantSession[] }>();
+    mocks.listConversationAssistantSessions
+      .mockResolvedValueOnce({ sessions: [session] })
+      .mockReturnValueOnce(hangingRefresh.promise);
+    mocks.deleteConversationAssistantSession.mockRejectedValue(new Error('Delete timed out'));
+    const { result } = renderHook(
+      () => useWhatsAppConversationAssistant({ loadChats: false, loadSessions: true }),
+      { wrapper: createWrapper() }
+    );
+    await waitFor(() => {
+      expect(result.current.sessions).toEqual([session]);
+    });
+
+    let deletePromise!: Promise<boolean>;
+    act(() => {
+      deletePromise = result.current.deleteSession(session.id, session.deletionToken);
+    });
+    const completion = await Promise.race([
+      deletePromise.then(() => 'settled' as const),
+      new Promise<'timed-out'>((resolve) => {
+        window.setTimeout(() => resolve('timed-out'), 1500);
+      }),
+    ]);
+    await act(async () => {
+      hangingRefresh.resolve({ sessions: [session] });
+      await deletePromise;
+    });
+
+    expect(completion).toBe('settled');
+    expect(result.current.deletingSessionId).toBeUndefined();
+    expect(result.current.deleteError).toBe('Delete timed out');
+  });
+
+  it('reconciles an interrupted deletion into a non-openable pending session', async () => {
+    const pendingDeletion: ConversationAssistantSession = {
+      ...session,
+      status: 'preparing',
+      preparationStage: 'queued',
+      deletionPending: true,
+    };
+    let sessionListCall = 0;
+    mocks.listConversationAssistantSessions.mockImplementation(() => {
+      sessionListCall += 1;
+      return Promise.resolve({
+        sessions: sessionListCall === 1 ? [session] : [pendingDeletion],
+      });
+    });
+    mocks.deleteConversationAssistantSession.mockRejectedValue(new Error('Connection lost'));
+    const intervalSpy = vi.spyOn(window, 'setInterval');
+    const { result } = renderHook(
+      () => useWhatsAppConversationAssistant({ loadChats: false, loadSessions: true }),
+      { wrapper: createWrapper() }
+    );
+    await waitFor(() => {
+      expect(result.current.sessions).toEqual([session]);
+    });
+
+    await act(async () => {
+      await expect(
+        result.current.deleteSession(session.id, session.deletionToken)
+      ).resolves.toBe(false);
+    });
+
+    expect(result.current.sessions).toEqual([pendingDeletion]);
+    expect(result.current.deleteError).toBe(
+      'Deletion was interrupted. Finish deletion to remove the remaining analysis data.'
+    );
+    expect(intervalSpy).not.toHaveBeenCalledWith(expect.any(Function), 3000);
+  });
+
+  it('does not let an in-flight list refresh restore a successfully deleted session', async () => {
+    const staleSessionList = createDeferred<{ sessions: ConversationAssistantSession[] }>();
+    const { result } = renderHook(
+      () => useWhatsAppConversationAssistant({ loadChats: false, loadSessions: true }),
+      { wrapper: createWrapper() }
+    );
+    await waitFor(() => {
+      expect(result.current.sessions).toEqual([session]);
+    });
+    mocks.listConversationAssistantSessions.mockReturnValueOnce(staleSessionList.promise);
+    let refreshPromise!: Promise<void>;
+    act(() => {
+      refreshPromise = result.current.refresh();
+    });
+    await waitFor(() => {
+      expect(mocks.listConversationAssistantSessions).toHaveBeenCalledTimes(2);
+    });
+
+    await act(async () => {
+      await expect(
+        result.current.deleteSession(session.id, session.deletionToken)
+      ).resolves.toBe(true);
+    });
+    expect(result.current.sessions).toEqual([]);
+
+    await act(async () => {
+      staleSessionList.resolve({ sessions: [session] });
+      await refreshPromise;
+    });
+    expect(result.current.sessions).toEqual([]);
+  });
+
+  it('does not let a list refresh started during deletion restore the deleted session', async () => {
+    const deletion = createDeferred<undefined>();
+    const staleSessionList = createDeferred<{ sessions: ConversationAssistantSession[] }>();
+    mocks.deleteConversationAssistantSession.mockReturnValue(deletion.promise);
+    const { result } = renderHook(
+      () => useWhatsAppConversationAssistant({ loadChats: false, loadSessions: true }),
+      { wrapper: createWrapper() }
+    );
+    await waitFor(() => {
+      expect(result.current.sessions).toEqual([session]);
+    });
+
+    let deletePromise!: Promise<boolean>;
+    act(() => {
+      deletePromise = result.current.deleteSession(session.id, session.deletionToken);
+    });
+    await waitFor(() => {
+      expect(mocks.deleteConversationAssistantSession).toHaveBeenCalledTimes(1);
+    });
+
+    mocks.listConversationAssistantSessions.mockReturnValueOnce(staleSessionList.promise);
+    let refreshPromise!: Promise<void>;
+    act(() => {
+      refreshPromise = result.current.refresh();
+    });
+    await waitFor(() => {
+      expect(mocks.listConversationAssistantSessions).toHaveBeenCalledTimes(2);
+    });
+
+    await act(async () => {
+      deletion.resolve(undefined);
+      await deletePromise;
+    });
+    expect(result.current.sessions).toEqual([]);
+
+    await act(async () => {
+      staleSessionList.resolve({ sessions: [session] });
+      await refreshPromise;
+    });
+    expect(result.current.sessions).toEqual([]);
+  });
+
+  it('keeps a replacement generation when an older deletion token completes as a no-op', async () => {
+    const replacementSession: ConversationAssistantSession = {
+      ...session,
+      deletionToken: 'deletion-token-replacement',
+      title: 'Replacement analysis',
+    };
+    mocks.listConversationAssistantSessions.mockResolvedValue({
+      sessions: [replacementSession],
+    });
+    const { result } = renderHook(
+      () => useWhatsAppConversationAssistant({ loadChats: false, loadSessions: true }),
+      { wrapper: createWrapper() }
+    );
+    await waitFor(() => {
+      expect(result.current.sessions).toEqual([replacementSession]);
+    });
+
+    await act(async () => {
+      await expect(
+        result.current.deleteSession(session.id, session.deletionToken)
+      ).resolves.toBe(true);
+    });
+
+    expect(mocks.deleteConversationAssistantSession).toHaveBeenCalledWith(
+      'tok',
+      session.id,
+      session.deletionToken
+    );
+    expect(result.current.sessions).toEqual([replacementSession]);
   });
 
   it('loads the selected conversation from an explicit route session id', async () => {
@@ -927,6 +1170,428 @@ describe('useWhatsAppConversationAssistant', () => {
     expect(mocks.listConversationAssistantSessions).toHaveBeenCalledTimes(2);
   });
 
+  it('reports submitting, waiting, streaming, and idle phases from stream events', async () => {
+    const sendRequest = createDeferred<undefined>();
+    let streamEventHandler: ((event: ConversationAssistantStreamEvent) => void) | undefined;
+    mocks.streamConversationAssistantTurn.mockImplementation(
+      async (
+        _token: string,
+        _sessionId: string,
+        _request: { question: string },
+        onEvent: (event: ConversationAssistantStreamEvent) => void
+      ) => {
+        streamEventHandler = onEvent;
+        return await sendRequest.promise;
+      }
+    );
+    const { result } = renderHook(() => useWhatsAppConversationAssistant(), {
+      wrapper: createWrapper('/whatsapp/conversation-assistant?session=session-1'),
+    });
+    await waitFor(() => {
+      expect(result.current.selectedSession?.id).toBe(session.id);
+    });
+    act(() => {
+      result.current.setFollowUpQuestion('Follow up?');
+    });
+    act(() => {
+      void result.current.sendFollowUp();
+    });
+    await waitFor(() => {
+      expect(result.current.turnPhase).toBe('submitting');
+    });
+    expect(result.current.followUpQuestion).toBe('Follow up?');
+
+    act(() => {
+      streamEventHandler?.({
+        type: 'user_turn',
+        turn: {
+          id: 'phase-user',
+          sessionId: session.id,
+          userId: 'user-1',
+          role: 'user',
+          text: 'Follow up?',
+          createdAt: '2026-06-21T11:06:00.000Z',
+        },
+      });
+    });
+    expect(result.current.turnPhase).toBe('waiting');
+    expect(result.current.followUpQuestion).toBe('');
+
+    act(() => {
+      result.current.setFollowUpQuestion('Draft the next question');
+      streamEventHandler?.({ type: 'assistant_delta', text: 'Answer starts' });
+    });
+    expect(result.current.turnPhase).toBe('streaming');
+    expect(result.current.followUpQuestion).toBe('Draft the next question');
+
+    act(() => {
+      streamEventHandler?.({
+        type: 'assistant_turn',
+        turn: {
+          id: 'phase-assistant',
+          sessionId: session.id,
+          userId: 'user-1',
+          role: 'assistant',
+          text: 'Answer starts and finishes.',
+          createdAt: '2026-06-21T11:07:00.000Z',
+        },
+      });
+    });
+    expect(result.current.turnPhase).toBe('streaming');
+
+    await act(async () => {
+      sendRequest.resolve(undefined);
+      await sendRequest.promise;
+    });
+    expect(result.current.turnPhase).toBe('idle');
+  });
+
+  it('returns to idle as soon as the completed stream closes without waiting for summary refresh', async () => {
+    const summaryRefresh = createDeferred<{ sessions: ConversationAssistantSession[] }>();
+    mocks.listConversationAssistantSessions
+      .mockResolvedValueOnce({ sessions: [session] })
+      .mockReturnValueOnce(summaryRefresh.promise);
+    mocks.streamConversationAssistantTurn.mockImplementation(
+      async (
+        _token: string,
+        streamSessionId: string,
+        request: { question: string },
+        onEvent: (event: ConversationAssistantStreamEvent) => void
+      ) => {
+        onEvent({
+          type: 'user_turn',
+          turn: {
+            id: 'completed-user',
+            sessionId: streamSessionId,
+            userId: 'user-1',
+            role: 'user',
+            text: request.question,
+            createdAt: '2026-06-21T11:06:00.000Z',
+          },
+        });
+        onEvent({ type: 'assistant_delta', text: 'Complete answer.' });
+        onEvent({
+          type: 'assistant_turn',
+          turn: {
+            id: 'completed-assistant',
+            sessionId: streamSessionId,
+            userId: 'user-1',
+            role: 'assistant',
+            text: 'Complete answer.',
+            createdAt: '2026-06-21T11:07:00.000Z',
+          },
+        });
+        onEvent({ type: 'done' });
+      }
+    );
+    const { result } = renderHook(() => useWhatsAppConversationAssistant(), {
+      wrapper: createWrapper('/whatsapp/conversation-assistant?session=session-1'),
+    });
+    await waitFor(() => {
+      expect(result.current.selectedSession?.id).toBe(session.id);
+    });
+    act(() => {
+      result.current.setFollowUpQuestion('Follow up?');
+    });
+    let sendPromise!: Promise<void>;
+    act(() => {
+      sendPromise = result.current.sendFollowUp();
+    });
+    await waitFor(() => {
+      expect(mocks.listConversationAssistantSessions).toHaveBeenCalledTimes(2);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    const phaseBeforeSummaryRefresh = result.current.turnPhase;
+
+    await act(async () => {
+      summaryRefresh.resolve({ sessions: [session] });
+      await sendPromise;
+    });
+    expect(phaseBeforeSummaryRefresh).toBe('idle');
+  });
+
+  it('returns to idle and preserves the draft when submission fails before acknowledgement', async () => {
+    mocks.streamConversationAssistantTurn.mockRejectedValue(new Error('Network failed'));
+    const { result } = renderHook(() => useWhatsAppConversationAssistant(), {
+      wrapper: createWrapper('/whatsapp/conversation-assistant?session=session-1'),
+    });
+    await waitFor(() => {
+      expect(result.current.selectedSession?.id).toBe(session.id);
+    });
+    act(() => {
+      result.current.setFollowUpQuestion('Keep this draft');
+    });
+
+    await act(async () => {
+      await result.current.sendFollowUp();
+    });
+
+    expect(result.current.turnPhase).toBe('idle');
+    expect(result.current.followUpQuestion).toBe('Keep this draft');
+    expect(result.current.error).toBe(
+      'Message was not sent. Your draft was kept. Try again.'
+    );
+  });
+
+  it('reports an acknowledged stream failure without restoring the already-sent draft', async () => {
+    const acknowledgedUserTurn: ConversationAssistantTurn = {
+      id: 'acknowledged-user',
+      sessionId: session.id,
+      userId: 'user-1',
+      role: 'user',
+      text: 'Already sent',
+      createdAt: '2026-06-21T11:06:00.000Z',
+    };
+    const savedErrorTurn: ConversationAssistantTurn = {
+      id: 'saved-error-answer',
+      sessionId: session.id,
+      userId: 'user-1',
+      role: 'assistant',
+      text: 'The assistant could not finish this answer.',
+      createdAt: '2026-06-21T11:07:00.000Z',
+      error: { code: 'LLM_ERROR', message: 'Answer stream disconnected' },
+    };
+    mocks.listConversationAssistantTurns
+      .mockResolvedValueOnce({ turns })
+      .mockResolvedValueOnce({ turns: [...turns, acknowledgedUserTurn] })
+      .mockResolvedValueOnce({ turns: [...turns, acknowledgedUserTurn, savedErrorTurn] });
+    mocks.streamConversationAssistantTurn.mockImplementation(
+      async (
+        _token: string,
+        _sessionId: string,
+        _request: { question: string },
+        onEvent: (event: ConversationAssistantStreamEvent) => void
+      ) => {
+        onEvent({
+          type: 'user_turn',
+          turn: acknowledgedUserTurn,
+        });
+        onEvent({ type: 'assistant_delta', text: 'Unpersisted partial answer' });
+        throw new Error('Answer stream disconnected');
+      }
+    );
+    const { result } = renderHook(() => useWhatsAppConversationAssistant(), {
+      wrapper: createWrapper('/whatsapp/conversation-assistant?session=session-1'),
+    });
+    await waitFor(() => {
+      expect(result.current.selectedSession?.id).toBe(session.id);
+    });
+    act(() => {
+      result.current.setFollowUpQuestion('Already sent');
+    });
+
+    await act(async () => {
+      await result.current.sendFollowUp();
+    });
+
+    expect(result.current.turnPhase).toBe('idle');
+    expect(result.current.followUpQuestion).toBe('');
+    expect(result.current.turns).toEqual([...turns, acknowledgedUserTurn, savedErrorTurn]);
+    expect(result.current.turns.some((turn) => turn.text === 'Unpersisted partial answer')).toBe(
+      false
+    );
+    expect(mocks.listConversationAssistantTurns).toHaveBeenCalledTimes(3);
+    expect(result.current.error).toBe(
+      'The live response was interrupted. Saved messages were refreshed.'
+    );
+  });
+
+  it('bounds acknowledged-turn recovery when one refresh attempt never answers', async () => {
+    const acknowledgedUserTurn: ConversationAssistantTurn = {
+      id: 'bounded-recovery-user',
+      sessionId: session.id,
+      userId: 'user-1',
+      role: 'user',
+      text: 'Already sent',
+      createdAt: '2026-06-21T11:06:00.000Z',
+    };
+    const savedAssistantTurn: ConversationAssistantTurn = {
+      id: 'bounded-recovery-assistant',
+      sessionId: session.id,
+      userId: 'user-1',
+      role: 'assistant',
+      text: 'Saved after disconnect.',
+      createdAt: '2026-06-21T11:07:00.000Z',
+    };
+    const hangingRefresh = createDeferred<{ turns: ConversationAssistantTurn[] }>();
+    mocks.listConversationAssistantTurns
+      .mockResolvedValueOnce({ turns })
+      .mockReturnValueOnce(hangingRefresh.promise)
+      .mockResolvedValue({ turns: [...turns, acknowledgedUserTurn, savedAssistantTurn] });
+    mocks.streamConversationAssistantTurn.mockImplementation(
+      async (
+        _token: string,
+        _sessionId: string,
+        _request: { question: string },
+        onEvent: (event: ConversationAssistantStreamEvent) => void
+      ) => {
+        onEvent({ type: 'user_turn', turn: acknowledgedUserTurn });
+        onEvent({ type: 'assistant_delta', text: 'Partial' });
+        throw new Error('Disconnected');
+      }
+    );
+    const { result } = renderHook(() => useWhatsAppConversationAssistant(), {
+      wrapper: createWrapper('/whatsapp/conversation-assistant?session=session-1'),
+    });
+    await waitFor(() => {
+      expect(result.current.selectedSession?.id).toBe(session.id);
+    });
+    act(() => {
+      result.current.setFollowUpQuestion('Already sent');
+    });
+
+    let sendPromise!: Promise<void>;
+    act(() => {
+      sendPromise = result.current.sendFollowUp();
+    });
+    const completion = await Promise.race([
+      sendPromise.then(() => 'settled' as const),
+      new Promise<'timed-out'>((resolve) => {
+        window.setTimeout(() => resolve('timed-out'), 1500);
+      }),
+    ]);
+    await act(async () => {
+      hangingRefresh.resolve({ turns: [...turns, acknowledgedUserTurn, savedAssistantTurn] });
+      await sendPromise;
+    });
+
+    expect(completion).toBe('settled');
+    expect(result.current.turnPhase).toBe('idle');
+  });
+
+  it('removes an unpersisted partial answer and asks for refresh when reconciliation fails', async () => {
+    mocks.listConversationAssistantTurns
+      .mockResolvedValueOnce({ turns })
+      .mockRejectedValue(new Error('Refresh failed'));
+    mocks.streamConversationAssistantTurn.mockImplementation(
+      async (
+        _token: string,
+        _sessionId: string,
+        _request: { question: string },
+        onEvent: (event: ConversationAssistantStreamEvent) => void
+      ) => {
+        onEvent({
+          type: 'user_turn',
+          turn: {
+            id: 'acknowledged-user',
+            sessionId: session.id,
+            userId: 'user-1',
+            role: 'user',
+            text: 'Already sent',
+            createdAt: '2026-06-21T11:06:00.000Z',
+          },
+        });
+        onEvent({ type: 'assistant_delta', text: 'Misleading partial answer' });
+        throw new Error('Connection ended');
+      }
+    );
+    const { result } = renderHook(() => useWhatsAppConversationAssistant(), {
+      wrapper: createWrapper('/whatsapp/conversation-assistant?session=session-1'),
+    });
+    await waitFor(() => {
+      expect(result.current.selectedSession?.id).toBe(session.id);
+    });
+    act(() => {
+      result.current.setFollowUpQuestion('Already sent');
+    });
+
+    await act(async () => {
+      await result.current.sendFollowUp();
+    });
+
+    expect(result.current.turns.some((turn) => turn.text === 'Misleading partial answer')).toBe(
+      false
+    );
+    expect(result.current.error).toBe(
+      'The live response was interrupted. Refresh the page to check the saved response.'
+    );
+  });
+
+  it('does not show a stale recovery error after switching analyses', async () => {
+    const secondSession: ConversationAssistantSession = {
+      ...session,
+      id: 'session-2',
+      title: 'Second context',
+      transcriptSha256: 'def456',
+    };
+    const acknowledgedUserTurn: ConversationAssistantTurn = {
+      id: 'acknowledged-user',
+      sessionId: session.id,
+      userId: 'user-1',
+      role: 'user',
+      text: 'Already sent',
+      createdAt: '2026-06-21T11:06:00.000Z',
+    };
+    const savedAssistantTurn: ConversationAssistantTurn = {
+      id: 'saved-assistant',
+      sessionId: session.id,
+      userId: 'user-1',
+      role: 'assistant',
+      text: 'Saved after the stream closed.',
+      createdAt: '2026-06-21T11:07:00.000Z',
+    };
+    const recoveryRequest = createDeferred<{ turns: ConversationAssistantTurn[] }>();
+    let firstSessionTurnsCalls = 0;
+    mocks.listConversationAssistantSessions.mockResolvedValue({ sessions: [session, secondSession] });
+    mocks.getConversationAssistantSession.mockImplementation((_token: string, sessionId: string) =>
+      Promise.resolve(sessionId === secondSession.id ? secondSession : session)
+    );
+    mocks.listConversationAssistantTurns.mockImplementation((_token: string, sessionId: string) => {
+      if (sessionId === secondSession.id) return Promise.resolve({ turns: [] });
+      firstSessionTurnsCalls += 1;
+      return firstSessionTurnsCalls === 1
+        ? Promise.resolve({ turns })
+        : recoveryRequest.promise;
+    });
+    mocks.streamConversationAssistantTurn.mockImplementation(
+      async (
+        _token: string,
+        _sessionId: string,
+        _request: { question: string },
+        onEvent: (event: ConversationAssistantStreamEvent) => void
+      ) => {
+        onEvent({ type: 'user_turn', turn: acknowledgedUserTurn });
+        throw new Error('Connection ended');
+      }
+    );
+
+    const { result } = renderHook(() => useAssistantWithLocationControls(), {
+      wrapper: createWrapper('/whatsapp/conversation-assistant?session=session-1'),
+    });
+    await waitFor(() => {
+      expect(result.current.selectedSession?.id).toBe(session.id);
+    });
+    act(() => {
+      result.current.setFollowUpQuestion('Already sent');
+    });
+
+    let sendPromise!: Promise<void>;
+    act(() => {
+      sendPromise = result.current.sendFollowUp();
+    });
+    await waitFor(() => {
+      expect(firstSessionTurnsCalls).toBe(2);
+    });
+
+    act(() => {
+      result.current.navigateToSession(secondSession.id);
+    });
+    await waitFor(() => {
+      expect(result.current.selectedSession?.id).toBe(secondSession.id);
+    });
+
+    await act(async () => {
+      recoveryRequest.resolve({ turns: [...turns, acknowledgedUserTurn, savedAssistantTurn] });
+      await sendPromise;
+    });
+
+    expect(result.current.selectedSession?.id).toBe(secondSession.id);
+    expect(result.current.turns).toEqual([]);
+    expect(result.current.error).toBeNull();
+  });
+
   it('ignores duplicate follow-up sends while a send is in flight', async () => {
     const sendRequest = createDeferred<undefined>();
     mocks.streamConversationAssistantTurn.mockReturnValue(sendRequest.promise);
@@ -1052,7 +1717,7 @@ describe('useWhatsAppConversationAssistant', () => {
     expect(result.current.selectedSession?.id).toBe(secondSession.id);
     expect(result.current.turns).toEqual([]);
     expect(result.current.followUpQuestion).toBe('');
-    expect(result.current.sending).toBe(false);
+    expect(result.current.turnPhase).toBe('idle');
     expect(result.current.error).toBeNull();
   });
 

--- a/apps/web/src/hooks/useWhatsAppConversationAssistant.ts
+++ b/apps/web/src/hooks/useWhatsAppConversationAssistant.ts
@@ -9,6 +9,7 @@ import {
 import { useAuth } from '@/context';
 import {
   createConversationAssistantSession,
+  deleteConversationAssistantSession,
   exportConversationAssistantSessionPdf,
   getConversationAssistantContext,
   getConversationAssistantSession,
@@ -31,6 +32,23 @@ import type {
 const CHAT_PAGE_SIZE = 100;
 const PENDING_CREATION_STORAGE_KEY = 'whatsapp-conversation-assistant-pending-creation';
 const CREATION_RECOVERY_DELAYS_MS = [0, 250, 750, 1500] as const;
+const TURN_RECOVERY_DELAYS_MS = [0, 150, 400, 900] as const;
+const BEST_EFFORT_RECONCILIATION_TIMEOUT_MS = 750;
+const MESSAGE_NOT_SENT_ERROR = 'Message was not sent. Your draft was kept. Try again.';
+
+async function withBestEffortReconciliationTimeout<T>(request: Promise<T>): Promise<T> {
+  let timeoutId: number | undefined;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timeoutId = window.setTimeout(() => {
+      reject(new Error('Best-effort reconciliation timed out'));
+    }, BEST_EFFORT_RECONCILIATION_TIMEOUT_MS);
+  });
+  try {
+    return await Promise.race([request, timeout]);
+  } finally {
+    if (timeoutId !== undefined) window.clearTimeout(timeoutId);
+  }
+}
 
 interface StoredPendingCreation {
   request: CreateConversationAssistantSessionRequest;
@@ -133,6 +151,40 @@ async function recoverPendingCreation(
   throw lastError;
 }
 
+async function recoverAcknowledgedTurn(
+  token: string,
+  sessionId: string,
+  acknowledgedUserTurnId: string,
+  isCurrentRequest: () => boolean
+): Promise<ConversationAssistantTurn[] | null> {
+  for (const delay of TURN_RECOVERY_DELAYS_MS) {
+    if (!isCurrentRequest()) return null;
+    if (delay > 0) {
+      await new Promise<void>((resolve) => {
+        window.setTimeout(resolve, delay);
+      });
+    }
+    if (!isCurrentRequest()) return null;
+    try {
+      const response = await withBestEffortReconciliationTimeout(
+        listConversationAssistantTurns(token, sessionId)
+      );
+      const acknowledgedIndex = response.turns.findIndex(
+        (turn) => turn.id === acknowledgedUserTurnId
+      );
+      if (
+        acknowledgedIndex >= 0 &&
+        response.turns.slice(acknowledgedIndex + 1).some((turn) => turn.role === 'assistant')
+      ) {
+        return response.turns;
+      }
+    } catch {
+      // Persistence can finish after the stream closes; retry within the bounded window.
+    }
+  }
+  return null;
+}
+
 export interface UseWhatsAppConversationAssistantResult {
   sessions: ConversationAssistantSession[];
   selectedSessionId: string | undefined;
@@ -150,11 +202,13 @@ export interface UseWhatsAppConversationAssistantResult {
   loadingContext: boolean;
   loadingMoreContext: boolean;
   creating: boolean;
-  sending: boolean;
+  turnPhase: ConversationAssistantTurnPhase;
   retryingPreparation: boolean;
   exporting: boolean;
+  deletingSessionId: string | undefined;
   error: string | null;
   contextError: string | null;
+  deleteError: string | null;
   selectSession: (sessionId: string) => void;
   selectChat: (chatId: string) => void;
   selectModel: (model: ConversationAssistantModel) => void;
@@ -167,8 +221,16 @@ export interface UseWhatsAppConversationAssistantResult {
   loadMoreContext: () => Promise<void>;
   retryPreparation: () => Promise<void>;
   exportSelectedSessionPdf: () => Promise<void>;
+  deleteSession: (sessionId: string, deletionToken: string | undefined) => Promise<boolean>;
+  clearDeleteError: () => void;
   refresh: () => Promise<void>;
 }
+
+export type ConversationAssistantTurnPhase =
+  | 'idle'
+  | 'submitting'
+  | 'waiting'
+  | 'streaming';
 
 export interface UseWhatsAppConversationAssistantOptions {
   sessionId?: string;
@@ -212,7 +274,10 @@ export function useWhatsAppConversationAssistant(
   const sessionListRequestIdRef = useRef(0);
   const sendRequestIdRef = useRef(0);
   const sendInFlightRef = useRef(false);
+  const acknowledgedSendRequestIdRef = useRef<number | null>(null);
+  const acknowledgedUserTurnIdRef = useRef<string | null>(null);
   const exportInFlightRef = useRef(false);
+  const deleteInFlightSessionIdRef = useRef<string | null>(null);
   const retryPreparationInFlightRef = useRef(false);
   const creationRecoveryStartedRef = useRef(false);
   const turnsRequestIdRef = useRef(0);
@@ -243,11 +308,13 @@ export function useWhatsAppConversationAssistant(
   const [loadingContext, setLoadingContext] = useState(false);
   const [loadingMoreContext, setLoadingMoreContext] = useState(false);
   const [creating, setCreating] = useState(false);
-  const [sending, setSending] = useState(false);
+  const [turnPhase, setTurnPhase] = useState<ConversationAssistantTurnPhase>('idle');
   const [retryingPreparation, setRetryingPreparation] = useState(false);
   const [exporting, setExporting] = useState(false);
+  const [deletingSessionId, setDeletingSessionId] = useState<string | undefined>(undefined);
   const [error, setError] = useState<string | null>(null);
   const [contextError, setContextError] = useState<string | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
 
   useEffect(() => {
     selectedSessionIdRef.current = selectedSessionId;
@@ -262,7 +329,8 @@ export function useWhatsAppConversationAssistant(
     setLoadingMoreContext(false);
     setFollowUpQuestion('');
     sendInFlightRef.current = false;
-    setSending(false);
+    acknowledgedSendRequestIdRef.current = null;
+    setTurnPhase('idle');
     setError(null);
     setInvalidSelectedSessionId(undefined);
     if (selectedSessionId === undefined) {
@@ -425,7 +493,13 @@ export function useWhatsAppConversationAssistant(
   }, [getAccessToken, loadChats, loadSessions, selectedSessionId, setSessionParam]);
 
   useEffect(() => {
-    if (selectedSessionId === undefined || selectedSession?.status !== 'preparing') return;
+    if (
+      selectedSessionId === undefined ||
+      selectedSession?.status !== 'preparing' ||
+      selectedSession.deletionPending === true
+    ) {
+      return;
+    }
     let cancelled = false;
     let requestInFlight = false;
     const poll = async (): Promise<void> => {
@@ -450,10 +524,17 @@ export function useWhatsAppConversationAssistant(
       cancelled = true;
       window.clearInterval(intervalId);
     };
-  }, [getAccessToken, selectedSession?.status, selectedSessionId]);
+  }, [getAccessToken, selectedSession?.deletionPending, selectedSession?.status, selectedSessionId]);
 
   useEffect(() => {
-    if (!loadSessions || !sessions.some((item) => item.status === 'preparing')) return;
+    if (
+      !loadSessions ||
+      !sessions.some(
+        (item) => item.status === 'preparing' && item.deletionPending !== true
+      )
+    ) {
+      return;
+    }
     let refreshInFlight = false;
     const intervalId = window.setInterval(() => {
       if (refreshInFlight) return;
@@ -516,7 +597,9 @@ export function useWhatsAppConversationAssistant(
       const requestId = activeRequestId ?? sendRequestIdRef.current + 1;
       sendRequestIdRef.current = requestId;
       sendInFlightRef.current = true;
-      setSending(true);
+      acknowledgedSendRequestIdRef.current = null;
+      acknowledgedUserTurnIdRef.current = null;
+      setTurnPhase('submitting');
       let streamUserId = '';
       let streamedAssistantText = '';
       let streamedAssistantUsage: ConversationAssistantTurn['usage'];
@@ -527,12 +610,16 @@ export function useWhatsAppConversationAssistant(
       const applyStreamEvent = (event: ConversationAssistantStreamEvent): void => {
         if (!isCurrentRequest()) return;
         if (event.type === 'user_turn') {
+          acknowledgedSendRequestIdRef.current = requestId;
+          acknowledgedUserTurnIdRef.current = event.turn.id;
           streamUserId = event.turn.userId;
           clearQuestion();
           setTurns((current) => [...current, event.turn]);
+          setTurnPhase('waiting');
           return;
         }
         if (event.type === 'assistant_delta') {
+          setTurnPhase('streaming');
           streamedAssistantText += event.text;
           setTurns((current) => {
             const existing = current.find((turn) => turn.id === streamingAssistantTurnId);
@@ -569,7 +656,11 @@ export function useWhatsAppConversationAssistant(
           return;
         }
         if (event.type === 'error') {
-          setError(event.error.message);
+          setError(
+            acknowledgedSendRequestIdRef.current === requestId
+              ? event.error.message
+              : MESSAGE_NOT_SENT_ERROR
+          );
           return;
         }
         if (event.type === 'assistant_turn') {
@@ -579,28 +670,32 @@ export function useWhatsAppConversationAssistant(
             );
             return [...withoutPlaceholder, event.turn];
           });
+          return;
         }
       };
 
       try {
         await streamConversationAssistantTurn(token, sessionId, { question }, applyStreamEvent);
         if (refreshSessionList) {
-          try {
-            const sessionRequestId = sessionListRequestIdRef.current + 1;
-            sessionListRequestIdRef.current = sessionRequestId;
-            const sessionResponse = await listConversationAssistantSessions(token);
-            if (sessionListRequestIdRef.current === sessionRequestId) {
-              setSessions(sessionResponse.sessions);
-            }
-          } catch {
-            // The turn was already saved; session-list refresh can recover on the next explicit refresh.
-          }
+          const sessionRequestId = sessionListRequestIdRef.current + 1;
+          sessionListRequestIdRef.current = sessionRequestId;
+          void listConversationAssistantSessions(token)
+            .then((sessionResponse) => {
+              if (sessionListRequestIdRef.current === sessionRequestId) {
+                setSessions(sessionResponse.sessions);
+              }
+            })
+            .catch(() => {
+              // The turn was already saved; an explicit refresh can recover the summary later.
+            });
         }
-      } finally {
-        if (sendRequestIdRef.current === requestId) {
-          sendInFlightRef.current = false;
-          setSending(false);
+      } catch (streamError) {
+        if (isCurrentRequest() && streamUserId !== '') {
+          setTurns((current) =>
+            current.filter((turn) => turn.id !== streamingAssistantTurnId)
+          );
         }
+        throw streamError;
       }
     },
     []
@@ -635,7 +730,7 @@ export function useWhatsAppConversationAssistant(
       setInvalidSelectedSessionId(undefined);
       setSelectedSessionOverride(session);
       setFollowUpQuestion('');
-      setSending(false);
+      setTurnPhase('idle');
       setError(null);
       creationClientRequestIdRef.current = null;
       pendingCreationRequestRef.current = null;
@@ -702,11 +797,19 @@ export function useWhatsAppConversationAssistant(
     if (sessionId === undefined || question === '') return;
 
     const requestId = sendRequestIdRef.current + 1;
+    sendRequestIdRef.current = requestId;
     sendInFlightRef.current = true;
-    setSending(true);
+    setTurnPhase('submitting');
     setError(null);
+    let token: string | undefined;
     try {
-      const token = await getAccessToken();
+      token = await getAccessToken();
+      if (
+        selectedSessionIdRef.current !== sessionId ||
+        sendRequestIdRef.current !== requestId
+      ) {
+        return;
+      }
       await streamQuestionIntoSession(
         token,
         sessionId,
@@ -717,14 +820,58 @@ export function useWhatsAppConversationAssistant(
         requestId,
         loadSessions
       );
-    } catch (err) {
+    } catch {
       if (selectedSessionIdRef.current === sessionId && sendRequestIdRef.current === requestId) {
-        setError(getErrorMessage(err, 'Failed to send follow-up question'));
+        if (acknowledgedSendRequestIdRef.current !== requestId) {
+          setError(MESSAGE_NOT_SENT_ERROR);
+        } else {
+          let reconciled = false;
+          let reconciliationRequestId: number | null = null;
+          const acknowledgedUserTurnId = acknowledgedUserTurnIdRef.current;
+          if (token !== undefined && acknowledgedUserTurnId !== null) {
+            reconciliationRequestId = turnsRequestIdRef.current + 1;
+            turnsRequestIdRef.current = reconciliationRequestId;
+            const savedTurns = await recoverAcknowledgedTurn(
+              token,
+              sessionId,
+              acknowledgedUserTurnId,
+              () =>
+                selectedSessionIdRef.current === sessionId &&
+                sendRequestIdRef.current === requestId &&
+                turnsRequestIdRef.current === reconciliationRequestId
+            );
+            if (savedTurns !== null) {
+              if (
+                selectedSessionIdRef.current === sessionId &&
+                sendRequestIdRef.current === requestId &&
+                turnsRequestIdRef.current === reconciliationRequestId
+              ) {
+                setTurns(savedTurns);
+                reconciled = true;
+              }
+            }
+          }
+          if (
+            selectedSessionIdRef.current !== sessionId ||
+            sendRequestIdRef.current !== requestId ||
+            (reconciliationRequestId !== null &&
+              turnsRequestIdRef.current !== reconciliationRequestId)
+          ) {
+            return;
+          }
+          setError(
+            reconciled
+              ? 'The live response was interrupted. Saved messages were refreshed.'
+              : 'The live response was interrupted. Refresh the page to check the saved response.'
+          );
+        }
       }
     } finally {
       if (selectedSessionIdRef.current === sessionId && sendRequestIdRef.current === requestId) {
         sendInFlightRef.current = false;
-        setSending(false);
+        acknowledgedSendRequestIdRef.current = null;
+        acknowledgedUserTurnIdRef.current = null;
+        setTurnPhase('idle');
       }
     }
   }, [followUpQuestion, getAccessToken, loadSessions, streamQuestionIntoSession]);
@@ -885,6 +1032,90 @@ export function useWhatsAppConversationAssistant(
     }
   }, [getAccessToken, selectedSession]);
 
+  const deleteSession = useCallback(
+    async (sessionId: string, deletionToken: string | undefined): Promise<boolean> => {
+      if (deleteInFlightSessionIdRef.current !== null) return false;
+      deleteInFlightSessionIdRef.current = sessionId;
+      setDeletingSessionId(sessionId);
+      setDeleteError(null);
+      let accessToken: string | undefined;
+      try {
+        if (deletionToken === undefined) {
+          setDeleteError('Refresh analyses before deleting this item.');
+          return false;
+        }
+        accessToken = await getAccessToken();
+        sessionListRequestIdRef.current += 1;
+        await deleteConversationAssistantSession(accessToken, sessionId, deletionToken);
+        sessionListRequestIdRef.current += 1;
+        setSessions((current) =>
+          current.filter(
+            (item) => item.id !== sessionId || item.deletionToken !== deletionToken
+          )
+        );
+        if (
+          selectedSessionIdRef.current === sessionId &&
+          selectedSession?.deletionToken === deletionToken
+        ) {
+          setSelectedSessionOverride(undefined);
+          setInvalidSelectedSessionId(sessionId);
+          setTurns([]);
+          setContext(null);
+        }
+        return true;
+      } catch (err) {
+        if (accessToken !== undefined) {
+          const reconciliationRequestId = sessionListRequestIdRef.current + 1;
+          sessionListRequestIdRef.current = reconciliationRequestId;
+          try {
+            const response = await withBestEffortReconciliationTimeout(
+              listConversationAssistantSessions(accessToken)
+            );
+            if (sessionListRequestIdRef.current === reconciliationRequestId) {
+              const reconciledSession = response.sessions.find((item) => item.id === sessionId);
+              setSessions(response.sessions);
+              if (reconciledSession === undefined) {
+                if (selectedSessionIdRef.current === sessionId) {
+                  setSelectedSessionOverride(undefined);
+                  setInvalidSelectedSessionId(sessionId);
+                  setTurns([]);
+                  setContext(null);
+                }
+                return true;
+              }
+              if (
+                reconciledSession.deletionToken === deletionToken &&
+                reconciledSession.deletionPending === true
+              ) {
+                if (selectedSessionIdRef.current === sessionId) {
+                  setSelectedSessionOverride(reconciledSession);
+                  setTurns([]);
+                  setContext(null);
+                }
+                setDeleteError(
+                  'Deletion was interrupted. Finish deletion to remove the remaining analysis data.'
+                );
+                return false;
+              }
+            }
+          } catch {
+            // Keep the original deletion error when reconciliation is unavailable.
+          }
+        }
+        setDeleteError(getErrorMessage(err, 'Failed to delete analysis'));
+        return false;
+      } finally {
+        deleteInFlightSessionIdRef.current = null;
+        setDeletingSessionId(undefined);
+      }
+    },
+    [getAccessToken, selectedSession]
+  );
+
+  const clearDeleteError = useCallback((): void => {
+    setDeleteError(null);
+  }, []);
+
   return {
     sessions,
     selectedSessionId,
@@ -902,11 +1133,13 @@ export function useWhatsAppConversationAssistant(
     loadingContext,
     loadingMoreContext,
     creating,
-    sending,
+    turnPhase,
     retryingPreparation,
     exporting,
+    deletingSessionId,
     error,
     contextError,
+    deleteError,
     selectSession,
     selectChat,
     selectModel,
@@ -919,6 +1152,8 @@ export function useWhatsAppConversationAssistant(
     loadMoreContext,
     retryPreparation,
     exportSelectedSessionPdf,
+    deleteSession,
+    clearDeleteError,
     refresh,
   };
 }

--- a/apps/web/src/pages/WhatsAppConversationAssistantListPage.tsx
+++ b/apps/web/src/pages/WhatsAppConversationAssistantListPage.tsx
@@ -2,21 +2,52 @@ import {
   AlertTriangle,
   ArrowRight,
   Bot,
+  CheckCircle2,
   Clock,
   LoaderCircle,
   MessageSquare,
   Plus,
 } from 'lucide-react';
-import { useEffect } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { Layout } from '@/components/Layout';
 import { ErrorBanner } from '@/components/ui/ErrorBanner';
+import { ConversationAssistantActionsMenu } from '@/components/whatsapp/ConversationAssistantActionsMenu';
+import { ConversationAssistantDeleteDialog } from '@/components/whatsapp/ConversationAssistantDeleteDialog';
 import { useWhatsAppConversationAssistant } from '@/hooks/useWhatsAppConversationAssistant';
 import { formatDateTime, formatDateTimeCompact } from '@/utils/dateFormat';
+import type { ConversationAssistantSession } from '@/types';
+
+const SESSION_ROW_CLASS =
+  'group grid min-w-0 flex-1 gap-2 rounded-l-lg px-4 py-3 transition-colors sm:grid-cols-[minmax(0,1fr)_minmax(15rem,0.8fr)_auto] sm:items-center sm:gap-3 sm:py-4';
 
 export function WhatsAppConversationAssistantListPage(): React.JSX.Element {
   const assistant = useWhatsAppConversationAssistant({ loadChats: false, loadSessions: true });
+  const location = useLocation();
   const navigate = useNavigate();
+  const [deleteTarget, setDeleteTarget] = useState<ConversationAssistantSession | null>(null);
+  const [statusNotification, setStatusNotification] = useState<{
+    id: number;
+    message: string;
+  } | null>(null);
+  const statusNotificationIdRef = useRef(0);
+  const deleteTriggerRef = useRef<HTMLButtonElement | null>(null);
+  const pageHeadingRef = useRef<HTMLHeadingElement | null>(null);
+  const deleteTargetPending =
+    deleteTarget?.deletionPending === true ||
+    assistant.sessions.some(
+      (session) =>
+        session.id === deleteTarget?.id &&
+        session.deletionToken === deleteTarget.deletionToken &&
+        session.deletionPending === true
+    );
+  const showDeletionStatus = useCallback((title?: string): void => {
+    statusNotificationIdRef.current += 1;
+    setStatusNotification({
+      id: statusNotificationIdRef.current,
+      message: title === undefined ? 'Analysis deleted.' : `Analysis deleted. ${title}`,
+    });
+  }, []);
 
   useEffect(() => {
     if (assistant.selectedSessionId !== undefined) {
@@ -26,12 +57,37 @@ export function WhatsAppConversationAssistantListPage(): React.JSX.Element {
     }
   }, [assistant.selectedSessionId, navigate]);
 
+  useEffect(() => {
+    const locationState = location.state as { deletedAnalysisTitle?: unknown } | null;
+    if (typeof locationState?.deletedAnalysisTitle !== 'string') return;
+    showDeletionStatus(locationState.deletedAnalysisTitle);
+    void navigate(location.pathname, { replace: true, state: null });
+  }, [location.pathname, location.state, navigate, showDeletionStatus]);
+
+  useEffect(() => {
+    if (statusNotification === null) return;
+    const focusTimeoutId = window.setTimeout(() => {
+      pageHeadingRef.current?.focus();
+    }, 0);
+    const timeoutId = window.setTimeout(() => {
+      setStatusNotification(null);
+    }, 5000);
+    return (): void => {
+      window.clearTimeout(focusTimeoutId);
+      window.clearTimeout(timeoutId);
+    };
+  }, [statusNotification]);
+
   return (
     <Layout>
       <div className="flex w-full min-w-0 flex-col gap-5">
         <header className="flex flex-col gap-4 border-b border-slate-200 pb-5 dark:border-slate-800 sm:flex-row sm:items-end sm:justify-between">
           <div>
-            <h2 className="flex items-center gap-2 text-2xl font-bold text-slate-950 dark:text-slate-50">
+            <h2
+              ref={pageHeadingRef}
+              tabIndex={-1}
+              className="flex items-center gap-2 text-2xl font-bold text-slate-950 focus:outline-none dark:text-slate-50"
+            >
               <Bot className="h-6 w-6 text-blue-600 dark:text-blue-400" />
               Conversation Assistant
             </h2>
@@ -49,8 +105,19 @@ export function WhatsAppConversationAssistantListPage(): React.JSX.Element {
         </header>
 
         <ErrorBanner message={assistant.error} />
+        {statusNotification !== null ? (
+          <div
+            key={statusNotification.id}
+            role="status"
+            aria-live="polite"
+            className="flex items-center gap-2 rounded-lg border border-green-200 bg-green-50 px-4 py-3 text-sm font-medium text-green-800 dark:border-green-900 dark:bg-green-950/40 dark:text-green-300"
+          >
+            <CheckCircle2 className="h-4 w-4 shrink-0" />
+            {statusNotification.message}
+          </div>
+        ) : null}
 
-        <section className="overflow-hidden rounded-lg border border-slate-200 bg-white dark:border-slate-800 dark:bg-slate-900">
+        <section className="rounded-lg border border-slate-200 bg-white dark:border-slate-800 dark:bg-slate-900">
           {assistant.loading ? (
             <p className="px-5 py-12 text-center text-sm text-slate-500 dark:text-slate-400">
               Loading analyses...
@@ -69,55 +136,126 @@ export function WhatsAppConversationAssistantListPage(): React.JSX.Element {
           {!assistant.loading && assistant.sessions.length > 0 ? (
             <ul className="divide-y divide-slate-200 dark:divide-slate-800">
               {assistant.sessions.map((session) => (
-                <li key={session.id}>
-                  <Link
-                    to={`/whatsapp/conversation-assistant/${session.id}`}
-                    className="group grid gap-3 px-4 py-4 transition-colors hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500 dark:hover:bg-slate-800/70 sm:grid-cols-[minmax(0,1fr)_minmax(15rem,0.8fr)_auto] sm:items-center"
-                  >
-                    <span className="min-w-0">
-                      <span className="block truncate text-sm font-semibold text-slate-950 dark:text-slate-50">
-                        {session.title}
-                      </span>
-                      <span className="mt-1 flex min-w-0 items-center gap-1.5 text-xs text-slate-500 dark:text-slate-400">
-                        <MessageSquare className="h-3.5 w-3.5 shrink-0" />
-                        <span className="truncate">
-                          {session.chatDisplayName ?? session.chatId}
-                        </span>
-                      </span>
-                    </span>
-                    <span className="min-w-0 text-xs text-slate-500 dark:text-slate-400">
-                      <span className="flex items-center gap-1.5">
-                        <Clock className="h-3.5 w-3.5 shrink-0" />
-                        <span className="truncate">
-                          {formatDateTime(session.range.from)} – {formatDateTime(session.range.to)}
-                        </span>
-                      </span>
-                      <span className="mt-1 block pl-5">
-                        Last activity {formatDateTimeCompact(session.lastTurnAt ?? session.updatedAt)}
-                      </span>
-                    </span>
-                    <span className="flex items-center justify-between gap-3 sm:justify-end">
-                      {session.status === 'preparing' ? (
-                        <span className="inline-flex items-center gap-1.5 rounded-full bg-blue-50 px-2 py-1 text-xs font-medium text-blue-700 dark:bg-blue-950/50 dark:text-blue-300">
-                          <LoaderCircle className="h-3.5 w-3.5 animate-spin" />
-                          Preparing
-                        </span>
-                      ) : null}
-                      {session.status === 'failed' ? (
-                        <span className="inline-flex items-center gap-1.5 rounded-full bg-red-50 px-2 py-1 text-xs font-medium text-red-700 dark:bg-red-950/50 dark:text-red-300">
-                          <AlertTriangle className="h-3.5 w-3.5" />
-                          Needs attention
-                        </span>
-                      ) : null}
-                      <ArrowRight className="hidden h-4 w-4 text-slate-400 transition-transform group-hover:translate-x-0.5 sm:block" />
-                    </span>
-                  </Link>
+                <li key={session.id} className="flex min-w-0 items-stretch">
+                  {session.deletionPending === true ? (
+                    <div
+                      aria-label={`Deletion interrupted for ${session.title}`}
+                      className={`${SESSION_ROW_CLASS} bg-amber-50/70 dark:bg-amber-950/20`}
+                    >
+                      <ConversationAssistantListSummary session={session} />
+                    </div>
+                  ) : (
+                    <Link
+                      to={`/whatsapp/conversation-assistant/${session.id}`}
+                      className={`${SESSION_ROW_CLASS} hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500 dark:hover:bg-slate-800/70`}
+                    >
+                      <ConversationAssistantListSummary session={session} />
+                    </Link>
+                  )}
+                  <div className="flex items-center pr-2">
+                    <ConversationAssistantActionsMenu
+                      title={session.title}
+                      deleteLabel={
+                        session.deletionPending === true ? 'Finish deletion' : 'Delete analysis'
+                      }
+                      onDelete={(trigger): void => {
+                        deleteTriggerRef.current = trigger;
+                        assistant.clearDeleteError();
+                        setDeleteTarget({ ...session });
+                      }}
+                    />
+                  </div>
                 </li>
               ))}
             </ul>
           ) : null}
         </section>
+
+        {deleteTarget !== null ? (
+          <ConversationAssistantDeleteDialog
+            open
+            title={deleteTarget.title}
+            deleting={assistant.deletingSessionId === deleteTarget.id}
+            error={assistant.deleteError}
+            resumePending={deleteTargetPending}
+            returnFocusTo={deleteTriggerRef.current}
+            onOpenChange={(open): void => {
+              if (!open) {
+                assistant.clearDeleteError();
+                setDeleteTarget(null);
+              }
+            }}
+            onConfirm={async (): Promise<void> => {
+              const deleted = await assistant.deleteSession(
+                deleteTarget.id,
+                deleteTarget.deletionToken
+              );
+              if (!deleted) return;
+              showDeletionStatus(deleteTarget.title);
+              setDeleteTarget(null);
+            }}
+          />
+        ) : null}
       </div>
     </Layout>
+  );
+}
+
+function ConversationAssistantListSummary({
+  session,
+}: {
+  session: ConversationAssistantSession;
+}): React.JSX.Element {
+  return (
+    <>
+      <span className="min-w-0">
+        <span className="block truncate text-sm font-semibold text-slate-950 dark:text-slate-50">
+          {session.title}
+        </span>
+        <span className="mt-1 flex min-w-0 items-center gap-1.5 text-xs text-slate-500 dark:text-slate-400">
+          <MessageSquare className="h-3.5 w-3.5 shrink-0" />
+          <span className="truncate">{session.chatDisplayName ?? session.chatId}</span>
+        </span>
+      </span>
+      <span className="min-w-0 text-xs text-slate-500 dark:text-slate-400">
+        <span className="flex items-center gap-1.5">
+          <Clock className="h-3.5 w-3.5 shrink-0" />
+          <span className="truncate sm:hidden">
+            {formatDateTimeCompact(session.range.from)} – {formatDateTimeCompact(session.range.to)}
+          </span>
+          <span className="hidden truncate sm:inline">
+            {formatDateTime(session.range.from)} – {formatDateTime(session.range.to)}
+          </span>
+        </span>
+        <span className="mt-1 block pl-5">
+          <span className="sm:hidden">Updated </span>
+          <span className="hidden sm:inline">Last activity </span>
+          {formatDateTimeCompact(session.lastTurnAt ?? session.updatedAt)}
+        </span>
+      </span>
+      <span className="flex items-center justify-between gap-3 sm:justify-end">
+        {session.deletionPending === true ? (
+          <span className="inline-flex items-center gap-1.5 rounded-full bg-amber-100 px-2 py-1 text-xs font-medium text-amber-800 dark:bg-amber-950/60 dark:text-amber-300">
+            <AlertTriangle className="h-3.5 w-3.5" />
+            Deletion interrupted
+          </span>
+        ) : null}
+        {session.deletionPending !== true && session.status === 'preparing' ? (
+          <span className="inline-flex items-center gap-1.5 rounded-full bg-blue-50 px-2 py-1 text-xs font-medium text-blue-700 dark:bg-blue-950/50 dark:text-blue-300">
+            <LoaderCircle className="h-3.5 w-3.5 animate-spin" />
+            Preparing
+          </span>
+        ) : null}
+        {session.deletionPending !== true && session.status === 'failed' ? (
+          <span className="inline-flex items-center gap-1.5 rounded-full bg-red-50 px-2 py-1 text-xs font-medium text-red-700 dark:bg-red-950/50 dark:text-red-300">
+            <AlertTriangle className="h-3.5 w-3.5" />
+            Needs attention
+          </span>
+        ) : null}
+        {session.deletionPending !== true ? (
+          <ArrowRight className="hidden h-4 w-4 text-slate-400 transition-transform group-hover:translate-x-0.5 sm:block" />
+        ) : null}
+      </span>
+    </>
   );
 }

--- a/apps/web/src/pages/WhatsAppConversationAssistantSessionPage.tsx
+++ b/apps/web/src/pages/WhatsAppConversationAssistantSessionPage.tsx
@@ -7,15 +7,17 @@ import {
   MessageSquareText,
 } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useNavigate, useParams } from 'react-router-dom';
 import { Layout } from '@/components/Layout';
 import { MarkdownContent } from '@/components/MarkdownContent';
 import { Button } from '@/components/ui/Button';
 import { ErrorBanner } from '@/components/ui/ErrorBanner';
 import { ConversationAssistantComposer } from '@/components/whatsapp/ConversationAssistantComposer';
+import { ConversationAssistantActionsMenu } from '@/components/whatsapp/ConversationAssistantActionsMenu';
 import { ConversationAssistantContextModal } from '@/components/whatsapp/ConversationAssistantContextModal';
+import { ConversationAssistantDeleteDialog } from '@/components/whatsapp/ConversationAssistantDeleteDialog';
 import { useWhatsAppConversationAssistant } from '@/hooks/useWhatsAppConversationAssistant';
-import type { ConversationAssistantOmittedCounts } from '@/types';
+import type { ConversationAssistantOmittedCounts, ConversationAssistantSession } from '@/types';
 import { formatDateTime, formatDateTimeCompact } from '@/utils/dateFormat';
 
 function sumOmitted(omitted: ConversationAssistantOmittedCounts): number {
@@ -44,6 +46,7 @@ function getPreparationStageLabel(
 
 export function WhatsAppConversationAssistantSessionPage(): React.JSX.Element {
   const { sessionId } = useParams<{ sessionId: string }>();
+  const navigate = useNavigate();
   const assistant = useWhatsAppConversationAssistant({
     ...(sessionId !== undefined ? { sessionId } : {}),
     loadChats: false,
@@ -51,7 +54,11 @@ export function WhatsAppConversationAssistantSessionPage(): React.JSX.Element {
   });
   const turnsScrollRef = useRef<HTMLDivElement | null>(null);
   const followTurnsRef = useRef(true);
+  const deleteTriggerRef = useRef<HTMLButtonElement | null>(null);
   const [contextOpen, setContextOpen] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState<ConversationAssistantSession | undefined>(
+    undefined
+  );
 
   const updateTurnScrollFollow = useCallback((): void => {
     const element = turnsScrollRef.current;
@@ -77,21 +84,26 @@ export function WhatsAppConversationAssistantSessionPage(): React.JSX.Element {
   }, [assistant.loadingTurns, assistant.turns]);
 
   useEffect(() => {
-    if (!assistant.sending) return;
+    if (assistant.turnPhase === 'idle') return;
     followTurnsRef.current = true;
     const element = turnsScrollRef.current;
     if (element !== null) {
       element.scrollTop = element.scrollHeight;
     }
-  }, [assistant.sending]);
+  }, [assistant.turnPhase]);
 
   const session = assistant.selectedSession;
-  const contextReady = session?.status === 'ready' || session?.status === 'active';
-  const contextPreparing = session?.status === 'preparing';
-  const contextFailed = session?.status === 'failed';
+  const deletionPending = session?.deletionPending === true;
+  const contextReady =
+    !deletionPending && (session?.status === 'ready' || session?.status === 'active');
+  const contextPreparing = !deletionPending && session?.status === 'preparing';
+  const contextFailed = !deletionPending && session?.status === 'failed';
   const hasUserQuestion = assistant.turns.some((turn) => turn.role === 'user');
   const canExport =
-    contextReady && assistant.turns.length > 0 && !assistant.sending && !assistant.exporting;
+    contextReady &&
+    assistant.turns.length > 0 &&
+    assistant.turnPhase === 'idle' &&
+    !assistant.exporting;
 
   return (
     <Layout>
@@ -105,7 +117,7 @@ export function WhatsAppConversationAssistantSessionPage(): React.JSX.Element {
               <ArrowLeft className="mr-1.5 h-4 w-4" />
               Back to analyses
             </Link>
-            <h2 className="mt-3 truncate text-2xl font-bold text-slate-950 dark:text-slate-50">
+            <h2 className="mt-3 line-clamp-2 break-words text-xl font-bold leading-tight text-slate-950 dark:text-slate-50 sm:block sm:truncate sm:text-2xl">
               {session?.title ?? 'Loading analysis...'}
             </h2>
             {session !== undefined ? (
@@ -123,22 +135,63 @@ export function WhatsAppConversationAssistantSessionPage(): React.JSX.Element {
               </div>
             ) : null}
           </div>
-          <Button
-            variant="secondary"
-            size="sm"
-            onClick={(): void => {
-              void assistant.exportSelectedSessionPdf();
-            }}
-            isLoading={assistant.exporting}
-            loadingText="Exporting"
-            disabled={!canExport}
-          >
-            <Download className="mr-2 h-4 w-4" />
-            Export PDF
-          </Button>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={(): void => {
+                void assistant.exportSelectedSessionPdf();
+              }}
+              isLoading={assistant.exporting}
+              loadingText="Exporting"
+              disabled={!canExport}
+            >
+              <Download className="mr-2 h-4 w-4" />
+              Export PDF
+            </Button>
+            {session !== undefined ? (
+              <ConversationAssistantActionsMenu
+                title={session.title}
+                onDelete={(trigger): void => {
+                  deleteTriggerRef.current = trigger;
+                  assistant.clearDeleteError();
+                  setDeleteTarget({ ...session });
+                }}
+                deleteLabel={session.deletionPending === true ? 'Finish deletion' : 'Delete analysis'}
+              />
+            ) : null}
+          </div>
         </header>
 
         <ErrorBanner message={assistant.error} />
+
+        {session !== undefined && deletionPending ? (
+          <section
+            role="status"
+            className="flex flex-col items-start rounded-lg border border-amber-200 bg-amber-50 px-5 py-5 text-amber-900 dark:border-amber-900 dark:bg-amber-950/30 dark:text-amber-200"
+          >
+            <div className="flex items-center gap-2 font-semibold">
+              <AlertTriangle aria-hidden="true" className="h-5 w-5" />
+              Deletion interrupted
+            </div>
+            <p className="mt-2 text-sm">
+              This analysis is no longer available. Finish deletion to remove its remaining data.
+            </p>
+            <Button
+              type="button"
+              variant="danger"
+              size="sm"
+              className="mt-4 min-h-11"
+              onClick={(event): void => {
+                deleteTriggerRef.current = event.currentTarget;
+                assistant.clearDeleteError();
+                setDeleteTarget({ ...session });
+              }}
+            >
+              Finish deletion
+            </Button>
+          </section>
+        ) : null}
 
         {session !== undefined && contextReady ? (
           <button
@@ -160,7 +213,8 @@ export function WhatsAppConversationAssistantSessionPage(): React.JSX.Element {
           </button>
         ) : null}
 
-        <section className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border border-slate-200 bg-white dark:border-slate-800 dark:bg-slate-900">
+        {!deletionPending ? (
+          <section className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border border-slate-200 bg-white dark:border-slate-800 dark:bg-slate-900">
           <div
             ref={turnsScrollRef}
             data-testid="conversation-assistant-turns"
@@ -218,8 +272,12 @@ export function WhatsAppConversationAssistantSessionPage(): React.JSX.Element {
                 </p>
               </div>
             ) : null}
-            {assistant.turns.map((turn) => {
+            {assistant.turns.map((turn, index) => {
               const isUser = turn.role === 'user';
+              const isStreamingAnswer =
+                assistant.turnPhase === 'streaming' &&
+                !isUser &&
+                index === assistant.turns.length - 1;
               return (
                 <article
                   key={turn.id}
@@ -230,7 +288,17 @@ export function WhatsAppConversationAssistantSessionPage(): React.JSX.Element {
                   }`}
                 >
                   <div className="mb-1 flex items-start justify-between gap-3 text-xs font-semibold uppercase text-slate-500 dark:text-slate-400">
-                    <span>{isUser ? 'You' : (session?.assistantRoleLabel ?? 'Assistant')}</span>
+                    <span className="flex items-center gap-2">
+                      {isUser ? 'You' : (session?.assistantRoleLabel ?? 'Assistant')}
+                      {isStreamingAnswer ? (
+                        <span
+                          aria-hidden="true"
+                          className="normal-case text-blue-600 dark:text-blue-400"
+                        >
+                          Responding…
+                        </span>
+                      ) : null}
+                    </span>
                     <span className="shrink-0">{formatDateTimeCompact(turn.createdAt)}</span>
                   </div>
                   {isUser ? (
@@ -250,21 +318,37 @@ export function WhatsAppConversationAssistantSessionPage(): React.JSX.Element {
                 </article>
               );
             })}
+            {assistant.turnPhase === 'waiting' ? (
+              <article
+                role="status"
+                aria-live="polite"
+                className="mr-auto flex max-w-[min(46rem,100%)] items-center gap-2 rounded-lg border border-slate-200 bg-white px-4 py-3 text-sm text-slate-600 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-300"
+              >
+                <LoaderCircle aria-hidden="true" className="h-4 w-4 animate-spin" />
+                Assistant is thinking…
+              </article>
+            ) : null}
+            {assistant.turnPhase === 'streaming' ? (
+              <span role="status" aria-live="polite" className="sr-only">
+                Assistant is responding.
+              </span>
+            ) : null}
           </div>
 
           {contextReady ? (
             <ConversationAssistantComposer
               value={assistant.followUpQuestion}
               disabled={assistant.retryingPreparation}
-              sending={assistant.sending}
+              turnPhase={assistant.turnPhase}
               mode={hasUserQuestion ? 'follow-up' : 'first-question'}
               onChange={assistant.setFollowUpQuestion}
               onSend={assistant.sendFollowUp}
             />
           ) : null}
-        </section>
+          </section>
+        ) : null}
 
-        {contextOpen && session !== undefined ? (
+        {contextOpen && session !== undefined && !deletionPending ? (
           <ConversationAssistantContextModal
             context={assistant.context}
             loading={assistant.loadingContext}
@@ -284,6 +368,38 @@ export function WhatsAppConversationAssistantSessionPage(): React.JSX.Element {
             }}
             onClose={(): void => {
               setContextOpen(false);
+            }}
+          />
+        ) : null}
+        {deleteTarget !== undefined ? (
+          <ConversationAssistantDeleteDialog
+            open
+            title={deleteTarget.title}
+            deleting={assistant.deletingSessionId === deleteTarget.id}
+            error={assistant.deleteError}
+            resumePending={
+              deleteTarget.deletionPending === true ||
+              (session?.id === deleteTarget.id &&
+                session.deletionToken === deleteTarget.deletionToken &&
+                session.deletionPending === true)
+            }
+            returnFocusTo={deleteTriggerRef.current}
+            onOpenChange={(open): void => {
+              if (!open) {
+                assistant.clearDeleteError();
+                setDeleteTarget(undefined);
+              }
+            }}
+            onConfirm={async (): Promise<void> => {
+              const deleted = await assistant.deleteSession(
+                deleteTarget.id,
+                deleteTarget.deletionToken
+              );
+              if (!deleted) return;
+              await navigate('/whatsapp/conversation-assistant', {
+                replace: true,
+                state: { deletedAnalysisTitle: deleteTarget.title },
+              });
             }}
           />
         ) : null}

--- a/apps/web/src/pages/__tests__/WhatsAppConversationAssistantSeparatedPages.test.tsx
+++ b/apps/web/src/pages/__tests__/WhatsAppConversationAssistantSeparatedPages.test.tsx
@@ -28,6 +28,7 @@ function createHookResult(
 ): UseWhatsAppConversationAssistantResult {
   const session: UseWhatsAppConversationAssistantResult['sessions'][number] = {
     id: 'session-1',
+    deletionToken: 'deletion-token-session-1',
     userId: 'user-1',
     chatId: 'chat-direct',
     chatDisplayName: 'Alice',
@@ -86,11 +87,13 @@ function createHookResult(
     loadingContext: false,
     loadingMoreContext: false,
     creating: false,
-    sending: false,
+    turnPhase: 'idle',
     retryingPreparation: false,
     exporting: false,
+    deletingSessionId: undefined,
     error: null,
     contextError: null,
+    deleteError: null,
     selectSession: vi.fn(),
     selectChat: vi.fn(),
     selectModel: vi.fn(),
@@ -103,6 +106,8 @@ function createHookResult(
     loadMoreContext: vi.fn(),
     retryPreparation: vi.fn(),
     exportSelectedSessionPdf: vi.fn(),
+    deleteSession: vi.fn().mockResolvedValue(true),
+    clearDeleteError: vi.fn(),
     refresh: vi.fn(),
     ...overrides,
   };
@@ -140,10 +145,12 @@ describe('separated Conversation Assistant pages', () => {
       'href',
       '/whatsapp/conversation-assistant/new'
     );
-    expect(screen.getByRole('link', { name: /Alice context/i })).toHaveAttribute(
+    const analysisLink = screen.getByRole('link', { name: /Alice context/i });
+    expect(analysisLink).toHaveAttribute(
       'href',
       '/whatsapp/conversation-assistant/session-1'
     );
+    expect(analysisLink).toHaveTextContent('Jun 20, 11:00 AM – Jun 21, 12:00 PM');
     expect(screen.queryByLabelText('Private direct chat')).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Send' })).not.toBeInTheDocument();
     expect(screen.queryByText('Psychologist')).not.toBeInTheDocument();
@@ -180,6 +187,232 @@ describe('separated Conversation Assistant pages', () => {
 
     expect(screen.getByText('Preparing')).toBeInTheDocument();
     expect(screen.getByText('Needs attention')).toBeInTheDocument();
+  });
+
+  it('shows an interrupted deletion as a retryable state instead of an openable analysis', async () => {
+    const user = userEvent.setup();
+    const result = createHookResult();
+    const pendingSession = {
+      ...firstSession(result),
+      deletionPending: true,
+    };
+    mockUseAssistant.mockReturnValue(createHookResult({ sessions: [pendingSession] }));
+
+    render(
+      <MemoryRouter>
+        <WhatsAppConversationAssistantListPage />
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByRole('link', { name: /Alice context/i })).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Deletion interrupted for Alice context')).toBeInTheDocument();
+    expect(screen.getByText('Deletion interrupted')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Actions for Alice context' }));
+    await user.click(screen.getByRole('menuitem', { name: 'Finish deletion' }));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Finish deletion?' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Finish deletion' })).toBeInTheDocument();
+  });
+
+  it('confirms deletion from the list without nesting the action inside navigation', async () => {
+    const user = userEvent.setup();
+    const deleteSession = vi.fn().mockResolvedValue(true);
+    mockUseAssistant.mockReturnValue(createHookResult({ deleteSession }));
+
+    render(
+      <MemoryRouter>
+        <WhatsAppConversationAssistantListPage />
+      </MemoryRouter>
+    );
+
+    const actions = screen.getByRole('button', { name: 'Actions for Alice context' });
+    expect(actions).toHaveClass('min-h-11', 'min-w-11');
+    expect(actions.closest('a')).toBeNull();
+    await user.click(actions);
+    const deleteMenuItem = screen.getByRole('menuitem', { name: 'Delete analysis' });
+    await waitFor(() => {
+      expect(deleteMenuItem).toHaveFocus();
+    });
+    await user.keyboard('{Escape}');
+    expect(screen.queryByRole('menuitem', { name: 'Delete analysis' })).not.toBeInTheDocument();
+    expect(actions).toHaveFocus();
+
+    await user.click(actions);
+    await waitFor(() => {
+      expect(screen.getByRole('menuitem', { name: 'Delete analysis' })).toHaveFocus();
+    });
+    await user.tab();
+    expect(screen.queryByRole('menuitem', { name: 'Delete analysis' })).not.toBeInTheDocument();
+
+    await user.click(actions);
+    await waitFor(() => {
+      expect(screen.getByRole('menuitem', { name: 'Delete analysis' })).toHaveFocus();
+    });
+    await user.tab({ shift: true });
+    await waitFor(() => {
+      expect(screen.queryByRole('menuitem', { name: 'Delete analysis' })).not.toBeInTheDocument();
+    });
+    expect(actions).toHaveFocus();
+
+    await user.click(actions);
+    await user.click(screen.getByRole('menuitem', { name: 'Delete analysis' }));
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Delete analysis?' })).toBeInTheDocument();
+    expect(screen.getByRole('note', { name: 'WhatsApp data safety' })).toHaveTextContent(
+      'Original WhatsApp conversation stays untouched.'
+    );
+    expect(screen.getByText('This action cannot be undone.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toHaveClass('min-h-11');
+    expect(screen.getByRole('button', { name: 'Delete analysis' })).toHaveClass('min-h-11');
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(deleteSession).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(actions).toHaveFocus();
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Actions for Alice context' }));
+    await user.click(screen.getByRole('menuitem', { name: 'Delete analysis' }));
+    await user.click(screen.getByRole('button', { name: 'Delete analysis' }));
+
+    expect(deleteSession).toHaveBeenCalledWith('session-1', 'deletion-token-session-1');
+    expect(await screen.findByRole('status')).toHaveTextContent('Analysis deleted.');
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Conversation Assistant' })).toHaveFocus();
+    });
+  });
+
+  it('deletes the exact analysis generation that was shown when the dialog opened', async () => {
+    const user = userEvent.setup();
+    const deleteSession = vi.fn().mockResolvedValue(true);
+    let hookResult = createHookResult({ deleteSession });
+    mockUseAssistant.mockImplementation(() => hookResult);
+    const view = render(
+      <MemoryRouter>
+        <WhatsAppConversationAssistantListPage />
+      </MemoryRouter>
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Actions for Alice context' }));
+    await user.click(screen.getByRole('menuitem', { name: 'Delete analysis' }));
+    const replacementSession = {
+      ...firstSession(hookResult),
+      deletionToken: 'deletion-token-replacement',
+      title: 'Replacement analysis',
+    };
+    hookResult = createHookResult({ sessions: [replacementSession], deleteSession });
+    view.rerender(
+      <MemoryRouter>
+        <WhatsAppConversationAssistantListPage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText(/permanently removes “Alice context”/i)).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Delete analysis' }));
+
+    expect(deleteSession).toHaveBeenCalledWith('session-1', 'deletion-token-session-1');
+  });
+
+  it('confirms deletion after returning from an open analysis', async () => {
+    mockUseAssistant.mockReturnValue(createHookResult({ sessions: [] }));
+
+    render(
+      <MemoryRouter
+        initialEntries={[
+          {
+            pathname: '/whatsapp/conversation-assistant',
+            state: { deletedAnalysisTitle: 'Alice context' },
+          },
+        ]}
+      >
+        <WhatsAppConversationAssistantListPage />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('status')).toHaveTextContent('Analysis deleted.');
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Conversation Assistant' })).toHaveFocus();
+    });
+  });
+
+  it('restarts deletion feedback when two analyses are deleted in quick succession', async () => {
+    const user = userEvent.setup();
+    const setTimeoutSpy = vi.spyOn(window, 'setTimeout');
+    const result = createHookResult();
+    const aliceSession = firstSession(result);
+    const bobSession = {
+      ...aliceSession,
+      id: 'session-2',
+      chatId: 'chat-bob',
+      chatDisplayName: 'Bob',
+      title: 'Bob context',
+    };
+    mockUseAssistant.mockReturnValue(
+      createHookResult({ sessions: [aliceSession, bobSession] })
+    );
+
+    render(
+      <MemoryRouter>
+        <WhatsAppConversationAssistantListPage />
+      </MemoryRouter>
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Actions for Alice context' }));
+    await user.click(screen.getByRole('menuitem', { name: 'Delete analysis' }));
+    await user.click(screen.getByRole('button', { name: 'Delete analysis' }));
+    const firstStatus = screen.getByRole('status');
+    expect(firstStatus).toHaveTextContent('Analysis deleted.');
+
+    await user.click(screen.getByRole('button', { name: 'Actions for Bob context' }));
+    await user.click(screen.getByRole('menuitem', { name: 'Delete analysis' }));
+    await user.click(screen.getByRole('button', { name: 'Delete analysis' }));
+    expect(screen.getByRole('status')).toHaveTextContent('Analysis deleted.');
+    expect(screen.getByRole('status')).not.toBe(firstStatus);
+    expect(setTimeoutSpy.mock.calls.filter(([, delay]) => delay === 5000)).toHaveLength(2);
+  });
+
+  it('keeps the deletion dialog open with a retryable error', async () => {
+    const user = userEvent.setup();
+    const deleteSession = vi.fn().mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+    mockUseAssistant.mockReturnValue(
+      createHookResult({ deleteSession, deleteError: 'Delete failed' })
+    );
+
+    render(
+      <MemoryRouter>
+        <WhatsAppConversationAssistantListPage />
+      </MemoryRouter>
+    );
+    await user.click(screen.getByRole('button', { name: 'Actions for Alice context' }));
+    await user.click(screen.getByRole('menuitem', { name: 'Delete analysis' }));
+    await user.click(screen.getByRole('button', { name: 'Delete analysis' }));
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('Delete failed')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Delete analysis' }));
+    expect(deleteSession).toHaveBeenCalledTimes(2);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('shows a non-dismissible deleting state with accessible touch targets', async () => {
+    const user = userEvent.setup();
+    const result = createHookResult();
+    mockUseAssistant.mockReturnValue(
+      createHookResult({ deletingSessionId: result.sessions[0]?.id })
+    );
+
+    render(
+      <MemoryRouter>
+        <WhatsAppConversationAssistantListPage />
+      </MemoryRouter>
+    );
+    await user.click(screen.getByRole('button', { name: 'Actions for Alice context' }));
+    await user.click(screen.getByRole('menuitem', { name: 'Delete analysis' }));
+
+    expect(screen.getByRole('button', { name: 'Deleting…' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Deleting…' })).toHaveClass('min-h-11');
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled();
   });
 
   it('redirects legacy session query links to the canonical conversation route', async () => {
@@ -253,18 +486,100 @@ describe('separated Conversation Assistant pages', () => {
       </MemoryRouter>
     );
 
-    expect(screen.getByRole('heading', { name: 'Alice context' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Alice context' })).toHaveClass(
+      'line-clamp-2',
+      'sm:truncate'
+    );
     expect(screen.getByRole('link', { name: 'Back to analyses' })).toHaveAttribute(
       'href',
       '/whatsapp/conversation-assistant'
     );
     expect(screen.getByLabelText('Ask first question')).toBeEnabled();
     expect(screen.getByPlaceholderText('Ask your first question about this conversation')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Send' })).toBeDisabled();
+    const sendButton = screen.getByRole('button', { name: 'Send' });
+    expect(sendButton).toBeDisabled();
+    expect(sendButton).toHaveClass('h-12', 'w-12', 'sm:w-auto');
+    expect(sendButton.closest('form')).toHaveClass('flex-row', 'items-end');
     expect(screen.getByLabelText('Model used')).toHaveTextContent('Gemini 3.5 Flash Thinking');
     expect(screen.queryByLabelText('Private direct chat')).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Create analysis' })).not.toBeInTheDocument();
     expect(screen.queryByRole('link', { name: /Alice context/i })).not.toBeInTheDocument();
+  });
+
+  it('deletes the open analysis and returns to the analysis list', async () => {
+    const user = userEvent.setup();
+    const result = createHookResult();
+    const deleteSession = vi.fn().mockResolvedValue(true);
+    mockUseAssistant.mockReturnValue(
+      createHookResult({
+        selectedSessionId: 'session-1',
+        selectedSession: result.sessions[0],
+        deleteSession,
+      })
+    );
+
+    render(
+      <MemoryRouter initialEntries={['/whatsapp/conversation-assistant/session-1']}>
+        <Routes>
+          <Route
+            path="/whatsapp/conversation-assistant/:sessionId"
+            element={<WhatsAppConversationAssistantSessionPage />}
+          />
+          <Route
+            path="/whatsapp/conversation-assistant"
+            element={<p>Analysis list destination</p>}
+          />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    const actions = screen.getByRole('button', { name: 'Actions for Alice context' });
+    expect(actions).toHaveClass('min-h-11', 'min-w-11');
+    await user.click(actions);
+    await user.click(screen.getByRole('menuitem', { name: 'Delete analysis' }));
+    await user.click(screen.getByRole('button', { name: 'Delete analysis' }));
+
+    expect(deleteSession).toHaveBeenCalledWith('session-1', 'deletion-token-session-1');
+    expect(await screen.findByText('Analysis list destination')).toBeInTheDocument();
+  });
+
+  it('shows an interrupted detail deletion as a dedicated finish-only state', async () => {
+    const user = userEvent.setup();
+    const result = createHookResult();
+    const pendingSession = {
+      ...firstSession(result),
+      deletionPending: true,
+    };
+    mockUseAssistant.mockReturnValue(
+      createHookResult({
+        selectedSessionId: pendingSession.id,
+        selectedSession: pendingSession,
+        turns: result.turns,
+      })
+    );
+
+    render(
+      <MemoryRouter initialEntries={['/whatsapp/conversation-assistant/session-1']}>
+        <Routes>
+          <Route
+            path="/whatsapp/conversation-assistant/:sessionId"
+            element={<WhatsAppConversationAssistantSessionPage />}
+          />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole('status')).toHaveTextContent('Deletion interrupted');
+    expect(screen.queryByLabelText('Ask first question')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Ask follow-up question')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'View frozen context' })).not.toBeInTheDocument();
+    const finishDeletionButton = screen.getByRole('button', { name: 'Finish deletion' });
+    await user.click(finishDeletionButton);
+    expect(screen.getByRole('heading', { name: 'Finish deletion?' })).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    await waitFor(() => {
+      expect(finishDeletionButton).toHaveFocus();
+    });
   });
 
   it('opens the exact frozen messages and omission breakdown from the context summary', async () => {
@@ -448,6 +763,83 @@ describe('separated Conversation Assistant pages', () => {
     expect(screen.queryByLabelText('Ask first question')).not.toBeInTheDocument();
   });
 
+  it('moves progress from the send button into the conversation after acknowledgement', () => {
+    const result = createHookResult();
+    const userTurn = {
+      id: 'phase-user',
+      sessionId: 'session-1',
+      userId: 'user-1',
+      role: 'user' as const,
+      text: 'What happened?',
+      createdAt: '2026-06-21T11:01:00.000Z',
+    };
+    const view = (): React.JSX.Element => (
+      <MemoryRouter initialEntries={['/whatsapp/conversation-assistant/session-1']}>
+        <Routes>
+          <Route
+            path="/whatsapp/conversation-assistant/:sessionId"
+            element={<WhatsAppConversationAssistantSessionPage />}
+          />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    mockUseAssistant.mockReturnValue(
+      createHookResult({
+        selectedSessionId: 'session-1',
+        selectedSession: result.sessions[0],
+        followUpQuestion: 'What happened?',
+        turnPhase: 'submitting',
+      })
+    );
+    const { rerender } = render(view());
+    const sendingButton = screen.getByRole('button', { name: 'Sending…' });
+    expect(sendingButton).toBeDisabled();
+    expect(sendingButton).toHaveClass('h-12', 'w-auto');
+    expect(sendingButton).not.toHaveClass('w-12');
+    expect(screen.getByLabelText('Ask first question')).toBeDisabled();
+
+    mockUseAssistant.mockReturnValue(
+      createHookResult({
+        selectedSessionId: 'session-1',
+        selectedSession: result.sessions[0],
+        turns: [userTurn],
+        followUpQuestion: 'Draft next question',
+        turnPhase: 'waiting',
+      })
+    );
+    rerender(view());
+    expect(screen.queryByText('Sending…')).not.toBeInTheDocument();
+    expect(screen.getByText('Assistant is thinking…')).toBeInTheDocument();
+    expect(screen.getByLabelText('Ask follow-up')).toBeEnabled();
+    expect(screen.getByRole('button', { name: 'Send' })).toBeDisabled();
+
+    mockUseAssistant.mockReturnValue(
+      createHookResult({
+        selectedSessionId: 'session-1',
+        selectedSession: result.sessions[0],
+        turns: [
+          userTurn,
+          {
+            id: 'phase-assistant',
+            sessionId: 'session-1',
+            userId: 'user-1',
+            role: 'assistant',
+            text: 'The answer is streaming.',
+            createdAt: '2026-06-21T11:02:00.000Z',
+          },
+        ],
+        followUpQuestion: 'Draft next question',
+        turnPhase: 'streaming',
+      })
+    );
+    rerender(view());
+    expect(screen.getByText('Responding…')).toBeInTheDocument();
+    expect(screen.getByRole('status')).toHaveTextContent('Assistant is responding.');
+    expect(screen.getByLabelText('Ask follow-up')).toBeEnabled();
+    expect(screen.getByRole('button', { name: 'Send' })).toBeDisabled();
+  });
+
   it('renders persisted turn errors inline with the affected answer', () => {
     const result = createHookResult();
     mockUseAssistant.mockReturnValue(
@@ -525,7 +917,7 @@ describe('separated Conversation Assistant pages', () => {
       createHookResult({
         selectedSessionId: 'session-1',
         selectedSession: result.sessions[0],
-        sending: true,
+        turnPhase: 'streaming',
         turns: [
           firstTurn,
           {

--- a/apps/web/src/services/__tests__/conversationAssistantApi.test.ts
+++ b/apps/web/src/services/__tests__/conversationAssistantApi.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   checkConversationAssistantContext,
   createConversationAssistantSession,
+  deleteConversationAssistantSession,
   exportConversationAssistantSessionPdf,
   getConversationAssistantContext,
   getConversationAssistantSession,
@@ -150,6 +151,23 @@ describe('conversationAssistantApi', () => {
     expect(result).toEqual(session);
   });
 
+  it('deletes a conversation assistant session with a URL-encoded id', async () => {
+    const { apiRequest } = await import('../apiClient.js');
+    vi.mocked(apiRequest).mockResolvedValue({ deleted: true });
+
+    await deleteConversationAssistantSession(TOKEN, 'session/with spaces?', 'delete-token');
+
+    expect(vi.mocked(apiRequest)).toHaveBeenCalledWith(
+      'https://wa.test',
+      '/conversation-assistant/sessions/session%2Fwith%20spaces%3F',
+      TOKEN,
+      {
+        method: 'DELETE',
+        headers: { 'X-Conversation-Assistant-Deletion-Token': 'delete-token' },
+      }
+    );
+  });
+
   it('loads the frozen context with a URL-encoded session id', async () => {
     const { apiRequest } = await import('../apiClient.js');
     const context = {
@@ -245,6 +263,11 @@ describe('conversationAssistantApi', () => {
         controller.enqueue(
           encoder.encode('event: assistant_delta\ndata: {"type":"assistant_delta","text":"Hello"}\n\n')
         );
+        controller.enqueue(
+          encoder.encode(
+            'event: assistant_turn\ndata: {"type":"assistant_turn","turn":{"id":"turn-2","sessionId":"session/with spaces?","userId":"user-1","role":"assistant","text":"Hello","createdAt":"2026-06-01T00:00:01.000Z"}}\n\n'
+          )
+        );
         controller.enqueue(encoder.encode('event: done\ndata: {"type":"done"}\n\n'));
         controller.close();
       },
@@ -282,8 +305,116 @@ describe('conversationAssistantApi', () => {
     expect(events.map((event) => (event as { type: string }).type)).toEqual([
       'user_turn',
       'assistant_delta',
+      'assistant_turn',
       'done',
     ]);
+  });
+
+  it('rejects an acknowledged error stream even when it ends with done', async () => {
+    const encoder = new TextEncoder();
+    const frames = [
+      'event: user_turn\ndata: {"type":"user_turn","turn":{"id":"turn-1","sessionId":"session-1","userId":"user-1","role":"user","text":"Hi","createdAt":"2026-06-01T00:00:00.000Z"}}\n\n',
+      'event: assistant_delta\ndata: {"type":"assistant_delta","text":"Partial"}\n\n',
+      'event: error\ndata: {"type":"error","error":{"code":"LLM_ERROR","message":"Disconnected"}}\n\n',
+      'event: done\ndata: {"type":"done"}\n\n',
+    ];
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller): void {
+        controller.enqueue(encoder.encode(frames.join('')));
+        controller.close();
+      },
+    });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(stream, {
+          status: 200,
+          headers: { 'Content-Type': 'text/event-stream' },
+        })
+      )
+    );
+
+    await expect(
+      streamConversationAssistantTurn(TOKEN, 'session-1', { question: 'Hi' }, vi.fn())
+    ).rejects.toThrow('Assistant response stream ended before completion');
+  });
+
+  it('accepts a persisted model error when the assistant turn and stream both complete', async () => {
+    const encoder = new TextEncoder();
+    const frames = [
+      'event: user_turn\ndata: {"type":"user_turn","turn":{"id":"turn-1","sessionId":"session-1","userId":"user-1","role":"user","text":"Hi","createdAt":"2026-06-01T00:00:00.000Z"}}\n\n',
+      'event: assistant_delta\ndata: {"type":"assistant_delta","text":"Partial"}\n\n',
+      'event: error\ndata: {"type":"error","error":{"code":"LLM_ERROR","message":"Disconnected"}}\n\n',
+      'event: assistant_turn\ndata: {"type":"assistant_turn","turn":{"id":"turn-2","sessionId":"session-1","userId":"user-1","role":"assistant","text":"Partial","createdAt":"2026-06-01T00:00:01.000Z","error":{"code":"LLM_ERROR","message":"Disconnected"}}}\n\n',
+      'event: done\ndata: {"type":"done"}\n\n',
+    ];
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller): void {
+        controller.enqueue(encoder.encode(frames.join('')));
+        controller.close();
+      },
+    });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(stream, {
+          status: 200,
+          headers: { 'Content-Type': 'text/event-stream' },
+        })
+      )
+    );
+    const events: unknown[] = [];
+
+    await expect(
+      streamConversationAssistantTurn(TOKEN, 'session-1', { question: 'Hi' }, (event) =>
+        events.push(event)
+      )
+    ).resolves.toBeUndefined();
+    expect(events.map((event) => (event as { type: string }).type)).toEqual([
+      'user_turn',
+      'assistant_delta',
+      'error',
+      'assistant_turn',
+      'done',
+    ]);
+  });
+
+  it.each([
+    { name: 'empty', frames: '' },
+    {
+      name: 'user acknowledgement only',
+      frames:
+        'event: user_turn\ndata: {"type":"user_turn","turn":{"id":"turn-1","sessionId":"session-1","userId":"user-1","role":"user","text":"Hi","createdAt":"2026-06-01T00:00:00.000Z"}}\n\n',
+    },
+    {
+      name: 'partial assistant answer',
+      frames:
+        'event: user_turn\ndata: {"type":"user_turn","turn":{"id":"turn-1","sessionId":"session-1","userId":"user-1","role":"user","text":"Hi","createdAt":"2026-06-01T00:00:00.000Z"}}\n\nevent: assistant_delta\ndata: {"type":"assistant_delta","text":"Partial"}\n\n',
+    },
+  ])('rejects a $name stream that closes without a done event', async ({ frames }) => {
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller): void {
+        if (frames !== '') controller.enqueue(encoder.encode(frames));
+        controller.close();
+      },
+    });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(stream, {
+          status: 200,
+          headers: { 'Content-Type': 'text/event-stream' },
+        })
+      )
+    );
+
+    await expect(
+      streamConversationAssistantTurn(TOKEN, 'session-1', { question: 'Hi' }, vi.fn())
+    ).rejects.toMatchObject<ApiError>({
+      code: 'SERVICE_UNAVAILABLE',
+      message: 'Assistant response stream ended before completion',
+    });
   });
 
   it('exports conversation assistant PDF with filename from content disposition', async () => {

--- a/apps/web/src/services/conversationAssistantApi.ts
+++ b/apps/web/src/services/conversationAssistantApi.ts
@@ -99,6 +99,22 @@ export async function getConversationAssistantSession(
   return response.session;
 }
 
+export async function deleteConversationAssistantSession(
+  accessToken: string,
+  sessionId: string,
+  deletionToken: string
+): Promise<void> {
+  await apiRequest<{ deleted: true }>(
+    config.whatsappServiceUrl,
+    getSessionPath(sessionId),
+    accessToken,
+    {
+      method: 'DELETE',
+      headers: { 'X-Conversation-Assistant-Deletion-Token': deletionToken },
+    }
+  );
+}
+
 export async function getConversationAssistantContext(
   accessToken: string,
   sessionId: string,
@@ -218,17 +234,32 @@ async function readConversationAssistantEventStream(
   const reader = body.getReader();
   const decoder = new TextDecoder();
   let buffer = '';
+  const receivedEventTypes = new Set<ConversationAssistantStreamEvent['type']>();
+  const trackEvent = (event: ConversationAssistantStreamEvent): void => {
+    receivedEventTypes.add(event.type);
+    onEvent(event);
+  };
 
   let next = await reader.read();
   while (!next.done) {
     buffer += decoder.decode(next.value, { stream: true });
-    buffer = dispatchCompleteSseFrames(buffer, onEvent);
+    buffer = dispatchCompleteSseFrames(buffer, trackEvent);
     next = await reader.read();
   }
 
   buffer += decoder.decode();
   if (buffer.trim() !== '') {
-    dispatchSseFrame(buffer, onEvent);
+    dispatchSseFrame(buffer, trackEvent);
+  }
+  if (
+    !receivedEventTypes.has('done') ||
+    (receivedEventTypes.has('user_turn') && !receivedEventTypes.has('assistant_turn'))
+  ) {
+    throw new ApiError(
+      'SERVICE_UNAVAILABLE',
+      'Assistant response stream ended before completion',
+      503
+    );
   }
 }
 

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -385,6 +385,8 @@ export interface ConversationAssistantSession {
   createdAt: string;
   updatedAt: string;
   lastTurnAt?: string;
+  deletionToken?: string;
+  deletionPending?: boolean;
 }
 
 export interface ConversationAssistantTurn {

--- a/apps/whatsapp-service/src/__tests__/conversationAssistantRoutes.test.ts
+++ b/apps/whatsapp-service/src/__tests__/conversationAssistantRoutes.test.ts
@@ -107,6 +107,8 @@ describe('Conversation Assistant routes', () => {
   }
 
   async function prepareSession(sessionId: string): Promise<void> {
+    const session = await ctx.conversationAssistantRepository.getSessionById(sessionId);
+    const generationId = session?.generationId;
     const response = await ctx.app.inject({
       method: 'POST',
       url: '/internal/whatsapp/pubsub/process-webhook',
@@ -119,6 +121,7 @@ describe('Conversation Assistant routes', () => {
               sessionId,
               userId: USER_ID,
               attempt: 1,
+              ...(generationId !== undefined ? { generationId } : {}),
             })
           ).toString('base64'),
           messageId: `prepare-${sessionId}`,
@@ -157,6 +160,8 @@ describe('Conversation Assistant routes', () => {
           modelDisplayName: string;
           status: string;
           preparationStage: string;
+          deletionToken: string;
+          deletionPending: boolean;
         };
       };
     };
@@ -170,6 +175,8 @@ describe('Conversation Assistant routes', () => {
     expect(body.data.session.modelDisplayName).toBe('MiniMax M3');
     expect(body.data.session.status).toBe('preparing');
     expect(body.data.session.preparationStage).toBe('queued');
+    expect(body.data.session.deletionToken).toMatch(/^[a-f0-9]{64}$/);
+    expect(body.data.session.deletionPending).toBe(false);
     expect(JSON.stringify(body)).not.toContain('We agreed to meet');
     expect(JSON.stringify(body)).not.toContain('transcriptText');
     expect(body.data).not.toHaveProperty('turns');
@@ -179,6 +186,7 @@ describe('Conversation Assistant routes', () => {
         sessionId: body.data.session.id,
         userId: USER_ID,
         attempt: 1,
+        generationId: expect.any(String),
       },
     ]);
 
@@ -191,6 +199,66 @@ describe('Conversation Assistant routes', () => {
     expect(JSON.parse(contextBeforeReady.body).error.message).toBe(
       'Conversation context is not ready yet'
     );
+  });
+
+  it('deletes an owned analysis and treats missing or foreign deletion as an idempotent success', async () => {
+    const token = await seed();
+    const sessionId = await createSessionWithFirstTurn(token);
+    const foreignToken = await createToken({ sub: 'other-user' });
+    const sessionResponse = await ctx.app.inject({
+      method: 'GET',
+      url: `/conversation-assistant/sessions/${sessionId}`,
+      headers: { authorization: `Bearer ${token}` },
+    });
+    const deletionToken = (
+      JSON.parse(sessionResponse.body) as { data: { session: { deletionToken: string } } }
+    ).data.session.deletionToken;
+
+    const missingTokenDelete = await ctx.app.inject({
+      method: 'DELETE',
+      url: `/conversation-assistant/sessions/${sessionId}`,
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(missingTokenDelete.statusCode).toBe(400);
+    await expect(
+      ctx.conversationAssistantRepository.getSessionById(sessionId)
+    ).resolves.not.toBeNull();
+
+    const foreignDelete = await ctx.app.inject({
+      method: 'DELETE',
+      url: `/conversation-assistant/sessions/${sessionId}`,
+      headers: {
+        authorization: `Bearer ${foreignToken}`,
+        'x-conversation-assistant-deletion-token': deletionToken,
+      },
+    });
+    expect(foreignDelete.statusCode).toBe(200);
+    expect(JSON.parse(foreignDelete.body).data).toEqual({ deleted: true });
+    await expect(ctx.conversationAssistantRepository.getSessionById(sessionId)).resolves.not.toBeNull();
+
+    const response = await ctx.app.inject({
+      method: 'DELETE',
+      url: `/conversation-assistant/sessions/${sessionId}`,
+      headers: {
+        authorization: `Bearer ${token}`,
+        'x-conversation-assistant-deletion-token': deletionToken,
+      },
+    });
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.body).data).toEqual({ deleted: true });
+    await expect(ctx.conversationAssistantRepository.getSessionById(sessionId)).resolves.toBeNull();
+    await expect(ctx.conversationAssistantRepository.listTurnsBySessionId(sessionId)).resolves.toEqual([]);
+
+    const repeated = await ctx.app.inject({
+      method: 'DELETE',
+      url: `/conversation-assistant/sessions/${sessionId}`,
+      headers: {
+        authorization: `Bearer ${token}`,
+        'x-conversation-assistant-deletion-token': deletionToken,
+      },
+    });
+    expect(repeated.statusCode).toBe(200);
+    expect(JSON.parse(repeated.body).data).toEqual({ deleted: true });
   });
 
   it('does not expose internal preparation bookkeeping in public session DTOs', async () => {
@@ -246,6 +314,8 @@ describe('Conversation Assistant routes', () => {
       expect(response.body).not.toContain('preparationClaimId');
       expect(response.body).not.toContain('preparationLeaseExpiresAt');
       expect(response.body).not.toContain('contextSnapshotId');
+      expect(response.body).not.toContain('generationId');
+      expect(response.body).not.toContain('deletionStartedAt');
     }
   });
 
@@ -371,6 +441,7 @@ describe('Conversation Assistant routes', () => {
         sessionId: failedSession.id,
         userId: USER_ID,
         attempt: 2,
+        generationId: expect.any(String),
       },
     ]);
 
@@ -949,6 +1020,7 @@ describe('Conversation Assistant routes', () => {
       { method: 'POST' as const, url: '/conversation-assistant/context/check', payload: {} },
       { method: 'GET' as const, url: '/conversation-assistant/session-requests/missing' },
       { method: 'GET' as const, url: '/conversation-assistant/sessions/missing' },
+      { method: 'DELETE' as const, url: '/conversation-assistant/sessions/missing' },
       { method: 'GET' as const, url: '/conversation-assistant/sessions/missing/context' },
       { method: 'GET' as const, url: '/conversation-assistant/sessions/missing/export.pdf' },
       { method: 'GET' as const, url: '/conversation-assistant/sessions/missing/turns' },
@@ -997,6 +1069,7 @@ describe('Conversation Assistant routes', () => {
       },
       { method: 'GET' as const, url: '/conversation-assistant/session-requests/missing' },
       { method: 'GET' as const, url: '/conversation-assistant/sessions/missing' },
+      { method: 'DELETE' as const, url: '/conversation-assistant/sessions/missing' },
       { method: 'GET' as const, url: '/conversation-assistant/sessions/missing/context' },
       { method: 'GET' as const, url: '/conversation-assistant/sessions/missing/export.pdf' },
       { method: 'GET' as const, url: '/conversation-assistant/sessions/missing/turns' },
@@ -1038,6 +1111,9 @@ describe('Conversation Assistant routes', () => {
       listSessionsByUserId: () => {
         throw new Error('list failed');
       },
+      deleteSession: () => {
+        throw new Error('delete failed');
+      },
       claimPreparation: (input) =>
         ctx.conversationAssistantRepository.claimPreparation(input),
       saveClaimedPreparationSession: (input) =>
@@ -1062,6 +1138,13 @@ describe('Conversation Assistant routes', () => {
       getContextPage: (sessionId, snapshotId, input) =>
         ctx.conversationAssistantRepository.getContextPage(sessionId, snapshotId, input),
       saveTurn: (turn) => ctx.conversationAssistantRepository.saveTurn(turn),
+      saveTurnIfSessionExists: (turn, expectedGenerationId) =>
+        ctx.conversationAssistantRepository.saveTurnIfSessionExists(
+          turn,
+          expectedGenerationId
+        ),
+      saveAssistantTurnAndTouchSession: (input) =>
+        ctx.conversationAssistantRepository.saveAssistantTurnAndTouchSession(input),
       listTurnsBySessionId: (sessionId) =>
         ctx.conversationAssistantRepository.listTurnsBySessionId(sessionId),
     };
@@ -1078,5 +1161,16 @@ describe('Conversation Assistant routes', () => {
 
     expect(response.statusCode).toBe(500);
     expect(JSON.parse(response.body).error.code).toBe('INTERNAL_ERROR');
+
+    const deleteResponse = await ctx.app.inject({
+      method: 'DELETE',
+      url: '/conversation-assistant/sessions/missing',
+      headers: {
+        authorization: `Bearer ${token}`,
+        'x-conversation-assistant-deletion-token': 'stale-token',
+      },
+    });
+    expect(deleteResponse.statusCode).toBe(500);
+    expect(JSON.parse(deleteResponse.body).error.code).toBe('INTERNAL_ERROR');
   });
 });

--- a/apps/whatsapp-service/src/__tests__/domain/conversation-assistant/sessionUseCases.test.ts
+++ b/apps/whatsapp-service/src/__tests__/domain/conversation-assistant/sessionUseCases.test.ts
@@ -14,6 +14,7 @@ import {
   checkConversationAssistantContext,
   conversationAssistantRandomIds,
   createConversationAssistantSession as createQueuedConversationAssistantSession,
+  deleteConversationAssistantSession,
   deriveEffectiveRange,
   exportConversationAssistantSessionPdf,
   getConversationAssistantContext,
@@ -41,6 +42,7 @@ import type {
   StorePrivateWhatsAppMessageInput,
 } from '../../../domain/whatsapp/models/PrivateWhatsApp.js';
 import { createHash } from 'node:crypto';
+import { createConversationAssistantDeletionToken } from '../../../domain/conversation-assistant/deletionToken.js';
 
 const USER_ID = 'user-123';
 const SOURCE_ACCOUNT_ID = 'source-123';
@@ -75,6 +77,13 @@ function makeDeps(): {
       sessionIdsByRequest.set(key, id);
       return id;
     },
+    sessionGenerationId: (() => {
+      let counter = 0;
+      return (): string => {
+        counter += 1;
+        return `generation-${String(counter)}`;
+      };
+    })(),
     turnId: (() => {
       let counter = 0;
       return (): string => {
@@ -241,9 +250,27 @@ async function createConversationAssistantSession(
     return created;
   }
   return await prepareConversationAssistantSession(
-    { userId: input.userId, sessionId: created.value.session.id },
+    preparationInput(created.value.session),
     deps
   );
+}
+
+function preparationInput(
+  session: { id: string; userId: string; generationId?: string },
+  overrides: { attempt?: number; claimId?: string } = {}
+): {
+  userId: string;
+  sessionId: string;
+  generationId?: string;
+  attempt?: number;
+  claimId?: string;
+} {
+  return {
+    userId: session.userId,
+    sessionId: session.id,
+    ...(session.generationId !== undefined ? { generationId: session.generationId } : {}),
+    ...overrides,
+  };
 }
 
 describe('Conversation Assistant session use cases', () => {
@@ -287,6 +314,7 @@ describe('Conversation Assistant session use cases', () => {
         sessionId: result.value.session.id,
         userId: USER_ID,
         attempt: 1,
+        generationId: 'generation-1',
       },
     ]);
   });
@@ -308,7 +336,7 @@ describe('Conversation Assistant session use cases', () => {
     if (!created.ok) return;
 
     const prepared = await prepareConversationAssistantSession(
-      { userId: USER_ID, sessionId: created.value.session.id },
+      preparationInput(created.value.session),
       deps
     );
 
@@ -332,6 +360,36 @@ describe('Conversation Assistant session use cases', () => {
       prepared.value.context?.messages
     );
     expect(llmFactoryCalls).toEqual([]);
+  });
+
+  it('rejects a generation-less preparation event for a generated session', async () => {
+    const { deps, privateRepository, conversationRepository } = makeDeps();
+    await seedDirectMessage(privateRepository);
+    const created = await createQueuedConversationAssistantSession(
+      {
+        userId: USER_ID,
+        requestId: 'request-generation-fence',
+        chatId: CHAT_ID,
+        from: '2026-06-30T00:00:00.000Z',
+        to: '2026-07-01T00:00:00.000Z',
+      },
+      deps
+    );
+    expect(created.ok).toBe(true);
+    if (!created.ok) return;
+
+    await expect(
+      prepareConversationAssistantSession(
+        { userId: USER_ID, sessionId: created.value.session.id },
+        deps
+      )
+    ).resolves.toEqual({
+      ok: false,
+      error: { code: 'NOT_FOUND', message: 'Conversation Assistant session not found' },
+    });
+    await expect(
+      conversationRepository.getSessionById(created.value.session.id)
+    ).resolves.toMatchObject({ status: 'preparing', preparationStage: 'queued' });
   });
 
   it('covers preparation entry boundaries and the legacy default attempt', async () => {
@@ -375,7 +433,7 @@ describe('Conversation Assistant session use cases', () => {
       preparationStage: 'ready',
     });
     const alreadyReady = await prepareConversationAssistantSession(
-      { userId: USER_ID, sessionId: created.value.session.id },
+      preparationInput(created.value.session),
       deps
     );
     expect(alreadyReady.ok && alreadyReady.value.session.status).toBe('ready');
@@ -385,6 +443,7 @@ describe('Conversation Assistant session use cases', () => {
       id: 'whatsapp_conv_session_legacy_attempt',
     };
     delete legacy.preparationAttempt;
+    delete legacy.generationId;
     await conversationRepository.saveSession(legacy);
     const attempts: number[] = [];
     conversationRepository.claimPreparation = (
@@ -394,7 +453,7 @@ describe('Conversation Assistant session use cases', () => {
       return Promise.resolve({ status: 'not_found' });
     };
     const disappeared = await prepareConversationAssistantSession(
-      { userId: USER_ID, sessionId: legacy.id },
+      preparationInput(legacy),
       deps
     );
     expect(attempts).toEqual([1]);
@@ -421,7 +480,7 @@ describe('Conversation Assistant session use cases', () => {
     if (!chatFailureSession.ok) return;
     first.privateRepository.failNext({ code: 'PERSISTENCE_ERROR', message: 'account failed' });
     const savedFailure = await prepareConversationAssistantSession(
-      { userId: USER_ID, sessionId: chatFailureSession.value.session.id },
+      preparationInput(chatFailureSession.value.session),
       first.deps
     );
     expect(savedFailure).toEqual({
@@ -448,7 +507,7 @@ describe('Conversation Assistant session use cases', () => {
       false
     );
     const currentAfterChatFailure = await prepareConversationAssistantSession(
-      { userId: USER_ID, sessionId: lostChatFailure.value.session.id },
+      preparationInput(lostChatFailure.value.session),
       second.deps
     );
     expect(currentAfterChatFailure.ok).toBe(true);
@@ -475,7 +534,7 @@ describe('Conversation Assistant session use cases', () => {
       false
     );
     const currentAfterMessageFailure = await prepareConversationAssistantSession(
-      { userId: USER_ID, sessionId: messageFailureSession.value.session.id },
+      preparationInput(messageFailureSession.value.session),
       third.deps
     );
     expect(currentAfterMessageFailure.ok).toBe(true);
@@ -505,7 +564,7 @@ describe('Conversation Assistant session use cases', () => {
     });
 
     const result = await prepareConversationAssistantSession(
-      { userId: USER_ID, sessionId: created.value.session.id },
+      preparationInput(created.value.session),
       deps
     );
 
@@ -540,7 +599,7 @@ describe('Conversation Assistant session use cases', () => {
     );
 
     const result = await prepareConversationAssistantSession(
-      { userId: USER_ID, sessionId: created.value.session.id },
+      preparationInput(created.value.session),
       deps
     );
 
@@ -573,12 +632,10 @@ describe('Conversation Assistant session use cases', () => {
     );
 
     const prepared = await prepareConversationAssistantSession(
-      {
-        userId: USER_ID,
-        sessionId: created.value.session.id,
+      preparationInput(created.value.session, {
         attempt: 1,
         claimId,
-      },
+      }),
       deps
     );
 
@@ -589,6 +646,32 @@ describe('Conversation Assistant session use cases', () => {
     expect(
       conversationRepository.getContextMessages(created.value.session.id, snapshotId)
     ).toEqual([]);
+  });
+
+  it('returns the current preparation state when the context snapshot fence is lost', async () => {
+    const { deps, privateRepository, conversationRepository } = makeDeps();
+    await seedDirectMessage(privateRepository);
+    const created = await createQueuedConversationAssistantSession(
+      {
+        userId: USER_ID,
+        requestId: 'request-context-snapshot-fence-loss',
+        chatId: CHAT_ID,
+        from: '2026-06-30T00:00:00.000Z',
+        to: '2026-07-01T00:00:00.000Z',
+      },
+      deps
+    );
+    expect(created.ok).toBe(true);
+    if (!created.ok) return;
+    vi.spyOn(conversationRepository, 'saveContextSnapshot').mockResolvedValue(false);
+
+    const prepared = await prepareConversationAssistantSession(
+      preparationInput(created.value.session),
+      deps
+    );
+
+    expect(prepared.ok).toBe(true);
+    if (prepared.ok) expect(prepared.value.session.status).toBe('preparing');
   });
 
   it('removes a partially written context snapshot when snapshot persistence fails', async () => {
@@ -619,12 +702,10 @@ describe('Conversation Assistant session use cases', () => {
 
     await expect(
       prepareConversationAssistantSession(
-        {
-          userId: USER_ID,
-          sessionId: created.value.session.id,
+        preparationInput(created.value.session, {
           attempt: 1,
           claimId,
-        },
+        }),
         deps
       )
     ).rejects.toThrow('Partial snapshot write');
@@ -660,16 +741,17 @@ describe('Conversation Assistant session use cases', () => {
       claimId: 'claim-1',
       now: '2026-06-30T12:00:00.000Z',
       leaseExpiresAt: '2026-06-30T12:05:00.000Z',
+      ...(created.value.session.generationId !== undefined
+        ? { expectedGenerationId: created.value.session.generationId }
+        : {}),
     });
     expect(firstClaim.status).toBe('claimed');
 
     const duplicate = await prepareConversationAssistantSession(
-      {
-        userId: USER_ID,
-        sessionId: created.value.session.id,
+      preparationInput(created.value.session, {
         attempt: 1,
         claimId: 'claim-2',
-      },
+      }),
       deps
     );
     expect(duplicate).toEqual({
@@ -694,12 +776,10 @@ describe('Conversation Assistant session use cases', () => {
     expect(retried.ok).toBe(true);
 
     const stale = await prepareConversationAssistantSession(
-      {
-        userId: USER_ID,
-        sessionId: created.value.session.id,
+      preparationInput(created.value.session, {
         attempt: 1,
         claimId: 'late-claim-1',
-      },
+      }),
       deps
     );
     expect(stale.ok).toBe(true);
@@ -733,11 +813,11 @@ describe('Conversation Assistant session use cases', () => {
     };
 
     await prepareConversationAssistantSession(
-      { userId: USER_ID, sessionId: created.value.session.id, attempt: 1 },
+      preparationInput(created.value.session, { attempt: 1 }),
       deps
     );
     await prepareConversationAssistantSession(
-      { userId: USER_ID, sessionId: created.value.session.id, attempt: 1 },
+      preparationInput(created.value.session, { attempt: 1 }),
       deps
     );
 
@@ -758,6 +838,9 @@ describe('Conversation Assistant session use cases', () => {
         claimId: 'worker-claim',
         now: '2026-06-30T12:00:00.000Z',
         leaseExpiresAt: '2026-06-30T12:05:00.000Z',
+        ...(event.generationId !== undefined
+          ? { expectedGenerationId: event.generationId }
+          : {}),
       });
       expect(claimed.status).toBe('claimed');
       return err({ code: 'INTERNAL_ERROR', message: 'Publish response was lost' });
@@ -914,6 +997,30 @@ describe('Conversation Assistant session use cases', () => {
     });
   });
 
+  it('does not reuse an idempotent session after deletion has started', async () => {
+    const { deps, privateRepository, conversationRepository } = makeDeps();
+    await seedDirectMessage(privateRepository);
+    const input = {
+      userId: USER_ID,
+      requestId: 'request-deleting-reuse',
+      chatId: CHAT_ID,
+      from: '2026-06-30T00:00:00.000Z',
+      to: '2026-07-01T00:00:00.000Z',
+    };
+    const created = await createQueuedConversationAssistantSession(input, deps);
+    expect(created.ok).toBe(true);
+    if (!created.ok) return;
+    await conversationRepository.saveSession({
+      ...created.value.session,
+      deletionStartedAt: '2026-06-30T12:01:00.000Z',
+    });
+
+    await expect(createQueuedConversationAssistantSession(input, deps)).resolves.toEqual({
+      ok: false,
+      error: { code: 'NOT_FOUND', message: 'Conversation Assistant session not found' },
+    });
+  });
+
   it('reuses a ready idempotent analysis and requeues a failed legacy analysis', async () => {
     const readyCase = makeDeps();
     await seedDirectMessage(readyCase.privateRepository);
@@ -950,6 +1057,7 @@ describe('Conversation Assistant session use cases', () => {
       preparationStage: 'failed' as const,
     };
     delete failedLegacy.preparationAttempt;
+    delete failedLegacy.generationId;
     await legacyCase.conversationRepository.saveSession(failedLegacy);
 
     const requeued = await createQueuedConversationAssistantSession(
@@ -1009,6 +1117,7 @@ describe('Conversation Assistant session use cases', () => {
       preparationStage: 'failed' as const,
     };
     delete failedFallback.preparationAttempt;
+    delete failedFallback.generationId;
     await fallbackCase.conversationRepository.saveSession(failedFallback);
     const queuedWithoutAttempt = {
       ...failedFallback,
@@ -1668,6 +1777,55 @@ describe('Conversation Assistant session use cases', () => {
     );
   });
 
+  it('returns not found when generation fences reject user or assistant turn persistence', async () => {
+    const { deps, privateRepository, conversationRepository } = makeDeps();
+    await seedDirectMessage(privateRepository);
+    const created = await createConversationAssistantSession(
+      {
+        userId: USER_ID,
+        chatId: CHAT_ID,
+        from: '2026-06-30T00:00:00.000Z',
+        to: '2026-07-01T00:00:00.000Z',
+      },
+      deps
+    );
+    expect(created.ok).toBe(true);
+    if (!created.ok) return;
+    const input = {
+      userId: USER_ID,
+      sessionId: created.value.session.id,
+      question: 'Will this persist?',
+    };
+
+    const rejectedUserTurn = vi
+      .spyOn(conversationRepository, 'saveTurnIfSessionExists')
+      .mockResolvedValueOnce(false);
+    await expect(sendConversationAssistantTurn(input, deps)).resolves.toEqual({
+      ok: false,
+      error: { code: 'NOT_FOUND', message: 'Conversation Assistant session not found' },
+    });
+    rejectedUserTurn.mockRestore();
+
+    const rejectedAssistantTurn = vi
+      .spyOn(conversationRepository, 'saveAssistantTurnAndTouchSession')
+      .mockResolvedValueOnce(false);
+    await expect(sendConversationAssistantTurn(input, deps)).resolves.toEqual({
+      ok: false,
+      error: { code: 'NOT_FOUND', message: 'Conversation Assistant session not found' },
+    });
+    rejectedAssistantTurn.mockRestore();
+
+    vi.spyOn(conversationRepository, 'saveTurnIfSessionExists').mockResolvedValueOnce(false);
+    const events: ConversationAssistantStreamEvent[] = [];
+    await expect(
+      streamConversationAssistantTurn(input, deps, (event) => events.push(event))
+    ).resolves.toEqual({
+      ok: false,
+      error: { code: 'NOT_FOUND', message: 'Conversation Assistant session not found' },
+    });
+    expect(events).toEqual([]);
+  });
+
   it('keeps neutral session metadata when the first private message is sent', async () => {
     const { deps, conversationRepository } = makeDeps();
     await seedDirectMessage(deps.privateWhatsAppRepository as FakePrivateWhatsAppRepository);
@@ -1781,6 +1939,95 @@ describe('Conversation Assistant session use cases', () => {
       code: 'LLM_ERROR',
       message: 'stream broke',
     });
+  });
+
+  it('does not recreate a session when it is deleted during a streamed response', async () => {
+    const { deps, privateRepository, conversationRepository, llmClient } = makeDeps();
+    await seedDirectMessage(privateRepository);
+    const created = await createConversationAssistantSession(
+      {
+        userId: USER_ID,
+        chatId: CHAT_ID,
+        from: '2026-06-30T00:00:00.000Z',
+        to: '2026-07-01T00:00:00.000Z',
+      },
+      deps
+    );
+    expect(created.ok).toBe(true);
+    if (!created.ok) return;
+    llmClient.setNextStreamEvents([{ type: 'delta', text: 'late answer' }]);
+
+    const result = await streamConversationAssistantTurn(
+      { userId: USER_ID, sessionId: created.value.session.id, question: 'Delete while answering.' },
+      deps,
+      (event) => {
+        if (event.type === 'user_turn') {
+          void conversationRepository.deleteSession({
+            sessionId: created.value.session.id,
+            userId: USER_ID,
+            deletionToken: createConversationAssistantDeletionToken(created.value.session),
+          });
+        }
+      }
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      error: { code: 'NOT_FOUND', message: 'Conversation Assistant session not found' },
+    });
+    expect(await conversationRepository.getSessionById(created.value.session.id)).toBeNull();
+    expect(conversationRepository.getAllTurns()).toEqual([]);
+  });
+
+  it('does not write a delayed streamed response into a replacement session with the same id', async () => {
+    const { deps, privateRepository, conversationRepository, llmClient } = makeDeps();
+    await seedDirectMessage(privateRepository);
+    const created = await createConversationAssistantSession(
+      {
+        userId: USER_ID,
+        chatId: CHAT_ID,
+        from: '2026-06-30T00:00:00.000Z',
+        to: '2026-07-01T00:00:00.000Z',
+      },
+      deps
+    );
+    expect(created.ok).toBe(true);
+    if (!created.ok) return;
+    const originalSession = {
+      ...created.value.session,
+      generationId: 'generation-original',
+    } as typeof created.value.session;
+    await conversationRepository.saveSession(originalSession);
+    llmClient.setNextStreamEvents([{ type: 'delta', text: 'late answer' }]);
+
+    const result = await streamConversationAssistantTurn(
+      { userId: USER_ID, sessionId: originalSession.id, question: 'Replace while answering.' },
+      deps,
+      (event) => {
+        if (event.type === 'user_turn') {
+          void conversationRepository.deleteSession({
+            sessionId: originalSession.id,
+            userId: USER_ID,
+            deletionToken: createConversationAssistantDeletionToken(originalSession),
+          });
+          void conversationRepository.saveSession({
+            ...originalSession,
+            generationId: 'generation-replacement',
+            updatedAt: '2026-06-30T13:00:00.000Z',
+          } as typeof originalSession);
+        }
+      }
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      error: { code: 'NOT_FOUND', message: 'Conversation Assistant session not found' },
+    });
+    expect(await conversationRepository.getSessionById(originalSession.id)).toMatchObject({
+      generationId: 'generation-replacement',
+      updatedAt: '2026-06-30T13:00:00.000Z',
+    });
+    expect(conversationRepository.getAllTurns()).toEqual([]);
   });
 
   it('exports an owned session PDF with mapped counts and chronological turns', async () => {
@@ -2305,7 +2552,8 @@ describe('Conversation Assistant session use cases', () => {
       legacyReady.id,
       USER_ID,
       snapshotId,
-      { messages: [], omittedMessages }
+      { messages: [], omittedMessages },
+      legacyReady.generationId
     );
     await conversationRepository.saveSession({
       ...legacyReady,
@@ -2575,6 +2823,85 @@ describe('Conversation Assistant session use cases', () => {
     expect(foreignTurns.ok).toBe(false);
     expect(ownedGet.ok).toBe(true);
     expect(ownedTurns).toEqual({ ok: true, value: [] });
+  });
+
+  it('deletes an owned session idempotently without deleting a foreign session', async () => {
+    const { deps, conversationRepository, privateRepository } = makeDeps();
+    await seedDirectMessage(privateRepository);
+    const created = await createConversationAssistantSession(
+      {
+        userId: USER_ID,
+        chatId: CHAT_ID,
+        from: '2026-06-30T00:00:00.000Z',
+        to: '2026-07-01T00:00:00.000Z',
+      },
+      deps
+    );
+    expect(created.ok).toBe(true);
+    if (!created.ok) return;
+
+    const ownedSession = created.value.session;
+    await conversationRepository.saveTurn({
+      id: 'owned-turn',
+      sessionId: ownedSession.id,
+      userId: USER_ID,
+      role: 'user',
+      text: 'Delete this analysis',
+      createdAt: '2026-06-30T12:01:00.000Z',
+    });
+    await conversationRepository.saveContextSnapshot(
+      ownedSession.id,
+      USER_ID,
+      'owned-snapshot',
+      { messages: [], omittedMessages: [] }
+    );
+    await conversationRepository.saveSession({
+      ...ownedSession,
+      id: 'foreign-session',
+      userId: 'other-user',
+    });
+
+    await expect(
+      deleteConversationAssistantSession(
+        {
+          userId: USER_ID,
+          sessionId: 'foreign-session',
+          deletionToken: createConversationAssistantDeletionToken({
+            ...ownedSession,
+            id: 'foreign-session',
+          }),
+        },
+        deps
+      )
+    ).resolves.toEqual({ ok: true, value: { deleted: true } });
+    expect(await conversationRepository.getSessionById('foreign-session')).not.toBeNull();
+
+    await expect(
+      deleteConversationAssistantSession(
+        {
+          userId: USER_ID,
+          sessionId: ownedSession.id,
+          deletionToken: createConversationAssistantDeletionToken(ownedSession),
+        },
+        deps
+      )
+    ).resolves.toEqual({ ok: true, value: { deleted: true } });
+    expect(await conversationRepository.getSessionById(ownedSession.id)).toBeNull();
+    expect(conversationRepository.getAllTurns()).toEqual([]);
+    expect(
+      conversationRepository.getContextMessages(ownedSession.id, 'owned-snapshot')
+    ).toEqual([]);
+
+    await expect(
+      deleteConversationAssistantSession(
+        {
+          userId: USER_ID,
+          sessionId: ownedSession.id,
+          deletionToken: createConversationAssistantDeletionToken(ownedSession),
+        },
+        deps
+      )
+    ).resolves.toEqual({ ok: true, value: { deleted: true } });
   });
 
   it('derives fallback titles and assistant error turns for unavailable chat generation', async () => {

--- a/apps/whatsapp-service/src/__tests__/fakes.ts
+++ b/apps/whatsapp-service/src/__tests__/fakes.ts
@@ -93,6 +93,7 @@ import type {
   ConversationAssistantSession,
   ConversationAssistantTurn,
 } from '../domain/conversation-assistant/types.js';
+import { createConversationAssistantDeletionToken } from '../domain/conversation-assistant/deletionToken.js';
 import type {
   MatrixOutboundGateway,
   MatrixOutboundReadinessInput,
@@ -107,7 +108,10 @@ export class FakeConversationAssistantRepository implements ConversationAssistan
   private readonly turns = new Map<string, ConversationAssistantTurn>();
   private readonly contextSnapshots = new Map<
     string,
-    Pick<ConversationAssistantContextResult, 'messages' | 'omittedMessages'> & { userId: string }
+    Pick<ConversationAssistantContextResult, 'messages' | 'omittedMessages'> & {
+      userId: string;
+      generationId?: string;
+    }
   >();
   readonly snapshotRequests: { sessionId: string; userId: string }[] = [];
 
@@ -130,7 +134,9 @@ export class FakeConversationAssistantRepository implements ConversationAssistan
 
   getSessionById(sessionId: string): Promise<ConversationAssistantSession | null> {
     const session = this.sessions.get(sessionId);
-    return Promise.resolve(session === undefined ? null : { ...session });
+    return Promise.resolve(
+      session === undefined || session.deletionStartedAt !== undefined ? null : { ...session }
+    );
   }
 
   getSessionSnapshotById(
@@ -138,7 +144,11 @@ export class FakeConversationAssistantRepository implements ConversationAssistan
   ): Promise<{ session: ConversationAssistantSession; turns: ConversationAssistantTurn[] } | null> {
     this.snapshotRequests.push(input);
     const session = this.sessions.get(input.sessionId);
-    if (session === undefined || session.userId !== input.userId) {
+    if (
+      session === undefined ||
+      session.userId !== input.userId ||
+      session.deletionStartedAt !== undefined
+    ) {
       return Promise.resolve(null);
     }
     return Promise.resolve({
@@ -158,6 +168,32 @@ export class FakeConversationAssistantRepository implements ConversationAssistan
     return Promise.resolve(sessions);
   }
 
+  deleteSession(input: {
+    sessionId: string;
+    userId: string;
+    deletionToken: string;
+  }): Promise<void> {
+    const session = this.sessions.get(input.sessionId);
+    if (
+      session?.userId !== input.userId ||
+      createConversationAssistantDeletionToken(session) !== input.deletionToken
+    ) {
+      return Promise.resolve();
+    }
+    this.sessions.delete(input.sessionId);
+    for (const [turnId, turn] of this.turns.entries()) {
+      if (turn.sessionId === input.sessionId && turn.userId === input.userId) {
+        this.turns.delete(turnId);
+      }
+    }
+    for (const [snapshotId, snapshot] of this.contextSnapshots.entries()) {
+      if (snapshotId.startsWith(`${input.sessionId}:`) && snapshot.userId === input.userId) {
+        this.contextSnapshots.delete(snapshotId);
+      }
+    }
+    return Promise.resolve();
+  }
+
   claimPreparation(input: {
     sessionId: string;
     userId: string;
@@ -165,6 +201,7 @@ export class FakeConversationAssistantRepository implements ConversationAssistan
     claimId: string;
     now: string;
     leaseExpiresAt: string;
+    expectedGenerationId?: string;
   }): Promise<
     | { status: 'claimed'; session: ConversationAssistantSession }
     | { status: 'busy'; session: ConversationAssistantSession }
@@ -172,7 +209,12 @@ export class FakeConversationAssistantRepository implements ConversationAssistan
     | { status: 'not_found' }
   > {
     const session = this.sessions.get(input.sessionId);
-    if (session === undefined || session.userId !== input.userId) {
+    if (
+      session === undefined ||
+      session.userId !== input.userId ||
+      session.deletionStartedAt !== undefined ||
+      session.generationId !== input.expectedGenerationId
+    ) {
       return Promise.resolve({ status: 'not_found' });
     }
     if (session.status !== 'preparing' || session.preparationAttempt !== input.attempt) {
@@ -205,7 +247,9 @@ export class FakeConversationAssistantRepository implements ConversationAssistan
     const current = this.sessions.get(input.session.id);
     if (
       current?.preparationAttempt !== input.attempt ||
-      current.preparationClaimId !== input.claimId
+      current.preparationClaimId !== input.claimId ||
+      current.deletionStartedAt !== undefined ||
+      current.generationId !== input.session.generationId
     ) {
       return Promise.resolve(false);
     }
@@ -218,12 +262,18 @@ export class FakeConversationAssistantRepository implements ConversationAssistan
     userId: string;
     expectedAttempt: number;
     updatedAt: string;
+    expectedGenerationId?: string;
   }): Promise<
     | { status: 'queued' | 'stale'; session: ConversationAssistantSession }
     | { status: 'not_found' }
   > {
     const session = this.sessions.get(input.sessionId);
-    if (session === undefined || session.userId !== input.userId) {
+    if (
+      session === undefined ||
+      session.userId !== input.userId ||
+      session.deletionStartedAt !== undefined ||
+      session.generationId !== input.expectedGenerationId
+    ) {
       return Promise.resolve({ status: 'not_found' });
     }
     if (
@@ -252,12 +302,18 @@ export class FakeConversationAssistantRepository implements ConversationAssistan
     attempt: number;
     error: { code: string; message: string };
     updatedAt: string;
+    expectedGenerationId?: string;
   }): Promise<
     | { status: 'saved' | 'stale'; session: ConversationAssistantSession }
     | { status: 'not_found' }
   > {
     const session = this.sessions.get(input.sessionId);
-    if (session === undefined || session.userId !== input.userId) {
+    if (
+      session === undefined ||
+      session.userId !== input.userId ||
+      session.deletionStartedAt !== undefined ||
+      session.generationId !== input.expectedGenerationId
+    ) {
       return Promise.resolve({ status: 'not_found' });
     }
     if (
@@ -283,26 +339,43 @@ export class FakeConversationAssistantRepository implements ConversationAssistan
     sessionId: string,
     userId: string,
     snapshotId: string,
-    snapshot: Pick<ConversationAssistantContextResult, 'messages' | 'omittedMessages'>
-  ): Promise<void> {
+    snapshot: Pick<ConversationAssistantContextResult, 'messages' | 'omittedMessages'>,
+    expectedGenerationId?: string
+  ): Promise<boolean> {
+    const session = this.sessions.get(sessionId);
+    if (
+      session?.userId !== userId ||
+      session.deletionStartedAt !== undefined ||
+      session.generationId !== expectedGenerationId
+    ) {
+      return Promise.resolve(false);
+    }
     this.contextSnapshots.set(
       `${sessionId}:${snapshotId}`,
       {
         userId,
+        ...(expectedGenerationId !== undefined
+          ? { generationId: expectedGenerationId }
+          : {}),
         messages: snapshot.messages.map((message) => ({ ...message })),
         omittedMessages: snapshot.omittedMessages.map((message) => ({ ...message })),
       }
     );
-    return Promise.resolve();
+    return Promise.resolve(true);
   }
 
   deleteContextSnapshot(
     sessionId: string,
     userId: string,
-    snapshotId: string
+    snapshotId: string,
+    expectedGenerationId?: string
   ): Promise<void> {
     const key = `${sessionId}:${snapshotId}`;
-    if (this.contextSnapshots.get(key)?.userId === userId) {
+    const snapshot = this.contextSnapshots.get(key);
+    if (
+      snapshot?.userId === userId &&
+      snapshot.generationId === expectedGenerationId
+    ) {
       this.contextSnapshots.delete(key);
     }
     return Promise.resolve();
@@ -339,6 +412,46 @@ export class FakeConversationAssistantRepository implements ConversationAssistan
   saveTurn(turn: ConversationAssistantTurn): Promise<void> {
     this.turns.set(turn.id, { ...turn });
     return Promise.resolve();
+  }
+
+  saveTurnIfSessionExists(
+    turn: ConversationAssistantTurn,
+    expectedGenerationId: string | undefined
+  ): Promise<boolean> {
+    const current = this.sessions.get(turn.sessionId);
+    if (
+      current?.userId !== turn.userId ||
+      current.deletionStartedAt !== undefined ||
+      current.generationId !== expectedGenerationId ||
+      (current.status !== 'ready' && current.status !== 'active')
+    ) {
+      return Promise.resolve(false);
+    }
+    this.turns.set(turn.id, { ...turn });
+    return Promise.resolve(true);
+  }
+
+  saveAssistantTurnAndTouchSession(input: {
+    session: ConversationAssistantSession;
+    turn: ConversationAssistantTurn;
+  }): Promise<boolean> {
+    const current = this.sessions.get(input.session.id);
+    if (
+      current?.userId !== input.session.userId ||
+      input.turn.userId !== input.session.userId ||
+      current.deletionStartedAt !== undefined ||
+      current.generationId !== input.session.generationId ||
+      (current.status !== 'ready' && current.status !== 'active')
+    ) {
+      return Promise.resolve(false);
+    }
+    this.turns.set(input.turn.id, { ...input.turn });
+    this.sessions.set(input.session.id, {
+      ...current,
+      updatedAt: input.turn.createdAt,
+      lastTurnAt: input.turn.createdAt,
+    });
+    return Promise.resolve(true);
   }
 
   listTurnsBySessionId(sessionId: string): Promise<ConversationAssistantTurn[]> {

--- a/apps/whatsapp-service/src/__tests__/infra/conversationAssistantRepository.test.ts
+++ b/apps/whatsapp-service/src/__tests__/infra/conversationAssistantRepository.test.ts
@@ -1,7 +1,8 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createFakeFirestore, resetFirestore, setFirestore } from '@intexuraos/infra-firestore';
 import { DEFAULT_CONVERSATION_ASSISTANT_MODEL } from '@intexuraos/llm-contract';
 import {
+  CASCADE_DELETE_BATCH_SIZE,
   CONTEXT_CHUNK_MAX_BYTES,
   createConversationAssistantRepository,
   TRANSCRIPT_CHUNK_MAX_BYTES,
@@ -14,6 +15,7 @@ import type {
   ConversationAssistantSession,
   ConversationAssistantTurn,
 } from '../../domain/conversation-assistant/types.js';
+import { createConversationAssistantDeletionToken } from '../../domain/conversation-assistant/deletionToken.js';
 
 function makeSession(overrides: Partial<ConversationAssistantSession> = {}): ConversationAssistantSession {
   return {
@@ -49,6 +51,17 @@ function makeTurn(overrides: Partial<ConversationAssistantTurn> = {}): Conversat
   };
 }
 
+function deletionInput(
+  session: ConversationAssistantSession,
+  userId = session.userId
+): { sessionId: string; userId: string; deletionToken: string } {
+  return {
+    sessionId: session.id,
+    userId,
+    deletionToken: createConversationAssistantDeletionToken(session),
+  };
+}
+
 describe('conversationAssistantRepository', () => {
   let fakeFirestore: ReturnType<typeof createFakeFirestore>;
   let repository: ReturnType<typeof createConversationAssistantRepository>;
@@ -61,6 +74,57 @@ describe('conversationAssistantRepository', () => {
 
   afterEach(() => {
     resetFirestore();
+  });
+
+  it('keeps cascade-delete transactions below a conservative Firestore payload budget', () => {
+    const largestChunkBytes = Math.max(TRANSCRIPT_CHUNK_MAX_BYTES, CONTEXT_CHUNK_MAX_BYTES);
+
+    expect(CASCADE_DELETE_BATCH_SIZE * largestChunkBytes).toBeLessThanOrEqual(5_000_000);
+  });
+
+  it('revalidates and deletes at most one cascade document per transaction', async () => {
+    const session = {
+      ...makeSession(),
+      generationId: 'generation-delete-one-at-a-time',
+    } as ConversationAssistantSession;
+    await repository.saveSession(session);
+    fakeFirestore.seedCollection(
+      WHATSAPP_CONVERSATION_ASSISTANT_TURNS_COLLECTION,
+      Array.from({ length: 3 }, (_value, index) => ({
+        id: `large-turn-${String(index)}`,
+        data: {
+          ...makeTurn({ id: `large-turn-${String(index)}` }),
+          sessionGenerationId: session.generationId,
+        },
+      }))
+    );
+    const originalRunTransaction = fakeFirestore.runTransaction.bind(fakeFirestore);
+    let maximumReadsInOneTransaction = 0;
+    vi.spyOn(fakeFirestore, 'runTransaction').mockImplementation(async (updateFn) =>
+      await originalRunTransaction(async (transaction) => {
+        let reads = 0;
+        const instrumentedTransaction = new Proxy(transaction, {
+          get(target, property, receiver): unknown {
+            if (property === 'get') {
+              return async (
+                ...args: Parameters<typeof target.get>
+              ): Promise<Awaited<ReturnType<typeof target.get>>> => {
+                reads += 1;
+                maximumReadsInOneTransaction = Math.max(maximumReadsInOneTransaction, reads);
+                return await target.get(...args);
+              };
+            }
+            const value = Reflect.get(target, property, receiver);
+            return typeof value === 'function' ? value.bind(target) : value;
+          },
+        });
+        return await updateFn(instrumentedTransaction);
+      })
+    );
+
+    await repository.deleteSession(deletionInput(session));
+
+    expect(maximumReadsInOneTransaction).toBe(1);
   });
 
   it('stores private transcript text in chunks and lists only the owning user sessions', async () => {
@@ -128,6 +192,591 @@ describe('conversationAssistantRepository', () => {
     expect(storedDoc.data()?.['role']).toBe('assistant');
   });
 
+  it('deletes every owned session record and leaves foreign records untouched', async () => {
+    const ownedSession = makeSession();
+    await repository.saveSession(ownedSession);
+    await repository.saveTurn(makeTurn());
+    fakeFirestore.seedCollection(WHATSAPP_CONVERSATION_ASSISTANT_CONTEXT_CHUNKS_COLLECTION, [
+      {
+        id: 'owned-context',
+        data: {
+          sessionId: 'whatsapp_conv_session_1',
+          userId: 'user-123',
+          snapshotId: 'snapshot-1',
+        },
+      },
+      {
+        id: 'foreign-context',
+        data: { sessionId: 'foreign-session', userId: 'other-user', snapshotId: 'snapshot-2' },
+      },
+    ]);
+    await repository.saveSession(
+      makeSession({ id: 'foreign-session', userId: 'other-user', transcriptSha256: 'foreign-hash' })
+    );
+    await repository.saveTurn(
+      makeTurn({ id: 'foreign-turn', sessionId: 'foreign-session', userId: 'other-user' })
+    );
+
+    await repository.deleteSession(deletionInput(ownedSession, 'other-user'));
+    expect(await repository.getSessionById('whatsapp_conv_session_1')).not.toBeNull();
+
+    await repository.deleteSession(deletionInput(ownedSession));
+
+    await expect(repository.getSessionById('whatsapp_conv_session_1')).resolves.toBeNull();
+    await expect(repository.listTurnsBySessionId('whatsapp_conv_session_1')).resolves.toEqual([]);
+    expect(
+      (
+        await fakeFirestore
+          .collection(WHATSAPP_CONVERSATION_ASSISTANT_TRANSCRIPT_CHUNKS_COLLECTION)
+          .doc('whatsapp_conv_session_1_hash_000000')
+          .get()
+      ).exists
+    ).toBe(false);
+    expect(
+      (
+        await fakeFirestore
+          .collection(WHATSAPP_CONVERSATION_ASSISTANT_CONTEXT_CHUNKS_COLLECTION)
+          .doc('owned-context')
+          .get()
+      ).exists
+    ).toBe(false);
+    await expect(repository.getSessionById('foreign-session')).resolves.not.toBeNull();
+    await expect(repository.listTurnsBySessionId('foreign-session')).resolves.toHaveLength(1);
+    expect(
+      (
+        await fakeFirestore
+          .collection(WHATSAPP_CONVERSATION_ASSISTANT_CONTEXT_CHUNKS_COLLECTION)
+          .doc('foreign-context')
+          .get()
+      ).exists
+    ).toBe(true);
+
+    await expect(
+      repository.deleteSession(deletionInput(ownedSession))
+    ).resolves.toBeUndefined();
+  });
+
+  it('persists turns only while their owned session still exists', async () => {
+    const session = makeSession();
+    const userTurn = makeTurn();
+    const assistantTurn = makeTurn({
+      id: 'assistant-turn',
+      role: 'assistant',
+      text: 'Answer',
+      createdAt: '2026-06-30T10:02:00.000Z',
+    });
+    await repository.saveSession(session);
+
+    await expect(
+      repository.saveTurnIfSessionExists(userTurn, session.generationId)
+    ).resolves.toBe(true);
+    await expect(
+      repository.saveAssistantTurnAndTouchSession({ session, turn: assistantTurn })
+    ).resolves.toBe(true);
+    await expect(repository.listTurnsBySessionId(session.id)).resolves.toHaveLength(2);
+    await expect(repository.getSessionById(session.id)).resolves.toMatchObject({
+      updatedAt: assistantTurn.createdAt,
+      lastTurnAt: assistantTurn.createdAt,
+    });
+
+    await repository.deleteSession(deletionInput(session));
+    await expect(
+      repository.saveTurnIfSessionExists(userTurn, session.generationId)
+    ).resolves.toBe(false);
+    await expect(
+      repository.saveAssistantTurnAndTouchSession({ session, turn: assistantTurn })
+    ).resolves.toBe(false);
+    await expect(repository.getSessionById(session.id)).resolves.toBeNull();
+    await expect(repository.listTurnsBySessionId(session.id)).resolves.toEqual([]);
+  });
+
+  it('touches a legacy session that has no transcript storage metadata', async () => {
+    const session = makeSession();
+    await fakeFirestore
+      .collection(WHATSAPP_CONVERSATION_ASSISTANT_SESSIONS_COLLECTION)
+      .doc(session.id)
+      .set(session);
+    const assistantTurn = makeTurn({
+      id: 'legacy-storage-assistant-turn',
+      role: 'assistant',
+      text: 'Legacy answer',
+      createdAt: '2026-06-30T10:03:00.000Z',
+    });
+
+    await expect(
+      repository.saveAssistantTurnAndTouchSession({ session, turn: assistantTurn })
+    ).resolves.toBe(true);
+    const stored = await fakeFirestore
+      .collection(WHATSAPP_CONVERSATION_ASSISTANT_SESSIONS_COLLECTION)
+      .doc(session.id)
+      .get();
+    expect(stored.data()?.['transcriptStorage']).toMatchObject({
+      type: 'chunks',
+      chunkCount: 0,
+    });
+  });
+
+  it('rejects delayed turns from an older generation of the same session id', async () => {
+    const originalSession = {
+      ...makeSession(),
+      generationId: 'generation-original',
+    } as ConversationAssistantSession;
+    const replacementSession = {
+      ...makeSession({ updatedAt: '2026-06-30T11:00:00.000Z' }),
+      generationId: 'generation-replacement',
+    } as ConversationAssistantSession;
+    const saveTurnForGeneration = repository.saveTurnIfSessionExists as unknown as (
+      turn: ConversationAssistantTurn,
+      expectedGenerationId: string | undefined
+    ) => Promise<boolean>;
+
+    await repository.saveSession(originalSession);
+    await repository.saveSession(replacementSession);
+
+    await expect(
+      saveTurnForGeneration(makeTurn({ id: 'late-user-turn' }), 'generation-original')
+    ).resolves.toBe(false);
+    await expect(
+      repository.saveAssistantTurnAndTouchSession({
+        session: originalSession,
+        turn: makeTurn({ id: 'late-assistant-turn', role: 'assistant', text: 'Late answer' }),
+      })
+    ).resolves.toBe(false);
+    await expect(repository.listTurnsBySessionId(originalSession.id)).resolves.toEqual([]);
+    await expect(repository.getSessionById(originalSession.id)).resolves.toMatchObject({
+      generationId: 'generation-replacement',
+      updatedAt: replacementSession.updatedAt,
+    });
+  });
+
+  it('keeps interrupted cascade deletion hidden and resumes it in bounded batches', async () => {
+    const session = {
+      ...makeSession(),
+      generationId: 'generation-delete',
+    } as ConversationAssistantSession;
+    await repository.saveSession(session);
+    fakeFirestore.seedCollection(
+      WHATSAPP_CONVERSATION_ASSISTANT_TURNS_COLLECTION,
+      Array.from({ length: 251 }, (_value, index) => ({
+        id: `turn-${String(index)}`,
+        data: {
+          ...makeTurn({ id: `turn-${String(index)}` }),
+          sessionGenerationId: 'generation-delete',
+        },
+      }))
+    );
+    fakeFirestore.seedCollection(WHATSAPP_CONVERSATION_ASSISTANT_CONTEXT_CHUNKS_COLLECTION, [
+      {
+        id: 'context-delete',
+        data: {
+          sessionId: session.id,
+          userId: session.userId,
+          sessionGenerationId: 'generation-delete',
+          snapshotId: 'snapshot-delete',
+        },
+      },
+    ]);
+
+    const originalRunTransaction = fakeFirestore.runTransaction.bind(fakeFirestore);
+    let transactionCount = 0;
+    const transactionSpy = vi
+      .spyOn(fakeFirestore, 'runTransaction')
+      .mockImplementation(async (updateFn) => {
+        transactionCount += 1;
+        if (transactionCount === 3) throw new Error('interrupted cascade');
+        return await originalRunTransaction(updateFn);
+      });
+
+    await expect(
+      repository.deleteSession(deletionInput(session))
+    ).rejects.toThrow('interrupted cascade');
+    const storedDuringDeletion = await fakeFirestore
+      .collection(WHATSAPP_CONVERSATION_ASSISTANT_SESSIONS_COLLECTION)
+      .doc(session.id)
+      .get();
+    expect(storedDuringDeletion.exists).toBe(true);
+    expect(storedDuringDeletion.data()?.['deletionStartedAt']).toEqual(expect.any(String));
+    await expect(repository.getSessionById(session.id)).resolves.toBeNull();
+    await expect(repository.listSessionsByUserId(session.userId)).resolves.toEqual([
+      expect.objectContaining({ id: session.id, deletionStartedAt: expect.any(String) }),
+    ]);
+
+    const saveTurnForGeneration = repository.saveTurnIfSessionExists as unknown as (
+      turn: ConversationAssistantTurn,
+      expectedGenerationId: string | undefined
+    ) => Promise<boolean>;
+    await expect(
+      saveTurnForGeneration(makeTurn({ id: 'turn-during-delete' }), 'generation-delete')
+    ).resolves.toBe(false);
+
+    transactionSpy.mockRestore();
+    await expect(
+      repository.deleteSession(deletionInput(session))
+    ).resolves.toBeUndefined();
+    expect(transactionCount).toBeGreaterThan(1);
+    await expect(repository.getSessionById(session.id)).resolves.toBeNull();
+    await expect(repository.listTurnsBySessionId(session.id)).resolves.toEqual([]);
+    expect(
+      (
+        await fakeFirestore
+          .collection(WHATSAPP_CONVERSATION_ASSISTANT_CONTEXT_CHUNKS_COLLECTION)
+          .doc('context-delete')
+          .get()
+      ).exists
+    ).toBe(false);
+  });
+
+  it('finishes idempotently when the deletion marker disappears before final cleanup', async () => {
+    const session = makeSession({ transcriptText: '', transcriptSha256: '' });
+    await repository.saveSession(session);
+    const sessionRef = fakeFirestore
+      .collection(WHATSAPP_CONVERSATION_ASSISTANT_SESSIONS_COLLECTION)
+      .doc(session.id);
+    const originalRunTransaction = fakeFirestore.runTransaction.bind(fakeFirestore);
+    let transactionNumber = 0;
+    vi.spyOn(fakeFirestore, 'runTransaction').mockImplementation(async (updateFn) => {
+      transactionNumber += 1;
+      if (transactionNumber === 2) await sessionRef.delete();
+      return await originalRunTransaction(updateFn);
+    });
+
+    await expect(repository.deleteSession(deletionInput(session))).resolves.toBeUndefined();
+    expect(transactionNumber).toBe(2);
+  });
+
+  it('deletes generation-less legacy data across more than one bounded query', async () => {
+    const session = makeSession({ transcriptText: '', transcriptSha256: '' });
+    await repository.saveSession(session);
+    fakeFirestore.seedCollection(
+      WHATSAPP_CONVERSATION_ASSISTANT_TURNS_COLLECTION,
+      Array.from({ length: 21 }, (_value, index) => ({
+        id: `legacy-turn-${String(index).padStart(2, '0')}`,
+        data: {
+          ...makeTurn({ id: `legacy-turn-${String(index).padStart(2, '0')}` }),
+          sessionGenerationId: null,
+        },
+      }))
+    );
+
+    await repository.deleteSession(deletionInput(session));
+
+    await expect(repository.listTurnsBySessionId(session.id)).resolves.toEqual([]);
+  });
+
+  it('does not let a stale conditional delete remove a replacement transcript chunk', async () => {
+    const originalSession = {
+      ...makeSession(),
+      generationId: 'generation-original',
+    } as ConversationAssistantSession;
+    await repository.saveSession(originalSession);
+    let releaseSlowDelete!: () => void;
+    let reportSlowDeleteStarted!: () => void;
+    const slowDeleteStarted = new Promise<void>((resolve) => {
+      reportSlowDeleteStarted = resolve;
+    });
+    const releaseSlow = new Promise<void>((resolve) => {
+      releaseSlowDelete = resolve;
+    });
+    const originalRunTransaction = fakeFirestore.runTransaction.bind(fakeFirestore);
+    let transactionNumber = 0;
+    vi.spyOn(fakeFirestore, 'runTransaction').mockImplementation(async (updateFn) => {
+      transactionNumber += 1;
+      if (transactionNumber === 2) {
+        reportSlowDeleteStarted();
+        await releaseSlow;
+      }
+      return await originalRunTransaction(updateFn);
+    });
+
+    const slowDeletion = repository.deleteSession({
+      sessionId: originalSession.id,
+      userId: originalSession.userId,
+      deletionToken: createConversationAssistantDeletionToken(originalSession),
+    });
+    await slowDeleteStarted;
+    await repository.deleteSession({
+      sessionId: originalSession.id,
+      userId: originalSession.userId,
+      deletionToken: createConversationAssistantDeletionToken(originalSession),
+    });
+    const replacementSession = {
+      ...makeSession({
+        updatedAt: '2026-06-30T13:00:00.000Z',
+        transcriptText: 'replacement transcript',
+      }),
+      generationId: 'generation-replacement',
+    } as ConversationAssistantSession;
+    await repository.saveSession(replacementSession);
+    await repository.saveTurn(
+      makeTurn({ id: 'replacement-turn', createdAt: '2026-06-30T13:01:00.000Z' })
+    );
+
+    releaseSlowDelete();
+    await slowDeletion;
+
+    await expect(repository.getSessionById(replacementSession.id)).resolves.toMatchObject({
+      generationId: 'generation-replacement',
+    });
+    const replacementChunk = await fakeFirestore
+      .collection(WHATSAPP_CONVERSATION_ASSISTANT_TRANSCRIPT_CHUNKS_COLLECTION)
+      .doc(`${replacementSession.id}_${replacementSession.transcriptSha256}_000000`)
+      .get();
+    expect(replacementChunk.data()).toMatchObject({
+      sessionGenerationId: 'generation-replacement',
+      text: 'replacement transcript',
+    });
+  });
+
+  it('does not let a completed deletion retry remove a replacement session', async () => {
+    const originalSession = {
+      ...makeSession(),
+      generationId: 'generation-original',
+    } as ConversationAssistantSession;
+    await repository.saveSession(originalSession);
+    await repository.deleteSession(deletionInput(originalSession));
+
+    const replacementSession = {
+      ...makeSession({
+        createdAt: '2026-06-30T13:00:00.000Z',
+        updatedAt: '2026-06-30T13:00:00.000Z',
+      }),
+      generationId: 'generation-replacement',
+    } as ConversationAssistantSession;
+    await repository.saveSession(replacementSession);
+
+    await repository.deleteSession(deletionInput(originalSession));
+
+    await expect(repository.getSessionById(replacementSession.id)).resolves.toMatchObject({
+      generationId: 'generation-replacement',
+    });
+  });
+
+  it('fences queued preparation failure by session generation', async () => {
+    const replacementSession = {
+      ...makeSession({
+        status: 'preparing',
+        preparationStage: 'queued',
+        preparationAttempt: 1,
+        transcriptText: '',
+        transcriptSha256: '',
+      }),
+      generationId: 'generation-replacement',
+    } as ConversationAssistantSession;
+    await repository.saveSession(replacementSession);
+    const failForGeneration = repository.failQueuedPreparation as unknown as (
+      input: Parameters<typeof repository.failQueuedPreparation>[0] & {
+        expectedGenerationId: string | undefined;
+      }
+    ) => ReturnType<typeof repository.failQueuedPreparation>;
+
+    await expect(
+      failForGeneration({
+        sessionId: replacementSession.id,
+        userId: replacementSession.userId,
+        attempt: 1,
+        expectedGenerationId: 'generation-original',
+        error: { code: 'INTERNAL_ERROR', message: 'Old publish failed' },
+        updatedAt: '2026-06-30T13:02:00.000Z',
+      })
+    ).resolves.toEqual({ status: 'not_found' });
+    await expect(repository.getSessionById(replacementSession.id)).resolves.toMatchObject({
+      generationId: 'generation-replacement',
+      status: 'preparing',
+    });
+  });
+
+  it('does not let a generation-less failure mutate a generated session', async () => {
+    const replacementSession = {
+      ...makeSession({
+        status: 'preparing',
+        preparationStage: 'queued',
+        preparationAttempt: 1,
+        transcriptText: '',
+        transcriptSha256: '',
+      }),
+      generationId: 'generation-replacement',
+    } as ConversationAssistantSession;
+    await repository.saveSession(replacementSession);
+
+    await expect(
+      repository.failQueuedPreparation({
+        sessionId: replacementSession.id,
+        userId: replacementSession.userId,
+        attempt: 1,
+        error: { code: 'INTERNAL_ERROR', message: 'Old publish failed' },
+        updatedAt: '2026-06-30T13:02:00.000Z',
+      })
+    ).resolves.toEqual({ status: 'not_found' });
+    await expect(repository.getSessionById(replacementSession.id)).resolves.toMatchObject({
+      generationId: 'generation-replacement',
+      status: 'preparing',
+    });
+  });
+
+  it('does not overwrite or clean up transcript chunks owned by a replacement generation', async () => {
+    const transcriptSha256 = 'shared-transcript';
+    const replacementSession = {
+      ...makeSession({
+        status: 'preparing',
+        preparationStage: 'loading_messages',
+        preparationAttempt: 1,
+        preparationClaimId: 'claim-replacement',
+        transcriptText: 'replacement transcript',
+        transcriptSha256,
+      }),
+      generationId: 'generation-replacement',
+    } as ConversationAssistantSession;
+    await repository.saveSession(replacementSession);
+    const sharedChunkId = `${replacementSession.id}_${transcriptSha256}_000000`;
+
+    await expect(
+      repository.saveClaimedPreparationSession({
+        session: {
+          ...replacementSession,
+          status: 'ready',
+          preparationStage: 'ready',
+          preparationClaimId: 'claim-original',
+          generationId: 'generation-original',
+          transcriptSha256,
+          transcriptText: 'replacement transcript',
+        },
+        attempt: 1,
+        claimId: 'claim-original',
+      })
+    ).resolves.toBe(false);
+    const sharedChunk = await fakeFirestore
+      .collection(WHATSAPP_CONVERSATION_ASSISTANT_TRANSCRIPT_CHUNKS_COLLECTION)
+      .doc(sharedChunkId)
+      .get();
+    expect(sharedChunk.data()).toMatchObject({
+      sessionGenerationId: 'generation-replacement',
+      text: 'replacement transcript',
+    });
+  });
+
+  it('does not write context chunks after deletion has started', async () => {
+    const session = {
+      ...makeSession(),
+      generationId: 'generation-delete-context',
+      deletionStartedAt: '2026-06-30T13:00:00.000Z',
+    } as ConversationAssistantSession;
+    await repository.saveSession(session);
+    const saveForGeneration = repository.saveContextSnapshot as unknown as (
+      sessionId: string,
+      userId: string,
+      snapshotId: string,
+      snapshot: { messages: []; omittedMessages: [] },
+      expectedGenerationId: string | undefined
+    ) => Promise<boolean>;
+
+    await expect(
+      saveForGeneration(
+        session.id,
+        session.userId,
+        'blocked-context',
+        { messages: [], omittedMessages: [] },
+        session.generationId
+      )
+    ).resolves.toBe(false);
+    const chunks = await fakeFirestore
+      .collection(WHATSAPP_CONVERSATION_ASSISTANT_CONTEXT_CHUNKS_COLLECTION)
+      .where('sessionId', '==', session.id)
+      .get();
+    expect(chunks.empty).toBe(true);
+  });
+
+  it('rejects context snapshots when the session is missing before or during chunk writes', async () => {
+    const message = {
+      id: 'context-race-message',
+      eventTimestamp: '2026-06-30T10:00:00.000Z',
+      importedAt: '2026-06-30T10:00:01.000Z',
+      direction: 'incoming' as const,
+      speakerLabel: 'Alice',
+      messageType: 'text' as const,
+      contentKind: 'text' as const,
+      content: 'Context race',
+    };
+    await expect(
+      repository.saveContextSnapshot('missing-session', 'user-123', 'missing-snapshot', {
+        messages: [message],
+        omittedMessages: [],
+      })
+    ).resolves.toBe(false);
+
+    const session = {
+      ...makeSession({ transcriptText: '', transcriptSha256: '' }),
+      generationId: 'generation-context-race',
+    } as ConversationAssistantSession;
+    await repository.saveSession(session);
+    const sessionRef = fakeFirestore
+      .collection(WHATSAPP_CONVERSATION_ASSISTANT_SESSIONS_COLLECTION)
+      .doc(session.id);
+    const originalRunTransaction = fakeFirestore.runTransaction.bind(fakeFirestore);
+    let transactionNumber = 0;
+    vi.spyOn(fakeFirestore, 'runTransaction').mockImplementation(async (updateFn) => {
+      transactionNumber += 1;
+      if (transactionNumber === 2) await sessionRef.delete();
+      return await originalRunTransaction(updateFn);
+    });
+
+    await expect(
+      repository.saveContextSnapshot(
+        session.id,
+        session.userId,
+        'racing-snapshot',
+        { messages: [message], omittedMessages: [] },
+        session.generationId
+      )
+    ).resolves.toBe(false);
+  });
+
+  it('cleans a context snapshot when its generation changes during a chunk write', async () => {
+    const session = {
+      ...makeSession({ transcriptText: '', transcriptSha256: '' }),
+      generationId: 'generation-context-original',
+    } as ConversationAssistantSession;
+    await repository.saveSession(session);
+    const message = {
+      id: 'context-replacement-message',
+      eventTimestamp: '2026-06-30T10:00:00.000Z',
+      importedAt: '2026-06-30T10:00:01.000Z',
+      direction: 'incoming' as const,
+      speakerLabel: 'Alice',
+      messageType: 'text' as const,
+      contentKind: 'text' as const,
+      content: 'Context replacement',
+    };
+    const sessionRef = fakeFirestore
+      .collection(WHATSAPP_CONVERSATION_ASSISTANT_SESSIONS_COLLECTION)
+      .doc(session.id);
+    const storedData = (await sessionRef.get()).data();
+    expect(storedData).toBeDefined();
+    const originalRunTransaction = fakeFirestore.runTransaction.bind(fakeFirestore);
+    let transactionNumber = 0;
+    vi.spyOn(fakeFirestore, 'runTransaction').mockImplementation(async (updateFn) => {
+      transactionNumber += 1;
+      if (transactionNumber === 2) {
+        await sessionRef.set({ ...storedData, generationId: 'generation-context-replacement' });
+      }
+      return await originalRunTransaction(updateFn);
+    });
+
+    await expect(
+      repository.saveContextSnapshot(
+        session.id,
+        session.userId,
+        'replacement-snapshot',
+        { messages: [message], omittedMessages: [] },
+        session.generationId
+      )
+    ).resolves.toBe(false);
+    const chunks = await fakeFirestore
+      .collection(WHATSAPP_CONVERSATION_ASSISTANT_CONTEXT_CHUNKS_COLLECTION)
+      .where('snapshotId', '==', 'replacement-snapshot')
+      .get();
+    expect(chunks.empty).toBe(true);
+  });
+
   it('creates a session only once without overwriting a preparation claim', async () => {
     const queued = makeSession({
       status: 'preparing',
@@ -160,6 +809,17 @@ describe('conversationAssistantRepository', () => {
     expect(
       (await repository.getSessionById(queued.id))?.preparationClaimId
     ).toBe('active-claim');
+
+    const deleting = {
+      ...queued,
+      id: 'whatsapp_conv_session_deleting_existing',
+      deletionStartedAt: '2026-06-30T10:02:00.000Z',
+    };
+    await repository.saveSession(deleting);
+    await expect(repository.createSessionIfAbsent(deleting)).resolves.toMatchObject({
+      status: 'existing',
+      session: { id: deleting.id, deletionStartedAt: deleting.deletionStartedAt },
+    });
   });
 
   it('handles missing, foreign, stale, and legacy preparation claims', async () => {
@@ -234,13 +894,21 @@ describe('conversationAssistantRepository', () => {
           status: 'ready',
           preparationStage: 'ready',
           preparationAttempt: 1,
-          transcriptText: '',
-          transcriptSha256: '',
+          transcriptText: 'orphan transcript',
+          transcriptSha256: 'orphan-hash',
         }),
         attempt: 1,
         claimId: 'claim-1',
       })
     ).resolves.toBe(false);
+    expect(
+      (
+        await fakeFirestore
+          .collection(WHATSAPP_CONVERSATION_ASSISTANT_TRANSCRIPT_CHUNKS_COLLECTION)
+          .doc('missing-session_orphan-hash_000000')
+          .get()
+      ).exists
+    ).toBe(false);
 
     await expect(
       repository.requeueFailedPreparation({
@@ -468,6 +1136,100 @@ describe('conversationAssistantRepository', () => {
     expect((await repository.getSessionById('whatsapp_conv_session_1'))?.status).toBe('ready');
   });
 
+  it('does not let stale claim cleanup remove a newer claim transcript', async () => {
+    const claimedByA = {
+      ...makeSession({
+        status: 'preparing',
+        preparationStage: 'loading_messages',
+        preparationAttempt: 1,
+        preparationClaimId: 'claim-a',
+        transcriptText: '',
+        transcriptSha256: '',
+      }),
+      generationId: 'shared-generation',
+    } as ConversationAssistantSession;
+    await repository.saveSession(claimedByA);
+
+    let releaseASessionWrite!: () => void;
+    let reportASessionWriteStarted!: () => void;
+    const aSessionWriteStarted = new Promise<void>((resolve) => {
+      reportASessionWriteStarted = resolve;
+    });
+    const aSessionWriteRelease = new Promise<void>((resolve) => {
+      releaseASessionWrite = resolve;
+    });
+    const originalRunTransaction = fakeFirestore.runTransaction.bind(fakeFirestore);
+    let transactionNumber = 0;
+    vi.spyOn(fakeFirestore, 'runTransaction').mockImplementation(async (updateFn) => {
+      transactionNumber += 1;
+      if (transactionNumber === 2) {
+        reportASessionWriteStarted();
+        await aSessionWriteRelease;
+      }
+      return await originalRunTransaction(updateFn);
+    });
+
+    const readyA = {
+      ...claimedByA,
+      status: 'ready' as const,
+      preparationStage: 'ready' as const,
+      transcriptSha256: 'shared-transcript',
+      transcriptText: 'transcript from claim A',
+    };
+    const saveA = repository.saveClaimedPreparationSession({
+      session: readyA,
+      attempt: 1,
+      claimId: 'claim-a',
+    });
+    await aSessionWriteStarted;
+
+    const claimedByB = {
+      ...claimedByA,
+      preparationClaimId: 'claim-b',
+    };
+    await repository.saveSession(claimedByB);
+    const readyB = {
+      ...claimedByB,
+      status: 'ready' as const,
+      preparationStage: 'ready' as const,
+      transcriptSha256: 'shared-transcript',
+      transcriptText: 'transcript from claim B',
+    };
+    await fakeFirestore
+      .collection(WHATSAPP_CONVERSATION_ASSISTANT_TRANSCRIPT_CHUNKS_COLLECTION)
+      .doc(`${claimedByA.id}_shared-transcript_000000`)
+      .set({
+        sessionId: claimedByA.id,
+        sessionGenerationId: 'shared-generation',
+        preparationAttempt: 1,
+        preparationClaimId: 'claim-b',
+        snapshotId: 'shared-transcript',
+        chunkIndex: 0,
+        text: 'transcript from claim B',
+      });
+
+    releaseASessionWrite();
+    await expect(saveA).resolves.toBe(false);
+    await expect(
+      repository.saveClaimedPreparationSession({
+        session: readyB,
+        attempt: 1,
+        claimId: 'claim-b',
+      })
+    ).resolves.toBe(true);
+
+    const sharedChunk = await fakeFirestore
+      .collection(WHATSAPP_CONVERSATION_ASSISTANT_TRANSCRIPT_CHUNKS_COLLECTION)
+      .doc(`${claimedByA.id}_shared-transcript_000000`)
+      .get();
+    expect(sharedChunk.data()).toMatchObject({
+      sessionGenerationId: 'shared-generation',
+      preparationAttempt: 1,
+      preparationClaimId: 'claim-b',
+      text: 'transcript from claim B',
+    });
+  });
+
   it('fails only an unclaimed queued preparation and preserves an active claim', async () => {
     await repository.saveSession(
       makeSession({
@@ -535,6 +1297,7 @@ describe('conversationAssistantRepository', () => {
   });
 
   it('round-trips reactions and exact omitted messages in a versioned context snapshot', async () => {
+    await repository.saveSession(makeSession());
     const includedMessage = {
       id: 'message-included',
       eventTimestamp: '2026-06-30T10:00:00.000Z',
@@ -877,6 +1640,7 @@ describe('conversationAssistantRepository', () => {
   });
 
   it('stores the frozen context in ordered chunks and replaces stale chunks on retry', async () => {
+    await repository.saveSession(makeSession());
     const firstMessage = {
       id: 'message-1',
       eventTimestamp: '2026-06-30T10:00:00.000Z',
@@ -953,6 +1717,7 @@ describe('conversationAssistantRepository', () => {
   });
 
   it('deletes only the owned context snapshot selected for cleanup', async () => {
+    await repository.saveSession(makeSession());
     const message = {
       id: 'message-1',
       eventTimestamp: '2026-06-30T10:00:00.000Z',
@@ -1112,6 +1877,7 @@ describe('conversationAssistantRepository', () => {
       .get();
     expect(chunk.data()).toEqual({
       sessionId: chunkSessionId,
+      sessionGenerationId: null,
       chunkIndex: 0,
       text: 'legacy chunk',
     });

--- a/apps/whatsapp-service/src/__tests__/openapi-contract.test.ts
+++ b/apps/whatsapp-service/src/__tests__/openapi-contract.test.ts
@@ -14,7 +14,7 @@ interface OpenApiSpec {
       {
         operationId?: string;
         responses?: Record<string, { content?: Record<string, unknown> }>;
-        parameters?: { in: string; name: string }[];
+        parameters?: { in: string; name: string; required?: boolean }[];
       }
     >
   >;
@@ -133,6 +133,19 @@ describe('whatsapp-service OpenAPI contract', () => {
 
     expect(paths?.['/webhooks']).toBeDefined();
     expect(paths?.['/health']).toBeDefined();
+  });
+
+  it('documents the required Conversation Assistant deletion token header', () => {
+    const deleteSession =
+      openapiSpec.paths?.['/conversation-assistant/sessions/{sessionId}']?.['delete'];
+
+    expect(deleteSession?.parameters).toContainEqual(
+      expect.objectContaining({
+        in: 'header',
+        name: 'x-conversation-assistant-deletion-token',
+        required: true,
+      })
+    );
   });
 
   it('POST /webhooks documents signature header', () => {

--- a/apps/whatsapp-service/src/domain/conversation-assistant/deletionToken.ts
+++ b/apps/whatsapp-service/src/domain/conversation-assistant/deletionToken.ts
@@ -1,0 +1,10 @@
+import { createHash } from 'node:crypto';
+import type { ConversationAssistantSession } from './types.js';
+
+export function createConversationAssistantDeletionToken(
+  session: Pick<ConversationAssistantSession, 'id' | 'createdAt' | 'generationId'>
+): string {
+  return createHash('sha256')
+    .update(`${session.id}\0${session.createdAt}\0${session.generationId ?? 'legacy'}`)
+    .digest('hex');
+}

--- a/apps/whatsapp-service/src/domain/conversation-assistant/ports.ts
+++ b/apps/whatsapp-service/src/domain/conversation-assistant/ports.ts
@@ -22,6 +22,11 @@ export interface ConversationAssistantRepository {
     input: { sessionId: string; userId: string }
   ): Promise<{ session: ConversationAssistantSession; turns: ConversationAssistantTurn[] } | null>;
   listSessionsByUserId(userId: string): Promise<ConversationAssistantSession[]>;
+  deleteSession(input: {
+    sessionId: string;
+    userId: string;
+    deletionToken: string;
+  }): Promise<void>;
   claimPreparation(input: {
     sessionId: string;
     userId: string;
@@ -29,6 +34,7 @@ export interface ConversationAssistantRepository {
     claimId: string;
     now: string;
     leaseExpiresAt: string;
+    expectedGenerationId?: string;
   }): Promise<
     | { status: 'claimed'; session: ConversationAssistantSession }
     | { status: 'busy'; session: ConversationAssistantSession }
@@ -45,6 +51,7 @@ export interface ConversationAssistantRepository {
     userId: string;
     expectedAttempt: number;
     updatedAt: string;
+    expectedGenerationId?: string;
   }): Promise<
     | { status: 'queued' | 'stale'; session: ConversationAssistantSession }
     | { status: 'not_found' }
@@ -55,6 +62,7 @@ export interface ConversationAssistantRepository {
     attempt: number;
     error: { code: string; message: string };
     updatedAt: string;
+    expectedGenerationId?: string;
   }): Promise<
     | { status: 'saved' | 'stale'; session: ConversationAssistantSession }
     | { status: 'not_found' }
@@ -63,12 +71,14 @@ export interface ConversationAssistantRepository {
     sessionId: string,
     userId: string,
     snapshotId: string,
-    snapshot: Pick<ConversationAssistantContextResult, 'messages' | 'omittedMessages'>
-  ): Promise<void>;
+    snapshot: Pick<ConversationAssistantContextResult, 'messages' | 'omittedMessages'>,
+    expectedGenerationId?: string
+  ): Promise<boolean>;
   deleteContextSnapshot(
     sessionId: string,
     userId: string,
-    snapshotId: string
+    snapshotId: string,
+    expectedGenerationId?: string
   ): Promise<void>;
   getContextPage(
     sessionId: string,
@@ -84,6 +94,14 @@ export interface ConversationAssistantRepository {
     Pick<ConversationAssistantContextResult, 'messages' | 'omittedMessages' | 'snapshotAvailable'>
   >;
   saveTurn(turn: ConversationAssistantTurn): Promise<void>;
+  saveTurnIfSessionExists(
+    turn: ConversationAssistantTurn,
+    expectedGenerationId: string | undefined
+  ): Promise<boolean>;
+  saveAssistantTurnAndTouchSession(input: {
+    session: ConversationAssistantSession;
+    turn: ConversationAssistantTurn;
+  }): Promise<boolean>;
   listTurnsBySessionId(sessionId: string): Promise<ConversationAssistantTurn[]>;
 }
 
@@ -93,6 +111,7 @@ export interface ConversationAssistantClock {
 
 export interface ConversationAssistantIdGenerator {
   sessionId(input?: { userId: string; requestId: string }): string;
+  sessionGenerationId(): string;
   turnId(): string;
 }
 

--- a/apps/whatsapp-service/src/domain/conversation-assistant/sessionUseCases.ts
+++ b/apps/whatsapp-service/src/domain/conversation-assistant/sessionUseCases.ts
@@ -25,6 +25,7 @@ import type {
   ConversationAssistantTurn,
   CreateConversationAssistantSessionInput,
   CreateConversationAssistantSessionResult,
+  DeleteConversationAssistantSessionInput,
   ExportConversationAssistantPdfInput,
   ExportConversationAssistantPdfResult,
   GetConversationAssistantContextInput,
@@ -51,6 +52,7 @@ export const conversationAssistantRandomIds = {
           .update(`${input.userId}:${input.requestId}`)
           .digest('hex')
           .slice(0, 32)}`,
+  sessionGenerationId: (): string => randomUUID(),
   turnId: (): string => `whatsapp_conv_turn_${randomUUID()}`,
 };
 
@@ -126,6 +128,7 @@ export async function createConversationAssistantSession(
     createdAt: now,
     updatedAt: now,
     creationRequestId,
+    generationId: deps.ids.sessionGenerationId(),
   };
   if (chatLoadResult.value.chat.displayName !== undefined) {
     session.chatDisplayName = chatLoadResult.value.chat.displayName;
@@ -146,12 +149,23 @@ export async function createConversationAssistantSession(
   return ok({ session: await publishQueuedConversationAssistantPreparation(session, deps) });
 }
 
+export async function deleteConversationAssistantSession(
+  input: DeleteConversationAssistantSessionInput,
+  deps: ConversationAssistantDeps
+): Promise<ConversationAssistantResult<{ deleted: true }>> {
+  await deps.repository.deleteSession(input);
+  return ok({ deleted: true });
+}
+
 export async function prepareConversationAssistantSession(
   input: PrepareConversationAssistantSessionInput,
   deps: ConversationAssistantDeps
 ): Promise<ConversationAssistantResult<PrepareConversationAssistantSessionResult>> {
   const session = await deps.repository.getSessionById(input.sessionId);
   if (!isOwnedSession(session, input.userId)) {
+    return err({ code: 'NOT_FOUND', message: 'Conversation Assistant session not found' });
+  }
+  if (session.generationId !== input.generationId) {
     return err({ code: 'NOT_FOUND', message: 'Conversation Assistant session not found' });
   }
   if (isSessionReady(session)) {
@@ -169,6 +183,9 @@ export async function prepareConversationAssistantSession(
     claimId,
     now,
     leaseExpiresAt: new Date(Date.parse(now) + CONVERSATION_PREPARATION_LEASE_MS).toISOString(),
+    ...(session.generationId !== undefined
+      ? { expectedGenerationId: session.generationId }
+      : {}),
   });
   if (claim.status === 'not_found') {
     return err({ code: 'NOT_FOUND', message: 'Conversation Assistant session not found' });
@@ -259,17 +276,22 @@ export async function prepareConversationAssistantSession(
 
   const contextSnapshotId = createContextSnapshotId(workingSession.id, attempt, claimId);
   try {
-    await deps.repository.saveContextSnapshot(
+    const contextSaved = await deps.repository.saveContextSnapshot(
       workingSession.id,
       workingSession.userId,
       contextSnapshotId,
-      { messages: context.messages, omittedMessages: context.omittedMessages }
+      { messages: context.messages, omittedMessages: context.omittedMessages },
+      workingSession.generationId
     );
+    if (!contextSaved) {
+      return await currentPreparationResult(session.id, input.userId, deps);
+    }
   } catch (error) {
     await deps.repository.deleteContextSnapshot(
       workingSession.id,
       workingSession.userId,
-      contextSnapshotId
+      contextSnapshotId,
+      workingSession.generationId
     );
     throw error;
   }
@@ -300,7 +322,8 @@ export async function prepareConversationAssistantSession(
     await deps.repository.deleteContextSnapshot(
       workingSession.id,
       workingSession.userId,
-      contextSnapshotId
+      contextSnapshotId,
+      workingSession.generationId
     );
     throw error;
   }
@@ -308,7 +331,8 @@ export async function prepareConversationAssistantSession(
     await deps.repository.deleteContextSnapshot(
       workingSession.id,
       workingSession.userId,
-      contextSnapshotId
+      contextSnapshotId,
+      workingSession.generationId
     );
     return await currentPreparationResult(session.id, input.userId, deps);
   }
@@ -409,7 +433,7 @@ export async function sendConversationAssistantTurn(
   }
 
   const result = await appendQuestionAndAssistantTurn({ session, question }, deps);
-  return ok(result.turns);
+  return result.ok ? ok(result.value.turns) : result;
 }
 
 export async function streamConversationAssistantTurn(
@@ -434,7 +458,9 @@ export async function streamConversationAssistantTurn(
   }
 
   const userTurn = createTurn(session, 'user', question, deps);
-  await deps.repository.saveTurn(userTurn);
+  if (!(await deps.repository.saveTurnIfSessionExists(userTurn, session.generationId))) {
+    return err({ code: 'NOT_FOUND', message: 'Conversation Assistant session not found' });
+  }
   onEvent({ type: 'user_turn', turn: userTurn });
 
   const promptInput = await buildPromptInputAfterUserTurn({ session, question }, deps);
@@ -458,7 +484,9 @@ export async function streamConversationAssistantTurn(
     });
   }
 
-  await persistAssistantTurnAndTouchSession(session, assistantTurn, deps);
+  if (!(await persistAssistantTurnAndTouchSession(session, assistantTurn, deps))) {
+    return err({ code: 'NOT_FOUND', message: 'Conversation Assistant session not found' });
+  }
   onEvent({ type: 'assistant_turn', turn: assistantTurn });
   onEvent({ type: 'done' });
 
@@ -632,9 +660,11 @@ export async function exportConversationAssistantSessionPdf(
 async function appendQuestionAndAssistantTurn(
   input: { session: ConversationAssistantSession; question: string },
   deps: ConversationAssistantDeps
-): Promise<{ turns: ConversationAssistantTurn[] }> {
+): Promise<ConversationAssistantResult<{ turns: ConversationAssistantTurn[] }>> {
   const userTurn = createTurn(input.session, 'user', input.question, deps);
-  await deps.repository.saveTurn(userTurn);
+  if (!(await deps.repository.saveTurnIfSessionExists(userTurn, input.session.generationId))) {
+    return err({ code: 'NOT_FOUND', message: 'Conversation Assistant session not found' });
+  }
 
   const promptInput = await buildPromptInputAfterUserTurn(input, deps);
   const llmResult = await callConversationAssistantModel(input.session, promptInput, deps);
@@ -645,9 +675,11 @@ async function appendQuestionAndAssistantTurn(
     'Chat message generation is unavailable'
   );
 
-  await persistAssistantTurnAndTouchSession(input.session, assistantTurn, deps);
+  if (!(await persistAssistantTurnAndTouchSession(input.session, assistantTurn, deps))) {
+    return err({ code: 'NOT_FOUND', message: 'Conversation Assistant session not found' });
+  }
 
-  return { turns: [userTurn, assistantTurn] };
+  return ok({ turns: [userTurn, assistantTurn] });
 }
 
 async function reuseOrRequeueConversationAssistantSession(
@@ -656,6 +688,9 @@ async function reuseOrRequeueConversationAssistantSession(
   creationRequestId: string,
   deps: ConversationAssistantDeps
 ): Promise<ConversationAssistantResult<CreateConversationAssistantSessionResult>> {
+  if (session.deletionStartedAt !== undefined) {
+    return err({ code: 'NOT_FOUND', message: 'Conversation Assistant session not found' });
+  }
   if (!isOwnedSession(session, userId) || session.creationRequestId !== creationRequestId) {
     return err({ code: 'INTERNAL_ERROR', message: 'Conversation Assistant request collision' });
   }
@@ -678,6 +713,9 @@ async function requeueConversationAssistantPreparation(
     userId: session.userId,
     expectedAttempt: session.preparationAttempt ?? 0,
     updatedAt: deps.clock.now(),
+    ...(session.generationId !== undefined
+      ? { expectedGenerationId: session.generationId }
+      : {}),
   });
   if (result.status === 'not_found') {
     return null;
@@ -697,6 +735,7 @@ async function publishQueuedConversationAssistantPreparation(
     sessionId: session.id,
     userId: session.userId,
     attempt: session.preparationAttempt ?? 1,
+    ...(session.generationId !== undefined ? { generationId: session.generationId } : {}),
   });
   if (publishResult.ok) {
     return session;
@@ -707,6 +746,9 @@ async function publishQueuedConversationAssistantPreparation(
     attempt: session.preparationAttempt ?? 1,
     error: publishResult.error,
     updatedAt: deps.clock.now(),
+    ...(session.generationId !== undefined
+      ? { expectedGenerationId: session.generationId }
+      : {}),
   });
   return failure.status === 'not_found' ? session : failure.session;
 }
@@ -902,12 +944,10 @@ async function persistAssistantTurnAndTouchSession(
   session: ConversationAssistantSession,
   assistantTurn: ConversationAssistantTurn,
   deps: ConversationAssistantDeps
-): Promise<void> {
-  await deps.repository.saveTurn(assistantTurn);
-  await deps.repository.saveSession({
-    ...session,
-    updatedAt: assistantTurn.createdAt,
-    lastTurnAt: assistantTurn.createdAt,
+): Promise<boolean> {
+  return await deps.repository.saveAssistantTurnAndTouchSession({
+    session,
+    turn: assistantTurn,
   });
 }
 

--- a/apps/whatsapp-service/src/domain/conversation-assistant/types.ts
+++ b/apps/whatsapp-service/src/domain/conversation-assistant/types.ts
@@ -49,6 +49,8 @@ export interface ConversationAssistantSession {
   lastTurnAt?: string;
   creationRequestId?: string;
   maxMessages?: number;
+  generationId?: string;
+  deletionStartedAt?: string;
 }
 
 export type PublicConversationAssistantSession = Omit<
@@ -59,7 +61,11 @@ export type PublicConversationAssistantSession = Omit<
   | 'preparationClaimId'
   | 'preparationLeaseExpiresAt'
   | 'contextSnapshotId'
+  | 'generationId'
+  | 'deletionStartedAt'
 > & {
+  deletionToken: string;
+  deletionPending: boolean;
   modelDisplayName: string;
 };
 
@@ -103,6 +109,12 @@ export interface SendConversationAssistantTurnInput {
   question: string;
 }
 
+export interface DeleteConversationAssistantSessionInput {
+  userId: string;
+  sessionId: string;
+  deletionToken: string;
+}
+
 export interface ExportConversationAssistantPdfInput {
   userId: string;
   sessionId: string;
@@ -117,6 +129,7 @@ export interface PrepareConversationAssistantSessionInput {
   sessionId: string;
   attempt?: number;
   claimId?: string;
+  generationId?: string;
 }
 
 export interface GetConversationAssistantSessionByRequestInput {

--- a/apps/whatsapp-service/src/domain/whatsapp/events/events.ts
+++ b/apps/whatsapp-service/src/domain/whatsapp/events/events.ts
@@ -372,6 +372,7 @@ export interface ConversationAssistantPreparationRequestedEvent {
   sessionId: string;
   userId: string;
   attempt: number;
+  generationId?: string;
 }
 
 /**

--- a/apps/whatsapp-service/src/infra/firestore/conversationAssistantRepository.ts
+++ b/apps/whatsapp-service/src/infra/firestore/conversationAssistantRepository.ts
@@ -8,6 +8,7 @@ import type {
   ConversationAssistantTurn,
 } from '../../domain/conversation-assistant/types.js';
 import { DEFAULT_CONVERSATION_ASSISTANT_ROLE_LABEL } from '../../domain/conversation-assistant/roleInference.js';
+import { createConversationAssistantDeletionToken } from '../../domain/conversation-assistant/deletionToken.js';
 
 export const WHATSAPP_CONVERSATION_ASSISTANT_SESSIONS_COLLECTION =
   'whatsapp_conversation_assistant_sessions';
@@ -19,6 +20,7 @@ export const WHATSAPP_CONVERSATION_ASSISTANT_TURNS_COLLECTION =
   'whatsapp_conversation_assistant_turns';
 export const TRANSCRIPT_CHUNK_MAX_BYTES = 200_000;
 export const CONTEXT_CHUNK_MAX_BYTES = 200_000;
+export const CASCADE_DELETE_BATCH_SIZE = 20;
 
 interface TranscriptChunkStorage {
   type: 'chunks';
@@ -77,6 +79,10 @@ export function createConversationAssistantRepository(): ConversationAssistantRe
         if (result.status === 'created') {
           return { status: 'created', session };
         }
+        const existing = toSession(session.id, result.data);
+        if (existing.deletionStartedAt !== undefined) {
+          return { status: 'existing', session: existing };
+        }
         return {
           status: 'existing',
           session: await toHydratedSession(db, session.id, result.data),
@@ -96,6 +102,9 @@ export function createConversationAssistantRepository(): ConversationAssistantRe
           .doc(sessionId)
           .get();
         if (!doc.exists) {
+          return null;
+        }
+        if (toSession(doc.id, doc.data()).deletionStartedAt !== undefined) {
           return null;
         }
         return await toHydratedSession(db, doc.id, doc.data());
@@ -119,7 +128,10 @@ export function createConversationAssistantRepository(): ConversationAssistantRe
           return null;
         }
         const sessionWithoutTranscript = toSession(sessionDoc.id, sessionDoc.data());
-        if (sessionWithoutTranscript.userId !== input.userId) {
+        if (
+          sessionWithoutTranscript.userId !== input.userId ||
+          sessionWithoutTranscript.deletionStartedAt !== undefined
+        ) {
           return null;
         }
         const session = await toHydratedSession(db, sessionDoc.id, sessionDoc.data());
@@ -157,6 +169,67 @@ export function createConversationAssistantRepository(): ConversationAssistantRe
       }
     },
 
+    async deleteSession(input: {
+      sessionId: string;
+      userId: string;
+      deletionToken: string;
+    }): Promise<void> {
+      try {
+        const db = getFirestore();
+        const sessionRef = db
+          .collection(WHATSAPP_CONVERSATION_ASSISTANT_SESSIONS_COLLECTION)
+          .doc(input.sessionId);
+        const deletionTarget = await db.runTransaction(async (transaction) => {
+          const sessionSnapshot = await transaction.get(sessionRef);
+          if (!sessionSnapshot.exists) return null;
+          const session = toSession(sessionSnapshot.id, sessionSnapshot.data());
+          if (
+            session.userId !== input.userId ||
+            createConversationAssistantDeletionToken(session) !== input.deletionToken
+          ) {
+            return null;
+          }
+          if (session.deletionStartedAt === undefined) {
+            transaction.set(sessionRef, {
+              ...sessionSnapshot.data(),
+              deletionStartedAt: new Date().toISOString(),
+            });
+          }
+          return { generationId: session.generationId };
+        });
+        if (deletionTarget === null) return;
+
+        for (const collectionName of [
+          WHATSAPP_CONVERSATION_ASSISTANT_TURNS_COLLECTION,
+          WHATSAPP_CONVERSATION_ASSISTANT_TRANSCRIPT_CHUNKS_COLLECTION,
+          WHATSAPP_CONVERSATION_ASSISTANT_CONTEXT_CHUNKS_COLLECTION,
+        ]) {
+          await deleteGenerationDocuments(
+            db,
+            collectionName,
+            input.sessionId,
+            deletionTarget.generationId
+          );
+        }
+        await db.runTransaction(async (transaction) => {
+          const currentSnapshot = await transaction.get(sessionRef);
+          if (!currentSnapshot.exists) return;
+          const current = toSession(currentSnapshot.id, currentSnapshot.data());
+          if (
+            current.userId === input.userId &&
+            current.deletionStartedAt !== undefined &&
+            current.generationId === deletionTarget.generationId
+          ) {
+            transaction.delete(sessionRef);
+          }
+        });
+      } catch (error) {
+        throw new Error(
+          `Failed to delete Conversation Assistant session: ${getErrorMessage(error)}`
+        );
+      }
+    },
+
     async claimPreparation(input): Promise<PreparationClaimResult> {
       try {
         const db = getFirestore();
@@ -169,7 +242,11 @@ export function createConversationAssistantRepository(): ConversationAssistantRe
             return { status: 'not_found' as const };
           }
           const session = toSession(snapshot.id, snapshot.data());
-          if (session.userId !== input.userId) {
+          if (
+            session.userId !== input.userId ||
+            session.deletionStartedAt !== undefined ||
+            session.generationId !== input.expectedGenerationId
+          ) {
             return { status: 'not_found' as const };
           }
           if (
@@ -209,17 +286,22 @@ export function createConversationAssistantRepository(): ConversationAssistantRe
     async saveClaimedPreparationSession(input): Promise<boolean> {
       try {
         const db = getFirestore();
-        const transcriptStorage = await saveTranscriptChunks(db, input.session);
+        const transcriptStorage = await saveTranscriptChunks(db, input.session, {
+          attempt: input.attempt,
+          claimId: input.claimId,
+        });
         const sessionRef = db
           .collection(WHATSAPP_CONVERSATION_ASSISTANT_SESSIONS_COLLECTION)
           .doc(input.session.id);
-        return await db.runTransaction(async (transaction) => {
+        const saved = await db.runTransaction(async (transaction) => {
           const snapshot = await transaction.get(sessionRef);
           if (!snapshot.exists) {
             return false;
           }
           const current = toSession(snapshot.id, snapshot.data());
           if (
+            current.deletionStartedAt !== undefined ||
+            current.generationId !== input.session.generationId ||
             current.preparationAttempt !== input.attempt ||
             current.preparationClaimId !== input.claimId
           ) {
@@ -228,6 +310,22 @@ export function createConversationAssistantRepository(): ConversationAssistantRe
           transaction.set(sessionRef, toSessionDocument(input.session, transcriptStorage));
           return true;
         });
+        if (!saved && transcriptStorage.chunkCount > 0) {
+          const currentSnapshot = await sessionRef.get();
+          const currentStorage = parseTranscriptStorage(
+            currentSnapshot.data()?.['transcriptStorage']
+          );
+          if (currentStorage?.snapshotId !== transcriptStorage.snapshotId) {
+            await deleteTranscriptChunks(
+              db,
+              input.session.id,
+              transcriptStorage,
+              input.session.generationId,
+              { attempt: input.attempt, claimId: input.claimId }
+            );
+          }
+        }
+        return saved;
       } catch (error) {
         throw new Error(
           `Failed to save claimed Conversation Assistant preparation: ${getErrorMessage(error)}`
@@ -247,7 +345,11 @@ export function createConversationAssistantRepository(): ConversationAssistantRe
             return { status: 'not_found' as const };
           }
           const session = toSession(snapshot.id, snapshot.data());
-          if (session.userId !== input.userId) {
+          if (
+            session.userId !== input.userId ||
+            session.deletionStartedAt !== undefined ||
+            session.generationId !== input.expectedGenerationId
+          ) {
             return { status: 'not_found' as const };
           }
           if (
@@ -290,7 +392,11 @@ export function createConversationAssistantRepository(): ConversationAssistantRe
             return { status: 'not_found' as const };
           }
           const session = toSession(snapshot.id, snapshot.data());
-          if (session.userId !== input.userId) {
+          if (
+            session.userId !== input.userId ||
+            session.deletionStartedAt !== undefined ||
+            session.generationId !== input.expectedGenerationId
+          ) {
             return { status: 'not_found' as const };
           }
           if (
@@ -327,12 +433,28 @@ export function createConversationAssistantRepository(): ConversationAssistantRe
       contextSnapshot: Pick<
         ConversationAssistantContextResult,
         'messages' | 'omittedMessages'
-      >
-    ): Promise<void> {
+      >,
+      expectedGenerationId?: string
+    ): Promise<boolean> {
       try {
-        const collection = getFirestore().collection(
+        const db = getFirestore();
+        const collection = db.collection(
           WHATSAPP_CONVERSATION_ASSISTANT_CONTEXT_CHUNKS_COLLECTION
         );
+        const canWrite = await db.runTransaction(async (transaction) => {
+          const sessionRef = db
+            .collection(WHATSAPP_CONVERSATION_ASSISTANT_SESSIONS_COLLECTION)
+            .doc(sessionId);
+          const sessionSnapshot = await transaction.get(sessionRef);
+          if (!sessionSnapshot.exists) return false;
+          const session = toSession(sessionSnapshot.id, sessionSnapshot.data());
+          return (
+            session.userId === userId &&
+            session.deletionStartedAt === undefined &&
+            session.generationId === expectedGenerationId
+          );
+        });
+        if (!canWrite) return false;
         const existing = await collection
           .where('sessionId', '==', sessionId)
           .where('snapshotId', '==', snapshotId)
@@ -343,23 +465,56 @@ export function createConversationAssistantRepository(): ConversationAssistantRe
         for (const [chunkIndex, chunk] of chunks.entries()) {
           const chunkId = toContextChunkId(sessionId, snapshotId, chunkIndex);
           expectedIds.add(chunkId);
-          await collection.doc(chunkId).set({
-            sessionId,
-            userId,
-            snapshotId,
-            chunkIndex,
-            kind: chunk.kind,
-            start: chunk.start,
-            end: chunk.end,
-            messages: chunk.messages,
-            omittedMessages: chunk.omittedMessages,
+          const saved = await db.runTransaction(async (transaction) => {
+            const sessionRef = db
+              .collection(WHATSAPP_CONVERSATION_ASSISTANT_SESSIONS_COLLECTION)
+              .doc(sessionId);
+            const sessionSnapshot = await transaction.get(sessionRef);
+            if (!sessionSnapshot.exists) return false;
+            const session = toSession(sessionSnapshot.id, sessionSnapshot.data());
+            if (
+              session.userId !== userId ||
+              session.deletionStartedAt !== undefined ||
+              session.generationId !== expectedGenerationId
+            ) {
+              return false;
+            }
+            transaction.set(collection.doc(chunkId), {
+              sessionId,
+              userId,
+              sessionGenerationId: expectedGenerationId ?? null,
+              snapshotId,
+              chunkIndex,
+              kind: chunk.kind,
+              start: chunk.start,
+              end: chunk.end,
+              messages: chunk.messages,
+              omittedMessages: chunk.omittedMessages,
+            });
+            return true;
           });
-        }
-        for (const document of existing.docs) {
-          if (!expectedIds.has(document.id)) {
-            await collection.doc(document.id).delete();
+          if (!saved) {
+            await deleteContextSnapshotForGeneration(
+              db,
+              sessionId,
+              userId,
+              snapshotId,
+              expectedGenerationId
+            );
+            return false;
           }
         }
+        for (const document of existing.docs) {
+          if (
+            !expectedIds.has(document.id) &&
+            documentBelongsToGeneration(document.data(), expectedGenerationId)
+          ) {
+            await deleteDocumentIfCurrentMatches(db, document.ref, (data) =>
+              documentBelongsToGeneration(data, expectedGenerationId)
+            );
+          }
+        }
+        return true;
       } catch (error) {
         throw new Error(
           `Failed to save Conversation Assistant context: ${getErrorMessage(error)}`
@@ -370,21 +525,17 @@ export function createConversationAssistantRepository(): ConversationAssistantRe
     async deleteContextSnapshot(
       sessionId: string,
       userId: string,
-      snapshotId: string
+      snapshotId: string,
+      expectedGenerationId?: string
     ): Promise<void> {
       try {
-        const collection = getFirestore().collection(
-          WHATSAPP_CONVERSATION_ASSISTANT_CONTEXT_CHUNKS_COLLECTION
+        await deleteContextSnapshotForGeneration(
+          getFirestore(),
+          sessionId,
+          userId,
+          snapshotId,
+          expectedGenerationId
         );
-        const snapshot = await collection
-          .where('sessionId', '==', sessionId)
-          .where('snapshotId', '==', snapshotId)
-          .get();
-        for (const document of snapshot.docs) {
-          if (document.data()['userId'] === userId) {
-            await collection.doc(document.id).delete();
-          }
-        }
       } catch (error) {
         throw new Error(
           `Failed to delete Conversation Assistant context: ${getErrorMessage(error)}`
@@ -468,6 +619,97 @@ export function createConversationAssistantRepository(): ConversationAssistantRe
       }
     },
 
+    async saveTurnIfSessionExists(
+      turn: ConversationAssistantTurn,
+      expectedGenerationId: string | undefined
+    ): Promise<boolean> {
+      try {
+        const db = getFirestore();
+        const sessionRef = db
+          .collection(WHATSAPP_CONVERSATION_ASSISTANT_SESSIONS_COLLECTION)
+          .doc(turn.sessionId);
+        const turnRef = db
+          .collection(WHATSAPP_CONVERSATION_ASSISTANT_TURNS_COLLECTION)
+          .doc(turn.id);
+        return await db.runTransaction(async (transaction) => {
+          const snapshot = await transaction.get(sessionRef);
+          if (!snapshot.exists) {
+            return false;
+          }
+          const current = toSession(snapshot.id, snapshot.data());
+          if (
+            current.userId !== turn.userId ||
+            current.deletionStartedAt !== undefined ||
+            current.generationId !== expectedGenerationId ||
+            (current.status !== 'ready' && current.status !== 'active')
+          ) {
+            return false;
+          }
+          transaction.set(turnRef, {
+            ...turn,
+            sessionGenerationId: expectedGenerationId ?? null,
+          });
+          return true;
+        });
+      } catch (error) {
+        throw new Error(
+          `Failed to save Conversation Assistant turn conditionally: ${getErrorMessage(error)}`
+        );
+      }
+    },
+
+    async saveAssistantTurnAndTouchSession(input: {
+      session: ConversationAssistantSession;
+      turn: ConversationAssistantTurn;
+    }): Promise<boolean> {
+      try {
+        const db = getFirestore();
+        const sessionRef = db
+          .collection(WHATSAPP_CONVERSATION_ASSISTANT_SESSIONS_COLLECTION)
+          .doc(input.session.id);
+        const turnRef = db
+          .collection(WHATSAPP_CONVERSATION_ASSISTANT_TURNS_COLLECTION)
+          .doc(input.turn.id);
+        return await db.runTransaction(async (transaction) => {
+          const snapshot = await transaction.get(sessionRef);
+          if (!snapshot.exists) return false;
+          const current = toSession(snapshot.id, snapshot.data());
+          if (
+            current.userId !== input.session.userId ||
+            input.turn.userId !== input.session.userId ||
+            current.deletionStartedAt !== undefined ||
+            current.generationId !== input.session.generationId ||
+            (current.status !== 'ready' && current.status !== 'active')
+          ) {
+            return false;
+          }
+          const storage =
+            parseTranscriptStorage(snapshot.data()?.['transcriptStorage']) ??
+            emptyTranscriptStorage();
+          transaction.set(turnRef, {
+            ...input.turn,
+            sessionGenerationId: input.session.generationId ?? null,
+          });
+          transaction.set(
+            sessionRef,
+            toSessionDocument(
+              {
+                ...current,
+                updatedAt: input.turn.createdAt,
+                lastTurnAt: input.turn.createdAt,
+              },
+              storage
+            )
+          );
+          return true;
+        });
+      } catch (error) {
+        throw new Error(
+          `Failed to save Conversation Assistant response conditionally: ${getErrorMessage(error)}`
+        );
+      }
+    },
+
     async listTurnsBySessionId(sessionId: string): Promise<ConversationAssistantTurn[]> {
       try {
         const snapshot = await getFirestore()
@@ -516,7 +758,10 @@ function toSession(
     userId: session?.userId ?? '',
     chatId: session?.chatId ?? '',
     status:
-      session?.status === 'preparing' || session?.status === 'failed' || session?.status === 'ready'
+      session?.status === 'preparing' ||
+      session?.status === 'failed' ||
+      session?.status === 'ready' ||
+      session?.status === 'active'
         ? session.status
         : 'ready',
     range,
@@ -576,6 +821,12 @@ function toSession(
   }
   if (typeof session?.contextSnapshotId === 'string') {
     projected.contextSnapshotId = session.contextSnapshotId;
+  }
+  if (typeof session?.generationId === 'string') {
+    projected.generationId = session.generationId;
+  }
+  if (typeof session?.deletionStartedAt === 'string') {
+    projected.deletionStartedAt = session.deletionStartedAt;
   }
   if (typeof session?.preparationClaimId === 'string') {
     projected.preparationClaimId = session.preparationClaimId;
@@ -663,7 +914,8 @@ function emptyTranscriptStorage(): TranscriptChunkStorage {
 
 async function saveTranscriptChunks(
   db: ReturnType<typeof getFirestore>,
-  session: ConversationAssistantSession
+  session: ConversationAssistantSession,
+  fence?: { attempt: number; claimId: string }
 ): Promise<TranscriptChunkStorage> {
   const chunks = splitTranscriptText(session.transcriptText);
   const snapshotId = chunks.length === 0 ? '' : session.transcriptSha256.trim();
@@ -678,14 +930,172 @@ async function saveTranscriptChunks(
     WHATSAPP_CONVERSATION_ASSISTANT_TRANSCRIPT_CHUNKS_COLLECTION
   );
   for (const [chunkIndex, text] of chunks.entries()) {
-    await chunkCollection.doc(toTranscriptChunkId(session.id, chunkIndex, storage.snapshotId)).set({
+    const chunkRef = chunkCollection.doc(
+      toTranscriptChunkId(session.id, chunkIndex, storage.snapshotId)
+    );
+    const chunkDocument = {
       sessionId: session.id,
+      sessionGenerationId: session.generationId ?? null,
+      ...(fence !== undefined
+        ? {
+            preparationAttempt: fence.attempt,
+            preparationClaimId: fence.claimId,
+          }
+        : {}),
       ...(storage.snapshotId !== undefined ? { snapshotId: storage.snapshotId } : {}),
       chunkIndex,
       text,
+    };
+    if (fence === undefined) {
+      await chunkRef.set(chunkDocument);
+      continue;
+    }
+    const sessionRef = db
+      .collection(WHATSAPP_CONVERSATION_ASSISTANT_SESSIONS_COLLECTION)
+      .doc(session.id);
+    const saved = await db.runTransaction(async (transaction) => {
+      const sessionSnapshot = await transaction.get(sessionRef);
+      if (!sessionSnapshot.exists) return false;
+      const current = toSession(sessionSnapshot.id, sessionSnapshot.data());
+      if (
+        current.userId !== session.userId ||
+        current.deletionStartedAt !== undefined ||
+        current.generationId !== session.generationId ||
+        current.preparationAttempt !== fence.attempt ||
+        current.preparationClaimId !== fence.claimId
+      ) {
+        return false;
+      }
+      transaction.set(chunkRef, chunkDocument);
+      return true;
     });
+    if (!saved) break;
   }
   return storage;
+}
+
+async function deleteTranscriptChunks(
+  db: ReturnType<typeof getFirestore>,
+  sessionId: string,
+  storage: TranscriptChunkStorage,
+  expectedGenerationId?: string,
+  expectedFence?: { attempt: number; claimId: string }
+): Promise<void> {
+  const collection = db.collection(WHATSAPP_CONVERSATION_ASSISTANT_TRANSCRIPT_CHUNKS_COLLECTION);
+  for (let chunkIndex = 0; chunkIndex < storage.chunkCount; chunkIndex += 1) {
+    const chunkRef = collection.doc(
+      toTranscriptChunkId(sessionId, chunkIndex, storage.snapshotId)
+    );
+    await deleteDocumentIfCurrentMatches(db, chunkRef, (data) =>
+      documentBelongsToGeneration(data, expectedGenerationId) &&
+      (expectedFence === undefined ||
+        (data?.['preparationAttempt'] === expectedFence.attempt &&
+          data['preparationClaimId'] === expectedFence.claimId))
+    );
+  }
+}
+
+async function deleteContextSnapshotForGeneration(
+  db: ReturnType<typeof getFirestore>,
+  sessionId: string,
+  userId: string,
+  snapshotId: string,
+  expectedGenerationId?: string
+): Promise<void> {
+  const collection = db.collection(WHATSAPP_CONVERSATION_ASSISTANT_CONTEXT_CHUNKS_COLLECTION);
+  const snapshot = await collection
+    .where('sessionId', '==', sessionId)
+    .where('snapshotId', '==', snapshotId)
+    .get();
+  for (const document of snapshot.docs) {
+    await deleteDocumentIfCurrentMatches(
+      db,
+      document.ref,
+      (data) =>
+        data?.['userId'] === userId &&
+        data['snapshotId'] === snapshotId &&
+        documentBelongsToGeneration(data, expectedGenerationId)
+    );
+  }
+}
+
+function documentBelongsToGeneration(
+  data: Record<string, unknown> | undefined,
+  expectedGenerationId: string | undefined
+): boolean {
+  const storedGenerationId = data?.['sessionGenerationId'];
+  return expectedGenerationId === undefined
+    ? typeof storedGenerationId !== 'string'
+    : storedGenerationId === expectedGenerationId;
+}
+
+async function deleteGenerationDocuments(
+  db: ReturnType<typeof getFirestore>,
+  collectionName: string,
+  sessionId: string,
+  expectedGenerationId: string | undefined
+): Promise<void> {
+  const collection = db.collection(collectionName);
+  if (expectedGenerationId !== undefined) {
+    let deletedDocumentCount: number;
+    do {
+      const snapshot = await collection
+        .where('sessionId', '==', sessionId)
+        .where('sessionGenerationId', '==', expectedGenerationId)
+        .limit(CASCADE_DELETE_BATCH_SIZE)
+        .get();
+      deletedDocumentCount = snapshot.size;
+      if (snapshot.empty) continue;
+      await deleteDocumentsIfCurrentMatch(db, snapshot.docs, (data) =>
+        documentBelongsToGeneration(data, expectedGenerationId)
+      );
+    } while (deletedDocumentCount > 0);
+    return;
+  }
+
+  let cursor: string | undefined;
+  let scannedDocumentCount: number;
+  do {
+    let query = collection
+      .where('sessionId', '==', sessionId)
+      .orderBy(FieldPath.documentId(), 'asc')
+      .limit(CASCADE_DELETE_BATCH_SIZE);
+    if (cursor !== undefined) query = query.startAfter(cursor);
+    const snapshot = await query.get();
+    scannedDocumentCount = snapshot.size;
+    const documents = snapshot.docs.filter((document) =>
+      documentBelongsToGeneration(document.data(), undefined)
+    );
+    if (documents.length > 0) {
+      await deleteDocumentsIfCurrentMatch(db, documents, (data) =>
+        documentBelongsToGeneration(data, undefined)
+      );
+    }
+    cursor = snapshot.docs.at(-1)?.id;
+  } while (scannedDocumentCount === CASCADE_DELETE_BATCH_SIZE && cursor !== undefined);
+}
+
+async function deleteDocumentIfCurrentMatches(
+  db: ReturnType<typeof getFirestore>,
+  documentRef: FirebaseFirestore.DocumentReference,
+  predicate: (data: Record<string, unknown> | undefined) => boolean
+): Promise<boolean> {
+  return await db.runTransaction(async (transaction) => {
+    const current = await transaction.get(documentRef);
+    if (!current.exists || !predicate(current.data())) return false;
+    transaction.delete(documentRef);
+    return true;
+  });
+}
+
+async function deleteDocumentsIfCurrentMatch(
+  db: ReturnType<typeof getFirestore>,
+  documents: FirebaseFirestore.QueryDocumentSnapshot[],
+  predicate: (data: Record<string, unknown> | undefined) => boolean
+): Promise<void> {
+  for (const document of documents) {
+    await deleteDocumentIfCurrentMatches(db, document.ref, predicate);
+  }
 }
 
 function splitTranscriptText(transcriptText: string): string[] {

--- a/apps/whatsapp-service/src/routes/conversationAssistantRoutes.ts
+++ b/apps/whatsapp-service/src/routes/conversationAssistantRoutes.ts
@@ -11,6 +11,7 @@ import {
   conversationAssistantRandomIds,
   conversationAssistantSystemClock,
   createConversationAssistantSession,
+  deleteConversationAssistantSession,
   exportConversationAssistantSessionPdf,
   getConversationAssistantContext,
   getConversationAssistantSession,
@@ -30,6 +31,7 @@ import type {
   CreateConversationAssistantSessionInput,
   PublicConversationAssistantSession,
 } from '../domain/conversation-assistant/types.js';
+import { createConversationAssistantDeletionToken } from '../domain/conversation-assistant/deletionToken.js';
 
 type ValidatedRequest = FastifyRequest & { validationError?: unknown };
 
@@ -50,6 +52,10 @@ interface CheckContextBody {
 
 interface SessionParams {
   sessionId: string;
+}
+
+interface DeleteSessionHeaders {
+  'x-conversation-assistant-deletion-token'?: string;
 }
 
 interface SessionRequestParams {
@@ -233,6 +239,55 @@ export const conversationAssistantRoutes: FastifyPluginCallback = (fastify, _opt
         return await sendConversationAssistantError(reply, result.error);
       }
       return await reply.ok({ session: toPublicSession(result.value) });
+    }
+  );
+
+  fastify.delete<{ Params: SessionParams; Headers: DeleteSessionHeaders }>(
+    '/conversation-assistant/sessions/:sessionId',
+    {
+      attachValidation: true,
+      schema: {
+        operationId: 'deleteWhatsAppConversationAssistantSession',
+        tags: ['whatsapp'],
+        headers: {
+          type: 'object',
+          required: ['x-conversation-assistant-deletion-token'],
+          properties: {
+            'x-conversation-assistant-deletion-token': { type: 'string', minLength: 1 },
+          },
+        },
+        response: routeResponseSchema(),
+      },
+    },
+    async (request, reply) => {
+      logIncomingRequest(request, {
+        message: 'Received request to DELETE /whatsapp/conversation-assistant/sessions/:sessionId',
+        bodyPreviewLength: 0,
+        additionalFields: { route: 'whatsapp_conversation_assistant_delete_session' },
+      });
+      const user = await requireAuth(request, reply);
+      if (user === null) return;
+      const deps = await getConversationAssistantDeps(reply);
+      if (deps === null) return;
+      const deletionToken = request.headers['x-conversation-assistant-deletion-token'];
+      if (typeof deletionToken !== 'string' || deletionToken.trim() === '') {
+        return await reply.fail('INVALID_REQUEST', 'Deletion token is required');
+      }
+
+      const result = await safeCall(() =>
+        deleteConversationAssistantSession(
+          {
+            userId: user.userId,
+            sessionId: request.params.sessionId,
+            deletionToken,
+          },
+          deps
+        )
+      );
+      if (!result.ok) {
+        return await sendConversationAssistantError(reply, result.error);
+      }
+      return await reply.ok(result.value);
     }
   );
 
@@ -598,10 +653,14 @@ function toPublicSession(
     preparationClaimId: _preparationClaimId,
     preparationLeaseExpiresAt: _preparationLeaseExpiresAt,
     contextSnapshotId: _contextSnapshotId,
+    generationId: _generationId,
+    deletionStartedAt: _deletionStartedAt,
     ...publicSession
   } = session;
   return {
     ...publicSession,
+    deletionToken: createConversationAssistantDeletionToken(session),
+    deletionPending: session.deletionStartedAt !== undefined,
     modelDisplayName: getConversationAssistantModelDisplayName(session.model),
   };
 }

--- a/apps/whatsapp-service/src/routes/pubsubRoutes.ts
+++ b/apps/whatsapp-service/src/routes/pubsubRoutes.ts
@@ -1082,6 +1082,9 @@ export function createPubsubRoutes(): FastifyPluginCallback {
               userId: preparationEvent.userId,
               sessionId: preparationEvent.sessionId,
               attempt: preparationEvent.attempt,
+              ...(typeof preparationEvent.generationId === 'string'
+                ? { generationId: preparationEvent.generationId }
+                : {}),
             },
             deps
           );

--- a/docs/superpowers/plans/2026-07-20-conversation-assistant-delete-send-status.md
+++ b/docs/superpowers/plans/2026-07-20-conversation-assistant-delete-send-status.md
@@ -1,0 +1,139 @@
+# Conversation Assistant Delete And Send Status Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Subagents may review completed work only.
+
+**Goal:** Add safe single-analysis deletion to Conversation Assistant on Web/PWA and replace the monolithic sending flag with accurate submission, waiting, and streaming phases.
+
+**Architecture:** Add one ownership-scoped deletion use case and repository cascade behind a new authenticated DELETE route. The shared React hook owns deletion state and a four-phase turn state machine; responsive page components expose confirmation and conversation-level progress without separate PWA behavior.
+
+**Tech Stack:** TypeScript, Fastify, Firestore, React 19, React Router, TailwindCSS, Vitest, Testing Library.
+
+## Global Constraints
+
+- No archive, bulk delete, swipe delete, source WhatsApp deletion, parallel turns, or stream cancellation.
+- First delete interaction opens confirmation; permanent deletion requires the second explicit action.
+- Web and PWA share behavior; interactive targets are at least 44 by 44 pixels.
+- Use test-first development and preserve strict TypeScript settings.
+- The user turn acknowledgement ends `submitting`; model work is represented by `waiting` and `streaming` in the conversation.
+- Subagents perform review only.
+- Make one final feature commit after the complete `pnpm run ci:tracked` gate.
+
+---
+
+### Task 1: Backend deletion contract and cascade
+
+**Files:**
+- Modify: `apps/whatsapp-service/src/domain/conversation-assistant/ports.ts`
+- Modify: `apps/whatsapp-service/src/domain/conversation-assistant/types.ts`
+- Modify: `apps/whatsapp-service/src/domain/conversation-assistant/sessionUseCases.ts`
+- Modify: `apps/whatsapp-service/src/infra/firestore/conversationAssistantRepository.ts`
+- Modify: `apps/whatsapp-service/src/routes/conversationAssistantRoutes.ts`
+- Test: `apps/whatsapp-service/src/__tests__/domain/conversation-assistant/sessionUseCases.test.ts`
+- Test: `apps/whatsapp-service/src/__tests__/infra/conversationAssistantRepository.test.ts`
+- Test: `apps/whatsapp-service/src/__tests__/conversationAssistantRoutes.test.ts`
+- Test support: `apps/whatsapp-service/src/__tests__/fakes.ts`
+
+**Interfaces:**
+- Repository produces `deleteSession(input: { sessionId: string; userId: string; deletionToken: string }): Promise<void>` and changes nothing for a missing, not-owned, or different-generation session.
+- Repository produces conditional turn persistence so work completing after deletion cannot recreate the session or leave orphan turns.
+- Domain produces `deleteConversationAssistantSession(input, deps): Promise<ConversationAssistantResult<{ deleted: true }>>`.
+- HTTP produces `DELETE /conversation-assistant/sessions/:sessionId`, requires `x-conversation-assistant-deletion-token`, and returns `{ deleted: true }`.
+
+- [x] Write failing domain tests proving owned, missing, not-owned, and stale-generation deletion all return idempotent success while only the exact owned generation changes.
+- [x] Run the focused domain tests and confirm the new tests fail before implementation.
+- [x] Add the repository port and ownership- and generation-scoped domain use case.
+
+```ts
+export interface DeleteConversationAssistantSessionInput {
+  userId: string;
+  sessionId: string;
+  deletionToken: string;
+}
+
+export async function deleteConversationAssistantSession(
+  input: DeleteConversationAssistantSessionInput,
+  deps: ConversationAssistantDeps
+): Promise<ConversationAssistantResult<{ deleted: true }>> {
+  await deps.repository.deleteSession(input);
+  return ok({ deleted: true });
+}
+```
+
+- [x] Write repository race and cleanup tests for session, turn, transcript, context, interrupted deletion, recreated generations, stale claims, and payload-bounded transactions.
+- [x] Implement deletion markers, bounded queries, per-document transactional revalidation, exact generation fencing, and safe retry cleanup.
+- [x] Run the repository and domain tests and confirm they pass.
+- [x] Write route and OpenAPI tests for auth, token validation, ownership, success envelope, dependency failure, and contract registration.
+- [x] Register the DELETE route with the standard request, auth, error, and response conventions.
+- [x] Run the focused backend tests and confirm they pass.
+
+### Task 2: Web deletion API, hook state, and responsive UI
+
+**Files:**
+- Modify: `apps/web/src/services/conversationAssistantApi.ts`
+- Modify: `apps/web/src/hooks/useWhatsAppConversationAssistant.ts`
+- Modify: `apps/web/src/pages/WhatsAppConversationAssistantListPage.tsx`
+- Modify: `apps/web/src/pages/WhatsAppConversationAssistantSessionPage.tsx`
+- Create: `apps/web/src/components/whatsapp/ConversationAssistantDeleteDialog.tsx`
+- Test: `apps/web/src/services/__tests__/conversationAssistantApi.test.ts`
+- Test: `apps/web/src/hooks/__tests__/useWhatsAppConversationAssistant.test.tsx`
+- Test: `apps/web/src/pages/__tests__/WhatsAppConversationAssistantSeparatedPages.test.tsx`
+
+**Interfaces:**
+- API produces `deleteConversationAssistantSession(accessToken, sessionId, deletionToken): Promise<void>`.
+- Hook produces `deletingSessionId`, `deleteSession(sessionId, capturedDeletionToken)`, tombstone reconciliation, and deletion error/reset state.
+- Dialog consumes session title, request state, error, cancel, and confirm callbacks.
+
+- [x] Write a failing API-client test proving DELETE uses the encoded path, bearer authentication, and captured generation token.
+- [x] Implement the API function and make the test pass.
+- [x] Write hook tests for success, duplicate blocking, failure, tombstone reconciliation, stale refreshes, recreated generations, and detail navigation.
+- [x] Implement deletion state independently from loading and streaming state.
+- [x] Write page tests for list/detail actions, confirmation, cancellation, progress, retry, tombstones, exact-generation snapshots, keyboard access, and touch targets.
+- [x] Implement the shared dialog, snapshot actions, non-openable tombstones, and sibling navigation/action controls.
+- [x] Run the focused Web deletion tests and confirm they pass.
+
+### Task 3: Accurate streamed-turn phase model
+
+**Files:**
+- Modify: `apps/web/src/hooks/useWhatsAppConversationAssistant.ts`
+- Modify: `apps/web/src/components/whatsapp/ConversationAssistantComposer.tsx`
+- Modify: `apps/web/src/pages/WhatsAppConversationAssistantSessionPage.tsx`
+- Test: `apps/web/src/hooks/__tests__/useWhatsAppConversationAssistant.test.tsx`
+- Test: `apps/web/src/pages/__tests__/WhatsAppConversationAssistantSeparatedPages.test.tsx`
+
+**Interfaces:**
+- Hook replaces public `sending: boolean` with `turnPhase: 'idle' | 'submitting' | 'waiting' | 'streaming'` and derives duplicate-send protection internally.
+- Composer consumes `turnPhase`; textarea disabling and submit disabling are separate decisions.
+
+- [x] Write failing hook tests for all phases, acknowledgement-aware draft handling, terminal stream completeness, reconciliation, and stale-session isolation.
+- [x] Implement phase transitions in stream events and every reset/finally path.
+- [x] Write page tests proving phase-accurate labels, editable next draft, disabled duplicate submit, and accessible live status.
+- [x] Update the composer and timeline with conversation-level thinking and streaming feedback.
+- [x] Run the focused stream and page tests and confirm they pass.
+
+### Task 4: Automated verification and two live UX rounds
+
+**Files:**
+- Modify only files justified by issues found during the two UX rounds.
+- Update relevant tests before each behavioral correction.
+
+- [ ] Run `pnpm run verify:workspace:tracked -- whatsapp-service` and fix every failure.
+- [ ] Run `pnpm run verify:workspace:tracked -- web` and fix every failure.
+- [ ] Start the local stack only when Chrome verification is ready.
+- [ ] In Chrome desktop, use MiniMax and `Test Number (WA)` to create/open an analysis, send a turn through every phase, delete from detail, and delete from the list.
+- [ ] In Chrome at PWA viewport size, repeat the overflow, dialog, typing-during-response, and deletion flows.
+- [x] UX round 1: add deletion success feedback, explicit WhatsApp-data safety copy, keyboard dismissal/focus restoration, and responsive compact list navigation.
+- [x] UX round 2: add mobile metadata prioritization, two-line titles, 48-pixel composer controls, accurate recovery feedback, and repeated live-status announcements.
+- [ ] Stop local processes after live verification.
+
+### Task 5: Review, CI, PR, merge, and production
+
+**Files:**
+- Review the full branch diff and update only accepted-scope files.
+
+- [ ] Dispatch subagents only for UX and code review; inspect every finding and implement only evidence-backed fixes with tests.
+- [ ] Run `pnpm run ci:tracked` and require complete success.
+- [ ] Stage intended files and commit once with `feat: add conversation assistant deletion and turn status`.
+- [ ] Fetch and rebase on latest `origin/development`; rerun `pnpm run ci:tracked` to complete success.
+- [ ] Push the feature branch and open a PR to `development` with the `$commit-push` Linear omission note.
+- [ ] Watch all GitHub Actions, resolve failures, enable merge, and verify the exact merge SHA lands in `development`.
+- [ ] Watch the production Hetzner deployment for that merge SHA and verify build publication, PM2 online state, nginx validation, and successful workflow conclusion.

--- a/docs/superpowers/specs/2026-07-20-conversation-assistant-delete-send-status-design.md
+++ b/docs/superpowers/specs/2026-07-20-conversation-assistant-delete-send-status-design.md
@@ -1,0 +1,81 @@
+# Conversation Assistant Delete And Send Status Design
+
+## Goal
+
+Give Web and PWA users a safe, consistent way to delete a Conversation Assistant analysis and make the composer describe the real phase of a streamed turn instead of showing `Sending` for the entire model response.
+
+## Scope
+
+- Delete one Conversation Assistant analysis from the list or the open-session header.
+- Require explicit confirmation; do not archive and do not delete on the first click.
+- Delete the assistant session, turns, transcript chunks, and frozen-context chunks without deleting the source WhatsApp chat or its messages.
+- Separate message submission from assistant waiting and streaming states.
+- Keep Web and PWA behavior consistent through the shared responsive web application.
+
+## Delete Experience
+
+- Every analysis row has an always-available overflow action with a minimum 44-by-44-pixel touch target. The open-session header exposes the same action next to export.
+- `Delete analysis` opens a confirmation dialog naming the analysis and explaining that the action removes the frozen analysis, questions, and answers but leaves the original WhatsApp conversation unchanged.
+- The dialog has `Cancel` and destructive `Delete analysis` actions. While the request is in flight, only the destructive action shows `Deleting…` and duplicate submission is blocked.
+- Success removes the item from the list. When deletion starts from the detail page, success navigates back to the analysis list. A short success notification confirms completion.
+- A failure before deletion starts leaves the analysis visible and keeps the dialog actionable with an inline error. If cleanup stops after deletion starts, the list and detail switch to a non-openable `Deletion interrupted` tombstone whose only analysis action is `Finish deletion`.
+- Deleting an absent or not-owned session is a successful no-op. This keeps retries idempotent without exposing whether another user owns the identifier.
+- The dialog snapshots the analysis id, title, and deletion token when it opens. A recreated analysis with the same deterministic id therefore cannot replace the generation the user confirmed.
+
+## Send And Response Experience
+
+The frontend uses an explicit phase: `idle`, `submitting`, `waiting`, or `streaming`.
+
+- `submitting`: the request has started but no `user_turn` acknowledgement has arrived. The submit button shows `Sending…`; the draft is preserved.
+- `waiting`: the `user_turn` acknowledgement has arrived. The draft clears, the normal user bubble appears, and a conversation-level assistant placeholder shows `Assistant is thinking…`. The button no longer claims the message is sending.
+- `streaming`: the first `assistant_delta` has arrived. The placeholder becomes the live assistant bubble and exposes a subtle `Responding…` label while text grows.
+- `idle`: the final assistant turn or terminal error has arrived and the stream has closed. No progress copy remains.
+- While waiting or streaming, the textarea remains editable so the user can draft the next question, but submitting another turn remains disabled until the current response finishes.
+- A failure before `user_turn` preserves the draft and reports that the message was not sent. A failure after `user_turn` keeps the user bubble and renders the persisted assistant error without returning to `Sending…`.
+
+## Backend Deletion
+
+Deletion is authenticated, ownership-scoped, and fenced to one session generation by a server-issued deletion token derived from immutable generation metadata. The repository first writes a deletion marker, then cleans assistant turns, transcript chunks, and context chunks in bounded queries with one revalidation-and-delete transaction per document before removing the session marker. Interrupted cleanup is safe to retry with the same token. A stale token is an idempotent no-op and cannot delete a recreated generation with the same deterministic id. Background preparation and response work use exact generation checks, cannot recreate a deleted session, and cannot remove data belonging to a replacement generation.
+
+## Endpoint Changes
+
+### Created
+
+`DELETE /conversation-assistant/sessions/:sessionId`
+
+- Required header: `x-conversation-assistant-deletion-token`, using the token returned with that exact public session snapshot.
+- Success: HTTP 200 envelope with `{ "deleted": true }`.
+- Missing or not owned: the same HTTP 200 `{ "deleted": true }` no-op response, without exposing ownership.
+- Internal failure: existing Conversation Assistant error envelope.
+
+### Modified
+
+- Public list and detail session DTOs expose `deletionToken` and `deletionPending` while keeping internal generation and deletion-marker fields private.
+- Stream completion is accepted only after `done`; an acknowledged user turn additionally requires a persisted `assistant_turn`, including persisted model-error turns.
+
+### Removed
+
+No endpoint is removed.
+
+### Unchanged
+
+- `POST /conversation-assistant/sessions`
+- `POST /conversation-assistant/sessions/:sessionId/turns`
+- `POST /conversation-assistant/sessions/:sessionId/turns/stream`
+- Existing list, detail, context, retry, turns, and export endpoints
+
+## Verification
+
+- Domain, repository, route, API-client, hook, and page tests are written before implementation and prove ownership, cascade cleanup, idempotent UI behavior, responsive action access, confirmation, navigation, and every send phase transition.
+- Live Chrome verification uses MiniMax and `Test Number (WA)` on desktop Web and a PWA-sized responsive viewport.
+- Two UX review rounds follow the core implementation. Each round must result in at least two implemented UX improvements and a live retest.
+- Subagents are used only for review, never implementation.
+- Finalization requires `pnpm run ci:tracked`, commit, rebase on `origin/development`, a second successful `pnpm run ci:tracked`, push, PR to `development` without a manual Linear ID, green GitHub Actions, merge, successful Hetzner production deployment, and production verification.
+
+## Non-Goals
+
+- Archiving analyses.
+- Bulk deletion.
+- Swipe-to-delete.
+- Deleting source WhatsApp chats or messages.
+- Parallel assistant turns or stream cancellation.


### PR DESCRIPTION
## Summary
- add confirmed permanent analysis deletion in list and detail views for Web and responsive PWA
- make deletion retryable and generation-safe with server-issued tokens, tombstones, bounded cleanup, and stale-request fencing
- separate analysis creation from conversation, expose frozen-message context, and model Sending, thinking, streaming, and idle states accurately
- include two UX improvement rounds covering feedback, focus, responsive navigation, metadata, touch targets, and live-status announcements

## Verification
- pnpm run ci:tracked
- 5,556 tests, coverage validation, Web build, formatting, and bundle budget passed
- live Google Chrome: MiniMax M3 with Test Number (WA), frozen context, two turns, desktop and PWA deletion, list reload without ghost entries
- UX and technical subagent reviews: no findings

Linear: omitted by $commit-push; GitHub automation will create or link the Linear issue after PR creation.

- Linear: [INT-1886](https://linear.app/pbuchman/issue/INT-1886)
- IntexuraOS Code Task: [View task](https://intexuraos.cloud/#/code-tasks/task_ddd0013e-cc39-42a8-88e9-e7fe045b6884)
- Worker Type: `codex-xhigh`
- Model: `default`
