### PR TITLE
[INT-1922] Fix zero-evidence Matrix provider retries

### DIFF
--- a/apps/intex-agent/src/__tests__/domain/matrixCorpus/matrixCorpusExecutionService.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/matrixCorpus/matrixCorpusExecutionService.test.ts
@@ -887,6 +887,160 @@ describe('Matrix corpus execution service', () => {
     expect(replyPublisher.publishReplyWithReceipt).not.toHaveBeenCalled();
   });
 
+  it('retries a normal turn after a zero-evidence provider failure and persists only final usage', async () => {
+    const fallbackRunner = {
+      run: vi.fn(),
+      executeConfirmed: vi.fn(),
+    };
+    const current = fixture(fallbackRunner as unknown as IntexAgentRunner);
+    let runnerAttempt = 0;
+    current.createRunner.mockImplementation((runnerInput) => ({
+      executeConfirmed: vi.fn(),
+      run: vi.fn(async () => {
+        const context = {
+          version: 1 as const,
+          runId: 'run_1',
+          scenarioId: 'scenario_001',
+          sessionId: stableKeys.sessionId,
+          turnIndex: 0,
+          stage: 'agent_generation' as const,
+          callOrdinal: 1,
+        };
+        runnerInput.execution.registerExpectedProviderCall(context);
+        runnerAttempt += 1;
+        if (runnerAttempt === 1) throw new Error('Matrix corpus agent generation failed');
+        await runnerInput.execution.recordProviderCall({
+          context,
+          modelId: 'or:deepseek/deepseek-v4-flash',
+          inputTokens: 21,
+          outputTokens: 4,
+          totalTokens: 25,
+          providerReportedUsd: 0.0000000025,
+        });
+        return { outcome: 'no_action' as const, reply: 'Recovered synthetic reply.' };
+      }),
+    }));
+
+    await expect(
+      current.service.executeVerifiedIngest({
+        claims: claims('query_calendar_events'),
+        stableKeys,
+      })
+    ).resolves.toEqual({ ok: true });
+
+    expect(current.createRunner).toHaveBeenCalledTimes(2);
+    const summaries = current.sessionRepository.appendMatrixCorpusEvent.mock.calls
+      .map(([input]) => input.event)
+      .filter(({ type }) => type === 'llm_usage_summary');
+    expect(summaries).toHaveLength(1);
+    expect(summaries[0]?.payload).toEqual({
+      turnIndex: 0,
+      status: 'complete',
+      expectedCallCount: 1,
+      reportedCallCount: 1,
+      inputTokens: 21,
+      outputTokens: 4,
+      totalTokens: 25,
+      costNanoUsd: 3,
+    });
+  });
+
+  it('stops after three zero-evidence provider failures and persists one failed summary', async () => {
+    const fallbackRunner = {
+      run: vi.fn(),
+      executeConfirmed: vi.fn(),
+    };
+    const current = fixture(fallbackRunner as unknown as IntexAgentRunner);
+    current.createRunner.mockImplementation((runnerInput) => ({
+      executeConfirmed: vi.fn(),
+      run: vi.fn(async () => {
+        runnerInput.execution.registerExpectedProviderCall({
+          version: 1,
+          runId: 'run_1',
+          scenarioId: 'scenario_001',
+          sessionId: stableKeys.sessionId,
+          turnIndex: 0,
+          stage: 'agent_generation',
+          callOrdinal: 1,
+        });
+        throw new Error('Matrix corpus intent classification failed');
+      }),
+    }));
+
+    await expect(
+      current.service.executeVerifiedIngest({
+        claims: claims('query_calendar_events'),
+        stableKeys,
+      })
+    ).rejects.toThrow('Matrix corpus intent classification failed');
+
+    expect(current.createRunner).toHaveBeenCalledTimes(3);
+    const summaries = current.sessionRepository.appendMatrixCorpusEvent.mock.calls
+      .map(([input]) => input.event)
+      .filter(({ type }) => type === 'llm_usage_summary');
+    expect(summaries).toHaveLength(1);
+    expect(summaries[0]?.payload).toEqual({
+      turnIndex: 0,
+      status: 'failed',
+      expectedCallCount: 1,
+      reportedCallCount: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      totalTokens: 0,
+      costNanoUsd: 0,
+    });
+  });
+
+  it('does not retry a generic provider failure after a provider response was observed', async () => {
+    const fallbackRunner = {
+      run: vi.fn(),
+      executeConfirmed: vi.fn(),
+    };
+    const current = fixture(fallbackRunner as unknown as IntexAgentRunner);
+    current.sessionRepository.appendMatrixCorpusEvent.mockImplementation(async (input) =>
+      input.event.type === 'llm_call_usage'
+        ? { ok: false, code: 'CORRELATED_REPLAY_CONFLICT' }
+        : { ok: true, disposition: 'applied', sequence: 2 }
+    );
+    current.createRunner.mockImplementation((runnerInput) => ({
+      executeConfirmed: vi.fn(),
+      run: vi.fn(async () => {
+        const context = {
+          version: 1 as const,
+          runId: 'run_1',
+          scenarioId: 'scenario_001',
+          sessionId: stableKeys.sessionId,
+          turnIndex: 0,
+          stage: 'agent_generation' as const,
+          callOrdinal: 1,
+        };
+        runnerInput.execution.registerExpectedProviderCall(context);
+        try {
+          await runnerInput.execution.recordProviderCall({
+            context,
+            modelId: 'or:deepseek/deepseek-v4-flash',
+            inputTokens: 21,
+            outputTokens: 4,
+            totalTokens: 25,
+            providerReportedUsd: 0.0000000025,
+          });
+        } catch {
+          throw new Error('Matrix corpus agent generation failed');
+        }
+        return { outcome: 'no_action' as const, reply: 'unreachable' };
+      }),
+    }));
+
+    await expect(
+      current.service.executeVerifiedIngest({
+        claims: claims('query_calendar_events'),
+        stableKeys,
+      })
+    ).rejects.toThrow('Matrix corpus agent generation failed');
+
+    expect(current.createRunner).toHaveBeenCalledTimes(1);
+  });
+
   it('creates a one-use confirmation without persisting raw tool arguments in session events', async () => {
     const runner = {
       run: vi.fn(async () => ({

--- a/apps/intex-agent/src/domain/matrixCorpus/matrixCorpusExecutionService.ts
+++ b/apps/intex-agent/src/domain/matrixCorpus/matrixCorpusExecutionService.ts
@@ -97,6 +97,12 @@ export interface MatrixCorpusExecutionServiceDeps {
   replyPublisher: Pick<MatrixCorpusWhatsAppReplyPublisher, 'publishReplyWithReceipt'>;
 }
 
+const MATRIX_CORPUS_ZERO_EVIDENCE_RUNNER_ATTEMPTS = 3;
+const MATRIX_CORPUS_RETRIABLE_ZERO_EVIDENCE_ERRORS = new Set([
+  'Error: Matrix corpus agent generation failed',
+  'Error: Matrix corpus intent classification failed',
+]);
+
 export function createMatrixCorpusExecutionService(
   deps: MatrixCorpusExecutionServiceDeps
 ): MatrixCorpusExecutionService {
@@ -123,6 +129,7 @@ export function createMatrixCorpusExecutionService(
       ]);
       if (!sessionResult.ok || !eventsResult.ok) return failure('SESSION_REJECTED');
       if (!promptResult.ok) return failure('CONTEXT_REJECTED');
+      const promptContext = promptResult.promptContext;
       const session = sessionResult.session;
       if (
         stableJson(session.matrixCorpusProfile.expectedToolSchedule) !==
@@ -152,14 +159,6 @@ export function createMatrixCorpusExecutionService(
         });
       }
 
-      const usageRecorder = createMatrixCorpusProviderUsageRecorder({
-        sessionRepository: deps.sessionRepository,
-        identity,
-        ingestReceiptId: context.ingestReceiptId,
-        expectedModelId: session.matrixCorpusProfile.agentModel,
-        turnIndex: context.turnIndex,
-        createdAt: ordinaryIngest.timestamp,
-      });
       const recordExecutionBoundary = createMatrixCorpusExecutionBoundaryRecorder({
         sessionRepository: deps.sessionRepository,
         identity,
@@ -169,6 +168,14 @@ export function createMatrixCorpusExecutionService(
         createdAt: ordinaryIngest.timestamp,
       });
       if (isMatrixCorpusIdleNewSessionStart(input.claims)) {
+        const usageRecorder = createMatrixCorpusProviderUsageRecorder({
+          sessionRepository: deps.sessionRepository,
+          identity,
+          ingestReceiptId: context.ingestReceiptId,
+          expectedModelId: session.matrixCorpusProfile.agentModel,
+          turnIndex: context.turnIndex,
+          createdAt: ordinaryIngest.timestamp,
+        });
         await recordExecutionBoundary('no_executor_required');
         await usageRecorder.finalize('natural', 'complete');
         return await persistAndPublishResult({
@@ -181,49 +188,69 @@ export function createMatrixCorpusExecutionService(
           },
         });
       }
-      const execution = createExecutionContext({
-        flow: 'normal',
-        turnIndex: context.turnIndex,
-        ingestReceiptId: context.ingestReceiptId,
-        expectedSchedule: context.expectedToolSchedule,
-        preferenceOverlay,
-        recordExecutionBoundary,
-        recordToolCallStarted: createMatrixCorpusToolCallStartedRecorder({
+      async function executeNaturalAttempt(
+        runnerAttempt: number
+      ): Promise<MatrixCorpusExecutionResult> {
+        const usageRecorder = createMatrixCorpusProviderUsageRecorder({
           sessionRepository: deps.sessionRepository,
           identity,
           ingestReceiptId: context.ingestReceiptId,
+          expectedModelId: session.matrixCorpusProfile.agentModel,
+          turnIndex: context.turnIndex,
           createdAt: ordinaryIngest.timestamp,
-        }),
-        registerExpectedProviderCall: (providerContext) => {
-          usageRecorder.registerExpectedProviderCall(providerContext);
-        },
-        recordProviderCall: async (providerCall) => {
-          await usageRecorder.recordProviderCall(providerCall);
-        },
-      });
-      const runner = deps.createRunner({
-        execution,
-        agentModel: session.matrixCorpusProfile.agentModel,
-        userId: ordinaryIngest.userId,
-        userPreferences: promptResult.promptContext,
-      });
-      let result: IntexAgentRunnerResult;
-      try {
-        result = await runner.run({
-          session,
-          events: previousEvents,
-          message: ordinaryIngest.text,
-          sourceType: ordinaryIngest.sourceType,
-          currentDateTime: context.currentDateTime,
-          timeZone: context.timeZone,
-          messageId: ordinaryIngest.messageId,
         });
-      } catch (error) {
-        await usageRecorder.finalize('natural', 'failed');
-        throw error;
+        const execution = createExecutionContext({
+          flow: 'normal',
+          turnIndex: context.turnIndex,
+          ingestReceiptId: context.ingestReceiptId,
+          expectedSchedule: context.expectedToolSchedule,
+          preferenceOverlay,
+          recordExecutionBoundary,
+          recordToolCallStarted: createMatrixCorpusToolCallStartedRecorder({
+            sessionRepository: deps.sessionRepository,
+            identity,
+            ingestReceiptId: context.ingestReceiptId,
+            createdAt: ordinaryIngest.timestamp,
+          }),
+          registerExpectedProviderCall: (providerContext) => {
+            usageRecorder.registerExpectedProviderCall(providerContext);
+          },
+          recordProviderCall: async (providerCall) => {
+            await usageRecorder.recordProviderCall(providerCall);
+          },
+        });
+        const runner = deps.createRunner({
+          execution,
+          agentModel: session.matrixCorpusProfile.agentModel,
+          userId: ordinaryIngest.userId,
+          userPreferences: promptContext,
+        });
+        let result: IntexAgentRunnerResult;
+        try {
+          result = await runner.run({
+            session,
+            events: previousEvents,
+            message: ordinaryIngest.text,
+            sourceType: ordinaryIngest.sourceType,
+            currentDateTime: context.currentDateTime,
+            timeZone: context.timeZone,
+            messageId: ordinaryIngest.messageId,
+          });
+        } catch (error) {
+          if (
+            !usageRecorder.hasObservedProviderResponse() &&
+            MATRIX_CORPUS_RETRIABLE_ZERO_EVIDENCE_ERRORS.has(String(error)) &&
+            runnerAttempt < MATRIX_CORPUS_ZERO_EVIDENCE_RUNNER_ATTEMPTS
+          ) {
+            return await executeNaturalAttempt(runnerAttempt + 1);
+          }
+          await usageRecorder.finalize('natural', 'failed');
+          throw error;
+        }
+        await usageRecorder.finalize('natural', 'complete');
+        return await persistAndPublishResult({ deps, input, identity, result });
       }
-      await usageRecorder.finalize('natural', 'complete');
-      return await persistAndPublishResult({ deps, input, identity, result });
+      return await executeNaturalAttempt(1);
     },
     async recoverVerifiedIngest(input): Promise<MatrixCorpusExecutionResult> {
       return await recoverReservedReply({ deps, ...input });
@@ -839,6 +866,7 @@ function sha256(value: string): string {
 interface MatrixCorpusProviderUsageRecorder {
   registerExpectedProviderCall(context: MatrixCorpusLlmCallContextV1): void;
   recordProviderCall(call: MatrixCorpusProviderCallUsageV1): Promise<void>;
+  hasObservedProviderResponse(): boolean;
   finalize(phase: 'natural' | 'confirmation', status: 'complete' | 'failed'): Promise<void>;
 }
 
@@ -854,6 +882,7 @@ function createMatrixCorpusProviderUsageRecorder(
 ): MatrixCorpusProviderUsageRecorder {
   const expectedCalls = new Map<string, MatrixCorpusLlmCallContextV1>();
   const actualCalls = new Map<string, MatrixCorpusProviderCallUsageV1>();
+  let providerResponseObserved = false;
   const registerExpected = (context: MatrixCorpusLlmCallContextV1): void => {
     assertProviderContext(input, context);
     const key = providerCallKey(context);
@@ -871,6 +900,7 @@ function createMatrixCorpusProviderUsageRecorder(
       registerExpected(context);
     },
     async recordProviderCall(call): Promise<void> {
+      providerResponseObserved = true;
       registerExpected(call.context);
       assertProviderContext(input, call.context);
       if (
@@ -922,6 +952,9 @@ function createMatrixCorpusProviderUsageRecorder(
       });
       if (!appended.ok) throw new Error('Matrix corpus provider usage persistence failed');
       actualCalls.set(key, structuredClone(call));
+    },
+    hasObservedProviderResponse(): boolean {
+      return providerResponseObserved;
     },
     async finalize(phase, status): Promise<void> {
       const projectedExpectedCalls =


### PR DESCRIPTION
## Summary

- retry Matrix corpus turns only when the provider failed without returning any response evidence
- cap zero-evidence retries at three attempts and persist only the terminal usage summary
- fail closed after any observed provider response, including usage correlation or persistence failures
- add regression coverage for recovery, exhaustion, and post-response persistence failure

## Verification

- `pnpm run verify:workspace:tracked intex-agent` (1813 tests passed)
- `pnpm run ci:tracked` (6898 tests passed)
- independent security review: no findings

## Linear

Linear: omitted by `$commit-push`; GitHub automation will create or link the Linear issue after PR creation.
