### PR TITLE
[INT-1908] fix: bind Matrix replies and enforce required tools

### DIFF
--- a/packages/infra-openrouter/src/__tests__/toolCallingClient.test.ts
+++ b/packages/infra-openrouter/src/__tests__/toolCallingClient.test.ts
@@ -384,8 +384,8 @@ describe('createOpenRouterToolCallingClient', () => {
     );
   });
 
-  it('characterizes required tool choice when the provider returns final text without a tool call', async () => {
-    let capturedBody: Record<string, unknown> | undefined;
+  it('retries required tool choice when the provider returns final text without a tool call', async () => {
+    const capturedBodies: Record<string, unknown>[] = [];
     const runTool = vi
       .fn()
       .mockResolvedValue(
@@ -393,7 +393,7 @@ describe('createOpenRouterToolCallingClient', () => {
       );
     nock(API_BASE_URL)
       .post('/chat/completions', (body) => {
-        capturedBody = body as Record<string, unknown>;
+        capturedBodies.push(body as Record<string, unknown>);
         return true;
       })
       .reply(200, {
@@ -412,6 +412,50 @@ describe('createOpenRouterToolCallingClient', () => {
           },
         ],
         usage: { prompt_tokens: 11, completion_tokens: 7, total_tokens: 18, cost: 0.00012 },
+      })
+      .post('/chat/completions', (body) => {
+        capturedBodies.push(body as Record<string, unknown>);
+        return true;
+      })
+      .reply(200, {
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content: null,
+              tool_calls: [
+                {
+                  id: 'call_required_retry',
+                  type: 'function',
+                  function: {
+                    name: 'add_user_preference',
+                    arguments: JSON.stringify({ text: 'Be concise.', expectedVersion: 0 }),
+                  },
+                },
+              ],
+            },
+          },
+        ],
+        usage: { prompt_tokens: 13, completion_tokens: 5, total_tokens: 18, cost: 0.00013 },
+      })
+      .post('/chat/completions', (body) => {
+        capturedBodies.push(body as Record<string, unknown>);
+        return true;
+      })
+      .reply(200, {
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content: JSON.stringify({
+                outcome: 'completed',
+                reply: 'Preference prepared.',
+                toolName: 'add_user_preference',
+              }),
+            },
+          },
+        ],
+        usage: { prompt_tokens: 15, completion_tokens: 6, total_tokens: 21, cost: 0.00014 },
       });
 
     const result = await createClient().run({
@@ -439,12 +483,25 @@ describe('createOpenRouterToolCallingClient', () => {
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     expect(result.value).toMatchObject({
-      content: JSON.stringify({ outcome: 'no_action', reply: 'No action needed.' }),
-      toolCallsMade: 0,
-      iterationCount: 1,
+      toolCallsMade: 1,
+      iterationCount: 3,
     });
-    expect(capturedBody?.['tool_choice']).toBe('required');
-    expect(runTool).not.toHaveBeenCalled();
+    expect(capturedBodies[0]?.['tool_choice']).toBe('required');
+    expect(capturedBodies[1]?.['tool_choice']).toBe('required');
+    expect(capturedBodies[2]?.['tool_choice']).toBe('auto');
+    expect(capturedBodies[1]?.['messages']).toEqual(
+      expect.arrayContaining([
+        {
+          role: 'assistant',
+          content: JSON.stringify({ outcome: 'no_action', reply: 'No action needed.' }),
+        },
+        {
+          role: 'user',
+          content: expect.stringContaining('Call one of the provided tools'),
+        },
+      ])
+    );
+    expect(runTool).toHaveBeenCalledWith({ text: 'Be concise.', expectedVersion: 0 });
   });
 
   it('logs ownerType and zero usage when OpenRouter omits usage metadata', async () => {

--- a/packages/infra-openrouter/src/toolCallingClient.ts
+++ b/packages/infra-openrouter/src/toolCallingClient.ts
@@ -67,6 +67,8 @@ const API_BASE_URL = 'https://openrouter.ai/api/v1';
 const APP_TITLE = 'IntexuraOS';
 const DEFAULT_TIMEOUT_MS = 840_000;
 const DEFAULT_MAX_ITERATIONS = 5;
+const REQUIRED_TOOL_RETRY_MESSAGE =
+  'Call one of the provided tools now. A tool call is required for this request; do not return final text before calling a tool.';
 const MATRIX_PROVIDER_FAILURE_CODE = 'MATRIX_PROVIDER_CALL_FAILED';
 const MATRIX_PROVIDER_FAILURE_MESSAGE = 'Matrix provider call failed';
 
@@ -328,6 +330,12 @@ export function createOpenRouterToolCallingClient(
                 promptType
               );
               return err({ code: 'API_ERROR', message: 'Empty response from model' });
+            }
+            if (tools.length > 0 && toolChoice === 'required' && totalToolCalls === 0) {
+              conversation.push({ role: 'assistant', content: finalText });
+              conversation.push({ role: 'user', content: REQUIRED_TOOL_RETRY_MESSAGE });
+              logger.info({ iteration }, 'OpenRouter tool calling: retrying required tool choice');
+              continue;
             }
 
             logger.info(

--- a/tools/intex-agent-evals/src/__tests__/matrixCorpusCorrelation.test.ts
+++ b/tools/intex-agent-evals/src/__tests__/matrixCorpusCorrelation.test.ts
@@ -189,8 +189,6 @@ describe('Matrix corpus reply correlation', () => {
   });
 
   it.each([
-    ['plain rendering policy', MATRIX_WHATSAPP_CONFIRMATION_MIRROR_SUFFIX, 'plain'],
-    ['missing interactive suffix', '', 'whatsapp_confirmation_buttons'],
     [
       'changed button label',
       '\n\n<Confirm> - <No>\nUse the WhatsApp app to click buttons',
@@ -230,6 +228,42 @@ describe('Matrix corpus reply correlation', () => {
     });
 
     expect(result).toEqual({ ok: false, code: 'unbound_reply' });
+  });
+
+  it.each([
+    ['expected confirmation but observed a plain reply', '', 'whatsapp_confirmation_buttons'],
+    [
+      'expected plain reply but observed confirmation buttons',
+      MATRIX_WHATSAPP_CONFIRMATION_MIRROR_SUFFIX,
+      'plain',
+    ],
+  ] as const)('correlates a digest-bound reply when %s', async (_label, suffix, rendering) => {
+    const assistantReply = 'What would you like me to save?';
+    const result = await collectCorrelatedReplies({
+      ...baseInput(
+        matrixWith([
+          {
+            ok: true,
+            nextBatch: 'cursor-2',
+            limited: false,
+            events: [reply('$reply-1', `${assistantReply}${suffix}`)],
+          },
+        ]),
+        evidenceWith([
+          {
+            status: 'completed',
+            replyCount: 1,
+            replyDigests: [digestMatrixReply(assistantReply, 0)],
+          },
+        ])
+      ),
+      expectedReplyRendering: rendering,
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      replies: [{ body: assistantReply, digest: digestMatrixReply(assistantReply, 0) }],
+    });
   });
 
   it('rejects a confirmation mirror without a non-empty assistant body', async () => {

--- a/tools/intex-agent-evals/src/matrixCorpus/correlation.ts
+++ b/tools/intex-agent-evals/src/matrixCorpus/correlation.ts
@@ -183,10 +183,7 @@ export async function collectCorrelatedReplies(input: {
       if (previousRawBody !== undefined && previousRawBody !== candidate.reply.body) {
         return { ok: false, code: 'unbound_reply' };
       }
-      const canonicalBody = canonicalMatrixReplyBody(
-        candidate.reply.body,
-        input.expectedReplyRendering
-      );
+      const canonicalBody = canonicalMatrixReplyBody(candidate.reply.body);
       if (canonicalBody === undefined) return { ok: false, code: 'unbound_reply' };
       const previous = byEventId.get(candidate.reply.eventId);
       if (previous !== undefined) {
@@ -239,12 +236,8 @@ export async function collectCorrelatedReplies(input: {
   }
 }
 
-function canonicalMatrixReplyBody(
-  body: string,
-  expectedRendering: MatrixCorpusExpectedReplyRendering
-): string | undefined {
-  if (expectedRendering === 'plain') return body;
-  if (!body.endsWith(MATRIX_WHATSAPP_CONFIRMATION_MIRROR_SUFFIX)) return undefined;
+function canonicalMatrixReplyBody(body: string): string | undefined {
+  if (!body.endsWith(MATRIX_WHATSAPP_CONFIRMATION_MIRROR_SUFFIX)) return body;
   const canonicalBody = body.slice(0, -MATRIX_WHATSAPP_CONFIRMATION_MIRROR_SUFFIX.length);
   return canonicalBody.length === 0 ? undefined : canonicalBody;
 }


### PR DESCRIPTION
## Summary

- bind Matrix corpus replies from the body actually observed on WhatsApp, while stripping only the exact evaluator confirmation mirror suffix
- retry a bounded OpenRouter turn when a provider ignores `tool_choice=required` and returns final text without a tool call
- preserve ordered durable digest correlation, strict mirror validation, and the existing maximum-iteration limit

## Verification

- `pnpm run ci:tracked` — PASS (6728 tests)
- targeted evaluator validation — PASS (956 tests)
- targeted OpenRouter tests — PASS (25 tests)
- independent security, test, and UX reviews — READY

- Linear: [INT-1908](https://linear.app/pbuchman/issue/INT-1908)
- IntexuraOS Code Task: [View task](https://intexuraos.cloud/#/code-tasks/task_ef5e9d5d-a4e2-4df0-bf86-9e98a18d425c)
- Worker Type: `codex-xhigh`
- Model: `default`