### PR TITLE
[INT-1928] fix: extend bounded Matrix LLM retries

### DIFF
--- a/apps/intex-agent/src/__tests__/domain/matrixCorpus/matrixCorpusExecutionService.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/matrixCorpus/matrixCorpusExecutionService.test.ts
@@ -271,6 +271,7 @@ function fixture(
   const replyPublisher = {
     publishReplyWithReceipt: vi.fn(async () => ({ publicationReceiptId: 'pubsub_message_1' })),
   };
+  const nowMs = vi.fn(() => 1_000_000);
   const waitForZeroEvidenceRetry = vi.fn(async (_delayMs: number) => undefined);
   const deps = {
     contextService,
@@ -279,6 +280,7 @@ function fixture(
     receiptRepository,
     createRunner,
     replyPublisher,
+    nowMs,
     waitForZeroEvidenceRetry,
   } as unknown as MatrixCorpusExecutionServiceDeps;
   return {
@@ -289,6 +291,7 @@ function fixture(
     receiptRepository,
     createRunner,
     replyPublisher,
+    nowMs,
     waitForZeroEvidenceRetry,
     service: createMatrixCorpusExecutionService(deps),
   };
@@ -950,7 +953,7 @@ describe('Matrix corpus execution service', () => {
     });
   });
 
-  it('stops after three zero-evidence provider failures and persists one failed summary', async () => {
+  it('stops after four zero-evidence provider failures with extended backoff and persists one failed summary', async () => {
     const fallbackRunner = {
       run: vi.fn(),
       executeConfirmed: vi.fn(),
@@ -979,8 +982,11 @@ describe('Matrix corpus execution service', () => {
       })
     ).rejects.toThrow('Matrix corpus intent classification failed');
 
-    expect(current.createRunner).toHaveBeenCalledTimes(3);
-    expect(current.waitForZeroEvidenceRetry.mock.calls).toEqual([[5_000], [20_000]]);
+    expect(current.createRunner).toHaveBeenCalledTimes(4);
+    expect(current.waitForZeroEvidenceRetry.mock.calls).toEqual([[5_000], [20_000], [60_000]]);
+    expect(
+      current.createRunner.mock.calls.map(([input]) => input.deadlineAtMs)
+    ).toEqual([1_180_000, 1_180_000, 1_180_000, 1_180_000]);
     const summaries = current.sessionRepository.appendMatrixCorpusEvent.mock.calls
       .map(([input]) => input.event)
       .filter(({ type }) => type === 'llm_usage_summary');
@@ -995,6 +1001,59 @@ describe('Matrix corpus execution service', () => {
       totalTokens: 0,
       costNanoUsd: 0,
     });
+  });
+
+  it('does not start a zero-evidence backoff that cannot finish before the shared deadline', async () => {
+    const fallbackRunner = {
+      run: vi.fn(),
+      executeConfirmed: vi.fn(),
+    };
+    const current = fixture(fallbackRunner as unknown as IntexAgentRunner);
+    current.nowMs.mockReturnValueOnce(1_000_000).mockReturnValueOnce(1_179_000);
+    current.createRunner.mockImplementation((runnerInput) => ({
+      executeConfirmed: vi.fn(),
+      run: vi.fn(async () => {
+        runnerInput.execution.registerExpectedProviderCall({
+          version: 1,
+          runId: 'run_1',
+          scenarioId: 'scenario_001',
+          sessionId: stableKeys.sessionId,
+          turnIndex: 0,
+          stage: 'intent_classification',
+          callOrdinal: 1,
+        });
+        throw new Error('Matrix corpus intent classification failed');
+      }),
+    }));
+
+    await expect(
+      current.service.executeVerifiedIngest({
+        claims: claims('query_calendar_events'),
+        stableKeys,
+      })
+    ).rejects.toThrow('Matrix corpus intent classification failed');
+
+    expect(current.createRunner).toHaveBeenCalledOnce();
+    expect(current.waitForZeroEvidenceRetry).not.toHaveBeenCalled();
+  });
+
+  it('fails closed before runner construction when the shared deadline clock is invalid', async () => {
+    const fallbackRunner = {
+      run: vi.fn(),
+      executeConfirmed: vi.fn(),
+    };
+    const current = fixture(fallbackRunner as unknown as IntexAgentRunner);
+    current.nowMs.mockReturnValue(Number.NaN);
+
+    await expect(
+      current.service.executeVerifiedIngest({
+        claims: claims('query_calendar_events'),
+        stableKeys,
+      })
+    ).rejects.toThrow('Invalid Matrix corpus model clock');
+
+    expect(current.createRunner).not.toHaveBeenCalled();
+    expect(current.waitForZeroEvidenceRetry).not.toHaveBeenCalled();
   });
 
   it('does not retry a generic provider failure after a provider response was observed', async () => {

--- a/apps/intex-agent/src/domain/matrixCorpus/matrixCorpusExecutionService.ts
+++ b/apps/intex-agent/src/domain/matrixCorpus/matrixCorpusExecutionService.ts
@@ -92,14 +92,17 @@ export interface MatrixCorpusExecutionServiceDeps {
       agentModel: MatrixCorpusAgentModel;
       userId: string;
       userPreferences: string | null;
+      deadlineAtMs: number;
     }>
   ): IntexAgentRunner;
   replyPublisher: Pick<MatrixCorpusWhatsAppReplyPublisher, 'publishReplyWithReceipt'>;
+  nowMs(): number;
   waitForZeroEvidenceRetry(delayMs: number): Promise<void>;
 }
 
-const MATRIX_CORPUS_ZERO_EVIDENCE_RUNNER_ATTEMPTS = 3;
-const MATRIX_CORPUS_ZERO_EVIDENCE_RETRY_DELAYS_MS = [5_000, 20_000] as const;
+export const MATRIX_CORPUS_MODEL_TURN_BUDGET_MS = 180_000;
+const MATRIX_CORPUS_ZERO_EVIDENCE_RUNNER_ATTEMPTS = 4;
+const MATRIX_CORPUS_ZERO_EVIDENCE_RETRY_DELAYS_MS = [5_000, 20_000, 60_000] as const;
 const MATRIX_CORPUS_RETRIABLE_ZERO_EVIDENCE_ERRORS = new Set([
   'Error: Matrix corpus agent generation failed',
   'Error: Matrix corpus intent classification failed',
@@ -133,6 +136,9 @@ export function createMatrixCorpusExecutionService(
       if (!promptResult.ok) return failure('CONTEXT_REJECTED');
       const promptContext = promptResult.promptContext;
       const session = sessionResult.session;
+      const startedAtMs = deps.nowMs();
+      if (!Number.isFinite(startedAtMs)) throw new Error('Invalid Matrix corpus model clock');
+      const deadlineAtMs = startedAtMs + MATRIX_CORPUS_MODEL_TURN_BUDGET_MS;
       if (
         stableJson(session.matrixCorpusProfile.expectedToolSchedule) !==
           stableJson(context.expectedToolSchedule) ||
@@ -158,6 +164,7 @@ export function createMatrixCorpusExecutionService(
           previousEvents: currentLogicalSessionEvents,
           userPreferences: promptResult.promptContext,
           preferenceOverlay,
+          deadlineAtMs,
         });
       }
 
@@ -226,6 +233,7 @@ export function createMatrixCorpusExecutionService(
           agentModel: session.matrixCorpusProfile.agentModel,
           userId: ordinaryIngest.userId,
           userPreferences: promptContext,
+          deadlineAtMs,
         });
         let result: IntexAgentRunnerResult;
         try {
@@ -247,8 +255,14 @@ export function createMatrixCorpusExecutionService(
             const retryDelayMs = MATRIX_CORPUS_ZERO_EVIDENCE_RETRY_DELAYS_MS[
               runnerAttempt - 1
             ] as (typeof MATRIX_CORPUS_ZERO_EVIDENCE_RETRY_DELAYS_MS)[number];
-            await deps.waitForZeroEvidenceRetry(retryDelayMs);
-            return await executeNaturalAttempt(runnerAttempt + 1);
+            const retryClockMs = deps.nowMs();
+            if (
+              Number.isFinite(retryClockMs) &&
+              retryDelayMs < deadlineAtMs - retryClockMs
+            ) {
+              await deps.waitForZeroEvidenceRetry(retryDelayMs);
+              return await executeNaturalAttempt(runnerAttempt + 1);
+            }
           }
           await usageRecorder.finalize('natural', 'failed');
           throw error;
@@ -382,6 +396,7 @@ async function executeConfirmation(
     previousEvents: readonly IntexAgentSessionEvent[];
     userPreferences: string;
     preferenceOverlay: ReturnType<MatrixCorpusContextService['createPreferenceOverlay']>;
+    deadlineAtMs: number;
   }>
 ): Promise<MatrixCorpusExecutionResult> {
   const { context, ordinaryIngest } = input.input.claims.payload;
@@ -474,6 +489,7 @@ async function executeConfirmation(
     agentModel: input.session.matrixCorpusProfile.agentModel,
     userId: ordinaryIngest.userId,
     userPreferences: input.userPreferences,
+    deadlineAtMs: input.deadlineAtMs,
   });
   let result: IntexAgentRunnerResult;
   try {

--- a/apps/intex-agent/src/services.ts
+++ b/apps/intex-agent/src/services.ts
@@ -84,6 +84,7 @@ import { createMatrixCorpusContextService } from './domain/matrixCorpus/contextS
 import { createMatrixCorpusMessageHandler } from './domain/matrixCorpus/matrixCorpusMessageHandler.js';
 import {
   createMatrixCorpusExecutionService,
+  MATRIX_CORPUS_MODEL_TURN_BUDGET_MS,
   type MatrixCorpusExecutionServiceDeps,
 } from './domain/matrixCorpus/matrixCorpusExecutionService.js';
 import {
@@ -118,8 +119,8 @@ export function composeIntexMatrixCorpusFeature<T>(
 
 const RUNTIME_SETTINGS_LOOKUP_TIMEOUT_MS = 2_000;
 export const MATRIX_CORPUS_MODEL_REQUEST_TIMEOUT_MS = 45_000;
-export const MATRIX_CORPUS_MODEL_TURN_BUDGET_MS = 180_000;
 export const MATRIX_CORPUS_MODEL_MAX_ATTEMPTS = 3;
+export { MATRIX_CORPUS_MODEL_TURN_BUDGET_MS };
 
 const MATRIX_CORPUS_RUNTIME_MODELS = {
   'or:deepseek/deepseek-v4-flash': IntexAgentModels.DeepSeekV4Flash,
@@ -255,6 +256,7 @@ export function createIntexMatrixCorpusRuntime(
     receiptRepository,
     createRunner: dependencies.createRunner,
     replyPublisher: dependencies.replyPublisher,
+    nowMs: () => Date.parse(dependencies.now()),
     waitForZeroEvidenceRetry: async (delayMs) => {
       await wait(delayMs);
     },
@@ -693,7 +695,7 @@ export async function initServices(config: ServiceConfig): Promise<void> {
           usageSink,
           timeoutMs: MATRIX_CORPUS_MODEL_REQUEST_TIMEOUT_MS,
           maxAttempts: MATRIX_CORPUS_MODEL_MAX_ATTEMPTS,
-          deadlineAtMs: Date.now() + MATRIX_CORPUS_MODEL_TURN_BUDGET_MS,
+          deadlineAtMs: input.deadlineAtMs,
         });
         return createMatrixCorpusRunner({
           execution: input.execution,


### PR DESCRIPTION
## Summary
- add a fourth zero-evidence MiniMax retry after a 60-second backoff
- share one absolute 180-second deadline across every retry attempt
- skip backoffs that cannot finish within the shared deadline
- fail closed when the deadline clock is invalid

## Testing
- pnpm --filter @intexuraos/intex-agent test:coverage (1817 tests passed)
- pnpm run ci:tracked (6901 tests passed)
- independent review: no findings

Linear: omitted by $commit-push; GitHub automation will create or link the Linear issue after PR creation.