### PR TITLE
[INT-1923] Back off zero-evidence Matrix retries

### DIFF
--- a/apps/intex-agent/src/__tests__/domain/matrixCorpus/matrixCorpusExecutionService.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/matrixCorpus/matrixCorpusExecutionService.test.ts
@@ -271,6 +271,7 @@ function fixture(
   const replyPublisher = {
     publishReplyWithReceipt: vi.fn(async () => ({ publicationReceiptId: 'pubsub_message_1' })),
   };
+  const waitForZeroEvidenceRetry = vi.fn(async (_delayMs: number) => undefined);
   const deps = {
     contextService,
     sessionRepository,
@@ -278,6 +279,7 @@ function fixture(
     receiptRepository,
     createRunner,
     replyPublisher,
+    waitForZeroEvidenceRetry,
   } as unknown as MatrixCorpusExecutionServiceDeps;
   return {
     session,
@@ -287,6 +289,7 @@ function fixture(
     receiptRepository,
     createRunner,
     replyPublisher,
+    waitForZeroEvidenceRetry,
     service: createMatrixCorpusExecutionService(deps),
   };
 }
@@ -929,6 +932,8 @@ describe('Matrix corpus execution service', () => {
     ).resolves.toEqual({ ok: true });
 
     expect(current.createRunner).toHaveBeenCalledTimes(2);
+    expect(current.waitForZeroEvidenceRetry).toHaveBeenCalledTimes(1);
+    expect(current.waitForZeroEvidenceRetry).toHaveBeenCalledWith(5_000);
     const summaries = current.sessionRepository.appendMatrixCorpusEvent.mock.calls
       .map(([input]) => input.event)
       .filter(({ type }) => type === 'llm_usage_summary');
@@ -975,6 +980,7 @@ describe('Matrix corpus execution service', () => {
     ).rejects.toThrow('Matrix corpus intent classification failed');
 
     expect(current.createRunner).toHaveBeenCalledTimes(3);
+    expect(current.waitForZeroEvidenceRetry.mock.calls).toEqual([[5_000], [20_000]]);
     const summaries = current.sessionRepository.appendMatrixCorpusEvent.mock.calls
       .map(([input]) => input.event)
       .filter(({ type }) => type === 'llm_usage_summary');

--- a/apps/intex-agent/src/domain/matrixCorpus/matrixCorpusExecutionService.ts
+++ b/apps/intex-agent/src/domain/matrixCorpus/matrixCorpusExecutionService.ts
@@ -95,9 +95,11 @@ export interface MatrixCorpusExecutionServiceDeps {
     }>
   ): IntexAgentRunner;
   replyPublisher: Pick<MatrixCorpusWhatsAppReplyPublisher, 'publishReplyWithReceipt'>;
+  waitForZeroEvidenceRetry(delayMs: number): Promise<void>;
 }
 
 const MATRIX_CORPUS_ZERO_EVIDENCE_RUNNER_ATTEMPTS = 3;
+const MATRIX_CORPUS_ZERO_EVIDENCE_RETRY_DELAYS_MS = [5_000, 20_000] as const;
 const MATRIX_CORPUS_RETRIABLE_ZERO_EVIDENCE_ERRORS = new Set([
   'Error: Matrix corpus agent generation failed',
   'Error: Matrix corpus intent classification failed',
@@ -242,6 +244,10 @@ export function createMatrixCorpusExecutionService(
             MATRIX_CORPUS_RETRIABLE_ZERO_EVIDENCE_ERRORS.has(String(error)) &&
             runnerAttempt < MATRIX_CORPUS_ZERO_EVIDENCE_RUNNER_ATTEMPTS
           ) {
+            const retryDelayMs = MATRIX_CORPUS_ZERO_EVIDENCE_RETRY_DELAYS_MS[
+              runnerAttempt - 1
+            ] as (typeof MATRIX_CORPUS_ZERO_EVIDENCE_RETRY_DELAYS_MS)[number];
+            await deps.waitForZeroEvidenceRetry(retryDelayMs);
             return await executeNaturalAttempt(runnerAttempt + 1);
           }
           await usageRecorder.finalize('natural', 'failed');

--- a/apps/intex-agent/src/services.ts
+++ b/apps/intex-agent/src/services.ts
@@ -1,4 +1,5 @@
 import { createHash, createPublicKey, randomUUID } from 'node:crypto';
+import { setTimeout as wait } from 'node:timers/promises';
 import { err, type Result } from '@intexuraos/common-core';
 import { createAppLogger, SKIP_SENTRY_KEY } from '@intexuraos/infra-sentry';
 import {
@@ -254,6 +255,9 @@ export function createIntexMatrixCorpusRuntime(
     receiptRepository,
     createRunner: dependencies.createRunner,
     replyPublisher: dependencies.replyPublisher,
+    waitForZeroEvidenceRetry: async (delayMs) => {
+      await wait(delayMs);
+    },
   });
   const terminalRecorder = createMatrixCorpusTurnTerminalRecorder({
     sessionRepository: dependencies.sessionRepository,


### PR DESCRIPTION
## Summary
- add bounded 5s/20s backoff between safe zero-evidence retries
- retain fail-closed behavior after any provider response
- test exact retry timing

## Verification
- `pnpm run verify:workspace:tracked intex-agent` (1813 tests)
- `pnpm run ci:tracked` (6898 tests)
- independent security review: no findings

## Linear
Linear: omitted by `$commit-push`; GitHub automation will create or link the Linear issue after PR creation.
