### PR TITLE
[INT-1893] fix(evals): require live Firestore indexes

### DIFF
--- a/docs/testing/intex-agent-evals.md
+++ b/docs/testing/intex-agent-evals.md
@@ -19,6 +19,9 @@ transport, or production tool execution.
 The preflight embedded in `matrix-corpus` is read-only: it sends no message, calls no LLM,
 creates no run or artifact, and performs no Firestore, Pub/Sub, or filesystem write. Only
 after preflight passes may the command provision the run and send the first Matrix message.
+It also reads the live Firestore index control plane through the authenticated, read-only
+Firestore Admin REST API and requires all eight Matrix-corpus composite indexes to report
+`READY`; a missing, incompatible, or still-building index closes admission.
 
 `endpoint`, `scenario`, `matrix-smoke`, and `full` remain diagnostics for the legacy
 evaluator path. They are not substitutes for the 20-scenario Matrix corpus and are not

--- a/tools/intex-agent-evals/src/__tests__/matrixCorpusLiveRuntime.test.ts
+++ b/tools/intex-agent-evals/src/__tests__/matrixCorpusLiveRuntime.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('firebase-admin/app', () => ({
+  applicationDefault: vi.fn(),
   getApp: vi.fn(),
   getApps: vi.fn(() => []),
   initializeApp: vi.fn(),
@@ -19,8 +20,10 @@ import {
   createMatrixCorpusLiveRuntime,
   inspectArtifactRoot,
   inspectHomeDevRuntime,
+  listHomeDevFirestoreCompositeIndexes,
   MATRIX_CORPUS_RUNTIME_CRITICAL_PATHS,
   resolveMatrixCorpusPuppetBinding,
+  type FirestoreAdminIndexListDeps,
   type HomeDevRuntimeInspectionDeps,
   type MatrixCorpusPreparedContext,
 } from '../matrixCorpus/liveRuntime.js';
@@ -102,6 +105,170 @@ describe('Matrix corpus live runtime handoff', () => {
 });
 
 describe('production Home Dev runtime inspection', () => {
+  it('lists paginated Firestore indexes through the bounded read-only Admin API', async () => {
+    const firstIndex = requiredFirestoreIndexes()[0];
+    const secondIndex = requiredFirestoreIndexes()[1];
+    const request = vi
+      .fn<FirestoreAdminIndexListDeps['fetch']>()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ indexes: [firstIndex], nextPageToken: 'next page' }))
+      )
+      .mockResolvedValueOnce(new Response(JSON.stringify({ indexes: [secondIndex] })));
+
+    const output = await listHomeDevFirestoreCompositeIndexes('intexuraos-dev-test', {
+      getAccessToken: async () => 'private-access-token',
+      fetch: request,
+    });
+
+    expect(JSON.parse(output)).toEqual([firstIndex, secondIndex]);
+    expect(request).toHaveBeenCalledTimes(2);
+    const firstUrl = new URL(request.mock.calls[0]?.[0] ?? '');
+    const secondUrl = new URL(request.mock.calls[1]?.[0] ?? '');
+    expect(firstUrl.origin).toBe('https://firestore.googleapis.com');
+    expect(firstUrl.pathname).toBe(
+      '/v1/projects/intexuraos-dev-test/databases/(default)/collectionGroups/-/indexes'
+    );
+    expect(firstUrl.searchParams.get('pageSize')).toBe('0');
+    expect(secondUrl.searchParams.get('pageToken')).toBe('next page');
+    expect(request.mock.calls[0]?.[1]).toMatchObject({
+      method: 'GET',
+      headers: { authorization: 'Bearer private-access-token' },
+    });
+  });
+
+  it('rejects failed Admin API reads and repeated pagination tokens', async () => {
+    const getAccessToken = vi.fn(async () => 'private-access-token');
+    await expect(
+      listHomeDevFirestoreCompositeIndexes('../unsafe', {
+        getAccessToken,
+        fetch: async () => new Response('{}'),
+      })
+    ).rejects.toThrow('firestore_index_project_invalid');
+    expect(getAccessToken).not.toHaveBeenCalled();
+
+    await expect(
+      listHomeDevFirestoreCompositeIndexes('intexuraos-dev-test', {
+        getAccessToken: async () => 'private-access-token',
+        fetch: async () => new Response('', { status: 403 }),
+      })
+    ).rejects.toThrow('firestore_index_list_failed');
+
+    await expect(
+      listHomeDevFirestoreCompositeIndexes('intexuraos-dev-test', {
+        getAccessToken: async () => 'private-access-token',
+        fetch: async () => new Response(JSON.stringify({ nextPageToken: 'repeat' })),
+      })
+    ).rejects.toThrow('firestore_index_page_token_invalid');
+  });
+
+  it('requires every Matrix corpus Firestore index to be READY', async () => {
+    const runtimeModule = (await import('../matrixCorpus/liveRuntime.js')) as unknown as {
+      inspectHomeDevFirestoreIndexes?: (
+        projectId: string,
+        dependencies: { listCompositeIndexes(projectId: string): Promise<string> }
+      ) => Promise<boolean>;
+    };
+    const inspect = runtimeModule.inspectHomeDevFirestoreIndexes;
+    expect(inspect).toBeTypeOf('function');
+    if (inspect === undefined) return;
+
+    const readyIndexes = requiredFirestoreIndexes();
+    const listCompositeIndexes = vi.fn(async () => JSON.stringify(readyIndexes));
+
+    await expect(inspect('intexuraos-dev-test', { listCompositeIndexes })).resolves.toBe(true);
+    expect(listCompositeIndexes).toHaveBeenCalledWith('intexuraos-dev-test');
+
+    await expect(
+      inspect('intexuraos-dev-test', {
+        listCompositeIndexes: async () =>
+          JSON.stringify(
+            readyIndexes.map((index, position) =>
+              position === 0 ? { ...index, state: 'CREATING' } : index
+            )
+          ),
+      })
+    ).resolves.toBe(false);
+    await expect(
+      inspect('intexuraos-dev-test', {
+        listCompositeIndexes: async () => JSON.stringify(readyIndexes.slice(1)),
+      })
+    ).resolves.toBe(false);
+    await expect(
+      inspect('intexuraos-dev-test', {
+        listCompositeIndexes: async () =>
+          JSON.stringify([
+            { ...readyIndexes[0], apiScope: 'MONGODB_COMPATIBLE_API' },
+            ...readyIndexes.slice(1),
+          ]),
+      })
+    ).resolves.toBe(false);
+    await expect(
+      inspect('intexuraos-dev-test', {
+        listCompositeIndexes: async () =>
+          JSON.stringify(
+            readyIndexes.map((index, position) =>
+              position === 0
+                ? {
+                    ...index,
+                    fields: (index['fields'] as Record<string, unknown>[]).map(
+                      (field, fieldPosition, fields) =>
+                        fieldPosition === fields.length - 1
+                          ? { ...field, order: 'DESCENDING' }
+                          : field
+                    ),
+                  }
+                : index
+            )
+          ),
+      })
+    ).resolves.toBe(false);
+    await expect(
+      inspect('intexuraos-dev-test', {
+        listCompositeIndexes: async () => 'not-json',
+      })
+    ).resolves.toBe(false);
+  });
+
+  it('fails closed for an unsafe project, unavailable control plane, or oversized response', async () => {
+    const { inspectHomeDevFirestoreIndexes: inspect } =
+      await import('../matrixCorpus/liveRuntime.js');
+    const listCompositeIndexes = vi.fn(async () => JSON.stringify(requiredFirestoreIndexes()));
+
+    await expect(inspect('../unsafe', { listCompositeIndexes })).resolves.toBe(false);
+    expect(listCompositeIndexes).not.toHaveBeenCalled();
+    await expect(
+      inspect('intexuraos-dev-test', {
+        listCompositeIndexes: async () => {
+          throw new Error('control plane unavailable');
+        },
+      })
+    ).resolves.toBe(false);
+    await expect(
+      inspect('intexuraos-dev-test', {
+        listCompositeIndexes: async () => ' '.repeat(5 * 1024 * 1024 + 1),
+      })
+    ).resolves.toBe(false);
+  });
+
+  it('ignores unrelated composite indexes while checking the exact required set', async () => {
+    const { inspectHomeDevFirestoreIndexes: inspect } =
+      await import('../matrixCorpus/liveRuntime.js');
+    const indexes = [
+      ...requiredFirestoreIndexes(),
+      firestoreIndex('unrelated_collection', [['value', 'ASCENDING']]),
+      {
+        ...firestoreIndex('vector_collection', [['value', 'ASCENDING']]),
+        fields: [{ fieldPath: 'embedding', vectorConfig: { dimension: 768 } }],
+      },
+    ];
+
+    await expect(
+      inspect('intexuraos-dev-test', {
+        listCompositeIndexes: async () => JSON.stringify(indexes),
+      })
+    ).resolves.toBe(true);
+  });
+
   it('resolves the current WhatsApp puppet from a limited initial Matrix timeline', () => {
     expect(
       resolveMatrixCorpusPuppetBinding(
@@ -249,6 +416,59 @@ function runtimeInspectionDeps(
       stdout: args[0] === 'rev-parse' ? `${'a'.repeat(40)}\n` : '',
     })),
     ...overrides,
+  };
+}
+
+function requiredFirestoreIndexes(): Record<string, unknown>[] {
+  return [
+    firestoreIndex('matrix_corpus_ingest_outbox', [
+      ['status', 'ASCENDING'],
+      ['createdAt', 'ASCENDING'],
+    ]),
+    firestoreIndex('matrix_corpus_ingest_outbox', [
+      ['status', 'ASCENDING'],
+      ['claim.expiresAt', 'ASCENDING'],
+    ]),
+    firestoreIndex('matrix_corpus_terminal_control_outbox', [
+      ['status', 'ASCENDING'],
+      ['createdAt', 'ASCENDING'],
+    ]),
+    firestoreIndex('matrix_corpus_terminal_control_outbox', [
+      ['status', 'ASCENDING'],
+      ['claim.expiresAt', 'ASCENDING'],
+    ]),
+    firestoreIndex('matrix_corpus_run_leases', [
+      ['phase', 'ASCENDING'],
+      ['expiresAt', 'ASCENDING'],
+    ]),
+    firestoreIndex('intex_agent_session_events', [
+      ['sessionId', 'ASCENDING'],
+      ['eventSequence', 'ASCENDING'],
+    ]),
+    firestoreIndex('intex_agent_test_runs', [
+      ['userId', 'ASCENDING'],
+      ['runtimeAudience', 'ASCENDING'],
+      ['startedAt', 'DESCENDING'],
+    ]),
+    firestoreIndex('intex_agent_test_runs', [
+      ['artifactDelivery.status', 'ASCENDING'],
+      ['finishedAt', 'ASCENDING'],
+    ]),
+  ];
+}
+
+function firestoreIndex(
+  collectionGroup: string,
+  fields: readonly (readonly [string, 'ASCENDING' | 'DESCENDING'])[]
+): Record<string, unknown> {
+  return {
+    name: `projects/test/databases/(default)/collectionGroups/${collectionGroup}/indexes/index`,
+    queryScope: 'COLLECTION',
+    state: 'READY',
+    fields: [
+      ...fields.map(([fieldPath, order]) => ({ fieldPath, order })),
+      { fieldPath: '__name__', order: fields.at(-1)?.[1] ?? 'ASCENDING' },
+    ],
   };
 }
 

--- a/tools/intex-agent-evals/src/matrixCorpus/liveRuntime.ts
+++ b/tools/intex-agent-evals/src/matrixCorpus/liveRuntime.ts
@@ -17,6 +17,7 @@ import {
   createOpenRouterCatalogClient,
   type OpenRouterCatalogClient,
 } from '@intexuraos/infra-openrouter';
+import { applicationDefault } from 'firebase-admin/app';
 
 import {
   CONFIG_MAX_BYTES,
@@ -38,6 +39,13 @@ import type { CanonicalMatrixCorpus } from './types.js';
 const INTEX_AGENT_BASE_URL = 'http://127.0.0.1:8134';
 const WHATSAPP_BASE_URL = 'http://127.0.0.1:8113';
 const MIN_ARTIFACT_FREE_BYTES = 128 * 1024 * 1024;
+const FIRESTORE_INDEX_LIST_MAX_BYTES = 5 * 1024 * 1024;
+const FIRESTORE_INDEX_LIST_TIMEOUT_MS = 10_000;
+// The Firestore wildcard collection-group listing accepts only zero and returns all indexes.
+const FIRESTORE_INDEX_LIST_PAGE_SIZE = 0;
+const FIRESTORE_INDEX_LIST_MAX_COUNT = 10_000;
+const FIRESTORE_INDEX_LIST_MAX_PAGES = 100;
+const FIRESTORE_ADMIN_BASE_URL = 'https://firestore.googleapis.com/v1';
 const execFileAsync = promisify(execFile);
 export const MATRIX_CORPUS_RUNTIME_CRITICAL_PATHS = [
   'apps/intex-agent/src/',
@@ -54,6 +62,48 @@ const NO_OP_LOGGER: InternalHttpClientLogger = {
   error: () => undefined,
   debug: () => undefined,
 };
+
+const MATRIX_CORPUS_REQUIRED_FIRESTORE_INDEXES = [
+  [
+    'matrix_corpus_ingest_outbox',
+    ['status:ASCENDING', 'createdAt:ASCENDING', '__name__:ASCENDING'],
+  ],
+  [
+    'matrix_corpus_ingest_outbox',
+    ['status:ASCENDING', 'claim.expiresAt:ASCENDING', '__name__:ASCENDING'],
+  ],
+  [
+    'matrix_corpus_terminal_control_outbox',
+    ['status:ASCENDING', 'createdAt:ASCENDING', '__name__:ASCENDING'],
+  ],
+  [
+    'matrix_corpus_terminal_control_outbox',
+    ['status:ASCENDING', 'claim.expiresAt:ASCENDING', '__name__:ASCENDING'],
+  ],
+  ['matrix_corpus_run_leases', ['phase:ASCENDING', 'expiresAt:ASCENDING', '__name__:ASCENDING']],
+  [
+    'intex_agent_session_events',
+    ['sessionId:ASCENDING', 'eventSequence:ASCENDING', '__name__:ASCENDING'],
+  ],
+  [
+    'intex_agent_test_runs',
+    [
+      'userId:ASCENDING',
+      'runtimeAudience:ASCENDING',
+      'startedAt:DESCENDING',
+      '__name__:DESCENDING',
+    ],
+  ],
+  [
+    'intex_agent_test_runs',
+    ['artifactDelivery.status:ASCENDING', 'finishedAt:ASCENDING', '__name__:ASCENDING'],
+  ],
+] as const;
+const MATRIX_CORPUS_REQUIRED_FIRESTORE_INDEX_SIGNATURES = new Set(
+  MATRIX_CORPUS_REQUIRED_FIRESTORE_INDEXES.map(([collectionGroup, fields]) =>
+    firestoreIndexSignature(collectionGroup, fields)
+  )
+);
 
 export interface MatrixCorpusPreparedContext {
   readonly account: ValidatedAccountContext;
@@ -179,6 +229,7 @@ export function createProductionMatrixCorpusLiveReadPort(options: {
   readonly intex?: IntexAgentServiceClient;
   readonly whatsapp?: WhatsAppServiceClient;
   readonly catalog?: OpenRouterCatalogClient;
+  readonly inspectFirestoreIndexes?: () => Promise<boolean>;
   readonly inspectRuntime?: () => Promise<{
     readonly ready: boolean;
     readonly deployedRevision: string;
@@ -233,17 +284,23 @@ export function createProductionMatrixCorpusLiveReadPort(options: {
       const cursorTimeout = setTimeout((): void => {
         cursorController.abort();
       }, 10_000);
-      const [acceptance, liveCatalog, artifact, whatsappReadiness, runtime] = await Promise.all([
-        intex.getMatrixCorpusCurrentAcceptance(account.userId),
-        modelCatalog.getIntexAgentCatalogEvidence(),
-        inspectArtifactRoot(join(options.repositoryRoot, '.artifacts', 'intex-agent-evals')),
-        whatsapp.getMatrixCorpusReadiness(),
-        (
-          options.inspectRuntime ??
-          ((): ReturnType<typeof inspectHomeDevRuntime> =>
-            inspectHomeDevRuntime(options.repositoryRoot))
-        )(),
-      ]);
+      const [acceptance, liveCatalog, artifact, whatsappReadiness, runtime, firestoreIndexesReady] =
+        await Promise.all([
+          intex.getMatrixCorpusCurrentAcceptance(account.userId),
+          modelCatalog.getIntexAgentCatalogEvidence(),
+          inspectArtifactRoot(join(options.repositoryRoot, '.artifacts', 'intex-agent-evals')),
+          whatsapp.getMatrixCorpusReadiness(),
+          (
+            options.inspectRuntime ??
+            ((): ReturnType<typeof inspectHomeDevRuntime> =>
+              inspectHomeDevRuntime(options.repositoryRoot))
+          )(),
+          (
+            options.inspectFirestoreIndexes ??
+            ((): ReturnType<typeof inspectHomeDevFirestoreIndexes> =>
+              inspectHomeDevFirestoreIndexes(env['INTEXURAOS_GCP_PROJECT_ID'] ?? ''))
+          )(),
+        ]);
       let sync: Awaited<ReturnType<MatrixClient['syncTargetRoom']>>;
       try {
         sync = await options.matrix.syncTargetRoom({
@@ -286,7 +343,7 @@ export function createProductionMatrixCorpusLiveReadPort(options: {
             : 'invalid',
           environmentAlias: env['INTEXURAOS_ENVIRONMENT'] ?? 'invalid',
           protectedConfigReady: true,
-          servicesReady: true,
+          servicesReady: firestoreIndexesReady,
           clocksReady,
           userReady: evaluatorUserId === account.userId,
           accountTupleCount,
@@ -314,6 +371,189 @@ export function createProductionMatrixCorpusLiveReadPort(options: {
       };
     },
   };
+}
+
+export interface HomeDevFirestoreIndexInspectionDeps {
+  listCompositeIndexes(projectId: string): Promise<string>;
+}
+
+const PRODUCTION_FIRESTORE_INDEX_INSPECTION_DEPS: HomeDevFirestoreIndexInspectionDeps = {
+  async listCompositeIndexes(projectId): Promise<string> {
+    const credential = applicationDefault();
+    return await listHomeDevFirestoreCompositeIndexes(projectId, {
+      async getAccessToken(): Promise<string> {
+        return (await credential.getAccessToken()).access_token;
+      },
+      fetch: async (input, init) => await fetch(input, init),
+    });
+  },
+};
+
+export interface FirestoreAdminIndexListDeps {
+  getAccessToken(): Promise<string>;
+  fetch(input: string, init: RequestInit): Promise<Response>;
+}
+
+/** List composite indexes through the read-only Firestore Admin REST API. */
+export async function listHomeDevFirestoreCompositeIndexes(
+  projectId: string,
+  deps: FirestoreAdminIndexListDeps
+): Promise<string> {
+  if (!/^[a-z][a-z0-9-]{4,61}[a-z0-9]$/u.test(projectId)) {
+    throw new Error('firestore_index_project_invalid');
+  }
+  const accessToken = await deps.getAccessToken();
+  if (accessToken.length === 0 || accessToken.length > 16_384) {
+    throw new Error('firestore_index_access_token_invalid');
+  }
+
+  const signal = AbortSignal.timeout(FIRESTORE_INDEX_LIST_TIMEOUT_MS);
+  const indexes: unknown[] = [];
+  const seenPageTokens = new Set<string>();
+  let pageToken: string | undefined;
+  let totalBytes = 0;
+
+  for (let pageNumber = 0; pageNumber < FIRESTORE_INDEX_LIST_MAX_PAGES; pageNumber += 1) {
+    const url = new URL(
+      `${FIRESTORE_ADMIN_BASE_URL}/projects/${projectId}/databases/(default)/collectionGroups/-/indexes`
+    );
+    url.searchParams.set('pageSize', String(FIRESTORE_INDEX_LIST_PAGE_SIZE));
+    if (pageToken !== undefined) url.searchParams.set('pageToken', pageToken);
+    const response = await deps.fetch(url.toString(), {
+      method: 'GET',
+      headers: { authorization: `Bearer ${accessToken}` },
+      signal,
+    });
+    if (!response.ok) throw new Error('firestore_index_list_failed');
+
+    const body = await readBoundedResponseBody(
+      response,
+      FIRESTORE_INDEX_LIST_MAX_BYTES - totalBytes
+    );
+    totalBytes += body.byteLength;
+    const page = JSON.parse(body.text) as unknown;
+    if (!isRecord(page)) throw new Error('firestore_index_list_invalid');
+    const rawPageIndexes = page['indexes'];
+    if (rawPageIndexes !== undefined && !Array.isArray(rawPageIndexes)) {
+      throw new Error('firestore_index_list_invalid');
+    }
+    const pageIndexes: unknown[] =
+      rawPageIndexes === undefined ? [] : (rawPageIndexes as unknown[]);
+    indexes.push(...pageIndexes);
+    if (indexes.length > FIRESTORE_INDEX_LIST_MAX_COUNT) {
+      throw new Error('firestore_index_list_too_large');
+    }
+
+    const nextPageToken = page['nextPageToken'];
+    if (nextPageToken === undefined || nextPageToken === '') return JSON.stringify(indexes);
+    if (
+      typeof nextPageToken !== 'string' ||
+      nextPageToken.length > 4096 ||
+      seenPageTokens.has(nextPageToken)
+    ) {
+      throw new Error('firestore_index_page_token_invalid');
+    }
+    seenPageTokens.add(nextPageToken);
+    pageToken = nextPageToken;
+  }
+  throw new Error('firestore_index_page_limit_exceeded');
+}
+
+async function readBoundedResponseBody(
+  response: Response,
+  maxBytes: number
+): Promise<{ readonly text: string; readonly byteLength: number }> {
+  if (maxBytes < 1 || response.body === null) {
+    throw new Error('firestore_index_list_too_large');
+  }
+  const contentLength = response.headers.get('content-length');
+  if (contentLength !== null) {
+    const advertisedBytes = Number(contentLength);
+    if (
+      !Number.isSafeInteger(advertisedBytes) ||
+      advertisedBytes < 0 ||
+      advertisedBytes > maxBytes
+    ) {
+      throw new Error('firestore_index_list_too_large');
+    }
+  }
+
+  const reader = (response.body as ReadableStream<Uint8Array>).getReader();
+  const chunks: Uint8Array[] = [];
+  let byteLength = 0;
+  for (;;) {
+    const chunk = await reader.read();
+    if (chunk.done) break;
+    byteLength += chunk.value.byteLength;
+    if (byteLength > maxBytes) {
+      await reader.cancel();
+      throw new Error('firestore_index_list_too_large');
+    }
+    chunks.push(chunk.value);
+  }
+  const bytes = new Uint8Array(byteLength);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return { text: new TextDecoder('utf-8', { fatal: true }).decode(bytes), byteLength };
+}
+
+/** Read the live index control plane without creating a Firestore probe document. */
+export async function inspectHomeDevFirestoreIndexes(
+  projectId: string,
+  deps: HomeDevFirestoreIndexInspectionDeps = PRODUCTION_FIRESTORE_INDEX_INSPECTION_DEPS
+): Promise<boolean> {
+  if (!/^[a-z][a-z0-9-]{4,61}[a-z0-9]$/u.test(projectId)) return false;
+  try {
+    const output = await deps.listCompositeIndexes(projectId);
+    if (output.length > FIRESTORE_INDEX_LIST_MAX_BYTES) return false;
+    const parsed = JSON.parse(output) as unknown;
+    if (!Array.isArray(parsed) || parsed.length > 10_000) return false;
+    const readySignatures = new Set<string>();
+    for (const value of parsed) {
+      const signature = readyFirestoreIndexSignature(value);
+      if (signature !== undefined) readySignatures.add(signature);
+    }
+    return [...MATRIX_CORPUS_REQUIRED_FIRESTORE_INDEX_SIGNATURES].every((signature) =>
+      readySignatures.has(signature)
+    );
+  } catch {
+    return false;
+  }
+}
+
+function readyFirestoreIndexSignature(value: unknown): string | undefined {
+  if (
+    !isRecord(value) ||
+    value['state'] !== 'READY' ||
+    value['queryScope'] !== 'COLLECTION' ||
+    (value['apiScope'] !== undefined && value['apiScope'] !== 'ANY_API')
+  ) {
+    return undefined;
+  }
+  const name = value['name'];
+  const fields = value['fields'];
+  if (typeof name !== 'string' || !Array.isArray(fields) || fields.length > 64) return undefined;
+  const collectionMatch = /\/collectionGroups\/([^/]+)\/indexes\//u.exec(name);
+  const collectionGroup = collectionMatch?.[1];
+  if (collectionGroup === undefined) return undefined;
+  const normalizedFields: string[] = [];
+  for (const field of fields) {
+    if (!isRecord(field) || typeof field['fieldPath'] !== 'string') return undefined;
+    if (field['order'] !== 'ASCENDING' && field['order'] !== 'DESCENDING') return undefined;
+    normalizedFields.push(`${field['fieldPath']}:${field['order']}`);
+  }
+  return firestoreIndexSignature(collectionGroup, normalizedFields);
+}
+
+function firestoreIndexSignature(collectionGroup: string, fields: readonly string[]): string {
+  return `${collectionGroup}|${fields.join('|')}`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 export interface HomeDevRuntimeInspectionDeps {


### PR DESCRIPTION
## Summary
- make Matrix corpus preflight verify all eight required Firestore composite indexes are exactly READY
- use authenticated read-only Firestore Admin REST so preflight preserves the zero-filesystem-write guarantee
- fail closed for missing, building, incompatible, malformed, oversized, or unavailable index state

## Verification
- `pnpm --filter @intexuraos/intex-agent-evals run validate` (24 files, 926 tests)
- focused security and test reviews: READY
- Home Dev Firestore Admin live read: HTTP 200, 175 indexes, required 8/8 READY
- `git diff --check`

- Linear: [INT-1893](https://linear.app/pbuchman/issue/INT-1893)
- IntexuraOS Code Task: [View task](https://intexuraos.cloud/#/code-tasks/task_b43ed235-81e8-42c7-baf7-4993171c752a)
- Worker Type: `codex-xhigh`
- Model: `default`