### PR TITLE
[INT-1914] fix: enforce Intex structured outputs

### DIFF
--- a/apps/intex-agent/src/__tests__/domain/intentClassifier.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/intentClassifier.test.ts
@@ -971,6 +971,58 @@ describe('createLlmIntexAgentIntentClassifier', () => {
     expect(client.calls[1]?.options.promptType).toBe(INTEX_AGENT_INTENT_CLASSIFIER_PROMPT_TYPE);
   });
 
+  it('requests strict structured output and normalizes provider nulls before validation', async () => {
+    const client = new FakeStructuredClient([
+      ok(
+        generateResult(
+          JSON.stringify({
+            outcome: 'tool',
+            confidence: 0.95,
+            allowedToolNames: ['create_calendar_event'],
+            question: null,
+            clarification: null,
+            reason: 'Explicit calendar creation request.',
+            blockerReason: null,
+            missingFields: null,
+            candidateIntents: null,
+            suggestedNextStep: null,
+            stylePreferenceAction: 'none',
+            languageOverride: null,
+            decisionEvidence: 'Create a calendar event.',
+          })
+        )
+      ),
+    ]);
+
+    await expect(
+      createLlmIntexAgentIntentClassifier({ client, logger: new FakeLogger() }).classify({
+        message: 'Create a calendar event tomorrow at 10.',
+        events: [],
+        currentDateTime: CURRENT_DATE_TIME,
+      })
+    ).resolves.toEqual({
+      kind: 'tool',
+      allowedToolNames: ['create_calendar_event'],
+      reason: 'Explicit calendar creation request.',
+      decisionEvidence: 'Create a calendar event.',
+    });
+
+    expect(client.calls).toHaveLength(1);
+    expect(client.calls[0]?.options['responseFormat']).toMatchObject({
+      type: 'json_schema',
+      json_schema: {
+        name: 'intex_agent_intent_classifier',
+        strict: true,
+        schema: {
+          type: 'object',
+          properties: expect.any(Object),
+          required: expect.any(Array),
+          additionalProperties: false,
+        },
+      },
+    });
+  });
+
   it('warns and fails closed to clarification when the classifier response cannot be repaired', async () => {
     const malformedClient = new FakeStructuredClient([
       ok(generateResult('not json')),

--- a/apps/intex-agent/src/__tests__/domain/intexAgentRunner.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/intexAgentRunner.test.ts
@@ -2792,6 +2792,44 @@ describe('createIntexAgentRunner', () => {
     });
   });
 
+  it('repairs conflicting runner-only fields instead of hiding a false tool completion', async () => {
+    const client = new FakeToolCallingClient([
+      ok({
+        content: JSON.stringify({
+          outcome: 'no_action',
+          reply: 'Saved the note.',
+          toolName: 'create_note',
+        }),
+        toolCallsMade: 0,
+        iterationCount: 1,
+        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2, costUsd: 0 },
+      }),
+    ]);
+    const responseRepairClient = new FakeStructuredClient([
+      ok(generateResult({ outcome: 'no_action', reply: 'I did not create a note.' })),
+    ]);
+    const runner = createIntexAgentRunner({
+      client,
+      responseRepairClient,
+      toolExecutor: fakeToolExecutor(),
+    });
+
+    await expect(
+      runner.run({
+        session: session(),
+        events: [],
+        message: 'something weird',
+        currentDateTime: CURRENT_DATE_TIME,
+      })
+    ).resolves.toEqual({
+      outcome: 'no_action',
+      reply: 'I did not create a note.',
+    });
+
+    expect(responseRepairClient.calls).toHaveLength(1);
+    expect(responseRepairClient.calls[0]?.prompt).toContain('"toolName":"create_note"');
+  });
+
   it('repairs malformed final runner output through the structured repair prompt', async () => {
     const client = new FakeToolCallingClient([
       ok({
@@ -2827,6 +2865,110 @@ describe('createIntexAgentRunner', () => {
     expect(responseRepairClient.calls[0]?.options.promptType).toBe(
       INTEX_AGENT_RUNNER_PROMPT_TYPE
     );
+  });
+
+  it('normalizes strict structured runner repair nulls before domain validation', async () => {
+    const client = new FakeToolCallingClient([
+      ok({
+        content: 'not json',
+        toolCallsMade: 0,
+        iterationCount: 1,
+        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2, costUsd: 0 },
+      }),
+    ]);
+    const responseRepairClient = new FakeStructuredClient([
+      ok(
+        generateResult({
+          outcome: 'needs_clarification',
+          reply: 'Which date?',
+          summary: null,
+          blockerReason: 'missing_required_details',
+          missingFields: ['date'],
+          suggestedNextStep: null,
+          clarification: null,
+          candidateIntents: ['create_calendar_event'],
+          errorCategory: null,
+          isRetryable: null,
+          attemptedAction: null,
+        })
+      ),
+    ]);
+    const runner = createIntexAgentRunner({
+      client,
+      responseRepairClient,
+      toolExecutor: fakeToolExecutor(),
+    });
+
+    await expect(
+      runner.run({
+        session: session(),
+        events: [],
+        message: 'create dentist appointment',
+        currentDateTime: CURRENT_DATE_TIME,
+      })
+    ).resolves.toMatchObject({
+      outcome: 'needs_clarification',
+      reply: 'Which date?',
+      blockerReason: 'missing_required_details',
+      missingFields: ['date'],
+      candidateIntents: ['create_calendar_event'],
+    });
+    expect(responseRepairClient.calls[0]?.options['responseFormat']).toMatchObject({
+      type: 'json_schema',
+      json_schema: {
+        name: 'intex_agent_runner_output',
+        strict: true,
+        schema: {
+          type: 'object',
+          properties: expect.any(Object),
+          required: expect.any(Array),
+          additionalProperties: false,
+        },
+      },
+    });
+  });
+
+  it('rejects a false tool completion embedded in a strict runner repair response', async () => {
+    const client = new FakeToolCallingClient([
+      ok({
+        content: 'not json',
+        toolCallsMade: 0,
+        iterationCount: 1,
+        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2, costUsd: 0 },
+      }),
+    ]);
+    const responseRepairClient = new FakeStructuredClient([
+      ok(
+        generateResult({
+          outcome: 'no_action',
+          reply: 'Saved the note.',
+          toolName: 'create_note',
+        })
+      ),
+    ]);
+    const runner = createIntexAgentRunner({
+      client,
+      responseRepairClient,
+      toolExecutor: fakeToolExecutor(),
+    });
+
+    await expect(
+      runner.run({
+        session: session(),
+        events: [],
+        message: 'something weird',
+        currentDateTime: CURRENT_DATE_TIME,
+      })
+    ).resolves.toEqual({
+      outcome: 'needs_clarification',
+      reply: 'What would you like me to do with this?',
+      blockerReason: 'not_enough_context',
+      suggestedNextStep: 'Ask the user to restate the action.',
+      fallbackReason: 'runner_output_malformed',
+      fallbackSourceOutcome: 'raw_response',
+    });
+
+    expect(responseRepairClient.calls).toHaveLength(1);
   });
 
   it('ignores malformed historical events when building the transcript', async () => {

--- a/apps/intex-agent/src/domain/agent/intentClassifier.ts
+++ b/apps/intex-agent/src/domain/agent/intentClassifier.ts
@@ -1,5 +1,6 @@
 import {
-  IntexAgentIntentClassifierOutputSchema,
+  IntexAgentIntentClassifierProviderOutputSchema,
+  INTEX_AGENT_INTENT_CLASSIFIER_RESPONSE_FORMAT,
   IntexAgentIntentClassifierToolNameSchema,
   IntexAgentBlockerReasonSchema,
   intexAgentIntentClassifierPrompt,
@@ -139,11 +140,14 @@ export function createLlmIntexAgentIntentClassifier(deps: {
       // multiplying those attempts inside the lease-bounded Matrix corpus lane.
       const retryingClient =
         matrixCorpusLlm === undefined ? createRetryingStructuredClient(deps.client) : deps.client;
-      const result = await generateStructured({
+      const result = await generateStructured<IntexAgentIntentClassifierOutput>({
         client: retryingClient,
         prompt,
         schema: classifierSchemaFor(activeClarification),
         promptType: INTEX_AGENT_INTENT_CLASSIFIER_PROMPT_TYPE,
+        options: {
+          responseFormat: INTEX_AGENT_INTENT_CLASSIFIER_RESPONSE_FORMAT,
+        },
         repairBuilder: (raw, error) =>
           intexAgentIntentClassifierRepairPrompt.build({
             originalPrompt: prompt,
@@ -332,17 +336,17 @@ interface ActiveClarificationContext {
 }
 
 type IntentClassifierSchema =
-  | typeof IntexAgentIntentClassifierOutputSchema
-  | ReturnType<typeof IntexAgentIntentClassifierOutputSchema.superRefine>;
+  | typeof IntexAgentIntentClassifierProviderOutputSchema
+  | ReturnType<typeof IntexAgentIntentClassifierProviderOutputSchema.superRefine>;
 
 function classifierSchemaFor(
   activeClarification: ActiveClarificationContext | undefined
 ): IntentClassifierSchema {
   if (activeClarification === undefined) {
-    return IntexAgentIntentClassifierOutputSchema;
+    return IntexAgentIntentClassifierProviderOutputSchema;
   }
 
-  return IntexAgentIntentClassifierOutputSchema.superRefine((output, context) => {
+  return IntexAgentIntentClassifierProviderOutputSchema.superRefine((output, context) => {
     if (
       output.outcome === 'needs_clarification' &&
       (output.candidateIntents === undefined || output.candidateIntents.length === 0)

--- a/apps/intex-agent/src/domain/agent/intexAgentRunner.ts
+++ b/apps/intex-agent/src/domain/agent/intexAgentRunner.ts
@@ -5,7 +5,9 @@ import type {
   ToolCallingMessage,
 } from '@intexuraos/llm-contract';
 import {
+  IntexAgentRunnerProviderOutputSchema,
   IntexAgentRunnerOutputSchema,
+  INTEX_AGENT_RUNNER_RESPONSE_FORMAT,
   intexAgentRunnerOutputRepairPrompt,
   type IntexAgentBlockerReason,
   type IntexAgentRunnerOutput,
@@ -1090,81 +1092,58 @@ function isConversationIntent(
 async function validateRunnerOutput(
   input: RunnerOutputValidationInput
 ): Promise<IntexAgentRunnerOutput | null> {
-  const matrixCorpusLlm = input.matrixCorpusLlm;
-  const firstResponseClient = createFirstResponseThenRepairClient(
-    input.content,
-    input.repairClient
-  );
-  const result = await generateStructured({
-    client: firstResponseClient,
+  const originalResult = await generateStructured<IntexAgentRunnerOutput>({
+    client: createStructuredContentClient(input.content),
     prompt: 'Validate the Intex Agent runner response.',
     schema: IntexAgentRunnerOutputSchema,
     promptType: INTEX_AGENT_RUNNER_PROMPT_TYPE,
-    ...(input.repairClient !== undefined
-      ? {
-          repairBuilder: (raw, error): string =>
-            intexAgentRunnerOutputRepairPrompt.build({
-              systemPrompt: input.systemPrompt,
-              messages: input.messages,
-              invalidResponse: raw,
-              errorMessage: formatZodErrors(error),
-            }),
-          maxRepairAttempts: 1,
-        }
-      : { maxRepairAttempts: 0 }),
-    ...(matrixCorpusLlm === undefined
+    maxRepairAttempts: 0,
+  });
+  if (originalResult.ok) return originalResult.value.data;
+  if (input.repairClient === undefined || originalResult.error.kind !== 'validation') return null;
+
+  const repairResult = await generateStructured<IntexAgentRunnerOutput>({
+    client: input.repairClient,
+    prompt: intexAgentRunnerOutputRepairPrompt.build({
+      systemPrompt: input.systemPrompt,
+      messages: input.messages,
+      invalidResponse: originalResult.error.raw,
+      errorMessage: formatZodErrors(originalResult.error.zodError),
+    }),
+    schema: IntexAgentRunnerProviderOutputSchema,
+    promptType: INTEX_AGENT_RUNNER_PROMPT_TYPE,
+    options: {
+      responseFormat: INTEX_AGENT_RUNNER_RESPONSE_FORMAT,
+      ...(input.matrixCorpusLlm === undefined
+        ? {}
+        : {
+            matrixCorpusContext:
+              input.matrixCorpusLlm.nextContext('response_schema_repair'),
+          }),
+    },
+    maxRepairAttempts: 0,
+    ...(input.matrixCorpusLlm === undefined
       ? {}
       : {
-          optionsForAttempt: (attempt: number): Record<string, unknown> =>
-            attempt === 0
-              ? {}
-              : {
-                  matrixCorpusContext: matrixCorpusLlm.nextContext('response_schema_repair'),
-                },
           onProviderCall: async (call: MatrixCorpusProviderCallUsageV1): Promise<void> => {
-            await matrixCorpusLlm.recordProviderCall(call);
+            await input.matrixCorpusLlm?.recordProviderCall(call);
           },
         }),
   });
 
-  return result.ok ? result.value.data : null;
+  return repairResult.ok ? repairResult.value.data : null;
 }
 
-function createFirstResponseThenRepairClient(
-  content: string,
-  repairClient: StructuredClient | undefined
-): StructuredClient {
-  if (repairClient === undefined) {
-    return {
-      generate(): ReturnType<StructuredClient['generate']> {
-        return Promise.resolve({
-          ok: true,
-          value: {
-            content,
-            usage: emptyStructuredUsage(),
-          },
-        });
-      },
-    };
-  }
-
-  let didReturnOriginalContent = false;
+function createStructuredContentClient(content: string): StructuredClient {
   return {
-    generate(
-      prompt: string,
-      options: Parameters<StructuredClient['generate']>[1]
-    ): ReturnType<StructuredClient['generate']> {
-      if (!didReturnOriginalContent) {
-        didReturnOriginalContent = true;
-        return Promise.resolve({
-          ok: true,
-          value: {
-            content,
-            usage: emptyStructuredUsage(),
-          },
-        });
-      }
-      return repairClient.generate(prompt, options);
+    generate(): ReturnType<StructuredClient['generate']> {
+      return Promise.resolve({
+        ok: true,
+        value: {
+          content,
+          usage: emptyStructuredUsage(),
+        },
+      });
     },
   };
 }

--- a/packages/infra-openrouter/src/__tests__/client.test.ts
+++ b/packages/infra-openrouter/src/__tests__/client.test.ts
@@ -958,6 +958,59 @@ describe('createOpenRouterClient', () => {
       expect(capturedBody).toHaveProperty('provider', { require_parameters: true });
     });
 
+    it('requires a provider that supports strict JSON Schema response formats', async () => {
+      let capturedBody: Record<string, unknown> | undefined;
+      const responseFormat = {
+        type: 'json_schema',
+        json_schema: {
+          name: 'classification',
+          strict: true,
+          schema: {
+            type: 'object',
+            properties: { outcome: { type: 'string' } },
+            required: ['outcome'],
+            additionalProperties: false,
+          },
+        },
+      } as const;
+
+      nock(API_BASE_URL)
+        .post('/chat/completions', (body) => {
+          capturedBody = body as Record<string, unknown>;
+          return true;
+        })
+        .reply(200, {
+          id: 'test-id',
+          model: TEST_MODEL,
+          created: Date.now(),
+          object: 'chat.completion',
+          choices: [
+            {
+              index: 0,
+              message: { content: '{"outcome":"tool"}', role: 'assistant' },
+              finish_reason: 'stop',
+            },
+          ],
+          usage: { prompt_tokens: 50, completion_tokens: 20, total_tokens: 70 },
+        });
+
+      const client = createOpenRouterClient({
+        apiKey: 'test-key',
+        model: TEST_MODEL,
+        userId: 'test-user',
+        logger: mockLogger,
+        usageSink: mockUsageSink,
+      });
+
+      await client.generate('Return structured JSON', {
+        responseFormat,
+        promptType: 'test-prompt',
+      });
+
+      expect(capturedBody).toHaveProperty('response_format', responseFormat);
+      expect(capturedBody).toHaveProperty('provider', { require_parameters: true });
+    });
+
     it('does NOT include response_format in request body when no options are provided', async () => {
       let capturedBody: Record<string, unknown> | undefined;
 
@@ -1282,6 +1335,19 @@ describe('createOpenRouterClient', () => {
         },
       });
       const events: unknown[] = [];
+      const responseFormat = {
+        type: 'json_schema',
+        json_schema: {
+          name: 'streamed_response',
+          strict: true,
+          schema: {
+            type: 'object',
+            properties: { message: { type: 'string' } },
+            required: ['message'],
+            additionalProperties: false,
+          },
+        },
+      } as const;
 
       const result = await client.generateChatStream(
         [{ role: 'user', content: 'hello' }],
@@ -1289,7 +1355,7 @@ describe('createOpenRouterClient', () => {
           promptType: 'whatsapp-conversation-assistant',
           reasoning: { enabled: true },
           sessionId: 'session-123',
-          responseFormat: { type: 'json_object' },
+          responseFormat,
         },
         (event) => {
           events.push(event);
@@ -1299,7 +1365,7 @@ describe('createOpenRouterClient', () => {
       expect(result.ok).toBe(true);
       expect(capturedBody).toMatchObject({
         session_id: 'session-123',
-        response_format: { type: 'json_object' },
+        response_format: responseFormat,
         provider: {
           require_parameters: true,
           order: ['gmicloud', 'minimax', 'morph'],
@@ -1323,6 +1389,54 @@ describe('createOpenRouterClient', () => {
         expect(result.value.usage.totalTokens).toBe(5);
         expect(result.value.usage.providerReportedUsd).toBe(0.001);
       }
+    });
+
+    it('requires strict-schema support for streaming without configured provider routing', async () => {
+      let capturedBody: Record<string, unknown> | undefined;
+      nock(API_BASE_URL)
+        .post('/chat/completions', (body) => {
+          capturedBody = body as Record<string, unknown>;
+          return true;
+        })
+        .reply(200, openRouterSse(['[DONE]']), {
+          'Content-Type': 'text/event-stream',
+        });
+
+      const client = createOpenRouterClient({
+        apiKey: 'test-key',
+        model: 'deepseek/deepseek-v4-flash',
+        userId: 'test-user',
+        logger: mockLogger,
+        usageSink: mockUsageSink,
+      });
+      const responseFormat = {
+        type: 'json_schema',
+        json_schema: {
+          name: 'streamed_response',
+          strict: true,
+          schema: {
+            type: 'object',
+            properties: { message: { type: 'string' } },
+            required: ['message'],
+            additionalProperties: false,
+          },
+        },
+      } as const;
+
+      const result = await client.generateChatStream(
+        [{ role: 'user', content: 'hello' }],
+        {
+          promptType: 'test-strict-stream',
+          responseFormat,
+        },
+        vi.fn()
+      );
+
+      expect(result.ok).toBe(true);
+      expect(capturedBody).toMatchObject({
+        response_format: responseFormat,
+        provider: { require_parameters: true },
+      });
     });
 
     it('ignores streaming comments and buffers incomplete SSE frames', async () => {

--- a/packages/infra-openrouter/src/client.ts
+++ b/packages/infra-openrouter/src/client.ts
@@ -221,6 +221,16 @@ export function createOpenRouterClient(config: OpenRouterConfig): OpenRouterClie
           ...(allowFallbacks !== undefined && { allow_fallbacks: allowFallbacks }),
         };
 
+  function providerRequestFor(
+    responseFormat: GenerateChatOptions['responseFormat']
+  ): Record<string, unknown> | undefined {
+    if (responseFormat?.type !== 'json_schema') return providerRequest;
+    return {
+      ...(providerRequest ?? {}),
+      require_parameters: true,
+    };
+  }
+
   async function postChatCompletion<T>(requestBody: Record<string, unknown>): Promise<T> {
     return await withRequestTimeout(
       resolveRequestTimeoutMs(timeoutMs, deadlineAtMs),
@@ -535,6 +545,7 @@ export function createOpenRouterClient(config: OpenRouterConfig): OpenRouterClie
           cachedTokens?: number;
           cacheWriteTokens?: number;
         }> => {
+          const requestProvider = providerRequestFor(options.responseFormat);
           const requestBody = {
             model, // No :online suffix for synthesis
             messages,
@@ -543,7 +554,7 @@ export function createOpenRouterClient(config: OpenRouterConfig): OpenRouterClie
             ...(options.responseFormat !== undefined && {
               response_format: options.responseFormat,
             }),
-            ...(providerRequest !== undefined && { provider: providerRequest }),
+            ...(requestProvider !== undefined && { provider: requestProvider }),
             ...(toOpenRouterReasoning(options.reasoning) !== undefined && {
               reasoning: toOpenRouterReasoning(options.reasoning),
             }),
@@ -616,6 +627,7 @@ export function createOpenRouterClient(config: OpenRouterConfig): OpenRouterClie
   ): Promise<Result<GenerateChatResult, OpenRouterError>> {
     const start = Date.now();
     try {
+      const requestProvider = providerRequestFor(options.responseFormat);
       const requestBody = {
         model,
         messages,
@@ -625,7 +637,7 @@ export function createOpenRouterClient(config: OpenRouterConfig): OpenRouterClie
         ...(options.responseFormat !== undefined && {
           response_format: options.responseFormat,
         }),
-        ...(providerRequest !== undefined && { provider: providerRequest }),
+        ...(requestProvider !== undefined && { provider: requestProvider }),
         ...(toOpenRouterReasoning(options.reasoning) !== undefined && {
           reasoning: toOpenRouterReasoning(options.reasoning),
         }),

--- a/packages/infra-openrouter/src/types.ts
+++ b/packages/infra-openrouter/src/types.ts
@@ -6,7 +6,11 @@
 
 import type { Logger } from '@intexuraos/common-core';
 import type { UsageSink } from '@intexuraos/llm-pricing';
-import type { MatrixCorpusLlmCallContextV1, OwnerType } from '@intexuraos/llm-contract';
+import type {
+  LlmResponseFormat,
+  MatrixCorpusLlmCallContextV1,
+  OwnerType,
+} from '@intexuraos/llm-contract';
 
 export type {
   LLMError as OpenRouterError,
@@ -27,7 +31,7 @@ export type {
  */
 export interface GenerateOptions {
   /** Request a specific response format from the model (e.g., JSON mode). */
-  responseFormat?: { type: 'json_object' | 'text' };
+  responseFormat?: LlmResponseFormat;
   /** Semantic identifier for what the prompt was used for (e.g., 'linear-issue-title', 'code-worker-validation') */
   promptType: string;
   /**

--- a/packages/llm-contract/src/index.ts
+++ b/packages/llm-contract/src/index.ts
@@ -16,6 +16,7 @@ export type {
   ConversationAssistantDateRange,
   GenerateChatReasoningEffort,
   GenerateChatReasoningOptions,
+  LlmResponseFormat,
   GenerateChatOptions,
   GenerateChatResult,
   GenerateChatStreamEvent,

--- a/packages/llm-contract/src/types.ts
+++ b/packages/llm-contract/src/types.ts
@@ -227,11 +227,22 @@ export interface GenerateChatReasoningOptions {
   exclude?: boolean;
 }
 
+export type LlmResponseFormat =
+  | { type: 'json_object' | 'text' }
+  | {
+      type: 'json_schema';
+      json_schema: {
+        name: string;
+        strict: boolean;
+        schema: Record<string, unknown>;
+      };
+    };
+
 export interface GenerateChatOptions {
   promptType: string;
   sessionId?: string;
   temperature?: number;
-  responseFormat?: { type: 'json_object' | 'text' };
+  responseFormat?: LlmResponseFormat;
   reasoning?: GenerateChatReasoningOptions;
   correlation?: LLMCorrelationOptions;
 }

--- a/packages/llm-factory/src/llmClientFactory.ts
+++ b/packages/llm-factory/src/llmClientFactory.ts
@@ -49,6 +49,7 @@ import {
   type LLMError,
   type LLMModel,
   type LlmChatMessage,
+  type LlmResponseFormat,
   type OpenRouterToolCallingModel,
   type ToolCallingClient,
   type ToolCallingModel,
@@ -126,6 +127,8 @@ export interface GenerateResult {
 export interface GenerateOptions {
   /** Semantic identifier for the prompt type (e.g., 'linear-issue-title', 'code-worker-validation') */
   promptType: string;
+  /** Optional provider-enforced response shape. */
+  responseFormat?: LlmResponseFormat;
   /**
    * Optional per-call correlation overrides. Threaded through to the
    * usage event's `correlation` block so attribution to a specific

--- a/packages/llm-prompts/package.json
+++ b/packages/llm-prompts/package.json
@@ -18,6 +18,7 @@
     "@intexuraos/common-core": "workspace:*",
     "@intexuraos/llm-utils": "workspace:*",
     "pino": "catalog:",
-    "zod": "catalog:"
+    "zod": "catalog:",
+    "zod-to-json-schema": "^3.25.1"
   }
 }

--- a/packages/llm-prompts/src/intex-agent/__tests__/structuredOutput.test.ts
+++ b/packages/llm-prompts/src/intex-agent/__tests__/structuredOutput.test.ts
@@ -1,0 +1,270 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+describe('Intex Agent strict structured output', () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.doUnmock('zod-to-json-schema');
+  });
+
+  it('derives provider-compatible strict root object schemas from the domain schemas', async () => {
+    const { INTEX_AGENT_INTENT_CLASSIFIER_RESPONSE_FORMAT, INTEX_AGENT_RUNNER_RESPONSE_FORMAT } =
+      await import('../structuredOutput.js');
+
+    expect(INTEX_AGENT_INTENT_CLASSIFIER_RESPONSE_FORMAT).toMatchObject({
+      type: 'json_schema',
+      json_schema: {
+        name: 'intex_agent_intent_classifier',
+        strict: true,
+        schema: {
+          type: 'object',
+          properties: expect.any(Object),
+          required: expect.any(Array),
+          additionalProperties: false,
+        },
+      },
+    });
+    expect(INTEX_AGENT_RUNNER_RESPONSE_FORMAT).toMatchObject({
+      type: 'json_schema',
+      json_schema: {
+        name: 'intex_agent_runner_output',
+        strict: true,
+        schema: {
+          type: 'object',
+          properties: expect.any(Object),
+          required: expect.any(Array),
+          additionalProperties: false,
+        },
+      },
+    });
+
+    for (const responseFormat of [
+      INTEX_AGENT_INTENT_CLASSIFIER_RESPONSE_FORMAT,
+      INTEX_AGENT_RUNNER_RESPONSE_FORMAT,
+    ]) {
+      const schema = responseFormat.json_schema.schema;
+      const properties = schema['properties'] as Record<string, unknown>;
+      const required = schema['required'] as string[];
+      expect(schema).not.toHaveProperty('anyOf');
+      expect([...required].sort()).toEqual(Object.keys(properties).sort());
+    }
+
+    expect(INTEX_AGENT_INTENT_CLASSIFIER_RESPONSE_FORMAT.json_schema.schema).toMatchObject({
+      properties: {
+        question: {
+          anyOf: expect.arrayContaining([{ type: 'null' }]),
+        },
+      },
+    });
+  });
+
+  it('removes provider nulls only from object fields before domain validation', async () => {
+    const { IntexAgentIntentClassifierProviderOutputSchema, IntexAgentRunnerProviderOutputSchema } =
+      await import('../structuredOutput.js');
+
+    const classifier = IntexAgentIntentClassifierProviderOutputSchema.safeParse({
+      outcome: 'tool',
+      confidence: 0.95,
+      allowedToolNames: ['create_calendar_event'],
+      question: null,
+      clarification: null,
+      reason: 'Explicit calendar creation request.',
+      blockerReason: null,
+      missingFields: null,
+      candidateIntents: null,
+      suggestedNextStep: null,
+      stylePreferenceAction: 'none',
+      languageOverride: null,
+      decisionEvidence: 'Create a calendar event.',
+    });
+    expect(classifier.success).toBe(true);
+    if (classifier.success) {
+      expect(classifier.data).not.toHaveProperty('question');
+      expect(classifier.data).not.toHaveProperty('blockerReason');
+    }
+
+    const runner = IntexAgentRunnerProviderOutputSchema.safeParse({
+      outcome: 'needs_clarification',
+      reply: 'Which date?',
+      summary: null,
+      blockerReason: 'missing_required_details',
+      missingFields: ['date'],
+      suggestedNextStep: null,
+      clarification: null,
+      candidateIntents: ['create_calendar_event'],
+      errorCategory: null,
+      isRetryable: null,
+      attemptedAction: null,
+    });
+    expect(runner.success).toBe(true);
+    if (runner.success) {
+      expect(runner.data).not.toHaveProperty('summary');
+      expect(runner.data).not.toHaveProperty('suggestedNextStep');
+    }
+  });
+
+  it.each([null, [], 'not an object'])(
+    'keeps non-object provider output invalid: %j',
+    async (providerOutput) => {
+      const { IntexAgentRunnerProviderOutputSchema } = await import('../structuredOutput.js');
+
+      expect(IntexAgentRunnerProviderOutputSchema.safeParse(providerOutput).success).toBe(false);
+    }
+  );
+
+  it('does not turn a required provider null into a valid optional field', async () => {
+    const { IntexAgentIntentClassifierProviderOutputSchema } =
+      await import('../structuredOutput.js');
+
+    expect(
+      IntexAgentIntentClassifierProviderOutputSchema.safeParse({
+        outcome: 'tool',
+        confidence: 0.95,
+        allowedToolNames: ['create_calendar_event'],
+        stylePreferenceAction: null,
+      }).success
+    ).toBe(false);
+  });
+
+  it('does not hide unknown null fields from strict domain validation', async () => {
+    const { IntexAgentRunnerProviderOutputSchema } = await import('../structuredOutput.js');
+
+    expect(
+      IntexAgentRunnerProviderOutputSchema.safeParse({
+        outcome: 'no_action',
+        reply: 'OK',
+        unknown: null,
+      }).success
+    ).toBe(false);
+  });
+
+  it.each([{ outcome: 1 }, { outcome: 'unknown' }])(
+    'keeps an invalid provider outcome fail-closed: %j',
+    async (providerOutput) => {
+      const { IntexAgentRunnerProviderOutputSchema } = await import('../structuredOutput.js');
+
+      expect(IntexAgentRunnerProviderOutputSchema.safeParse(providerOutput).success).toBe(false);
+    }
+  );
+
+  it('projects only explicitly safe non-null strict-superset fields', async () => {
+    const { IntexAgentIntentClassifierProviderOutputSchema, IntexAgentRunnerProviderOutputSchema } =
+      await import('../structuredOutput.js');
+
+    const classifier = IntexAgentIntentClassifierProviderOutputSchema.safeParse({
+      outcome: 'needs_clarification',
+      confidence: 0.95,
+      question: 'Should this repeat?',
+      blockerReason: 'missing_required_details',
+      missingFields: ['recurrence'],
+      candidateIntents: ['create_calendar_event'],
+      stylePreferenceAction: 'none',
+      allowedToolNames: ['create_calendar_event'],
+    });
+    expect(classifier.success).toBe(true);
+    if (classifier.success) {
+      expect(classifier.data).not.toHaveProperty('allowedToolNames');
+    }
+
+    const runnerNullPlaceholders = IntexAgentRunnerProviderOutputSchema.safeParse({
+      outcome: 'no_action',
+      reply: 'OK',
+      toolName: null,
+      blockerReason: null,
+      missingFields: null,
+      suggestedNextStep: null,
+    });
+    expect(runnerNullPlaceholders.success).toBe(true);
+    if (runnerNullPlaceholders.success) {
+      expect(runnerNullPlaceholders.data).not.toHaveProperty('toolName');
+      expect(runnerNullPlaceholders.data).not.toHaveProperty('blockerReason');
+    }
+
+    expect(
+      IntexAgentRunnerProviderOutputSchema.safeParse({
+        outcome: 'no_action',
+        reply: 'Saved the note.',
+        toolName: 'create_note',
+      }).success
+    ).toBe(false);
+  });
+
+  it('fails module initialization when JSON Schema conversion omits a definition', async () => {
+    vi.doMock('zod-to-json-schema', () => ({
+      zodToJsonSchema: vi.fn(() => ({})),
+    }));
+
+    await expect(import('../structuredOutput.js')).rejects.toThrow(
+      'Failed to derive strict JSON schema definition for intex_agent_intent_classifier'
+    );
+  });
+
+  it.each([{ anyOf: undefined }, { anyOf: [] }])(
+    'rejects a converted domain schema without a non-empty root union: %j',
+    async (definition) => {
+      mockConvertedDefinition(definition);
+
+      await expect(import('../structuredOutput.js')).rejects.toThrow(
+        'Strict JSON schema intex_agent_intent_classifier must provide a non-empty root anyOf'
+      );
+    }
+  );
+
+  it.each([null, { type: 'array' }, { type: 'object', properties: null, required: [] }])(
+    'rejects a non-object root union branch: %j',
+    async (branch) => {
+      mockConvertedDefinition({ anyOf: [branch] });
+
+      await expect(import('../structuredOutput.js')).rejects.toThrow(
+        'Strict JSON schema intex_agent_intent_classifier branch 0 must be an object'
+      );
+    }
+  );
+
+  it.each([
+    { type: 'object', properties: { value: { type: 'string' } } },
+    { type: 'object', properties: { value: { type: 'string' } }, required: [1] },
+  ])('rejects a root union branch without string required fields: %j', async (branch) => {
+    mockConvertedDefinition({ anyOf: [branch] });
+
+    await expect(import('../structuredOutput.js')).rejects.toThrow(
+      'Strict JSON schema intex_agent_intent_classifier branch 0 must declare required'
+    );
+  });
+
+  it.each([
+    {
+      type: 'object',
+      properties: { outcome: { const: 'tool' } },
+      required: [],
+    },
+    {
+      type: 'object',
+      properties: { outcome: {} },
+      required: ['outcome'],
+    },
+    {
+      type: 'object',
+      properties: { outcome: { enum: [] } },
+      required: ['outcome'],
+    },
+    {
+      type: 'object',
+      properties: { outcome: { enum: [1] } },
+      required: ['outcome'],
+    },
+  ])('rejects a root union branch without a string outcome discriminator: %j', async (branch) => {
+    mockConvertedDefinition({ anyOf: [branch] });
+
+    await expect(import('../structuredOutput.js')).rejects.toThrow(
+      'Strict JSON schema intex_agent_intent_classifier branch 0 must declare an outcome discriminator'
+    );
+  });
+});
+
+function mockConvertedDefinition(definition: Record<string, unknown>): void {
+  vi.doMock('zod-to-json-schema', () => ({
+    zodToJsonSchema: vi.fn((_schema: unknown, options: { name: string }) => ({
+      definitions: { [options.name]: definition },
+    })),
+  }));
+}

--- a/packages/llm-prompts/src/intex-agent/index.ts
+++ b/packages/llm-prompts/src/intex-agent/index.ts
@@ -33,6 +33,13 @@ export {
 } from './runnerOutputSchemas.js';
 
 export {
+  INTEX_AGENT_INTENT_CLASSIFIER_RESPONSE_FORMAT,
+  INTEX_AGENT_RUNNER_RESPONSE_FORMAT,
+  IntexAgentIntentClassifierProviderOutputSchema,
+  IntexAgentRunnerProviderOutputSchema,
+} from './structuredOutput.js';
+
+export {
   intexAgentRunnerOutputRepairPrompt,
   type IntexAgentRunnerOutputRepairPromptDeps,
   type IntexAgentRunnerOutputRepairPromptInput,

--- a/packages/llm-prompts/src/intex-agent/structuredOutput.ts
+++ b/packages/llm-prompts/src/intex-agent/structuredOutput.ts
@@ -1,0 +1,220 @@
+import type { LlmResponseFormat } from '@intexuraos/llm-contract';
+import { z, type ZodTypeAny } from 'zod';
+import { zodToJsonSchema } from 'zod-to-json-schema';
+
+import { IntexAgentIntentClassifierOutputSchema } from './intentClassifierSchemas.js';
+import { IntexAgentRunnerOutputSchema } from './runnerOutputSchemas.js';
+
+type StrictJsonSchemaResponseFormat = Extract<LlmResponseFormat, { type: 'json_schema' }>;
+type ZodSchemaInput = Parameters<typeof zodToJsonSchema>[0];
+type JsonSchema = Record<string, unknown>;
+
+interface StrictProviderContract {
+  responseFormat: StrictJsonSchemaResponseFormat;
+  nullableFields: ReadonlySet<string>;
+  knownFields: ReadonlySet<string>;
+  allowedFieldsByOutcome: ReadonlyMap<string, ReadonlySet<string>>;
+  projectableDisallowedFields: ReadonlySet<string>;
+}
+
+const intentClassifierProviderContract = strictProviderContract(
+  'intex_agent_intent_classifier',
+  IntexAgentIntentClassifierOutputSchema,
+  ['allowedToolNames']
+);
+const runnerProviderContract = strictProviderContract(
+  'intex_agent_runner_output',
+  IntexAgentRunnerOutputSchema
+);
+
+export const IntexAgentIntentClassifierProviderOutputSchema = z.preprocess(
+  normalizeStrictProviderOutput(intentClassifierProviderContract),
+  IntexAgentIntentClassifierOutputSchema
+) as z.ZodType<z.infer<typeof IntexAgentIntentClassifierOutputSchema>>;
+
+export const IntexAgentRunnerProviderOutputSchema = z.preprocess(
+  normalizeStrictProviderOutput(runnerProviderContract),
+  IntexAgentRunnerOutputSchema
+) as z.ZodType<z.infer<typeof IntexAgentRunnerOutputSchema>>;
+
+export const INTEX_AGENT_INTENT_CLASSIFIER_RESPONSE_FORMAT =
+  intentClassifierProviderContract.responseFormat;
+
+export const INTEX_AGENT_RUNNER_RESPONSE_FORMAT = runnerProviderContract.responseFormat;
+
+function strictProviderContract(
+  name: string,
+  schema: ZodTypeAny,
+  projectableDisallowedFields: readonly string[] = []
+): StrictProviderContract {
+  const converted = zodToJsonSchema(schema as ZodSchemaInput, {
+    name,
+    $refStrategy: 'none',
+  }) as { definitions?: Record<string, JsonSchema> };
+  const definition = converted.definitions?.[name];
+  if (definition === undefined) {
+    throw new Error(`Failed to derive strict JSON schema definition for ${name}`);
+  }
+
+  const {
+    schema: strictSchema,
+    nullableFields,
+    knownFields,
+    allowedFieldsByOutcome,
+  } = collapseRootUnion(name, definition);
+  return {
+    responseFormat: {
+      type: 'json_schema',
+      json_schema: {
+        name,
+        strict: true,
+        schema: strictSchema,
+      },
+    },
+    nullableFields,
+    knownFields,
+    allowedFieldsByOutcome,
+    projectableDisallowedFields: new Set(projectableDisallowedFields),
+  };
+}
+
+function collapseRootUnion(
+  name: string,
+  definition: JsonSchema
+): {
+  schema: JsonSchema;
+  nullableFields: ReadonlySet<string>;
+  knownFields: ReadonlySet<string>;
+  allowedFieldsByOutcome: ReadonlyMap<string, ReadonlySet<string>>;
+} {
+  const rawBranches = definition['anyOf'];
+  if (!Array.isArray(rawBranches) || rawBranches.length === 0) {
+    throw new Error(`Strict JSON schema ${name} must provide a non-empty root anyOf`);
+  }
+
+  const branches = rawBranches.map((rawBranch, index) => readObjectBranch(name, index, rawBranch));
+  const propertyNames = [...new Set(branches.flatMap((branch) => Object.keys(branch.properties)))];
+  const knownFields = new Set(propertyNames);
+  const allowedFieldsByOutcome = new Map<string, ReadonlySet<string>>();
+  branches.forEach((branch, index) => {
+    const allowedFields = new Set(Object.keys(branch.properties));
+    for (const outcome of readOutcomeValues(name, index, branch)) {
+      allowedFieldsByOutcome.set(outcome, allowedFields);
+    }
+  });
+  const nullableFields = new Set<string>();
+  const properties = Object.fromEntries(
+    propertyNames.map((propertyName) => {
+      const propertySchemas = branches.flatMap((branch) => {
+        const propertySchema = branch.properties[propertyName];
+        return propertySchema === undefined ? [] : [propertySchema];
+      });
+      const requiredInEveryBranch = branches.every(
+        (branch) =>
+          branch.properties[propertyName] !== undefined && branch.required.has(propertyName)
+      );
+      const mergedSchema = mergePropertySchemas(propertySchemas);
+      if (requiredInEveryBranch) return [propertyName, mergedSchema];
+      nullableFields.add(propertyName);
+      return [propertyName, { anyOf: [mergedSchema, { type: 'null' }] }];
+    })
+  );
+
+  return {
+    schema: {
+      type: 'object',
+      properties,
+      required: propertyNames,
+      additionalProperties: false,
+    },
+    nullableFields,
+    knownFields,
+    allowedFieldsByOutcome,
+  };
+}
+
+function readObjectBranch(
+  name: string,
+  index: number,
+  value: unknown
+): { properties: Record<string, JsonSchema>; required: ReadonlySet<string> } {
+  if (!isJsonSchema(value) || value['type'] !== 'object' || !isJsonSchema(value['properties'])) {
+    throw new Error(`Strict JSON schema ${name} branch ${String(index)} must be an object`);
+  }
+  const rawRequired = value['required'];
+  if (!Array.isArray(rawRequired) || !rawRequired.every((field) => typeof field === 'string')) {
+    throw new Error(`Strict JSON schema ${name} branch ${String(index)} must declare required`);
+  }
+
+  return {
+    properties: value['properties'] as Record<string, JsonSchema>,
+    required: new Set(rawRequired),
+  };
+}
+
+function readOutcomeValues(
+  name: string,
+  index: number,
+  branch: {
+    properties: Record<string, JsonSchema>;
+    required: ReadonlySet<string>;
+  }
+): readonly string[] {
+  const outcomeSchema = branch.properties['outcome'];
+  if (!branch.required.has('outcome') || outcomeSchema === undefined) {
+    throw new Error(
+      `Strict JSON schema ${name} branch ${String(index)} must declare an outcome discriminator`
+    );
+  }
+
+  const constant = outcomeSchema['const'];
+  if (typeof constant === 'string') return [constant];
+
+  const enumeration = outcomeSchema['enum'];
+  if (
+    Array.isArray(enumeration) &&
+    enumeration.length > 0 &&
+    enumeration.every((outcome) => typeof outcome === 'string')
+  ) {
+    return enumeration;
+  }
+
+  throw new Error(
+    `Strict JSON schema ${name} branch ${String(index)} must declare an outcome discriminator`
+  );
+}
+
+function mergePropertySchemas(schemas: readonly JsonSchema[]): JsonSchema {
+  const uniqueSchemas = [
+    ...new Map(schemas.map((schema) => [JSON.stringify(schema), schema])).values(),
+  ];
+  const firstSchema = uniqueSchemas[0] as JsonSchema;
+  return uniqueSchemas.length === 1 ? firstSchema : { anyOf: uniqueSchemas };
+}
+
+function normalizeStrictProviderOutput(
+  contract: StrictProviderContract
+): (value: unknown) => unknown {
+  return (value): unknown => {
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) return value;
+    const record = value as Record<string, unknown>;
+    const outcome = record['outcome'];
+    if (typeof outcome !== 'string') return value;
+    const allowedFields = contract.allowedFieldsByOutcome.get(outcome);
+    if (allowedFields === undefined) return value;
+
+    return Object.fromEntries(
+      Object.entries(record).filter(([key, field]) => {
+        if (!contract.knownFields.has(key)) return true;
+        if (!allowedFields.has(key)) {
+          return field !== null && !contract.projectableDisallowedFields.has(key);
+        }
+        return field !== null || !contract.nullableFields.has(key);
+      })
+    );
+  };
+}
+
+function isJsonSchema(value: unknown): value is JsonSchema {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1834,6 +1834,9 @@ importers:
       zod:
         specifier: 'catalog:'
         version: 3.25.76
+      zod-to-json-schema:
+        specifier: ^3.25.1
+        version: 3.25.1(zod@3.25.76)
 
   packages/llm-utils:
     dependencies:


### PR DESCRIPTION
## Summary

- derive provider-compatible strict JSON schemas for Intex classifier and runner repair responses
- require OpenRouter providers that support strict schema parameters while preserving configured routing
- normalize strict-superset placeholders per outcome without hiding unknown fields or false tool completions
- validate original tool-calling runner output fail-closed before invoking the structured repair path
- add regression coverage for DeepSeek cross-outcome output, non-stream and stream provider routing, and false completion safety

## Verification

- pnpm run ci:tracked (6738 tests, build, format, and static validation passed)
- targeted Intex Agent verification: 1643 tests passed
- targeted llm-prompts verification: 773 tests passed
- targeted infra-openrouter verification: 161 tests passed
- independent security, UX, and test review: Ready

Linear: [INT-1914](https://linear.app/pbuchman/issue/INT-1914)
IntexuraOS Code Task: [View task](https://intexuraos.cloud/#/code-tasks/task_c22f673a-6095-4fab-afd1-d6cfbc2da95c)
Worker Type: `codex-xhigh`
Model: `default`