### PR TITLE
[INT-1929] fix: fall back from MiniMax JSON schema

### DIFF
--- a/apps/intex-agent/src/__tests__/domain/intentClassifier.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/intentClassifier.test.ts
@@ -1087,6 +1087,46 @@ describe('createLlmIntexAgentIntentClassifier', () => {
     });
   });
 
+  it('uses prompt JSON without provider response_format for a Matrix corpus fallback attempt', async () => {
+    const client = new FakeStructuredClient([
+      ok(
+        generateResult({
+          outcome: 'needs_clarification',
+          confidence: 0.9,
+          question: 'Which date should I use?',
+          blockerReason: 'missing_required_details',
+          missingFields: ['date'],
+          candidateIntents: ['create_calendar_event'],
+        })
+      ),
+    ]);
+
+    await expect(
+      createLlmIntexAgentIntentClassifier({
+        client,
+        logger: new FakeLogger(),
+        responseFormatMode: 'prompt_json',
+      }).classify({
+        message: 'Add lunch with Marta at noon.',
+        events: [],
+        currentDateTime: CURRENT_DATE_TIME,
+        timeZone: 'Europe/Warsaw',
+        matrixCorpusLlm: {
+          nextContext: (stage) => matrixContext(stage, 1),
+          recordProviderCall: vi.fn(async () => undefined),
+        },
+      })
+    ).resolves.toMatchObject({
+      kind: 'needs_clarification',
+      blockerReason: 'missing_required_details',
+      missingFields: ['date'],
+      candidateIntents: ['create_calendar_event'],
+    });
+
+    expect(client.calls).toHaveLength(1);
+    expect(client.calls[0]?.options).not.toHaveProperty('responseFormat');
+  });
+
   it('warns and fails closed to clarification when the classifier response cannot be repaired', async () => {
     const malformedClient = new FakeStructuredClient([
       ok(generateResult('not json')),

--- a/apps/intex-agent/src/__tests__/domain/matrixCorpus/matrixCorpusExecutionService.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/matrixCorpus/matrixCorpusExecutionService.test.ts
@@ -935,6 +935,9 @@ describe('Matrix corpus execution service', () => {
     ).resolves.toEqual({ ok: true });
 
     expect(current.createRunner).toHaveBeenCalledTimes(2);
+    expect(
+      current.createRunner.mock.calls.map(([input]) => input.intentClassifierResponseMode)
+    ).toEqual(['json_schema', 'prompt_json']);
     expect(current.waitForZeroEvidenceRetry).toHaveBeenCalledTimes(1);
     expect(current.waitForZeroEvidenceRetry).toHaveBeenCalledWith(5_000);
     const summaries = current.sessionRepository.appendMatrixCorpusEvent.mock.calls
@@ -983,6 +986,9 @@ describe('Matrix corpus execution service', () => {
     ).rejects.toThrow('Matrix corpus intent classification failed');
 
     expect(current.createRunner).toHaveBeenCalledTimes(4);
+    expect(
+      current.createRunner.mock.calls.map(([input]) => input.intentClassifierResponseMode)
+    ).toEqual(['json_schema', 'prompt_json', 'prompt_json', 'prompt_json']);
     expect(current.waitForZeroEvidenceRetry.mock.calls).toEqual([[5_000], [20_000], [60_000]]);
     expect(
       current.createRunner.mock.calls.map(([input]) => input.deadlineAtMs)

--- a/apps/intex-agent/src/domain/agent/intentClassifier.ts
+++ b/apps/intex-agent/src/domain/agent/intentClassifier.ts
@@ -115,9 +115,12 @@ export interface IntexAgentIntentClassifier {
   classify(input: IntexAgentIntentClassifierInput): Promise<IntexAgentIntentClassification>;
 }
 
+export type IntexAgentIntentClassifierResponseFormatMode = 'json_schema' | 'prompt_json';
+
 export function createLlmIntexAgentIntentClassifier(deps: {
   client: StructuredClient;
   logger: AppLogger;
+  responseFormatMode?: IntexAgentIntentClassifierResponseFormatMode;
 }): IntexAgentIntentClassifier {
   return {
     async classify(input): Promise<IntexAgentIntentClassification> {
@@ -148,9 +151,10 @@ export function createLlmIntexAgentIntentClassifier(deps: {
         prompt,
         schema: classifierSchemaFor(activeClarification),
         promptType: INTEX_AGENT_INTENT_CLASSIFIER_PROMPT_TYPE,
-        options: {
-          responseFormat: INTEX_AGENT_INTENT_CLASSIFIER_RESPONSE_FORMAT,
-        },
+        options:
+          deps.responseFormatMode === 'prompt_json'
+            ? {}
+            : { responseFormat: INTEX_AGENT_INTENT_CLASSIFIER_RESPONSE_FORMAT },
         repairBuilder: (raw, error) =>
           intexAgentIntentClassifierRepairPrompt.build({
             originalPrompt: prompt,

--- a/apps/intex-agent/src/domain/matrixCorpus/matrixCorpusExecutionService.ts
+++ b/apps/intex-agent/src/domain/matrixCorpus/matrixCorpusExecutionService.ts
@@ -13,6 +13,7 @@ import type {
   IntexAgentRunnerResult,
   MatrixCorpusWhatsAppReplyPublisher,
 } from '../messages/handleIncomingMessage.js';
+import type { IntexAgentIntentClassifierResponseFormatMode } from '../agent/intentClassifier.js';
 import type {
   MatrixCorpusSession,
   MatrixCorpusSessionIdentity,
@@ -93,6 +94,7 @@ export interface MatrixCorpusExecutionServiceDeps {
       userId: string;
       userPreferences: string | null;
       deadlineAtMs: number;
+      intentClassifierResponseMode: IntexAgentIntentClassifierResponseFormatMode;
     }>
   ): IntexAgentRunner;
   replyPublisher: Pick<MatrixCorpusWhatsAppReplyPublisher, 'publishReplyWithReceipt'>;
@@ -234,6 +236,8 @@ export function createMatrixCorpusExecutionService(
           userId: ordinaryIngest.userId,
           userPreferences: promptContext,
           deadlineAtMs,
+          intentClassifierResponseMode:
+            runnerAttempt === 1 ? 'json_schema' : 'prompt_json',
         });
         let result: IntexAgentRunnerResult;
         try {
@@ -490,6 +494,7 @@ async function executeConfirmation(
     userId: ordinaryIngest.userId,
     userPreferences: input.userPreferences,
     deadlineAtMs: input.deadlineAtMs,
+    intentClassifierResponseMode: 'json_schema',
   });
   let result: IntexAgentRunnerResult;
   try {

--- a/apps/intex-agent/src/services.ts
+++ b/apps/intex-agent/src/services.ts
@@ -704,6 +704,7 @@ export async function initServices(config: ServiceConfig): Promise<void> {
           intentClassifier: createLlmIntexAgentIntentClassifier({
             client: clients.structuredClient,
             logger,
+            responseFormatMode: input.intentClassifierResponseMode,
           }),
           userPreferences: input.userPreferences,
           webAppUrl: config.webAppUrl,


### PR DESCRIPTION
## Summary
- keep strict JSON Schema on the first Matrix corpus classifier attempt
- switch zero-evidence retries to prompt-validated JSON while staying on MiniMax M3
- preserve isolated provider usage evidence per runner attempt

## Verification
- pnpm run ci:tracked (6901 tests passed)
- independent review: NO FINDINGS
- live synthetic MiniMax probe without response_format returned validated needs_clarification

Linear: omitted by $commit-push; GitHub automation will create or link the Linear issue after PR creation.