### PR TITLE
[INT-1906] Expose safe Matrix corpus failure diagnostics

### DIFF
--- a/scripts/__tests__/run-intex-agent-evals-home-dev.test.ts
+++ b/scripts/__tests__/run-intex-agent-evals-home-dev.test.ts
@@ -919,6 +919,13 @@ describe('run-intex-agent-evals-home-dev wrapper', () => {
         'evaluation result PASS exit 0\nevaluation result PASS exit 0\n'
       ),
     },
+    {
+      label: 'failure code before pass',
+      payload: matrixCorpusPayload(0).replace(
+        'evaluation result PASS exit 0\n',
+        'evaluation failure reply_timeout\nevaluation result PASS exit 0\n'
+      ),
+    },
   ])('rejects a matrix-corpus payload with $label', ({ payload }) => {
     const run = runWrapper(['__production-matrix-corpus'], {
       sshStdout: framedOutput(payload, 0),
@@ -927,6 +934,55 @@ describe('run-intex-agent-evals-home-dev wrapper', () => {
     expect(run.result.status).toBe(2);
     expect(run.result.stdout).toBe('');
     expect(run.result.stderr).toBe('remote_execution_failed\n');
+  });
+
+  it('rejects a matrix-corpus failure code outside the allowlist', () => {
+    const payload = matrixCorpusPayload(2).replace(
+      'evaluation result INFRASTRUCTURE_FAILURE exit 2\n',
+      'evaluation failure PRIVATE_TOKEN_ABC123\nevaluation result INFRASTRUCTURE_FAILURE exit 2\n'
+    );
+    const run = runWrapper(['__production-matrix-corpus'], {
+      sshExit: 2,
+      sshStdout: framedOutput(payload, 2),
+    });
+
+    expect(run.result.status).toBe(2);
+    expect(run.result.stdout).toBe('');
+    expect(run.result.stderr).toBe('remote_execution_failed\n');
+  });
+
+  it.each([
+    { count: 100, accepted: true },
+    { count: 101, accepted: false },
+  ])('enforces the matrix-corpus failure-code limit at $count lines', ({ count, accepted }) => {
+    const failureLines = 'evaluation failure reply_timeout\n'.repeat(count);
+    const payload = matrixCorpusPayload(2).replace(
+      'evaluation result INFRASTRUCTURE_FAILURE exit 2\n',
+      `${failureLines}evaluation result INFRASTRUCTURE_FAILURE exit 2\n`
+    );
+    const run = runWrapper(['__production-matrix-corpus'], {
+      sshExit: 2,
+      sshStdout: framedOutput(payload, 2),
+    });
+
+    expect(run.result.status).toBe(2);
+    expect(run.result.stdout).toBe(accepted ? payload : '');
+    expect(run.result.stderr).toBe(accepted ? '' : 'remote_execution_failed\n');
+  });
+
+  it('preserves a validated matrix-corpus infrastructure failure code', () => {
+    const payload = matrixCorpusPayload(2).replace(
+      'evaluation result INFRASTRUCTURE_FAILURE exit 2\n',
+      'evaluation failure reply_timeout\nevaluation result INFRASTRUCTURE_FAILURE exit 2\n'
+    );
+    const run = runWrapper(['__production-matrix-corpus'], {
+      sshExit: 2,
+      sshStdout: framedOutput(payload, 2),
+    });
+
+    expect(run.result.status).toBe(2);
+    expect(run.result.stdout).toBe(payload);
+    expect(run.result.stderr).toBe('');
   });
 
   it.each([

--- a/scripts/run-intex-agent-evals-home-dev.sh
+++ b/scripts/run-intex-agent-evals-home-dev.sh
@@ -567,8 +567,10 @@ validate_matrix_corpus_payload() {
   local terminal_status=''
   local report_seen=0
   local scenario_seen=0
+  local evaluation_failure_seen=0
   local run_pattern="^evaluation run (${safe_run_id_pattern}) command matrix-corpus$"
   local scenario_pattern='^scenario intex-eval-([0-9]{3}) (PASS|BEHAVIORAL_FAILURE|INFRASTRUCTURE_FAILURE)$'
+  local evaluation_failure_pattern='^evaluation failure (UNKNOWN_FAILURE|MINIMAX_JUDGE_(INVALID_OUTPUT|KEY_MISSING|PROVIDER_FAILED|TIMEOUT|USAGE_INVALID)|REPORT_(PUBLICATION|STAGING|VALIDATION)_FAILED|RETENTION_CLEANUP_FAILED|TURN_(AGENT_(CALL_COUNT_MISMATCH|COST_UNRECONCILED|MODEL_MISMATCH|USAGE_INVALID)|CATALOG_EVIDENCE_MISSING|CONFIRMATION_EVIDENCE_MISMATCH|REPLY_(COUNT_INVALID|DIGEST_COUNT_MISMATCH|EVALUATION_COUNT_MISMATCH|METADATA_MISMATCH)|SCENARIO_LABEL_MISMATCH|SESSION_(BINDING_MISMATCH|ID_MISMATCH|ID_MISSING)|TERMINAL_EVIDENCE_MISSING|TOOL_EVIDENCE_INVALID)|activation_failed|capability_issue_failed|context_(finalization|registration)_failed|drain_timeout|duplicate_scenario_session|final_projection_retry_exhausted|finalization_readiness_(failed|mismatch)|finalizing_projection_failed|judge_evidence_mismatch|lease_renewal_failed|matrix_(outbound_ambiguous|send_proof_rejected|sync_failed|sync_invalid|timeline_limited)|outbound_event_(mismatch|timeout)|preflight_handoff_invalid|projection_(creation_failed|retry_exhausted|revision_conflict|status_failed)|provision_failed|provisioning_abort_(ack_timeout|failed)|quiesce_failed|release_failed|reply_(overflow|timeout)|retention_cleanup_failed|running_projection_(failed|retry_exhausted)|scenario_(binding_timeout|projection_failed|projection_missing_evidence|status_mismatch)|stopped_scenario_(binding_mismatch|evidence_missing|evidence_revision_mismatch|missing|projection_failed|reconciliation_retry_exhausted|status_missing|strict_mock_proof_failed|unsafe_evidence_shape|usage_regressed|usage_totals_mismatch)|strict_mock_proof_failed|terminal_ack_timeout|turn_(catalog_mismatch|evidence_mismatch|evidence_missing|processing_failed)|unbound_reply|unexpected_(failure|judge_failure|projection_failure|turn_failure)|unsafe_evidence_shape|wrong_puppet)$'
   local report_pattern="^evaluation report \\.artifacts/intex-agent-evals/(${safe_run_id_pattern})$"
   local failure_pattern="^preflight result FAIL ${matrix_corpus_failure_pattern}$"
 
@@ -599,6 +601,12 @@ validate_matrix_corpus_payload() {
       [[ ${BASH_REMATCH[1]} == "$expected_scenario_ordinal" ]] || return 1
       continue
     fi
+    if [[ $line =~ $evaluation_failure_pattern ]]; then
+      [[ -n $run_id && -z $terminal_status ]] || return 1
+      evaluation_failure_seen=$((evaluation_failure_seen + 1))
+      ((evaluation_failure_seen <= 100)) || return 1
+      continue
+    fi
     case $line in
       'evaluation result PASS exit 0')
         [[ -n $run_id && -z $terminal_status ]] || return 1
@@ -625,6 +633,7 @@ validate_matrix_corpus_payload() {
   done
 
   [[ -n $terminal_status && $terminal_status == "$expected_status" ]] || return 1
+  ((evaluation_failure_seen == 0)) || [[ $terminal_status == 2 ]] || return 1
   if [[ -z $run_id ]]; then
     [[ $expected_status == 2 && $preflight_seen -eq 0 && $report_seen -eq 0 ]]
     return

--- a/tools/intex-agent-evals/src/__tests__/cli.test.ts
+++ b/tools/intex-agent-evals/src/__tests__/cli.test.ts
@@ -552,7 +552,7 @@ describe('runCli evaluation orchestration and projection', () => {
           runId,
           effectiveKind: 'infrastructure_failure' as const,
           exitCode: 2 as const,
-          failureCodes: ['REPORT_PUBLICATION_FAILED'],
+          failureCodes: ['REPORT_PUBLICATION_FAILED', 'PRIVATE_TOKEN_ABC123'],
           scenarios: [
             { scenarioId: 'intex-eval-001', status: 'passed' as const, completedTurns: 2 },
           ],
@@ -578,8 +578,11 @@ describe('runCli evaluation orchestration and projection', () => {
       ['scenario intex-eval-001 PASS'],
     ]);
     expect(harness.stderr.mock.calls).toEqual([
+      ['evaluation failure REPORT_PUBLICATION_FAILED'],
+      ['evaluation failure UNKNOWN_FAILURE'],
       ['evaluation result INFRASTRUCTURE_FAILURE exit 2'],
     ]);
+    expect(harness.outputText()).not.toContain('PRIVATE_TOKEN_ABC123');
     expect(harness.outputText()).not.toContain('evaluation report');
     expect(harness.outputText()).not.toContain(`.artifacts/intex-agent-evals/${runId}`);
   });

--- a/tools/intex-agent-evals/src/cli.ts
+++ b/tools/intex-agent-evals/src/cli.ts
@@ -363,6 +363,9 @@ async function runMatrixCorpusCommand(dependencies: CliDependencies): Promise<Ex
       dependencies.output.stderr(`scenario ${scenario.scenarioId} INFRASTRUCTURE_FAILURE`);
     }
   }
+  if (result.run.effectiveKind === 'infrastructure_failure') {
+    renderMatrixCorpusFailureCodes(result.run.failureCodes, dependencies.output);
+  }
   renderEvaluationResult(result.run.effectiveKind, dependencies.output);
   if (
     result.reportReady &&
@@ -372,6 +375,107 @@ async function runMatrixCorpusCommand(dependencies: CliDependencies): Promise<Ex
     return result.run.exitCode;
   }
   return 2;
+}
+
+const SAFE_MATRIX_CORPUS_FAILURE_CODES = new Set<string>([
+  'MINIMAX_JUDGE_INVALID_OUTPUT',
+  'MINIMAX_JUDGE_KEY_MISSING',
+  'MINIMAX_JUDGE_PROVIDER_FAILED',
+  'MINIMAX_JUDGE_TIMEOUT',
+  'MINIMAX_JUDGE_USAGE_INVALID',
+  'REPORT_PUBLICATION_FAILED',
+  'REPORT_STAGING_FAILED',
+  'REPORT_VALIDATION_FAILED',
+  'RETENTION_CLEANUP_FAILED',
+  'TURN_AGENT_CALL_COUNT_MISMATCH',
+  'TURN_AGENT_COST_UNRECONCILED',
+  'TURN_AGENT_MODEL_MISMATCH',
+  'TURN_AGENT_USAGE_INVALID',
+  'TURN_CATALOG_EVIDENCE_MISSING',
+  'TURN_CONFIRMATION_EVIDENCE_MISMATCH',
+  'TURN_REPLY_COUNT_INVALID',
+  'TURN_REPLY_DIGEST_COUNT_MISMATCH',
+  'TURN_REPLY_EVALUATION_COUNT_MISMATCH',
+  'TURN_REPLY_METADATA_MISMATCH',
+  'TURN_SCENARIO_LABEL_MISMATCH',
+  'TURN_SESSION_BINDING_MISMATCH',
+  'TURN_SESSION_ID_MISMATCH',
+  'TURN_SESSION_ID_MISSING',
+  'TURN_TERMINAL_EVIDENCE_MISSING',
+  'TURN_TOOL_EVIDENCE_INVALID',
+  'activation_failed',
+  'capability_issue_failed',
+  'context_finalization_failed',
+  'context_registration_failed',
+  'drain_timeout',
+  'duplicate_scenario_session',
+  'final_projection_retry_exhausted',
+  'finalization_readiness_failed',
+  'finalization_readiness_mismatch',
+  'finalizing_projection_failed',
+  'judge_evidence_mismatch',
+  'lease_renewal_failed',
+  'matrix_outbound_ambiguous',
+  'matrix_send_proof_rejected',
+  'matrix_sync_failed',
+  'matrix_sync_invalid',
+  'matrix_timeline_limited',
+  'outbound_event_mismatch',
+  'outbound_event_timeout',
+  'preflight_handoff_invalid',
+  'projection_creation_failed',
+  'projection_retry_exhausted',
+  'projection_revision_conflict',
+  'projection_status_failed',
+  'provision_failed',
+  'provisioning_abort_ack_timeout',
+  'provisioning_abort_failed',
+  'quiesce_failed',
+  'release_failed',
+  'reply_overflow',
+  'reply_timeout',
+  'retention_cleanup_failed',
+  'running_projection_failed',
+  'running_projection_retry_exhausted',
+  'scenario_binding_timeout',
+  'scenario_projection_failed',
+  'scenario_projection_missing_evidence',
+  'scenario_status_mismatch',
+  'stopped_scenario_binding_mismatch',
+  'stopped_scenario_evidence_missing',
+  'stopped_scenario_evidence_revision_mismatch',
+  'stopped_scenario_missing',
+  'stopped_scenario_projection_failed',
+  'stopped_scenario_reconciliation_retry_exhausted',
+  'stopped_scenario_status_missing',
+  'stopped_scenario_strict_mock_proof_failed',
+  'stopped_scenario_unsafe_evidence_shape',
+  'stopped_scenario_usage_regressed',
+  'stopped_scenario_usage_totals_mismatch',
+  'strict_mock_proof_failed',
+  'terminal_ack_timeout',
+  'turn_catalog_mismatch',
+  'turn_evidence_mismatch',
+  'turn_evidence_missing',
+  'turn_processing_failed',
+  'unbound_reply',
+  'unexpected_failure',
+  'unexpected_judge_failure',
+  'unexpected_projection_failure',
+  'unexpected_turn_failure',
+  'unsafe_evidence_shape',
+  'wrong_puppet',
+]);
+
+function renderMatrixCorpusFailureCodes(
+  failureCodes: readonly string[],
+  output: CliTextOutput
+): void {
+  for (const code of new Set(failureCodes)) {
+    output.stderr(
+      `evaluation failure ${SAFE_MATRIX_CORPUS_FAILURE_CODES.has(code) ? code : 'UNKNOWN_FAILURE'}`
+    );
+  }
 }
 
 async function runSetup(dependencies: CliDependencies): Promise<ExitCode> {


### PR DESCRIPTION
## Summary

- expose closed, privacy-safe Matrix corpus failure codes in production runner output
- reject unknown codes, failure codes on successful runs, and more than 100 failure lines
- add regression coverage for redaction, terminal-status consistency, and output bounds

## Verification

- `pnpm --filter @intexuraos/intex-agent-evals validate`
- `pnpm run ci:tracked`

## Linear

Linear: [INT-1906](https://linear.app/pbuchman/issue/INT-1906)
IntexuraOS Code Task: [View task](https://intexuraos.cloud/#/code-tasks/task_19bae662-83b7-4372-adca-ddbe640795bb)
Worker Type: `codex-xhigh`
Model: `default`