### PR TITLE
[INT-1926] Fix legacy MiniMax cleanup evidence

### DIFF
--- a/apps/intex-agent/src/__tests__/infra/firestore/testRunRepository.test.ts
+++ b/apps/intex-agent/src/__tests__/infra/firestore/testRunRepository.test.ts
@@ -538,6 +538,135 @@ describe('Firestore Test Run foundation repository', () => {
     ).resolves.toMatchObject({ ok: true, disposition: 'already_applied' });
   });
 
+  it('cleans terminal evidence with a legacy single-call failed MiniMax evaluation', async () => {
+    const { firestore, repository } = fixture();
+    await writeCleanupFixture(firestore);
+    const projectionId = createHash('sha256')
+      .update('v1\u0000run_target\u0000scenario_001', 'utf8')
+      .digest('hex');
+    const projectionRef = firestore
+      .collection('intex_agent_test_run_scenarios')
+      .doc(`v1_${projectionId}`);
+    const projection = await projectionRef.get();
+    await projectionRef.set({
+      ...projection.data(),
+      replyEvaluations: [
+        {
+          turnIndex: 0,
+          replyIndex: 1,
+          verdict: 'passed',
+          score: 5,
+          criteria: {
+            understoodIntent: true,
+            helpful: true,
+            conciseAndClear: true,
+            professionalTone: true,
+            noPassiveAggression: true,
+          },
+          failureCodes: [],
+          latencyMs: 1,
+          usage: {
+            logicalCalls: 1,
+            repairCount: 0,
+            inputTokens: 2,
+            outputTokens: 1,
+            totalTokens: 3,
+            costNanoUsd: 7,
+          },
+        },
+        {
+          turnIndex: 0,
+          replyIndex: 2,
+          verdict: 'failed',
+          score: 4,
+          criteria: {
+            understoodIntent: true,
+            helpful: false,
+            conciseAndClear: true,
+            professionalTone: true,
+            noPassiveAggression: true,
+          },
+          failureCodes: ['helpful'],
+          latencyMs: 1,
+          usage: {
+            logicalCalls: 1,
+            repairCount: 0,
+            inputTokens: 2,
+            outputTokens: 1,
+            totalTokens: 3,
+            costNanoUsd: 7,
+          },
+        },
+      ],
+    });
+
+    await expect(repository.cleanupExactRun(cleanupInput())).resolves.toMatchObject({
+      ok: true,
+      disposition: 'applied',
+      removed: { scenarioProjections: 1 },
+    });
+  });
+
+  it('does not let legacy MiniMax cleanup compatibility mask other corrupt evidence', async () => {
+    for (const usage of [
+      {
+        logicalCalls: 1,
+        repairCount: 2,
+        inputTokens: 2,
+        outputTokens: 1,
+        totalTokens: 3,
+        costNanoUsd: 7,
+      },
+      {
+        logicalCalls: 1,
+        repairCount: 0,
+        inputTokens: 2,
+        outputTokens: 1,
+        totalTokens: 4,
+        costNanoUsd: 7,
+      },
+    ]) {
+      const { firestore, repository } = fixture();
+      await writeCleanupFixture(firestore);
+      const projectionId = createHash('sha256')
+        .update('v1\u0000run_target\u0000scenario_001', 'utf8')
+        .digest('hex');
+      const projectionRef = firestore
+        .collection('intex_agent_test_run_scenarios')
+        .doc(`v1_${projectionId}`);
+      const projection = await projectionRef.get();
+      await projectionRef.set({
+        ...projection.data(),
+        replyEvaluations: [
+          {
+            turnIndex: 0,
+            replyIndex: 1,
+            verdict: 'failed',
+            score: 4,
+            criteria: {
+              understoodIntent: true,
+              helpful: false,
+              conciseAndClear: true,
+              professionalTone: true,
+              noPassiveAggression: true,
+            },
+            failureCodes: ['helpful'],
+            latencyMs: 1,
+            usage,
+          },
+        ],
+      });
+
+      await expect(repository.cleanupExactRun(cleanupInput())).resolves.toEqual({
+        ok: false,
+        code: 'EVIDENCE_MISMATCH',
+      });
+      await expect(
+        firestore.collection('intex_agent_session_events').doc('target_event_1').get()
+      ).resolves.toMatchObject({ exists: true });
+    }
+  });
+
   it('refuses to clean the latest retained successful run before deleting child evidence', async () => {
     const { firestore, repository } = fixture();
     await writeCleanupFixture(firestore);

--- a/apps/intex-agent/src/infra/firestore/testRunRepository.ts
+++ b/apps/intex-agent/src/infra/firestore/testRunRepository.ts
@@ -426,7 +426,7 @@ export class FirestoreTestRunRepository implements TestRunRepository {
         ? parseMatrixCorpusSessionDocument(item.sessionSnapshot.id, item.sessionSnapshot.data())
         : undefined;
       const projection = item.projectionSnapshot.exists
-        ? parseScenarioProjection(item.projectionSnapshot.data())
+        ? parseCleanupScenarioProjection(item.projectionSnapshot.data())
         : null;
       const isAbandonedProjectionGap =
         acceptsAbandonedProjectionGap &&
@@ -606,7 +606,7 @@ export class FirestoreTestRunRepository implements TestRunRepository {
               summary !== undefined &&
               isUnprojectedAbandonedScenario(summary)
             );
-          const projection = parseScenarioProjection(snapshot.data());
+          const projection = parseCleanupScenarioProjection(snapshot.data());
           return (
             projection?.runId !== input.targetIdentity.runId ||
             projection.userId !== input.targetIdentity.userId ||
@@ -1544,6 +1544,43 @@ function isUnprojectedAbandonedScenario(
 function parseScenarioProjection(value: unknown): TestRunScenarioProjectionV1 | null {
   const parsed = testRunScenarioProjectionV1Schema.safeParse(value);
   return parsed.success ? parsed.data : null;
+}
+
+function parseCleanupScenarioProjection(value: unknown): TestRunScenarioProjectionV1 | null {
+  const current = testRunScenarioProjectionV1Schema.safeParse(value);
+  if (current.success) return current.data;
+  if (!isUnknownRecord(value) || !Array.isArray(value['replyEvaluations'])) return null;
+
+  if (!value['replyEvaluations'].some(isLegacySingleCallFailedEvaluation)) return null;
+  const replyEvaluations = value['replyEvaluations'].map((evaluation: unknown) => {
+    if (!isLegacySingleCallFailedEvaluation(evaluation)) return evaluation;
+    return { ...evaluation, usage: { ...evaluation.usage, logicalCalls: 2 } };
+  });
+
+  const compatible = testRunScenarioProjectionV1Schema.safeParse({
+    ...value,
+    replyEvaluations,
+  });
+  return compatible.success ? compatible.data : null;
+}
+
+function isLegacySingleCallFailedEvaluation(
+  value: unknown
+): value is Record<string, unknown> & { usage: Record<string, unknown> } {
+  if (!isUnknownRecord(value) || value['verdict'] !== 'failed') return false;
+  const usage = value['usage'];
+  return (
+    isUnknownRecord(usage) &&
+    usage['logicalCalls'] === 1 &&
+    typeof usage['repairCount'] === 'number' &&
+    Number.isSafeInteger(usage['repairCount']) &&
+    usage['repairCount'] >= 0 &&
+    usage['repairCount'] <= 1
+  );
+}
+
+function isUnknownRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 function matchesIdentity(record: TestRunIdentity, identity: TestRunIdentity): boolean {


### PR DESCRIPTION
## Summary
- accept only historical failed MiniMax evaluations with one logical call during exact retention cleanup
- keep normal projection reads and the global schema strict
- fail closed when legacy evidence contains any additional corruption

## Testing
- pnpm run verify:workspace:tracked intex-agent
- pnpm run ci:tracked (6899 tests passed)
- security review: no findings

Linear: omitted by $commit-push; GitHub automation will create or link the Linear issue after PR creation.