### PR TITLE
[INT-1894] Fix Matrix corpus live run recovery

### DIFF
--- a/apps/whatsapp-service/src/__tests__/infra/firestore/matrixCorpusIngress.test.ts
+++ b/apps/whatsapp-service/src/__tests__/infra/firestore/matrixCorpusIngress.test.ts
@@ -86,6 +86,50 @@ describe('Firestore Matrix corpus ingress', () => {
     });
   });
 
+  it('normalizes the Unix-seconds timestamp delivered by Meta before attesting the ingest', async () => {
+    const current = ingressFixture(storedCapability());
+    const metaTimestamp = '1784675542';
+
+    await expect(
+      current.ingress.consumeReservedMessage({
+        ...startInput(),
+        timestamp: metaTimestamp,
+      })
+    ).resolves.toEqual({ code: 'INGEST_ENQUEUED' });
+
+    expect(current.consumeCapabilityAndEnqueueIngest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        facts: expect.objectContaining({
+          ingressRequest: expect.objectContaining({
+            ordinaryTimestamp: new Date(Number(metaTimestamp) * 1_000).toISOString(),
+          }),
+          payload: expect.objectContaining({
+            ordinaryIngest: expect.objectContaining({
+              timestamp: new Date(Number(metaTimestamp) * 1_000).toISOString(),
+            }),
+          }),
+        }),
+      })
+    );
+  });
+
+  it.each([
+    ['non-numeric transport timestamp', 'not-a-timestamp'],
+    ['unsafe Unix-seconds integer', '9999999999999'],
+    ['Unix-seconds timestamp outside the supported RFC3339 year range', '253402300800'],
+  ])('fails closed before consumption for %s', async (_description, invalidTimestamp) => {
+    const current = ingressFixture(storedCapability());
+
+    await expect(
+      current.ingress.consumeReservedMessage({
+        ...startInput(),
+        timestamp: invalidTimestamp,
+      })
+    ).resolves.toEqual({ code: 'NOT_READY' });
+
+    expect(current.consumeCapabilityAndEnqueueIngest).not.toHaveBeenCalled();
+  });
+
   it('fails closed before consumption for a prompt or identity mismatch', async () => {
     const fake = createFakeFirestore();
     fake.clear();

--- a/apps/whatsapp-service/src/__tests__/infra/firestore/matrixCorpusRepository.test.ts
+++ b/apps/whatsapp-service/src/__tests__/infra/firestore/matrixCorpusRepository.test.ts
@@ -3758,6 +3758,66 @@ describe('FirestoreMatrixCorpusSignedEnvelopeStore', () => {
     ).rejects.toThrow('MATRIX_CORPUS_SIGNED_ENVELOPE_CONFLICT');
   });
 
+  it('reserves expired-lease signing only for a claimed abandoned terminal control', async () => {
+    const issuedAfterLeaseExpiry = '2026-07-20T10:05:30.001Z';
+    const liveClaimExpiresAt = '2026-07-20T10:06:30.001Z';
+    const proposedExpiresAt = '2026-07-20T10:10:30.001Z';
+    const abandoned = terminalFixture();
+    await abandoned.firestore
+      .collection(MATRIX_CORPUS_TERMINAL_CONTROL_OUTBOX_COLLECTION)
+      .doc('terminal_1')
+      .set({
+        ...terminalOutbox(),
+        claim: {
+          ownerDigest,
+          purpose: 'publish',
+          claimedAt: issuedAfterLeaseExpiry,
+          expiresAt: liveClaimExpiresAt,
+        },
+      });
+
+    await expect(
+      abandoned.repo.prepareTerminal({
+        ...terminalAuthority({ expectedClaimExpiresAt: liveClaimExpiresAt }),
+        proposedIssuedAt: issuedAfterLeaseExpiry,
+        proposedExpiresAt,
+      })
+    ).resolves.toEqual({
+      kind: 'reserved',
+      generation: 1,
+      issuedAt: issuedAfterLeaseExpiry,
+      expiresAt: proposedExpiresAt,
+    });
+
+    const release = terminalFixture();
+    await persistLeasePair(release.firestore, {
+      ...terminalLease(),
+      phase: 'release_pending',
+    });
+    await release.firestore
+      .collection(MATRIX_CORPUS_TERMINAL_CONTROL_OUTBOX_COLLECTION)
+      .doc('terminal_1')
+      .set({
+        ...terminalOutbox(),
+        kind: 'release',
+        payload: { ...terminalOutbox().payload, kind: 'release' },
+        claim: {
+          ownerDigest,
+          purpose: 'publish',
+          claimedAt: issuedAfterLeaseExpiry,
+          expiresAt: liveClaimExpiresAt,
+        },
+      });
+
+    await expect(
+      release.repo.prepareTerminal({
+        ...terminalAuthority({ expectedClaimExpiresAt: liveClaimExpiresAt }),
+        proposedIssuedAt: issuedAfterLeaseExpiry,
+        proposedExpiresAt,
+      })
+    ).rejects.toThrow('MATRIX_CORPUS_SIGNED_ENVELOPE_AUTHORITY_REJECTED');
+  });
+
   it('rejects foreign terminal authority and replays only the exact completed terminal envelope', async () => {
     const mismatchedId = terminalFixture();
     await expect(

--- a/apps/whatsapp-service/src/infra/firestore/matrixCorpusIngress.ts
+++ b/apps/whatsapp-service/src/infra/firestore/matrixCorpusIngress.ts
@@ -3,6 +3,7 @@ import {
   canonicalMatrixCorpusIngressRequestV1,
   matrixCorpusCapabilityV1Schema,
   matrixCorpusCapabilityConsumeFactsV1Schema,
+  matrixCorpusRfc3339TimestampSchema,
   matrixCorpusSafeIdSchema,
   type MatrixCorpusParsedIngressFactsV1,
   type MatrixCorpusVisibleHeaderV1,
@@ -111,6 +112,8 @@ export class FirestoreMatrixCorpusIngress implements MatrixCorpusIngressPort {
         !matrixCorpusSafeIdSchema.safeParse(ingestOutboxId).success
       )
         return { code: 'NOT_READY' };
+      const ordinaryTimestamp = normalizeTransportTimestamp(input.timestamp);
+      if (ordinaryTimestamp === null) return { code: 'NOT_READY' };
 
       const payload = {
         version: 1 as const,
@@ -121,7 +124,7 @@ export class FirestoreMatrixCorpusIngress implements MatrixCorpusIngressPort {
           messageId: input.transportMessageId,
           text: input.message.textAfterHeaderRemoval,
           sourceType: 'whatsapp_text' as const,
-          timestamp: input.timestamp,
+          timestamp: ordinaryTimestamp,
         },
         context: {
           version: 1 as const,
@@ -165,7 +168,7 @@ export class FirestoreMatrixCorpusIngress implements MatrixCorpusIngressPort {
         pendingConfirmationId: stored.pendingConfirmationId,
         expectedDecision: stored.expectedDecision,
         ordinaryMessageId: input.transportMessageId,
-        ordinaryTimestamp: input.timestamp,
+        ordinaryTimestamp,
         ingestReceiptId,
         payloadDigest,
         ingestOutboxId,
@@ -189,6 +192,21 @@ export class FirestoreMatrixCorpusIngress implements MatrixCorpusIngressPort {
     } catch {
       return { code: 'NOT_READY' };
     }
+  }
+}
+
+function normalizeTransportTimestamp(timestamp: string): string | null {
+  const rfc3339 = matrixCorpusRfc3339TimestampSchema.safeParse(timestamp);
+  if (rfc3339.success) return rfc3339.data;
+  if (!/^(?:0|[1-9][0-9]{0,12})$/u.test(timestamp)) return null;
+  const milliseconds = Number(timestamp) * 1_000;
+  if (!Number.isSafeInteger(milliseconds)) return null;
+  try {
+    const normalized = new Date(milliseconds).toISOString();
+    const parsed = matrixCorpusRfc3339TimestampSchema.safeParse(normalized);
+    return parsed.success ? parsed.data : null;
+  } catch {
+    return null;
   }
 }
 

--- a/apps/whatsapp-service/src/infra/firestore/matrixCorpusRepository.ts
+++ b/apps/whatsapp-service/src/infra/firestore/matrixCorpusRepository.ts
@@ -3150,7 +3150,12 @@ export class FirestoreMatrixCorpusSignedEnvelopeStore
       const claimExpiresAt = parsed.data.claim?.expiresAt;
       if (
         claimExpiresAt === undefined ||
-        !hasLiveSigningAuthority(pair.current.expiresAt, claimExpiresAt, input.proposedIssuedAt)
+        !hasLiveTerminalSigningAuthority(
+          pair.current,
+          parsed.data,
+          claimExpiresAt,
+          input.proposedIssuedAt
+        )
       )
         throw authorityRejected();
 
@@ -3339,6 +3344,19 @@ function hasLiveSigningAuthority(
 ): boolean {
   const issuedAt = Date.parse(proposedIssuedAt);
   return issuedAt < Date.parse(leaseExpiresAt) && issuedAt < Date.parse(claimExpiresAt);
+}
+
+function hasLiveTerminalSigningAuthority(
+  lease: ReturnType<typeof matrixCorpusCurrentLeaseHistoryPairV1Schema.parse>['current'],
+  outbox: ReturnType<typeof matrixCorpusTerminalControlOutboxRecordV1Schema.parse>,
+  claimExpiresAt: string,
+  proposedIssuedAt: string
+): boolean {
+  const issuedAt = Date.parse(proposedIssuedAt);
+  const hasLiveLease = issuedAt < Date.parse(lease.expiresAt);
+  const isExpiredLeaseAbandonment =
+    lease.phase === 'abandon_pending' && outbox.kind === 'abandoned';
+  return issuedAt < Date.parse(claimExpiresAt) && (hasLiveLease || isExpiredLeaseAbandonment);
 }
 
 function ingestPreparation(

--- a/tools/intex-agent-evals/src/__tests__/fixtures/matrixCorpusCompositionHarness.ts
+++ b/tools/intex-agent-evals/src/__tests__/fixtures/matrixCorpusCompositionHarness.ts
@@ -75,11 +75,21 @@ interface SharedState {
   terminalAcknowledged: boolean;
   readonly failArtifactReady: boolean;
   readonly failMiniMaxScenarioNumber: number | null;
+  readonly wrongPuppetScenarioNumber: number | null;
+  readonly advanceEventRevisionAfterBindingScenarioNumber: number | null;
+  readonly deferBindingUntilQuiesceScenarioNumber: number | null;
+  readonly scenarioStatusReads: Map<string, number>;
+  readonly conflictStoppedScenarioProjectionOnce: boolean;
+  stoppedScenarioProjectionConflictInjected: boolean;
 }
 
 export interface MatrixCorpusCompositionHarnessOptions {
   readonly failArtifactReady?: boolean;
   readonly failMiniMaxScenarioNumber?: number;
+  readonly wrongPuppetScenarioNumber?: number;
+  readonly advanceEventRevisionAfterBindingScenarioNumber?: number;
+  readonly deferBindingUntilQuiesceScenarioNumber?: number;
+  readonly conflictStoppedScenarioProjectionOnce?: boolean;
 }
 
 export interface MatrixCorpusCompositionMetrics {
@@ -88,6 +98,8 @@ export interface MatrixCorpusCompositionMetrics {
   deepSeekAgentCalls: number;
   confirmationAgentCalls: number;
   miniMaxJudgeCalls: number;
+  readonly scenarioProjectionSessions: string[];
+  readonly scenarioProjectionEventWatermarks: number[];
   productionExecutorResolutions: 0;
   productionExecutorAdmissions: 0;
 }
@@ -119,6 +131,8 @@ export async function createPassingMatrixCorpusCompositionHarness(
     deepSeekAgentCalls: 0,
     confirmationAgentCalls: 0,
     miniMaxJudgeCalls: 0,
+    scenarioProjectionSessions: [],
+    scenarioProjectionEventWatermarks: [],
     productionExecutorResolutions: 0,
     productionExecutorAdmissions: 0,
   };
@@ -141,6 +155,13 @@ export async function createPassingMatrixCorpusCompositionHarness(
     terminalAcknowledged: false,
     failArtifactReady: options.failArtifactReady ?? false,
     failMiniMaxScenarioNumber: options.failMiniMaxScenarioNumber ?? null,
+    wrongPuppetScenarioNumber: options.wrongPuppetScenarioNumber ?? null,
+    advanceEventRevisionAfterBindingScenarioNumber:
+      options.advanceEventRevisionAfterBindingScenarioNumber ?? null,
+    deferBindingUntilQuiesceScenarioNumber: options.deferBindingUntilQuiesceScenarioNumber ?? null,
+    scenarioStatusReads: new Map(),
+    conflictStoppedScenarioProjectionOnce: options.conflictStoppedScenarioProjectionOnce ?? false,
+    stoppedScenarioProjectionConflictInjected: false,
   };
 
   return {
@@ -278,7 +299,10 @@ function createWhatsAppBoundary(state: SharedState): WhatsAppServiceClient {
         eventId: `$matrix_reply_${String(state.metrics.matrixMessages.length + 1)}`,
         originServerTs: Date.parse(NOW) + state.metrics.matrixMessages.length,
         type: 'm.room.message',
-        sender: '@whatsapp_lid-private-puppet-sentinel:example.test',
+        sender:
+          entry.scenarioNumber === state.wrongPuppetScenarioNumber
+            ? '@whatsapp_lid-wrong-puppet-sentinel:example.test'
+            : '@whatsapp_lid-private-puppet-sentinel:example.test',
         content: { msgtype: 'm.text', body: reply },
       });
       state.metrics.matrixMessages.push(request.text);
@@ -414,10 +438,25 @@ function createIntexBoundary(state: SharedState): IntexAgentServiceClient {
         if (expectedRevision !== state.revision) {
           return { ok: false, error: { code: 'rejected', httpStatus: 409 } };
         }
+        const scenario = request.command['scenario'];
+        if (
+          state.conflictStoppedScenarioProjectionOnce &&
+          !state.stoppedScenarioProjectionConflictInjected &&
+          scenario !== null &&
+          scenario !== undefined &&
+          (scenario as Readonly<Record<string, unknown>>)['lifecycle'] === 'stopped'
+        ) {
+          state.stoppedScenarioProjectionConflictInjected = true;
+          state.revision += 1;
+          return { ok: false, error: { code: 'rejected', httpStatus: 409 } };
+        }
         state.revision += 1;
         const command = request.command;
         if (command['retentionReconciled'] === true) state.retentionReconciled = true;
         if (command['scenario'] !== null && command['scenario'] !== undefined) {
+          const scenario = command['scenario'] as Readonly<Record<string, unknown>>;
+          state.metrics.scenarioProjectionSessions.push(String(scenario['sessionId']));
+          state.metrics.scenarioProjectionEventWatermarks.push(Number(scenario['eventWatermark']));
           state.lifecycle = 'running';
         }
       }
@@ -453,7 +492,20 @@ function createIntexBoundary(state: SharedState): IntexAgentServiceClient {
       const entry = findEntry(state.catalog, input.scenarioId);
       const progress = state.progress.get(input.scenarioId);
       if (progress === undefined) return { ok: true, value: { kind: 'not_ready' } };
+      const priorReads = state.scenarioStatusReads.get(input.scenarioId) ?? 0;
+      state.scenarioStatusReads.set(input.scenarioId, priorReads + 1);
+      if (
+        entry.scenarioNumber === state.deferBindingUntilQuiesceScenarioNumber &&
+        state.transportPhase === 'active'
+      )
+        return { ok: true, value: { kind: 'not_ready' } };
       const nextTurn = entry.scenario.turns[progress.lastTurnIndex + 1];
+      const eventRevision = progress.eventRevision;
+      if (
+        entry.scenarioNumber === state.advanceEventRevisionAfterBindingScenarioNumber &&
+        priorReads === 0
+      )
+        progress.eventRevision += 1;
       return {
         ok: true,
         value: {
@@ -463,7 +515,7 @@ function createIntexBoundary(state: SharedState): IntexAgentServiceClient {
           leaseFence: input.leaseFence,
           scenarioId: input.scenarioId,
           sessionId: progress.sessionId,
-          eventRevision: progress.eventRevision,
+          eventRevision,
           lifecycle: 'running',
           pendingConfirmationId:
             nextTurn?.kind === 'confirmation_button'

--- a/tools/intex-agent-evals/src/__tests__/matrixCorpusComposition.test.ts
+++ b/tools/intex-agent-evals/src/__tests__/matrixCorpusComposition.test.ts
@@ -196,4 +196,114 @@ describe('production Matrix corpus composition', () => {
       true
     );
   });
+
+  it('terminalizes a persisted session binding when Matrix correlation fails before observation', async () => {
+    const catalog = await loadCanonicalMatrixCorpus(scenariosDirectory);
+    const harness = await createPassingMatrixCorpusCompositionHarness(catalog, {
+      wrongPuppetScenarioNumber: 1,
+      advanceEventRevisionAfterBindingScenarioNumber: 1,
+      conflictStoppedScenarioProjectionOnce: true,
+    });
+    cleanup.push(harness.cleanup);
+    const execute = createProductionMatrixCorpusExecutor({
+      repositoryRoot: harness.repositoryRoot,
+      matrix: harness.matrix,
+      whatsapp: harness.whatsapp,
+      intex: harness.intex,
+      evaluator: harness.evaluator,
+      env: {
+        INTEXURAOS_MATRIX_CORPUS_BINDING_HMAC_KEY:
+          'composition-harness-binding-key-with-at-least-thirty-two-bytes',
+      },
+      now: harness.now,
+    });
+
+    const result = await execute({
+      runId: harness.runId,
+      preflight: harness.preflight,
+      prepared: harness.prepared,
+    });
+
+    expect(result).toMatchObject({
+      reportReady: true,
+      run: {
+        exitCode: 2,
+        effectiveKind: 'infrastructure_failure',
+        failureCodes: ['wrong_puppet'],
+        terminalAcknowledged: true,
+        cleanupCompleted: true,
+        totals: { agentCostNanoUsd: 1_000 },
+      },
+    });
+    expect(result.run.scenarios[0]).toMatchObject({ status: 'stopped', completedTurns: 0 });
+    expect(result.run.scenarios.slice(1).every((scenario) => scenario.status === 'not_run')).toBe(
+      true
+    );
+    expect(harness.metrics.scenarioProjectionSessions).toEqual(['matrix_session_1_1']);
+    expect(harness.metrics.scenarioProjectionEventWatermarks).toEqual([2]);
+    const report = MatrixCorpusReportV1Schema.parse(
+      JSON.parse(
+        await readFile(
+          `${harness.repositoryRoot}/${result.relativeReportDirectory}/report.json`,
+          'utf8'
+        )
+      )
+    );
+    expect(report.scenarios[0]?.agentUsage).toMatchObject({
+      logicalCalls: 1,
+      totalTokens: 15,
+      costNanoUsd: 1_000,
+      costComplete: true,
+    });
+    expect(report.scenarios[0]?.judge).toMatchObject({ status: 'not_run', passed: null });
+    expect(report.scenarios[0]?.strictMockProof.status).toBe('passed');
+    expect(report.usage.agent).toMatchObject({
+      logicalCalls: 1,
+      totalTokens: 15,
+      costNanoUsd: 1_000,
+      costComplete: true,
+    });
+    expect(report.usage).toMatchObject({ totalCostNanoUsd: 1_000, costComplete: true });
+  });
+
+  it('reconciles a session binding that appears while the failed turn is draining', async () => {
+    const catalog = await loadCanonicalMatrixCorpus(scenariosDirectory);
+    const harness = await createPassingMatrixCorpusCompositionHarness(catalog, {
+      deferBindingUntilQuiesceScenarioNumber: 1,
+    });
+    cleanup.push(harness.cleanup);
+    const execute = createProductionMatrixCorpusExecutor({
+      repositoryRoot: harness.repositoryRoot,
+      matrix: harness.matrix,
+      whatsapp: harness.whatsapp,
+      intex: harness.intex,
+      evaluator: harness.evaluator,
+      env: {
+        INTEXURAOS_MATRIX_CORPUS_BINDING_HMAC_KEY:
+          'composition-harness-binding-key-with-at-least-thirty-two-bytes',
+      },
+      correlationTimeoutMs: 5,
+      pollIntervalMs: 1,
+      now: harness.now,
+    });
+
+    const result = await execute({
+      runId: harness.runId,
+      preflight: harness.preflight,
+      prepared: harness.prepared,
+    });
+
+    expect(result).toMatchObject({
+      reportReady: true,
+      run: {
+        exitCode: 2,
+        failureCodes: ['scenario_binding_timeout'],
+        terminalAcknowledged: true,
+        cleanupCompleted: true,
+      },
+    });
+    expect(result.run.scenarios[0]).toMatchObject({ status: 'stopped', completedTurns: 0 });
+    expect(harness.metrics.scenarioProjectionSessions).toEqual(['matrix_session_1_1']);
+    expect(harness.metrics.scenarioProjectionEventWatermarks).toEqual([1]);
+  });
 });

--- a/tools/intex-agent-evals/src/__tests__/matrixCorpusRunner.test.ts
+++ b/tools/intex-agent-evals/src/__tests__/matrixCorpusRunner.test.ts
@@ -51,6 +51,8 @@ describe('sequential Matrix corpus state machine', () => {
       catalog.scenarios.map(({ scenario }) => `renew:${scenario.id}`)
     );
     expect(trace.indexOf('retention')).toBeLessThan(trace.indexOf('activate'));
+    expect(trace.indexOf('activate')).toBeLessThan(trace.indexOf('project-running'));
+    expect(trace.indexOf('project-running')).toBeLessThan(trace.indexOf('turn:intex-eval-001:0'));
     expect(trace.slice(-7)).toEqual([
       'quiesce',
       'drain',
@@ -90,7 +92,12 @@ describe('sequential Matrix corpus state machine', () => {
     const ports = passingPorts(trace);
     vi.mocked(ports.executeTurn).mockImplementation(async (input) =>
       input.scenario.id === 'intex-eval-003'
-        ? { ok: false, kind: 'safety_failure', code: 'wrong_puppet' }
+        ? {
+            ok: false,
+            kind: 'safety_failure',
+            code: 'wrong_puppet',
+            boundSessionId: `session_${input.scenario.id}`,
+          }
         : { ok: true, observation: observation(input.scenario, input.turnIndex) }
     );
 
@@ -100,6 +107,86 @@ describe('sequential Matrix corpus state machine', () => {
     expect(result.failureCodes).toContain('wrong_puppet');
     expect(result.scenarios[2]?.status).toBe('stopped');
     expect(result.scenarios[3]?.status).toBe('not_run');
+    expect(result.terminalAcknowledged).toBe(true);
+  });
+
+  it('does not invent a scenario projection when infrastructure fails before session binding', async () => {
+    const catalog = await loadCanonicalMatrixCorpus(scenariosDirectory);
+    const trace: string[] = [];
+    const ports = passingPorts(trace);
+    vi.mocked(ports.executeTurn).mockResolvedValue({
+      ok: false,
+      kind: 'infrastructure_failure',
+      code: 'scenario_binding_timeout',
+    });
+
+    const result = await runMatrixCorpus({ runId: 'run_unbound', catalog }, ports);
+
+    expect(result.exitCode).toBe(2);
+    expect(result.failureCodes).toContain('scenario_binding_timeout');
+    expect(result.scenarios[0]).toMatchObject({ status: 'not_run', completedTurns: 0 });
+    expect(ports.projectScenario).not.toHaveBeenCalled();
+    expect(ports.reconcileStoppedScenario).toHaveBeenCalledWith(
+      expect.objectContaining({ scenarioId: 'intex-eval-001', observedSessionId: null })
+    );
+    expect(trace).toContain('stage');
+    expect(result.terminalAcknowledged).toBe(true);
+    expect(result.cleanupCompleted).toBe(true);
+  });
+
+  it('projects a persisted session binding as stopped when correlation fails before observation', async () => {
+    const catalog = await loadCanonicalMatrixCorpus(scenariosDirectory);
+    const ports = passingPorts([]);
+    vi.mocked(ports.executeTurn).mockResolvedValue({
+      ok: false,
+      kind: 'infrastructure_failure',
+      code: 'reply_timeout',
+      boundSessionId: 'session_intex-eval-001',
+    });
+
+    const result = await runMatrixCorpus({ runId: 'run_bound_failure', catalog }, ports);
+
+    expect(result.exitCode).toBe(2);
+    expect(result.scenarios[0]).toMatchObject({ status: 'stopped', completedTurns: 0 });
+    expect(ports.reconcileStoppedScenario).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scenarioId: 'intex-eval-001',
+        observedSessionId: 'session_intex-eval-001',
+      })
+    );
+    expect(ports.projectScenario).not.toHaveBeenCalledWith(
+      expect.objectContaining({ scenarioId: 'intex-eval-001', lifecycle: 'stopped' })
+    );
+    expect(result.terminalAcknowledged).toBe(true);
+  });
+
+  it('reconciles a late session binding only after the stopped turn is drained', async () => {
+    const catalog = await loadCanonicalMatrixCorpus(scenariosDirectory);
+    const trace: string[] = [];
+    const ports = passingPorts(trace);
+    vi.mocked(ports.executeTurn).mockResolvedValue({
+      ok: false,
+      kind: 'infrastructure_failure',
+      code: 'scenario_binding_timeout',
+    });
+    vi.mocked(ports.reconcileStoppedScenario).mockImplementation(async (input) => {
+      trace.push('reconcile-stopped');
+      return {
+        ok: true,
+        revision: input.expectedRevision + 1,
+        disposition: 'projected',
+        additionalAgentCostNanoUsd: 0,
+      };
+    });
+
+    const result = await runMatrixCorpus({ runId: 'run_late_binding', catalog }, ports);
+
+    expect(result.scenarios[0]?.status).toBe('stopped');
+    expect(trace.indexOf('drain')).toBeLessThan(trace.indexOf('reconcile-stopped'));
+    expect(trace.indexOf('reconcile-stopped')).toBeLessThan(trace.indexOf('stage'));
+    expect(ports.reconcileStoppedScenario).toHaveBeenCalledWith(
+      expect.objectContaining({ scenarioId: 'intex-eval-001', observedSessionId: null })
+    );
     expect(result.terminalAcknowledged).toBe(true);
   });
 
@@ -318,6 +405,8 @@ describe('sequential Matrix corpus state machine', () => {
     expect(result.exitCode).toBe(2);
     expect(result.failureCodes).toContain('lease_renewal_failed');
     expect(ports.executeTurn).not.toHaveBeenCalled();
+    expect(result.scenarios[0]?.status).toBe('not_run');
+    expect(ports.projectScenario).not.toHaveBeenCalled();
     expect(result.terminalAcknowledged).toBe(true);
   });
 
@@ -432,7 +521,12 @@ describe('sequential Matrix corpus state machine', () => {
     const ports = passingPorts([]);
     vi.mocked(ports.executeTurn).mockImplementation(async (input) => {
       if (input.scenario.id === 'intex-eval-002') {
-        return { ok: false, kind: 'infrastructure_failure', code: 'matrix_sync_failed' };
+        return {
+          ok: false,
+          kind: 'infrastructure_failure',
+          code: 'matrix_sync_failed',
+          boundSessionId: `session_${input.scenario.id}`,
+        };
       }
       return {
         ok: true,
@@ -622,6 +716,11 @@ function passingPorts(trace: string[]): MatrixCorpusRunPorts {
       trace.push('activate');
       return { ok: true, value: undefined } as const;
     }),
+    projectRunning: vi.fn(async (input) => {
+      trace.push('project-running');
+      revision = input.expectedRevision + 1;
+      return { ok: true, revision } as const;
+    }),
     renewLease: vi.fn(async ({ scenarioId }) => {
       trace.push(`renew:${scenarioId}`);
       return { ok: true, value: undefined } as const;
@@ -650,6 +749,25 @@ function passingPorts(trace: string[]): MatrixCorpusRunPorts {
       revision = input.expectedRevision + 1;
       return { ok: true, revision } as const;
     }),
+    reconcileStoppedScenario: vi.fn(
+      async (input: { expectedRevision: number; observedSessionId: string | null }) => {
+        trace.push('reconcile-stopped');
+        if (input.observedSessionId === null)
+          return {
+            ok: true,
+            revision: input.expectedRevision,
+            disposition: 'not_bound',
+            additionalAgentCostNanoUsd: 0,
+          } as const;
+        revision = input.expectedRevision + 1;
+        return {
+          ok: true,
+          revision,
+          disposition: 'projected',
+          additionalAgentCostNanoUsd: 0,
+        } as const;
+      }
+    ),
     getProjectionRevision: vi.fn(async () => ({ ok: true, value: { revision } }) as const),
     quiesceRun: vi.fn(async () => {
       trace.push('quiesce');

--- a/tools/intex-agent-evals/src/matrixCorpus/liveExecution.ts
+++ b/tools/intex-agent-evals/src/matrixCorpus/liveExecution.ts
@@ -56,6 +56,7 @@ import {
   type MatrixCorpusProjectionMutationResult,
   type MatrixCorpusRunPorts,
   type MatrixCorpusRunResult,
+  type MatrixCorpusStoppedScenarioReconciliationResult,
   type MatrixCorpusTurnObservation,
 } from './runMatrixCorpus.js';
 import type { CanonicalMatrixCorpus, CanonicalMatrixCorpusScenario } from './types.js';
@@ -87,6 +88,7 @@ interface ScenarioExecutionState {
   readonly deterministicChecks: SafeDeterministicCheckV1[];
   deterministicPassed: boolean;
   strictMockProofTurns: number;
+  strictMockProofReconciled: boolean;
   readonly failureCodes: string[];
 }
 
@@ -336,6 +338,31 @@ function createRunPorts(input: {
       return activated ? passed(undefined) : failed('activation_failed');
     },
 
+    async projectRunning(command): MatrixCorpusPortReturn<'projectRunning'> {
+      const result = await input.control.mutateProjection({
+        runId: command.runId,
+        leaseFence: command.leaseFence,
+        request: {
+          kind: 'cas',
+          userId: state.prepared.account.userId,
+          leaseFence: command.leaseFence,
+          command: {
+            expectedRevision: command.expectedRevision,
+            nextLifecycle: 'running',
+            updatedAt: input.now().toISOString(),
+            scenario: null,
+            finalization: null,
+          },
+        },
+      });
+      if (!result.ok)
+        return result.error.httpStatus === 409
+          ? { ok: false, kind: 'revision_conflict', code: 'projection_revision_conflict' }
+          : projectionFailed('running_projection_failed');
+      state.revision = result.value.revision;
+      return { ok: true, revision: result.value.revision };
+    },
+
     async renewLease({ runId, leaseFence, scenarioId }): MatrixCorpusPortReturn<'renewLease'> {
       const result = await input.whatsapp.renewMatrixCorpusLease({
         runId,
@@ -420,6 +447,115 @@ function createRunPorts(input: {
       state.revision = result.value.revision;
       scenario.projectionRevision += 1;
       return { ok: true, revision: result.value.revision };
+    },
+
+    async reconcileStoppedScenario(command): MatrixCorpusPortReturn<'reconcileStoppedScenario'> {
+      const scenario = state.scenarios.get(command.scenarioId);
+      if (scenario === undefined)
+        return stoppedScenarioReconciliationFailed('stopped_scenario_missing');
+      const status = await readScenarioStatus(
+        input.intex,
+        state,
+        command.scenarioId,
+        command.leaseFence
+      );
+      if (status === null) {
+        if (scenario.sessionId !== null || command.observedSessionId !== null)
+          return stoppedScenarioReconciliationFailed('stopped_scenario_status_missing');
+        return {
+          ok: true,
+          revision: command.expectedRevision,
+          disposition: 'not_bound',
+          additionalAgentCostNanoUsd: 0,
+        };
+      }
+      if (
+        (command.observedSessionId !== null && command.observedSessionId !== status.sessionId) ||
+        (scenario.sessionId !== null && scenario.sessionId !== status.sessionId)
+      )
+        return stoppedScenarioReconciliationFailed('stopped_scenario_binding_mismatch');
+      const evidenceResult = await input.intex.getMatrixCorpusEvidence({
+        ...identity(state, command.runId, command.leaseFence),
+        scenarioId: command.scenarioId,
+        sessionId: status.sessionId,
+        eventRevision: status.eventRevision,
+      });
+      if (!evidenceResult.ok)
+        return stoppedScenarioReconciliationFailed('stopped_scenario_evidence_missing');
+      const evidence = evidenceResult.value;
+      if (evidence.eventRevision !== status.eventRevision)
+        return stoppedScenarioReconciliationFailed('stopped_scenario_evidence_revision_mismatch');
+      if (evidence.strictMockProof.mockProfileDigest !== scenario.entry.mockProfileDigest)
+        return stoppedScenarioReconciliationFailed('stopped_scenario_strict_mock_proof_failed');
+      const safeToolEvidence = evidence.toolEvidence.flatMap((item) => {
+        const parsed = safeToolEvidenceV1Schema.safeParse(item);
+        return parsed.success ? [parsed.data] : [];
+      });
+      const safeAgentUsage = evidence.agentUsage.flatMap((item) => {
+        const parsed = safeAgentUsageV1Schema.safeParse(item);
+        return parsed.success ? [parsed.data] : [];
+      });
+      if (
+        safeToolEvidence.length !== evidence.toolEvidence.length ||
+        safeAgentUsage.length !== evidence.agentUsage.length
+      )
+        return stoppedScenarioReconciliationFailed('stopped_scenario_unsafe_evidence_shape');
+      const previousUsageTotals = sumAgentUsage(scenario.agentUsage);
+      const usageTotals = sumAgentUsage(safeAgentUsage);
+      if (
+        usageTotals.inputTokens !== evidence.agentUsageTotals.inputTokens ||
+        usageTotals.outputTokens !== evidence.agentUsageTotals.outputTokens ||
+        usageTotals.totalTokens !== evidence.agentUsageTotals.totalTokens ||
+        usageTotals.costNanoUsd !== evidence.agentUsageTotals.costNanoUsd
+      )
+        return stoppedScenarioReconciliationFailed('stopped_scenario_usage_totals_mismatch');
+      if (usageTotals.costNanoUsd < previousUsageTotals.costNanoUsd)
+        return stoppedScenarioReconciliationFailed('stopped_scenario_usage_regressed');
+      const updatedAt = input.now().toISOString();
+      const reconciledScenario: ScenarioExecutionState = {
+        ...scenario,
+        sessionId: status.sessionId,
+        eventRevision: evidence.eventRevision,
+        toolEvidence: safeToolEvidence,
+        agentUsage: safeAgentUsage,
+        strictMockProofReconciled: true,
+        finishedAt: updatedAt,
+      };
+      const result = await input.control.mutateProjection({
+        runId: command.runId,
+        leaseFence: command.leaseFence,
+        request: {
+          kind: 'cas',
+          userId: state.prepared.account.userId,
+          leaseFence: command.leaseFence,
+          command: createScenarioProjectionCommand(
+            state,
+            reconciledScenario,
+            command.expectedRevision,
+            'stopped',
+            'not_evaluated',
+            updatedAt
+          ),
+        },
+      });
+      if (!result.ok)
+        return result.error.httpStatus === 409
+          ? { ok: false, kind: 'revision_conflict', code: 'projection_revision_conflict' }
+          : stoppedScenarioReconciliationFailed('stopped_scenario_projection_failed');
+      state.revision = result.value.revision;
+      scenario.sessionId = reconciledScenario.sessionId;
+      scenario.eventRevision = reconciledScenario.eventRevision;
+      scenario.toolEvidence = reconciledScenario.toolEvidence;
+      scenario.agentUsage = reconciledScenario.agentUsage;
+      scenario.strictMockProofReconciled = reconciledScenario.strictMockProofReconciled;
+      scenario.finishedAt = reconciledScenario.finishedAt;
+      scenario.projectionRevision += 1;
+      return {
+        ok: true,
+        revision: result.value.revision,
+        disposition: 'projected',
+        additionalAgentCostNanoUsd: usageTotals.costNanoUsd - previousUsageTotals.costNanoUsd,
+      };
     },
 
     async getProjectionRevision({
@@ -804,6 +940,8 @@ async function executeLiveTurn(input: {
   );
   if (status === undefined)
     return { ok: false, kind: 'infrastructure_failure', code: 'scenario_binding_timeout' };
+  state.sessionId = status.sessionId;
+  state.eventRevision = status.eventRevision;
 
   const evidenceCapture: { value: MatrixCorpusEvidenceResult | null } = { value: null };
   const replyController = new AbortController();
@@ -862,6 +1000,7 @@ async function executeLiveTurn(input: {
       ok: false,
       kind: 'infrastructure_failure',
       code: correlated.ok ? 'turn_evidence_missing' : correlated.code,
+      boundSessionId: status.sessionId,
     };
 
   input.state.turnsCorrelated += 1;
@@ -870,8 +1009,14 @@ async function executeLiveTurn(input: {
   state.matrixMirrors += correlated.replies.length;
 
   const evidence = evidenceCapture.value;
+  state.eventRevision = evidence.eventRevision;
   if (evidence.strictMockProof.mockProfileDigest !== entry.mockProfileDigest)
-    return { ok: false, kind: 'safety_failure', code: 'strict_mock_proof_failed' };
+    return {
+      ok: false,
+      kind: 'safety_failure',
+      code: 'strict_mock_proof_failed',
+      boundSessionId: status.sessionId,
+    };
   const safeToolEvidence = evidence.toolEvidence.flatMap((item) => {
     const parsed = safeToolEvidenceV1Schema.safeParse(item);
     return parsed.success ? [parsed.data] : [];
@@ -884,7 +1029,12 @@ async function executeLiveTurn(input: {
     safeToolEvidence.length !== evidence.toolEvidence.length ||
     safeAgentUsage.length !== evidence.agentUsage.length
   )
-    return { ok: false, kind: 'safety_failure', code: 'unsafe_evidence_shape' };
+    return {
+      ok: false,
+      kind: 'safety_failure',
+      code: 'unsafe_evidence_shape',
+      boundSessionId: status.sessionId,
+    };
   const toolEvidence = safeToolEvidence.filter((item) => item.turnIndex === input.turnIndex);
   const agentUsage = safeAgentUsage.filter((item) => item.turnIndex === input.turnIndex);
   const selected = toolEvidence
@@ -1037,6 +1187,7 @@ function createState(
           deterministicChecks: [],
           deterministicPassed: true,
           strictMockProofTurns: 0,
+          strictMockProofReconciled: false,
           failureCodes: [],
         },
       ])
@@ -1355,17 +1506,17 @@ function buildReport(
               20
           );
     const judgeStatus: 'passed' | 'failed' | 'not_run' =
-      lifecycle === 'not_run'
+      lifecycle === 'not_run' || execution.replyEvaluations.length === 0
         ? 'not_run'
-        : execution.replyEvaluations.length > 0 &&
-            execution.replyEvaluations.every((evaluation) => evaluation.verdict === 'passed')
+        : execution.replyEvaluations.every((evaluation) => evaluation.verdict === 'passed')
           ? 'passed'
           : 'failed';
     const strictMockStatus: 'passed' | 'failed' | 'not_run' =
       lifecycle === 'not_run'
         ? 'not_run'
-        : execution.completedTurns > 0 &&
-            execution.strictMockProofTurns === execution.completedTurns
+        : execution.strictMockProofReconciled ||
+            (execution.completedTurns > 0 &&
+              execution.strictMockProofTurns === execution.completedTurns)
           ? 'passed'
           : 'failed';
     return {
@@ -2154,6 +2305,12 @@ function failed(code: string): { readonly ok: false; readonly code: string } {
 }
 
 function projectionFailed(code: string): MatrixCorpusProjectionMutationResult {
+  return { ok: false as const, kind: 'failed' as const, code };
+}
+
+function stoppedScenarioReconciliationFailed(
+  code: string
+): MatrixCorpusStoppedScenarioReconciliationResult {
   return { ok: false as const, kind: 'failed' as const, code };
 }
 

--- a/tools/intex-agent-evals/src/matrixCorpus/runMatrixCorpus.ts
+++ b/tools/intex-agent-evals/src/matrixCorpus/runMatrixCorpus.ts
@@ -67,6 +67,7 @@ export type MatrixCorpusTurnExecutionResult =
       readonly ok: false;
       readonly kind: 'infrastructure_failure' | 'safety_failure';
       readonly code: string;
+      readonly boundSessionId?: string;
     };
 
 export type MatrixCorpusJudgeResult =
@@ -89,6 +90,15 @@ export type MatrixCorpusProjectionMutationResult =
   | { readonly ok: true; readonly revision: number }
   | { readonly ok: false; readonly kind: 'revision_conflict' | 'failed'; readonly code: string };
 
+export type MatrixCorpusStoppedScenarioReconciliationResult =
+  | {
+      readonly ok: true;
+      readonly revision: number;
+      readonly disposition: 'projected' | 'not_bound';
+      readonly additionalAgentCostNanoUsd: number;
+    }
+  | { readonly ok: false; readonly kind: 'revision_conflict' | 'failed'; readonly code: string };
+
 export interface MatrixCorpusRunPorts {
   provisionRun(input: {
     runId: string;
@@ -109,6 +119,11 @@ export interface MatrixCorpusRunPorts {
     leaseFence: string;
   }): Promise<MatrixCorpusOperationResult<{ revision: number }>>;
   activateRun(input: { runId: string; leaseFence: string }): Promise<MatrixCorpusOperationResult>;
+  projectRunning(input: {
+    runId: string;
+    leaseFence: string;
+    expectedRevision: number;
+  }): Promise<MatrixCorpusProjectionMutationResult>;
   renewLease(input: {
     runId: string;
     leaseFence: string;
@@ -134,6 +149,13 @@ export interface MatrixCorpusRunPorts {
     lifecycle: 'running' | 'completed' | 'stopped';
     verdict: 'pending' | 'passed' | 'failed' | 'not_evaluated';
   }): Promise<MatrixCorpusProjectionMutationResult>;
+  reconcileStoppedScenario(input: {
+    runId: string;
+    leaseFence: string;
+    expectedRevision: number;
+    scenarioId: string;
+    observedSessionId: string | null;
+  }): Promise<MatrixCorpusStoppedScenarioReconciliationResult>;
   getProjectionRevision(input: {
     runId: string;
     leaseFence: string;
@@ -213,6 +235,11 @@ export async function runMatrixCorpus(
   let evaluatorCostNanoUsd = 0;
   let terminalAcknowledged = false;
   let cleanupCompleted = false;
+  let pendingStoppedScenario: {
+    readonly scenarioOffset: number;
+    readonly scenarioId: string;
+    readonly observedSessionId: string | null;
+  } | null = null;
 
   const provision = await safely(() => ports.provisionRun(input));
   if (!provision.ok) return earlyFailure(input.runId, scenarios, provision.code);
@@ -235,6 +262,18 @@ export async function runMatrixCorpus(
   const activation = await safely(() => ports.activateRun({ runId: input.runId, leaseFence }));
   if (!activation.ok) return await terminateAfterProvision(activation.code);
   active = true;
+  const runningProjection = await projectRunningWithRefetch({
+    ports,
+    runId: input.runId,
+    leaseFence,
+    revision,
+  });
+  if (!runningProjection.ok) {
+    failureCodes.push(runningProjection.code);
+    stopped = true;
+    return await terminalize();
+  }
+  revision = runningProjection.revision;
 
   for (const [scenarioOffset, entry] of input.catalog.scenarios.entries()) {
     const scenarioResult = scenarios[scenarioOffset];
@@ -244,7 +283,11 @@ export async function runMatrixCorpus(
     );
     if (!renewal.ok) {
       failureCodes.push(renewal.code);
-      scenarios[scenarioOffset] = { ...scenarioResult, status: 'stopped' };
+      pendingStoppedScenario = {
+        scenarioOffset,
+        scenarioId: entry.scenario.id,
+        observedSessionId: null,
+      };
       stopped = true;
       break;
     }
@@ -266,6 +309,7 @@ export async function runMatrixCorpus(
       );
       let portBehavioralFailureCode: string | undefined;
       if (!execution.ok && execution.kind !== 'behavioral_failure') {
+        sessionId ??= execution.boundSessionId ?? null;
         failureCodes.push(execution.code);
         scenarioStopped = true;
         stopped = true;
@@ -352,26 +396,41 @@ export async function runMatrixCorpus(
       revision = progress.revision;
     }
 
-    const nextStatus = scenarioStopped ? 'stopped' : scenarioFailed ? 'failed' : 'passed';
+    const nextStatus =
+      sessionId === null
+        ? 'not_run'
+        : scenarioStopped
+          ? 'stopped'
+          : scenarioFailed
+            ? 'failed'
+            : 'passed';
     scenarios[scenarioOffset] = {
       scenarioId: entry.scenario.id,
       status: nextStatus,
       completedTurns: scenarioCompletedTurns,
     };
-    const projected = await projectWithRefetch({
-      ports,
-      runId: input.runId,
-      leaseFence,
-      revision,
-      scenarioId: entry.scenario.id,
-      lifecycle: scenarioStopped ? 'stopped' : 'completed',
-      verdict: scenarioStopped ? 'not_evaluated' : scenarioFailed ? 'failed' : 'passed',
-    });
-    if (!projected.ok) {
-      failureCodes.push(projected.code);
-      stopped = true;
-    } else {
-      revision = projected.revision;
+    if (scenarioStopped) {
+      pendingStoppedScenario = {
+        scenarioOffset,
+        scenarioId: entry.scenario.id,
+        observedSessionId: sessionId,
+      };
+    } else if (sessionId !== null) {
+      const projected = await projectWithRefetch({
+        ports,
+        runId: input.runId,
+        leaseFence,
+        revision,
+        scenarioId: entry.scenario.id,
+        lifecycle: 'completed',
+        verdict: scenarioFailed ? 'failed' : 'passed',
+      });
+      if (!projected.ok) {
+        failureCodes.push(projected.code);
+        stopped = true;
+      } else {
+        revision = projected.revision;
+      }
     }
     if (stopped) break;
   }
@@ -396,6 +455,26 @@ export async function runMatrixCorpus(
     if (!quiesce.ok) return terminalFailure(quiesce.code);
     const drain = await safely(() => ports.waitForDrain({ runId: input.runId, leaseFence }));
     if (!drain.ok) return terminalFailure(drain.code);
+    if (pendingStoppedScenario !== null) {
+      const reconciled = await reconcileStoppedScenarioWithRefetch({
+        ports,
+        runId: input.runId,
+        leaseFence,
+        revision,
+        scenarioId: pendingStoppedScenario.scenarioId,
+        observedSessionId: pendingStoppedScenario.observedSessionId,
+      });
+      if (!reconciled.ok) return terminalFailure(reconciled.code);
+      revision = reconciled.revision;
+      agentCostNanoUsd += reconciled.additionalAgentCostNanoUsd;
+      const scenario = scenarios[pendingStoppedScenario.scenarioOffset];
+      if (scenario === undefined) return terminalFailure('stopped_scenario_missing');
+      scenarios[pendingStoppedScenario.scenarioOffset] = {
+        ...scenario,
+        status: reconciled.disposition === 'projected' ? 'stopped' : 'not_run',
+      };
+      pendingStoppedScenario = null;
+    }
     const staged = await safely(() =>
       ports.stageArtifacts({ runId: input.runId, leaseFence, outcome })
     );
@@ -458,6 +537,72 @@ export async function runMatrixCorpus(
       cleanupCompleted,
     };
   }
+}
+
+async function projectRunningWithRefetch(input: {
+  ports: MatrixCorpusRunPorts;
+  runId: string;
+  leaseFence: string;
+  revision: number;
+}): Promise<{ ok: true; revision: number } | { ok: false; code: string }> {
+  let revision = input.revision;
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const result = await safelyProjection(() =>
+      input.ports.projectRunning({
+        runId: input.runId,
+        leaseFence: input.leaseFence,
+        expectedRevision: revision,
+      })
+    );
+    if (result.ok) return result;
+    if (result.kind !== 'revision_conflict' || attempt === 1)
+      return { ok: false, code: result.code };
+    const current = await safely(() =>
+      input.ports.getProjectionRevision({ runId: input.runId, leaseFence: input.leaseFence })
+    );
+    if (!current.ok) return current;
+    revision = current.value.revision;
+  }
+  return { ok: false, code: 'running_projection_retry_exhausted' };
+}
+
+async function reconcileStoppedScenarioWithRefetch(input: {
+  ports: MatrixCorpusRunPorts;
+  runId: string;
+  leaseFence: string;
+  revision: number;
+  scenarioId: string;
+  observedSessionId: string | null;
+}): Promise<
+  | {
+      ok: true;
+      revision: number;
+      disposition: 'projected' | 'not_bound';
+      additionalAgentCostNanoUsd: number;
+    }
+  | { ok: false; code: string }
+> {
+  let revision = input.revision;
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const result = await safelyStoppedScenarioReconciliation(() =>
+      input.ports.reconcileStoppedScenario({
+        runId: input.runId,
+        leaseFence: input.leaseFence,
+        expectedRevision: revision,
+        scenarioId: input.scenarioId,
+        observedSessionId: input.observedSessionId,
+      })
+    );
+    if (result.ok) return result;
+    if (result.kind !== 'revision_conflict' || attempt === 1)
+      return { ok: false, code: result.code };
+    const current = await safely(() =>
+      input.ports.getProjectionRevision({ runId: input.runId, leaseFence: input.leaseFence })
+    );
+    if (!current.ok) return current;
+    revision = current.value.revision;
+  }
+  return { ok: false, code: 'stopped_scenario_reconciliation_retry_exhausted' };
 }
 
 async function projectWithRefetch(input: {
@@ -733,6 +878,16 @@ async function safelyJudge(
 async function safelyProjection(
   operation: () => Promise<MatrixCorpusProjectionMutationResult>
 ): Promise<MatrixCorpusProjectionMutationResult> {
+  try {
+    return await operation();
+  } catch {
+    return { ok: false, kind: 'failed', code: 'unexpected_projection_failure' };
+  }
+}
+
+async function safelyStoppedScenarioReconciliation(
+  operation: () => Promise<MatrixCorpusStoppedScenarioReconciliationResult>
+): Promise<MatrixCorpusStoppedScenarioReconciliationResult> {
   try {
     return await operation();
   } catch {


### PR DESCRIPTION
## Summary

- normalize Meta Unix-second timestamps before Matrix corpus ingest attestation
- allow tightly scoped signing recovery for claimed abandoned terminal controls
- persist running state and reconcile late session binding/evidence after transport drain
- keep runner, projection, report usage, judge, and strict-mock statuses consistent across CAS retries

## Verification

- `pnpm run ci:tracked` (6,696 tests, coverage, build, static validation)
- `pnpm --filter @intexuraos/intex-agent-evals validate` (931 tests)
- independent security, test/architecture, and UX reviews: READY

## Linear

- Linear: [INT-1894](https://linear.app/pbuchman/issue/INT-1894)
- IntexuraOS Code Task: [View task](https://intexuraos.cloud/#/code-tasks/task_8bdc896f-1c9c-4f4c-859c-0c6850133617)
- Worker Type: `codex-xhigh`
- Model: `default`