### PR TITLE
[INT-1891] Fix Matrix corpus sync response limit

### DIFF
--- a/tools/intex-agent-evals/src/__tests__/matrixClient.test.ts
+++ b/tools/intex-agent-evals/src/__tests__/matrixClient.test.ts
@@ -330,6 +330,75 @@ describe('createMatrixClient', () => {
     ]);
   });
 
+  it('accepts a bounded 100-event sync response larger than the whoami body limit', async () => {
+    const events = Array.from({ length: 100 }, (_, index) => ({
+      event_id: `$event-${String(index)}:home-dev`,
+      origin_server_ts: 1_721_466_000_000 + index,
+      type: 'm.room.message',
+      sender: '@whatsapp_48123123123:home-dev',
+      content: { msgtype: 'm.text', body: 'x'.repeat(700) },
+    }));
+    const body = targetSyncBody(events, { limited: true });
+    expect(JSON.stringify(body).length).toBeGreaterThan(64 * 1024);
+    const client = createMatrixClient({
+      fetchImpl: vi.fn<typeof fetch>(async () => jsonResponse(body)),
+      timeoutMs: 50,
+    });
+
+    const result = await client.syncTargetRoom({
+      homeserverUrl: 'https://matrix.synthetic.test',
+      accessToken: 'private-token-sentinel',
+      targetRoomId: TARGET_ROOM_ID,
+      timeoutMs: 0,
+      signal: new AbortController().signal,
+    });
+
+    expect(result).toMatchObject({ ok: true, limited: true });
+    if (!result.ok) throw new Error('expected valid sync');
+    expect(result.events).toHaveLength(100);
+  });
+
+  it('keeps the default whoami and sync response limits independently fail-closed', async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        jsonResponse(
+          { user_id: '@operator:home-dev' },
+          {
+            headers: {
+              'content-type': 'application/json',
+              'content-length': String(64 * 1024 + 1),
+            },
+          }
+        )
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(targetSyncBody(), {
+          headers: {
+            'content-type': 'application/json',
+            'content-length': String(1024 * 1024 + 1),
+          },
+        })
+      );
+    const client = createMatrixClient({ fetchImpl, timeoutMs: 50 });
+
+    await expect(
+      client.whoAmI({
+        homeserverUrl: 'https://matrix.synthetic.test',
+        accessToken: 'private-token-sentinel',
+      })
+    ).resolves.toEqual({ ok: false, reason: 'invalid_response' });
+    await expect(
+      client.syncTargetRoom({
+        homeserverUrl: 'https://matrix.synthetic.test',
+        accessToken: 'private-token-sentinel',
+        targetRoomId: TARGET_ROOM_ID,
+        timeoutMs: 0,
+        signal: new AbortController().signal,
+      })
+    ).resolves.toEqual({ ok: false, reason: 'invalid_response' });
+  });
+
   it('ignores unrelated top-level sections and joined rooms without inspecting their events', async () => {
     const body = targetSyncBody([
       {

--- a/tools/intex-agent-evals/src/live/matrixClient.ts
+++ b/tools/intex-agent-evals/src/live/matrixClient.ts
@@ -146,7 +146,8 @@ export interface MatrixClientOptions {
 }
 
 const MATRIX_WHOAMI_TIMEOUT_MS = 10_000;
-const MATRIX_JSON_MAX_BYTES = 64 * 1024;
+const MATRIX_WHOAMI_JSON_MAX_BYTES = 64 * 1024;
+const MATRIX_SYNC_JSON_MAX_BYTES = 1024 * 1024;
 
 function isJsonResponse(response: Response): boolean {
   const contentType = response.headers.get('content-type');
@@ -362,7 +363,8 @@ export function isWhatsAppPuppetSender(value: string): boolean {
 export function createMatrixClient(options: MatrixClientOptions = {}): MatrixClient {
   const fetchImpl = options.fetchImpl ?? fetch;
   const timeoutMs = options.timeoutMs ?? MATRIX_WHOAMI_TIMEOUT_MS;
-  const maxBytes = options.maxBytes ?? MATRIX_JSON_MAX_BYTES;
+  const whoAmIMaxBytes = options.maxBytes ?? MATRIX_WHOAMI_JSON_MAX_BYTES;
+  const syncMaxBytes = options.maxBytes ?? MATRIX_SYNC_JSON_MAX_BYTES;
 
   return {
     async whoAmI(input): Promise<MatrixWhoAmIResult> {
@@ -395,7 +397,7 @@ export function createMatrixClient(options: MatrixClientOptions = {}): MatrixCli
           return { ok: false, reason: 'invalid_response' };
         }
 
-        const body = await readBoundedBody(response, maxBytes);
+        const body = await readBoundedBody(response, whoAmIMaxBytes);
         if (body === undefined) {
           return { ok: false, reason: 'invalid_response' };
         }
@@ -447,7 +449,7 @@ export function createMatrixClient(options: MatrixClientOptions = {}): MatrixCli
           return { ok: false, reason: 'invalid_response' };
         }
 
-        const body = await readBoundedBody(response, maxBytes);
+        const body = await readBoundedBody(response, syncMaxBytes);
         if (body === undefined) {
           return { ok: false, reason: 'invalid_response' };
         }


### PR DESCRIPTION
## Summary

- keep the Matrix `whoami` response limit at 64 KiB
- give the filtered target-room `/sync` response its own hard 1 MiB limit
- cover a valid 100-event sync response larger than 64 KiB

## Live root cause

Home Dev returned a valid, filtered Matrix sync payload of 66,102 bytes. The shared 65,536-byte default rejected it before strict schema validation. The new sync-specific limit remains bounded while supporting the declared maximum of 100 timeline events.

## Verification

- RED observed for the >64 KiB bounded sync regression
- evaluator validation: typecheck, lint, scenario validation, 916 tests passed
- Prettier and `git diff --check` passed
- independent security review: READY
- independent test-completeness review: READY

No scenario, LLM call, Matrix message, or corpus mutation was executed. No ticket required.

## Code Task

- Linear: [INT-1891](https://linear.app/pbuchman/issue/INT-1891)
- IntexuraOS Code Task: [View task](https://intexuraos.cloud/#/code-tasks/task_65ca71d5-a0dc-4e60-8143-eea2e20d6e47)
- Worker Type: `codex-xhigh`
- Model: `default`

Fixes INT-1891