### PR TITLE
[INT-1897] fix: preserve production corpus secrets

### DIFF
--- a/scripts/__tests__/hetzner-runtime.test.ts
+++ b/scripts/__tests__/hetzner-runtime.test.ts
@@ -1,7 +1,8 @@
-import { execFileSync, spawnSync } from 'node:child_process';
+import { execFileSync, spawnSync, type SpawnSyncReturns } from 'node:child_process';
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { resolve } from 'node:path';
+import { parse as parseDotenv } from 'dotenv';
 import { describe, expect, it } from 'vitest';
 
 const repoRoot = resolve(__dirname, '..', '..');
@@ -17,6 +18,10 @@ const pubsubPublishTestPath = resolve(repoRoot, 'scripts/pubsub-publish-test.mjs
 const installNginxPath = resolve(repoRoot, 'scripts/hetzner/install-nginx-and-cert.sh');
 const provisionPath = resolve(repoRoot, 'scripts/hetzner/provision.sh');
 const githubActionsDeployPath = resolve(repoRoot, 'scripts/hetzner/github-actions-deploy.sh');
+const verifyMatrixCorpusRuntimePath = resolve(
+  repoRoot,
+  'scripts/hetzner/verify-matrix-corpus-runtime.sh'
+);
 const deploymentDocumentVerifierPath = resolve(
   repoRoot,
   'scripts/hetzner/verify-deployment-document.mjs'
@@ -1361,6 +1366,73 @@ describe('Hetzner async edge cutover', () => {
 });
 
 describe('Hetzner secret loader', () => {
+  it('round-trips JSON secret material through the generated dotenv file', () => {
+    const directory = mkdtempSync(resolve(tmpdir(), 'intexuraos-secret-loader-'));
+    const outputPath = resolve(directory, '.env.prod');
+    const gcloudPath = resolve(directory, 'gcloud');
+    const installPath = resolve(directory, 'install');
+    const secretValue = JSON.stringify({
+      crv: 'Ed25519',
+      d: 'd'.repeat(43),
+      kid: 'production-test-v1',
+      kty: 'OKP',
+      x: 'x'.repeat(43),
+    });
+    const currentUser = execFileSync('id', ['-u'], { encoding: 'utf8' }).trim();
+    const currentGroup = execFileSync('id', ['-g'], { encoding: 'utf8' }).trim();
+
+    try {
+      writeFileSync(gcloudPath, '#!/usr/bin/env bash\nprintf \'%s\' "${MOCK_SECRET_VALUE}"\n', {
+        mode: 0o755,
+      });
+      writeFileSync(
+        installPath,
+        [
+          '#!/usr/bin/env bash',
+          'set -euo pipefail',
+          'if [[ "$1" == "-d" ]]; then',
+          '  mkdir -p "${@: -1}"',
+          'else',
+          '  cp "${@: -2:1}" "${@: -1}"',
+          'fi',
+          '',
+        ].join('\n'),
+        { mode: 0o755 }
+      );
+      const result = spawnSync(
+        'bash',
+        [
+          loadSecretsPath,
+          '--output',
+          outputPath,
+          '--secret',
+          'INTEXURAOS_MATRIX_CORPUS_SIGNING_PRIVATE_KEY',
+        ],
+        {
+          cwd: repoRoot,
+          encoding: 'utf8',
+          env: {
+            ...process.env,
+            PATH: `${directory}:${process.env.PATH ?? ''}`,
+            INTEXURAOS_ENVIRONMENT: 'prod',
+            DEPLOY_USER: currentUser,
+            NGINX_TOKEN_GROUP: currentGroup,
+            MOCK_SECRET_VALUE: secretValue,
+            PROVISIONER_SA_KEY_FILE: resolve(directory, 'missing-provisioner-key.json'),
+            RUNTIME_SA_KEY_FILE: resolve(directory, 'runtime-key.json'),
+            INTERNAL_AUTH_TOKEN_FILE: resolve(directory, 'internal-auth-token'),
+          },
+        }
+      );
+
+      expect(result.status, result.stderr).toBe(0);
+      const parsed = parseDotenv(readFileSync(outputPath, 'utf8'));
+      expect(parsed['INTEXURAOS_MATRIX_CORPUS_SIGNING_PRIVATE_KEY']).toBe(secretValue);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
   it('declares and loads the complete production Matrix corpus secret inventory', () => {
     const script = readRequired(loadSecretsPath);
     const terraform = readRequired(terraformDevMainPath);
@@ -1651,6 +1723,88 @@ describe('Hetzner secret loader', () => {
     expect(hetznerImports).not.toContain(
       retiredDashed('intexuraos', 'todos', 'processing', 'prod', 'hetzner')
     );
+  });
+});
+
+describe('Hetzner Matrix corpus runtime verification', () => {
+  it('verifies the effective PM2 app configuration instead of sourcing the secret file', () => {
+    const directory = mkdtempSync(resolve(tmpdir(), 'intexuraos-corpus-runtime-'));
+    const renderedConfigPath = resolve(directory, 'ecosystem.json');
+    const curlPath = resolve(directory, 'curl');
+    const runtimeEnv = {
+      INTEXURAOS_INTERNAL_AUTH_TOKEN: 'test-internal-token',
+      INTEXURAOS_MATRIX_CORPUS_ENABLED: 'true',
+      INTEXURAOS_MATRIX_CORPUS_EVALUATOR_USER_ID: 'user-test-1',
+      INTEXURAOS_MATRIX_CORPUS_RUNTIME_AUDIENCE: 'hetzner-prod',
+      INTEXURAOS_MATRIX_CORPUS_TRUSTED_RUNTIME: 'hetzner-prod',
+    };
+
+    try {
+      writeFileSync(
+        renderedConfigPath,
+        JSON.stringify({
+          apps: [
+            { name: 'whatsapp-service', env: runtimeEnv },
+            { name: 'intex-agent', env: runtimeEnv },
+          ],
+        })
+      );
+      writeFileSync(
+        curlPath,
+        [
+          '#!/usr/bin/env bash',
+          'set -euo pipefail',
+          'output=""',
+          'url=""',
+          'while [[ $# -gt 0 ]]; do',
+          '  case "$1" in',
+          '    --output) output="$2"; shift 2 ;;',
+          '    http://*) url="$1"; shift ;;',
+          '    *) shift ;;',
+          '  esac',
+          'done',
+          'if [[ "$url" == *"/readiness" ]]; then',
+          '  printf \'%s\' \'{"success":true,"data":{"status":"ready"},"diagnostics":{}}\' > "$output"',
+          'else',
+          '  printf \'%s\' \'{"success":true,"data":{"kind":"admission_ready","current":{}},"diagnostics":{}}\' > "$output"',
+          'fi',
+          '',
+        ].join('\n'),
+        { mode: 0o755 }
+      );
+
+      const verify = (configPath: string): SpawnSyncReturns<string> =>
+        spawnSync('bash', [verifyMatrixCorpusRuntimePath], {
+          cwd: repoRoot,
+          encoding: 'utf8',
+          env: {
+            ...process.env,
+            PATH: `${directory}:${process.env.PATH ?? ''}`,
+            INTEXURAOS_ENVIRONMENT: 'prod',
+            RENDERED_CONFIG: configPath,
+            ENV_FILE: resolve(directory, 'missing.env.prod'),
+          },
+        });
+
+      const accepted = verify(renderedConfigPath);
+      expect(accepted.status, accepted.stderr).toBe(0);
+
+      writeFileSync(
+        renderedConfigPath,
+        JSON.stringify({
+          apps: [
+            { name: 'whatsapp-service', env: runtimeEnv },
+            {
+              name: 'intex-agent',
+              env: { ...runtimeEnv, INTEXURAOS_MATRIX_CORPUS_RUNTIME_AUDIENCE: 'home-dev' },
+            },
+          ],
+        })
+      );
+      expect(verify(renderedConfigPath).status).not.toBe(0);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
   });
 });
 

--- a/scripts/hetzner/load-secrets.sh
+++ b/scripts/hetzner/load-secrets.sh
@@ -153,7 +153,6 @@ dotenv_escape() {
   local value="$1"
 
   value="${value//\\/\\\\}"
-  value="${value//\"/\\\"}"
   value="${value//$'\n'/\\n}"
   value="${value//$'\r'/\\r}"
   printf '"%s"' "${value}"

--- a/scripts/hetzner/verify-matrix-corpus-runtime.sh
+++ b/scripts/hetzner/verify-matrix-corpus-runtime.sh
@@ -3,28 +3,58 @@
 set -euo pipefail
 umask 077
 
-ENV_FILE="${ENV_FILE:-/etc/intexuraos/.env.prod}"
+RENDERED_CONFIG="${RENDERED_CONFIG:-/home/deploy/.pm2/intexuraos-prod-ecosystem.json}"
 [[ "${INTEXURAOS_ENVIRONMENT:-}" == 'prod' ]] || exit 1
-[[ -r "${ENV_FILE}" ]] || exit 1
-
-set -a
-# shellcheck disable=SC1090
-source "${ENV_FILE}"
-set +a
-
-[[ "${INTEXURAOS_MATRIX_CORPUS_ENABLED:-}" == 'true' ]] || exit 1
-[[ "${INTEXURAOS_MATRIX_CORPUS_TRUSTED_RUNTIME:-}" == 'hetzner-prod' ]] || exit 1
-[[ "${INTEXURAOS_MATRIX_CORPUS_RUNTIME_AUDIENCE:-}" == 'hetzner-prod' ]] || exit 1
-[[ "${INTEXURAOS_MATRIX_CORPUS_EVALUATOR_USER_ID:-}" =~ ^[A-Za-z0-9][A-Za-z0-9._:|-]{0,127}$ ]] || exit 1
-[[ -n "${INTEXURAOS_INTERNAL_AUTH_TOKEN:-}" ]] || exit 1
+[[ -r "${RENDERED_CONFIG}" ]] || exit 1
 
 temporary_directory="$(mktemp -d "${TMPDIR:-/tmp}/intexuraos-matrix-corpus-readiness.XXXXXX")"
 trap 'rm -rf -- "${temporary_directory}"' EXIT
 chmod 700 "${temporary_directory}"
 
-printf 'X-Internal-Auth: %s\n' "${INTEXURAOS_INTERNAL_AUTH_TOKEN}" > "${temporary_directory}/auth-header"
-node -e 'require("node:fs").writeFileSync(process.argv[1], JSON.stringify({ runtimeAudience: "hetzner-prod", userId: process.env.INTEXURAOS_MATRIX_CORPUS_EVALUATOR_USER_ID }))' \
-  "${temporary_directory}/acceptance-request.json"
+node - \
+  "${RENDERED_CONFIG}" \
+  "${temporary_directory}/auth-header" \
+  "${temporary_directory}/acceptance-request.json" <<'NODE'
+const fs = require('node:fs');
+
+const config = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+if (config === null || typeof config !== 'object' || !Array.isArray(config.apps)) process.exit(1);
+
+const app = (name) => {
+  const matches = config.apps.filter((candidate) => candidate?.name === name);
+  if (matches.length !== 1) process.exit(1);
+  const env = matches[0]?.env;
+  if (env === null || typeof env !== 'object' || Array.isArray(env)) process.exit(1);
+  return env;
+};
+const whatsapp = app('whatsapp-service');
+const intex = app('intex-agent');
+const safeUserId = /^[A-Za-z0-9][A-Za-z0-9._:|-]{0,127}$/u;
+
+for (const env of [whatsapp, intex]) {
+  if (env.INTEXURAOS_MATRIX_CORPUS_ENABLED !== 'true') process.exit(1);
+  if (env.INTEXURAOS_MATRIX_CORPUS_TRUSTED_RUNTIME !== 'hetzner-prod') process.exit(1);
+  if (env.INTEXURAOS_MATRIX_CORPUS_RUNTIME_AUDIENCE !== 'hetzner-prod') process.exit(1);
+  if (!safeUserId.test(env.INTEXURAOS_MATRIX_CORPUS_EVALUATOR_USER_ID ?? '')) process.exit(1);
+  if (typeof env.INTEXURAOS_INTERNAL_AUTH_TOKEN !== 'string' || env.INTEXURAOS_INTERNAL_AUTH_TOKEN.length === 0)
+    process.exit(1);
+}
+if (whatsapp.INTEXURAOS_MATRIX_CORPUS_EVALUATOR_USER_ID !== intex.INTEXURAOS_MATRIX_CORPUS_EVALUATOR_USER_ID)
+  process.exit(1);
+if (whatsapp.INTEXURAOS_INTERNAL_AUTH_TOKEN !== intex.INTEXURAOS_INTERNAL_AUTH_TOKEN) process.exit(1);
+
+fs.writeFileSync(process.argv[3], `X-Internal-Auth: ${whatsapp.INTEXURAOS_INTERNAL_AUTH_TOKEN}\n`, {
+  mode: 0o600,
+});
+fs.writeFileSync(
+  process.argv[4],
+  JSON.stringify({
+    runtimeAudience: 'hetzner-prod',
+    userId: whatsapp.INTEXURAOS_MATRIX_CORPUS_EVALUATOR_USER_ID,
+  }),
+  { mode: 0o600 }
+);
+NODE
 
 curl --fail --silent --show-error --max-time 10 \
   --header "@${temporary_directory}/auth-header" \


### PR DESCRIPTION
## Summary

- preserve JSON JWK secret values when writing the production dotenv file
- verify corpus readiness from the effective PM2 app configuration instead of sourcing the secret file
- add executable regressions for JSON secret round-tripping and production runtime verification

## Root cause

The secret loader escaped inner JSON quotes, while `dotenv` intentionally retained those backslashes. WhatsApp and Intex therefore received non-JSON key material and restarted. The deployment verifier also looked for non-secret corpus flags in the secret file instead of the rendered PM2 configuration.

## Verification

- `pnpm run ci:tracked` — passed (6715 tests, coverage validation, build and format)
- Hetzner secret/PM2 suites — 60 passed
- fixed loader restored all 18 production processes and sustained health checks
- fixed runtime verifier passed against the live Hetzner PM2 configuration and production readiness endpoints

- Linear: [INT-1897](https://linear.app/pbuchman/issue/INT-1897)
- IntexuraOS Code Task: [View task](https://intexuraos.cloud/#/code-tasks/task_5775b69f-b2c8-402c-830a-ff3df87cc08f)
- Worker Type: `codex-xhigh`
- Model: `default`
