### PR TITLE
[INT-1910] fix: preserve Matrix reply cursor boundaries

### DIFF
--- a/tools/intex-agent-evals/src/__tests__/fixtures/matrixCorpusCompositionHarness.ts
+++ b/tools/intex-agent-evals/src/__tests__/fixtures/matrixCorpusCompositionHarness.ts
@@ -106,6 +106,8 @@ export interface MatrixCorpusCompositionHarnessOptions {
 
 export interface MatrixCorpusCompositionMetrics {
   maxConcurrentTurns: number;
+  initialCursorCaptures: number;
+  readonly matrixSyncSince: (string | undefined)[];
   readonly matrixMessages: string[];
   readonly leaseRenewalKeys: string[];
   deepSeekAgentCalls: number;
@@ -145,6 +147,8 @@ export async function createPassingMatrixCorpusCompositionHarness(
   });
   const metrics: MatrixCorpusCompositionMetrics = {
     maxConcurrentTurns: 0,
+    initialCursorCaptures: 0,
+    matrixSyncSince: [],
     matrixMessages: [],
     leaseRenewalKeys: [],
     deepSeekAgentCalls: 0,
@@ -220,8 +224,10 @@ function createMatrixBoundary(state: SharedState): MatrixClient {
       return { ok: true, userId: '@private_user_sentinel:example.test' };
     },
     async syncTargetRoom(input) {
+      state.metrics.matrixSyncSince.push(input.since);
       cursor += 1;
       if (input.timeoutMs === 0) {
+        state.metrics.initialCursorCaptures += 1;
         if (state.hangInitialCursor) return await matrixTimeoutAfterAbort(input.signal);
         return { ok: true, nextBatch: `batch_${String(cursor)}`, limited: false, events: [] };
       }

--- a/tools/intex-agent-evals/src/__tests__/matrixCorpusComposition.test.ts
+++ b/tools/intex-agent-evals/src/__tests__/matrixCorpusComposition.test.ts
@@ -58,6 +58,11 @@ describe('production Matrix corpus composition', () => {
     expect(result.run.scenarios).toHaveLength(20);
     expect(result.run.scenarios.every((scenario) => scenario.status === 'passed')).toBe(true);
     expect(harness.metrics.maxConcurrentTurns).toBe(1);
+    expect(harness.metrics.initialCursorCaptures).toBe(1);
+    expect(harness.metrics.matrixSyncSince).toEqual([
+      undefined,
+      ...Array.from({ length: 118 }, (_, index) => `batch_${String(index + 1)}`),
+    ]);
     expect(harness.metrics.matrixMessages).toHaveLength(59);
     expect(
       harness.metrics.matrixMessages.filter((message) => message.startsWith('new session:'))

--- a/tools/intex-agent-evals/src/__tests__/matrixCorpusCorrelation.test.ts
+++ b/tools/intex-agent-evals/src/__tests__/matrixCorpusCorrelation.test.ts
@@ -43,7 +43,62 @@ describe('Matrix corpus reply correlation', () => {
         messageText,
         signal: signal(),
       })
-    ).resolves.toEqual({ ok: true, cursor: 'cursor-2' });
+    ).resolves.toEqual({ ok: true, cursor: 'cursor-2', eventsAfterOutbound: [] });
+  });
+
+  it('partitions a sync batch at the exact outbound and preserves only later reply events', async () => {
+    const messageText = 'exact outbound message';
+    const currentReply = reply('$reply-current', 'Current reply');
+    const matrix = matrixWith([
+      {
+        ok: true,
+        nextBatch: 'cursor-2',
+        limited: false,
+        events: [
+          reply('$reply-previous', 'Previous reply'),
+          reply('$sent-1', messageText, '@operator:home-dev'),
+          currentReply,
+        ],
+      },
+      { ok: true, nextBatch: 'cursor-3', limited: false, events: [] },
+    ]);
+
+    const proof = await proveMatrixCorpusOutboundEvent({
+      matrix,
+      context: CONTEXT,
+      cursor: 'cursor-1',
+      matrixUserId: '@operator:home-dev',
+      matrixEventId: '$sent-1',
+      messageText,
+      signal: signal(),
+    });
+    expect(proof).toEqual({
+      ok: true,
+      cursor: 'cursor-2',
+      eventsAfterOutbound: [currentReply],
+    });
+    if (!proof.ok) throw new Error('expected outbound proof');
+
+    await expect(
+      collectCorrelatedReplies({
+        ...baseInput(
+          matrix,
+          evidenceWith([
+            {
+              status: 'completed',
+              replyCount: 1,
+              replyDigests: [digestMatrixReply('Current reply')],
+            },
+          ])
+        ),
+        cursor: proof.cursor,
+        initialEvents: proof.eventsAfterOutbound,
+      })
+    ).resolves.toMatchObject({
+      ok: true,
+      cursor: 'cursor-2',
+      replies: [{ eventId: '$reply-current', body: 'Current reply' }],
+    });
   });
 
   it.each([

--- a/tools/intex-agent-evals/src/matrixCorpus/correlation.ts
+++ b/tools/intex-agent-evals/src/matrixCorpus/correlation.ts
@@ -65,7 +65,11 @@ export type MatrixCorpusCorrelatedRepliesResult =
   | { readonly ok: false; readonly code: MatrixCorpusCorrelationFailureCode };
 
 export type MatrixCorpusOutboundProofResult =
-  | { readonly ok: true; readonly cursor: string }
+  | {
+      readonly ok: true;
+      readonly cursor: string;
+      readonly eventsAfterOutbound: readonly MatrixTimelineEvent[];
+    }
   | { readonly ok: false; readonly code: MatrixCorpusCorrelationFailureCode };
 
 export interface MatrixCorpusMatrixContext {
@@ -112,7 +116,7 @@ export async function proveMatrixCorpusOutboundEvent(input: {
     if (!sync.ok) return { ok: false, code: mapSyncFailure(sync.reason, input.signal) };
     if (sync.limited) return { ok: false, code: 'matrix_timeline_limited' };
     cursor = sync.nextBatch;
-    for (const event of sync.events) {
+    for (const [eventIndex, event] of sync.events.entries()) {
       const isExpectedId = event.eventId === input.matrixEventId;
       const isSameSelfAuthoredText =
         event.sender === input.matrixUserId && event.content?.body === input.messageText;
@@ -127,7 +131,11 @@ export async function proveMatrixCorpusOutboundEvent(input: {
         event.unsigned?.redacted_because !== undefined
       )
         return { ok: false, code: 'outbound_event_mismatch' };
-      return { ok: true, cursor };
+      return {
+        ok: true,
+        cursor,
+        eventsAfterOutbound: sync.events.slice(eventIndex + 1),
+      };
     }
   }
 }
@@ -137,6 +145,7 @@ export async function collectCorrelatedReplies(input: {
   evidence: MatrixCorpusReplyEvidencePort;
   context: MatrixCorpusMatrixContext;
   cursor: string;
+  initialEvents?: readonly MatrixTimelineEvent[];
   matrixUserId: string;
   expectedPuppetSender: string;
   runId: string;
@@ -151,20 +160,28 @@ export async function collectCorrelatedReplies(input: {
   const byEventId = new Map<string, CorrelatedMatrixReply>();
   const rawBodiesByEventId = new Map<string, string>();
   const redactedEventIds = new Set<string>();
+  let initialEvents = input.initialEvents;
 
   for (;;) {
     if (input.signal.aborted) return { ok: false, code: 'reply_timeout' };
-    const sync = await input.matrix.syncTargetRoom({
-      ...input.context,
-      since: cursor,
-      timeoutMs: 30_000,
-      signal: input.signal,
-    });
-    if (!sync.ok) return { ok: false, code: mapSyncFailure(sync.reason, input.signal) };
-    if (sync.limited) return { ok: false, code: 'matrix_timeline_limited' };
-    cursor = sync.nextBatch;
+    let events: readonly MatrixTimelineEvent[];
+    if (initialEvents === undefined) {
+      const sync = await input.matrix.syncTargetRoom({
+        ...input.context,
+        since: cursor,
+        timeoutMs: 30_000,
+        signal: input.signal,
+      });
+      if (!sync.ok) return { ok: false, code: mapSyncFailure(sync.reason, input.signal) };
+      if (sync.limited) return { ok: false, code: 'matrix_timeline_limited' };
+      cursor = sync.nextBatch;
+      events = sync.events;
+    } else {
+      events = initialEvents;
+      initialEvents = undefined;
+    }
 
-    for (const event of sync.events) {
+    for (const event of events) {
       if (event.type === 'm.room.redaction') {
         if (event.eventId === undefined || event.redacts === undefined) {
           return { ok: false, code: 'matrix_sync_invalid' };

--- a/tools/intex-agent-evals/src/matrixCorpus/liveExecution.ts
+++ b/tools/intex-agent-evals/src/matrixCorpus/liveExecution.ts
@@ -104,6 +104,7 @@ interface LiveRunState {
   readonly startedAt: string;
   leaseFence: string | null;
   revision: number;
+  matrixCursor: string | null;
   turnsSent: number;
   turnsCorrelated: number;
   finalizedScenarioContextCount: number;
@@ -834,15 +835,18 @@ async function executeLiveTurn(input: {
     return { ok: false, kind: 'infrastructure_failure', code: 'turn_catalog_mismatch' };
   state.startedAt ??= input.now().toISOString();
 
-  const cursor = await runWithMatrixCorpusDeadline(
-    input.correlationTimeoutMs,
-    async (signal) =>
-      await captureMatrixCorpusCursor({
-        matrix: input.matrix,
-        context: input.state.prepared.account,
-        signal,
-      })
-  );
+  const cursor =
+    input.state.matrixCursor === null
+      ? await runWithMatrixCorpusDeadline(
+          input.correlationTimeoutMs,
+          async (signal) =>
+            await captureMatrixCorpusCursor({
+              matrix: input.matrix,
+              context: input.state.prepared.account,
+              signal,
+            })
+        )
+      : { ok: true as const, cursor: input.state.matrixCursor };
   if (!cursor.ok) return { ok: false, kind: 'infrastructure_failure', code: cursor.code };
 
   const before =
@@ -983,7 +987,8 @@ async function executeLiveTurn(input: {
       await collectCorrelatedReplies({
         matrix: input.matrix,
         context: input.state.prepared.account,
-        cursor: cursor.cursor,
+        cursor: observedProof.cursor,
+        initialEvents: observedProof.eventsAfterOutbound,
         matrixUserId: input.state.prepared.account.matrixUserId,
         expectedPuppetSender: input.state.prepared.expectedPuppetSender,
         runId: input.runId,
@@ -1037,6 +1042,7 @@ async function executeLiveTurn(input: {
     };
 
   input.state.turnsCorrelated += 1;
+  input.state.matrixCursor = correlated.cursor;
   state.whatsappIngress += 1;
   state.whatsappEgress += correlated.replies.length;
   state.matrixMirrors += correlated.replies.length;
@@ -1182,6 +1188,7 @@ function createState(
     startedAt: now().toISOString(),
     leaseFence: null,
     revision: 0,
+    matrixCursor: null,
     turnsSent: 0,
     turnsCorrelated: 0,
     finalizedScenarioContextCount: 0,


### PR DESCRIPTION
## Summary

- keep one monotonic Matrix sync cursor across all corpus turns
- partition the outbound proof batch at the exact sent event and preserve only later replies
- cover same-batch replies and the complete 20-scenario / 59-turn cursor chain

## Verification

- `pnpm run ci:tracked` (6733 tests passed)
- `pnpm --filter @intexuraos/intex-agent-evals test -- matrixCorpusCorrelation matrixCorpusComposition` (957 tests passed)
- security, test, and UX reviews: READY

## Linear

- Linear: [INT-1910](https://linear.app/pbuchman/issue/INT-1910)
- IntexuraOS Code Task: [View task](https://intexuraos.cloud/#/code-tasks/task_30fb462b-d9c8-4ae9-8886-23af5792fb4a)
- Worker Type: `codex-xhigh`
- Model: `default`
