### PR TITLE
[INT-1890] Fix limited initial Matrix corpus sync

### DIFF
--- a/tools/intex-agent-evals/src/__tests__/matrixCorpusCorrelation.test.ts
+++ b/tools/intex-agent-evals/src/__tests__/matrixCorpusCorrelation.test.ts
@@ -58,7 +58,7 @@ describe('Matrix corpus reply correlation', () => {
     expect(result).toEqual({ ok: false, code: 'outbound_event_mismatch' });
   });
 
-  it('captures a clean cursor and rejects a limited capture', async () => {
+  it('captures the current cursor even when the initial timeline is limited', async () => {
     const clean = matrixWith([{ ok: true, nextBatch: 'cursor-1', limited: false, events: [] }]);
     const limited = matrixWith([{ ok: true, nextBatch: 'cursor-2', limited: true, events: [] }]);
 
@@ -67,7 +67,41 @@ describe('Matrix corpus reply correlation', () => {
     ).resolves.toEqual({ ok: true, cursor: 'cursor-1' });
     await expect(
       captureMatrixCorpusCursor({ matrix: limited, context: CONTEXT, signal: signal() })
+    ).resolves.toEqual({ ok: true, cursor: 'cursor-2' });
+  });
+
+  it('keeps the incremental outbound proof fail-closed after a limited initial capture', async () => {
+    const messageText = 'exact outbound message';
+    const matrix = matrixWith([
+      { ok: true, nextBatch: 'cursor-1', limited: true, events: [] },
+      {
+        ok: true,
+        nextBatch: 'cursor-2',
+        limited: true,
+        events: [reply('$sent-1', messageText, '@operator:home-dev')],
+      },
+    ]);
+    const captured = await captureMatrixCorpusCursor({
+      matrix,
+      context: CONTEXT,
+      signal: signal(),
+    });
+    if (!captured.ok) throw new Error('expected initial cursor');
+
+    await expect(
+      proveMatrixCorpusOutboundEvent({
+        matrix,
+        context: CONTEXT,
+        cursor: captured.cursor,
+        matrixUserId: '@operator:home-dev',
+        matrixEventId: '$sent-1',
+        messageText,
+        signal: signal(),
+      })
     ).resolves.toEqual({ ok: false, code: 'matrix_timeline_limited' });
+    expect(matrix.syncTargetRoom).toHaveBeenLastCalledWith(
+      expect.objectContaining({ since: 'cursor-1', timeoutMs: 30_000 })
+    );
   });
 
   it('deduplicates events, ignores edits/redactions, and returns the exact durable reply set', async () => {

--- a/tools/intex-agent-evals/src/__tests__/matrixCorpusLiveRuntime.test.ts
+++ b/tools/intex-agent-evals/src/__tests__/matrixCorpusLiveRuntime.test.ts
@@ -20,6 +20,7 @@ import {
   inspectArtifactRoot,
   inspectHomeDevRuntime,
   MATRIX_CORPUS_RUNTIME_CRITICAL_PATHS,
+  resolveMatrixCorpusPuppetBinding,
   type HomeDevRuntimeInspectionDeps,
   type MatrixCorpusPreparedContext,
 } from '../matrixCorpus/liveRuntime.js';
@@ -101,6 +102,29 @@ describe('Matrix corpus live runtime handoff', () => {
 });
 
 describe('production Home Dev runtime inspection', () => {
+  it('resolves the current WhatsApp puppet from a limited initial Matrix timeline', () => {
+    expect(
+      resolveMatrixCorpusPuppetBinding(
+        {
+          ok: true,
+          nextBatch: 'current-cursor',
+          limited: true,
+          events: [
+            {
+              type: 'm.room.message',
+              sender: '@whatsapp_1:example.test',
+              content: { msgtype: 'm.text', body: 'historical reply' },
+            },
+          ],
+        },
+        true
+      )
+    ).toEqual({
+      expectedPuppetSender: '@whatsapp_1:example.test',
+      accountTupleCount: 1,
+    });
+  });
+
   it('accepts only the exact Home Dev host, canonical repository, clean critical paths, and commit', async () => {
     const deps = runtimeInspectionDeps();
 

--- a/tools/intex-agent-evals/src/matrixCorpus/correlation.ts
+++ b/tools/intex-agent-evals/src/matrixCorpus/correlation.ts
@@ -78,7 +78,9 @@ export async function captureMatrixCorpusCursor(input: {
     signal: input.signal,
   });
   if (!result.ok) return { ok: false, code: mapSyncFailure(result.reason, input.signal) };
-  if (result.limited) return { ok: false, code: 'matrix_timeline_limited' };
+  // An initial /sync may legitimately truncate historical events in an active room.
+  // Its next_batch still represents the current cursor. Incremental polls below keep
+  // rejecting limited timelines because missing new events there would be unsafe.
   return { ok: true, cursor: result.nextBatch };
 }
 

--- a/tools/intex-agent-evals/src/matrixCorpus/liveRuntime.ts
+++ b/tools/intex-agent-evals/src/matrixCorpus/liveRuntime.ts
@@ -80,6 +80,29 @@ export interface MatrixCorpusLiveRuntime {
   }>;
 }
 
+export function resolveMatrixCorpusPuppetBinding(
+  sync: Awaited<ReturnType<MatrixClient['syncTargetRoom']>>,
+  evaluatorUserMatches: boolean
+):
+  | {
+      readonly expectedPuppetSender: string | undefined;
+      readonly accountTupleCount: number;
+    }
+  | undefined {
+  if (!sync.ok) return undefined;
+  // A limited initial timeline is normal once the room has more than 100 events.
+  // We only use this tail to resolve the current puppet; later incremental reads
+  // continue to reject limited results before correlating any test evidence.
+  const puppetSenders = [
+    ...new Set(sync.events.map((event) => event.sender).filter(isWhatsAppPuppetSender)),
+  ];
+  return {
+    expectedPuppetSender: puppetSenders[0],
+    accountTupleCount:
+      evaluatorUserMatches && puppetSenders.length === 1 ? 1 : puppetSenders.length,
+  };
+}
+
 export function createMatrixCorpusLiveRuntime(input: {
   readonly loadCatalog: () => Promise<CanonicalMatrixCorpus>;
   readonly read: MatrixCorpusLiveReadPort;
@@ -227,14 +250,13 @@ export function createProductionMatrixCorpusLiveReadPort(options: {
       } finally {
         clearTimeout(cursorTimeout);
       }
-      if (!sync.ok || sync.limited) throw new Error('matrix_not_ready');
-      const puppetSenders = [
-        ...new Set(sync.events.map((event) => event.sender).filter(isWhatsAppPuppetSender)),
-      ];
-      const expectedPuppetSender = puppetSenders[0];
       const evaluatorUserId = env['INTEXURAOS_MATRIX_CORPUS_EVALUATOR_USER_ID'];
-      const accountTupleCount =
-        evaluatorUserId === account.userId && puppetSenders.length === 1 ? 1 : puppetSenders.length;
+      const puppetBinding = resolveMatrixCorpusPuppetBinding(
+        sync,
+        evaluatorUserId === account.userId
+      );
+      if (puppetBinding === undefined) throw new Error('matrix_not_ready');
+      const { expectedPuppetSender, accountTupleCount } = puppetBinding;
       const modelBoundaryReady =
         liveCatalog !== null &&
         liveCatalog.models.some((model) => model.id === catalog.agentModel) &&


### PR DESCRIPTION
## Summary

- accept a legitimate `limited=true` response from the initial Matrix `/sync` when capturing the current cursor
- resolve the current WhatsApp puppet from the bounded initial timeline tail
- keep every incremental outbound/reply correlation poll fail-closed on a limited timeline

## Live root cause

The bound Home Dev room contains more than 100 events. Matrix correctly returns a bounded initial timeline with `limited=true` and a valid `next_batch`; rejecting that response made zero-side-effect corpus preflight impossible for an active room.

## Verification

- RED observed for limited initial cursor capture and puppet resolution
- evaluator validation: typecheck, lint, scenario validation, 914 tests passed
- focused regression after review: 14 tests passed
- Prettier and `git diff --check` passed
- independent security review: READY
- independent test-completeness review: READY

No live scenario, LLM call, Matrix message, or corpus mutation was executed while diagnosing this issue. No ticket required.

Fixes INT-1890

- Linear: [INT-1890](https://linear.app/pbuchman/issue/INT-1890)
- IntexuraOS Code Task: [View task](https://intexuraos.cloud/#/code-tasks/task_a36f552d-2698-4bff-a31e-3455640ed223)
- Worker Type: `codex-xhigh`
- Model: `default`