### PR TITLE
[INT-1903] fix(intex-agent): recover runs with encrypted confirmations

### DIFF
--- a/apps/intex-agent/src/__tests__/infra/firestore/testConfirmationRepository.test.ts
+++ b/apps/intex-agent/src/__tests__/infra/firestore/testConfirmationRepository.test.ts
@@ -10,6 +10,7 @@ import { createMatrixCorpusContextCrypto } from '../../../domain/matrixCorpus/co
 import {
   FirestoreTestConfirmationRepository,
   INTEX_AGENT_TEST_CONFIRMATIONS_COLLECTION,
+  parseMatrixCorpusTestConfirmationEvidenceDocument,
 } from '../../../infra/firestore/testConfirmationRepository.js';
 
 const createdAt = '2026-07-20T10:00:00.000Z';
@@ -67,6 +68,62 @@ function fixture(): Readonly<{
 }
 
 describe('FirestoreTestConfirmationRepository', () => {
+  it('verifies complete AEAD-bound confirmation evidence for a run owner', async () => {
+    const { firestore, crypto, repository } = fixture();
+    await repository.createOrGet(pendingInput());
+    const snapshot = await firestore
+      .collection(INTEX_AGENT_TEST_CONFIRMATIONS_COLLECTION)
+      .doc('confirmation_1')
+      .get();
+
+    expect(
+      parseMatrixCorpusTestConfirmationEvidenceDocument(
+        snapshot.id,
+        snapshot.data(),
+        crypto,
+        identity()
+      )
+    ).toEqual({
+      confirmationId: 'confirmation_1',
+      runId: 'run_1',
+      scenarioId: 'scenario_1',
+      sessionId: 'session_1',
+      leaseFence: '7',
+    });
+    expect(
+      parseMatrixCorpusTestConfirmationEvidenceDocument(
+        snapshot.id,
+        { ...snapshot.data(), sessionId: 'session_2' },
+        crypto,
+        identity()
+      )
+    ).toBeUndefined();
+    expect(
+      parseMatrixCorpusTestConfirmationEvidenceDocument(
+        snapshot.id,
+        null,
+        crypto,
+        identity()
+      )
+    ).toBeUndefined();
+    expect(
+      parseMatrixCorpusTestConfirmationEvidenceDocument(
+        snapshot.id,
+        { scenarioId: 1, sessionId: 'session_1' },
+        crypto,
+        identity()
+      )
+    ).toBeUndefined();
+    expect(
+      parseMatrixCorpusTestConfirmationEvidenceDocument(
+        snapshot.id,
+        { scenarioId: 'scenario_1', sessionId: 1 },
+        crypto,
+        identity()
+      )
+    ).toBeUndefined();
+  });
+
   it('creates one immutable Matrix-corpus confirmation foundation', async () => {
     const { firestore, repository } = fixture();
 

--- a/apps/intex-agent/src/__tests__/infra/firestore/testRunRepository.test.ts
+++ b/apps/intex-agent/src/__tests__/infra/firestore/testRunRepository.test.ts
@@ -8,6 +8,7 @@ import type {
   MatrixCorpusPrivateRunContextV1,
   MatrixCorpusPrivateScenarioContextV1,
 } from '../../../domain/matrixCorpus/ports/matrixCorpusContextRepository.js';
+import { createMatrixCorpusContextCrypto } from '../../../domain/matrixCorpus/contextCrypto.js';
 import type {
   MatrixCorpusRunManifestV1,
   MatrixCorpusTerminalCandidateV1,
@@ -27,11 +28,19 @@ import {
   testRunScenario,
 } from '../../domain/testRuns/testRunFixtures.js';
 import { FirestoreTestRunRepository } from '../../../infra/firestore/testRunRepository.js';
+import { FirestoreTestConfirmationRepository } from '../../../infra/firestore/testConfirmationRepository.js';
 
 const later = '2026-07-20T10:05:00.000Z';
 
 function identity(): TestRunIdentity {
   return { runId: 'run_1', userId: 'auth0:user_1', leaseFence: '7' };
+}
+
+function contextCrypto(): ReturnType<typeof createMatrixCorpusContextCrypto> {
+  return createMatrixCorpusContextCrypto({
+    key: Buffer.alloc(32, 7),
+    keyVersion: 'context-key-v1',
+  });
 }
 
 function cleanupInput(): Parameters<TestRunRepository['cleanupExactRun']>[0] {
@@ -47,7 +56,10 @@ function fixture(): Readonly<{
   repository: FirestoreTestRunRepository;
 }> {
   const firestore = createFakeFirestore() as unknown as Firestore;
-  return { firestore, repository: new FirestoreTestRunRepository({ firestore }) };
+  return {
+    firestore,
+    repository: new FirestoreTestRunRepository({ firestore, crypto: contextCrypto() }),
+  };
 }
 
 describe('Firestore Test Run foundation repository', () => {
@@ -268,7 +280,10 @@ describe('Firestore Test Run foundation repository', () => {
 
   it('serializes an artifact-timeout claim across repository instances', async () => {
     const { firestore, repository } = fixture();
-    const competingRepository = new FirestoreTestRunRepository({ firestore });
+    const competingRepository = new FirestoreTestRunRepository({
+      firestore,
+      crypto: contextCrypto(),
+    });
     const jsonCandidateDigest = '1'.repeat(64);
     const markdownCandidateDigest = '2'.repeat(64);
     const artifactStageDigest = digestArtifactCandidates(
@@ -726,7 +741,10 @@ describe('Firestore Test Run foundation repository', () => {
       .collection('intex_agent_matrix_corpus_test_confirmations')
       .doc('target_confirmation_1');
     const confirmation = await confirmationRef.get();
-    await confirmationRef.set({ ...confirmation.data(), userId: 'auth0:foreign' });
+    await confirmationRef.set({
+      ...confirmation.data(),
+      userBindingDigest: 'f'.repeat(64),
+    });
 
     await expect(
       repository.cleanupExactRun({
@@ -2757,7 +2775,6 @@ describe('Firestore Test Run foundation repository', () => {
         finalization: null,
       },
     });
-
     await expect(repository.applyAbandonedRecovery(abandonedRecovery())).resolves.toMatchObject({
       ok: true,
       disposition: 'applied',
@@ -2785,24 +2802,19 @@ describe('Firestore Test Run foundation repository', () => {
       .collection('intex_agent_matrix_corpus_run_contexts')
       .doc('run_1')
       .set(activeRunContext());
-    await firestore
-      .collection('intex_agent_matrix_corpus_run_manifests')
-      .doc('run_1')
-      .set({
-        ...emptyRunManifest(),
-        scenarioBindings: [
-          {
-            scenarioId: 'scenario_001',
-            scenarioNumber: 1,
-            scenarioLabel: 'Scenario 001/020',
-            sessionId: 'matrix_session_1',
-          },
-        ],
-      });
+    await writeScenarioEvidence(firestore);
     await firestore
       .collection('intex_agent_matrix_corpus_scenario_contexts')
       .doc('scenario_context_1')
       .set(activeScenarioContext());
+    await writeTestConfirmation(firestore, {
+      confirmationId: 'confirmation_1',
+      runId: 'run_1',
+      scenarioId: 'scenario_001',
+      sessionId: 'matrix_session_1',
+      userId: 'auth0:user_1',
+      leaseFence: '7',
+    });
 
     await expect(repository.applyAbandonedRecovery(abandonedRecovery())).resolves.toMatchObject({
       ok: true,
@@ -2815,6 +2827,33 @@ describe('Firestore Test Run foundation repository', () => {
         .doc('scenario_context_1')
         .get()
     ).resolves.toMatchObject({ exists: false });
+  });
+
+  it('rejects an AEAD-valid confirmation outside the exact manifest session binding', async () => {
+    const { firestore, repository } = fixture();
+    await createRunningScenarioRun(repository);
+    await firestore
+      .collection('intex_agent_matrix_corpus_run_contexts')
+      .doc('run_1')
+      .set(activeRunContext());
+    await writeScenarioEvidence(firestore);
+    await firestore
+      .collection('intex_agent_matrix_corpus_scenario_contexts')
+      .doc('scenario_context_1')
+      .set(activeScenarioContext());
+    await writeTestConfirmation(firestore, {
+      confirmationId: 'confirmation_1',
+      runId: 'run_1',
+      scenarioId: 'scenario_001',
+      sessionId: 'orphan_session_1',
+      userId: 'auth0:user_1',
+      leaseFence: '7',
+    });
+
+    await expect(repository.applyAbandonedRecovery(abandonedRecovery())).resolves.toEqual({
+      ok: false,
+      code: 'CORRELATED_REPLAY_CONFLICT',
+    });
   });
 
   it('validates abandoned recovery commands and stored receipts field by field', async () => {
@@ -2964,21 +3003,9 @@ describe('Firestore Test Run foundation repository', () => {
         code: 'CORRELATED_REPLAY_CONFLICT',
       },
       {
-        collection: 'intex_agent_matrix_corpus_test_confirmations',
-        id: 'confirmation_1',
-        value: { runId: 'run_1', leaseFence: '7', userId: 'auth0:foreign' },
-        code: 'CORRELATED_REPLAY_CONFLICT',
-      },
-      {
         collection: 'intex_agent_matrix_corpus_ingest_receipts',
         id: 'ingest_1',
         value: { runId: 'run_1', leaseFence: '7' },
-        code: 'EVIDENCE_MISMATCH',
-      },
-      {
-        collection: 'intex_agent_matrix_corpus_test_confirmations',
-        id: 'confirmation_1',
-        value: { runId: 'run_1', leaseFence: '7', userId: 'auth0:user_1' },
         code: 'EVIDENCE_MISMATCH',
       },
     ] as const;
@@ -2989,6 +3016,26 @@ describe('Firestore Test Run foundation repository', () => {
       await expect(repository.applyAbandonedRecovery(abandonedRecovery())).resolves.toEqual({
         ok: false,
         code: evidence.code,
+      });
+    }
+
+    for (const owner of [
+      { userId: 'auth0:foreign', code: 'CORRELATED_REPLAY_CONFLICT' },
+      { userId: 'auth0:user_1', code: 'EVIDENCE_MISMATCH' },
+    ] as const) {
+      const { firestore, repository } = fixture();
+      await repository.createOrGet(testRunRecord());
+      await writeTestConfirmation(firestore, {
+        confirmationId: 'confirmation_1',
+        runId: 'run_1',
+        scenarioId: 'scenario_001',
+        sessionId: 'matrix_session_1',
+        userId: owner.userId,
+        leaseFence: '7',
+      });
+      await expect(repository.applyAbandonedRecovery(abandonedRecovery())).resolves.toEqual({
+        ok: false,
+        code: owner.code,
       });
     }
   });
@@ -3538,6 +3585,33 @@ async function createRunningScenarioRun(repository: FirestoreTestRunRepository):
   if (!running.ok) throw new Error('running fixture transition failed');
 }
 
+async function writeTestConfirmation(
+  firestore: Firestore,
+  identity: Readonly<{
+    confirmationId: string;
+    runId: string;
+    scenarioId: string;
+    sessionId: string;
+    userId: string;
+    leaseFence: string;
+  }>
+): Promise<void> {
+  const repository = new FirestoreTestConfirmationRepository({
+    firestore,
+    crypto: contextCrypto(),
+  });
+  const result = await repository.createOrGet({
+    identity,
+    toolName: 'create_note',
+    toolArgs: { content: 'Synthetic Matrix confirmation' },
+    selectionTurnIndex: 0,
+    selectionOrdinal: 1,
+    createdAt: '2026-07-20T10:00:00.000Z',
+    expiresAt: '2026-07-20T10:05:00.000Z',
+  });
+  if (!result.ok) throw new Error('confirmation fixture creation failed');
+}
+
 async function prepareEmptyFinalizationFixture(): Promise<
   Readonly<{
     firestore: Firestore;
@@ -3931,18 +4005,14 @@ async function writeCleanupFixture(firestore: Firestore): Promise<void> {
     createdAt: later,
     eventSequence: 1,
   });
-  await firestore
-    .collection('intex_agent_matrix_corpus_test_confirmations')
-    .doc('target_confirmation_1')
-    .set({
-      runId: 'run_target',
-      scenarioId: 'scenario_001',
-      sessionId: 'matrix_target_session',
-      userId: 'auth0:user_1',
-      leaseFence: '7',
-      runtimeAudience: 'hetzner-prod',
-      lane: 'matrix_corpus',
-    });
+  await writeTestConfirmation(firestore, {
+    confirmationId: 'target_confirmation_1',
+    runId: 'run_target',
+    scenarioId: 'scenario_001',
+    sessionId: 'matrix_target_session',
+    userId: 'auth0:user_1',
+    leaseFence: '7',
+  });
   await firestore
     .collection('intex_agent_matrix_corpus_ingest_receipts')
     .doc('target_ingest_1')

--- a/apps/intex-agent/src/infra/firestore/testConfirmationRepository.ts
+++ b/apps/intex-agent/src/infra/firestore/testConfirmationRepository.ts
@@ -226,6 +226,42 @@ type StoredMatrixCorpusTestConfirmationV1 = Omit<
     userBindingDigest: string;
   }>;
 
+export interface MatrixCorpusTestConfirmationEvidenceIdentity {
+  confirmationId: string;
+  runId: string;
+  scenarioId: string;
+  sessionId: string;
+  leaseFence: string;
+}
+
+export function parseMatrixCorpusTestConfirmationEvidenceDocument(
+  documentId: string,
+  data: unknown,
+  crypto: MatrixCorpusContextCrypto,
+  expected: Pick<MatrixCorpusTestConfirmationIdentity, 'runId' | 'userId' | 'leaseFence'>
+): MatrixCorpusTestConfirmationEvidenceIdentity | undefined {
+  if (!isRecord(data)) return undefined;
+  const scenarioId = data['scenarioId'];
+  const sessionId = data['sessionId'];
+  if (typeof scenarioId !== 'string' || typeof sessionId !== 'string') return undefined;
+  const parsed = classifyConfirmation(data, crypto, {
+    confirmationId: documentId,
+    runId: expected.runId,
+    scenarioId,
+    sessionId,
+    userId: expected.userId,
+    leaseFence: expected.leaseFence,
+  });
+  if (!parsed.ok) return undefined;
+  return {
+    confirmationId: parsed.confirmation.confirmationId,
+    runId: parsed.confirmation.runId,
+    scenarioId: parsed.confirmation.scenarioId,
+    sessionId: parsed.confirmation.sessionId,
+    leaseFence: parsed.confirmation.leaseFence,
+  };
+}
+
 function encryptConfirmation(
   confirmation: MatrixCorpusTestConfirmation,
   crypto: MatrixCorpusContextCrypto

--- a/apps/intex-agent/src/infra/firestore/testRunRepository.ts
+++ b/apps/intex-agent/src/infra/firestore/testRunRepository.ts
@@ -2,6 +2,8 @@ import { createHash } from 'node:crypto';
 
 import type { Firestore } from '@intexuraos/infra-firestore';
 
+import type { MatrixCorpusContextCrypto } from '../../domain/matrixCorpus/contextCrypto.js';
+
 import type {
   TestRunIdentity,
   TestRunCurrentAcceptance,
@@ -64,7 +66,11 @@ import {
   parseMatrixCorpusSessionDocument,
 } from './sessionRepository.js';
 import { INTEX_AGENT_MATRIX_CORPUS_INGEST_RECEIPTS_COLLECTION } from './ingestReceiptRepository.js';
-import { INTEX_AGENT_TEST_CONFIRMATIONS_COLLECTION } from './testConfirmationRepository.js';
+import {
+  INTEX_AGENT_TEST_CONFIRMATIONS_COLLECTION,
+  parseMatrixCorpusTestConfirmationEvidenceDocument,
+  type MatrixCorpusTestConfirmationEvidenceIdentity,
+} from './testConfirmationRepository.js';
 
 type FirestoreDocumentReference = ReturnType<ReturnType<Firestore['collection']>['doc']>;
 
@@ -76,7 +82,12 @@ const FENCE_PATTERN = /^[1-9][0-9]{0,19}$/u;
 const SHA_256_PATTERN = /^[0-9a-f]{64}$/u;
 
 export class FirestoreTestRunRepository implements TestRunRepository {
-  constructor(private readonly deps: Readonly<{ firestore: Firestore }>) {}
+  constructor(
+    private readonly deps: Readonly<{
+      firestore: Firestore;
+      crypto: MatrixCorpusContextCrypto;
+    }>
+  ) {}
 
   static digestTerminalCandidate(candidate: MatrixCorpusTerminalCandidateV1): string {
     const parsed = matrixCorpusTerminalCandidateV1Schema.parse(candidate);
@@ -422,21 +433,17 @@ export class FirestoreTestRunRepository implements TestRunRepository {
         ) ||
         item.confirmationSnapshot.docs.some(
           (document) =>
-            !matchesCleanupChild(
+            !matchesConfirmationEvidence(
+              document.id,
               document.data(),
+              this.deps.crypto,
               input.targetIdentity,
-              item.binding,
-              true
+              item.binding
             )
         ) ||
         item.ingestSnapshot.docs.some(
           (document) =>
-            !matchesCleanupChild(
-              document.data(),
-              input.targetIdentity,
-              item.binding,
-              false
-            )
+            !matchesIngestEvidence(document.data(), input.targetIdentity, item.binding)
         )
       )
         return failure('EVIDENCE_MISMATCH');
@@ -1338,6 +1345,14 @@ export class FirestoreTestRunRepository implements TestRunRepository {
         ref: FirestoreDocumentReference;
         context: MatrixCorpusPrivateScenarioContextV1;
       }[];
+      const confirmations = confirmationSnapshot.docs.map((document) =>
+        parseMatrixCorpusTestConfirmationEvidenceDocument(
+          document.id,
+          document.data(),
+          this.deps.crypto,
+          input.identity
+        )
+      );
       const current = parsedCurrent ?? undefined;
       if (
         (current !== undefined && !matchesIdentity(current, input.identity)) ||
@@ -1353,11 +1368,11 @@ export class FirestoreTestRunRepository implements TestRunRepository {
         ingestSnapshot.docs.some(
           (document) => !matchesRunFence(document.data(), input.identity)
         ) ||
-        confirmationSnapshot.docs.some(
-          (document) => !matchesRunFenceAndUser(document.data(), input.identity)
-        )
+        confirmations.some((confirmation) => confirmation === undefined)
       )
         return failure('CORRELATED_REPLAY_CONFLICT');
+
+      const exactConfirmations = confirmations as MatrixCorpusTestConfirmationEvidenceIdentity[];
 
       const hasExecutionEvidence =
         sessionSnapshot.docs.length > 0 ||
@@ -1393,6 +1408,27 @@ export class FirestoreTestRunRepository implements TestRunRepository {
 
       if (context === undefined || manifest === undefined)
         return failure('FINALIZATION_MISMATCH');
+      if (
+        exactConfirmations.some((confirmation) => {
+          const binding = manifest.scenarioBindings.find(
+            (candidate) => candidate.scenarioId === confirmation.scenarioId
+          );
+          if (binding?.sessionId !== confirmation.sessionId) return true;
+          const sessionDocument = sessionSnapshot.docs.find(
+            (document) => document.id === confirmation.sessionId
+          );
+          const profile = (sessionDocument?.data() as Record<string, unknown> | undefined)?.[
+            'matrixCorpusProfile'
+          ];
+          return (
+            typeof profile !== 'object' ||
+            profile === null ||
+            Array.isArray(profile) ||
+            (profile as Record<string, unknown>)['scenarioId'] !== confirmation.scenarioId
+          );
+        })
+      )
+        return failure('CORRELATED_REPLAY_CONFLICT');
       let contextFinalizationTombstoneDigest = current.contextFinalizationTombstoneDigest;
       if (current.lifecycle === 'running') {
         if (
@@ -1636,25 +1672,42 @@ function cleanupSuccess(
   };
 }
 
-function matchesCleanupChild(
+function matchesIngestEvidence(
   value: unknown,
   identity: TestRunIdentity,
   binding: Readonly<{
     scenarioId: string;
     sessionId: string;
-  }>,
-  requireUserAndLane: boolean
+  }>
 ): boolean {
   const record = value as Record<string, unknown>;
   return (
     record['runId'] === identity.runId &&
     record['scenarioId'] === binding.scenarioId &&
     record['sessionId'] === binding.sessionId &&
-    record['leaseFence'] === identity.leaseFence &&
-    (!requireUserAndLane ||
-      (record['userId'] === identity.userId &&
-        record['runtimeAudience'] === 'hetzner-prod' &&
-        record['lane'] === 'matrix_corpus'))
+    record['leaseFence'] === identity.leaseFence
+  );
+}
+
+function matchesConfirmationEvidence(
+  documentId: string,
+  value: unknown,
+  crypto: MatrixCorpusContextCrypto,
+  identity: TestRunIdentity,
+  binding: Readonly<{
+    scenarioId: string;
+    sessionId: string;
+  }>
+): boolean {
+  const confirmation = parseMatrixCorpusTestConfirmationEvidenceDocument(
+    documentId,
+    value,
+    crypto,
+    identity
+  );
+  return (
+    confirmation?.scenarioId === binding.scenarioId &&
+    confirmation.sessionId === binding.sessionId
   );
 }
 
@@ -1773,13 +1826,6 @@ function hasExactMatrixRunEvidence(value: unknown, identity: TestRunIdentity): b
 function matchesRunFence(value: unknown, identity: TestRunIdentity): boolean {
   const record = value as Record<string, unknown>;
   return record['runId'] === identity.runId && record['leaseFence'] === identity.leaseFence;
-}
-
-function matchesRunFenceAndUser(value: unknown, identity: TestRunIdentity): boolean {
-  return (
-    matchesRunFence(value, identity) &&
-    (value as Record<string, unknown>)['userId'] === identity.userId
-  );
 }
 
 function failure(

--- a/apps/intex-agent/src/services.ts
+++ b/apps/intex-agent/src/services.ts
@@ -268,7 +268,10 @@ export function createIntexMatrixCorpusRuntime(
     contextService,
     contextRepository,
     manifestRepository,
-    testRunRepository: new FirestoreTestRunRepository({ firestore: dependencies.firestore }),
+    testRunRepository: new FirestoreTestRunRepository({
+      firestore: dependencies.firestore,
+      crypto: contextCrypto,
+    }),
     sessionRepository: dependencies.sessionRepository,
     evidenceService,
     verifyAttestation,


### PR DESCRIPTION
## Summary
- validate Matrix-corpus confirmation evidence with the production closed schema and AEAD binding
- correlate recovery evidence with the exact manifest scenario and session
- use the same verified confirmation path during retention cleanup

## Verification
- Intex Agent: 1533 tests passed; typecheck and lint passed
- repository CI: 6715 tests passed; all type/lint/static gates passed
- targeted confirmation repository coverage: 100% statements, branches, functions, and lines
- v8-ignore coverage validator passed
- independent security and test reviews: READY

- Linear: [INT-1903](https://linear.app/pbuchman/issue/INT-1903)
- IntexuraOS Code Task: [View task](https://intexuraos.cloud/#/code-tasks/task_0b49e555-882d-499d-a0da-7b7622744592)
- Worker Type: `codex-xhigh`
- Model: `default`