### PR TITLE
[INT-1916] fix: continue Matrix corpus after behavioral failures

### DIFF
--- a/tools/intex-agent-evals/src/__tests__/matrixCorpusComposition.test.ts
+++ b/tools/intex-agent-evals/src/__tests__/matrixCorpusComposition.test.ts
@@ -187,7 +187,7 @@ describe('production Matrix corpus composition', () => {
       exitCode: 1,
       effectiveKind: 'behavioral_failure',
       failureCodes: ['deterministic_evidence_failed'],
-      totals: { completedTurns: 58 },
+      totals: { completedTurns: 59 },
     });
     expect(result.run.scenarios[1]).toMatchObject({
       scenarioId: 'intex-eval-002',
@@ -432,7 +432,7 @@ describe('production Matrix corpus composition', () => {
       },
     });
     expect(result).not.toHaveProperty('relativeReportDirectory');
-    expect(result.run.scenarios[0]).toMatchObject({ status: 'failed', completedTurns: 1 });
+    expect(result.run.scenarios[0]).toMatchObject({ status: 'failed', completedTurns: 2 });
     expect(result.run.scenarios.slice(1).every((scenario) => scenario.status === 'passed')).toBe(
       true
     );

--- a/tools/intex-agent-evals/src/__tests__/matrixCorpusRunner.test.ts
+++ b/tools/intex-agent-evals/src/__tests__/matrixCorpusRunner.test.ts
@@ -79,7 +79,7 @@ describe('sequential Matrix corpus state machine', () => {
     expect(result.cleanupCompleted).toBe(true);
   });
 
-  it('skips dependent turns after a behavioral failure but still runs through scenario 20', async () => {
+  it('records a behavioral failure but still runs every remaining turn and scenario', async () => {
     const catalog = await loadCanonicalMatrixCorpus(scenariosDirectory);
     const trace: string[] = [];
     const ports = passingPorts(trace);
@@ -87,26 +87,24 @@ describe('sequential Matrix corpus state machine', () => {
       ok: true,
       observation: {
         ...observation(input.scenario, input.turnIndex),
-        deterministicPassed: !(input.scenario.id === 'intex-eval-002' && input.turnIndex === 0),
+        deterministicPassed: !(input.scenario.id === 'intex-eval-003' && input.turnIndex === 1),
       },
     }));
 
     const result = await runMatrixCorpus({ runId: 'run_1', catalog }, ports);
 
     expect(result.exitCode).toBe(1);
-    expect(result.scenarios[1]?.status).toBe('failed');
-    expect(result.scenarios[1]?.completedTurns).toBe(1);
+    expect(result.scenarios[2]?.status).toBe('failed');
+    expect(result.scenarios[2]?.completedTurns).toBe(3);
     expect(result.scenarios[19]?.status).toBe('passed');
     expect(
       vi
         .mocked(ports.executeTurn)
         .mock.calls.map(([input]) => input)
-        .filter(({ scenario }) => scenario.id === 'intex-eval-002')
+        .filter(({ scenario }) => scenario.id === 'intex-eval-003')
         .map(({ turnIndex }) => turnIndex)
-    ).toEqual([0]);
-    expect(result.totals.completedTurns).toBe(
-      59 - ((catalog.scenarios[1]?.scenario.turns.length ?? 1) - 1)
-    );
+    ).toEqual([0, 1, 2]);
+    expect(result.totals.completedTurns).toBe(59);
   });
 
   it('stops immediately on safety failure, marks later scenarios not run, and still terminalizes', async () => {
@@ -304,8 +302,8 @@ describe('sequential Matrix corpus state machine', () => {
     const result = await runMatrixCorpus({ runId: 'run_behavioral', catalog }, ports);
 
     expect(result.exitCode).toBe(1);
-    expect(ports.judgeReply).toHaveBeenCalledTimes(20);
-    expect(result.totals.completedTurns).toBe(20);
+    expect(ports.judgeReply).toHaveBeenCalledTimes(59);
+    expect(result.totals.completedTurns).toBe(59);
     expect(result.scenarios.every(({ status }) => status === 'failed')).toBe(true);
   });
 

--- a/tools/intex-agent-evals/src/matrixCorpus/runMatrixCorpus.ts
+++ b/tools/intex-agent-evals/src/matrixCorpus/runMatrixCorpus.ts
@@ -432,7 +432,6 @@ export async function runMatrixCorpus(
         break;
       }
       revision = progress.revision;
-      if (scenarioFailed) break;
     }
 
     const nextStatus =


### PR DESCRIPTION
## Summary

- continue every remaining turn and scenario after a behavioral failure
- retain the failed verdict while producing complete 59-turn evidence required by production finalization
- add runner and live-composition regression coverage for early failures in multi-turn scenarios

## Production evidence

- run `eval-042bc157-542c-4a7e-a0df-19a1b89cafd4` passed scenarios 001 and 002
- scenario 003 failed semantically after turn 2/3
- the old runner skipped turn 3, then production rejected the incomplete completed-scenario projection

## Verification

- `pnpm --filter @intexuraos/intex-agent-evals validate`
- `pnpm run ci:tracked` (6781 tests)

Fixes INT-1916