### PR TITLE
[INT-1907] Fix repaired judge evidence and calendar date formatting

### DIFF
--- a/apps/intex-agent/src/__tests__/domain/intexAgentRunner.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/intexAgentRunner.test.ts
@@ -112,7 +112,7 @@ describe('createIntexAgentRunner', () => {
     expect(client.calls[0]?.systemPrompt).toContain(
       'today: timeMin=2026-06-24T00:00:00.000+00:00; timeMax=2026-06-25T00:00:00.000+00:00'
     );
-    expect(INTEX_AGENT_SYSTEM_PROMPT.version).toBe('20.0.0');
+    expect(INTEX_AGENT_SYSTEM_PROMPT.version).toBe('21.0.0');
     expect(client.calls[0]?.systemPrompt).toContain('You are Intex in WhatsApp Assistant conversations.');
     expect(client.calls[0]?.systemPrompt).not.toContain('You are IntexuraOS');
     expect(client.calls[0]?.systemPrompt).toContain(
@@ -2364,7 +2364,7 @@ describe('createIntexAgentRunner', () => {
       reply: 'Do tej pory powiedziałeś, że chcesz zbierać fragmenty notatki.',
     });
 
-    expect(INTEX_AGENT_SYSTEM_PROMPT.version).toBe('20.0.0');
+    expect(INTEX_AGENT_SYSTEM_PROMPT.version).toBe('21.0.0');
     expect(client.calls[0]?.systemPrompt).toContain('You can use the current session transcript');
     expect(client.calls[0]?.systemPrompt).toContain('Do not claim you cannot review the current conversation');
     expect(client.calls[0]?.tools).toEqual([]);
@@ -2950,6 +2950,7 @@ describe('createIntexAgentRunner', () => {
           events: [],
           message: explicitMessageFor(toolName),
           currentDateTime: CURRENT_DATE_TIME,
+          timeZone: 'Europe/Warsaw',
         })
       ).resolves.toEqual({
         outcome: 'needs_confirmation',
@@ -2969,8 +2970,8 @@ describe('createIntexAgentRunner', () => {
         'Czy dodać wydarzenie w kalendarzu?',
         '',
         'Tytuł: Dentist',
-        'Początek: 2026-06-25T09:00:00+02:00',
-        'Koniec: 2026-06-25T10:00:00+02:00',
+        'Początek: 25 czerwca 2026, 09:00',
+        'Koniec: 25 czerwca 2026, 10:00',
         'Miejsce: Dental Clinic',
         'Uczestnicy: pat@example.com',
       ].join('\n'),
@@ -3014,6 +3015,7 @@ describe('createIntexAgentRunner', () => {
         events: [],
         message,
         currentDateTime: CURRENT_DATE_TIME,
+        timeZone: 'Europe/Warsaw',
       })
     ).resolves.toMatchObject({
       outcome: 'needs_confirmation',
@@ -4137,17 +4139,122 @@ describe('createIntexAgentRunner', () => {
         events: [],
         message: 'Create a calendar event for Dentist tomorrow 9-10am.',
         currentDateTime: CURRENT_DATE_TIME,
+        timeZone: 'Europe/Warsaw',
       })
     ).resolves.toEqual({
       outcome: 'needs_confirmation',
       reply:
-        'Add this calendar event?\n\nTitle: Dentist\nStart: 2026-06-25T09:00:00+02:00\nEnd: 2026-06-25T10:00:00+02:00',
+        'Add this calendar event?\n\nTitle: Dentist\nStart: 25 June 2026, 09:00\nEnd: 25 June 2026, 10:00',
       toolName: 'create_calendar_event',
       toolArgs: {
         summary: 'Dentist',
         start: '2026-06-25T09:00:00+02:00',
         end: '2026-06-25T10:00:00+02:00',
       },
+    });
+  });
+
+  it('renders calendar confirmation instants in the supplied local time zone without ISO metadata', async () => {
+    const client = new ToolExecutingFakeToolCallingClient({
+      toolName: 'create_calendar_event',
+      args: {
+        summary: 'Dentist',
+        start: '2026-12-25T08:00:00.000Z',
+        end: '2026-12-25T09:00:00.000Z',
+        timeZone: 'Europe/Warsaw',
+      },
+    }, [
+      ok(
+        toolResult({
+          outcome: 'completed',
+          reply: 'Done.',
+          toolName: 'create_calendar_event',
+        })
+      ),
+    ]);
+    const runner = createIntexAgentRunner({ client, toolExecutor: fakeToolExecutor() });
+
+    const result = await runner.run({
+      session: session(),
+      events: [],
+      message: 'Create a calendar event for Dentist on 25 December 9-10am.',
+      currentDateTime: CURRENT_DATE_TIME,
+    });
+
+    expect(result).toMatchObject({
+      outcome: 'needs_confirmation',
+      reply:
+        'Add this calendar event?\n\nTitle: Dentist\nStart: 25 December 2026, 09:00\nEnd: 25 December 2026, 10:00',
+    });
+    expect(result.reply).not.toMatch(/\.000|Europe\/Warsaw|[+-]\d{2}:\d{2}|T\d{2}:/u);
+  });
+
+  it('preserves offset-less calendar wall time in the tool time zone', async () => {
+    const client = new ToolExecutingFakeToolCallingClient({
+      toolName: 'create_calendar_event',
+      args: {
+        summary: 'Dentist',
+        start: '2026-07-15T09:00:00',
+        end: '2026-07-15T10:00:00',
+        timeZone: 'Europe/Warsaw',
+      },
+    }, [
+      ok(
+        toolResult({
+          outcome: 'completed',
+          reply: 'Done.',
+          toolName: 'create_calendar_event',
+        })
+      ),
+    ]);
+    const runner = createIntexAgentRunner({ client, toolExecutor: fakeToolExecutor() });
+
+    const result = await runner.run({
+      session: session(),
+      events: [],
+      message: 'Create a calendar event for Dentist on 15 July 9-10am.',
+      currentDateTime: CURRENT_DATE_TIME,
+      timeZone: 'America/New_York',
+    });
+
+    expect(result).toMatchObject({
+      outcome: 'needs_confirmation',
+      reply:
+        'Add this calendar event?\n\nTitle: Dentist\nStart: 15 July 2026, 09:00\nEnd: 15 July 2026, 10:00',
+    });
+  });
+
+  it('uses the validated account time zone when calendar arguments omit one', async () => {
+    const client = new ToolExecutingFakeToolCallingClient({
+      toolName: 'create_calendar_event',
+      args: {
+        summary: 'Dentist',
+        start: '2026-07-15T09:00:00.000Z',
+        end: '2026-07-15T10:00:00.000Z',
+      },
+    }, [
+      ok(
+        toolResult({
+          outcome: 'completed',
+          reply: 'Done.',
+          toolName: 'create_calendar_event',
+        })
+      ),
+    ]);
+    const runner = createIntexAgentRunner({ client, toolExecutor: fakeToolExecutor() });
+
+    const result = await runner.run({
+      session: session(),
+      events: [],
+      message: 'Create a calendar event for Dentist on 15 July 11-12.',
+      currentDateTime: CURRENT_DATE_TIME,
+      timeZone: 'Europe/Warsaw',
+    });
+
+    expect(result).toMatchObject({
+      outcome: 'needs_confirmation',
+      reply:
+        'Add this calendar event?\n\nTitle: Dentist\nStart: 15 July 2026, 11:00\nEnd: 15 July 2026, 12:00',
     });
   });
 
@@ -5240,8 +5347,8 @@ function expectedConfirmationReplyFor(toolName: PreviewToolName): string {
       'Add this calendar event?',
       '',
       'Title: Dentist',
-      'Start: 2026-06-25T09:00:00+02:00',
-      'End: 2026-06-25T10:00:00+02:00',
+      'Start: 25 June 2026, 09:00',
+      'End: 25 June 2026, 10:00',
       'Location: Dental Clinic',
       'Attendees: pat@example.com',
     ].join('\n');

--- a/apps/intex-agent/src/__tests__/domain/toolDefinitions.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/toolDefinitions.test.ts
@@ -626,6 +626,74 @@ describe('createIntexAgentToolDefinitions', () => {
       })
     ).rejects.toThrow('Tool argument timeZone must be a string');
     await expect(
+      calendarTool?.run({
+        summary: 'Dentist',
+        start: '2026-02-30T09:00:00',
+        end: '2026-02-30T10:00:00',
+        timeZone: 'Europe/Warsaw',
+      })
+    ).rejects.toThrow('Tool argument start must be a valid ISO date-time string');
+    await expect(
+      calendarTool?.run({
+        summary: 'Dentist',
+        start: '2026-08-18T14:30:00',
+        end: '2026-08-18T15:15:00',
+        timeZone: 'Invalid/Zone',
+      })
+    ).rejects.toThrow('Tool argument timeZone must be a valid IANA time zone');
+    await expect(
+      calendarTool?.run({
+        summary: 'Dentist',
+        start: '2026-08-18T14:30:00',
+        end: '2026-08-18T15:15:00',
+        timeZone: '   ',
+      })
+    ).rejects.toThrow('Tool argument timeZone must be a valid IANA time zone');
+    await expect(
+      calendarTool?.run({
+        summary: 'Dentist',
+        start: '2026-08-18T14:30:00',
+        end: '2026-08-18T15:15:00',
+      })
+    ).rejects.toThrow('Tool argument start without an offset requires timeZone');
+    await expect(
+      calendarTool?.run({
+        summary: 'DST gap',
+        start: '2026-03-29T02:15:00',
+        end: '2026-03-29T03:15:00',
+        timeZone: 'Europe/Warsaw',
+      })
+    ).rejects.toThrow(
+      'Tool argument start must resolve to exactly one instant in timeZone; include an explicit offset'
+    );
+    await expect(
+      calendarTool?.run({
+        summary: 'DST fold',
+        start: '2026-10-25T02:15:00',
+        end: '2026-10-25T04:15:00',
+        timeZone: 'Europe/Warsaw',
+      })
+    ).rejects.toThrow(
+      'Tool argument start must resolve to exactly one instant in timeZone; include an explicit offset'
+    );
+    await expect(
+      calendarTool?.run({
+        summary: 'Dentist',
+        start: '2026-08-18T15:15:00+02:00',
+        end: '2026-08-18T14:30:00+02:00',
+      })
+    ).rejects.toThrow('Tool argument end must be after start');
+    await expect(
+      calendarTool?.run({
+        summary: 'Dentist',
+        start: '2026-08-18T14:30:00+02:00',
+        end: '2026-08-18T15:15:00',
+        timeZone: 'Europe/Warsaw',
+      })
+    ).rejects.toThrow(
+      'Tool arguments start and end must both include offsets or both use timeZone'
+    );
+    await expect(
       codeTaskTool?.run({ prompt: 'Implement this', taskMode: 'fast' })
     ).rejects.toThrow('Tool argument taskMode must be one of: planning, execution');
     await expect(
@@ -722,6 +790,29 @@ describe('createIntexAgentToolDefinitions', () => {
           maxResults: 2501,
         })
     ).rejects.toThrow('Tool argument maxResults must be a positive integer');
+  });
+
+  it.each([
+    ['zero month', '2026-00-18T14:30:00+02:00'],
+    ['month above twelve', '2026-13-18T14:30:00+02:00'],
+    ['zero day', '2026-08-00T14:30:00+02:00'],
+    ['hour above twenty-three', '2026-08-18T24:30:00+02:00'],
+    ['minute above fifty-nine', '2026-08-18T14:60:00+02:00'],
+    ['second above fifty-nine', '2026-08-18T14:30:60+02:00'],
+    ['offset hour above twenty-three', '2026-08-18T14:30:00+24:00'],
+    ['offset minute above fifty-nine', '2026-08-18T14:30:00+02:60'],
+  ])('rejects a calendar start with %s', async (_label, start) => {
+    const calendarTool = createIntexAgentToolDefinitions(createExecutor()).find(
+      (tool) => tool.name === 'create_calendar_event'
+    );
+
+    await expect(
+      calendarTool?.run({
+        summary: 'Dentist',
+        start,
+        end: '2026-08-18T15:15:00+02:00',
+      })
+    ).rejects.toThrow('Tool argument start must be a valid ISO date-time string');
   });
 });
 

--- a/apps/intex-agent/src/domain/agent/intexAgentRunner.ts
+++ b/apps/intex-agent/src/domain/agent/intexAgentRunner.ts
@@ -347,7 +347,8 @@ export function createIntexAgentRunner(config: IntexAgentRunnerConfig): IntexAge
             'save_external',
             args,
             config.userPreferences ?? null,
-            detectedReplyLanguage
+            detectedReplyLanguage,
+            input.timeZone
           ),
           toolName: 'save_external',
           toolArgs: args,
@@ -507,7 +508,8 @@ export function createIntexAgentRunner(config: IntexAgentRunnerConfig): IntexAge
         toolExecutions,
         config.webAppUrl ?? DEFAULT_WEB_APP_URL,
         config.userPreferences ?? null,
-        replyLanguage
+        replyLanguage,
+        input.timeZone
       );
     },
   };
@@ -854,7 +856,8 @@ async function parseRunnerContent(
   toolExecutions: IntexAgentToolExecution[],
   webAppUrl: string,
   userPreferences: string | null,
-  replyLanguage: IntexAgentReplyLanguage
+  replyLanguage: IntexAgentReplyLanguage,
+  runtimeTimeZone: string
 ): Promise<IntexAgentRunnerResult> {
   const rejectedSelection = toolExecutions.find(
     (execution) => execution.selectionRejection !== undefined
@@ -903,7 +906,8 @@ async function parseRunnerContent(
         toolExecution.toolName,
         confirmationArgs,
         userPreferences,
-        replyLanguage
+        replyLanguage,
+        runtimeTimeZone
       ),
       toolName: toolExecution.toolName,
       toolArgs: confirmationArgs,
@@ -1385,7 +1389,8 @@ function buildConfirmationReply(
   toolName: MutatingIntexAgentToolName,
   args: Record<string, unknown>,
   userPreferences: string | null,
-  replyLanguage: IntexAgentReplyLanguage
+  replyLanguage: IntexAgentReplyLanguage,
+  runtimeTimeZone: string
 ): string {
   if (toolName === 'create_note') {
     const lines = [CONFIRMATION_INTROS.create_note[replyLanguage]];
@@ -1402,9 +1407,28 @@ function buildConfirmationReply(
 
   if (toolName === 'create_calendar_event') {
     const lines = [CONFIRMATION_INTROS.create_calendar_event[replyLanguage]];
+    const timeZone = readRawString(args, 'timeZone');
+    const start = readRawString(args, 'start');
+    const end = readRawString(args, 'end');
     appendConfirmationLine(lines, CONFIRMATION_LABELS.title[replyLanguage], readRawString(args, 'summary'));
-    appendConfirmationLine(lines, CONFIRMATION_LABELS.start[replyLanguage], readRawString(args, 'start'));
-    appendConfirmationLine(lines, CONFIRMATION_LABELS.end[replyLanguage], readRawString(args, 'end'));
+    appendConfirmationLine(
+      lines,
+      CONFIRMATION_LABELS.start[replyLanguage],
+      /* v8 ignore start -- schema: validated calendar tool args always include start @preserve */
+      start === undefined
+        ? undefined
+        : formatCalendarConfirmationDateTime(start, timeZone, runtimeTimeZone, replyLanguage)
+      /* v8 ignore stop @preserve */
+    );
+    appendConfirmationLine(
+      lines,
+      CONFIRMATION_LABELS.end[replyLanguage],
+      /* v8 ignore start -- schema: validated calendar tool args always include end @preserve */
+      end === undefined
+        ? undefined
+        : formatCalendarConfirmationDateTime(end, timeZone, runtimeTimeZone, replyLanguage)
+      /* v8 ignore stop @preserve */
+    );
     appendConfirmationLine(
       lines,
       CONFIRMATION_LABELS.location[replyLanguage],
@@ -1490,6 +1514,45 @@ function appendConfirmationLine(lines: string[], label: string, value: string | 
     lines.push('');
   }
   lines.push(`${label}: ${value}`);
+}
+
+function formatCalendarConfirmationDateTime(
+  value: string,
+  toolTimeZone: string | undefined,
+  runtimeTimeZone: string,
+  replyLanguage: IntexAgentReplyLanguage
+): string {
+  const instant = new Date(value);
+  const preferredTimeZone = toolTimeZone ?? runtimeTimeZone;
+  const hasExplicitOffset = /(?:Z|[+-]\d{2}:\d{2})$/u.test(value);
+  const displayTimeZone = hasExplicitOffset ? preferredTimeZone : 'UTC';
+  const displayInstant = hasExplicitOffset ? instant : dateFromIsoWallClock(value);
+  const locale = replyLanguage === 'pl' ? 'pl-PL' : 'en-GB';
+  const date = new Intl.DateTimeFormat(locale, {
+    timeZone: displayTimeZone,
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+  }).format(displayInstant);
+  const time = new Intl.DateTimeFormat(locale, {
+    timeZone: displayTimeZone,
+    hour: '2-digit',
+    minute: '2-digit',
+    hourCycle: 'h23',
+  }).format(displayInstant);
+  return `${date}, ${time}`;
+}
+
+function dateFromIsoWallClock(value: string): Date {
+  return new Date(
+    Date.UTC(
+      Number(value.slice(0, 4)),
+      Number(value.slice(5, 7)) - 1,
+      Number(value.slice(8, 10)),
+      Number(value.slice(11, 13)),
+      Number(value.slice(14, 16))
+    )
+  );
 }
 
 function appendConfirmationListLine(

--- a/apps/intex-agent/src/domain/agent/toolDefinitions.ts
+++ b/apps/intex-agent/src/domain/agent/toolDefinitions.ts
@@ -583,22 +583,207 @@ function toCreateNoteArgs(args: Record<string, unknown>): CreateNoteToolArgs {
 
 function toCreateCalendarEventArgs(args: Record<string, unknown>): CreateCalendarEventToolArgs {
   const summary = requiredString(args, 'summary');
-  const start = requiredString(args, 'start');
-  const end = requiredString(args, 'end');
   const timeZone = optionalString(args, 'timeZone');
+  if (timeZone !== undefined && !isValidTimeZone(timeZone)) {
+    throw new Error('Tool argument timeZone must be a valid IANA time zone');
+  }
+  const start = requiredCalendarEventDateTime(args, 'start', timeZone);
+  const end = requiredCalendarEventDateTime(args, 'end', timeZone);
+  if (start.hasOffset !== end.hasOffset) {
+    throw new Error(
+      'Tool arguments start and end must both include offsets or both use timeZone'
+    );
+  }
+  if (start.comparisonMs >= end.comparisonMs) {
+    throw new Error('Tool argument end must be after start');
+  }
   const location = optionalString(args, 'location');
   const description = optionalString(args, 'description');
   const attendees = optionalStringArray(args, 'attendees');
 
   return {
     summary,
-    start,
-    end,
+    start: start.value,
+    end: end.value,
     ...(timeZone !== undefined ? { timeZone } : {}),
     ...(location !== undefined ? { location } : {}),
     ...(description !== undefined ? { description } : {}),
     ...(attendees !== undefined ? { attendees } : {}),
   };
+}
+
+interface ValidatedCalendarEventDateTime {
+  value: string;
+  hasOffset: boolean;
+  comparisonMs: number;
+}
+
+const CALENDAR_EVENT_DATE_TIME_PATTERN =
+  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,9}))?(Z|[+-]\d{2}:\d{2})?$/u;
+
+function requiredCalendarEventDateTime(
+  args: Record<string, unknown>,
+  key: 'start' | 'end',
+  timeZone: string | undefined
+): ValidatedCalendarEventDateTime {
+  const value = requiredString(args, key);
+  const match = CALENDAR_EVENT_DATE_TIME_PATTERN.exec(value);
+  if (match === null || !hasValidCalendarDateTimeParts(match)) {
+    throw new Error(`Tool argument ${key} must be a valid ISO date-time string`);
+  }
+  const hasOffset = match[8] !== undefined;
+  if (hasOffset) {
+    return { value, hasOffset, comparisonMs: Date.parse(value) };
+  }
+  if (timeZone === undefined) {
+    throw new Error(`Tool argument ${key} without an offset requires timeZone`);
+  }
+  const comparisonMs = resolveUniqueCalendarInstant(match, timeZone);
+  if (!Number.isFinite(comparisonMs)) {
+    throw new Error(
+      `Tool argument ${key} must resolve to exactly one instant in timeZone; include an explicit offset`
+    );
+  }
+  return { value, hasOffset, comparisonMs };
+}
+
+function hasValidCalendarDateTimeParts(match: RegExpExecArray): boolean {
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const hour = Number(match[4]);
+  const minute = Number(match[5]);
+  const second = Number(match[6]);
+  if (
+    month < 1 ||
+    month > 12 ||
+    day < 1 ||
+    hour > 23 ||
+    minute > 59 ||
+    second > 59
+  )
+    return false;
+  const civil = new Date(Date.UTC(year, month - 1, day, hour, minute, second));
+  if (
+    civil.getUTCFullYear() !== year ||
+    civil.getUTCMonth() !== month - 1 ||
+    civil.getUTCDate() !== day ||
+    civil.getUTCHours() !== hour ||
+    civil.getUTCMinutes() !== minute ||
+    civil.getUTCSeconds() !== second
+  )
+    return false;
+  const offset = match[8];
+  if (offset === undefined || offset === 'Z') return true;
+  const offsetHour = Number(offset.slice(1, 3));
+  const offsetMinute = Number(offset.slice(4, 6));
+  return offsetHour <= 23 && offsetMinute <= 59;
+}
+
+function calendarWallClockMs(match: RegExpExecArray): number {
+  const milliseconds = Number((match[7] ?? '').padEnd(3, '0').slice(0, 3));
+  return Date.UTC(
+    Number(match[1]),
+    Number(match[2]) - 1,
+    Number(match[3]),
+    Number(match[4]),
+    Number(match[5]),
+    Number(match[6]),
+    milliseconds
+  );
+}
+
+function resolveUniqueCalendarInstant(match: RegExpExecArray, timeZone: string): number {
+  const wallClockMs = calendarWallClockMs(match);
+  const formatter = new Intl.DateTimeFormat('en-CA', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hourCycle: 'h23',
+  });
+  const possibleOffsets = new Set<number>();
+  const halfHourMs = 30 * 60 * 1000;
+  const searchRadiusMs = 36 * 60 * 60 * 1000;
+  const alignedWallClockMs = Math.floor(wallClockMs / halfHourMs) * halfHourMs;
+  for (let delta = -searchRadiusMs; delta <= searchRadiusMs; delta += halfHourMs) {
+    const sampleMs = alignedWallClockMs + delta;
+    const parts = readZonedCalendarParts(formatter, sampleMs);
+    possibleOffsets.add(calendarWallClockFromParts(parts) - sampleMs);
+  }
+  const matches = [...possibleOffsets]
+    .map((offsetMs) => wallClockMs - offsetMs)
+    .filter((candidateMs) => sameCalendarWallClock(match, formatter, candidateMs));
+  return matches.length === 1 ? Number(matches[0]) : Number.NaN;
+}
+
+interface CalendarDateTimeParts {
+  year: number;
+  month: number;
+  day: number;
+  hour: number;
+  minute: number;
+  second: number;
+}
+
+function readZonedCalendarParts(
+  formatter: Intl.DateTimeFormat,
+  instantMs: number
+): CalendarDateTimeParts {
+  const parts = Object.fromEntries(
+    formatter
+      .formatToParts(new Date(instantMs))
+      .filter((part) => part.type !== 'literal')
+      .map((part) => [part.type, Number(part.value)])
+  );
+  return {
+    year: Number(parts['year']),
+    month: Number(parts['month']),
+    day: Number(parts['day']),
+    hour: Number(parts['hour']),
+    minute: Number(parts['minute']),
+    second: Number(parts['second']),
+  };
+}
+
+function calendarWallClockFromParts(parts: CalendarDateTimeParts): number {
+  return Date.UTC(
+    parts.year,
+    parts.month - 1,
+    parts.day,
+    parts.hour,
+    parts.minute,
+    parts.second
+  );
+}
+
+function sameCalendarWallClock(
+  match: RegExpExecArray,
+  formatter: Intl.DateTimeFormat,
+  candidateMs: number
+): boolean {
+  const actual = readZonedCalendarParts(formatter, candidateMs);
+  return (
+    actual.year === Number(match[1]) &&
+    actual.month === Number(match[2]) &&
+    actual.day === Number(match[3]) &&
+    actual.hour === Number(match[4]) &&
+    actual.minute === Number(match[5]) &&
+    actual.second === Number(match[6])
+  );
+}
+
+function isValidTimeZone(value: string): boolean {
+  if (value.trim() === '') return false;
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone: value }).format(0);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function toQueryCalendarEventsArgs(args: Record<string, unknown>): QueryCalendarEventsToolArgs {

--- a/packages/llm-prompts/src/intex-agent/__tests__/systemPrompt.test.ts
+++ b/packages/llm-prompts/src/intex-agent/__tests__/systemPrompt.test.ts
@@ -7,10 +7,10 @@ const TIME_ZONE = 'UTC';
 describe('buildIntexAgentSystemPrompt', () => {
   it('exposes prompt metadata with semver versions', () => {
     expect(INTEX_AGENT_SYSTEM_PROMPT.version).toMatch(/^\d+\.\d+\.\d+$/);
-    expect(INTEX_AGENT_SYSTEM_PROMPT.version).toBe('20.0.0');
+    expect(INTEX_AGENT_SYSTEM_PROMPT.version).toBe('21.0.0');
     expect(buildIntexAgentSystemPrompt.name).toBe('intex-agent-system-prompt');
     expect(buildIntexAgentSystemPrompt.version).toMatch(/^\d+\.\d+\.\d+$/);
-    expect(buildIntexAgentSystemPrompt.version).toBe('13.0.0');
+    expect(buildIntexAgentSystemPrompt.version).toBe('14.0.0');
   });
 
   it('builds the base prompt with the current date-time', () => {
@@ -74,6 +74,21 @@ describe('buildIntexAgentSystemPrompt', () => {
     );
     expect(prompt).toContain('`*important*`');
     expect(prompt).toContain('Do not use double-asterisk Markdown bold such as `**important**`');
+  });
+
+  it('requires human-readable local dates in WhatsApp replies', () => {
+    const prompt = buildIntexAgentSystemPrompt.build({
+      currentDateTime: CURRENT_DATE_TIME,
+      timeZone: TIME_ZONE,
+      userPreferences: null,
+    });
+
+    expect(prompt).toContain(
+      'Format dates and times in replies as concise, human-readable local values'
+    );
+    expect(prompt).toContain(
+      'Never expose raw ISO timestamps, milliseconds, UTC offsets, or IANA time-zone identifiers'
+    );
   });
 
   it('prioritizes useful analysis before tool execution boundaries', () => {

--- a/packages/llm-prompts/src/intex-agent/systemPrompt.ts
+++ b/packages/llm-prompts/src/intex-agent/systemPrompt.ts
@@ -1,7 +1,7 @@
 import type { PromptBuilder } from '../types.js';
 
 export const INTEX_AGENT_SYSTEM_PROMPT = {
-  version: '20.0.0',
+  version: '21.0.0',
   text: [
     'You are Intex in WhatsApp Assistant conversations.',
     'Default to the language of the last reasonable user message in the current session, unless an explicit current-turn instruction or allowed user preference says otherwise. Ignore bare links, image-only messages, attachments, and trivial greetings such as "hello" when selecting the language. For ambiguous simple messages, use the wider conversation context before falling back to English. If no specific language can be classified, reply in English. The JSON reply value must follow this language rule.',
@@ -25,6 +25,7 @@ export const INTEX_AGENT_SYSTEM_PROMPT = {
     'If the user explicitly asks to create a note, research draft, calendar event, or code task that includes a URL, use that explicit tool instead of create_link.',
     'For greetings, thanks, smalltalk, or questions about what you can do, do not call a tool. Return no_action with a concise helpful reply.',
     'When bold text is useful in the reply value, wrap it in single asterisks, for example `*important*`. Do not use double-asterisk Markdown bold such as `**important**`.',
+    'Format dates and times in replies as concise, human-readable local values in the reply language. Never expose raw ISO timestamps, milliseconds, UTC offsets, or IANA time-zone identifiers unless the user explicitly asks for technical timestamp details.',
     'Use create_note only when the user explicitly asks to create, save, note, remember, or write down a note or specific information.',
     'Use create_calendar_event only when the user explicitly asks to create, add, schedule, or plan a meeting, appointment, scheduled block, or calendar item.',
     'For calendar events, ask a clarification before using the tool if title, date, time, start, or end is missing or ambiguous.',
@@ -71,7 +72,7 @@ export const buildIntexAgentSystemPrompt: PromptBuilder<BuildIntexAgentSystemPro
   name: 'intex-agent-system-prompt',
   description:
     'Intex Agent system prompt with optional user preferences and DST-safe local calendar context',
-  version: '13.0.0',
+  version: '14.0.0',
   build(input: BuildIntexAgentSystemPromptInput): string {
     const lines: string[] = [INTEX_AGENT_SYSTEM_PROMPT.text];
     if (input.userPreferences !== null && input.userPreferences.trim() !== '') {

--- a/tools/intex-agent-evals/src/__tests__/matrixCorpusRunner.test.ts
+++ b/tools/intex-agent-evals/src/__tests__/matrixCorpusRunner.test.ts
@@ -587,6 +587,30 @@ describe('sequential Matrix corpus state machine', () => {
     expect(modelResult.failureCodes).toContain('judge_evidence_mismatch');
   });
 
+  it('accepts one MiniMax repair attempt as valid judge evidence', async () => {
+    const catalog = await loadCanonicalMatrixCorpus(scenariosDirectory);
+    const ports = passingPorts([]);
+    vi.mocked(ports.judgeReply).mockResolvedValue({
+      ok: true,
+      pass: true,
+      model: 'or:minimax/minimax-m3',
+      usage: {
+        logicalCalls: 2,
+        repairCount: 1,
+        inputTokens: 2,
+        outputTokens: 2,
+        totalTokens: 4,
+        costNanoUsd: 2,
+      },
+    });
+
+    const result = await runMatrixCorpus({ runId: 'run_repaired_judge', catalog }, ports);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.failureCodes).not.toContain('judge_evidence_mismatch');
+    expect(result.scenarios.every(({ status }) => status === 'passed')).toBe(true);
+  });
+
   it('rejects reuse of one created session across two scenarios before judging the second', async () => {
     const catalog = await loadCanonicalMatrixCorpus(scenariosDirectory);
     const ports = passingPorts([]);

--- a/tools/intex-agent-evals/src/matrixCorpus/runMatrixCorpus.ts
+++ b/tools/intex-agent-evals/src/matrixCorpus/runMatrixCorpus.ts
@@ -860,7 +860,7 @@ function validUsage(usage: MatrixCorpusTurnObservation['agentUsage']): boolean {
 
 function validJudgeUsage(usage: Extract<MatrixCorpusJudgeResult, { ok: true }>['usage']): boolean {
   return (
-    usage.logicalCalls === 1 &&
+    usage.logicalCalls === usage.repairCount + 1 &&
     (usage.repairCount === 0 || usage.repairCount === 1) &&
     validTokenUsage(usage) &&
     Number.isSafeInteger(usage.costNanoUsd) &&


### PR DESCRIPTION
## Summary

- accept valid MiniMax M3 judge responses that required one schema repair
- render calendar confirmations as readable localized dates without raw timestamps
- validate calendar date-times, IANA zones, ordering, and DST gaps/folds fail-closed

## Verification

- `pnpm run ci:tracked` (6728 tests passed)
- Intex Agent package: 1545 tests passed with 100% branch coverage in changed agent code
- final UX, security, and evaluator reviews: READY

## Linear

- Linear: [INT-1907](https://linear.app/pbuchman/issue/INT-1907)
- IntexuraOS Code Task: [View task](https://intexuraos.cloud/#/code-tasks/task_793790a8-ddfd-4690-b8c8-2d5ff9497986)
- Worker Type: `codex-xhigh`
- Model: `default`
