### PR TITLE
[INT-1924] Preserve MiniMax judge quorum evidence

### DIFF
--- a/apps/intex-agent/src/routes/matrixCorpusRoutes.ts
+++ b/apps/intex-agent/src/routes/matrixCorpusRoutes.ts
@@ -689,8 +689,8 @@ const safeUsageJsonSchema = closedJsonObject(
   ['logicalCalls', 'repairCount', 'inputTokens', 'outputTokens', 'totalTokens', 'costNanoUsd'],
   ['logicalCalls', 'repairCount', 'inputTokens', 'outputTokens', 'totalTokens', 'costNanoUsd'],
   {
-    logicalCalls: { type: 'integer', enum: [1] },
-    repairCount: { type: 'integer', enum: [0, 1] },
+    logicalCalls: { type: 'integer', minimum: 1, maximum: 3 },
+    repairCount: { type: 'integer', minimum: 0, maximum: 3 },
     inputTokens: safeIntegerJsonSchema,
     outputTokens: safeIntegerJsonSchema,
     totalTokens: safeIntegerJsonSchema,

--- a/packages/http-contracts/src/__tests__/intexAgentTestRuns.test.ts
+++ b/packages/http-contracts/src/__tests__/intexAgentTestRuns.test.ts
@@ -471,6 +471,39 @@ describe('Intex Agent Test Runs public contracts', () => {
       },
     };
     expect(safeReplyEvaluationV1Schema.safeParse(evaluation).success).toBe(true);
+    expect(
+      safeReplyEvaluationV1Schema.safeParse({
+        ...evaluation,
+        usage: { ...evaluation.usage, logicalCalls: 3, repairCount: 3 },
+      }).success
+    ).toBe(true);
+    const failedEvaluation = {
+      ...evaluation,
+      verdict: 'failed' as const,
+      score: 2 as const,
+      criteria: { ...evaluation.criteria, helpful: false },
+      failureCodes: ['helpful' as const],
+      usage: { ...evaluation.usage, logicalCalls: 2, repairCount: 1 },
+    };
+    expect(safeReplyEvaluationV1Schema.safeParse(failedEvaluation).success).toBe(true);
+    expect(
+      safeReplyEvaluationV1Schema.safeParse({
+        ...evaluation,
+        usage: { ...evaluation.usage, logicalCalls: 2 },
+      }).success
+    ).toBe(false);
+    expect(
+      safeReplyEvaluationV1Schema.safeParse({
+        ...failedEvaluation,
+        usage: { ...failedEvaluation.usage, logicalCalls: 1, repairCount: 0 },
+      }).success
+    ).toBe(false);
+    expect(
+      safeReplyEvaluationV1Schema.safeParse({
+        ...evaluation,
+        usage: { ...evaluation.usage, repairCount: 2 },
+      }).success
+    ).toBe(false);
     expect(safeReplyEvaluationV1Schema.safeParse({ ...evaluation, turnIndex: 20 }).success).toBe(
       false
     );
@@ -769,6 +802,7 @@ describe('Intex Agent Test Runs public contracts', () => {
       score: 1 as const,
       criteria: { ...passed.criteria, helpful: false },
       failureCodes: ['helpful' as const],
+      usage: { ...passed.usage, logicalCalls: 2 as const },
     };
 
     expect(safeReplyEvaluationV1Schema.safeParse(passed).success).toBe(true);

--- a/packages/http-contracts/src/intexAgentTestRuns.ts
+++ b/packages/http-contracts/src/intexAgentTestRuns.ts
@@ -545,8 +545,8 @@ const minimaxCriteriaSchema = z
   .strict();
 const usageTokensSchema = z
   .object({
-    logicalCalls: z.literal(1),
-    repairCount: z.union([z.literal(0), z.literal(1)]),
+    logicalCalls: positiveSafeIntegerSchema.max(3),
+    repairCount: safeIntegerSchema.max(3),
     inputTokens: safeIntegerSchema,
     outputTokens: safeIntegerSchema,
     totalTokens: safeIntegerSchema,
@@ -581,6 +581,16 @@ export const safeReplyEvaluationV1Schema = z
       context.addIssue({
         code: z.ZodIssueCode.custom,
         message: 'MiniMax verdict, criteria, and failure codes must agree',
+      });
+    const decisionCallsMatchVerdict =
+      evaluation.verdict === 'passed'
+        ? evaluation.usage.logicalCalls === 1 || evaluation.usage.logicalCalls === 3
+        : evaluation.usage.logicalCalls === 2 || evaluation.usage.logicalCalls === 3;
+    if (!decisionCallsMatchVerdict || evaluation.usage.repairCount > evaluation.usage.logicalCalls)
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['usage'],
+        message: 'MiniMax quorum calls and repairs must agree with the verdict',
       });
   });
 export type SafeReplyEvaluationV1 = z.infer<typeof safeReplyEvaluationV1Schema>;

--- a/tools/intex-agent-evals/src/__tests__/fixtures/matrixCorpusCompositionHarness.ts
+++ b/tools/intex-agent-evals/src/__tests__/fixtures/matrixCorpusCompositionHarness.ts
@@ -16,6 +16,7 @@ import {
   safeToolFactV1Schema,
   type MatrixCorpusSignedControlMutationV1,
   type SafeDeterministicCheckV1,
+  type SafeReplyEvaluationV1,
   type SafeToolFactV1,
 } from '@intexuraos/http-contracts';
 
@@ -128,6 +129,7 @@ export interface MatrixCorpusCompositionMetrics {
   readonly scenarioProjectionSessions: string[];
   readonly scenarioProjectionEventWatermarks: number[];
   readonly scenarioProjectionDeterministicChecks: SafeDeterministicCheckV1[][];
+  readonly scenarioProjectionReplyEvaluations: SafeReplyEvaluationV1[][];
   readonly judgeAssistantTexts: string[];
   transportReadinessChecks: number;
   artifactDeliveryStatus: 'pending' | 'staged' | 'ready' | 'failed';
@@ -180,6 +182,7 @@ export async function createPassingMatrixCorpusCompositionHarness(
     scenarioProjectionSessions: [],
     scenarioProjectionEventWatermarks: [],
     scenarioProjectionDeterministicChecks: [],
+    scenarioProjectionReplyEvaluations: [],
     judgeAssistantTexts: [],
     transportReadinessChecks: 0,
     artifactDeliveryStatus: 'pending',
@@ -570,6 +573,9 @@ function createIntexBoundary(state: SharedState): IntexAgentServiceClient {
           state.metrics.scenarioProjectionDeterministicChecks.push(
             structuredClone(projection['deterministicChecks'] as SafeDeterministicCheckV1[])
           );
+          state.metrics.scenarioProjectionReplyEvaluations.push(
+            structuredClone(projection['replyEvaluations'] as SafeReplyEvaluationV1[])
+          );
           state.lifecycle = 'running';
         }
       }
@@ -821,6 +827,16 @@ function createMiniMaxBoundary(state: SharedState): MiniMaxEvaluator {
           },
         };
       }
+      const decisionCalls = inputs.reduce((total, input) => {
+        const entry = findEntry(state.catalog, input.scenarioId);
+        return total + (entry.scenarioNumber === state.failMiniMaxScenarioNumber ? 2 : 1);
+      }, 0);
+      const repairCount = inputs.filter(
+        (input) =>
+          findEntry(state.catalog, input.scenarioId).scenarioNumber ===
+          state.failMiniMaxScenarioNumber
+      ).length;
+      const providerCalls = decisionCalls + repairCount;
       return {
         ok: true,
         verdicts: inputs.map((input) => {
@@ -846,12 +862,12 @@ function createMiniMaxBoundary(state: SharedState): MiniMaxEvaluator {
           };
         }),
         usage: {
-          logicalCalls: inputs.length,
-          repairCount: 0,
-          inputTokens: inputs.length * 10,
-          outputTokens: inputs.length * 5,
-          totalTokens: inputs.length * 15,
-          providerReportedUsd: inputs.length * 0.000001,
+          logicalCalls: providerCalls,
+          repairCount,
+          inputTokens: providerCalls * 10,
+          outputTokens: providerCalls * 5,
+          totalTokens: providerCalls * 15,
+          providerReportedUsd: providerCalls * 0.000001,
           providerReportedUsdComplete: true,
         },
       };

--- a/tools/intex-agent-evals/src/__tests__/matrixCorpusComposition.test.ts
+++ b/tools/intex-agent-evals/src/__tests__/matrixCorpusComposition.test.ts
@@ -495,6 +495,16 @@ describe('production Matrix corpus composition', () => {
     expect(result.run.scenarios.slice(1).every((scenario) => scenario.status === 'passed')).toBe(
       true
     );
+    expect(
+      harness.metrics.scenarioProjectionReplyEvaluations
+        .flat()
+        .some(
+          (evaluation) =>
+            evaluation.verdict === 'failed' &&
+            evaluation.usage.logicalCalls === 2 &&
+            evaluation.usage.repairCount === 1
+        )
+    ).toBe(true);
   });
 
   it('publishes a valid stopped report when MiniMax infrastructure fails after a completed turn', async () => {
@@ -535,7 +545,7 @@ describe('production Matrix corpus composition', () => {
         totals: {
           completedTurns: 25,
           judgedReplies: 24,
-          evaluatorCostNanoUsd: 26_000,
+          evaluatorCostNanoUsd: 32_000,
         },
       },
     });
@@ -580,12 +590,12 @@ describe('production Matrix corpus composition', () => {
       },
     });
     expect(report.usage.evaluator).toEqual({
-      logicalCalls: 25,
-      repairCount: 1,
-      inputTokens: 260,
-      outputTokens: 130,
-      totalTokens: 390,
-      costNanoUsd: 26_000,
+      logicalCalls: 28,
+      repairCount: 4,
+      inputTokens: 320,
+      outputTokens: 160,
+      totalTokens: 480,
+      costNanoUsd: 32_000,
       costComplete: true,
     });
   });

--- a/tools/intex-agent-evals/src/__tests__/matrixCorpusReport.test.ts
+++ b/tools/intex-agent-evals/src/__tests__/matrixCorpusReport.test.ts
@@ -546,6 +546,99 @@ describe('matrix corpus artifact lifecycle', () => {
     expect(MatrixCorpusReportV1Schema.safeParse(contradictory).success).toBe(false);
   });
 
+  it('accepts bounded MiniMax quorum votes in complete passing evidence', () => {
+    const valid = report('ready');
+    const withQuorum = {
+      ...valid,
+      usage: {
+        ...valid.usage,
+        evaluator: usage(61),
+        totalCostNanoUsd: 80,
+      },
+      scenarios: valid.scenarios.map((scenario, offset) =>
+        offset === 0
+          ? {
+              ...scenario,
+              judge: {
+                ...scenario.judge,
+                usage: usage(4),
+              },
+            }
+          : scenario
+      ),
+    };
+
+    expect(MatrixCorpusReportV1Schema.safeParse(withQuorum).success).toBe(true);
+    expect(
+      MatrixCorpusReportV1Schema.safeParse({
+        ...withQuorum,
+        usage: {
+          ...withQuorum.usage,
+          evaluator: usage(64),
+          totalCostNanoUsd: 83,
+        },
+        scenarios: withQuorum.scenarios.map((scenario, offset) =>
+          offset === 0
+            ? {
+                ...scenario,
+                judge: {
+                  ...scenario.judge,
+                  usage: usage(7),
+                },
+              }
+            : scenario
+        ),
+      }).success
+    ).toBe(false);
+    expect(
+      MatrixCorpusReportV1Schema.safeParse({
+        ...withQuorum,
+        usage: {
+          ...withQuorum.usage,
+          evaluator: usage(60),
+          totalCostNanoUsd: 79,
+        },
+        scenarios: withQuorum.scenarios.map((scenario, offset) =>
+          offset === 0
+            ? {
+                ...scenario,
+                judge: {
+                  ...scenario.judge,
+                  usage: usage(3),
+                },
+              }
+            : scenario
+        ),
+      }).success
+    ).toBe(false);
+    expect(
+      MatrixCorpusReportV1Schema.safeParse({
+        ...withQuorum,
+        usage: {
+          ...withQuorum.usage,
+          evaluator: {
+            ...withQuorum.usage.evaluator,
+            repairCount: 5,
+          },
+        },
+        scenarios: withQuorum.scenarios.map((scenario, offset) =>
+          offset === 0
+            ? {
+                ...scenario,
+                judge: {
+                  ...scenario.judge,
+                  usage: {
+                    ...scenario.judge.usage,
+                    repairCount: 5,
+                  },
+                },
+              }
+            : scenario
+        ),
+      }).success
+    ).toBe(false);
+  });
+
   it('rejects PASS with reused sessions, empty MiniMax evidence, failed ready cleanup, or a forged tool schedule', () => {
     const valid = report('ready');
     expect(

--- a/tools/intex-agent-evals/src/__tests__/matrixCorpusRunner.test.ts
+++ b/tools/intex-agent-evals/src/__tests__/matrixCorpusRunner.test.ts
@@ -690,7 +690,7 @@ describe('sequential Matrix corpus state machine', () => {
       pass: true,
       model: 'or:minimax/minimax-m3',
       usage: {
-        logicalCalls: 2,
+        logicalCalls: 4,
         repairCount: 0,
         inputTokens: 1,
         outputTokens: 1,
@@ -747,6 +747,83 @@ describe('sequential Matrix corpus state machine', () => {
     expect(result.failureCodes).not.toContain('judge_evidence_mismatch');
     expect(result.scenarios.every(({ status }) => status === 'passed')).toBe(true);
   });
+
+  it.each([
+    ['two-vote negative quorum', false, 2, 0, 1],
+    ['three-vote positive tie breaker', true, 3, 0, 0],
+    ['two-vote negative quorum with one repaired response', false, 3, 1, 1],
+    ['three-vote positive tie breaker with three repaired responses', true, 6, 3, 0],
+  ] as const)(
+    'accepts MiniMax %s as valid judge evidence',
+    async (_label, pass, logicalCalls, repairCount, expectedExitCode) => {
+      const catalog = await loadCanonicalMatrixCorpus(scenariosDirectory);
+      const ports = passingPorts([]);
+      vi.mocked(ports.judgeReply).mockResolvedValue({
+        ok: true,
+        pass,
+        model: 'or:minimax/minimax-m3',
+        usage: {
+          logicalCalls,
+          repairCount,
+          inputTokens: logicalCalls,
+          outputTokens: logicalCalls,
+          totalTokens: logicalCalls * 2,
+          costNanoUsd: logicalCalls,
+        },
+      });
+
+      const result = await runMatrixCorpus(
+        {
+          runId: `run_judge_quorum_${String(logicalCalls)}_${String(repairCount)}`,
+          catalog,
+        },
+        ports
+      );
+
+      expect(result.exitCode).toBe(expectedExitCode);
+      expect(result.failureCodes).not.toContain('judge_evidence_mismatch');
+      expect(result.scenarios.every(({ status }) => status === (pass ? 'passed' : 'failed'))).toBe(
+        true
+      );
+    }
+  );
+
+  it.each([
+    ['a passing verdict after two decision votes', true, 2, 0],
+    ['four decision votes', true, 4, 0],
+    ['more repairs than decision votes', true, 3, 2],
+    ['zero decision votes', true, 0, 0],
+  ] as const)(
+    'rejects MiniMax evidence with %s',
+    async (_label, pass, logicalCalls, repairCount) => {
+      const catalog = await loadCanonicalMatrixCorpus(scenariosDirectory);
+      const ports = passingPorts([]);
+      vi.mocked(ports.judgeReply).mockResolvedValue({
+        ok: true,
+        pass,
+        model: 'or:minimax/minimax-m3',
+        usage: {
+          logicalCalls,
+          repairCount,
+          inputTokens: 1,
+          outputTokens: 1,
+          totalTokens: 2,
+          costNanoUsd: 1,
+        },
+      });
+
+      const result = await runMatrixCorpus(
+        {
+          runId: `run_invalid_judge_evidence_${String(logicalCalls)}_${String(repairCount)}`,
+          catalog,
+        },
+        ports
+      );
+
+      expect(result.exitCode).toBe(2);
+      expect(result.failureCodes).toContain('judge_evidence_mismatch');
+    }
+  );
 
   it('rejects reuse of one created session across two scenarios before judging the second', async () => {
     const catalog = await loadCanonicalMatrixCorpus(scenariosDirectory);

--- a/tools/intex-agent-evals/src/matrixCorpus/liveExecution.ts
+++ b/tools/intex-agent-evals/src/matrixCorpus/liveExecution.ts
@@ -437,6 +437,7 @@ function createRunPorts(input: {
         return { ok: false, code: 'MINIMAX_JUDGE_USAGE_INVALID' };
       const safeEvaluation = toSafeReplyEvaluation(
         { ...verdict, score: verdict.score },
+        result.usage.logicalCalls,
         result.usage.repairCount,
         result.usage.inputTokens,
         result.usage.outputTokens,
@@ -2191,6 +2192,7 @@ function toSafeReplyEvaluation(
     score: 1 | 2 | 3 | 4 | 5;
     criteria: SafeReplyEvaluationV1['criteria'];
   },
+  logicalCalls: number,
   repairCount: number,
   inputTokens: number,
   outputTokens: number,
@@ -2207,6 +2209,7 @@ function toSafeReplyEvaluation(
       'noPassiveAggression',
     ] as const
   ).filter((criterion) => !verdict.criteria[criterion]);
+  const decisionCalls = logicalCalls - repairCount;
   return {
     turnIndex: verdict.turnIndex,
     replyIndex: verdict.replyIndex + 1,
@@ -2216,8 +2219,8 @@ function toSafeReplyEvaluation(
     failureCodes,
     latencyMs,
     usage: {
-      logicalCalls: 1,
-      repairCount: repairCount === 0 ? 0 : 1,
+      logicalCalls: decisionCalls,
+      repairCount,
       inputTokens,
       outputTokens,
       totalTokens,

--- a/tools/intex-agent-evals/src/matrixCorpus/reportSchema.ts
+++ b/tools/intex-agent-evals/src/matrixCorpus/reportSchema.ts
@@ -427,7 +427,10 @@ export const MatrixCorpusReportV1Schema = z
         report.usage.agent.totalTokens > 0 &&
         report.usage.agent.costComplete &&
         report.usage.agent.costNanoUsd !== null &&
-        report.usage.evaluator.logicalCalls === 59 &&
+        report.usage.evaluator.logicalCalls >= 59 &&
+        report.usage.evaluator.logicalCalls <= 59 * 3 &&
+        (report.usage.evaluator.logicalCalls - 59) % 2 === 0 &&
+        report.usage.evaluator.repairCount <= report.usage.evaluator.logicalCalls &&
         report.usage.evaluator.totalTokens > 0 &&
         report.usage.evaluator.costComplete &&
         report.usage.evaluator.costNanoUsd !== null &&
@@ -458,7 +461,10 @@ export const MatrixCorpusReportV1Schema = z
             entry.judge.passed === true &&
             entry.judge.criteriaPassed > 0 &&
             entry.judge.criteriaFailed === 0 &&
-            entry.judge.usage.logicalCalls === entry.plannedTurns &&
+            entry.judge.usage.logicalCalls >= entry.plannedTurns &&
+            entry.judge.usage.logicalCalls <= entry.plannedTurns * 3 &&
+            (entry.judge.usage.logicalCalls - entry.plannedTurns) % 2 === 0 &&
+            entry.judge.usage.repairCount <= entry.judge.usage.logicalCalls &&
             entry.judge.usage.totalTokens > 0 &&
             entry.judge.usage.costComplete &&
             entry.judge.usage.costNanoUsd !== null &&

--- a/tools/intex-agent-evals/src/matrixCorpus/runMatrixCorpus.ts
+++ b/tools/intex-agent-evals/src/matrixCorpus/runMatrixCorpus.ts
@@ -416,7 +416,7 @@ export async function runMatrixCorpus(
         if (
           !judged.ok ||
           judged.model !== input.catalog.evaluatorModel ||
-          !validJudgeUsage(judged.usage)
+          !validJudgeUsage(judged.usage, judged.pass)
         ) {
           if (!judged.ok && judged.usage !== undefined && validJudgeUsage(judged.usage)) {
             evaluatorCostNanoUsd += judged.usage.costNanoUsd;
@@ -927,10 +927,21 @@ function validUsage(usage: MatrixCorpusTurnObservation['agentUsage']): boolean {
   );
 }
 
-function validJudgeUsage(usage: MatrixCorpusJudgeUsage): boolean {
+function validJudgeUsage(usage: MatrixCorpusJudgeUsage, pass?: boolean): boolean {
+  const decisionCalls = usage.logicalCalls - usage.repairCount;
+  const verdictCallsValid =
+    pass === undefined ||
+    (pass
+      ? decisionCalls === 1 || decisionCalls === 3
+      : decisionCalls === 2 || decisionCalls === 3);
   return (
-    usage.logicalCalls === usage.repairCount + 1 &&
-    (usage.repairCount === 0 || usage.repairCount === 1) &&
+    Number.isSafeInteger(usage.logicalCalls) &&
+    Number.isSafeInteger(usage.repairCount) &&
+    decisionCalls >= 1 &&
+    decisionCalls <= 3 &&
+    usage.repairCount >= 0 &&
+    usage.repairCount <= decisionCalls &&
+    verdictCallsValid &&
     validTokenUsage(usage) &&
     Number.isSafeInteger(usage.costNanoUsd) &&
     usage.costNanoUsd >= 0


### PR DESCRIPTION
## Summary
- accept the MiniMax negative-verdict 2-of-3 quorum as valid evaluator evidence
- bind persisted vote counts and repairs to the final pass/fail verdict
- keep complete reports fail-closed on impossible vote ranges, parity, or repair counts

## Verification
- `pnpm run verify:workspace:tracked http-contracts` (136 tests, 100% coverage)
- `pnpm run verify:workspace:tracked intex-agent` (1813 tests)
- `pnpm --filter @intexuraos/intex-agent-evals validate` (996 tests)
- `pnpm run ci:tracked` (6898 tests)
- independent security review: no findings

## Production evidence
- run `eval-9325ed65-b83d-46f7-a5d5-c162ea0fd8ce`
- scenarios 001 and 002 passed
- scenario 003 produced a valid three-vote negative quorum that the runner incorrectly classified as infrastructure failure

## Linear
Linear: omitted by `$commit-push`; GitHub automation will create or link the Linear issue after PR creation.
