### PR TITLE
[INT-1895] fix: accept padded WhatsApp transport ids

### DIFF
--- a/apps/intex-agent/src/__tests__/infra/firestore/testConfirmationRepository.test.ts
+++ b/apps/intex-agent/src/__tests__/infra/firestore/testConfirmationRepository.test.ts
@@ -14,6 +14,7 @@ import {
 
 const createdAt = '2026-07-20T10:00:00.000Z';
 const expiresAt = '2026-07-20T10:05:00.000Z';
+const paddedWamid = `wamid.${'A'.repeat(58)}==`;
 
 function identity(
   overrides: Partial<MatrixCorpusTestConfirmationIdentity> = {}
@@ -224,6 +225,32 @@ describe('FirestoreTestConfirmationRepository', () => {
         pendingInput({ toolName: 'create_calendar_event' as const })
       )
     ).resolves.toEqual({ ok: false, code: 'CORRELATED_REPLAY_CONFLICT' });
+  });
+
+  it('resolves and reads a confirmation using a padded Meta transport message id', async () => {
+    const { repository } = fixture();
+    await repository.createOrGet(pendingInput());
+
+    await expect(
+      repository.resolveExact({
+        identity: identity(),
+        decision: 'confirm',
+        resolutionMessageId: paddedWamid,
+        now: '2026-07-20T10:01:00.000Z',
+      })
+    ).resolves.toMatchObject({
+      ok: true,
+      disposition: 'applied',
+      confirmation: {
+        state: 'resolved',
+        decision: 'confirm',
+        resolutionMessageId: paddedWamid,
+      },
+    });
+    await expect(repository.getExact({ ...identity(), now: createdAt })).resolves.toMatchObject({
+      ok: true,
+      confirmation: { resolutionMessageId: paddedWamid },
+    });
   });
 
   it.each([

--- a/apps/intex-agent/src/domain/matrixCorpus/contextCrypto.ts
+++ b/apps/intex-agent/src/domain/matrixCorpus/contextCrypto.ts
@@ -8,6 +8,7 @@ import {
   intexAgentToolNameV1Schema,
   matrixCorpusDecimalFenceSchema,
   matrixCorpusSafeIdSchema,
+  matrixCorpusTransportMessageIdSchema,
 } from '@intexuraos/http-contracts';
 
 const AES_256_KEY_BYTES = 32;
@@ -236,7 +237,7 @@ function hasValidConfirmationResolutionBinding(binding: Record<string, unknown>)
   return (
     binding['state'] === 'resolved' &&
     (binding['decision'] === 'confirm' || binding['decision'] === 'reject') &&
-    matrixCorpusSafeIdSchema.safeParse(binding['resolutionMessageId']).success &&
+    matrixCorpusTransportMessageIdSchema.safeParse(binding['resolutionMessageId']).success &&
     isRfc3339(binding['resolvedAt'])
   );
 }

--- a/apps/intex-agent/src/infra/firestore/testConfirmationRepository.ts
+++ b/apps/intex-agent/src/infra/firestore/testConfirmationRepository.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'node:crypto';
 
+import { matrixCorpusTransportMessageIdSchema } from '@intexuraos/http-contracts';
 import type { Firestore } from '@intexuraos/infra-firestore';
 
 import type {
@@ -131,7 +132,7 @@ export class FirestoreTestConfirmationRepository implements TestConfirmationRepo
   async resolveExact(
     input: Parameters<TestConfirmationRepository['resolveExact']>[0]
   ): Promise<MatrixCorpusTestConfirmationResolveResult> {
-    if (!isRfc3339(input.now) || !isSafeId(input.resolutionMessageId))
+    if (!isRfc3339(input.now) || !isTransportMessageId(input.resolutionMessageId))
       return { ok: false, code: 'CORRUPT_CONFIRMATION' };
     const ref = this.confirmationRef(input.identity.confirmationId);
     return await this.firestore.runTransaction(async (transaction) => {
@@ -346,6 +347,10 @@ function isSafeId(value: unknown): value is string {
   return typeof value === 'string' && safeIdPattern.test(value);
 }
 
+function isTransportMessageId(value: unknown): value is string {
+  return matrixCorpusTransportMessageIdSchema.safeParse(value).success;
+}
+
 function isValidCreateInput(
   input: Parameters<TestConfirmationRepository['createOrGet']>[0]
 ): boolean {
@@ -440,7 +445,7 @@ function hasValidResolutionState(record: Record<string, unknown>): boolean {
   return (
     record['state'] === 'resolved' &&
     (record['decision'] === 'confirm' || record['decision'] === 'reject') &&
-    isSafeId(record['resolutionMessageId']) &&
+    isTransportMessageId(record['resolutionMessageId']) &&
     isRfc3339(record['createdAt']) &&
     isRfc3339(record['expiresAt']) &&
     isRfc3339(record['resolvedAt']) &&

--- a/apps/whatsapp-service/src/__tests__/infra/firestore/matrixCorpusIngress.test.ts
+++ b/apps/whatsapp-service/src/__tests__/infra/firestore/matrixCorpusIngress.test.ts
@@ -113,6 +113,30 @@ describe('Firestore Matrix corpus ingress', () => {
     );
   });
 
+  it('accepts a real-shaped Meta WAMID with terminal base64 padding', async () => {
+    const current = ingressFixture(storedCapability());
+    const metaMessageId = `wamid.${'A'.repeat(58)}==`;
+
+    await expect(
+      current.ingress.consumeReservedMessage({
+        ...startInput(),
+        transportMessageId: metaMessageId,
+      })
+    ).resolves.toEqual({ code: 'INGEST_ENQUEUED' });
+
+    expect(current.consumeCapabilityAndEnqueueIngest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        transportMessageId: metaMessageId,
+        facts: expect.objectContaining({
+          ingressRequest: expect.objectContaining({ ordinaryMessageId: metaMessageId }),
+          payload: expect.objectContaining({
+            ordinaryIngest: expect.objectContaining({ messageId: metaMessageId }),
+          }),
+        }),
+      })
+    );
+  });
+
   it.each([
     ['non-numeric transport timestamp', 'not-a-timestamp'],
     ['unsafe Unix-seconds integer', '9999999999999'],

--- a/packages/http-contracts/src/__tests__/matrixCorpus.test.ts
+++ b/packages/http-contracts/src/__tests__/matrixCorpus.test.ts
@@ -32,6 +32,7 @@ import {
   matrixCorpusPromptDigestInputSchema,
   matrixCorpusRfc3339TimestampSchema,
   matrixCorpusSafeIdSchema,
+  matrixCorpusTransportMessageIdSchema,
   matrixCorpusSha256DigestSchema,
   matrixCorpusSignedIngestV1Schema,
   matrixCorpusSignedControlMutationV1Schema,
@@ -275,6 +276,11 @@ describe('Matrix corpus shared contract', () => {
     expect(matrixCorpusSafeIdSchema.safeParse('auth0|operator_1').success).toBe(true);
     for (const invalid of ['', 'has space', 'mail@example.com', '🧪']) {
       expect(matrixCorpusSafeIdSchema.safeParse(invalid).success).toBe(false);
+    }
+    const paddedWamid = `wamid.${'A'.repeat(58)}==`;
+    expect(matrixCorpusTransportMessageIdSchema.safeParse(paddedWamid).success).toBe(true);
+    for (const invalid of ['wamid.bad=padding', 'wamid.has space', `wamid.${'A'.repeat(250)}==`]) {
+      expect(matrixCorpusTransportMessageIdSchema.safeParse(invalid).success).toBe(false);
     }
     expect(matrixCorpusRfc3339TimestampSchema.safeParse(now).success).toBe(true);
     expect(matrixCorpusRfc3339TimestampSchema.safeParse('2026-07-19T00:00:00Z').success).toBe(true);

--- a/packages/http-contracts/src/index.ts
+++ b/packages/http-contracts/src/index.ts
@@ -131,6 +131,7 @@ export {
   matrixCorpusKeyedDigestSchema,
   matrixCorpusDecimalFenceSchema,
   matrixCorpusSafeIdSchema,
+  matrixCorpusTransportMessageIdSchema,
   matrixCorpusRfc3339TimestampSchema,
   matrixCorpusIanaTimeZoneSchema,
   matrixCorpusPromptDigestInputSchema,

--- a/packages/http-contracts/src/matrixCorpus.ts
+++ b/packages/http-contracts/src/matrixCorpus.ts
@@ -17,6 +17,7 @@ export const MATRIX_CORPUS_MAX_COMPACT_JWS_CODE_UNITS =
 
 const SHA_256_DIGEST_PATTERN = /^[0-9a-f]{64}$/;
 const SAFE_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:|-]{0,127}$/;
+const TRANSPORT_MESSAGE_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,253}={0,2}$/;
 const MOCK_ID_PATTERN = /^mock_[A-Za-z0-9_-]{1,120}$/;
 const MOCK_PREFERENCE_ID_PATTERN = /^mock_pref_[A-Za-z0-9_-]{1,112}$/;
 const BASE64URL_SEGMENT_PATTERN = /^[A-Za-z0-9_-]+$/;
@@ -25,6 +26,14 @@ export const matrixCorpusSha256DigestSchema = z.string().regex(SHA_256_DIGEST_PA
 export const matrixCorpusKeyedDigestSchema = matrixCorpusSha256DigestSchema;
 export const matrixCorpusDecimalFenceSchema = z.string().regex(/^[1-9][0-9]{0,19}$/);
 export const matrixCorpusSafeIdSchema = z.string().regex(SAFE_ID_PATTERN);
+/**
+ * Meta WAMIDs are opaque transport identifiers and may end in base64 padding.
+ * Keep that allowance isolated from the stricter internal-ID contract.
+ */
+export const matrixCorpusTransportMessageIdSchema = z
+  .string()
+  .max(256)
+  .regex(TRANSPORT_MESSAGE_ID_PATTERN);
 const safeIdSchema = matrixCorpusSafeIdSchema;
 const boundedTextSchema = z.string().min(1).max(4096);
 const cannedMessageSchema = z.string().min(1).max(1024);
@@ -552,7 +561,7 @@ export const matrixCorpusOrdinaryIngestV1Schema = z
   .object({
     type: z.literal('intex.message.ingest'),
     userId: safeIdSchema,
-    messageId: safeIdSchema,
+    messageId: matrixCorpusTransportMessageIdSchema,
     text: boundedTextSchema,
     sourceType: z.literal('whatsapp_text'),
     timestamp: rfc3339Schema,
@@ -744,7 +753,7 @@ export const matrixCorpusCanonicalIngressDigestInputV1Schema = z
     expectedSessionId: safeIdSchema.nullable(),
     pendingConfirmationId: safeIdSchema.nullable(),
     expectedDecision: z.enum(['confirm', 'reject']).nullable(),
-    ordinaryMessageId: safeIdSchema,
+    ordinaryMessageId: matrixCorpusTransportMessageIdSchema,
     ordinaryTimestamp: rfc3339Schema,
     ingestReceiptId: safeIdSchema,
     payloadDigest: matrixCorpusSha256DigestSchema,


### PR DESCRIPTION
## Summary

- accept real Meta WAMIDs with terminal base64 padding in Matrix corpus ingress
- preserve strict internal IDs while using a dedicated transport-message contract
- support the same padded IDs through confirmation encryption and correlation

## Verification

- `pnpm run ci:tracked` (6,696 tests passed)
- subagent security, test, and UX reviews: READY

## Linear

Linear: omitted by `$commit-push`; GitHub automation will create or link the Linear issue after PR creation.

## Automated Review

- Linear: [INT-1895](https://linear.app/pbuchman/issue/INT-1895)
- IntexuraOS Code Task: [View task](https://intexuraos.cloud/#/code-tasks/task_d9b67b04-050b-4bbe-a4b3-43c88da27659)
- Worker Type: `codex-xhigh`
- Model: `default`
