### PR TITLE
[INT-1930] fix: diversify required tool retries

### DIFF
--- a/packages/infra-openrouter/src/__tests__/toolCallingClient.test.ts
+++ b/packages/infra-openrouter/src/__tests__/toolCallingClient.test.ts
@@ -627,10 +627,7 @@ describe('createOpenRouterToolCallingClient', () => {
       type: 'function',
       function: { name: 'add_user_preference' },
     });
-    expect(capturedBodies[1]?.['tool_choice']).toEqual({
-      type: 'function',
-      function: { name: 'add_user_preference' },
-    });
+    expect(capturedBodies[1]?.['tool_choice']).toBe('required');
     expect(capturedBodies[2]?.['tool_choice']).toBe('auto');
     expect(capturedBodies[1]?.['messages']).toEqual(
       expect.arrayContaining([
@@ -640,7 +637,7 @@ describe('createOpenRouterToolCallingClient', () => {
         },
         {
           role: 'user',
-          content: expect.stringContaining('Call one of the provided tools'),
+          content: expect.stringContaining('Call the required add_user_preference tool now'),
         },
       ])
     );
@@ -798,10 +795,25 @@ describe('createOpenRouterToolCallingClient', () => {
   });
 
   it('keeps generic required tool choice when multiple tools are available', async () => {
-    let capturedBody: Record<string, unknown> | undefined;
+    const capturedBodies: Record<string, unknown>[] = [];
     nock(API_BASE_URL)
       .post('/chat/completions', (body) => {
-        capturedBody = body as Record<string, unknown>;
+        capturedBodies.push(body as Record<string, unknown>);
+        return true;
+      })
+      .reply(200, {
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content: '{"outcome":"no_action","reply":"No tool selected."}',
+            },
+          },
+        ],
+        usage: { prompt_tokens: 10, completion_tokens: 4, total_tokens: 14, cost: 0.0001 },
+      })
+      .post('/chat/completions', (body) => {
+        capturedBodies.push(body as Record<string, unknown>);
         return true;
       })
       .reply(200, {
@@ -846,7 +858,16 @@ describe('createOpenRouterToolCallingClient', () => {
     });
 
     expect(result.ok).toBe(true);
-    expect(capturedBody?.['tool_choice']).toBe('required');
+    expect(capturedBodies[0]?.['tool_choice']).toBe('required');
+    expect(capturedBodies[1]?.['tool_choice']).toBe('required');
+    expect(capturedBodies[1]?.['messages']).toEqual(
+      expect.arrayContaining([
+        {
+          role: 'user',
+          content: expect.stringContaining('Call one of the provided tools'),
+        },
+      ])
+    );
   });
 
   it('uses auto tool choice when requested', async () => {

--- a/packages/infra-openrouter/src/toolCallingClient.ts
+++ b/packages/infra-openrouter/src/toolCallingClient.ts
@@ -273,7 +273,8 @@ export function createOpenRouterToolCallingClient(
               conversation,
               tools,
               totalToolCalls,
-              toolChoice
+              toolChoice,
+              iteration
             );
 
             const responseResult = await withRetry(
@@ -406,7 +407,10 @@ export function createOpenRouterToolCallingClient(
             }
             if (tools.length > 0 && toolChoice === 'required' && totalToolCalls === 0) {
               conversation.push({ role: 'assistant', content: finalText });
-              conversation.push({ role: 'user', content: REQUIRED_TOOL_RETRY_MESSAGE });
+              conversation.push({
+                role: 'user',
+                content: requiredToolRetryMessage(tools),
+              });
               logger.info({ iteration }, 'OpenRouter tool calling: retrying required tool choice');
               continue;
             }
@@ -518,11 +522,12 @@ function buildRequestBody(
   messages: OpenRouterMessage[],
   tools: ToolDefinition[],
   totalToolCalls: number,
-  toolChoice: 'auto' | 'required'
+  toolChoice: 'auto' | 'required',
+  iteration: number
 ): Record<string, unknown> {
   const onlyTool = tools.length === 1 ? tools[0] : undefined;
   const initialToolChoice =
-    toolChoice === 'required' && onlyTool !== undefined
+    toolChoice === 'required' && onlyTool !== undefined && iteration === 1
       ? { type: 'function', function: { name: onlyTool.name } }
       : toolChoice;
   return {
@@ -541,6 +546,12 @@ function buildRequestBody(
       tool_choice: totalToolCalls === 0 ? initialToolChoice : 'auto',
     }),
   };
+}
+
+function requiredToolRetryMessage(tools: ToolDefinition[]): string {
+  const onlyTool = tools.length === 1 ? tools[0] : undefined;
+  if (onlyTool === undefined) return REQUIRED_TOOL_RETRY_MESSAGE;
+  return `Call the required ${onlyTool.name} tool now with arguments derived from the original request. Do not return final text before calling the tool.`;
 }
 
 async function runToolCall(


### PR DESCRIPTION
## Summary
- keep exact single-function forcing for the first OpenRouter request
- switch required-tool retries to generic provider forcing and name the only available tool in the retry prompt
- cover both single-tool and multi-tool retry behavior

## Verification
- pnpm run verify:workspace:tracked infra-openrouter (166 tests)
- pnpm run ci:tracked (6901 tests)
- independent review: no findings

Linear: omitted by $commit-push; GitHub automation will create or link the Linear issue after PR creation.