### PR TITLE
[INT-1916] fix: stabilize Matrix corpus preference reads

### DIFF
--- a/apps/intex-agent/src/__tests__/domain/intexAgentRunner.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/intexAgentRunner.test.ts
@@ -1,4 +1,5 @@
 import { err, ok, type Result } from '@intexuraos/common-core';
+import { sanitizeIntexAgentReplyText } from '@intexuraos/http-contracts';
 import type {
   LLMError,
   ToolCallingClient,
@@ -12,7 +13,10 @@ import {
   INTEX_AGENT_RUNNER_PROMPT_TYPE,
   INTEX_AGENT_SYSTEM_PROMPT,
 } from '../../domain/agent/systemPrompt.js';
-import type { IntexAgentIntentClassifier } from '../../domain/agent/intentClassifier.js';
+import type {
+  IntexAgentIntentClassification,
+  IntexAgentIntentClassifier,
+} from '../../domain/agent/intentClassifier.js';
 import type {
   IntexAgentSession,
   IntexAgentSessionEvent,
@@ -259,6 +263,143 @@ describe('createIntexAgentRunner', () => {
     expect(createNoteCalls).toBe(0);
     expect(client.calls[0]?.tools.map((tool) => tool.name)).toEqual(['create_note']);
   });
+
+  it('does not clarify for an optional note title when the note content is already known', async () => {
+    const content = 'Passport expires in November 2029.';
+    const client = new ToolExecutingFakeToolCallingClient(
+      { toolName: 'create_note', args: { content } },
+      [ok(toolResult({ outcome: 'completed', reply: 'Ready.', toolName: 'create_note' }))]
+    );
+    const runner = createIntexAgentRunner({
+      client,
+      intentClassifier: {
+        async classify() {
+          return {
+            kind: 'needs_clarification' as const,
+            question: 'Please provide a title or confirm.',
+            blockerReason: 'missing_required_details' as const,
+            missingFields: ['title'],
+            candidateIntents: ['create_note' as const],
+            suggestedNextStep: 'Ask for a title.',
+          };
+        },
+      },
+      toolExecutor: fakeToolExecutor(),
+    });
+
+    await expect(
+      runner.run({
+        session: session(),
+        events: [],
+        message: `Keep this for later: ${content}`,
+        currentDateTime: CURRENT_DATE_TIME,
+      })
+    ).resolves.toEqual({
+      outcome: 'needs_confirmation',
+      reply: `Add this note?\nContent: ${content}`,
+      toolName: 'create_note',
+      toolArgs: { content },
+    });
+    expect(client.calls[0]?.tools.map((tool) => tool.name)).toEqual(['create_note']);
+  });
+
+  it('preserves classifier metadata when only optional note fields are missing', async () => {
+    const content = 'Passport expires in November 2029.';
+    const client = new ToolExecutingFakeToolCallingClient(
+      { toolName: 'create_note', args: { content } },
+      [ok(toolResult({ outcome: 'completed', reply: 'Ready.', toolName: 'create_note' }))]
+    );
+    const runner = createIntexAgentRunner({
+      client,
+      intentClassifier: {
+        async classify() {
+          return {
+            kind: 'needs_clarification' as const,
+            question: 'Please provide optional note metadata.',
+            blockerReason: 'missing_required_details' as const,
+            missingFields: ['tags', 'sourceMessageIds'],
+            candidateIntents: ['create_note' as const],
+            suggestedNextStep: 'Ask for optional metadata.',
+            reason: 'The note content is complete.',
+            stylePreferenceAction: 'none' as const,
+            languageOverride: 'en',
+            decisionEvidence: 'Keep this passport-expiry detail for later.',
+          };
+        },
+      },
+      toolExecutor: fakeToolExecutor(),
+    });
+
+    await expect(
+      runner.run({
+        session: session(),
+        events: [],
+        message: `Keep this for later: ${content}`,
+        currentDateTime: CURRENT_DATE_TIME,
+      })
+    ).resolves.toMatchObject({
+      outcome: 'needs_confirmation',
+      toolName: 'create_note',
+      toolArgs: { content },
+    });
+    expect(client.calls[0]?.tools.map((tool) => tool.name)).toEqual(['create_note']);
+  });
+
+  it.each([
+    {
+      label: 'a required content field is also missing',
+      blockerReason: 'missing_required_details',
+      missingFields: ['title', 'content'],
+      candidateIntents: ['create_note'],
+    },
+    {
+      label: 'more than one candidate intent remains',
+      blockerReason: 'missing_required_details',
+      missingFields: ['title'],
+      candidateIntents: ['create_note', 'create_link'],
+    },
+    {
+      label: 'the blocker is not missing required details',
+      blockerReason: 'not_enough_context',
+      missingFields: ['title'],
+      candidateIntents: ['create_note'],
+    },
+  ] as const)(
+    'keeps note clarification when $label',
+    async ({ blockerReason, missingFields, candidateIntents }) => {
+      const client = new FakeToolCallingClient([]);
+      const classification: IntexAgentIntentClassification = {
+        kind: 'needs_clarification',
+        question: 'Please clarify the note request.',
+        blockerReason,
+        missingFields: [...missingFields],
+        candidateIntents: [...candidateIntents],
+        suggestedNextStep: 'Ask for the missing information.',
+      };
+      const runner = createIntexAgentRunner({
+        client,
+        intentClassifier: { classify: async () => classification },
+        toolExecutor: fakeToolExecutor(),
+      });
+
+      await expect(
+        runner.run({
+          session: session(),
+          events: [],
+          message: 'Keep this for later.',
+          currentDateTime: CURRENT_DATE_TIME,
+        })
+      ).resolves.toEqual({
+        outcome: 'needs_clarification',
+        reply: 'Please clarify the note request.',
+        blockerReason,
+        missingFields: [...missingFields],
+        candidateIntents: [...candidateIntents],
+        suggestedNextStep: 'Ask for the missing information.',
+      });
+      expect(client.calls).toEqual([]);
+    }
+  );
 
   it('restores every exact current-message opaque reference in note confirmation arguments', async () => {
     const client = new ToolExecutingFakeToolCallingClient(
@@ -616,6 +757,33 @@ describe('createIntexAgentRunner', () => {
       });
     }
   );
+
+  it('keeps the bookmark confirmation action visible after production reply sanitization', async () => {
+    const client = new ToolExecutingFakeToolCallingClient(
+      {
+        toolName: 'create_link',
+        args: { url: 'https://example.com/private', title: 'Private bookmark title' },
+      },
+      [ok(toolResult({ outcome: 'completed', reply: 'Done.', toolName: 'create_link' }))]
+    );
+    const runner = createIntexAgentRunner({ client, toolExecutor: fakeToolExecutor() });
+    const result = await runner.run({
+      session: session(),
+      events: [],
+      message: 'Save link https://example.com/private',
+      currentDateTime: CURRENT_DATE_TIME,
+    });
+
+    expect(sanitizeIntexAgentReplyText(result.reply)).toBe(
+      [
+        'Save this bookmark?',
+        'Confirm to save it, or cancel to leave it unchanged.',
+        '',
+        'URL: [redacted]',
+        'Title: [redacted]',
+      ].join('\n')
+    );
+  });
 
   it.each([
     {
@@ -3685,6 +3853,17 @@ describe('createIntexAgentRunner', () => {
         'Czy utworzyć szkic researchu?\n\nTytuł: Research topic\nPolecenie: Research this topic.',
     },
     {
+      toolName: 'create_link' as const,
+      message: 'Zapisz ten link jako bookmark.',
+      expectedReply: [
+        'Czy zapisać bookmark?',
+        'Potwierdź, aby go zapisać, albo anuluj, aby niczego nie zmieniać.',
+        '',
+        'URL: https://example.com',
+        'Tytuł: Example',
+      ].join('\n'),
+    },
+    {
       toolName: 'create_code_task' as const,
       message: 'Utwórz zadanie programistyczne execution dla Linear LIN-123.',
       expectedReply: [
@@ -5430,6 +5609,100 @@ describe('createIntexAgentRunner', () => {
     ]);
   });
 
+  it('renders non-empty preference items returned by the isolated Matrix overlay', async () => {
+    const overlayResult = {
+      toolName: 'get_user_preferences',
+      status: 'completed',
+      currentVersion: 2,
+      items: [
+        { id: 'mock_pref_concise', text: 'Use concise replies.' },
+        { id: 'mock_pref_language', text: 'Reply in Polish by default.' },
+      ],
+    };
+    const client = new ToolExecutingFakeToolCallingClient(
+      { toolName: 'get_user_preferences', args: {} },
+      [
+        ok({
+          content: '',
+          toolCallsMade: 1,
+          iterationCount: 1,
+          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2, costUsd: 0 },
+        }),
+      ]
+    );
+    const runner = createIntexAgentRunner({
+      client,
+      intentClassifier: toolIntentClassifier(['get_user_preferences']),
+      toolExecutor: fakeToolExecutor({
+        getUserPreferences: async () => JSON.stringify(overlayResult),
+      }),
+    });
+
+    await expect(
+      runner.run({
+        session: session(),
+        events: [],
+        message: 'Show my saved Intex Agent preferences.',
+        currentDateTime: CURRENT_DATE_TIME,
+      })
+    ).resolves.toMatchObject({
+      outcome: 'completed',
+      reply: [
+        'User Preferences v2:',
+        '1. (id: mock_pref_concise) "Use concise replies."',
+        '2. (id: mock_pref_language) "Reply in Polish by default."',
+      ].join('\n'),
+      toolName: 'get_user_preferences',
+      toolResult: overlayResult,
+    });
+  });
+
+  it.each([
+    ['a scalar item', ['invalid']],
+    ['a null item', [null]],
+    ['an array item', [[]]],
+    ['a missing id', [{ text: 'Use concise replies.' }]],
+    ['a missing text', [{ id: 'mock_pref_concise' }]],
+  ])('falls back safely when the Matrix preference overlay contains %s', async (_label, items) => {
+    const client = new ToolExecutingFakeToolCallingClient(
+      { toolName: 'get_user_preferences', args: {} },
+      [
+        ok({
+          content: '',
+          toolCallsMade: 1,
+          iterationCount: 1,
+          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2, costUsd: 0 },
+        }),
+      ]
+    );
+    const runner = createIntexAgentRunner({
+      client,
+      intentClassifier: toolIntentClassifier(['get_user_preferences']),
+      toolExecutor: fakeToolExecutor({
+        getUserPreferences: async () =>
+          JSON.stringify({
+            toolName: 'get_user_preferences',
+            status: 'completed',
+            currentVersion: 2,
+            items,
+          }),
+      }),
+    });
+
+    await expect(
+      runner.run({
+        session: session(),
+        events: [],
+        message: 'Show my saved Intex Agent preferences.',
+        currentDateTime: CURRENT_DATE_TIME,
+      })
+    ).resolves.toMatchObject({
+      outcome: 'completed',
+      reply: 'No Intex Agent preferences are defined yet.',
+      toolName: 'get_user_preferences',
+    });
+  });
+
   it('returns the completed preference result when the final model envelope says no_action', async () => {
     const promptBlock =
       'User Preferences v1:\n1. (id: pref_jakub) "When I ask to invite Jakub, invite jakub@gmail.com."';
@@ -6059,7 +6332,13 @@ function expectedConfirmationReplyFor(toolName: PreviewToolName): string {
     return 'Create this research draft?\n\nTitle: Research topic\nPrompt: Research this topic.';
   }
   if (toolName === 'create_link') {
-    return 'Save this bookmark?\n\nURL: https://example.com\nTitle: Example';
+    return [
+      'Save this bookmark?',
+      'Confirm to save it, or cancel to leave it unchanged.',
+      '',
+      'URL: https://example.com',
+      'Title: Example',
+    ].join('\n');
   }
   if (toolName === 'create_code_task') {
     return [

--- a/apps/intex-agent/src/__tests__/domain/matrixCorpus/contextService.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/matrixCorpus/contextService.test.ts
@@ -983,7 +983,7 @@ describe('Matrix corpus context service', () => {
     ).resolves.toEqual({ ok: false, code: 'CONTEXT_DECRYPTION_FAILED' });
   });
 
-  it('rejects a preference-overlay read whose configured value differs from private state', async () => {
+  it('returns private preference-overlay state when the catalog contains a fixed read placeholder', async () => {
     const current = await preferenceOverlayFixture();
     await expect(
       current.overlay.read({
@@ -996,6 +996,28 @@ describe('Matrix corpus context service', () => {
           status: 'completed',
           currentVersion: 99,
           items: [],
+        },
+      })
+    ).resolves.toEqual({
+      toolName: 'get_user_preferences',
+      status: 'completed',
+      currentVersion: 2,
+      items: [{ id: syntheticPreferenceId, text: privatePreference }],
+    });
+  });
+
+  it('rejects a preference-overlay read whose catalog result names another tool', async () => {
+    const current = await preferenceOverlayFixture();
+    await expect(
+      current.overlay.read({
+        ingestReceiptId: 'receipt_wrong_read_tool',
+        toolName: 'get_user_preferences',
+        turnIndex: 0,
+        ordinal: 1,
+        configuredResult: {
+          toolName: 'create_note',
+          status: 'completed',
+          message: 'Synthetic note result',
         },
       })
     ).rejects.toMatchObject({ code: 'PREFERENCE_OVERLAY_REJECTED' });

--- a/apps/intex-agent/src/__tests__/domain/matrixCorpus/strictToolMockExecutor.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/matrixCorpus/strictToolMockExecutor.test.ts
@@ -249,6 +249,53 @@ describe('strict Matrix corpus tool-mock executor', () => {
     expect(overlay.mutate).not.toHaveBeenCalled();
   });
 
+  it('returns the dynamic encrypted overlay snapshot instead of the fixed catalog placeholder', async () => {
+    const configured = resultFor('get_user_preferences');
+    const overlayResult: StrictMockResultV1 = {
+      toolName: 'get_user_preferences',
+      status: 'completed',
+      currentVersion: 2,
+      items: [{ id: 'mock_pref_existing', text: 'Use concise replies.' }],
+    };
+    const overlay = preferenceOverlay({ readResult: overlayResult });
+    const executor = executorFor([successCall('get_user_preferences', 1, configured)], {
+      preferenceOverlay: overlay,
+    });
+
+    await expect(executor.getUserPreferences()).resolves.toBe(JSON.stringify(overlayResult));
+    expect(overlay.read).toHaveBeenCalledWith({
+      ingestReceiptId: 'receipt_1',
+      toolName: 'get_user_preferences',
+      turnIndex: 0,
+      ordinal: 1,
+      configuredResult: configured,
+    });
+  });
+
+  it.each([
+    ['a different tool result', resultFor('create_note')],
+    [
+      'a malformed preference result',
+      {
+        toolName: 'get_user_preferences',
+        status: 'completed',
+        currentVersion: -1,
+        items: [],
+      } as unknown as StrictMockResultV1,
+    ],
+  ])('fails closed when the preference overlay returns %s', async (_label, readResult) => {
+    const configured = resultFor('get_user_preferences');
+    const overlay = preferenceOverlay({ readResult });
+    const executor = executorFor([successCall('get_user_preferences', 1, configured)], {
+      preferenceOverlay: overlay,
+    });
+
+    await expect(executor.getUserPreferences()).rejects.toMatchObject({
+      category: 'safety_stop',
+      code: 'PREFERENCE_OVERLAY_RESULT_MISMATCH',
+    });
+  });
+
   it('fails closed when a preference tool has no encrypted scenario overlay', async () => {
     const executor = executorFor([
       successCall('get_user_preferences', 1, resultFor('get_user_preferences')),
@@ -302,6 +349,23 @@ describe('strict Matrix corpus tool-mock executor', () => {
     >;
     const overlay = preferenceOverlay({
       mutateResult: { ...expected, currentVersion: 2 },
+    });
+    const executor = executorFor([successCall('add_user_preference', 1, expected)], {
+      preferenceOverlay: overlay,
+    });
+
+    await expect(
+      executor.addUserPreference({ text: 'Short replies', expectedVersion: 0 })
+    ).rejects.toMatchObject({
+      category: 'safety_stop',
+      code: 'PREFERENCE_OVERLAY_RESULT_MISMATCH',
+    });
+  });
+
+  it('fails closed when a mutation overlay returns a non-object result', async () => {
+    const expected = resultFor('add_user_preference');
+    const overlay = preferenceOverlay({
+      mutateResult: [] as unknown as StrictMockResultV1,
     });
     const executor = executorFor([successCall('add_user_preference', 1, expected)], {
       preferenceOverlay: overlay,

--- a/apps/intex-agent/src/domain/agent/intexAgentRunner.ts
+++ b/apps/intex-agent/src/domain/agent/intexAgentRunner.ts
@@ -221,6 +221,11 @@ const CONFIRMATION_INTROS: Record<MutatingIntexAgentToolName, LocalizedText> = {
   },
 };
 
+const LINK_CONFIRMATION_ACTION_HINT: LocalizedText = {
+  en: 'Confirm to save it, or cancel to leave it unchanged.',
+  pl: 'Potwierdź, aby go zapisać, albo anuluj, aby niczego nie zmieniać.',
+};
+
 const CONFIRMATION_LABELS = {
   title: { en: 'Title', pl: 'Tytuł' },
   content: { en: 'Content', pl: 'Treść' },
@@ -401,12 +406,14 @@ export function createIntexAgentRunner(config: IntexAgentRunnerConfig): IntexAge
                 ? { matrixCorpusLlm: config.matrixCorpusLlm }
                 : {}),
             });
-      const intent = applyRuntimeTimeZoneToCalendarIntent(classifiedIntent, {
-        timeZone: input.timeZone,
-        message: input.message,
-        events: input.events,
-        replyContext: input.replyContext,
-      });
+      const intent = applyOptionalNoteFieldClarification(
+        applyRuntimeTimeZoneToCalendarIntent(classifiedIntent, {
+          timeZone: input.timeZone,
+          message: input.message,
+          events: input.events,
+          replyContext: input.replyContext,
+        })
+      );
       const replyLanguage = replyLanguageForIntent(intent, detectedReplyLanguage);
       if (intent.kind === 'unsupported') {
         return normalizeClassifierUnsupportedIntent(intent, replyLanguage);
@@ -601,6 +608,38 @@ function applyRuntimeTimeZoneToCalendarIntent(
     ...(intent.languageOverride !== undefined ? { languageOverride: intent.languageOverride } : {}),
     ...(intent.decisionEvidence !== undefined ? { decisionEvidence: intent.decisionEvidence } : {}),
   };
+}
+
+function applyOptionalNoteFieldClarification(
+  intent: IntexAgentIntentClassification
+): IntexAgentIntentClassification {
+  if (
+    intent.kind !== 'needs_clarification' ||
+    intent.blockerReason !== 'missing_required_details' ||
+    intent.candidateIntents?.length !== 1 ||
+    intent.candidateIntents[0] !== 'create_note' ||
+    intent.missingFields === undefined ||
+    intent.missingFields.length === 0 ||
+    !intent.missingFields.every(isOptionalNoteField)
+  ) {
+    return intent;
+  }
+
+  return {
+    kind: 'tool',
+    allowedToolNames: ['create_note'],
+    ...(intent.reason !== undefined ? { reason: intent.reason } : {}),
+    ...(intent.stylePreferenceAction !== undefined
+      ? { stylePreferenceAction: intent.stylePreferenceAction }
+      : {}),
+    ...(intent.languageOverride !== undefined ? { languageOverride: intent.languageOverride } : {}),
+    ...(intent.decisionEvidence !== undefined ? { decisionEvidence: intent.decisionEvidence } : {}),
+  };
+}
+
+function isOptionalNoteField(field: string): boolean {
+  const canonical = field.trim().toLocaleLowerCase('en-US').replace(/[\s_-]+/gu, '');
+  return canonical === 'title' || canonical === 'tags' || canonical === 'sourcemessageids';
 }
 
 function isRuntimeTimeZoneMissingField(field: string): boolean {
@@ -1696,7 +1735,11 @@ function buildConfirmationReply(
   }
 
   if (toolName === 'create_link') {
-    const lines = [CONFIRMATION_INTROS.create_link[replyLanguage]];
+    const lines = [
+      CONFIRMATION_INTROS.create_link[replyLanguage],
+      LINK_CONFIRMATION_ACTION_HINT[replyLanguage],
+      '',
+    ];
     appendConfirmationLine(lines, 'URL', readRawString(args, 'url'));
     appendConfirmationLine(lines, CONFIRMATION_LABELS.title[replyLanguage], readRawString(args, 'title'));
     return lines.join('\n');
@@ -1909,11 +1952,13 @@ function buildCompletedReply(
 
   if (isPreferenceToolName(toolName)) {
     const promptBlock = readRawString(result, 'promptBlock');
+    const renderedPromptBlock =
+      promptBlock !== undefined && promptBlock.trim() !== '' ? promptBlock : undefined;
+    const overlayBlock =
+      toolName === 'get_user_preferences' ? renderPreferenceOverlayItems(result) : undefined;
     return {
       reply:
-        promptBlock !== undefined && promptBlock.trim() !== ''
-          ? promptBlock
-          : COMPLETED_REPLIES.preferencesEmpty[replyLanguage],
+        renderedPromptBlock ?? overlayBlock ?? COMPLETED_REPLIES.preferencesEmpty[replyLanguage],
     };
   }
 
@@ -2035,6 +2080,30 @@ function isPreferenceVersionConflictMessage(errorMessage: string): boolean {
 function readRawString(record: Record<string, unknown>, key: string): string | undefined {
   const value = record[key];
   return typeof value === 'string' ? value : undefined;
+}
+
+function renderPreferenceOverlayItems(result: Record<string, unknown>): string | undefined {
+  const currentVersion = result['currentVersion'];
+  const items = result['items'];
+  if (
+    !Number.isSafeInteger(currentVersion) ||
+    (currentVersion as number) < 0 ||
+    !Array.isArray(items) ||
+    items.length === 0
+  ) {
+    return undefined;
+  }
+
+  const renderedItems: string[] = [];
+  for (const [index, item] of items.entries()) {
+    if (typeof item !== 'object' || item === null || Array.isArray(item)) return undefined;
+    const record = item as Record<string, unknown>;
+    const id = readString(record, 'id');
+    const text = readString(record, 'text');
+    if (id === undefined || text === undefined) return undefined;
+    renderedItems.push(`${String(index + 1)}. (id: ${id}) ${JSON.stringify(text)}`);
+  }
+  return [`User Preferences v${String(currentVersion)}:`, ...renderedItems].join('\n');
 }
 
 function readString(record: Record<string, unknown>, key: string): string | undefined {

--- a/apps/intex-agent/src/domain/matrixCorpus/contextService.ts
+++ b/apps/intex-agent/src/domain/matrixCorpus/contextService.ts
@@ -400,7 +400,7 @@ export function createMatrixCorpusContextService(
             currentVersion: loaded.payload.preferenceOverlay.currentVersion,
             items: loaded.payload.preferenceOverlay.items.map((item) => ({ ...item })),
           };
-          if (stableJson(request.configuredResult) !== stableJson(result))
+          if (request.configuredResult.toolName !== 'get_user_preferences')
             throw overlayRejected();
           return result;
         },

--- a/apps/intex-agent/src/domain/matrixCorpus/strictToolMockExecutor.ts
+++ b/apps/intex-agent/src/domain/matrixCorpus/strictToolMockExecutor.ts
@@ -1,8 +1,9 @@
 import { createHash } from 'node:crypto';
 
-import type {
-  IntexAgentToolNameV1,
-  StrictMockResultV1,
+import {
+  strictMockResultV1Schema,
+  type IntexAgentToolNameV1,
+  type StrictMockResultV1,
 } from '@intexuraos/http-contracts';
 
 import type {
@@ -275,7 +276,7 @@ export function createStrictToolMockExecutor(
         ordinal,
         configuredResult,
       });
-      return encodeMatchingOverlayResult(actual, configuredResult);
+      return encodePreferenceOverlayReadResult(actual);
     }
     if (isPreferenceMutationTool(toolName)) {
       const overlay = requirePreferenceOverlay(input.preferenceOverlay);
@@ -380,6 +381,17 @@ function encodeMatchingOverlayResult(
     );
   }
   return JSON.stringify(expected);
+}
+
+function encodePreferenceOverlayReadResult(actual: StrictMockResultV1): string {
+  const parsed = strictMockResultV1Schema.safeParse(actual);
+  if (!parsed.success || parsed.data.toolName !== 'get_user_preferences') {
+    throw new MatrixCorpusStrictToolMockError(
+      'safety_stop',
+      'PREFERENCE_OVERLAY_RESULT_MISMATCH'
+    );
+  }
+  return JSON.stringify(parsed.data);
 }
 
 export function matrixCorpusPreferenceMutationReceipt(


### PR DESCRIPTION
## Summary
- return the encrypted per-scenario preference overlay for strict Matrix reads
- treat optional note metadata as non-blocking when note content is complete
- keep link confirmation guidance visible after WhatsApp sanitization
- render non-empty preference overlays in deterministic completed replies
- fail closed for malformed or mismatched mock results

## Verification
- pnpm run ci:tracked
- 6801 tests passed
- focused Matrix/runner suites: 285 tests passed
- correctness, security, and test-completeness reviews: ready