### PR TITLE
[INT-1925] Fix Matrix corpus retention backlog

### DIFF
--- a/apps/whatsapp-service/src/__tests__/domain/matrixCorpus/controlPlane.test.ts
+++ b/apps/whatsapp-service/src/__tests__/domain/matrixCorpus/controlPlane.test.ts
@@ -1610,6 +1610,45 @@ describe('Matrix corpus A2 frozen contracts', () => {
       drain: { ...lease.drain, drained: false },
     };
     expect(matrixCorpusLeaseV1Schema.safeParse({ ...provisioningLease, finalCleanupReceipt }).success).toBe(true);
+    const priorFinalCleanupReceipt = {
+      ...finalCleanupReceipt,
+      idempotencyKeyDigest: 'c'.repeat(64),
+      canonicalRequestDigest: 'd'.repeat(64),
+      replayProjection: {
+        ...finalCleanupReceipt.replayProjection,
+        targetRunId: 'old_run_2',
+        targetLeaseFence: '3',
+        targetRunFenceDigest: 'e'.repeat(64),
+      },
+    };
+    expect(
+      matrixCorpusLeaseV1Schema.safeParse({
+        ...provisioningLease,
+        priorFinalCleanupReceipts: [priorFinalCleanupReceipt],
+        finalCleanupReceipt,
+      }).success
+    ).toBe(true);
+    expect(
+      matrixCorpusLeaseV1Schema.safeParse({
+        ...provisioningLease,
+        priorFinalCleanupReceipts: [finalCleanupReceipt],
+        finalCleanupReceipt,
+      }).success
+    ).toBe(false);
+    expect(
+      matrixCorpusLeaseV1Schema.safeParse({
+        ...provisioningLease,
+        priorFinalCleanupReceipts: [priorFinalCleanupReceipt],
+        finalCleanupReceipt: null,
+      }).success
+    ).toBe(false);
+    expect(
+      matrixCorpusLeaseV1Schema.safeParse({
+        ...lease,
+        priorFinalCleanupReceipts: [priorFinalCleanupReceipt],
+        finalCleanupReceipt,
+      }).success
+    ).toBe(false);
     expect(
       matrixCorpusLeaseV1Schema.safeParse({
         ...provisioningLease,
@@ -6943,6 +6982,7 @@ describe('FakeMatrixCorpusRepository A2 fake core', () => {
       terminalControlOutboxIds: [...lease.terminalControlOutboxIds],
       terminalWinner: lease.terminalWinner,
       cleanupProgress: lease.cleanupProgress,
+      priorFinalCleanupReceipts: lease.priorFinalCleanupReceipts ?? [],
       finalCleanupReceipt: lease.finalCleanupReceipt,
       drain: lease.drain,
     };
@@ -10708,6 +10748,145 @@ describe('FakeMatrixCorpusRepository A2 fake core', () => {
     });
     expect(digestCalls).toBe(3);
     expect(repository.operationCounts('cleanup')).toEqual({ invocations: 4, commits: 1 });
+  });
+
+  it('A2 cleanup preserves and exposes receipts while reconciling sequential terminal targets', async () => {
+    const repository = new FakeMatrixCorpusRepository({
+      replayProjectionDigest: { digest: () => digest },
+    });
+    const first = cleanupTerminalFixture();
+    const acquireReceipt = first.target.operationReceipts.acquire;
+    const activateReceipt = first.target.operationReceipts.activate;
+    const quiesceReceipt = first.target.operationReceipts.quiesce;
+    const releaseReceipt = first.target.operationReceipts.release;
+    const terminalWinner = first.target.terminalWinner;
+    if (
+      acquireReceipt === null ||
+      acquireReceipt.replayProjection.operation !== 'acquire' ||
+      activateReceipt === null ||
+      activateReceipt.replayProjection.operation !== 'activate' ||
+      quiesceReceipt === null ||
+      quiesceReceipt.replayProjection.operation !== 'quiesce' ||
+      releaseReceipt === null ||
+      releaseReceipt.replayProjection.operation !== 'release' ||
+      terminalWinner?.kind !== 'release'
+    )
+      throw new Error('terminal cleanup fixture requires complete lifecycle receipts');
+    const secondRunId = 'run_10';
+    const secondLeaseFence = '3';
+    const secondRunFenceDigest = 'd'.repeat(64);
+    const secondTerminalControlId = 'event_2';
+    const secondTarget = {
+      ...first.target,
+      runId: secondRunId,
+      leaseFence: secondLeaseFence,
+      fenceEpoch: secondLeaseFence,
+      runFenceDigest: secondRunFenceDigest,
+      operationReceipts: {
+        acquire: {
+          ...acquireReceipt,
+          replayProjection: {
+            ...acquireReceipt.replayProjection,
+            runId: secondRunId,
+            leaseFence: secondLeaseFence,
+          },
+        },
+        activate: {
+          ...activateReceipt,
+          replayProjection: {
+            ...activateReceipt.replayProjection,
+            runId: secondRunId,
+            leaseFence: secondLeaseFence,
+          },
+        },
+        quiesce: {
+          ...quiesceReceipt,
+          replayProjection: {
+            ...quiesceReceipt.replayProjection,
+            runId: secondRunId,
+            leaseFence: secondLeaseFence,
+          },
+        },
+        release: {
+          ...releaseReceipt,
+          replayProjection: {
+            ...releaseReceipt.replayProjection,
+            runId: secondRunId,
+            leaseFence: secondLeaseFence,
+            terminalControlId: secondTerminalControlId,
+            eventId: secondTerminalControlId,
+          },
+        },
+      },
+      terminalControlOutboxIds: [secondTerminalControlId],
+      terminalWinner: {
+        ...terminalWinner,
+        eventId: secondTerminalControlId,
+      },
+    } satisfies MatrixCorpusLeaseHistoryV1;
+    const secondTerminal = {
+      ...first.terminal,
+      terminalControlId: secondTerminalControlId,
+      eventId: secondTerminalControlId,
+      runId: secondRunId,
+      leaseFence: secondLeaseFence,
+      payload: {
+        ...first.terminal.payload,
+        eventId: secondTerminalControlId,
+        runId: secondRunId,
+        leaseFence: secondLeaseFence,
+      },
+    } satisfies MatrixCorpusTerminalControlOutboxRecordV1;
+    repository.seedValidCleanupOutboxState({
+      ...first.seed,
+      retainedHistories: [first.target, secondTarget],
+      terminalControlOutboxes: [first.terminal, secondTerminal],
+    });
+    const secondCommand = {
+      ...first.command,
+      targetRunId: secondTarget.runId,
+      targetLeaseFence: secondTarget.leaseFence,
+      targetRunFenceDigest: secondTarget.runFenceDigest,
+      idempotencyKeyDigest: '6'.repeat(64),
+      canonicalRequestDigest: '7'.repeat(64),
+      now: '2026-07-20T00:00:07.000Z',
+    } satisfies CleanupExactRunCommand;
+
+    await expect(repository.cleanupExactRun(first.command)).resolves.toMatchObject({
+      code: 'RUN_CLEANED',
+      finalRevision: 1,
+    });
+    await expect(repository.cleanupExactRun(secondCommand)).resolves.toMatchObject({
+      code: 'RUN_CLEANED',
+      finalRevision: 1,
+    });
+    await expect(repository.cleanupExactRun(first.command)).resolves.toMatchObject({
+      code: 'ALREADY_APPLIED',
+      operation: 'cleanup',
+      result: 'cleaned',
+      targetRunFenceDigest: first.target.runFenceDigest,
+    });
+    await expect(repository.cleanupExactRun(secondCommand)).resolves.toMatchObject({
+      code: 'ALREADY_APPLIED',
+      operation: 'cleanup',
+      result: 'cleaned',
+      targetRunFenceDigest: secondTarget.runFenceDigest,
+    });
+    expect(repository.safeStateSummary().current[0]?.lease).toMatchObject({
+      priorFinalCleanupReceipts: [
+        {
+          replayProjection: {
+            targetRunFenceDigest: first.target.runFenceDigest,
+          },
+        },
+      ],
+      finalCleanupReceipt: {
+        replayProjection: {
+          targetRunFenceDigest: secondTarget.runFenceDigest,
+        },
+      },
+    });
+    expect(repository.operationCounts('cleanup')).toEqual({ invocations: 4, commits: 2 });
   });
 
   it('A2 cleanup gives the current non-provisioning phase precedence over a missing target', async () => {

--- a/apps/whatsapp-service/src/__tests__/domain/matrixCorpus/fakes.ts
+++ b/apps/whatsapp-service/src/__tests__/domain/matrixCorpus/fakes.ts
@@ -276,6 +276,7 @@ export interface FakeMatrixCorpusCoreLeaseSummary {
   readonly terminalControlOutboxIds: readonly string[];
   readonly terminalWinner: MatrixCorpusTerminalAuthoritativeWinnerV1 | null;
   readonly cleanupProgress: MatrixCorpusCleanupProgressV1 | null;
+  readonly priorFinalCleanupReceipts: readonly MatrixCorpusCleanupChunkReceiptV1[];
   readonly finalCleanupReceipt: MatrixCorpusCleanupChunkReceiptV1 | null;
   readonly drain: Readonly<{
     consumedCapabilityCount: number;
@@ -562,6 +563,7 @@ function leaseSummary(lease: MatrixCorpusLeaseV1): FakeMatrixCorpusCoreLeaseSumm
     terminalControlOutboxIds: [...lease.terminalControlOutboxIds],
     terminalWinner: structuredClone(lease.terminalWinner),
     cleanupProgress: structuredClone(lease.cleanupProgress),
+    priorFinalCleanupReceipts: structuredClone(lease.priorFinalCleanupReceipts ?? []),
     finalCleanupReceipt: structuredClone(lease.finalCleanupReceipt),
     drain: lease.drain,
   };
@@ -1623,8 +1625,13 @@ export class FakeMatrixCorpusRepository implements MatrixCorpusRepository {
       }
     }
 
-    const finalReceipt = currentPair.data.current.finalCleanupReceipt;
-    if (finalReceipt !== null) {
+    const finalReceipts = [
+      ...(currentPair.data.current.priorFinalCleanupReceipts ?? []),
+      ...(currentPair.data.current.finalCleanupReceipt === null
+        ? []
+        : [currentPair.data.current.finalCleanupReceipt]),
+    ];
+    for (const finalReceipt of finalReceipts) {
       const projection = finalReceipt.replayProjection;
       if (
         projection.operation !== 'cleanup' ||
@@ -1761,6 +1768,7 @@ export class FakeMatrixCorpusRepository implements MatrixCorpusRepository {
         },
         terminalWinner: null,
         cleanupProgress: null,
+        priorFinalCleanupReceipts: [],
         finalCleanupReceipt: null,
       } satisfies MatrixCorpusLeaseV1;
       const pair = this.buildCurrentPair(command.data.leaseSlotDigest, lease);
@@ -1867,6 +1875,7 @@ export class FakeMatrixCorpusRepository implements MatrixCorpusRepository {
         phase: 'active' as const,
         activatedAt: command.data.now,
         operationReceipts: { ...lease.operationReceipts, activate: receipt.data },
+        priorFinalCleanupReceipts: [],
         finalCleanupReceipt: null,
       } satisfies MatrixCorpusLeaseV1;
       const pair = this.buildCurrentPair(command.data.leaseSlotDigest, updated);
@@ -3060,6 +3069,7 @@ export class FakeMatrixCorpusRepository implements MatrixCorpusRepository {
         terminalWinner: null,
         releasedAt: null,
         abandonedAt: null,
+        priorFinalCleanupReceipts: [],
         finalCleanupReceipt: lease.phase === 'provisioning' ? null : lease.finalCleanupReceipt,
         drain: { ...lease.drain, drained: false },
       } satisfies MatrixCorpusLeaseV1;
@@ -3151,8 +3161,27 @@ export class FakeMatrixCorpusRepository implements MatrixCorpusRepository {
       )
         return { kind: 'read_only', result: { code: 'STALE_FENCE' } };
 
-      const finalReceipt = lease.finalCleanupReceipt;
-      if (finalReceipt !== null) {
+      const finalReceipts = [
+        ...(lease.priorFinalCleanupReceipts ?? []),
+        ...(lease.finalCleanupReceipt === null ? [] : [lease.finalCleanupReceipt]),
+      ];
+      const finalReplayReceipt = finalReceipts.find((receipt) => {
+        const projection = receipt.replayProjection;
+        return (
+          projection.operation === 'cleanup' &&
+          projection.result === 'cleaned' &&
+          projection.targetRunFenceDigest === command.data.targetRunFenceDigest
+        );
+      });
+      if (
+        finalReplayReceipt !== undefined &&
+        finalReplayReceipt.idempotencyKeyDigest !== command.data.idempotencyKeyDigest
+      )
+        return {
+          kind: 'read_only',
+          result: { code: 'PHASE_CONFLICT', actualPhase: lease.phase },
+        };
+      for (const finalReceipt of finalReceipts) {
         const parsed = matrixCorpusCleanupChunkReceiptV1Schema.safeParse(finalReceipt);
         if (
           !parsed.success ||
@@ -3160,8 +3189,6 @@ export class FakeMatrixCorpusRepository implements MatrixCorpusRepository {
           parsed.data.replayProjection.result !== 'cleaned'
         )
           return { kind: 'read_only', result: { code: 'CORRUPT_STATE', recordKind: 'cleanup_progress' } };
-        if (parsed.data.idempotencyKeyDigest !== command.data.idempotencyKeyDigest)
-          return { kind: 'read_only', result: { code: 'PHASE_CONFLICT', actualPhase: lease.phase } };
         const storedDigest = this.digestProjection(parsed.data.replayProjection);
         if (storedDigest === null || storedDigest !== parsed.data.resultDigest)
           return {
@@ -3170,6 +3197,18 @@ export class FakeMatrixCorpusRepository implements MatrixCorpusRepository {
               code: 'CORRUPT_STATE',
               recordKind: storedDigest === null ? 'dependency_result' : 'cleanup_progress',
             },
+          };
+      }
+      if (finalReplayReceipt !== undefined) {
+        const parsed = matrixCorpusCleanupChunkReceiptV1Schema.safeParse(finalReplayReceipt);
+        if (
+          !parsed.success ||
+          parsed.data.replayProjection.operation !== 'cleanup' ||
+          parsed.data.replayProjection.result !== 'cleaned'
+        )
+          return {
+            kind: 'read_only',
+            result: { code: 'CORRUPT_STATE', recordKind: 'cleanup_progress' },
           };
         const projection = parsed.data.replayProjection;
         if (
@@ -3194,6 +3233,17 @@ export class FakeMatrixCorpusRepository implements MatrixCorpusRepository {
           ? { kind: 'read_only', result: replay.data }
           : { kind: 'read_only', result: { code: 'CORRUPT_STATE', recordKind: 'repository_result' } };
       }
+      if (
+        finalReceipts.some(
+          (receipt) => receipt.idempotencyKeyDigest === command.data.idempotencyKeyDigest
+        )
+      )
+        return { kind: 'read_only', result: { code: 'IDEMPOTENCY_CONFLICT' } };
+      if (finalReceipts.length >= 3)
+        return {
+          kind: 'read_only',
+          result: { code: 'PHASE_CONFLICT', actualPhase: lease.phase },
+        };
       if (lease.phase !== 'provisioning')
         return { kind: 'read_only', result: { code: 'PHASE_CONFLICT', actualPhase: lease.phase } };
 
@@ -3435,6 +3485,10 @@ export class FakeMatrixCorpusRepository implements MatrixCorpusRepository {
       this.throwAt('cleanup_after_child_deletes_draft');
       const pair = this.buildCurrentPair(command.data.leaseSlotDigest, {
         ...lease,
+        priorFinalCleanupReceipts: [
+          ...(lease.priorFinalCleanupReceipts ?? []),
+          ...(lease.finalCleanupReceipt === null ? [] : [lease.finalCleanupReceipt]),
+        ],
         finalCleanupReceipt: receipt.data,
       });
       if (pair === null)

--- a/apps/whatsapp-service/src/__tests__/infra/firestore/matrixCorpusRepository.test.ts
+++ b/apps/whatsapp-service/src/__tests__/infra/firestore/matrixCorpusRepository.test.ts
@@ -1308,7 +1308,7 @@ function transportStatusLifecycleCommand() {
   };
 }
 
-async function cleanupFixture(renewReceiptCount = 1) {
+async function cleanupFixture(renewReceiptCount = 1, includeSecondTarget = false) {
   const fakeFirestore = createFakeFirestore();
   fakeFirestore.clear();
   const firestore = fakeFirestore as unknown as Firestore;
@@ -1353,12 +1353,64 @@ async function cleanupFixture(renewReceiptCount = 1) {
     status: 'published' as const,
     acknowledgedAt: timestamp,
   };
+  const secondRunFenceDigest = '2'.repeat(64);
+  const secondTerminalControlId = 'terminal_cleanup_2';
+  const secondTarget = {
+    ...target,
+    runId: 'run_2',
+    runFenceDigest: secondRunFenceDigest,
+    leaseFence: '6',
+    fenceEpoch: '6',
+    operationReceipts: {
+      ...target.operationReceipts,
+      acquire: {
+        ...target.operationReceipts.acquire,
+        replayProjection: {
+          ...target.operationReceipts.acquire.replayProjection,
+          runId: 'run_2',
+          leaseFence: '6',
+        },
+      },
+      activate: {
+        ...target.operationReceipts.activate,
+        replayProjection: {
+          ...target.operationReceipts.activate.replayProjection,
+          runId: 'run_2',
+          leaseFence: '6',
+        },
+      },
+    },
+    renewReceiptIds: [],
+    terminalControlOutboxIds: [secondTerminalControlId],
+    terminalWinner: {
+      ...target.terminalWinner,
+      eventId: secondTerminalControlId,
+    },
+  };
+  const secondTargetTerminal = {
+    ...targetTerminal,
+    terminalControlId: secondTerminalControlId,
+    eventId: secondTerminalControlId,
+    runId: 'run_2',
+    leaseFence: '6',
+    payload: {
+      ...targetTerminal.payload,
+      eventId: secondTerminalControlId,
+      runId: 'run_2',
+      leaseFence: '6',
+    },
+  };
   fakeFirestore.seedCollection(MATRIX_CORPUS_RUN_LEASES_COLLECTION, [
     { id: leaseSlotDigest, data: target },
   ]);
   fakeFirestore.seedCollection(
     `${MATRIX_CORPUS_RUN_LEASES_COLLECTION}/${leaseSlotDigest}/runs`,
-    [{ id: runFenceDigest, data: { ...target, leaseSlotDigest } }]
+    [
+      { id: runFenceDigest, data: { ...target, leaseSlotDigest } },
+      ...(includeSecondTarget
+        ? [{ id: secondRunFenceDigest, data: { ...secondTarget, leaseSlotDigest } }]
+        : []),
+    ]
   );
   fakeFirestore.seedCollection(
     `${MATRIX_CORPUS_RUN_LEASES_COLLECTION}/${leaseSlotDigest}/runs/${runFenceDigest}/renew_receipts`,
@@ -1387,6 +1439,9 @@ async function cleanupFixture(renewReceiptCount = 1) {
   );
   fakeFirestore.seedCollection(MATRIX_CORPUS_TERMINAL_CONTROL_OUTBOX_COLLECTION, [
     { id: terminalControlId, data: targetTerminal },
+    ...(includeSecondTarget
+      ? [{ id: secondTerminalControlId, data: secondTargetTerminal }]
+      : []),
   ]);
   const repository = lifecycleRepository(firestore);
   const currentRunFenceDigest = 'c'.repeat(64);
@@ -1399,7 +1454,14 @@ async function cleanupFixture(renewReceiptCount = 1) {
     now: '2026-07-20T10:06:00.000Z',
     expiresAt: '2026-07-20T10:11:00.000Z',
   });
-  return { firestore, repository, currentRunFenceDigest, terminalControlId };
+  return {
+    firestore,
+    repository,
+    currentRunFenceDigest,
+    terminalControlId,
+    secondRunFenceDigest,
+    secondTerminalControlId,
+  };
 }
 
 async function fullCleanupFixture() {
@@ -3024,6 +3086,127 @@ describe('FirestoreMatrixCorpusRepository lifecycle', () => {
         .get()
         .then((snapshot) => snapshot.exists)
     ).resolves.toBe(false);
+  });
+
+  it('cleans two exact predecessors under one provisioning lease and replays both receipts', async () => {
+    const { firestore, repository, currentRunFenceDigest, secondRunFenceDigest } = await cleanupFixture(
+      1,
+      true
+    );
+    const first = cleanupCommand(currentRunFenceDigest);
+    const second = {
+      ...first,
+      targetRunId: 'run_2',
+      targetLeaseFence: '6',
+      targetRunFenceDigest: secondRunFenceDigest,
+      idempotencyKeyDigest: '1'.repeat(64),
+      canonicalRequestDigest: '2'.repeat(64),
+      now: '2026-07-20T10:06:02.000Z',
+    };
+
+    await expect(repository.cleanupExactRun(first)).resolves.toMatchObject({
+      code: 'RUN_CLEANED',
+      targetRunId: 'run_1',
+      finalRevision: 1,
+    });
+    await expect(
+      repository.cleanupExactRun({
+        ...second,
+        idempotencyKeyDigest: first.idempotencyKeyDigest,
+      })
+    ).resolves.toEqual({ code: 'IDEMPOTENCY_CONFLICT' });
+    await expect(repository.cleanupExactRun(second)).resolves.toMatchObject({
+      code: 'RUN_CLEANED',
+      targetRunId: 'run_2',
+      finalRevision: 1,
+    });
+    await expect(repository.cleanupExactRun(first)).resolves.toMatchObject({
+      code: 'ALREADY_APPLIED',
+      targetRunId: 'run_1',
+    });
+    await expect(repository.cleanupExactRun(second)).resolves.toMatchObject({
+      code: 'ALREADY_APPLIED',
+      targetRunId: 'run_2',
+    });
+
+    const current = (await readCurrentLease(firestore)) as MatrixCorpusLeaseV1;
+    const secondReceipt = current.finalCleanupReceipt;
+    if (
+      secondReceipt === null ||
+      secondReceipt.replayProjection.operation !== 'cleanup' ||
+      secondReceipt.replayProjection.result !== 'cleaned'
+    )
+      throw new Error('second cleanup must retain a final receipt');
+    const saturated = {
+      ...current,
+      priorFinalCleanupReceipts: [
+        ...(current.priorFinalCleanupReceipts ?? []),
+        secondReceipt,
+      ],
+      finalCleanupReceipt: {
+        ...secondReceipt,
+        idempotencyKeyDigest: '3'.repeat(64),
+        canonicalRequestDigest: '4'.repeat(64),
+        replayProjection: {
+          ...secondReceipt.replayProjection,
+          targetRunId: 'run_3',
+          targetLeaseFence: '5',
+          targetRunFenceDigest: '3'.repeat(64),
+          cleanedAt: '2026-07-20T10:06:03.000Z',
+        },
+        recordedAt: '2026-07-20T10:06:03.000Z',
+      },
+    } satisfies MatrixCorpusLeaseV1;
+    const slotRef = firestore
+      .collection(MATRIX_CORPUS_RUN_LEASES_COLLECTION)
+      .doc(leaseSlotDigest);
+    await slotRef.set(saturated);
+    await slotRef
+      .collection('runs')
+      .doc(currentRunFenceDigest)
+      .set({ ...saturated, leaseSlotDigest });
+    await expect(
+      repository.cleanupExactRun({
+        ...first,
+        targetRunId: 'run_4',
+        targetLeaseFence: '4',
+        targetRunFenceDigest: '4'.repeat(64),
+        idempotencyKeyDigest: '5'.repeat(64),
+        canonicalRequestDigest: '6'.repeat(64),
+        now: '2026-07-20T10:06:04.000Z',
+      })
+    ).resolves.toEqual({ code: 'PHASE_CONFLICT', actualPhase: 'provisioning' });
+  });
+
+  it('cleans a predecessor from a legacy provisioning lease without receipt history', async () => {
+    const { firestore, repository, currentRunFenceDigest } = await cleanupFixture();
+    const current = (await readCurrentLease(firestore)) as MatrixCorpusLeaseV1;
+    const { priorFinalCleanupReceipts: _omitted, ...legacyCurrent } = current;
+    const slotRef = firestore
+      .collection(MATRIX_CORPUS_RUN_LEASES_COLLECTION)
+      .doc(leaseSlotDigest);
+    await slotRef.set(legacyCurrent);
+    await slotRef
+      .collection('runs')
+      .doc(currentRunFenceDigest)
+      .set({ ...legacyCurrent, leaseSlotDigest });
+
+    await expect(
+      repository.cleanupExactRun(cleanupCommand(currentRunFenceDigest))
+    ).resolves.toMatchObject({
+      code: 'RUN_CLEANED',
+      targetRunId: 'run_1',
+    });
+    await expect(readCurrentLease(firestore)).resolves.toMatchObject({
+      priorFinalCleanupReceipts: [],
+      finalCleanupReceipt: {
+        replayProjection: {
+          operation: 'cleanup',
+          result: 'cleaned',
+          targetRunId: 'run_1',
+        },
+      },
+    });
   });
 
   it('cleans every exact child kind produced by a complete strict-mock run', async () => {

--- a/apps/whatsapp-service/src/domain/matrixCorpus/types.ts
+++ b/apps/whatsapp-service/src/domain/matrixCorpus/types.ts
@@ -1122,6 +1122,7 @@ const leaseRecordShape = {
   drain: booleanDrainSchema,
   terminalWinner: matrixCorpusTerminalAuthoritativeWinnerV1Schema.nullable(),
   cleanupProgress: matrixCorpusCleanupProgressV1Schema.nullable(),
+  priorFinalCleanupReceipts: z.array(matrixCorpusCleanupChunkReceiptV1Schema).max(2).optional(),
   finalCleanupReceipt: matrixCorpusCleanupChunkReceiptV1Schema.nullable(),
 } as const;
 
@@ -1188,21 +1189,47 @@ function refineMatrixCorpusLeaseRecord(
     lease.terminalControlOutboxIds.length;
   if (cleanupReferenceCount > MATRIX_CORPUS_MAX_CLEANUP_REFERENCES_PER_RUN)
     context.addIssue({ code: z.ZodIssueCode.custom, message: 'Lease cleanup reference bound exceeded' });
+  const finalCleanupReceipts = [
+    ...(lease.priorFinalCleanupReceipts ?? []),
+    ...(lease.finalCleanupReceipt === null ? [] : [lease.finalCleanupReceipt]),
+  ];
   if (
-    lease.finalCleanupReceipt !== null &&
-    (lease.finalCleanupReceipt.replayProjection.operation !== 'cleanup' ||
-      lease.finalCleanupReceipt.replayProjection.result !== 'cleaned')
+    finalCleanupReceipts.some(
+      (receipt) =>
+        receipt.replayProjection.operation !== 'cleanup' ||
+        receipt.replayProjection.result !== 'cleaned'
+    )
   )
     context.addIssue({ code: z.ZodIssueCode.custom, message: 'Final cleanup receipt must be terminal cleanup' });
-  if (lease.finalCleanupReceipt !== null && lease.phase !== 'provisioning')
+  if (finalCleanupReceipts.length > 0 && lease.phase !== 'provisioning')
     context.addIssue({ code: z.ZodIssueCode.custom, message: 'Final cleanup receipt requires provisioning lease' });
-  const finalCleanupProjection = lease.finalCleanupReceipt?.replayProjection;
+  if ((lease.priorFinalCleanupReceipts?.length ?? 0) > 0 && lease.finalCleanupReceipt === null)
+    context.addIssue({ code: z.ZodIssueCode.custom, message: 'Prior cleanup receipts require a final receipt' });
+  const cleanupTargetDigests = finalCleanupReceipts.flatMap((receipt) => {
+    const projection = receipt.replayProjection;
+    return projection.operation === 'cleanup' && projection.result === 'cleaned'
+      ? [projection.targetRunFenceDigest]
+      : [];
+  });
+  const cleanupIdempotencyDigests = finalCleanupReceipts.map(
+    (receipt) => receipt.idempotencyKeyDigest
+  );
   if (
-    finalCleanupProjection?.operation === 'cleanup' &&
-    finalCleanupProjection.result === 'cleaned' &&
-    (finalCleanupProjection.targetRunId === lease.runId ||
-      finalCleanupProjection.targetLeaseFence === lease.leaseFence ||
-      finalCleanupProjection.targetRunFenceDigest === lease.runFenceDigest)
+    !hasUniqueItems(cleanupTargetDigests) ||
+    !hasUniqueItems(cleanupIdempotencyDigests)
+  )
+    context.addIssue({ code: z.ZodIssueCode.custom, message: 'Final cleanup receipts must be unique' });
+  if (
+    finalCleanupReceipts.some((receipt) => {
+      const projection = receipt.replayProjection;
+      return (
+        projection.operation === 'cleanup' &&
+        projection.result === 'cleaned' &&
+        (projection.targetRunId === lease.runId ||
+          projection.targetLeaseFence === lease.leaseFence ||
+          projection.targetRunFenceDigest === lease.runFenceDigest)
+      );
+    })
   )
     context.addIssue({ code: z.ZodIssueCode.custom, message: 'Cleanup target identity must differ from current lease' });
   const drained =

--- a/apps/whatsapp-service/src/infra/firestore/matrixCorpusRepository.ts
+++ b/apps/whatsapp-service/src/infra/firestore/matrixCorpusRepository.ts
@@ -391,6 +391,7 @@ export class FirestoreMatrixCorpusRepository
           },
           terminalWinner: null,
           cleanupProgress: null,
+          priorFinalCleanupReceipts: [],
           finalCleanupReceipt: null,
         });
         const history = matrixCorpusLeaseHistoryV1Schema.parse({
@@ -486,6 +487,7 @@ export class FirestoreMatrixCorpusRepository
           phase: 'active',
           activatedAt: command.data.now,
           operationReceipts: { ...lease.operationReceipts, activate: receipt },
+          priorFinalCleanupReceipts: [],
           finalCleanupReceipt: null,
         });
         const history = matrixCorpusLeaseHistoryV1Schema.parse({
@@ -1742,6 +1744,7 @@ export class FirestoreMatrixCorpusRepository
           terminalWinner: null,
           releasedAt: null,
           abandonedAt: null,
+          priorFinalCleanupReceipts: [],
           finalCleanupReceipt: lease.phase === 'provisioning' ? null : lease.finalCleanupReceipt,
           drain: { ...lease.drain, drained: false },
         });
@@ -1843,8 +1846,11 @@ export class FirestoreMatrixCorpusRepository
         )
           return { code: 'STALE_FENCE' as const };
 
-        if (lease.finalCleanupReceipt !== null) {
-          const receipt = lease.finalCleanupReceipt;
+        const finalCleanupReceipts = [
+          ...(lease.priorFinalCleanupReceipts ?? []),
+          ...(lease.finalCleanupReceipt === null ? [] : [lease.finalCleanupReceipt]),
+        ];
+        for (const receipt of finalCleanupReceipts) {
           const projection = receipt.replayProjection;
           const digest = this.digestReplayProjection(projection);
           if (digest === null || digest !== receipt.resultDigest)
@@ -1852,14 +1858,28 @@ export class FirestoreMatrixCorpusRepository
               code: 'CORRUPT_STATE' as const,
               recordKind: digest === null ? ('dependency_result' as const) : ('cleanup_progress' as const),
             };
-          if (receipt.idempotencyKeyDigest !== command.data.idempotencyKeyDigest)
+        }
+        const finalReplayReceipt = finalCleanupReceipts.find(
+          (receipt) => {
+            const projection = receipt.replayProjection;
+            return (
+              projection.operation === 'cleanup' &&
+              projection.result === 'cleaned' &&
+              projection.targetRunFenceDigest === command.data.targetRunFenceDigest
+            );
+          }
+        );
+        if (finalReplayReceipt !== undefined) {
+          const projection = finalReplayReceipt.replayProjection;
+          if (finalReplayReceipt.idempotencyKeyDigest !== command.data.idempotencyKeyDigest)
             return { code: 'PHASE_CONFLICT' as const, actualPhase: lease.phase };
           if (
-            receipt.canonicalRequestDigest !== command.data.canonicalRequestDigest ||
-            receipt.expectedRevision !== command.data.expectedRevision ||
+            finalReplayReceipt.canonicalRequestDigest !== command.data.canonicalRequestDigest ||
+            finalReplayReceipt.expectedRevision !== command.data.expectedRevision ||
             projection.operation !== 'cleanup' ||
             projection.result !== 'cleaned' ||
-            projection.targetRunFenceDigest !== command.data.targetRunFenceDigest
+            projection.targetRunId !== command.data.targetRunId ||
+            projection.targetLeaseFence !== command.data.targetLeaseFence
           )
             return { code: 'IDEMPOTENCY_CONFLICT' as const };
           return parseLifecycleResult(cleanupResultSchema, {
@@ -1873,6 +1893,15 @@ export class FirestoreMatrixCorpusRepository
             cleanedAt: projection.cleanedAt,
           });
         }
+        if (
+          finalCleanupReceipts.some(
+            (receipt) =>
+              receipt.idempotencyKeyDigest === command.data.idempotencyKeyDigest
+          )
+        )
+          return { code: 'IDEMPOTENCY_CONFLICT' as const };
+        if (finalCleanupReceipts.length >= 3)
+          return { code: 'PHASE_CONFLICT' as const, actualPhase: lease.phase };
         if (lease.phase !== 'provisioning')
           return { code: 'PHASE_CONFLICT' as const, actualPhase: lease.phase };
 
@@ -2065,6 +2094,10 @@ export class FirestoreMatrixCorpusRepository
         });
         const updatedCurrent = matrixCorpusLeaseV1Schema.parse({
           ...lease,
+          priorFinalCleanupReceipts: [
+            ...(lease.priorFinalCleanupReceipts ?? []),
+            ...(lease.finalCleanupReceipt === null ? [] : [lease.finalCleanupReceipt]),
+          ],
           finalCleanupReceipt: receipt,
         });
         const updatedCurrentHistory = matrixCorpusLeaseHistoryV1Schema.parse({

--- a/docs/testing/intex-agent-evals.md
+++ b/docs/testing/intex-agent-evals.md
@@ -194,10 +194,10 @@ timeline field through the privacy-safe evidence DTO; those fields remain `not_o
 rather than being inferred from expectations. Extending that DTO is the remaining path to
 full internal-transition attestation.
 
-Steady-state retention removes at most one old exact run per new provisioning lease. A
-pre-existing backlog requiring more than one owner cleanup fails closed before mutation
-and requires an explicit recovery operation; the runner never falls back to a user-wide
-delete.
+Steady-state retention reconciles every superseded run returned by the bounded four-run
+plan during the new provisioning lease. Each target is removed through its own
+owner-authorized exact-run/fence cleanup before the next target starts; any failure stops
+the sequence, and the runner never falls back to a user-wide delete.
 
 ## Exit codes and triage
 

--- a/tools/intex-agent-evals/src/__tests__/matrixCorpusRetention.test.ts
+++ b/tools/intex-agent-evals/src/__tests__/matrixCorpusRetention.test.ts
@@ -360,9 +360,8 @@ describe('matrix corpus exact-ID retention', () => {
     expect(removeExactPrivateDirectory).toHaveBeenCalledWith('/private/artifacts/.run_old.staging');
   });
 
-  it('fails closed before owner mutation when bounded history would require two evictions', async () => {
-    const cleanupMatrixCorpusRun = vi.fn();
-    const records = [
+  it('reconciles a bounded backlog through separately authorized exact-run cleanups', async () => {
+    const firstPlan = [
       record('run_current', {
         startedAt: '2026-07-20T10:00:00.000Z',
         lifecycle: 'preflight',
@@ -375,6 +374,103 @@ describe('matrix corpus exact-ID retention', () => {
       record('run_old_1', { startedAt: '2026-07-20T08:00:00.000Z', verdict: 'failed' }),
       record('run_old_2', { startedAt: '2026-07-20T07:00:00.000Z', verdict: 'failed' }),
     ];
+    const getMatrixCorpusRetentionPlan = vi.fn(async () => ({
+      ok: true as const,
+      value: {
+        kind: 'retention_plan' as const,
+        runId: 'run_current',
+        userId: 'user_1',
+        leaseFence: '11',
+        records: firstPlan,
+      },
+    }));
+    const cleanupWhatsApp = vi.fn(
+      async (input: {
+        targetRunId: string;
+        targetLeaseFence: string;
+        targetRunFenceDigest: string;
+        expectedRevision: number;
+      }) => ({
+        ok: true as const,
+        value: {
+          code: 'RUN_CLEANED' as const,
+          targetRunId: input.targetRunId,
+          targetLeaseFence: input.targetLeaseFence,
+          targetRunFenceDigest: input.targetRunFenceDigest,
+          state: 'cleaned' as const,
+          finalRevision: input.expectedRevision + 1,
+          cleanedAt: '2026-07-20T10:00:01.000Z',
+        },
+      })
+    );
+    let currentRevision = 1;
+    const cleanupIntex = vi.fn(async (_input: { request: { targetRunId: string } }) => ({
+      ok: true as const,
+      value: {
+        disposition: 'applied' as const,
+        runId: 'run_current',
+        userId: 'user_1',
+        leaseFence: '11',
+        currentRevision: ++currentRevision,
+        retentionReconciled: true as const,
+        removed: {
+          runs: 1,
+          sessions: 0,
+          events: 0,
+          confirmations: 0,
+          ingestReceipts: 0,
+          scenarioProjections: 0,
+          scenarioContexts: 0,
+          runContexts: 1,
+          manifests: 1,
+        },
+      },
+    }));
+    const removeExactPrivateDirectory = vi.fn(async (_path: string) => 'removed' as const);
+    const result = await reconcileMatrixCorpusRetention({
+      runId: 'run_current',
+      userId: 'user_1',
+      leaseFence: '11',
+      currentRevision: 1,
+      bindingHmacKey: 'h'.repeat(32),
+      artifactRoot: '/private/artifacts',
+      files: { removeExactPrivateDirectory },
+      sagas: sagaPort(),
+      intex: {
+        getMatrixCorpusRetentionPlan,
+        cleanupMatrixCorpusRun: cleanupIntex,
+      },
+      whatsapp: { cleanupMatrixCorpusRun: cleanupWhatsApp },
+      now: () => new Date('2026-07-20T10:00:00.000Z'),
+    });
+    expect(result).toMatchObject({
+      ok: true,
+      revision: 3,
+      stats: {
+        status: 'passed',
+        runs: { considered: 4, retained: 2, removed: 2, failed: 0 },
+        artifacts: { considered: 4, retained: 2, removed: 2, failed: 0 },
+      },
+    });
+    expect(getMatrixCorpusRetentionPlan).toHaveBeenCalledTimes(1);
+    expect(cleanupWhatsApp.mock.calls.map(([input]) => input.targetRunId)).toEqual([
+      'run_old_1',
+      'run_old_2',
+    ]);
+    expect(cleanupIntex.mock.calls.map(([input]) => input.request.targetRunId)).toEqual([
+      'run_old_1',
+      'run_old_2',
+    ]);
+    expect(removeExactPrivateDirectory.mock.calls.map(([path]) => path)).toEqual([
+      '/private/artifacts/run_old_1',
+      '/private/artifacts/.run_old_1.staging',
+      '/private/artifacts/run_old_2',
+      '/private/artifacts/.run_old_2.staging',
+    ]);
+  });
+
+  it('fails closed before mutation when persisted cleanup work exceeds the receipt bound', async () => {
+    const cleanupMatrixCorpusRun = vi.fn();
     const result = await reconcileMatrixCorpusRetention({
       runId: 'run_current',
       userId: 'user_1',
@@ -383,7 +479,16 @@ describe('matrix corpus exact-ID retention', () => {
       bindingHmacKey: 'h'.repeat(32),
       artifactRoot: '/private/artifacts',
       files: { removeExactPrivateDirectory: vi.fn() },
-      sagas: sagaPort(),
+      sagas: sagaPort(
+        Array.from({ length: 4 }, (_, index) => ({
+          version: 1 as const,
+          targetRunId: `run_old_${String(index + 1)}`,
+          targetLeaseFence: String(index + 1),
+          targetRunFenceDigest: String(index + 1).repeat(64),
+          stage: 'whatsapp_pending' as const,
+          whatsappRevision: 0,
+        }))
+      ),
       intex: {
         getMatrixCorpusRetentionPlan: vi.fn(async () => ({
           ok: true as const,
@@ -392,7 +497,15 @@ describe('matrix corpus exact-ID retention', () => {
             runId: 'run_current',
             userId: 'user_1',
             leaseFence: '11',
-            records,
+            records: [
+              record('run_current', {
+                lifecycle: 'preflight',
+                verdict: 'pending',
+                artifactDelivery: 'pending',
+                completedAt: null,
+                isCurrent: true,
+              }),
+            ],
           },
         })),
         cleanupMatrixCorpusRun,
@@ -400,7 +513,15 @@ describe('matrix corpus exact-ID retention', () => {
       whatsapp: { cleanupMatrixCorpusRun },
       now: () => new Date('2026-07-20T10:00:00.000Z'),
     });
-    expect(result).toMatchObject({ ok: false, code: 'retention_cleanup_failed' });
+
+    expect(result).toMatchObject({
+      ok: false,
+      code: 'retention_cleanup_failed',
+      stats: {
+        runs: { failed: 4 },
+        artifacts: { failed: 4 },
+      },
+    });
     expect(cleanupMatrixCorpusRun).not.toHaveBeenCalled();
   });
 

--- a/tools/intex-agent-evals/src/matrixCorpus/retentionExecution.ts
+++ b/tools/intex-agent-evals/src/matrixCorpus/retentionExecution.ts
@@ -19,6 +19,7 @@ const MAX_CLEANUP_CHUNKS = 10_000;
 const TRANSIENT_RETRY_LIMIT = 3;
 const RETENTION_SAGA_VERSION = 1;
 const MAX_RETENTION_SAGAS = 4;
+const MAX_RETENTION_EVICTIONS = 3;
 
 export interface MatrixCorpusRetentionSaga {
   readonly version: 1;
@@ -111,7 +112,7 @@ export async function reconcileMatrixCorpusRetention(input: {
     targets.set(saga.targetRunId, fromPlan ?? sagaRecord(saga));
   }
   for (const target of selection.evict) targets.set(target.runId, target);
-  if (targets.size > 1 || selection.evict.length > 1) {
+  if (targets.size > MAX_RETENTION_EVICTIONS) {
     stats.runs.failed = targets.size;
     stats.artifacts.failed = targets.size;
     return failed(stats);


### PR DESCRIPTION
## Summary
- reconcile every bounded retention eviction sequentially before activating a Matrix corpus run
- retain and replay up to three exact owner-authorized cleanup receipts, including legacy lease compatibility
- cover cross-target idempotency, receipt saturation, multi-target replay, and runner safety limits
- document the bounded automatic cleanup behavior

## Verification
- `pnpm run ci:tracked` — 6899 tests passed; typecheck, lint, static validation, coverage, build, and format all passed
- final security/correctness review — NO FINDINGS

Linear: omitted by $commit-push; GitHub automation will create or link the Linear issue after PR creation.