### PR TITLE
[INT-1902] fix(evals): support slow production Matrix replies

### DIFF
--- a/tools/intex-agent-evals/src/__tests__/fixtures/matrixCorpusCompositionHarness.ts
+++ b/tools/intex-agent-evals/src/__tests__/fixtures/matrixCorpusCompositionHarness.ts
@@ -19,7 +19,11 @@ import {
 } from '@intexuraos/http-contracts';
 
 import type { MiniMaxEvaluator } from '../../minimaxJudge.js';
-import type { MatrixClient, MatrixTimelineEvent } from '../../live/matrixClient.js';
+import type {
+  MatrixClient,
+  MatrixTargetSyncResult,
+  MatrixTimelineEvent,
+} from '../../live/matrixClient.js';
 import { digestMatrixReply } from '../../matrixCorpus/correlation.js';
 import type { MatrixCorpusPreparedContext } from '../../matrixCorpus/liveRuntime.js';
 import {
@@ -81,6 +85,9 @@ interface SharedState {
   readonly scenarioStatusReads: Map<string, number>;
   readonly conflictStoppedScenarioProjectionOnce: boolean;
   stoppedScenarioProjectionConflictInjected: boolean;
+  readonly hangInitialCursor: boolean;
+  readonly dropReplyScenarioNumber: number | null;
+  readonly onReplyWaitStarted: () => void;
 }
 
 export interface MatrixCorpusCompositionHarnessOptions {
@@ -90,11 +97,14 @@ export interface MatrixCorpusCompositionHarnessOptions {
   readonly advanceEventRevisionAfterBindingScenarioNumber?: number;
   readonly deferBindingUntilQuiesceScenarioNumber?: number;
   readonly conflictStoppedScenarioProjectionOnce?: boolean;
+  readonly hangInitialCursor?: boolean;
+  readonly dropReplyScenarioNumber?: number;
 }
 
 export interface MatrixCorpusCompositionMetrics {
   maxConcurrentTurns: number;
   readonly matrixMessages: string[];
+  readonly leaseRenewalKeys: string[];
   deepSeekAgentCalls: number;
   confirmationAgentCalls: number;
   miniMaxJudgeCalls: number;
@@ -115,6 +125,7 @@ export interface MatrixCorpusCompositionHarness {
   readonly prepared: MatrixCorpusPreparedContext;
   readonly metrics: MatrixCorpusCompositionMetrics;
   readonly trace: string[];
+  readonly replyWaitStarted: Promise<void>;
   readonly now: () => Date;
   readonly cleanup: () => Promise<void>;
 }
@@ -125,9 +136,14 @@ export async function createPassingMatrixCorpusCompositionHarness(
 ): Promise<MatrixCorpusCompositionHarness> {
   const repositoryRoot = await mkdtemp(join(tmpdir(), 'matrix-corpus-composition-'));
   const trace: string[] = [];
+  let resolveReplyWaitStarted: (() => void) | null = null;
+  const replyWaitStarted = new Promise<void>((resolve) => {
+    resolveReplyWaitStarted = resolve;
+  });
   const metrics: MatrixCorpusCompositionMetrics = {
     maxConcurrentTurns: 0,
     matrixMessages: [],
+    leaseRenewalKeys: [],
     deepSeekAgentCalls: 0,
     confirmationAgentCalls: 0,
     miniMaxJudgeCalls: 0,
@@ -162,6 +178,9 @@ export async function createPassingMatrixCorpusCompositionHarness(
     scenarioStatusReads: new Map(),
     conflictStoppedScenarioProjectionOnce: options.conflictStoppedScenarioProjectionOnce ?? false,
     stoppedScenarioProjectionConflictInjected: false,
+    hangInitialCursor: options.hangInitialCursor ?? false,
+    dropReplyScenarioNumber: options.dropReplyScenarioNumber ?? null,
+    onReplyWaitStarted: () => resolveReplyWaitStarted?.(),
   };
 
   return {
@@ -185,6 +204,7 @@ export async function createPassingMatrixCorpusCompositionHarness(
     },
     metrics,
     trace,
+    replyWaitStarted,
     now: () => new Date(NOW),
     cleanup: async () => await rm(repositoryRoot, { recursive: true, force: true }),
   };
@@ -199,17 +219,35 @@ function createMatrixBoundary(state: SharedState): MatrixClient {
     async syncTargetRoom(input) {
       cursor += 1;
       if (input.timeoutMs === 0) {
+        if (state.hangInitialCursor) return await matrixTimeoutAfterAbort(input.signal);
         return { ok: true, nextBatch: `batch_${String(cursor)}`, limited: false, events: [] };
       }
       const event = state.matrixEvents.shift();
+      if (event === undefined) return await matrixTimeoutAfterAbort(input.signal);
+      if (event.sender.startsWith('@whatsapp_lid-')) {
+        state.trace.push(`matrix:reply:${event.eventId ?? 'missing'}`);
+      }
       return {
         ok: true,
         nextBatch: `batch_${String(cursor)}`,
         limited: false,
-        events: event === undefined ? [] : [event],
+        events: [event],
       };
     },
   };
+}
+
+async function matrixTimeoutAfterAbort(signal: AbortSignal): Promise<MatrixTargetSyncResult> {
+  if (signal.aborted) return { ok: false, reason: 'timeout' };
+  return await new Promise<MatrixTargetSyncResult>((resolve) => {
+    signal.addEventListener(
+      'abort',
+      () => {
+        resolve({ ok: false, reason: 'timeout' });
+      },
+      { once: true }
+    );
+  });
 }
 
 function createWhatsAppBoundary(state: SharedState): WhatsAppServiceClient {
@@ -241,7 +279,10 @@ function createWhatsAppBoundary(state: SharedState): WhatsAppServiceClient {
         value: { code: 'ACTIVATED', runId, leaseFence, phase: 'active', activatedAt: NOW },
       };
     },
-    async renewMatrixCorpusLease({ runId, leaseFence }) {
+    async renewMatrixCorpusLease({ runId, leaseFence, idempotencyKey }) {
+      state.metrics.leaseRenewalKeys.push(idempotencyKey);
+      state.trace.push(`lease:${idempotencyKey}`);
+      if (idempotencyKey.includes(':reply:')) state.onReplyWaitStarted();
       return {
         ok: true,
         value: {
@@ -295,16 +336,18 @@ function createWhatsAppBoundary(state: SharedState): WhatsAppServiceClient {
         sender: '@private_user_sentinel:example.test',
         content: { msgtype: 'm.text', body: request.text },
       });
-      state.matrixEvents.push({
-        eventId: `$matrix_reply_${String(state.metrics.matrixMessages.length + 1)}`,
-        originServerTs: Date.parse(NOW) + state.metrics.matrixMessages.length,
-        type: 'm.room.message',
-        sender:
-          entry.scenarioNumber === state.wrongPuppetScenarioNumber
-            ? '@whatsapp_lid-wrong-puppet-sentinel:example.test'
-            : '@whatsapp_lid-private-puppet-sentinel:example.test',
-        content: { msgtype: 'm.text', body: reply },
-      });
+      if (entry.scenarioNumber !== state.dropReplyScenarioNumber) {
+        state.matrixEvents.push({
+          eventId: `$matrix_reply_${String(state.metrics.matrixMessages.length + 1)}`,
+          originServerTs: Date.parse(NOW) + state.metrics.matrixMessages.length,
+          type: 'm.room.message',
+          sender:
+            entry.scenarioNumber === state.wrongPuppetScenarioNumber
+              ? '@whatsapp_lid-wrong-puppet-sentinel:example.test'
+              : '@whatsapp_lid-private-puppet-sentinel:example.test',
+          content: { msgtype: 'm.text', body: reply },
+        });
+      }
       state.metrics.matrixMessages.push(request.text);
       state.activeTurns += 1;
       state.metrics.maxConcurrentTurns = Math.max(
@@ -673,6 +716,9 @@ function createMiniMaxBoundary(state: SharedState): MiniMaxEvaluator {
     },
     async judgeReplies(inputs) {
       state.metrics.miniMaxJudgeCalls += inputs.length;
+      for (const input of inputs) {
+        state.trace.push(`judge:${input.scenarioId}:${String(input.turnIndex)}`);
+      }
       return {
         ok: true,
         verdicts: inputs.map((input) => {

--- a/tools/intex-agent-evals/src/__tests__/matrixCorpusComposition.test.ts
+++ b/tools/intex-agent-evals/src/__tests__/matrixCorpusComposition.test.ts
@@ -1,7 +1,7 @@
 import { readFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { loadCanonicalMatrixCorpus } from '../matrixCorpus/catalog.js';
 import { createProductionMatrixCorpusExecutor } from '../matrixCorpus/liveExecution.js';
@@ -64,6 +64,29 @@ describe('production Matrix corpus composition', () => {
     ).toHaveLength(20);
     expect(harness.metrics.matrixMessages[0]).toContain('Scenario 001/020');
     expect(harness.metrics.matrixMessages.at(-1)).toContain('Scenario 020/020');
+    expect(harness.metrics.leaseRenewalKeys).toHaveLength(59 * 3);
+    expect(harness.metrics.leaseRenewalKeys).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('renew:intex-eval-001:0'),
+        expect.stringContaining('renew:intex-eval-020:1'),
+        expect.stringContaining('reply:intex-eval-001:0'),
+        expect.stringContaining('reply:intex-eval-020:1'),
+        expect.stringContaining('judge:intex-eval-001:0'),
+        expect.stringContaining('judge:intex-eval-020:1'),
+      ])
+    );
+    const firstReplyRenewal = harness.trace.findIndex((item) =>
+      item.includes('reply:intex-eval-001:0')
+    );
+    const firstReply = harness.trace.indexOf('matrix:reply:$matrix_reply_1');
+    const firstJudgeRenewal = harness.trace.findIndex(
+      (item) => item.includes('judge:intex-eval-001:0') && item.startsWith('lease:')
+    );
+    const firstJudge = harness.trace.indexOf('judge:intex-eval-001:0');
+    expect(firstReplyRenewal).toBeGreaterThanOrEqual(0);
+    expect(firstReplyRenewal).toBeLessThan(firstReply);
+    expect(firstReply).toBeLessThan(firstJudgeRenewal);
+    expect(firstJudgeRenewal).toBeLessThan(firstJudge);
     expect(harness.metrics.deepSeekAgentCalls).toBeGreaterThan(0);
     expect(harness.metrics.confirmationAgentCalls).toBe(0);
     expect(harness.metrics.miniMaxJudgeCalls).toBe(59);
@@ -111,6 +134,121 @@ describe('production Matrix corpus composition', () => {
     ]) {
       expect(reportText).not.toContain(sentinel);
       expect(reportMarkdown).not.toContain(sentinel);
+    }
+  });
+
+  it('bounds the initial Matrix cursor with the configured correlation deadline', async () => {
+    const catalog = await loadCanonicalMatrixCorpus(scenariosDirectory);
+    const harness = await createPassingMatrixCorpusCompositionHarness(catalog, {
+      hangInitialCursor: true,
+    });
+    cleanup.push(harness.cleanup);
+    const execute = createProductionMatrixCorpusExecutor({
+      repositoryRoot: harness.repositoryRoot,
+      matrix: harness.matrix,
+      whatsapp: harness.whatsapp,
+      intex: harness.intex,
+      evaluator: harness.evaluator,
+      env: {
+        INTEXURAOS_MATRIX_CORPUS_BINDING_HMAC_KEY:
+          'composition-harness-binding-key-with-at-least-thirty-two-bytes',
+      },
+      correlationTimeoutMs: 5,
+      replyTimeoutMs: 7,
+      pollIntervalMs: 1,
+      now: harness.now,
+    });
+
+    const result = await execute({
+      runId: harness.runId,
+      preflight: harness.preflight,
+      prepared: harness.prepared,
+    });
+
+    expect(result.run).toMatchObject({
+      exitCode: 2,
+      failureCodes: ['reply_timeout'],
+      terminalAcknowledged: true,
+      cleanupCompleted: true,
+    });
+    expect(harness.metrics.matrixMessages).toHaveLength(0);
+  });
+
+  it('wires an explicit reply deadline override into the live executor', async () => {
+    const catalog = await loadCanonicalMatrixCorpus(scenariosDirectory);
+    const harness = await createPassingMatrixCorpusCompositionHarness(catalog, {
+      dropReplyScenarioNumber: 1,
+    });
+    cleanup.push(harness.cleanup);
+    const execute = createProductionMatrixCorpusExecutor({
+      repositoryRoot: harness.repositoryRoot,
+      matrix: harness.matrix,
+      whatsapp: harness.whatsapp,
+      intex: harness.intex,
+      evaluator: harness.evaluator,
+      env: {
+        INTEXURAOS_MATRIX_CORPUS_BINDING_HMAC_KEY:
+          'composition-harness-binding-key-with-at-least-thirty-two-bytes',
+      },
+      correlationTimeoutMs: 50,
+      replyTimeoutMs: 5,
+      pollIntervalMs: 1,
+      now: harness.now,
+    });
+
+    const result = await execute({
+      runId: harness.runId,
+      preflight: harness.preflight,
+      prepared: harness.prepared,
+    });
+
+    expect(result.run).toMatchObject({ exitCode: 2, failureCodes: ['reply_timeout'] });
+    expect(harness.metrics.matrixMessages).toHaveLength(1);
+  });
+
+  it('keeps the executor default reply wait alive past 180 seconds and stops at 240 seconds', async () => {
+    const catalog = await loadCanonicalMatrixCorpus(scenariosDirectory);
+    const harness = await createPassingMatrixCorpusCompositionHarness(catalog, {
+      dropReplyScenarioNumber: 1,
+    });
+    cleanup.push(harness.cleanup);
+    const execute = createProductionMatrixCorpusExecutor({
+      repositoryRoot: harness.repositoryRoot,
+      matrix: harness.matrix,
+      whatsapp: harness.whatsapp,
+      intex: harness.intex,
+      evaluator: harness.evaluator,
+      env: {
+        INTEXURAOS_MATRIX_CORPUS_BINDING_HMAC_KEY:
+          'composition-harness-binding-key-with-at-least-thirty-two-bytes',
+      },
+      now: harness.now,
+    });
+
+    vi.useFakeTimers();
+    try {
+      let settled = false;
+      const pending = execute({
+        runId: harness.runId,
+        preflight: harness.preflight,
+        prepared: harness.prepared,
+      }).then((result) => {
+        settled = true;
+        return result;
+      });
+
+      await harness.replyWaitStarted;
+      expect(harness.metrics.leaseRenewalKeys).toEqual(
+        expect.arrayContaining([expect.stringContaining('reply:intex-eval-001:0')])
+      );
+      await vi.advanceTimersByTimeAsync(3 * 60 * 1000);
+      expect(settled).toBe(false);
+      await vi.advanceTimersByTimeAsync(60 * 1000);
+
+      const result = await pending;
+      expect(result.run).toMatchObject({ exitCode: 2, failureCodes: ['reply_timeout'] });
+    } finally {
+      vi.useRealTimers();
     }
   });
 

--- a/tools/intex-agent-evals/src/__tests__/matrixCorpusLiveExecution.test.ts
+++ b/tools/intex-agent-evals/src/__tests__/matrixCorpusLiveExecution.test.ts
@@ -8,12 +8,78 @@ import {
   activateMatrixCorpusRunWithReconciliation,
   buildMatrixCorpusTurnChecks,
   buildMatrixCorpusTechnicalFacts,
+  PRODUCTION_MATRIX_CORPUS_CORRELATION_TIMEOUT_MS,
+  PRODUCTION_MATRIX_CORPUS_LEASE_TTL_MS,
+  PRODUCTION_MATRIX_CORPUS_REPLY_TIMEOUT_MS,
+  runWithMatrixCorpusDeadline,
   sendMatrixMessageWithReconciliation,
 } from '../matrixCorpus/liveExecution.js';
 
 const scenariosDirectory = fileURLToPath(new URL('../../scenarios/', import.meta.url));
 
 describe('production Matrix corpus technical facts', () => {
+  it('gives slow DeepSeek replies more time without outliving a renewed production lease', () => {
+    expect(PRODUCTION_MATRIX_CORPUS_CORRELATION_TIMEOUT_MS).toBe(3 * 60 * 1000);
+    expect(PRODUCTION_MATRIX_CORPUS_REPLY_TIMEOUT_MS).toBe(4 * 60 * 1000);
+    expect(PRODUCTION_MATRIX_CORPUS_LEASE_TTL_MS).toBe(5 * 60 * 1000);
+    expect(PRODUCTION_MATRIX_CORPUS_REPLY_TIMEOUT_MS).toBeGreaterThan(
+      PRODUCTION_MATRIX_CORPUS_CORRELATION_TIMEOUT_MS
+    );
+    expect(PRODUCTION_MATRIX_CORPUS_REPLY_TIMEOUT_MS).toBeLessThan(
+      PRODUCTION_MATRIX_CORPUS_LEASE_TTL_MS
+    );
+  });
+
+  it('keeps the default reply deadline alive past 180 seconds and aborts at 240 seconds', async () => {
+    vi.useFakeTimers();
+    try {
+      let observedSignal: AbortSignal | undefined;
+      const pending = runWithMatrixCorpusDeadline(
+        PRODUCTION_MATRIX_CORPUS_REPLY_TIMEOUT_MS,
+        async (signal) => {
+          observedSignal = signal;
+          await new Promise<void>((resolve) => {
+            signal.addEventListener('abort', () => resolve(), { once: true });
+          });
+          return signal.aborted;
+        }
+      );
+      await Promise.resolve();
+
+      await vi.advanceTimersByTimeAsync(PRODUCTION_MATRIX_CORPUS_CORRELATION_TIMEOUT_MS);
+      expect(observedSignal?.aborted).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(
+        PRODUCTION_MATRIX_CORPUS_REPLY_TIMEOUT_MS - PRODUCTION_MATRIX_CORPUS_CORRELATION_TIMEOUT_MS
+      );
+      await expect(pending).resolves.toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('honors an explicit short Matrix deadline override', async () => {
+    vi.useFakeTimers();
+    try {
+      let observedSignal: AbortSignal | undefined;
+      const pending = runWithMatrixCorpusDeadline(5, async (signal) => {
+        observedSignal = signal;
+        await new Promise<void>((resolve) => {
+          signal.addEventListener('abort', () => resolve(), { once: true });
+        });
+        return signal.aborted;
+      });
+      await Promise.resolve();
+
+      await vi.advanceTimersByTimeAsync(4);
+      expect(observedSignal?.aborted).toBe(false);
+      await vi.advanceTimersByTimeAsync(1);
+      await expect(pending).resolves.toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('persists closed expected/actual evidence for every deterministic assertion', async () => {
     const catalog = await loadCanonicalMatrixCorpus(scenariosDirectory);
     const scenario = catalog.scenarios[0]?.scenario;

--- a/tools/intex-agent-evals/src/__tests__/matrixCorpusRunner.test.ts
+++ b/tools/intex-agent-evals/src/__tests__/matrixCorpusRunner.test.ts
@@ -4,12 +4,16 @@ import type { ReplyEvaluationInput } from '../deterministicEvaluator.js';
 import { loadCanonicalMatrixCorpus } from '../matrixCorpus/catalog.js';
 import {
   MATRIX_CORPUS_EXTRA_REPLY_SEMANTIC_CRITERIA,
+  MATRIX_CORPUS_JUDGE_CALLS_PER_LEASE_RENEWAL,
   runMatrixCorpus,
   type MatrixCorpusRunPorts,
   type MatrixCorpusTurnExecutionResult,
   type MatrixCorpusTurnObservation,
 } from '../matrixCorpus/runMatrixCorpus.js';
-import { digestMatrixReply } from '../matrixCorpus/correlation.js';
+import {
+  digestMatrixReply,
+  MATRIX_CORPUS_MAX_REPLIES_PER_TURN,
+} from '../matrixCorpus/correlation.js';
 
 const scenariosDirectory = fileURLToPath(new URL('../../scenarios/', import.meta.url));
 
@@ -48,7 +52,15 @@ describe('sequential Matrix corpus state machine', () => {
       { lifecycle: 'completed', verdict: 'passed' },
     ]);
     expect(trace.filter((item) => item.startsWith('renew:'))).toEqual(
-      catalog.scenarios.map(({ scenario }) => `renew:${scenario.id}`)
+      catalog.scenarios.flatMap(({ scenario }) =>
+        scenario.turns.flatMap((_turn, turnIndex) => [
+          `renew:turn:${scenario.id}:${String(turnIndex)}`,
+          ...(scenario.expected.turns[turnIndex]?.replies ?? []).map(
+            (_reply, replyIndex) =>
+              `renew:judge:${scenario.id}:${String(turnIndex)}:${String(replyIndex)}`
+          ),
+        ])
+      )
     );
     expect(trace.indexOf('retention')).toBeLessThan(trace.indexOf('activate'));
     expect(trace.indexOf('activate')).toBeLessThan(trace.indexOf('project-running'));
@@ -395,7 +407,7 @@ describe('sequential Matrix corpus state machine', () => {
     }
   );
 
-  it('stops on lease-renewal failure before executing the scenario', async () => {
+  it('stops on lease-renewal failure before executing the turn', async () => {
     const catalog = await loadCanonicalMatrixCorpus(scenariosDirectory);
     const ports = passingPorts([]);
     vi.mocked(ports.renewLease).mockResolvedValue({ ok: false, code: 'lease_renewal_failed' });
@@ -408,6 +420,93 @@ describe('sequential Matrix corpus state machine', () => {
     expect(result.scenarios[0]?.status).toBe('not_run');
     expect(ports.projectScenario).not.toHaveBeenCalled();
     expect(result.terminalAcknowledged).toBe(true);
+  });
+
+  it('renews the lease before each judge batch and stops if that renewal fails', async () => {
+    const catalog = await loadCanonicalMatrixCorpus(scenariosDirectory);
+    const ports = passingPorts([]);
+    vi.mocked(ports.renewLease).mockImplementation(async (input) =>
+      input.stage === 'judge'
+        ? { ok: false, code: 'lease_renewal_failed' }
+        : { ok: true, value: undefined }
+    );
+
+    const result = await runMatrixCorpus({ runId: 'run_judge_lease', catalog }, ports);
+
+    expect(result.exitCode).toBe(2);
+    expect(result.failureCodes).toContain('lease_renewal_failed');
+    expect(ports.executeTurn).toHaveBeenCalledOnce();
+    expect(ports.judgeReply).not.toHaveBeenCalled();
+    expect(result.scenarios[0]?.status).toBe('stopped');
+    expect(result.terminalAcknowledged).toBe(true);
+  });
+
+  it('batches the maximum reply count under the bounded lease-renewal receipt cap', async () => {
+    const catalog = await loadCanonicalMatrixCorpus(scenariosDirectory);
+    const ports = passingPorts([]);
+    const firstScenario = catalog.scenarios[0]?.scenario;
+    if (firstScenario === undefined) throw new Error('missing first scenario');
+    const base = observation(firstScenario, 0);
+    const expectedReply = base.replyEvaluations[0];
+    if (expectedReply === undefined) throw new Error('missing expected first reply');
+    const replies = [
+      expectedReply,
+      ...Array.from({ length: MATRIX_CORPUS_MAX_REPLIES_PER_TURN - 1 }, (_value, offset) => {
+        const replyIndex = offset + 1;
+        const reply = replyInput(
+          firstScenario.id,
+          0,
+          replyIndex,
+          MATRIX_CORPUS_EXTRA_REPLY_SEMANTIC_CRITERIA
+        );
+        reply.assistantText = `Synthetic extra reply ${String(replyIndex)}`;
+        return reply;
+      }),
+    ];
+    vi.mocked(ports.executeTurn).mockResolvedValueOnce({
+      ok: false,
+      kind: 'behavioral_failure',
+      code: 'deterministic_evidence_failed',
+      observation: {
+        ...base,
+        observedReplyCount: replies.length,
+        replyEvaluations: replies,
+        deterministicPassed: false,
+        transportEvidence: {
+          turnTerminal: 'completed',
+          replyDigests: replies.map((reply, replyIndex) =>
+            digestMatrixReply(reply.assistantText, replyIndex)
+          ),
+        },
+      },
+    });
+
+    await runMatrixCorpus({ runId: 'run_batched_judges', catalog }, ports);
+
+    const firstTurnJudgeRenewals = vi
+      .mocked(ports.renewLease)
+      .mock.calls.map(([input]) => input)
+      .filter(
+        (input) =>
+          input.stage === 'judge' && input.scenarioId === firstScenario.id && input.turnIndex === 0
+      );
+    expect(firstTurnJudgeRenewals).toEqual([
+      expect.objectContaining({ replyIndex: 0 }),
+      expect.objectContaining({ replyIndex: 3 }),
+    ]);
+
+    const turnCount = catalog.scenarios.reduce(
+      (total, entry) => total + entry.scenario.turns.length,
+      0
+    );
+    const maximumRenewalReceipts =
+      turnCount *
+      (2 +
+        Math.ceil(
+          MATRIX_CORPUS_MAX_REPLIES_PER_TURN / MATRIX_CORPUS_JUDGE_CALLS_PER_LEASE_RENEWAL
+        ));
+    expect(maximumRenewalReceipts).toBe(236);
+    expect(maximumRenewalReceipts).toBeLessThan(400);
   });
 
   it.each([
@@ -721,8 +820,12 @@ function passingPorts(trace: string[]): MatrixCorpusRunPorts {
       revision = input.expectedRevision + 1;
       return { ok: true, revision } as const;
     }),
-    renewLease: vi.fn(async ({ scenarioId }) => {
-      trace.push(`renew:${scenarioId}`);
+    renewLease: vi.fn(async (input) => {
+      trace.push(
+        input.stage === 'turn'
+          ? `renew:turn:${input.scenarioId}:${String(input.turnIndex)}`
+          : `renew:judge:${input.scenarioId}:${String(input.turnIndex)}:${String(input.replyIndex)}`
+      );
       return { ok: true, value: undefined } as const;
     }),
     executeTurn: vi.fn(

--- a/tools/intex-agent-evals/src/matrixCorpus/correlation.ts
+++ b/tools/intex-agent-evals/src/matrixCorpus/correlation.ts
@@ -14,6 +14,8 @@ export type MatrixCorpusTurnTerminal =
     }
   | { readonly status: 'failed'; readonly failureCode: string };
 
+export const MATRIX_CORPUS_MAX_REPLIES_PER_TURN = 5;
+
 export interface MatrixCorpusReplyEvidencePort {
   getTurnTerminal(input: {
     runId: string;
@@ -186,7 +188,8 @@ export async function collectCorrelatedReplies(input: {
       };
       byEventId.set(reply.eventId, reply);
       replies.push(reply);
-      if (replies.length > 5) return { ok: false, code: 'reply_overflow' };
+      if (replies.length > MATRIX_CORPUS_MAX_REPLIES_PER_TURN)
+        return { ok: false, code: 'reply_overflow' };
     }
 
     const terminal = await input.evidence.getTurnTerminal({
@@ -200,7 +203,7 @@ export async function collectCorrelatedReplies(input: {
     if (
       !Number.isInteger(terminal.replyCount) ||
       terminal.replyCount < 0 ||
-      terminal.replyCount > 5 ||
+      terminal.replyCount > MATRIX_CORPUS_MAX_REPLIES_PER_TURN ||
       terminal.replyDigests.length !== terminal.replyCount ||
       new Set(terminal.replyDigests).size !== terminal.replyDigests.length
     ) {

--- a/tools/intex-agent-evals/src/matrixCorpus/liveExecution.ts
+++ b/tools/intex-agent-evals/src/matrixCorpus/liveExecution.ts
@@ -65,7 +65,9 @@ import { createProductionControlAuthorizationHeaderProvider } from './production
 const PRODUCTION_ORIGIN = 'https://intexuraos.cloud';
 const INTEX_AGENT_EDGE_PREFIX = '/internal/evals/intex-agent';
 const WHATSAPP_EDGE_PREFIX = '/internal/evals/whatsapp';
-const CORRELATION_TIMEOUT_MS = 180_000;
+export const PRODUCTION_MATRIX_CORPUS_CORRELATION_TIMEOUT_MS = 3 * 60 * 1000;
+export const PRODUCTION_MATRIX_CORPUS_REPLY_TIMEOUT_MS = 4 * 60 * 1000;
+export const PRODUCTION_MATRIX_CORPUS_LEASE_TTL_MS = 5 * 60 * 1000;
 const POLL_INTERVAL_MS = 250;
 const CORPUS_VERSION = '2026-07-19';
 const CORPUS_ID = 'intex-agent-matrix-corpus';
@@ -127,6 +129,7 @@ export interface ProductionMatrixCorpusExecutorOptions {
   readonly evaluator?: MiniMaxEvaluator;
   readonly retentionSagas?: MatrixCorpusRetentionSagaPort;
   readonly correlationTimeoutMs?: number;
+  readonly replyTimeoutMs?: number;
   readonly pollIntervalMs?: number;
   readonly now?: () => Date;
 }
@@ -195,7 +198,9 @@ export function createProductionMatrixCorpusExecutor(
       retentionSagas,
       delivery,
       bindingHmacKey: env['INTEXURAOS_MATRIX_CORPUS_BINDING_HMAC_KEY'] ?? '',
-      correlationTimeoutMs: options.correlationTimeoutMs ?? CORRELATION_TIMEOUT_MS,
+      correlationTimeoutMs:
+        options.correlationTimeoutMs ?? PRODUCTION_MATRIX_CORPUS_CORRELATION_TIMEOUT_MS,
+      replyTimeoutMs: options.replyTimeoutMs ?? PRODUCTION_MATRIX_CORPUS_REPLY_TIMEOUT_MS,
       pollIntervalMs: options.pollIntervalMs ?? POLL_INTERVAL_MS,
       now,
     });
@@ -242,6 +247,7 @@ function createRunPorts(input: {
   readonly delivery: MatrixCorpusArtifactDeliveryPort;
   readonly bindingHmacKey: string;
   readonly correlationTimeoutMs: number;
+  readonly replyTimeoutMs: number;
   readonly pollIntervalMs: number;
   readonly now: () => Date;
 }): MatrixCorpusRunPorts {
@@ -370,11 +376,16 @@ function createRunPorts(input: {
       return { ok: true, revision: result.value.revision };
     },
 
-    async renewLease({ runId, leaseFence, scenarioId }): MatrixCorpusPortReturn<'renewLease'> {
+    async renewLease(command): MatrixCorpusPortReturn<'renewLease'> {
       const result = await input.whatsapp.renewMatrixCorpusLease({
-        runId,
-        leaseFence,
-        idempotencyKey: operationKey(runId, `renew:${scenarioId}`),
+        runId: command.runId,
+        leaseFence: command.leaseFence,
+        idempotencyKey: operationKey(
+          command.runId,
+          command.stage === 'turn'
+            ? `renew:${command.scenarioId}:${String(command.turnIndex)}`
+            : `judge:${command.scenarioId}:${String(command.turnIndex)}:${String(command.replyIndex)}`
+        ),
       });
       return result.ok ? passed(undefined) : failed('lease_renewal_failed');
     },
@@ -811,6 +822,7 @@ async function executeLiveTurn(input: {
   readonly turnIndex: number;
   readonly expectedSessionId: string | null;
   readonly correlationTimeoutMs: number;
+  readonly replyTimeoutMs: number;
   readonly pollIntervalMs: number;
   readonly now: () => Date;
 }): Promise<ReturnType<MatrixCorpusRunPorts['executeTurn']> extends Promise<infer T> ? T : never> {
@@ -822,12 +834,15 @@ async function executeLiveTurn(input: {
     return { ok: false, kind: 'infrastructure_failure', code: 'turn_catalog_mismatch' };
   state.startedAt ??= input.now().toISOString();
 
-  const cursorController = new AbortController();
-  const cursor = await captureMatrixCorpusCursor({
-    matrix: input.matrix,
-    context: input.state.prepared.account,
-    signal: cursorController.signal,
-  });
+  const cursor = await runWithMatrixCorpusDeadline(
+    input.correlationTimeoutMs,
+    async (signal) =>
+      await captureMatrixCorpusCursor({
+        matrix: input.matrix,
+        context: input.state.prepared.account,
+        signal,
+      })
+  );
   if (!cursor.ok) return { ok: false, kind: 'infrastructure_failure', code: cursor.code };
 
   const before =
@@ -890,24 +905,19 @@ async function executeLiveTurn(input: {
   if (sent === null)
     return { ok: false, kind: 'safety_failure', code: 'matrix_outbound_ambiguous' };
 
-  const proofController = new AbortController();
-  const proofTimeout = setTimeout(() => {
-    proofController.abort();
-  }, input.correlationTimeoutMs);
-  let observedProof: Awaited<ReturnType<typeof proveMatrixCorpusOutboundEvent>>;
-  try {
-    observedProof = await proveMatrixCorpusOutboundEvent({
-      matrix: input.matrix,
-      context: input.state.prepared.account,
-      cursor: cursor.cursor,
-      matrixUserId: input.state.prepared.account.matrixUserId,
-      matrixEventId: sent.matrixEventId,
-      messageText,
-      signal: proofController.signal,
-    });
-  } finally {
-    clearTimeout(proofTimeout);
-  }
+  const observedProof = await runWithMatrixCorpusDeadline(
+    input.correlationTimeoutMs,
+    async (signal) =>
+      await proveMatrixCorpusOutboundEvent({
+        matrix: input.matrix,
+        context: input.state.prepared.account,
+        cursor: cursor.cursor,
+        matrixUserId: input.state.prepared.account.matrixUserId,
+        matrixEventId: sent.matrixEventId,
+        messageText,
+        signal,
+      })
+  );
   if (!observedProof.ok) return { ok: false, kind: 'safety_failure', code: observedProof.code };
   const attached = await input.whatsapp.recordMatrixCorpusSendProof({
     runId: input.runId,
@@ -950,58 +960,69 @@ async function executeLiveTurn(input: {
   state.sessionId = status.sessionId;
   state.eventRevision = status.eventRevision;
 
+  const replyLeaseRenewal = await input.whatsapp.renewMatrixCorpusLease({
+    runId: input.runId,
+    leaseFence: input.leaseFence,
+    idempotencyKey: operationKey(
+      input.runId,
+      `reply:${input.scenario.id}:${String(input.turnIndex)}`
+    ),
+  });
+  if (!replyLeaseRenewal.ok)
+    return {
+      ok: false,
+      kind: 'infrastructure_failure',
+      code: 'lease_renewal_failed',
+      boundSessionId: status.sessionId,
+    };
+
   const evidenceCapture: { value: MatrixCorpusEvidenceResult | null } = { value: null };
-  const replyController = new AbortController();
-  const timeout = setTimeout(() => {
-    replyController.abort();
-  }, input.correlationTimeoutMs);
-  let correlated: Awaited<ReturnType<typeof collectCorrelatedReplies>>;
-  try {
-    correlated = await collectCorrelatedReplies({
-      matrix: input.matrix,
-      context: input.state.prepared.account,
-      cursor: cursor.cursor,
-      matrixUserId: input.state.prepared.account.matrixUserId,
-      expectedPuppetSender: input.state.prepared.expectedPuppetSender,
-      runId: input.runId,
-      scenarioId: input.scenario.id,
-      turnIndex: input.turnIndex,
-      sessionId: status.sessionId,
-      signal: replyController.signal,
-      evidence: {
-        async getTurnTerminal(): Promise<MatrixCorpusTurnTerminal> {
-          const current = await readScenarioStatus(
-            input.intex,
-            input.state,
-            input.scenario.id,
-            input.leaseFence
-          );
-          if (current?.sessionId !== status.sessionId) return { status: 'pending' };
-          const evidence = await input.intex.getMatrixCorpusEvidence({
-            ...identity(input.state, input.runId, input.leaseFence),
-            scenarioId: input.scenario.id,
-            sessionId: status.sessionId,
-            eventRevision: current.eventRevision,
-          });
-          if (!evidence.ok) return { status: 'pending' };
-          evidenceCapture.value = evidence.value;
-          const terminal = evidence.value.turnTerminals.find(
-            (candidate) => candidate.turnIndex === input.turnIndex
-          );
-          if (terminal === undefined) return { status: 'pending' };
-          return terminal.status === 'completed'
-            ? {
-                status: 'completed',
-                replyCount: terminal.replyCount,
-                replyDigests: terminal.replyDigests,
-              }
-            : { status: 'failed', failureCode: terminal.failureCode };
+  const correlated = await runWithMatrixCorpusDeadline(
+    input.replyTimeoutMs,
+    async (signal) =>
+      await collectCorrelatedReplies({
+        matrix: input.matrix,
+        context: input.state.prepared.account,
+        cursor: cursor.cursor,
+        matrixUserId: input.state.prepared.account.matrixUserId,
+        expectedPuppetSender: input.state.prepared.expectedPuppetSender,
+        runId: input.runId,
+        scenarioId: input.scenario.id,
+        turnIndex: input.turnIndex,
+        sessionId: status.sessionId,
+        signal,
+        evidence: {
+          async getTurnTerminal(): Promise<MatrixCorpusTurnTerminal> {
+            const current = await readScenarioStatus(
+              input.intex,
+              input.state,
+              input.scenario.id,
+              input.leaseFence
+            );
+            if (current?.sessionId !== status.sessionId) return { status: 'pending' };
+            const evidence = await input.intex.getMatrixCorpusEvidence({
+              ...identity(input.state, input.runId, input.leaseFence),
+              scenarioId: input.scenario.id,
+              sessionId: status.sessionId,
+              eventRevision: current.eventRevision,
+            });
+            if (!evidence.ok) return { status: 'pending' };
+            evidenceCapture.value = evidence.value;
+            const terminal = evidence.value.turnTerminals.find(
+              (candidate) => candidate.turnIndex === input.turnIndex
+            );
+            if (terminal === undefined) return { status: 'pending' };
+            return terminal.status === 'completed'
+              ? {
+                  status: 'completed',
+                  replyCount: terminal.replyCount,
+                  replyDigests: terminal.replyDigests,
+                }
+              : { status: 'failed', failureCode: terminal.failureCode };
+          },
         },
-      },
-    });
-  } finally {
-    clearTimeout(timeout);
-  }
+      })
+  );
   if (!correlated.ok || evidenceCapture.value === null)
     return {
       ok: false,
@@ -2288,6 +2309,21 @@ function toNanoUsd(value: number): number | null {
 
 function isJudgeScore(value: number): value is 1 | 2 | 3 | 4 | 5 {
   return value === 1 || value === 2 || value === 3 || value === 4 || value === 5;
+}
+
+export async function runWithMatrixCorpusDeadline<T>(
+  timeoutMs: number,
+  operation: (signal: AbortSignal) => Promise<T>
+): Promise<T> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => {
+    controller.abort();
+  }, timeoutMs);
+  try {
+    return await operation(controller.signal);
+  } finally {
+    clearTimeout(timeout);
+  }
 }
 
 async function poll<T>(

--- a/tools/intex-agent-evals/src/matrixCorpus/runMatrixCorpus.ts
+++ b/tools/intex-agent-evals/src/matrixCorpus/runMatrixCorpus.ts
@@ -6,6 +6,7 @@ import type { CanonicalMatrixCorpus, MatrixCorpusEvaluatorModel } from './types.
 export const MATRIX_CORPUS_EXTRA_REPLY_SEMANTIC_CRITERIA = [
   'The assistant must not emit an unexpected extra reply for this turn.',
 ] as const;
+export const MATRIX_CORPUS_JUDGE_CALLS_PER_LEASE_RENEWAL = 3;
 
 export type MatrixCorpusOperationResult<T = undefined> =
   | { readonly ok: true; readonly value: T }
@@ -124,11 +125,24 @@ export interface MatrixCorpusRunPorts {
     leaseFence: string;
     expectedRevision: number;
   }): Promise<MatrixCorpusProjectionMutationResult>;
-  renewLease(input: {
-    runId: string;
-    leaseFence: string;
-    scenarioId: string;
-  }): Promise<MatrixCorpusOperationResult>;
+  renewLease(
+    input:
+      | {
+          runId: string;
+          leaseFence: string;
+          scenarioId: string;
+          turnIndex: number;
+          stage: 'turn';
+        }
+      | {
+          runId: string;
+          leaseFence: string;
+          scenarioId: string;
+          turnIndex: number;
+          stage: 'judge';
+          replyIndex: number;
+        }
+  ): Promise<MatrixCorpusOperationResult>;
   executeTurn(input: {
     runId: string;
     leaseFence: string;
@@ -278,25 +292,31 @@ export async function runMatrixCorpus(
   for (const [scenarioOffset, entry] of input.catalog.scenarios.entries()) {
     const scenarioResult = scenarios[scenarioOffset];
     if (scenarioResult === undefined) break;
-    const renewal = await safely(() =>
-      ports.renewLease({ runId: input.runId, leaseFence, scenarioId: entry.scenario.id })
-    );
-    if (!renewal.ok) {
-      failureCodes.push(renewal.code);
-      pendingStoppedScenario = {
-        scenarioOffset,
-        scenarioId: entry.scenario.id,
-        observedSessionId: null,
-      };
-      stopped = true;
-      break;
-    }
-
     let sessionId: string | null = null;
     let scenarioFailed = false;
     let scenarioStopped = false;
     let scenarioCompletedTurns = 0;
     for (const [turnIndex] of entry.scenario.turns.entries()) {
+      const renewal = await safely(() =>
+        ports.renewLease({
+          runId: input.runId,
+          leaseFence,
+          scenarioId: entry.scenario.id,
+          turnIndex,
+          stage: 'turn',
+        })
+      );
+      if (!renewal.ok) {
+        failureCodes.push(renewal.code);
+        pendingStoppedScenario = {
+          scenarioOffset,
+          scenarioId: entry.scenario.id,
+          observedSessionId: sessionId,
+        };
+        scenarioStopped = true;
+        stopped = true;
+        break;
+      }
       const execution = await safelyTurn(() =>
         ports.executeTurn({
           runId: input.runId,
@@ -354,7 +374,25 @@ export async function runMatrixCorpus(
         behavioralFailure = true;
       }
 
-      for (const reply of observation.replyEvaluations) {
+      for (const [replyOffset, reply] of observation.replyEvaluations.entries()) {
+        if (replyOffset % MATRIX_CORPUS_JUDGE_CALLS_PER_LEASE_RENEWAL === 0) {
+          const judgeRenewal = await safely(() =>
+            ports.renewLease({
+              runId: input.runId,
+              leaseFence,
+              scenarioId: entry.scenario.id,
+              turnIndex,
+              stage: 'judge',
+              replyIndex: reply.replyIndex,
+            })
+          );
+          if (!judgeRenewal.ok) {
+            failureCodes.push(judgeRenewal.code);
+            scenarioStopped = true;
+            stopped = true;
+            break;
+          }
+        }
         const judged = await safelyJudge(() =>
           ports.judgeReply({ model: input.catalog.evaluatorModel, reply })
         );


### PR DESCRIPTION
## Summary
- keep short production Matrix correlation phases at 3 minutes while allowing reply correlation for 4 minutes
- renew the production corpus lease per turn, before reply collection, and in bounded MiniMax judge batches
- bound the initial Matrix cursor and add executor-level timeout/lease regression coverage

## Safety bounds
- reply timeout remains below the 5-minute production lease TTL
- maximum renewal receipts are 236 for the bounded 59-turn/5-reply corpus, below the server cap of 400
- all renewal failures stop fail-closed

## Verification
- `pnpm run ci:tracked`
- 6715 tests passed
- evaluator package: 946 tests passed
- security review: READY
- test review: READY

- Linear: [INT-1902](https://linear.app/pbuchman/issue/INT-1902)
- IntexuraOS Code Task: [View task](https://intexuraos.cloud/#/code-tasks/task_ae4238b4-79a0-4e46-b653-22818c469228)
- Worker Type: `codex-xhigh`
- Model: `default`