### PR TITLE
[INT-1905] Fix Matrix confirmation reply correlation

### DIFF
--- a/integration-tests/fixtures/intexAgentMatrixCorpusRuntimeHarness.ts
+++ b/integration-tests/fixtures/intexAgentMatrixCorpusRuntimeHarness.ts
@@ -46,6 +46,7 @@ import type {
 } from '../../tools/intex-agent-evals/src/live/matrixClient.js';
 import type { MiniMaxEvaluator } from '../../tools/intex-agent-evals/src/minimaxJudge.js';
 import { loadCanonicalMatrixCorpus } from '../../tools/intex-agent-evals/src/matrixCorpus/catalog.js';
+import { MATRIX_WHATSAPP_CONFIRMATION_MIRROR_SUFFIX } from '../../tools/intex-agent-evals/src/matrixCorpus/correlation.js';
 import { createProductionMatrixCorpusExecutor } from '../../tools/intex-agent-evals/src/matrixCorpus/liveExecution.js';
 import { createNodeMatrixCorpusRetentionSagaPort } from '../../tools/intex-agent-evals/src/matrixCorpus/retentionExecution.js';
 import type { MatrixCorpusPreparedContext } from '../../tools/intex-agent-evals/src/matrixCorpus/liveRuntime.js';
@@ -230,12 +231,16 @@ export async function createIntexAgentMatrixCorpusRuntimeHarness(): Promise<Inte
         async publishReplyWithReceipt(input) {
           metrics.replyPublications += 1;
           matrixState.eventOrdinal += 1;
+          const matrixBody =
+            input.buttons !== undefined && input.buttons.length > 0
+              ? `${input.message}${MATRIX_WHATSAPP_CONFIRMATION_MIRROR_SUFFIX}`
+              : input.message;
           matrixState.events.push({
             eventId: `$matrix_reply_${String(matrixState.eventOrdinal)}`,
             originServerTs: Date.parse(NOW) + matrixState.eventOrdinal,
             type: 'm.room.message',
             sender: MATRIX_PUPPET_ID,
-            content: { msgtype: 'm.text', body: input.message },
+            content: { msgtype: 'm.text', body: matrixBody },
           });
           return { publicationReceiptId: `reply_publication_${String(metrics.replyPublications)}` };
         },

--- a/tools/intex-agent-evals/src/__tests__/fixtures/matrixCorpusCompositionHarness.ts
+++ b/tools/intex-agent-evals/src/__tests__/fixtures/matrixCorpusCompositionHarness.ts
@@ -24,7 +24,10 @@ import type {
   MatrixTargetSyncResult,
   MatrixTimelineEvent,
 } from '../../live/matrixClient.js';
-import { digestMatrixReply } from '../../matrixCorpus/correlation.js';
+import {
+  digestMatrixReply,
+  MATRIX_WHATSAPP_CONFIRMATION_MIRROR_SUFFIX,
+} from '../../matrixCorpus/correlation.js';
 import type { MatrixCorpusPreparedContext } from '../../matrixCorpus/liveRuntime.js';
 import {
   MATRIX_CORPUS_PREFLIGHT_CHECKS,
@@ -324,6 +327,13 @@ function createWhatsAppBoundary(state: SharedState): WhatsAppServiceClient {
         createScenarioProgress(entry, state.progress.size + 1);
       state.progress.set(issued.scenarioId, progress);
       const reply = `Scenario ${String(entry.scenarioNumber).padStart(3, '0')} turn ${String(issued.turnIndex + 1)} completed.`;
+      const expectedTurn = entry.scenario.expected.turns[issued.turnIndex];
+      if (expectedTurn === undefined) throw new Error('turn expectation is missing');
+      const matrixReply = expectedTurn.timeline.requiredEventTypes.includes(
+        'confirmation_requested'
+      )
+        ? `${reply}${MATRIX_WHATSAPP_CONFIRMATION_MIRROR_SUFFIX}`
+        : reply;
       progress.lastTurnIndex = issued.turnIndex;
       progress.eventRevision = issued.turnIndex + 1;
       progress.replies.set(issued.turnIndex, reply);
@@ -345,7 +355,7 @@ function createWhatsAppBoundary(state: SharedState): WhatsAppServiceClient {
             entry.scenarioNumber === state.wrongPuppetScenarioNumber
               ? '@whatsapp_lid-wrong-puppet-sentinel:example.test'
               : '@whatsapp_lid-private-puppet-sentinel:example.test',
-          content: { msgtype: 'm.text', body: reply },
+          content: { msgtype: 'm.text', body: matrixReply },
         });
       }
       state.metrics.matrixMessages.push(request.text);

--- a/tools/intex-agent-evals/src/__tests__/matrixCorpusCorrelation.test.ts
+++ b/tools/intex-agent-evals/src/__tests__/matrixCorpusCorrelation.test.ts
@@ -4,6 +4,7 @@ import {
   captureMatrixCorpusCursor,
   collectCorrelatedReplies,
   digestMatrixReply,
+  MATRIX_WHATSAPP_CONFIRMATION_MIRROR_SUFFIX,
   proveMatrixCorpusOutboundEvent,
   type MatrixCorpusReplyEvidencePort,
 } from '../matrixCorpus/correlation.js';
@@ -14,8 +15,13 @@ const CONTEXT = {
   targetRoomId: '!room:home-dev',
 };
 const PUPPET = '@whatsapp_48123123123:home-dev';
-
 describe('Matrix corpus reply correlation', () => {
+  it('pins the exact production WhatsApp confirmation mirror rendering', () => {
+    expect(MATRIX_WHATSAPP_CONFIRMATION_MIRROR_SUFFIX).toBe(
+      '\n\n<Yes> - <No>\nUse the WhatsApp app to click buttons'
+    );
+  });
+
   it('proves the exact self-authored outbound event in the bound room', async () => {
     const messageText = '🧪 Scenario 001/020 · Matrix corpus · tools mocked · imc1_fixture';
     const matrix = matrixWith([
@@ -143,6 +149,135 @@ describe('Matrix corpus reply correlation', () => {
       cursor: 'cursor-3',
       replies: [{ body: 'First' }, { body: 'Second' }],
     });
+  });
+
+  it('correlates the exact WhatsApp confirmation mirror with the durable assistant reply', async () => {
+    const assistantReply = 'Save this note?\n\nContent: [redacted]';
+    const matrix = matrixWith([
+      {
+        ok: true,
+        nextBatch: 'cursor-2',
+        limited: false,
+        events: [
+          reply('$reply-1', `${assistantReply}${MATRIX_WHATSAPP_CONFIRMATION_MIRROR_SUFFIX}`),
+        ],
+      },
+    ]);
+    const evidence = evidenceWith([
+      {
+        status: 'completed',
+        replyCount: 1,
+        replyDigests: [digestMatrixReply(assistantReply, 0)],
+      },
+    ]);
+
+    const result = await collectCorrelatedReplies({
+      ...baseInput(matrix, evidence),
+      expectedReplyRendering: 'whatsapp_confirmation_buttons',
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      replies: [
+        {
+          eventId: '$reply-1',
+          body: assistantReply,
+          digest: digestMatrixReply(assistantReply, 0),
+        },
+      ],
+    });
+  });
+
+  it.each([
+    ['plain rendering policy', MATRIX_WHATSAPP_CONFIRMATION_MIRROR_SUFFIX, 'plain'],
+    ['missing interactive suffix', '', 'whatsapp_confirmation_buttons'],
+    [
+      'changed button label',
+      '\n\n<Confirm> - <No>\nUse the WhatsApp app to click buttons',
+      'whatsapp_confirmation_buttons',
+    ],
+    [
+      'changed instruction',
+      '\n\n<Yes> - <No>\nUse WhatsApp to click buttons',
+      'whatsapp_confirmation_buttons',
+    ],
+    [
+      'extra trailing newline',
+      `${MATRIX_WHATSAPP_CONFIRMATION_MIRROR_SUFFIX}\n`,
+      'whatsapp_confirmation_buttons',
+    ],
+  ] as const)('rejects a confirmation mirror with %s', async (_label, suffix, rendering) => {
+    const assistantReply = 'Save this note?';
+    const result = await collectCorrelatedReplies({
+      ...baseInput(
+        matrixWith([
+          {
+            ok: true,
+            nextBatch: 'cursor-2',
+            limited: false,
+            events: [reply('$reply-1', `${assistantReply}${suffix}`)],
+          },
+        ]),
+        evidenceWith([
+          {
+            status: 'completed',
+            replyCount: 1,
+            replyDigests: [digestMatrixReply(assistantReply, 0)],
+          },
+        ])
+      ),
+      expectedReplyRendering: rendering,
+    });
+
+    expect(result).toEqual({ ok: false, code: 'unbound_reply' });
+  });
+
+  it('rejects a confirmation mirror without a non-empty assistant body', async () => {
+    const result = await collectCorrelatedReplies({
+      ...baseInput(
+        matrixWith([
+          {
+            ok: true,
+            nextBatch: 'cursor-2',
+            limited: false,
+            events: [reply('$reply-1', MATRIX_WHATSAPP_CONFIRMATION_MIRROR_SUFFIX)],
+          },
+        ]),
+        evidenceWith([
+          {
+            status: 'completed',
+            replyCount: 1,
+            replyDigests: [digestMatrixReply('', 0)],
+          },
+        ])
+      ),
+      expectedReplyRendering: 'whatsapp_confirmation_buttons',
+    });
+
+    expect(result).toEqual({ ok: false, code: 'unbound_reply' });
+  });
+
+  it('rejects duplicate event identities whose raw Matrix bodies differ after normalization', async () => {
+    const assistantReply = 'Save this note?';
+    const result = await collectCorrelatedReplies({
+      ...baseInput(
+        matrixWith([
+          {
+            ok: true,
+            nextBatch: 'cursor-2',
+            limited: false,
+            events: [
+              reply('$reply-1', `${assistantReply}${MATRIX_WHATSAPP_CONFIRMATION_MIRROR_SUFFIX}`),
+              reply('$reply-1', assistantReply),
+            ],
+          },
+        ]),
+        evidenceWith([{ status: 'pending' }])
+      ),
+      expectedReplyRendering: 'whatsapp_confirmation_buttons',
+    });
+
+    expect(result).toEqual({ ok: false, code: 'unbound_reply' });
   });
 
   it.each([
@@ -278,6 +413,7 @@ function baseInput(
     scenarioId: 'intex-eval-001',
     turnIndex: 0,
     sessionId: 'session_1',
+    expectedReplyRendering: 'plain',
     signal: signal(),
   } as const;
 }

--- a/tools/intex-agent-evals/src/matrixCorpus/correlation.ts
+++ b/tools/intex-agent-evals/src/matrixCorpus/correlation.ts
@@ -34,6 +34,11 @@ export interface CorrelatedMatrixReply {
 
 type UnhashedMatrixReply = Omit<CorrelatedMatrixReply, 'digest'>;
 
+export type MatrixCorpusExpectedReplyRendering = 'plain' | 'whatsapp_confirmation_buttons';
+
+export const MATRIX_WHATSAPP_CONFIRMATION_MIRROR_SUFFIX =
+  '\n\n<Yes> - <No>\nUse the WhatsApp app to click buttons';
+
 export type MatrixCorpusCorrelationFailureCode =
   | 'matrix_sync_failed'
   | 'matrix_sync_invalid'
@@ -138,11 +143,13 @@ export async function collectCorrelatedReplies(input: {
   scenarioId: string;
   turnIndex: number;
   sessionId: string;
+  expectedReplyRendering: MatrixCorpusExpectedReplyRendering;
   signal: AbortSignal;
 }): Promise<MatrixCorpusCorrelatedRepliesResult> {
   let cursor = input.cursor;
   const replies: CorrelatedMatrixReply[] = [];
   const byEventId = new Map<string, CorrelatedMatrixReply>();
+  const rawBodiesByEventId = new Map<string, string>();
   const redactedEventIds = new Set<string>();
 
   for (;;) {
@@ -172,10 +179,19 @@ export async function collectCorrelatedReplies(input: {
       if (redactedEventIds.has(candidate.reply.eventId)) {
         return { ok: false, code: 'unbound_reply' };
       }
+      const previousRawBody = rawBodiesByEventId.get(candidate.reply.eventId);
+      if (previousRawBody !== undefined && previousRawBody !== candidate.reply.body) {
+        return { ok: false, code: 'unbound_reply' };
+      }
+      const canonicalBody = canonicalMatrixReplyBody(
+        candidate.reply.body,
+        input.expectedReplyRendering
+      );
+      if (canonicalBody === undefined) return { ok: false, code: 'unbound_reply' };
       const previous = byEventId.get(candidate.reply.eventId);
       if (previous !== undefined) {
         if (
-          previous.body !== candidate.reply.body ||
+          previous.body !== canonicalBody ||
           previous.originServerTs !== candidate.reply.originServerTs
         ) {
           return { ok: false, code: 'unbound_reply' };
@@ -184,8 +200,10 @@ export async function collectCorrelatedReplies(input: {
       }
       const reply = {
         ...candidate.reply,
-        digest: digestMatrixReply(candidate.reply.body, replies.length),
+        body: canonicalBody,
+        digest: digestMatrixReply(canonicalBody, replies.length),
       };
+      rawBodiesByEventId.set(reply.eventId, candidate.reply.body);
       byEventId.set(reply.eventId, reply);
       replies.push(reply);
       if (replies.length > MATRIX_CORPUS_MAX_REPLIES_PER_TURN)
@@ -219,6 +237,16 @@ export async function collectCorrelatedReplies(input: {
     }
     return { ok: true, cursor, replies };
   }
+}
+
+function canonicalMatrixReplyBody(
+  body: string,
+  expectedRendering: MatrixCorpusExpectedReplyRendering
+): string | undefined {
+  if (expectedRendering === 'plain') return body;
+  if (!body.endsWith(MATRIX_WHATSAPP_CONFIRMATION_MIRROR_SUFFIX)) return undefined;
+  const canonicalBody = body.slice(0, -MATRIX_WHATSAPP_CONFIRMATION_MIRROR_SUFFIX.length);
+  return canonicalBody.length === 0 ? undefined : canonicalBody;
 }
 
 function classifyReplyEvent(

--- a/tools/intex-agent-evals/src/matrixCorpus/liveExecution.ts
+++ b/tools/intex-agent-evals/src/matrixCorpus/liveExecution.ts
@@ -990,6 +990,11 @@ async function executeLiveTurn(input: {
         scenarioId: input.scenario.id,
         turnIndex: input.turnIndex,
         sessionId: status.sessionId,
+        expectedReplyRendering: expectation.timeline.requiredEventTypes.includes(
+          'confirmation_requested'
+        )
+          ? 'whatsapp_confirmation_buttons'
+          : 'plain',
         signal,
         evidence: {
           async getTurnTerminal(): Promise<MatrixCorpusTurnTerminal> {


### PR DESCRIPTION
## Summary

- normalize the exact WhatsApp Matrix confirmation-button rendering before durable reply correlation
- fail closed when expected buttons are missing, changed, empty, redacted, duplicated inconsistently, or sent by the wrong puppet
- cover both evaluator composition harnesses with production-shaped interactive replies

## Verification

- pnpm run ci:tracked (6724 tests passed)
- Intex Agent evaluator package: 955 tests passed
- production runtime composition: 20 scenarios / 59 turns passed locally

## Linear

- Linear: [INT-1905](https://linear.app/pbuchman/issue/INT-1905)
- IntexuraOS Code Task: [View task](https://intexuraos.cloud/#/code-tasks/task_1ed2780e-6a68-4cc8-8be5-d353ceb62147)
- Worker Type: `codex-xhigh`
- Model: `default`