### PR TITLE
[INT-1909] fix: bound Matrix provider latency

### DIFF
--- a/apps/intex-agent/src/__tests__/domain/intentClassifier.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/intentClassifier.test.ts
@@ -946,6 +946,33 @@ describe('createLlmIntexAgentIntentClassifier', () => {
     ).rejects.toThrowError('Matrix corpus intent classification failed');
   });
 
+  it('does not multiply provider-owned transient retries in the Matrix corpus lane', async () => {
+    const client = new FakeStructuredClient([
+      err({ code: 'TIMEOUT', message: 'bounded provider timeout' }),
+      ok(
+        generateResult({
+          outcome: 'tool',
+          allowedToolNames: ['create_note'],
+          confidence: 0.9,
+        })
+      ),
+    ]);
+
+    await expect(
+      createLlmIntexAgentIntentClassifier({ client, logger: new FakeLogger() }).classify({
+        message: 'Create a note for me.',
+        events: [],
+        currentDateTime: CURRENT_DATE_TIME,
+        matrixCorpusLlm: {
+          nextContext: (stage) => matrixContext(stage, 1),
+          recordProviderCall: vi.fn(async () => undefined),
+        },
+      })
+    ).rejects.toThrowError('Matrix corpus intent classification failed');
+
+    expect(client.calls).toHaveLength(1);
+  });
+
   it('retries transient classifier provider errors before falling back', async () => {
     const client = new FakeStructuredClient([
       err({ code: 'RATE_LIMITED', message: 'slow down', retryAfterMs: 0 } as LLMError & {

--- a/apps/intex-agent/src/__tests__/services.test.ts
+++ b/apps/intex-agent/src/__tests__/services.test.ts
@@ -6,6 +6,9 @@ import {
   composeIntexAgentExecutionServices,
   createIntexMatrixCorpusRuntime,
   createMatrixCorpusRunner,
+  MATRIX_CORPUS_MODEL_MAX_ATTEMPTS,
+  MATRIX_CORPUS_MODEL_REQUEST_TIMEOUT_MS,
+  MATRIX_CORPUS_MODEL_TURN_BUDGET_MS,
   createTestConversationRunnerService,
   createRuntimeBoundModelClients,
   resolveRuntimeSettingsWithDeadline,
@@ -50,6 +53,7 @@ import type {
 } from '../domain/sessions/types.js';
 import type { TestConversationRunner } from '../domain/testConversation/runTestConversation.js';
 import { FirestoreSessionRepository } from '../infra/firestore/sessionRepository.js';
+import { FakeUsageSink } from '@intexuraos/llm-pricing';
 
 describe('resolveRuntimeSettingsWithDeadline', () => {
   it('retains the successful closed User Service runtime DTO', async () => {
@@ -1191,6 +1195,124 @@ describe('createRuntimeBoundModelClients', () => {
     expect(createLlmClientFn).toHaveBeenCalledWith(
       expect.objectContaining({ model, apiKey: 'platform-key' })
     );
+  });
+
+  it('binds the Matrix corpus request policy to both DeepSeek clients', () => {
+    const createToolCallingClientFn = vi.fn(() => fakeToolCallingClient());
+    const createLlmClientFn = vi.fn(() => fakeStructuredClient());
+
+    createRuntimeBoundModelClients({
+      runtimeSettings: Object.freeze({
+        status: 'available' as const,
+        effectiveModel: IntexAgentModels.DeepSeekV4Flash,
+        explicitModel: IntexAgentModels.DeepSeekV4Flash,
+        source: 'explicit' as const,
+        revision: 1,
+        timeZone: 'Europe/Warsaw',
+      }),
+      apiKey: 'platform-key',
+      userId: 'user-1',
+      logger: silentLogger(),
+      usageSink: {} as CreateTestConversationRunnerServiceInput['usageSink'],
+      timeoutMs: MATRIX_CORPUS_MODEL_REQUEST_TIMEOUT_MS,
+      maxAttempts: MATRIX_CORPUS_MODEL_MAX_ATTEMPTS,
+      deadlineAtMs: MATRIX_CORPUS_MODEL_TURN_BUDGET_MS,
+      createToolCallingClientFn,
+      createLlmClientFn,
+    });
+
+    expect(MATRIX_CORPUS_MODEL_REQUEST_TIMEOUT_MS).toBe(45_000);
+    expect(MATRIX_CORPUS_MODEL_MAX_ATTEMPTS).toBe(2);
+    expect(MATRIX_CORPUS_MODEL_TURN_BUDGET_MS).toBe(180_000);
+    expect(createToolCallingClientFn).toHaveBeenCalledWith(
+      expect.objectContaining({ timeoutMs: 45_000, maxAttempts: 2, deadlineAtMs: 180_000 })
+    );
+    expect(createLlmClientFn).toHaveBeenCalledWith(
+      expect.objectContaining({ timeoutMs: 45_000, maxAttempts: 2, deadlineAtMs: 180_000 })
+    );
+  });
+
+  it('shares one absolute Matrix turn deadline across the real structured and tool clients', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-20T10:00:00.000Z'));
+    const startedAtMs = Date.now();
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    fetchSpy.mockImplementationOnce(async () => {
+      vi.setSystemTime(startedAtMs + 15);
+      return new Response(
+        JSON.stringify({
+          id: 'chatcmpl-structured',
+          model: 'deepseek/deepseek-v4-flash',
+          created: 1,
+          object: 'chat.completion',
+          choices: [
+            {
+              index: 0,
+              message: { role: 'assistant', content: '{}' },
+              finish_reason: 'stop',
+            },
+          ],
+          usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      );
+    });
+    fetchSpy.mockImplementationOnce(
+      async (_url, init) =>
+        await new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => {
+            reject(new DOMException('deadline reached', 'AbortError'));
+          });
+        })
+    );
+
+    try {
+      const clients = createRuntimeBoundModelClients({
+        runtimeSettings: Object.freeze({
+          status: 'available' as const,
+          effectiveModel: IntexAgentModels.DeepSeekV4Flash,
+          explicitModel: IntexAgentModels.DeepSeekV4Flash,
+          source: 'explicit' as const,
+          revision: 1,
+          timeZone: 'Europe/Warsaw',
+        }),
+        apiKey: 'platform-key',
+        userId: 'user-1',
+        logger: silentLogger(),
+        usageSink: new FakeUsageSink() as never,
+        timeoutMs: 100,
+        deadlineAtMs: startedAtMs + 20,
+        maxAttempts: 2,
+      } as CreateRuntimeBoundModelClientsInput);
+
+      await expect(
+        clients.structuredClient.generate('Classify.', { promptType: 'matrix-classifier' })
+      ).resolves.toMatchObject({ ok: true });
+
+      const toolResultPromise = clients.toolCallingClient.run({
+        systemPrompt: 'Respond.',
+        messages: [{ role: 'user', content: 'Test.' }],
+        tools: [],
+        promptType: 'matrix-agent',
+      });
+      let settled = false;
+      void toolResultPromise.finally(() => {
+        settled = true;
+      });
+
+      await vi.advanceTimersByTimeAsync(5);
+
+      expect(settled).toBe(true);
+      await expect(toolResultPromise).resolves.toMatchObject({
+        ok: false,
+        error: { code: 'TIMEOUT' },
+      });
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    } finally {
+      await vi.runAllTimersAsync();
+      fetchSpy.mockRestore();
+      vi.useRealTimers();
+    }
   });
 
   it('does not retry or substitute a model when product client construction fails', () => {

--- a/apps/intex-agent/src/domain/agent/intentClassifier.ts
+++ b/apps/intex-agent/src/domain/agent/intentClassifier.ts
@@ -132,7 +132,10 @@ export function createLlmIntexAgentIntentClassifier(deps: {
         messages: buildClassifierMessages(input.events, input.message, input.replyContext),
         ...(activeClarification !== undefined ? { activeClarification } : {}),
       });
-      const retryingClient = createRetryingStructuredClient(deps.client);
+      // The production OpenRouter client already retries transient failures. Avoid
+      // multiplying those attempts inside the lease-bounded Matrix corpus lane.
+      const retryingClient =
+        matrixCorpusLlm === undefined ? createRetryingStructuredClient(deps.client) : deps.client;
       const result = await generateStructured({
         client: retryingClient,
         prompt,

--- a/apps/intex-agent/src/services.ts
+++ b/apps/intex-agent/src/services.ts
@@ -114,6 +114,9 @@ export function composeIntexMatrixCorpusFeature<T>(
 }
 
 const RUNTIME_SETTINGS_LOOKUP_TIMEOUT_MS = 2_000;
+export const MATRIX_CORPUS_MODEL_REQUEST_TIMEOUT_MS = 45_000;
+export const MATRIX_CORPUS_MODEL_TURN_BUDGET_MS = 180_000;
+export const MATRIX_CORPUS_MODEL_MAX_ATTEMPTS = 2;
 
 export interface RuntimeSettingsDeadlineScheduler {
   setTimeout(callback: () => void, delayMs: number): unknown;
@@ -133,6 +136,9 @@ export interface CreateRuntimeBoundModelClientsInput {
   userId: string;
   logger: CreateTestConversationRunnerServiceInput['logger'];
   usageSink: HttpInternalAuthUsageSink;
+  timeoutMs?: number;
+  maxAttempts?: number;
+  deadlineAtMs?: number;
   createToolCallingClientFn?: typeof createToolCallingClient;
   createLlmClientFn?: typeof createLlmClient;
 }
@@ -148,6 +154,9 @@ export function createRuntimeBoundModelClients(input: CreateRuntimeBoundModelCli
     logger: input.logger,
     usageSink: input.usageSink,
     ownerType: 'user' as const,
+    ...(input.timeoutMs === undefined ? {} : { timeoutMs: input.timeoutMs }),
+    ...(input.maxAttempts === undefined ? {} : { maxAttempts: input.maxAttempts }),
+    ...(input.deadlineAtMs === undefined ? {} : { deadlineAtMs: input.deadlineAtMs }),
   };
   return {
     toolCallingClient: (input.createToolCallingClientFn ?? createToolCallingClient)(sharedConfig),
@@ -664,6 +673,9 @@ export async function initServices(config: ServiceConfig): Promise<void> {
           userId: input.userId,
           logger,
           usageSink,
+          timeoutMs: MATRIX_CORPUS_MODEL_REQUEST_TIMEOUT_MS,
+          maxAttempts: MATRIX_CORPUS_MODEL_MAX_ATTEMPTS,
+          deadlineAtMs: Date.now() + MATRIX_CORPUS_MODEL_TURN_BUDGET_MS,
         });
         return createMatrixCorpusRunner({
           execution: input.execution,

--- a/packages/infra-openrouter/src/__tests__/client.test.ts
+++ b/packages/infra-openrouter/src/__tests__/client.test.ts
@@ -488,6 +488,63 @@ describe('createOpenRouterClient', () => {
   });
 
   describe('generate', () => {
+    it('aborts while a successful response body is still being consumed', async () => {
+      nock(API_BASE_URL)
+        .post('/chat/completions')
+        .delayBody(50)
+        .reply(200, {
+          id: 'chatcmpl-delayed-body',
+          model: TEST_MODEL,
+          created: Date.now(),
+          object: 'chat.completion',
+          choices: [
+            {
+              index: 0,
+              message: { role: 'assistant', content: 'Too late.' },
+              finish_reason: 'stop',
+            },
+          ],
+          usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+        });
+
+      const client = createOpenRouterClient({
+        apiKey: 'test-key',
+        model: TEST_MODEL,
+        userId: 'test-user',
+        logger: mockLogger,
+        usageSink: mockUsageSink,
+        timeoutMs: 10,
+        maxAttempts: 1,
+      });
+
+      const result = await client.generate('Write something', { promptType: 'test-prompt' });
+
+      expect(result).toMatchObject({ ok: false, error: { code: 'TIMEOUT' } });
+    });
+
+    it('honors a configured provider attempt cap', async () => {
+      const fetchSpy = vi
+        .spyOn(globalThis, 'fetch')
+        .mockImplementation(async () => new Response('Service overloaded', { status: 503 }));
+      try {
+        const client = createOpenRouterClient({
+          apiKey: 'test-key',
+          model: TEST_MODEL,
+          userId: 'test-user',
+          logger: mockLogger,
+          usageSink: mockUsageSink,
+          maxAttempts: 2,
+        } as Parameters<typeof createOpenRouterClient>[0]);
+
+        const result = await client.generate('Write something', { promptType: 'test-prompt' });
+
+        expect(result).toMatchObject({ ok: false, error: { code: 'OVERLOADED' } });
+        expect(fetchSpy).toHaveBeenCalledTimes(2);
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    });
+
     it('does NOT append :online suffix for synthesis', async () => {
       let capturedBody: Record<string, unknown> | undefined;
 
@@ -1046,6 +1103,30 @@ describe('createOpenRouterClient', () => {
   });
 
   describe('generateChat', () => {
+    it('fails before fetch when the shared deadline is already exhausted', async () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch');
+      try {
+        const client = createOpenRouterClient({
+          apiKey: 'test-key',
+          model: TEST_MODEL,
+          userId: 'test-user',
+          logger: mockLogger,
+          usageSink: mockUsageSink,
+          maxAttempts: 1,
+          deadlineAtMs: Date.now() - 1,
+        });
+
+        const result = await client.generateChat([{ role: 'user', content: 'hello' }], {
+          promptType: 'test-chat',
+        });
+
+        expect(result).toMatchObject({ ok: false, error: { code: 'TIMEOUT' } });
+        expect(fetchSpy).not.toHaveBeenCalled();
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    });
+
     it('returns provider-reported USD separately from normalized chat cost', async () => {
       let capturedBody: Record<string, unknown> | undefined;
 

--- a/packages/infra-openrouter/src/__tests__/toolCallingClient.test.ts
+++ b/packages/infra-openrouter/src/__tests__/toolCallingClient.test.ts
@@ -1250,4 +1250,69 @@ describe('createOpenRouterToolCallingClient', () => {
     if (result.ok) return;
     expect(result.error.code).toBe('TIMEOUT');
   });
+
+  it('fails before fetch when the shared deadline is already exhausted', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    try {
+      const result = await createClientWithConfig({ deadlineAtMs: Date.now() - 1 }).run({
+        systemPrompt: 'Test',
+        messages: [{ role: 'user', content: 'test' }],
+        tools: [],
+        promptType: 'github-agent-pr-triage',
+      });
+
+      expect(result).toMatchObject({ ok: false, error: { code: 'TIMEOUT' } });
+      expect(fetchSpy).not.toHaveBeenCalled();
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('aborts while a successful response body is still being consumed', async () => {
+    nock(API_BASE_URL)
+      .post('/chat/completions')
+      .delayBody(50)
+      .reply(200, {
+        id: 'chatcmpl-delayed-body',
+        model: TEST_MODEL,
+        created: Date.now(),
+        object: 'chat.completion',
+        choices: [{ message: { role: 'assistant', content: 'Too late.' } }],
+      });
+
+    const result = await createClientWithConfig({ timeoutMs: 10 }).run({
+      systemPrompt: 'Test',
+      messages: [{ role: 'user', content: 'test' }],
+      tools: [],
+      promptType: 'github-agent-pr-triage',
+    });
+
+    expect(result).toMatchObject({ ok: false, error: { code: 'TIMEOUT' } });
+  });
+
+  it('retries a transient provider response up to the configured attempt cap', async () => {
+    nock(API_BASE_URL).post('/chat/completions').reply(503, 'Service overloaded');
+    nock(API_BASE_URL)
+      .post('/chat/completions')
+      .reply(200, {
+        id: 'chatcmpl-recovered',
+        model: TEST_MODEL,
+        created: Date.now(),
+        object: 'chat.completion',
+        choices: [{ message: { role: 'assistant', content: 'Recovered.' } }],
+      });
+
+    const client = createClientWithConfig({ maxAttempts: 2 } as Partial<
+      Parameters<typeof createOpenRouterToolCallingClient>[0]
+    >);
+    const result = await client.run({
+      systemPrompt: 'Test',
+      messages: [{ role: 'user', content: 'test' }],
+      tools: [],
+      promptType: 'github-agent-pr-triage',
+    });
+
+    expect(result).toMatchObject({ ok: true, value: { content: 'Recovered.' } });
+    expect(nock.isDone()).toBe(true);
+  });
 });

--- a/packages/infra-openrouter/src/client.ts
+++ b/packages/infra-openrouter/src/client.ts
@@ -113,21 +113,27 @@ function nonNegativeProviderCost(value: unknown): number | null {
   return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : null;
 }
 
-async function fetchWithTimeout(
-  url: string,
-  options: RequestInit,
-  timeoutMs: number
-): Promise<Response> {
+async function withRequestTimeout<T>(
+  timeoutMs: number,
+  operation: (signal: AbortSignal) => Promise<T>
+): Promise<T> {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => {
     controller.abort();
   }, timeoutMs);
 
   try {
-    return await fetch(url, { ...options, signal: controller.signal });
+    return await operation(controller.signal);
   } finally {
     clearTimeout(timeoutId);
   }
+}
+
+function resolveRequestTimeoutMs(timeoutMs: number, deadlineAtMs?: number): number {
+  if (deadlineAtMs === undefined) return timeoutMs;
+  const remainingMs = deadlineAtMs - Date.now();
+  if (remainingMs <= 0) throw new Error('OpenRouter request deadline timeout');
+  return Math.min(timeoutMs, remainingMs);
 }
 
 class OpenRouterApiError extends Error {
@@ -193,6 +199,8 @@ export function createOpenRouterClient(config: OpenRouterConfig): OpenRouterClie
     model,
     userId,
     timeoutMs = DEFAULT_TIMEOUT_MS,
+    maxAttempts = 3,
+    deadlineAtMs,
     logger,
     usageSink,
     ownerType,
@@ -212,6 +220,30 @@ export function createOpenRouterClient(config: OpenRouterConfig): OpenRouterClie
           ...(providerOrder !== undefined && { order: [...providerOrder] }),
           ...(allowFallbacks !== undefined && { allow_fallbacks: allowFallbacks }),
         };
+
+  async function postChatCompletion<T>(requestBody: Record<string, unknown>): Promise<T> {
+    return await withRequestTimeout(
+      resolveRequestTimeoutMs(timeoutMs, deadlineAtMs),
+      async (signal) => {
+        const response = await fetch(`${API_BASE_URL}/chat/completions`, {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+            'Content-Type': 'application/json',
+            'HTTP-Referer': 'https://intexuraos.cloud',
+            'X-Title': APP_TITLE,
+          },
+          body: JSON.stringify(requestBody),
+          signal,
+        });
+        if (!response.ok) {
+          const errorText = await response.text();
+          throw new OpenRouterApiError(response.status, errorText);
+        }
+        return (await response.json()) as T;
+      }
+    );
+  }
 
   function trackUsage(
     callType: CallType,
@@ -323,45 +355,7 @@ export function createOpenRouterClient(config: OpenRouterConfig): OpenRouterClie
           temperature: 0.2,
         };
 
-        const response = await fetchWithTimeout(
-          `${API_BASE_URL}/chat/completions`,
-          {
-            method: 'POST',
-            headers: {
-              Authorization: `Bearer ${apiKey}`,
-              'Content-Type': 'application/json',
-              'HTTP-Referer': 'https://intexuraos.cloud',
-              'X-Title': APP_TITLE,
-            },
-            body: JSON.stringify(requestBody),
-          },
-          timeoutMs
-        );
-
-        if (!response.ok) {
-          const durationMs = Date.now() - start;
-          const errorText = await response.text();
-          const apiError = new OpenRouterApiError(response.status, errorText);
-          const emptyUsage: NormalizedUsage = {
-            inputTokens: 0,
-            outputTokens: 0,
-            totalTokens: 0,
-            costUsd: 0,
-          };
-          trackUsage(
-            'research',
-            emptyUsage,
-            false,
-            durationMs,
-            toOpenRouterUsageErrorCategory(apiError),
-            undefined,
-            options?.promptType ?? RESEARCH_PROMPT_TYPE,
-            options?.correlation
-          );
-          return err(mapOpenRouterError(apiError));
-        }
-
-        const data = (await response.json()) as OpenRouterResponse;
+        const data = await postChatCompletion<OpenRouterResponse>(requestBody);
         const rawContent = data.choices[0]?.message.content;
         const content = typeof rawContent === 'string' ? rawContent : '';
         const { normalized, providerReportedUsd } = extractUsage(data.usage);
@@ -425,8 +419,9 @@ export function createOpenRouterClient(config: OpenRouterConfig): OpenRouterClie
       options: GenerateOptions
     ): Promise<Result<GenerateResult, OpenRouterError>> {
       return await withRetry(() => generateOnce(prompt, options), {
-        maxAttempts: 3,
+        maxAttempts,
         baseDelayMs: 500,
+        ...(deadlineAtMs === undefined ? {} : { deadlineAtMs }),
       });
     },
 
@@ -435,8 +430,9 @@ export function createOpenRouterClient(config: OpenRouterConfig): OpenRouterClie
       options: GenerateChatOptions
     ): Promise<Result<GenerateChatResult, OpenRouterError>> {
       return await withRetry(() => generateChatOnce(messages, options), {
-        maxAttempts: 3,
+        maxAttempts,
         baseDelayMs: 500,
+        ...(deadlineAtMs === undefined ? {} : { deadlineAtMs }),
       });
     },
 
@@ -450,26 +446,25 @@ export function createOpenRouterClient(config: OpenRouterConfig): OpenRouterClie
 
     async validateKey(key: string): Promise<Result<OpenRouterKeyInfo, OpenRouterError>> {
       try {
-        const response = await fetchWithTimeout(
-          `${API_BASE_URL}/key`,
-          {
-            method: 'GET',
-            headers: {
-              Authorization: `Bearer ${key}`,
-              'HTTP-Referer': 'https://intexuraos.cloud',
-              'X-Title': APP_TITLE,
-            },
-          },
-          10_000 // 10 second timeout for lightweight key check
+        const data = await withRequestTimeout(
+          resolveRequestTimeoutMs(10_000, deadlineAtMs),
+          async (signal) => {
+            const response = await fetch(`${API_BASE_URL}/key`, {
+              method: 'GET',
+              headers: {
+                Authorization: `Bearer ${key}`,
+                'HTTP-Referer': 'https://intexuraos.cloud',
+                'X-Title': APP_TITLE,
+              },
+              signal,
+            });
+            if (!response.ok) {
+              const errorText = await response.text();
+              throw new OpenRouterApiError(response.status, errorText);
+            }
+            return (await response.json()) as OpenRouterKeyInfo;
+          }
         );
-
-        if (!response.ok) {
-          const errorText = await response.text();
-          const apiError = new OpenRouterApiError(response.status, errorText);
-          return err(mapOpenRouterError(apiError));
-        }
-
-        const data = (await response.json()) as OpenRouterKeyInfo;
         return ok(data);
       } catch (error) {
         return err(mapOpenRouterError(error));
@@ -554,29 +549,7 @@ export function createOpenRouterClient(config: OpenRouterConfig): OpenRouterClie
             }),
           };
 
-          const response = await fetchWithTimeout(
-            `${API_BASE_URL}/chat/completions`,
-            {
-              method: 'POST',
-              headers: {
-                Authorization: `Bearer ${apiKey}`,
-                'Content-Type': 'application/json',
-                'HTTP-Referer': 'https://intexuraos.cloud',
-                'X-Title': APP_TITLE,
-              },
-              body: JSON.stringify(requestBody),
-            },
-            timeoutMs
-          );
-
-          // Throw on HTTP error so measureLlmCall rethrows errors. The outer
-          // catch below maps the error and logs usage with measured duration.
-          if (!response.ok) {
-            const errorText = await response.text();
-            throw new OpenRouterApiError(response.status, errorText);
-          }
-
-          const data = (await response.json()) as OpenRouterResponse;
+          const data = await postChatCompletion<OpenRouterResponse>(requestBody);
           const firstChoice = data.choices[0];
           if (
             firstChoice === undefined ||
@@ -658,27 +631,27 @@ export function createOpenRouterClient(config: OpenRouterConfig): OpenRouterClie
         }),
       };
 
-      const response = await fetchWithTimeout(
-        `${API_BASE_URL}/chat/completions`,
-        {
-          method: 'POST',
-          headers: {
-            Authorization: `Bearer ${apiKey}`,
-            'Content-Type': 'application/json',
-            'HTTP-Referer': 'https://intexuraos.cloud',
-            'X-Title': APP_TITLE,
-          },
-          body: JSON.stringify(requestBody),
-        },
-        timeoutMs
+      const streamResult = await withRequestTimeout(
+        resolveRequestTimeoutMs(timeoutMs, deadlineAtMs),
+        async (signal) => {
+          const response = await fetch(`${API_BASE_URL}/chat/completions`, {
+            method: 'POST',
+            headers: {
+              Authorization: `Bearer ${apiKey}`,
+              'Content-Type': 'application/json',
+              'HTTP-Referer': 'https://intexuraos.cloud',
+              'X-Title': APP_TITLE,
+            },
+            body: JSON.stringify(requestBody),
+            signal,
+          });
+          if (!response.ok) {
+            const errorText = await response.text();
+            throw new OpenRouterApiError(response.status, errorText);
+          }
+          return await processChatStream(response, onEvent);
+        }
       );
-
-      if (!response.ok) {
-        const errorText = await response.text();
-        throw new OpenRouterApiError(response.status, errorText);
-      }
-
-      const streamResult = await processChatStream(response, onEvent);
       const durationMs = Date.now() - start;
       trackUsage(
         'generate',
@@ -800,6 +773,9 @@ function mapOpenRouterError(error: unknown): OpenRouterError {
     if (error.status === 429) return { code: 'RATE_LIMITED', message };
     if (error.status === 503) return { code: 'OVERLOADED', message };
     return { code: 'API_ERROR', message };
+  }
+  if (error instanceof Error && error.name === 'AbortError') {
+    return { code: 'TIMEOUT', message: error.message };
   }
   const message = getErrorMessage(error);
   // Check for timeout indicators in the error message

--- a/packages/infra-openrouter/src/toolCallingClient.ts
+++ b/packages/infra-openrouter/src/toolCallingClient.ts
@@ -18,6 +18,7 @@ import {
   type ToolDefinition,
 } from '@intexuraos/llm-contract';
 import { createUsageLogger, type UsageSink } from '@intexuraos/llm-pricing';
+import { withRetry } from '@intexuraos/llm-utils';
 import type { Logger } from '@intexuraos/common-core';
 import { normalizeUsage } from './costCalculator.js';
 import type { OpenRouterUsage } from './types.js';
@@ -30,6 +31,10 @@ export interface OpenRouterToolCallingConfig {
   usageSink: UsageSink;
   ownerType?: OwnerType;
   timeoutMs?: number;
+  /** Maximum transient attempts for each provider iteration. Default: 1. */
+  maxAttempts?: number;
+  /** Optional absolute wall-clock deadline shared by all iterations and retries. */
+  deadlineAtMs?: number;
   evidenceModelId?: string;
 }
 
@@ -86,20 +91,33 @@ class OpenRouterApiError extends Error {
   }
 }
 
-async function fetchWithTimeout(
-  url: string,
-  options: RequestInit,
-  timeoutMs: number
-): Promise<Response> {
+async function withRequestTimeout<T>(
+  timeoutMs: number,
+  operation: (signal: AbortSignal) => Promise<T>
+): Promise<T> {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => {
     controller.abort();
   }, timeoutMs);
 
   try {
-    return await fetch(url, { ...options, signal: controller.signal });
+    return await operation(controller.signal);
   } finally {
     clearTimeout(timeoutId);
+  }
+}
+
+function resolveRequestTimeoutMs(timeoutMs: number, deadlineAtMs?: number): number {
+  if (deadlineAtMs === undefined) return timeoutMs;
+  const remainingMs = deadlineAtMs - Date.now();
+  if (remainingMs <= 0) throw new Error('OpenRouter request deadline timeout');
+  return Math.min(timeoutMs, remainingMs);
+}
+
+class OpenRouterLlmError extends Error {
+  constructor(public readonly llmError: LLMError) {
+    super(llmError.message);
+    this.name = 'OpenRouterLlmError';
   }
 }
 
@@ -114,9 +132,37 @@ export function createOpenRouterToolCallingClient(
     usageSink,
     ownerType,
     timeoutMs = DEFAULT_TIMEOUT_MS,
+    maxAttempts = 1,
+    deadlineAtMs,
     evidenceModelId = model,
   } = config;
   const usageLogger = createUsageLogger({ logger, sink: usageSink });
+
+  async function postChatCompletion(
+    requestBody: Record<string, unknown>
+  ): Promise<OpenRouterToolCallingResponse> {
+    return await withRequestTimeout(
+      resolveRequestTimeoutMs(timeoutMs, deadlineAtMs),
+      async (signal) => {
+        const response = await fetch(`${API_BASE_URL}/chat/completions`, {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+            'Content-Type': 'application/json',
+            'HTTP-Referer': 'https://intexuraos.cloud',
+            'X-Title': APP_TITLE,
+          },
+          body: JSON.stringify(requestBody),
+          signal,
+        });
+        if (!response.ok) {
+          const errorText = await response.text();
+          throw new OpenRouterApiError(response.status, errorText);
+        }
+        return (await response.json()) as OpenRouterToolCallingResponse;
+      }
+    );
+  }
 
   function trackUsage(
     usage: NormalizedUsage,
@@ -230,27 +276,22 @@ export function createOpenRouterToolCallingClient(
               toolChoice
             );
 
-            const response = await fetchWithTimeout(
-              `${API_BASE_URL}/chat/completions`,
-              {
-                method: 'POST',
-                headers: {
-                  Authorization: `Bearer ${apiKey}`,
-                  'Content-Type': 'application/json',
-                  'HTTP-Referer': 'https://intexuraos.cloud',
-                  'X-Title': APP_TITLE,
-                },
-                body: JSON.stringify(requestBody),
+            const responseResult = await withRetry(
+              async () => {
+                try {
+                  return ok(await postChatCompletion(requestBody));
+                } catch (error) {
+                  return err(mapOpenRouterError(error));
+                }
               },
-              timeoutMs
+              {
+                maxAttempts,
+                baseDelayMs: 500,
+                ...(deadlineAtMs === undefined ? {} : { deadlineAtMs }),
+              }
             );
-
-            if (!response.ok) {
-              const errorText = await response.text();
-              throw new OpenRouterApiError(response.status, errorText);
-            }
-
-            const data = (await response.json()) as OpenRouterToolCallingResponse;
+            if (!responseResult.ok) throw new OpenRouterLlmError(responseResult.error);
+            const data = responseResult.value;
             const message = data.choices[0]?.message;
             const usage = extractUsage(data.usage);
             if (params.matrixCorpusContext !== undefined) {
@@ -533,12 +574,17 @@ function addUsage(a: NormalizedUsage, b: NormalizedUsage): NormalizedUsage {
 }
 
 function mapOpenRouterError(error: unknown): LLMError {
+  if (error instanceof OpenRouterLlmError) return error.llmError;
   if (error instanceof OpenRouterApiError) {
     const message = error.message;
     if (error.status === 401) return { code: 'INVALID_KEY', message };
     if (error.status === 429) return { code: 'RATE_LIMITED', message };
     if (error.status === 503) return { code: 'OVERLOADED', message };
     return { code: 'API_ERROR', message };
+  }
+
+  if (error instanceof Error && error.name === 'AbortError') {
+    return { code: 'TIMEOUT', message: error.message };
   }
 
   const message = getErrorMessage(error);

--- a/packages/infra-openrouter/src/types.ts
+++ b/packages/infra-openrouter/src/types.ts
@@ -88,6 +88,10 @@ export interface OpenRouterConfig {
   userId: string;
   /** Request timeout in milliseconds. Default: 840000 (14 minutes) */
   timeoutMs?: number;
+  /** Maximum transient provider attempts. Default: 3. */
+  maxAttempts?: number;
+  /** Optional absolute wall-clock deadline shared across provider calls. */
+  deadlineAtMs?: number;
   /** Pino logger for structured LLM usage logging */
   logger: Logger;
   /** Usage sink. Required — pass NoopUsageSink to explicitly opt out. */

--- a/packages/llm-factory/src/__tests__/llmClientFactory.test.ts
+++ b/packages/llm-factory/src/__tests__/llmClientFactory.test.ts
@@ -353,6 +353,25 @@ describe('llmClientFactory', () => {
         );
       }
     );
+
+    it('forwards the bounded OpenRouter policy through the generation boundary', async () => {
+      const { createOpenRouterGenerateClient } = await import('../openRouterGenerateClient.js');
+
+      createLlmClient({
+        apiKey: 'test-key',
+        model: IntexAgentModels.DeepSeekV4Flash,
+        userId: 'user-123',
+        logger: mockLogger,
+        usageSink: mockUsageSink,
+        timeoutMs: 45_000,
+        maxAttempts: 2,
+        deadlineAtMs: 123_456,
+      });
+
+      expect(createOpenRouterGenerateClient).toHaveBeenCalledWith(
+        expect.objectContaining({ timeoutMs: 45_000, maxAttempts: 2, deadlineAtMs: 123_456 })
+      );
+    });
   });
 
   describe('createToolCallingClient', () => {
@@ -391,6 +410,25 @@ describe('llmClientFactory', () => {
           usageSink: mockUsageSink,
           ownerType: 'user',
         })
+      );
+    });
+
+    it('forwards the bounded OpenRouter policy through the tool-calling boundary', async () => {
+      const { createOpenRouterToolCallingClient } = await import('@intexuraos/infra-openrouter');
+
+      createToolCallingClient({
+        apiKey: 'test-key',
+        model: IntexAgentModels.DeepSeekV4Flash,
+        userId: 'test-user',
+        logger: mockLogger,
+        usageSink: mockUsageSink,
+        timeoutMs: 45_000,
+        maxAttempts: 2,
+        deadlineAtMs: 123_456,
+      });
+
+      expect(createOpenRouterToolCallingClient).toHaveBeenCalledWith(
+        expect.objectContaining({ timeoutMs: 45_000, maxAttempts: 2, deadlineAtMs: 123_456 })
       );
     });
 

--- a/packages/llm-factory/src/__tests__/openRouterGenerateClient.test.ts
+++ b/packages/llm-factory/src/__tests__/openRouterGenerateClient.test.ts
@@ -303,4 +303,19 @@ describe('createOpenRouterGenerateClient', () => {
       expect(callArg?.['ownerType']).toBeUndefined();
     });
   });
+
+  it('forwards the bounded request policy to the OpenRouter client', async () => {
+    const { createOpenRouterClient } = await import('@intexuraos/infra-openrouter');
+
+    createOpenRouterGenerateClient({
+      ...baseConfig,
+      timeoutMs: 45_000,
+      maxAttempts: 2,
+      deadlineAtMs: 123_456,
+    });
+
+    expect(createOpenRouterClient).toHaveBeenCalledWith(
+      expect.objectContaining({ timeoutMs: 45_000, maxAttempts: 2, deadlineAtMs: 123_456 })
+    );
+  });
 });

--- a/packages/llm-factory/src/llmClientFactory.ts
+++ b/packages/llm-factory/src/llmClientFactory.ts
@@ -80,6 +80,12 @@ export interface LlmClientConfig {
    * Pass 'user' for calls initiated directly by a human (e.g. chat, code tasks).
    */
   ownerType?: OwnerType;
+  /** Optional provider request timeout in milliseconds. */
+  timeoutMs?: number;
+  /** Optional transient provider attempt cap. */
+  maxAttempts?: number;
+  /** Optional absolute wall-clock deadline shared by provider calls. */
+  deadlineAtMs?: number;
 }
 
 export interface ToolCallingClientConfig {
@@ -89,6 +95,12 @@ export interface ToolCallingClientConfig {
   logger: Logger;
   usageSink: UsageSink;
   ownerType?: OwnerType;
+  /** Optional provider request timeout in milliseconds. */
+  timeoutMs?: number;
+  /** Optional transient provider attempt cap. */
+  maxAttempts?: number;
+  /** Optional absolute wall-clock deadline shared by provider calls. */
+  deadlineAtMs?: number;
 }
 
 /**
@@ -283,6 +295,9 @@ export function createToolCallingClient(config: ToolCallingClientConfig): ToolCa
       logger: config.logger,
       usageSink: config.usageSink,
       ...(config.ownerType !== undefined && { ownerType: config.ownerType }),
+      ...(config.timeoutMs !== undefined && { timeoutMs: config.timeoutMs }),
+      ...(config.maxAttempts !== undefined && { maxAttempts: config.maxAttempts }),
+      ...(config.deadlineAtMs !== undefined && { deadlineAtMs: config.deadlineAtMs }),
       evidenceModelId: model,
     });
   }

--- a/packages/llm-factory/src/openRouterGenerateClient.ts
+++ b/packages/llm-factory/src/openRouterGenerateClient.ts
@@ -28,6 +28,9 @@ export function createOpenRouterGenerateClient(config: LlmClientConfig): LlmGene
     logger: config.logger,
     usageSink: config.usageSink,
     ...(config.ownerType !== undefined && { ownerType: config.ownerType }),
+    ...(config.timeoutMs !== undefined && { timeoutMs: config.timeoutMs }),
+    ...(config.maxAttempts !== undefined && { maxAttempts: config.maxAttempts }),
+    ...(config.deadlineAtMs !== undefined && { deadlineAtMs: config.deadlineAtMs }),
     evidenceModelId: config.model as string,
   });
 

--- a/packages/llm-utils/src/__tests__/withRetry.test.ts
+++ b/packages/llm-utils/src/__tests__/withRetry.test.ts
@@ -143,4 +143,26 @@ describe('withRetry', () => {
       vi.useRealTimers();
     }
   });
+
+  it('does not start another attempt after the shared deadline is reached', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-20T10:00:00.000Z'));
+    try {
+      const fn = vi
+        .fn<() => Promise<Result<string, LLMError>>>()
+        .mockResolvedValue(err({ code: 'TIMEOUT', message: 'provider timeout' }));
+      const promise = withRetry(fn, {
+        maxAttempts: 3,
+        baseDelayMs: 100,
+        deadlineAtMs: Date.now() + 50,
+      } as Parameters<typeof withRetry>[1]);
+
+      await vi.runAllTimersAsync();
+
+      await expect(promise).resolves.toEqual(err({ code: 'TIMEOUT', message: 'provider timeout' }));
+      expect(fn).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/packages/llm-utils/src/withRetry.ts
+++ b/packages/llm-utils/src/withRetry.ts
@@ -31,6 +31,8 @@ export interface WithRetryOptions {
   maxDelayMs?: number;
   /** Sleep override for tests. Defaults to `setTimeout`-based promise. */
   sleep?: (ms: number) => Promise<void>;
+  /** Optional absolute wall-clock deadline shared by every attempt and backoff. */
+  deadlineAtMs?: number;
 }
 
 /**
@@ -64,6 +66,9 @@ export async function withRetry<T>(
 
   let last: Result<T, LLMError> | null = null;
   for (let attempt = 1; attempt <= opts.maxAttempts; attempt++) {
+    if (last !== null && opts.deadlineAtMs !== undefined && Date.now() >= opts.deadlineAtMs) {
+      break;
+    }
     const res = await fn();
     if (res.ok) return res;
     last = res;
@@ -71,7 +76,11 @@ export async function withRetry<T>(
     if (attempt === opts.maxAttempts) break;
     const providerDelay = (res.error as { retryAfterMs?: number }).retryAfterMs;
     const expBackoff = Math.min(opts.baseDelayMs * 2 ** (attempt - 1), maxDelay);
-    const delay = providerDelay ?? expBackoff;
+    const requestedDelay = providerDelay ?? expBackoff;
+    const deadlineDelay =
+      opts.deadlineAtMs === undefined ? Number.POSITIVE_INFINITY : opts.deadlineAtMs - Date.now();
+    if (deadlineDelay <= 0) break;
+    const delay = Math.min(requestedDelay, deadlineDelay);
     await sleeper(delay);
   }
   return last as Result<T, LLMError>;


### PR DESCRIPTION
## Summary

- enforce one 180-second deadline across Matrix classifier, schema repair, and tool calls
- cap Matrix OpenRouter calls at two attempts with 45-second end-to-end request timeouts
- preserve ordinary user retry defaults and strict mocked-tool isolation

## Verification

- `pnpm run ci:tracked`
- 6732 tests passed
- security, test, and UX reviews: READY

## Linear

Linear: omitted by `$commit-push`; GitHub automation will create or link the Linear issue after PR creation.

## Code Task

- Linear: [INT-1909](https://linear.app/pbuchman/issue/INT-1909)
- IntexuraOS Code Task: [View task](https://intexuraos.cloud/#/code-tasks/task_776d5902-e9f8-4309-a6f0-bc87950d7ceb)
- Worker Type: `codex-xhigh`
- Model: `default`