### PR TITLE
[INT-1916] fix: prevent empty Matrix corpus replies

### DIFF
--- a/apps/intex-agent/src/__tests__/domain/intexAgentRunner.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/intexAgentRunner.test.ts
@@ -2285,6 +2285,86 @@ describe('createIntexAgentRunner', () => {
     expect(getUserPreferencesCalls).toBe(1);
   });
 
+  it('finishes an empty preference read from the tool result without another model iteration', async () => {
+    let getUserPreferencesCalls = 0;
+    const client = new ToolExecutingFakeToolCallingClient(
+      { toolName: 'get_user_preferences', args: {} },
+      [
+        ok({
+          content: '',
+          toolCallsMade: 1,
+          iterationCount: 1,
+          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2, costUsd: 0 },
+        }),
+      ]
+    );
+    const runner = createIntexAgentRunner({
+      client,
+      intentClassifier: toolIntentClassifier(['get_user_preferences']),
+      toolExecutor: fakeToolExecutor({
+        getUserPreferences: async () => {
+          getUserPreferencesCalls += 1;
+          return JSON.stringify({ status: 'completed', currentVersion: 0, promptBlock: '' });
+        },
+      }),
+    });
+
+    await expect(
+      runner.run({
+        session: session(),
+        events: [],
+        message: 'Show my saved Intex Agent preferences.',
+        currentDateTime: CURRENT_DATE_TIME,
+      })
+    ).resolves.toEqual({
+      outcome: 'completed',
+      reply: 'No Intex Agent preferences are defined yet.',
+      toolName: 'get_user_preferences',
+      toolResult: { status: 'completed', currentVersion: 0, promptBlock: '' },
+    });
+    expect(getUserPreferencesCalls).toBe(1);
+    expect(
+      client.calls[0]?.tools.find((tool) => tool.name === 'get_user_preferences')?.stopAfterRun
+    ).toBe(true);
+  });
+
+  it('keeps an empty terminal response fail-closed when the preference read fails', async () => {
+    const client = new ToolExecutingFakeToolCallingClient(
+      { toolName: 'get_user_preferences', args: {} },
+      [
+        ok({
+          content: '',
+          toolCallsMade: 1,
+          iterationCount: 1,
+          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2, costUsd: 0 },
+        }),
+      ]
+    );
+    const runner = createIntexAgentRunner({
+      client,
+      intentClassifier: toolIntentClassifier(['get_user_preferences']),
+      toolExecutor: fakeToolExecutor({
+        getUserPreferences: () => {
+          throw new Error('Preference backend unavailable');
+        },
+      }),
+    });
+
+    const result = await runner.run({
+      session: session(),
+      events: [],
+      message: 'Show my saved Intex Agent preferences.',
+      currentDateTime: CURRENT_DATE_TIME,
+    });
+
+    expect(result).toMatchObject({
+      outcome: 'tool_failed',
+      toolName: 'get_user_preferences',
+      error: 'Preference backend unavailable',
+    });
+    expect(result.reply.trim()).not.toBe('');
+  });
+
   it('keeps malformed runner output fail-closed when mutating preview arguments fail validation', async () => {
     let addUserPreferenceCalls = 0;
     const client = new ToolExecutingFakeToolCallingClient(
@@ -5844,7 +5924,7 @@ describe('createIntexAgentRunner', () => {
       category: 'behavioral_failure',
       code: 'FORBIDDEN_TOOL_SELECTED',
       toolSelection: { turnIndex: 4, ordinal: 1 },
-      reply: '',
+      reply: "I couldn't complete that request because the selected action is not allowed.",
     });
     expect(executorCalls).toBe(0);
     expect(repairClient.calls).toHaveLength(0);

--- a/apps/intex-agent/src/domain/agent/intexAgentRunner.ts
+++ b/apps/intex-agent/src/domain/agent/intexAgentRunner.ts
@@ -259,6 +259,11 @@ const COMPLETED_REPLIES = {
   linkUrl: { en: 'Saved the link.', pl: 'Zapisałem link.' },
 } satisfies Record<string, LocalizedText>;
 
+const TOOL_SELECTION_REJECTED_REPLIES = {
+  en: "I couldn't complete that request because the selected action is not allowed.",
+  pl: 'Nie mogę zrealizować tej prośby, ponieważ wybrana akcja jest niedozwolona.',
+} satisfies LocalizedText;
+
 const CTA_LABELS = {
   openNote: { en: 'Open note', pl: 'Otwórz notatkę' },
   openResearch: { en: 'Open research', pl: 'Otwórz research' },
@@ -474,7 +479,8 @@ export function createIntexAgentRunner(config: IntexAgentRunnerConfig): IntexAge
             intent.allowedToolNames.includes(tool.name as IntexAgentToolName)
         )
         .map((tool) =>
-          isMutatingToolName(tool.name as IntexAgentToolName)
+          isMutatingToolName(tool.name as IntexAgentToolName) ||
+          tool.name === 'get_user_preferences'
             ? { ...tool, stopAfterRun: true }
             : tool
         );
@@ -1115,10 +1121,26 @@ async function parseRunnerContent(
       category: rejectedSelection.selectionRejection.category,
       code: rejectedSelection.selectionRejection.code,
       toolSelection: rejectedSelection.selectionMetadata,
-      reply: '',
+      reply: TOOL_SELECTION_REJECTED_REPLIES[replyLanguage],
     };
   }
   const toolExecution = getCompletedToolExecution(toolExecutions);
+  if (
+    toolExecution?.toolName === 'get_user_preferences' &&
+    toolExecution.error === undefined &&
+    toolExecution.result !== undefined &&
+    input.content.trim() === ''
+  ) {
+    return buildCompletedToolExecutionResult(
+      toolExecution.toolName,
+      toolExecution.result,
+      '',
+      undefined,
+      webAppUrl,
+      replyLanguage,
+      toolExecution.selectionMetadata
+    );
+  }
   const parsed = await validateRunnerOutput(
     toolExecution !== undefined && isMutatingToolName(toolExecution.toolName)
       ? { ...input, repairClient: undefined }


### PR DESCRIPTION
## Summary
- finish `get_user_preferences` after one successful tool callback and build the reply from its validated result
- keep failed preference reads fail-closed and return a non-empty user-facing reply for rejected tool selections
- add regressions for the production scenario 016 empty-body failure

## Production evidence
- run `eval-2803d409-b8e9-473e-83a1-df3717954222` reached scenario 016
- WhatsApp rejected the empty agent response with `text.body is required`, causing Matrix `reply_timeout`

## Verification
- `pnpm run ci:tracked` — PASS (6788 tests)
- three independent read-only reviews — READY