### PR TITLE
[INT-1916] fix: stabilize Matrix classifier retries and mobile auth tests

### DIFF
--- a/apps/intex-agent/src/__tests__/services.test.ts
+++ b/apps/intex-agent/src/__tests__/services.test.ts
@@ -1197,7 +1197,7 @@ describe('createRuntimeBoundModelClients', () => {
     );
   });
 
-  it('binds the Matrix corpus request policy to both DeepSeek clients', () => {
+  it('gives both DeepSeek clients three attempts within the Matrix turn budget', () => {
     const createToolCallingClientFn = vi.fn(() => fakeToolCallingClient());
     const createLlmClientFn = vi.fn(() => fakeStructuredClient());
 
@@ -1222,13 +1222,13 @@ describe('createRuntimeBoundModelClients', () => {
     });
 
     expect(MATRIX_CORPUS_MODEL_REQUEST_TIMEOUT_MS).toBe(45_000);
-    expect(MATRIX_CORPUS_MODEL_MAX_ATTEMPTS).toBe(2);
+    expect(MATRIX_CORPUS_MODEL_MAX_ATTEMPTS).toBe(3);
     expect(MATRIX_CORPUS_MODEL_TURN_BUDGET_MS).toBe(180_000);
     expect(createToolCallingClientFn).toHaveBeenCalledWith(
-      expect.objectContaining({ timeoutMs: 45_000, maxAttempts: 2, deadlineAtMs: 180_000 })
+      expect.objectContaining({ timeoutMs: 45_000, maxAttempts: 3, deadlineAtMs: 180_000 })
     );
     expect(createLlmClientFn).toHaveBeenCalledWith(
-      expect.objectContaining({ timeoutMs: 45_000, maxAttempts: 2, deadlineAtMs: 180_000 })
+      expect.objectContaining({ timeoutMs: 45_000, maxAttempts: 3, deadlineAtMs: 180_000 })
     );
   });
 

--- a/apps/intex-agent/src/services.ts
+++ b/apps/intex-agent/src/services.ts
@@ -116,7 +116,7 @@ export function composeIntexMatrixCorpusFeature<T>(
 const RUNTIME_SETTINGS_LOOKUP_TIMEOUT_MS = 2_000;
 export const MATRIX_CORPUS_MODEL_REQUEST_TIMEOUT_MS = 45_000;
 export const MATRIX_CORPUS_MODEL_TURN_BUDGET_MS = 180_000;
-export const MATRIX_CORPUS_MODEL_MAX_ATTEMPTS = 2;
+export const MATRIX_CORPUS_MODEL_MAX_ATTEMPTS = 3;
 
 export interface RuntimeSettingsDeadlineScheduler {
   setTimeout(callback: () => void, delayMs: number): unknown;

--- a/apps/mobile-notifications-service/src/__tests__/routes.test.ts
+++ b/apps/mobile-notifications-service/src/__tests__/routes.test.ts
@@ -14,25 +14,7 @@ import {
 } from './fakes.js';
 import { hashSignature } from '../domain/notifications/index.js';
 
-// Test JWT (from user-service tests pattern)
 const TEST_USER_ID = 'auth0|test-user-123';
-const TEST_JWT =
-  'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6InRlc3Qta2V5In0.' +
-  'eyJpc3MiOiJodHRwczovL3Rlc3QuYXV0aDAuY29tLyIsInN1YiI6ImF1dGgwfHRlc3QtdXNlci0xMjMiLCJhdWQiOiJ1cm46aW50ZXh1cmFvczphcGkiLCJleHAiOjk5OTk5OTk5OTl9.' +
-  'test-signature';
-
-// Mock JWKS response
-const mockJwks = {
-  keys: [
-    {
-      kty: 'RSA',
-      kid: 'test-key',
-      use: 'sig',
-      n: 'test-modulus',
-      e: 'AQAB',
-    },
-  ],
-};
 
 describe('Connect Routes', () => {
   let app: FastifyInstance;
@@ -87,42 +69,6 @@ describe('Connect Routes', () => {
     expect(body.error.code).toBe('UNAUTHORIZED');
   });
 
-  it('POST /mobile-notifications/connect creates connection with valid auth', async () => {
-    // Mock JWKS endpoint
-    nock('https://test.auth0.com').get('/.well-known/jwks.json').reply(200, mockJwks);
-
-    const response = await app.inject({
-      method: 'POST',
-      url: '/connect',
-      headers: {
-        authorization: `Bearer ${TEST_JWT}`,
-      },
-      payload: { deviceLabel: 'My Phone' },
-    });
-
-    // Even though JWT verification might fail in tests, we can verify the route structure
-    // For real tests, we'd need proper JWT mocking
-    expect([200, 401]).toContain(response.statusCode);
-  });
-
-  it('POST /mobile-notifications/connect returns 500 on repository failure', async () => {
-    fakeSignatureRepo.setFailNextSave(true);
-
-    // Mock JWKS endpoint
-    nock('https://test.auth0.com').get('/.well-known/jwks.json').reply(200, mockJwks);
-
-    const response = await app.inject({
-      method: 'POST',
-      url: '/connect',
-      headers: {
-        authorization: `Bearer ${TEST_JWT}`,
-      },
-      payload: {},
-    });
-
-    // Will return 401 due to JWT verification failing in test
-    expect([500, 401]).toContain(response.statusCode);
-  });
 });
 
 describe('Status Routes', () => {
@@ -177,21 +123,6 @@ describe('Status Routes', () => {
     expect(body.error.code).toBe('UNAUTHORIZED');
   });
 
-  it('GET /mobile-notifications/status returns configured: false when no signature exists', async () => {
-    // Mock JWKS endpoint
-    nock('https://test.auth0.com').get('/.well-known/jwks.json').reply(200, mockJwks);
-
-    const response = await app.inject({
-      method: 'GET',
-      url: '/status',
-      headers: {
-        authorization: `Bearer ${TEST_JWT}`,
-      },
-    });
-
-    // Will return 401 due to JWT verification failing in test
-    expect([200, 401]).toContain(response.statusCode);
-  });
 });
 
 describe('Webhook Routes', () => {


### PR DESCRIPTION
## Summary

- give the production Matrix corpus DeepSeek classifier three transient-failure attempts within the existing 180-second turn budget
- remove three slow authentication checks built around an invalid JWT and permissive status assertions
- retain complete authenticated-route coverage using cryptographically valid test tokens

## Production evidence

- run eval-ee53fa11-0085-4448-b121-ac5a6c5062fa reached scenario 002 after scenario 001 passed
- DeepSeek intent classification received OPENROUTER_TIMEOUT and OPENROUTER_HTTP_500 on its two configured attempts
- no production tool executor was resolved or admitted

## Verification

- pnpm run verify:workspace:tracked mobile-notifications-service
- pnpm run verify:workspace:tracked intex-agent
- pnpm run ci:tracked (6781 tests passed)

Fixes INT-1916