### PR TITLE
[INT-1898] Fix production Matrix corpus preflight

### DIFF
--- a/tools/intex-agent-evals/src/__tests__/matrixCorpusLiveRuntime.test.ts
+++ b/tools/intex-agent-evals/src/__tests__/matrixCorpusLiveRuntime.test.ts
@@ -4,6 +4,9 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import type { IntexAgentServiceClient, WhatsAppServiceClient } from '@intexuraos/internal-clients';
+import type { OpenRouterCatalogClient } from '@intexuraos/infra-openrouter';
+
 vi.mock('firebase-admin/app', () => ({
   applicationDefault: vi.fn(),
   getApp: vi.fn(),
@@ -18,6 +21,7 @@ vi.mock('firebase-admin/auth', () => ({
 import { loadCanonicalMatrixCorpus } from '../matrixCorpus/catalog.js';
 import {
   createMatrixCorpusLiveRuntime,
+  createProductionMatrixCorpusLiveReadPort,
   inspectArtifactRoot,
   inspectHomeDevRuntime,
   listHomeDevFirestoreCompositeIndexes,
@@ -27,6 +31,13 @@ import {
   type HomeDevRuntimeInspectionDeps,
   type MatrixCorpusPreparedContext,
 } from '../matrixCorpus/liveRuntime.js';
+import type { MatrixClient } from '../live/matrixClient.js';
+import {
+  canonicalizeEvaluatorConfig,
+  MATRIX_ADAPTER_HEALTH_URL,
+  type EvaluatorConfig,
+  type SetupPorts,
+} from '../preflight.js';
 import type { MatrixCorpusPreflightSnapshot } from '../matrixCorpus/preflight.js';
 import type { MatrixCorpusRunResult } from '../matrixCorpus/runMatrixCorpus.js';
 
@@ -105,6 +116,169 @@ describe('Matrix corpus live runtime handoff', () => {
 });
 
 describe('production Hetzner runtime inspection from the Home Dev runner', () => {
+  it('reads the production boundary without falling back to Home Dev product services', async () => {
+    const catalog = await loadCanonicalMatrixCorpus(scenariosDirectory);
+    const repositoryRoot = await mkdtemp(join(tmpdir(), 'matrix-corpus-production-read-'));
+    temporaryDirectories.push(repositoryRoot);
+    const artifactRoot = join(repositoryRoot, '.artifacts', 'intex-agent-evals');
+    await mkdir(artifactRoot, { recursive: true, mode: 0o700 });
+    await chmod(artifactRoot, 0o700);
+
+    const evaluatorUserId = 'auth0|production-evaluator';
+    const matrixUserId = '@operator:matrix.test';
+    const puppetUserId = '@whatsapp_1:matrix.test';
+    const config: EvaluatorConfig = {
+      schemaVersion: 1,
+      accountAlias: 'Production evaluator',
+      userId: evaluatorUserId,
+      matrixUserId,
+      matrixAccessTokenFile: '/home/operator/.config/matrix-token',
+      matrixTargetsFile: '/home/operator/.config/matrix-targets.json',
+    };
+    const env: NodeJS.ProcessEnv = {
+      GOOGLE_APPLICATION_CREDENTIALS: '/synthetic/service-account.json',
+      INTEXURAOS_ENVIRONMENT: 'prod',
+      INTEXURAOS_INTERNAL_AUTH_TOKEN: 'synthetic-internal-token',
+      INTEXURAOS_GCP_PROJECT_ID: 'intexuraos-dev-test',
+      INTEXURAOS_OPENROUTER_APP_API_KEY: 'synthetic-openrouter-key',
+      INTEXURAOS_MATRIX_CORPUS_BINDING_HMAC_KEY: 'synthetic-hmac-key',
+      INTEXURAOS_MATRIX_CORPUS_ENABLED: 'true',
+      INTEXURAOS_MATRIX_CORPUS_TRUSTED_RUNTIME: 'hetzner-prod',
+      INTEXURAOS_MATRIX_CORPUS_RUNTIME_AUDIENCE: 'hetzner-prod',
+      INTEXURAOS_MATRIX_CORPUS_EVALUATOR_USER_ID: evaluatorUserId,
+      INTEXURAOS_MATRIX_CORPUS_MATRIX_PUPPET_USER_ID: puppetUserId,
+      INTEXURAOS_EVAL_REQUESTED_REVISION: 'a'.repeat(40),
+      INTEXURAOS_EVAL_WRAPPER_ATTESTED: 'true',
+      INTEXURAOS_EVAL_LOCAL_CRITICAL_PATHS_CLEAN: 'true',
+    };
+    const matrix = {
+      whoAmI: vi.fn(async () => ({ ok: true as const, userId: matrixUserId })),
+      syncTargetRoom: vi.fn(async () => ({
+        ok: true as const,
+        nextBatch: 'next-batch',
+        limited: false,
+        events: [
+          {
+            type: 'm.room.message' as const,
+            sender: puppetUserId,
+            content: { msgtype: 'm.text' as const, body: 'historical reply' },
+          },
+        ],
+      })),
+    } as unknown as MatrixClient;
+    const setup: SetupPorts = {
+      configPath: '/home/operator/.config/intexuraos/intex-agent-evals.json',
+      runtime: {
+        platform: () => 'linux',
+        hostname: () => 'home-dev',
+        uid: () => process.getuid?.() ?? 1000,
+        env: (name) => env[name],
+      },
+      protectedFiles: {
+        read: vi.fn(async (path) => {
+          if (path === config.matrixAccessTokenFile) {
+            return { ok: true as const, contents: 'synthetic-matrix-token' };
+          }
+          if (path === config.matrixTargetsFile) {
+            return {
+              ok: true as const,
+              contents: JSON.stringify({
+                'source-account': { intex_agent: '!agent-room:matrix.test' },
+              }),
+            };
+          }
+          return { ok: true as const, contents: canonicalizeEvaluatorConfig(config) };
+        }),
+        validatePrivateDirectory: vi.fn(async () => ({ ok: true as const })),
+        ensurePrivateDirectory: vi.fn(async () => ({ ok: true as const })),
+        createExclusive: vi.fn(async () => ({ state: 'exists' as const })),
+      },
+      healthHttp: {
+        get: vi.fn(async (url) => {
+          if (url !== MATRIX_ADAPTER_HEALTH_URL) {
+            throw new Error('Home Dev product health must not be called');
+          }
+          return {
+            ok: true as const,
+            status: 200,
+            body: {
+              ok: true,
+              state: 'running',
+              homeserverUrl: 'https://matrix.test',
+              matrixUserId,
+              ingestUrl: 'http://127.0.0.1:8113/internal/whatsapp/private/matrix/events',
+              sourceAccountId: 'source-account',
+              counters: { received: 1 },
+            },
+          };
+        }),
+      },
+      firebaseIdentity: {
+        getUserState: vi.fn(async () => ({ ok: true as const, state: 'enabled' as const })),
+      },
+      matrix,
+      whatsapp: {
+        getDeliveryStatus: vi.fn(async () => {
+          throw new Error('Home Dev WhatsApp delivery must not be called');
+        }),
+      },
+    };
+    const intex = {
+      getMatrixCorpusCurrentAcceptance: vi.fn(async () => ({
+        ok: true as const,
+        value: { kind: 'admission_ready' as const, current: 'absent' as const },
+      })),
+    } as unknown as IntexAgentServiceClient;
+    const whatsapp = {
+      getMatrixCorpusReadiness: vi.fn(async () => ({
+        ok: true as const,
+        value: { status: 'ready' as const },
+      })),
+    } as unknown as WhatsAppServiceClient;
+    const modelCatalog = {
+      getIntexAgentCatalogEvidence: vi.fn(async () => ({
+        snapshotVersion: '2026-07-19' as const,
+        fetchedAt: new Date().toISOString(),
+        models: [{ id: catalog.agentModel }, { id: catalog.evaluatorModel }],
+      })),
+    } as unknown as OpenRouterCatalogClient;
+
+    const read = createProductionMatrixCorpusLiveReadPort({
+      matrix,
+      repositoryRoot,
+      env,
+      intex,
+      whatsapp,
+      catalog: modelCatalog,
+      inspectFirestoreIndexes: async () => true,
+      inspectRuntime: async () => ({
+        ready: true,
+        deployedRevision: 'a'.repeat(40),
+        criticalPathsClean: true,
+      }),
+      setup,
+    });
+
+    const result = await read.read(catalog);
+
+    expect(result.snapshot).toMatchObject({
+      environmentAlias: 'prod',
+      runtimeAudience: 'hetzner-prod',
+      servicesReady: true,
+      userReady: true,
+      accountTupleCount: 1,
+      matrixReady: true,
+      whatsappReady: true,
+      modelBoundaryReady: true,
+      runAdmission: 'absent',
+    });
+    expect(intex.getMatrixCorpusCurrentAcceptance).toHaveBeenCalledWith(evaluatorUserId);
+    expect(whatsapp.getMatrixCorpusReadiness).toHaveBeenCalledOnce();
+    expect(setup.healthHttp.get).toHaveBeenCalledOnce();
+    expect(setup.healthHttp.get).toHaveBeenCalledWith(MATRIX_ADAPTER_HEALTH_URL);
+    expect(setup.whatsapp.getDeliveryStatus).not.toHaveBeenCalled();
+  });
+
   it('lists paginated Firestore indexes through the bounded read-only Admin API', async () => {
     const firstIndex = requiredFirestoreIndexes()[0];
     const secondIndex = requiredFirestoreIndexes()[1];

--- a/tools/intex-agent-evals/src/__tests__/preflight.test.ts
+++ b/tools/intex-agent-evals/src/__tests__/preflight.test.ts
@@ -55,6 +55,7 @@ import {
   runPreflight,
   setupEvaluatorConfig,
   withValidatedAccountContext,
+  withValidatedProductionMatrixAccountContext,
   type EvaluatorConfig,
   type FirebaseAdminDependencies,
   type PreflightPorts,
@@ -1022,6 +1023,46 @@ describe('withValidatedAccountContext', () => {
     expect(result).toMatchObject({ ok: false, code: 'UNEXPECTED_FAILURE' });
     expect(JSON.stringify(result)).not.toContain('private callback exception sentinel');
     expect(JSON.stringify(result)).not.toContain('synthetic-matrix-token');
+  });
+});
+
+describe('withValidatedProductionMatrixAccountContext', () => {
+  it('validates the Home Dev Matrix account under prod without calling Home Dev product services', async () => {
+    const ports = createSetupPorts(VALID_CONFIG, createPreflightProtectedFiles(VALID_CONFIG));
+    ports.runtime = createRuntimePort({ INTEXURAOS_ENVIRONMENT: 'prod' });
+    ports.healthHttp.get = vi.fn(async (url) => {
+      if (url !== MATRIX_ADAPTER_HEALTH_URL) {
+        throw new Error('Home Dev product services must not be called');
+      }
+      return {
+        ok: true as const,
+        status: 200,
+        body: runningMatrixHealth(VALID_CONFIG.matrixUserId),
+      };
+    });
+    ports.whatsapp.getDeliveryStatus = vi.fn(async () => {
+      throw new Error('Home Dev WhatsApp delivery must not be called');
+    });
+    const callback = vi.fn(async (_context: ValidatedAccountContext) => undefined);
+
+    const result = await withValidatedProductionMatrixAccountContext(ports, callback);
+
+    expect(result).toEqual({
+      ok: true,
+      checks: [
+        { check: 'runtime', status: 'passed' },
+        { check: 'environment', status: 'passed' },
+        { check: 'config', status: 'passed' },
+        { check: 'matrix_files', status: 'passed' },
+        { check: 'matrix_health', status: 'passed' },
+        { check: 'firebase_identity', status: 'passed' },
+        { check: 'matrix_identity', status: 'passed' },
+      ],
+    });
+    expect(callback).toHaveBeenCalledOnce();
+    expect(ports.healthHttp.get).toHaveBeenCalledOnce();
+    expect(ports.healthHttp.get).toHaveBeenCalledWith(MATRIX_ADAPTER_HEALTH_URL);
+    expect(ports.whatsapp.getDeliveryStatus).not.toHaveBeenCalled();
   });
 });
 

--- a/tools/intex-agent-evals/src/matrixCorpus/liveRuntime.ts
+++ b/tools/intex-agent-evals/src/matrixCorpus/liveRuntime.ts
@@ -23,7 +23,8 @@ import {
   CONFIG_MAX_BYTES,
   createProductionSetupPorts,
   parseEvaluatorConfigContents,
-  withValidatedAccountContext,
+  withValidatedProductionMatrixAccountContext,
+  type SetupPorts,
   type ValidatedAccountContext,
 } from '../preflight.js';
 import type { MatrixClient } from '../live/matrixClient.js';
@@ -232,6 +233,7 @@ export function createProductionMatrixCorpusLiveReadPort(options: {
   readonly intex?: IntexAgentServiceClient;
   readonly whatsapp?: WhatsAppServiceClient;
   readonly catalog?: OpenRouterCatalogClient;
+  readonly setup?: SetupPorts;
   readonly inspectFirestoreIndexes?: () => Promise<boolean>;
   readonly inspectRuntime?: () => Promise<{
     readonly ready: boolean;
@@ -240,7 +242,7 @@ export function createProductionMatrixCorpusLiveReadPort(options: {
   }>;
 }): MatrixCorpusLiveReadPort {
   const env = options.env ?? process.env;
-  const setup = createProductionSetupPorts({ matrix: options.matrix });
+  const setup = options.setup ?? createProductionSetupPorts({ matrix: options.matrix });
   const authorizationHeaderProvider = createProductionControlAuthorizationHeaderProvider();
   const intex =
     options.intex ??
@@ -275,9 +277,12 @@ export function createProductionMatrixCorpusLiveReadPort(options: {
       prepared: MatrixCorpusPreparedContext;
     }> {
       let account: ValidatedAccountContext | undefined;
-      const accountResult = await withValidatedAccountContext(setup, (value): void => {
-        account = value;
-      });
+      const accountResult = await withValidatedProductionMatrixAccountContext(
+        setup,
+        (value): void => {
+          account = value;
+        }
+      );
       if (!accountResult.ok || account === undefined) throw new Error('account_not_ready');
 
       const configRead = await setup.protectedFiles.read(setup.configPath, {

--- a/tools/intex-agent-evals/src/preflight.ts
+++ b/tools/intex-agent-evals/src/preflight.ts
@@ -587,7 +587,8 @@ function setupFailure(
 
 function validateRuntime(
   runtime: RuntimeIdentityPort,
-  includeMiniMaxKey: boolean
+  includeMiniMaxKey: boolean,
+  expectedEnvironment: 'dev' | 'prod'
 ):
   | { ok: true; checks: SafeCheckResult[] }
   | { ok: false; check: PreflightCheckId; code: PreflightFailureCode; checks: SafeCheckResult[] } {
@@ -605,7 +606,7 @@ function validateRuntime(
   checks.push({ check: 'runtime', status: 'passed' });
 
   if (
-    runtime.env('INTEXURAOS_ENVIRONMENT') !== 'dev' ||
+    runtime.env('INTEXURAOS_ENVIRONMENT') !== expectedEnvironment ||
     !isNonEmpty(runtime.env('INTEXURAOS_INTERNAL_AUTH_TOKEN')) ||
     !isNonEmpty(runtime.env('INTEXURAOS_GCP_PROJECT_ID')) ||
     !isNonEmpty(runtime.env('GOOGLE_APPLICATION_CREDENTIALS'))
@@ -646,7 +647,8 @@ function isHealthyService(result: SafeHttpResult, serviceName: string): boolean 
 
 async function validateAccountReadiness(
   config: EvaluatorConfig,
-  ports: AccountReadinessPorts
+  ports: AccountReadinessPorts,
+  includeHomeDevProductReadiness: boolean
 ): Promise<ReadinessResult> {
   const checks: SafeCheckResult[] = [];
   const tokenRead = await ports.protectedFiles.read(config.matrixAccessTokenFile, {
@@ -674,17 +676,19 @@ async function validateAccountReadiness(
   }
   checks.push({ check: 'matrix_files', status: 'passed' });
 
-  const intexHealth = await ports.healthHttp.get(INTEX_AGENT_HEALTH_URL);
-  if (!isHealthyService(intexHealth, 'intex-agent')) {
-    return readinessFailure(checks, 'intex_agent_health', 'INTEX_AGENT_HEALTH_FAILED');
-  }
-  checks.push({ check: 'intex_agent_health', status: 'passed' });
+  if (includeHomeDevProductReadiness) {
+    const intexHealth = await ports.healthHttp.get(INTEX_AGENT_HEALTH_URL);
+    if (!isHealthyService(intexHealth, 'intex-agent')) {
+      return readinessFailure(checks, 'intex_agent_health', 'INTEX_AGENT_HEALTH_FAILED');
+    }
+    checks.push({ check: 'intex_agent_health', status: 'passed' });
 
-  const whatsappHealth = await ports.healthHttp.get(WHATSAPP_HEALTH_URL);
-  if (!isHealthyService(whatsappHealth, 'whatsapp-service')) {
-    return readinessFailure(checks, 'whatsapp_health', 'WHATSAPP_HEALTH_FAILED');
+    const whatsappHealth = await ports.healthHttp.get(WHATSAPP_HEALTH_URL);
+    if (!isHealthyService(whatsappHealth, 'whatsapp-service')) {
+      return readinessFailure(checks, 'whatsapp_health', 'WHATSAPP_HEALTH_FAILED');
+    }
+    checks.push({ check: 'whatsapp_health', status: 'passed' });
   }
-  checks.push({ check: 'whatsapp_health', status: 'passed' });
 
   const matrixHealthResult = await ports.healthHttp.get(MATRIX_ADAPTER_HEALTH_URL);
   if (!matrixHealthResult.ok || matrixHealthResult.status !== 200) {
@@ -739,18 +743,20 @@ async function validateAccountReadiness(
   }
   checks.push({ check: 'matrix_identity', status: 'passed' });
 
-  const deliveryStatus = await ports.whatsapp.getDeliveryStatus(config.userId);
-  if (!deliveryStatus.ok) {
-    return readinessFailure(checks, 'whatsapp_delivery', 'WHATSAPP_DELIVERY_FAILED');
+  if (includeHomeDevProductReadiness) {
+    const deliveryStatus = await ports.whatsapp.getDeliveryStatus(config.userId);
+    if (!deliveryStatus.ok) {
+      return readinessFailure(checks, 'whatsapp_delivery', 'WHATSAPP_DELIVERY_FAILED');
+    }
+    const delivery = DeliveryStatusSchema.safeParse(deliveryStatus.value);
+    if (!delivery.success) {
+      return readinessFailure(checks, 'whatsapp_delivery', 'WHATSAPP_DELIVERY_FAILED');
+    }
+    if (delivery.data.status !== 'ready') {
+      return readinessFailure(checks, 'whatsapp_delivery', 'WHATSAPP_DELIVERY_NOT_READY');
+    }
+    checks.push({ check: 'whatsapp_delivery', status: 'passed' });
   }
-  const delivery = DeliveryStatusSchema.safeParse(deliveryStatus.value);
-  if (!delivery.success) {
-    return readinessFailure(checks, 'whatsapp_delivery', 'WHATSAPP_DELIVERY_FAILED');
-  }
-  if (delivery.data.status !== 'ready') {
-    return readinessFailure(checks, 'whatsapp_delivery', 'WHATSAPP_DELIVERY_NOT_READY');
-  }
-  checks.push({ check: 'whatsapp_delivery', status: 'passed' });
   return {
     ok: true,
     checks,
@@ -774,7 +780,7 @@ export async function setupEvaluatorConfig(
 ): Promise<SetupResult> {
   let checks: SafeCheckResult[] = [];
   try {
-    const runtime = validateRuntime(ports.runtime, false);
+    const runtime = validateRuntime(ports.runtime, false, 'dev');
     checks = runtime.checks;
     if (!runtime.ok) {
       return setupFailure(checks, runtime.check, runtime.code);
@@ -787,7 +793,7 @@ export async function setupEvaluatorConfig(
     const config = parsedCandidate.data;
     checks.push({ check: 'config', status: 'passed' });
 
-    const readiness = await validateAccountReadiness(config, ports);
+    const readiness = await validateAccountReadiness(config, ports, true);
     checks.push(...readiness.checks);
     if (!readiness.ok) {
       return setupFailure(checks, readiness.check, readiness.code);
@@ -909,12 +915,16 @@ type LoadedAccountReadinessResult =
 
 async function loadAccountReadiness(
   ports: SetupPorts,
-  includeMiniMaxKey: boolean
+  includeMiniMaxKey: boolean,
+  options: {
+    readonly expectedEnvironment: 'dev' | 'prod';
+    readonly includeHomeDevProductReadiness: boolean;
+  } = { expectedEnvironment: 'dev', includeHomeDevProductReadiness: true }
 ): Promise<LoadedAccountReadinessResult> {
   let checks: SafeCheckResult[] = [];
   let currentCheck: PreflightCheckId = 'runtime';
   try {
-    const runtime = validateRuntime(ports.runtime, includeMiniMaxKey);
+    const runtime = validateRuntime(ports.runtime, includeMiniMaxKey, options.expectedEnvironment);
     checks = runtime.checks;
     if (!runtime.ok) {
       return runtime;
@@ -950,7 +960,11 @@ async function loadAccountReadiness(
     checks.push({ check: 'config', status: 'passed' });
 
     currentCheck = 'matrix_files';
-    const readiness = await validateAccountReadiness(loadedConfig.value, ports);
+    const readiness = await validateAccountReadiness(
+      loadedConfig.value,
+      ports,
+      options.includeHomeDevProductReadiness
+    );
     checks.push(...readiness.checks);
     if (!readiness.ok) {
       return { ...readiness, checks };
@@ -977,6 +991,30 @@ export async function withValidatedAccountContext(
   callback: (context: ValidatedAccountContext) => void | Promise<void>
 ): Promise<ValidatedAccountContextResult> {
   const readiness = await loadAccountReadiness(ports, false);
+  if (!readiness.ok) {
+    return {
+      ok: false,
+      code: readiness.code,
+      checks: [...readiness.checks, failedCheck(readiness.check, readiness.code)],
+    };
+  }
+
+  try {
+    await callback(readiness.context);
+    return { ok: true, checks: readiness.checks };
+  } catch {
+    return { ok: false, code: 'UNEXPECTED_FAILURE', checks: readiness.checks };
+  }
+}
+
+export async function withValidatedProductionMatrixAccountContext(
+  ports: SetupPorts,
+  callback: (context: ValidatedAccountContext) => void | Promise<void>
+): Promise<ValidatedAccountContextResult> {
+  const readiness = await loadAccountReadiness(ports, false, {
+    expectedEnvironment: 'prod',
+    includeHomeDevProductReadiness: false,
+  });
   if (!readiness.ok) {
     return {
       ok: false,


### PR DESCRIPTION
## Summary

- validate the protected Home Dev Matrix account under the production runner environment
- prevent production preflight from probing Home Dev Intex Agent or WhatsApp product services
- cover the public production live reader and the original account_not_ready regression

## Verification

- `pnpm run ci:tracked`
- 6715 tests passed
- correctness/security review: READY
- test-completeness review: READY

## Linear

Linear: omitted by `$commit-push`; GitHub automation will create or link the Linear issue after PR creation.

Linear: [INT-1898](https://linear.app/pbuchman/issue/INT-1898)
IntexuraOS Code Task: [View task](https://intexuraos.cloud/#/code-tasks/task_3195f50a-4cd6-4b12-b540-d89b901dc748)
Worker Type: `codex-xhigh`
Model: `default`