### PR TITLE
[INT-1899] fix(evals): expose production test run mutations

### DIFF
--- a/scripts/__tests__/hetzner-runtime.test.ts
+++ b/scripts/__tests__/hetzner-runtime.test.ts
@@ -118,24 +118,71 @@ function upstreamName(serviceName: string): string {
 }
 
 describe('Hetzner nginx runtime config', () => {
-  it('exposes only the two OIDC-protected production corpus evaluator prefixes', () => {
+  it('exposes only the required OIDC-protected production corpus evaluator prefixes', () => {
     const config = readRequired(nginxConfigPath);
     const verifier = readRequired(jwtVerifierPath);
+    const testRunMutationPattern =
+      '^/internal/evals/intex-agent/test-runs/[^/]+/(?:projection|artifact-delivery)$';
 
     expect(config).toContain('location ^~ /internal/evals/whatsapp/matrix-corpus/');
     expect(config).toContain('location ^~ /internal/evals/intex-agent/matrix-corpus/');
+    expect(config).toContain('location ^~ /internal/evals/intex-agent/test-runs/');
     expect(config).toContain('proxy_pass http://whatsapp_service/internal/matrix-corpus/;');
     expect(config).toContain('proxy_pass http://intex_agent/internal/matrix-corpus/;');
+    expect(config).toContain('proxy_pass http://intex_agent/internal/test-runs/;');
     for (const prefix of ['whatsapp', 'intex-agent'] as const) {
       const start = config.indexOf(`location ^~ /internal/evals/${prefix}/matrix-corpus/ {`);
       const end = config.indexOf('\n    }', start);
       expect(start).toBeGreaterThanOrEqual(0);
       expect(config.slice(start, end)).toContain('access_log off;');
     }
+    const testRunsStart = config.indexOf('location ^~ /internal/evals/intex-agent/test-runs/ {');
+    const testRunsEnd = config.indexOf('\n    }', testRunsStart);
+    expect(testRunsStart).toBeGreaterThanOrEqual(0);
+    expect(config.slice(testRunsStart, testRunsEnd)).toContain('access_log off;');
     expect(config).not.toContain('rewrite ^/internal/evals/');
     expect(verifier).toContain('^/internal/evals/(?:whatsapp|intex-agent)/matrix-corpus(?:/|$)');
+    expect(verifier).toContain(`pattern = [[${testRunMutationPattern}]]`);
     expect(verifier).toContain('caller_role = "matrix_corpus_runner"');
     expect(verifier).toContain('claude-code-dev@intexuraos-dev-pbuchman.iam.gserviceaccount.com');
+
+    const testRunPatternStart = verifier.indexOf(`pattern = [[${testRunMutationPattern}]]`);
+    const testRunPatternEnd = verifier.indexOf('\n  },', testRunPatternStart);
+    const testRunPatternBlock = verifier.slice(testRunPatternStart, testRunPatternEnd);
+    expect(testRunPatternBlock).toContain('allowed_methods = { PUT = true }');
+    expect(testRunPatternBlock).not.toContain('GET = true');
+
+    const testRunMutationMatcher = new RegExp(testRunMutationPattern);
+    expect(
+      testRunMutationMatcher.test('/internal/evals/intex-agent/test-runs/eval-1/projection')
+    ).toBe(true);
+    expect(
+      testRunMutationMatcher.test('/internal/evals/intex-agent/test-runs/eval-1/artifact-delivery')
+    ).toBe(true);
+    expect(
+      testRunMutationMatcher.test('/internal/evals/intex-agent/test-runs/eval-1/cleanup')
+    ).toBe(false);
+    expect(
+      testRunMutationMatcher.test('/internal/evals/intex-agent/test-runs/eval-1/projection/extra')
+    ).toBe(false);
+
+    const allowFunction = verifier.slice(
+      verifier.indexOf('local function is_service_account_allowed'),
+      verifier.indexOf('local auth_header')
+    );
+    const patternLookupIndex = allowFunction.indexOf('ROUTE_PATTERN_ALLOWED_SERVICE_ACCOUNTS');
+    const methodLookupIndex = allowFunction.indexOf('ngx.req.get_method()');
+    const evaluatorFailClosedIndex = allowFunction.indexOf('string.len(EVALUATOR_ROUTE_PREFIX)');
+    const evaluatorDenyIndex = allowFunction.indexOf('return false, nil', evaluatorFailClosedIndex);
+    const routePrefixLookupIndex = allowFunction.indexOf('ROUTE_PREFIX_ALLOWED_SERVICE_ACCOUNTS');
+    const globalLookupIndex = allowFunction.indexOf('GLOBAL_ALLOWED_SERVICE_ACCOUNTS[email]');
+    expect(verifier).toContain('local EVALUATOR_ROUTE_PREFIX = "/internal/evals/"');
+    expect(patternLookupIndex).toBeGreaterThanOrEqual(0);
+    expect(methodLookupIndex).toBeGreaterThan(patternLookupIndex);
+    expect(evaluatorFailClosedIndex).toBeGreaterThan(patternLookupIndex);
+    expect(evaluatorDenyIndex).toBeGreaterThan(evaluatorFailClosedIndex);
+    expect(routePrefixLookupIndex).toBeGreaterThan(evaluatorFailClosedIndex);
+    expect(globalLookupIndex).toBeGreaterThan(routePrefixLookupIndex);
   });
 
   it('serves only the exact deployment attestation path as uncached JSON', () => {

--- a/scripts/__tests__/run-intex-agent-evals-home-dev.test.ts
+++ b/scripts/__tests__/run-intex-agent-evals-home-dev.test.ts
@@ -39,6 +39,7 @@ const IMPLEMENTATION_PATHS = [
   'apps/user-service/src/',
   'packages/',
   'tools/intex-agent-evals/',
+  'scripts/hetzner/nginx/',
   'scripts/run-intex-agent-evals-home-dev.sh',
   'scripts/run-intex-agent-evals-prod.sh',
   'package.json',
@@ -91,7 +92,8 @@ fi
 if ! remote_status=$(git status --porcelain=v1 --untracked-files=all -- \\
   apps/intex-agent/src/ apps/whatsapp-service/src/ apps/user-service/src/ \\
   packages/ \\
-  tools/intex-agent-evals/ scripts/run-intex-agent-evals-home-dev.sh \\
+  tools/intex-agent-evals/ scripts/hetzner/nginx/ \\
+  scripts/run-intex-agent-evals-home-dev.sh \\
   scripts/run-intex-agent-evals-prod.sh package.json 2>/dev/null); then
   emit 'remote_implementation_paths_dirty'
   finish 2

--- a/scripts/hetzner/nginx/intexuraos.conf
+++ b/scripts/hetzner/nginx/intexuraos.conf
@@ -142,6 +142,11 @@ server {
         access_by_lua_file /etc/nginx/lua/jwt-verify.lua;
         proxy_pass http://intex_agent/internal/matrix-corpus/;
     }
+    location ^~ /internal/evals/intex-agent/test-runs/ {
+        access_log off;
+        access_by_lua_file /etc/nginx/lua/jwt-verify.lua;
+        proxy_pass http://intex_agent/internal/test-runs/;
+    }
 
     location /internal/whatsapp/ { access_by_lua_file /etc/nginx/lua/jwt-verify.lua; proxy_pass http://whatsapp_service; }
     location /internal/llm/ { access_by_lua_file /etc/nginx/lua/jwt-verify.lua; proxy_pass http://research_agent; }

--- a/scripts/hetzner/nginx/jwt-verify.lua
+++ b/scripts/hetzner/nginx/jwt-verify.lua
@@ -4,6 +4,7 @@ local openidc = require("resty.openidc")
 local EXPECTED_ISS = "https://accounts.google.com"
 local EXPECTED_AUD = "https://intexuraos.cloud"
 local INTERNAL_AUTH_TOKEN_FILE = "/etc/intexuraos/internal-auth-token"
+local EVALUATOR_ROUTE_PREFIX = "/internal/evals/"
 local GLOBAL_ALLOWED_SERVICE_ACCOUNTS = {
   ["intexuraos-scheduler-dev@intexuraos-dev-pbuchman.iam.gserviceaccount.com"] = true,
   ["intexuraos-whatsapp-svc-dev@intexuraos-dev-pbuchman.iam.gserviceaccount.com"] = true,
@@ -33,6 +34,14 @@ local ROUTE_PATTERN_ALLOWED_SERVICE_ACCOUNTS = {
   {
     pattern = [[^/internal/evals/(?:whatsapp|intex-agent)/matrix-corpus(?:/|$)]],
     caller_role = "matrix_corpus_runner",
+    allowed_service_accounts = {
+      ["claude-code-dev@intexuraos-dev-pbuchman.iam.gserviceaccount.com"] = true,
+    },
+  },
+  {
+    pattern = [[^/internal/evals/intex-agent/test-runs/[^/]+/(?:projection|artifact-delivery)$]],
+    caller_role = "matrix_corpus_runner",
+    allowed_methods = { PUT = true },
     allowed_service_accounts = {
       ["claude-code-dev@intexuraos-dev-pbuchman.iam.gserviceaccount.com"] = true,
     },
@@ -102,9 +111,17 @@ local function is_service_account_allowed(email)
 
   for _, route_pattern in ipairs(ROUTE_PATTERN_ALLOWED_SERVICE_ACCOUNTS) do
     if ngx.re.match(ngx.var.uri, route_pattern.pattern, "jo") ~= nil then
-      local allowed = route_pattern.allowed_service_accounts[email] == true
+      local request_method = ngx.req.get_method()
+      local method_allowed = route_pattern.allowed_methods == nil
+        or route_pattern.allowed_methods[request_method] == true
+      local allowed = method_allowed and route_pattern.allowed_service_accounts[email] == true
       return allowed, allowed and route_pattern.caller_role or nil
     end
+  end
+
+  if string.sub(ngx.var.uri, 1, string.len(EVALUATOR_ROUTE_PREFIX)) ==
+      EVALUATOR_ROUTE_PREFIX then
+    return false, nil
   end
 
   for prefix, route_prefix_allowed_service_accounts in pairs(ROUTE_PREFIX_ALLOWED_SERVICE_ACCOUNTS) do

--- a/scripts/run-intex-agent-evals-home-dev.sh
+++ b/scripts/run-intex-agent-evals-home-dev.sh
@@ -74,6 +74,7 @@ implementation_paths=(
   'apps/user-service/src/'
   'packages/'
   'tools/intex-agent-evals/'
+  'scripts/hetzner/nginx/'
   'scripts/run-intex-agent-evals-home-dev.sh'
   'scripts/run-intex-agent-evals-prod.sh'
   'package.json'
@@ -163,7 +164,8 @@ fi
 if ! remote_status=$(git status --porcelain=v1 --untracked-files=all -- \
   apps/intex-agent/src/ apps/whatsapp-service/src/ apps/user-service/src/ \
   packages/ \
-  tools/intex-agent-evals/ scripts/run-intex-agent-evals-home-dev.sh \
+  tools/intex-agent-evals/ scripts/hetzner/nginx/ \
+  scripts/run-intex-agent-evals-home-dev.sh \
   scripts/run-intex-agent-evals-prod.sh package.json 2>/dev/null); then
   emit 'remote_implementation_paths_dirty'
   finish 2

--- a/tools/intex-agent-evals/src/__tests__/matrixCorpusLiveRuntime.test.ts
+++ b/tools/intex-agent-evals/src/__tests__/matrixCorpusLiveRuntime.test.ts
@@ -535,6 +535,7 @@ describe('production Hetzner runtime inspection from the Home Dev runner', () =>
       expect.arrayContaining(['status', '--porcelain=v1', 'packages/'])
     );
     expect(MATRIX_CORPUS_RUNTIME_CRITICAL_PATHS).toContain('packages/');
+    expect(MATRIX_CORPUS_RUNTIME_CRITICAL_PATHS).toContain('scripts/hetzner/nginx/');
     expect(deps.fetchDeploymentDocument).toHaveBeenCalledOnce();
   });
 

--- a/tools/intex-agent-evals/src/matrixCorpus/liveRuntime.ts
+++ b/tools/intex-agent-evals/src/matrixCorpus/liveRuntime.ts
@@ -56,6 +56,7 @@ export const MATRIX_CORPUS_RUNTIME_CRITICAL_PATHS = [
   'apps/user-service/src/',
   'packages/',
   'tools/intex-agent-evals/',
+  'scripts/hetzner/nginx/',
   'scripts/run-intex-agent-evals-home-dev.sh',
   'scripts/run-intex-agent-evals-prod.sh',
   'package.json',


### PR DESCRIPTION
## Summary
- expose the production evaluator Test Run projection and artifact-delivery mutations through the Hetzner edge
- restrict them to PUT from the dedicated Matrix corpus runner and fail closed for unmatched evaluator routes
- include the Nginx evaluator sources in every local and Home Dev runtime cleanliness gate

## Root cause
The production Matrix corpus acquired its lease, then PUT /internal/evals/intex-agent/test-runs/{runId}/projection was rejected by Nginx with HTTP 403 because only matrix-corpus paths were routed and allowlisted.

## Verification
- production evidence: lease acquired, projection request 403, provisioning safely rolled back
- focused runtime suites: 160/160
- independent security review: READY
- independent test-completeness review: READY
- pnpm run ci:tracked: PASS, 6715 tests

Fixes INT-1899

- Linear: [INT-1899](https://linear.app/pbuchman/issue/INT-1899)
- IntexuraOS Code Task: [View task](https://intexuraos.cloud/#/code-tasks/task_eaf142b7-c35a-4aab-aa48-ecad78dd9c51)
- Worker Type: `codex-xhigh`
- Model: `default`