### PR TITLE
[INT-1916] fix: retry provider HTTP 5xx responses

### DIFF
--- a/packages/infra-openrouter/src/__tests__/client.test.ts
+++ b/packages/infra-openrouter/src/__tests__/client.test.ts
@@ -345,7 +345,7 @@ describe('createOpenRouterClient', () => {
       }
     });
 
-    it('handles 500 API error', async () => {
+    it('handles 500 overloaded error', async () => {
       nock(API_BASE_URL).post('/chat/completions').reply(500, 'Server error');
 
       const client = createOpenRouterClient({
@@ -360,7 +360,7 @@ describe('createOpenRouterClient', () => {
 
       expect(result.ok).toBe(false);
       if (!result.ok) {
-        expect(result.error.code).toBe('API_ERROR');
+        expect(result.error.code).toBe('OVERLOADED');
       }
     });
 
@@ -539,6 +539,38 @@ describe('createOpenRouterClient', () => {
         const result = await client.generate('Write something', { promptType: 'test-prompt' });
 
         expect(result).toMatchObject({ ok: false, error: { code: 'OVERLOADED' } });
+        expect(fetchSpy).toHaveBeenCalledTimes(2);
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    });
+
+    it('retries a provider HTTP 500 within the configured attempt cap', async () => {
+      const fetchSpy = vi
+        .spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce(new Response('Server error', { status: 500 }))
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              choices: [{ message: { role: 'assistant', content: 'Recovered.' } }],
+              usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+            }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } }
+          )
+        );
+      try {
+        const client = createOpenRouterClient({
+          apiKey: 'test-key',
+          model: TEST_MODEL,
+          userId: 'test-user',
+          logger: mockLogger,
+          usageSink: mockUsageSink,
+          maxAttempts: 2,
+        });
+
+        const result = await client.generate('Write something', { promptType: 'test-prompt' });
+
+        expect(result).toMatchObject({ ok: true, value: { content: 'Recovered.' } });
         expect(fetchSpy).toHaveBeenCalledTimes(2);
       } finally {
         fetchSpy.mockRestore();
@@ -741,8 +773,8 @@ describe('createOpenRouterClient', () => {
       );
     });
 
-    it('handles API error', async () => {
-      nock(API_BASE_URL).post('/chat/completions').reply(500, 'Internal error');
+    it('handles non-retriable API error', async () => {
+      nock(API_BASE_URL).post('/chat/completions').reply(400, 'Invalid request');
 
       const client = createOpenRouterClient({
         apiKey: 'test-key',
@@ -2111,7 +2143,7 @@ describe('createOpenRouterClient', () => {
       }
     });
 
-    it('handles 500 API error', async () => {
+    it('handles 500 overloaded error', async () => {
       nock(API_BASE_URL).get('/key').reply(500, 'Internal server error');
 
       const client = createOpenRouterClient({
@@ -2126,7 +2158,7 @@ describe('createOpenRouterClient', () => {
 
       expect(result.ok).toBe(false);
       if (!result.ok) {
-        expect(result.error.code).toBe('API_ERROR');
+        expect(result.error.code).toBe('OVERLOADED');
       }
     });
 

--- a/packages/infra-openrouter/src/__tests__/toolCallingClient.test.ts
+++ b/packages/infra-openrouter/src/__tests__/toolCallingClient.test.ts
@@ -310,7 +310,7 @@ describe('createOpenRouterToolCallingClient', () => {
 
     expect(result).toEqual({
       ok: false,
-      error: { code: 'API_ERROR', message: 'Matrix provider call failed' },
+      error: { code: 'OVERLOADED', message: 'Matrix provider call failed' },
     });
     expect(onProviderCall).toHaveBeenCalledTimes(1);
     expect(onProviderCall).toHaveBeenCalledWith(
@@ -1189,8 +1189,9 @@ describe('createOpenRouterToolCallingClient', () => {
   it.each([
     { status: 401, code: 'INVALID_KEY' },
     { status: 429, code: 'RATE_LIMITED' },
+    { status: 400, code: 'API_ERROR' },
     { status: 503, code: 'OVERLOADED' },
-    { status: 500, code: 'API_ERROR' },
+    { status: 500, code: 'OVERLOADED' },
   ] as const)('maps HTTP $status to $code', async ({ status, code }) => {
     nock(API_BASE_URL).post('/chat/completions').reply(status, 'provider error');
 
@@ -1290,8 +1291,8 @@ describe('createOpenRouterToolCallingClient', () => {
     expect(result).toMatchObject({ ok: false, error: { code: 'TIMEOUT' } });
   });
 
-  it('retries a transient provider response up to the configured attempt cap', async () => {
-    nock(API_BASE_URL).post('/chat/completions').reply(503, 'Service overloaded');
+  it('retries a transient provider HTTP 500 up to the configured attempt cap', async () => {
+    nock(API_BASE_URL).post('/chat/completions').reply(500, 'Server error');
     nock(API_BASE_URL)
       .post('/chat/completions')
       .reply(200, {

--- a/packages/infra-openrouter/src/client.ts
+++ b/packages/infra-openrouter/src/client.ts
@@ -783,7 +783,7 @@ function mapOpenRouterError(error: unknown): OpenRouterError {
     const message = error.message;
     if (error.status === 401) return { code: 'INVALID_KEY', message };
     if (error.status === 429) return { code: 'RATE_LIMITED', message };
-    if (error.status === 503) return { code: 'OVERLOADED', message };
+    if (error.status >= 500) return { code: 'OVERLOADED', message };
     return { code: 'API_ERROR', message };
   }
   if (error instanceof Error && error.name === 'AbortError') {

--- a/packages/infra-openrouter/src/toolCallingClient.ts
+++ b/packages/infra-openrouter/src/toolCallingClient.ts
@@ -579,7 +579,7 @@ function mapOpenRouterError(error: unknown): LLMError {
     const message = error.message;
     if (error.status === 401) return { code: 'INVALID_KEY', message };
     if (error.status === 429) return { code: 'RATE_LIMITED', message };
-    if (error.status === 503) return { code: 'OVERLOADED', message };
+    if (error.status >= 500) return { code: 'OVERLOADED', message };
     return { code: 'API_ERROR', message };
   }
 

--- a/packages/infra-perplexity/src/__tests__/client.test.ts
+++ b/packages/infra-perplexity/src/__tests__/client.test.ts
@@ -630,8 +630,14 @@ describe('createPerplexityClient', () => {
       }
     });
 
-    it('handles API error', async () => {
+    it('retries a provider HTTP 500 and returns the recovered response', async () => {
       nock(API_BASE_URL).post('/chat/completions').reply(500, 'Internal error');
+      nock(API_BASE_URL)
+        .post('/chat/completions')
+        .reply(200, {
+          choices: [{ message: { role: 'assistant', content: 'Recovered.' } }],
+          usage: { prompt_tokens: 50, completion_tokens: 10, total_tokens: 60 },
+        });
 
       const client = createPerplexityClient({
         apiKey: 'test-key',
@@ -642,10 +648,24 @@ describe('createPerplexityClient', () => {
       });
       const result = await client.generate('Write something', { promptType: 'test-prompt' });
 
-      expect(result.ok).toBe(false);
-      if (!result.ok) {
-        expect(result.error.code).toBe('API_ERROR');
-      }
+      expect(result).toMatchObject({ ok: true, value: { content: 'Recovered.' } });
+      expect(nock.isDone()).toBe(true);
+    });
+
+    it('does not retry a non-transient provider HTTP 400', async () => {
+      nock(API_BASE_URL).post('/chat/completions').reply(400, 'Invalid request');
+
+      const client = createPerplexityClient({
+        apiKey: 'test-key',
+        model: TEST_MODEL,
+        userId: 'test-user',
+        logger: mockLogger,
+        usageSink: mockUsageSink,
+      });
+      const result = await client.generate('Write something', { promptType: 'test-prompt' });
+
+      expect(result).toMatchObject({ ok: false, error: { code: 'API_ERROR' } });
+      expect(nock.isDone()).toBe(true);
     });
 
     it('handles network error', async () => {

--- a/packages/infra-perplexity/src/client.ts
+++ b/packages/infra-perplexity/src/client.ts
@@ -471,7 +471,7 @@ function mapPerplexityError(error: unknown): PerplexityError {
     const message = error.message;
     if (error.status === 401) return { code: 'INVALID_KEY', message };
     if (error.status === 429) return { code: 'RATE_LIMITED', message };
-    if (error.status === 503) return { code: 'OVERLOADED', message };
+    if (error.status >= 500) return { code: 'OVERLOADED', message };
     return { code: 'API_ERROR', message };
   }
   if (error instanceof Error && error.name === 'AbortError') {


### PR DESCRIPTION
## Summary
- classify every provider HTTP 5xx response as a transient overload
- reuse existing bounded retry policy in OpenRouter chat/tool-calling and Perplexity clients
- cover retry-success and non-retriable HTTP 400 branches with regression tests

## Production evidence
Production Matrix corpus run `eval-e46c549d-b8e6-4460-806a-bedd5879915f` stopped on scenario 003 after an OpenRouter HTTP 500 was classified as a terminal API error.

## Verification
- `pnpm run ci:tracked`
- 6781 tests passed
- coverage, build, format, and static validation passed

Fixes INT-1916