### PR TITLE
[INT-1931] fix: synthesize MiniMax terminal tool arguments

### DIFF
--- a/packages/infra-openrouter/src/__tests__/toolCallingClient.test.ts
+++ b/packages/infra-openrouter/src/__tests__/toolCallingClient.test.ts
@@ -644,6 +644,348 @@ describe('createOpenRouterToolCallingClient', () => {
     expect(runTool).toHaveBeenCalledWith({ text: 'Be concise.', expectedVersion: 0 });
   });
 
+  it('falls back to validated JSON arguments when MiniMax exhausts a single required terminal tool', async () => {
+    const capturedBodies: Record<string, unknown>[] = [];
+    const runTool = vi.fn().mockResolvedValue('{"status":"needs_confirmation"}');
+    const scope = nock(API_BASE_URL)
+      .post('/chat/completions', (body) => {
+        capturedBodies.push(body as Record<string, unknown>);
+        return true;
+      })
+      .times(2)
+      .reply(200, {
+        choices: [{ message: { role: 'assistant', content: 'I will remember that.' } }],
+        usage: { prompt_tokens: 10, completion_tokens: 2, total_tokens: 12, cost: 0.0001 },
+      })
+      .post('/chat/completions', (body) => {
+        capturedBodies.push(body as Record<string, unknown>);
+        return true;
+      })
+      .reply(200, {
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content: '```json\n{"content":"Garage code is 7241."}\n```',
+            },
+          },
+        ],
+        usage: { prompt_tokens: 20, completion_tokens: 4, total_tokens: 24, cost: 0.0002 },
+      });
+    const onProviderCall = vi.fn().mockResolvedValue(undefined);
+
+    const result = await createClientWithConfig({ model: 'minimax/minimax-m3' }).run({
+      systemPrompt: 'Use the note tool when the user asks to retain a factual note.',
+      messages: [{ role: 'user', content: 'Remember that the garage code is 7241.' }],
+      tools: [
+        {
+          name: 'create_note',
+          description: 'Create a note preview.',
+          parameters: {
+            type: 'object',
+            additionalProperties: false,
+            required: ['content'],
+            properties: { content: { type: 'string' } },
+          },
+          stopAfterRun: true,
+          run: runTool,
+        },
+      ],
+      toolChoice: 'required',
+      maxIterations: 2,
+      matrixCorpusContext: {
+        version: 1,
+        runId: 'run_1',
+        scenarioId: 'scenario_006',
+        sessionId: 'session_6',
+        turnIndex: 0,
+        stage: 'agent_generation',
+        callOrdinal: 1,
+      },
+      onMatrixCorpusProviderCall: onProviderCall,
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      value: {
+        content: '',
+        toolCallsMade: 1,
+        iterationCount: 3,
+        usage: expect.objectContaining({
+          inputTokens: 40,
+          outputTokens: 8,
+          totalTokens: 48,
+          providerReportedUsd: 0.0004,
+        }),
+        providerCalls: [
+          expect.objectContaining({ context: expect.objectContaining({ callOrdinal: 1 }) }),
+          expect.objectContaining({ context: expect.objectContaining({ callOrdinal: 2 }) }),
+          expect.objectContaining({ context: expect.objectContaining({ callOrdinal: 3 }) }),
+        ],
+      },
+    });
+    expect(runTool).toHaveBeenCalledOnce();
+    expect(runTool).toHaveBeenCalledWith({ content: 'Garage code is 7241.' });
+    expect(capturedBodies[2]).not.toHaveProperty('tools');
+    expect(capturedBodies[2]).not.toHaveProperty('tool_choice');
+    expect(capturedBodies[2]?.['messages']).toEqual(
+      expect.arrayContaining([
+        {
+          role: 'user',
+          content: expect.stringMatching(/create_note[\s\S]*"required":\["content"\]/u),
+        },
+      ])
+    );
+    expect(onProviderCall).toHaveBeenCalledTimes(3);
+    expect(scope.isDone()).toBe(true);
+  });
+
+  it('returns a non-Matrix MiniMax fallback result from bare JSON', async () => {
+    const runTool = vi.fn().mockResolvedValue('{"status":"needs_confirmation"}');
+    nock(API_BASE_URL)
+      .post('/chat/completions')
+      .reply(200, {
+        choices: [{ message: { role: 'assistant', content: 'I will remember that.' } }],
+        usage: { prompt_tokens: 10, completion_tokens: 2, total_tokens: 12, cost: 0.0001 },
+      })
+      .post('/chat/completions')
+      .reply(200, {
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content: '{"content":"Garage code is 7241."}',
+            },
+          },
+        ],
+        usage: { prompt_tokens: 20, completion_tokens: 4, total_tokens: 24, cost: 0.0002 },
+      });
+
+    const result = await createClientWithConfig({ model: 'minimax/minimax-m3' }).run({
+      systemPrompt: 'Use the note tool.',
+      messages: [{ role: 'user', content: 'Remember the garage code.' }],
+      tools: [
+        {
+          name: 'create_note',
+          description: 'Create a note preview.',
+          parameters: { type: 'object', required: ['content'] },
+          stopAfterRun: true,
+          run: runTool,
+        },
+      ],
+      toolChoice: 'required',
+      maxIterations: 1,
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      value: expect.objectContaining({
+        content: '',
+        toolCallsMade: 1,
+        iterationCount: 2,
+      }),
+    });
+    expect(result).toEqual({
+      ok: true,
+      value: expect.not.objectContaining({ providerCalls: expect.anything() }),
+    });
+    expect(runTool).toHaveBeenCalledWith({ content: 'Garage code is 7241.' });
+  });
+
+  it('maps a MiniMax fallback provider failure after recording the native iteration', async () => {
+    nock(API_BASE_URL)
+      .post('/chat/completions')
+      .reply(200, {
+        choices: [{ message: { role: 'assistant', content: 'I will remember that.' } }],
+        usage: { prompt_tokens: 10, completion_tokens: 2, total_tokens: 12, cost: 0.0001 },
+      })
+      .post('/chat/completions')
+      .reply(503, 'fallback provider unavailable');
+
+    const result = await createClientWithConfig({
+      model: 'minimax/minimax-m3',
+      deadlineAtMs: Date.now() + 60_000,
+    }).run({
+      systemPrompt: 'Use the note tool.',
+      messages: [{ role: 'user', content: 'Remember the garage code.' }],
+      tools: [
+        {
+          name: 'create_note',
+          description: 'Create a note preview.',
+          parameters: { type: 'object', required: ['content'] },
+          stopAfterRun: true,
+          run: vi.fn(),
+        },
+      ],
+      toolChoice: 'required',
+      maxIterations: 1,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: { code: 'OVERLOADED', message: 'fallback provider unavailable' },
+    });
+  });
+
+  it('does not override a caller that explicitly declines exhausted-loop repair', async () => {
+    const runTool = vi.fn();
+    const scope = nock(API_BASE_URL)
+      .post('/chat/completions')
+      .reply(200, {
+        choices: [{ message: { role: 'assistant', content: 'I will remember that.' } }],
+        usage: { prompt_tokens: 10, completion_tokens: 2, total_tokens: 12, cost: 0.0001 },
+      });
+
+    const result = await createClientWithConfig({ model: 'minimax/minimax-m3' }).run({
+      systemPrompt: 'Use the note tool.',
+      messages: [{ role: 'user', content: 'Remember the garage code.' }],
+      tools: [
+        {
+          name: 'create_note',
+          description: 'Create a note preview.',
+          parameters: { type: 'object', required: ['content'] },
+          stopAfterRun: true,
+          run: runTool,
+        },
+      ],
+      toolChoice: 'required',
+      maxIterations: 1,
+      onExhausted: () => undefined,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: { code: 'API_ERROR', message: 'Tool calling loop exceeded maxIterations' },
+    });
+    expect(runTool).not.toHaveBeenCalled();
+    expect(scope.isDone()).toBe(true);
+  });
+
+  it.each([
+    ['missing content', [], true],
+    ['invalid JSON', [{ message: { role: 'assistant', content: 'PRIVATE_INVALID_JSON' } }], false],
+    ['a JSON array', [{ message: { role: 'assistant', content: '[]' } }], true],
+  ])('rejects MiniMax fallback arguments with %s', async (_case, fallbackChoices, matrix) => {
+    const runTool = vi.fn();
+    nock(API_BASE_URL)
+      .post('/chat/completions')
+      .reply(200, {
+        choices: [{ message: { role: 'assistant', content: 'I will remember that.' } }],
+        usage: { prompt_tokens: 10, completion_tokens: 2, total_tokens: 12, cost: 0.0001 },
+      })
+      .post('/chat/completions')
+      .reply(200, {
+        choices: fallbackChoices,
+        usage: { prompt_tokens: 20, completion_tokens: 4, total_tokens: 24, cost: 0.0002 },
+      });
+
+    const result = await createClientWithConfig({ model: 'minimax/minimax-m3' }).run({
+      systemPrompt: 'Use the note tool.',
+      messages: [{ role: 'user', content: 'Remember the garage code.' }],
+      tools: [
+        {
+          name: 'create_note',
+          description: 'Create a note preview.',
+          parameters: { type: 'object', required: ['content'] },
+          stopAfterRun: true,
+          run: runTool,
+        },
+      ],
+      toolChoice: 'required',
+      maxIterations: 1,
+      ...(matrix
+        ? {
+            matrixCorpusContext: {
+              version: 1 as const,
+              runId: 'run_1',
+              scenarioId: 'scenario_006',
+              sessionId: 'session_6',
+              turnIndex: 0,
+              stage: 'agent_generation' as const,
+              callOrdinal: 1,
+            },
+          }
+        : {}),
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: { code: 'API_ERROR', message: 'Tool calling loop exceeded maxIterations' },
+    });
+    expect(runTool).not.toHaveBeenCalled();
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        errorCode: 'MINIMAX_REQUIRED_TOOL_ARGUMENT_FALLBACK_REJECTED',
+        ...(matrix ? { _skipSentry: true } : {}),
+      }),
+      expect.any(String)
+    );
+    expect(JSON.stringify(vi.mocked(mockLogger.warn).mock.calls)).not.toContain(
+      'PRIVATE_INVALID_JSON'
+    );
+  });
+
+  it('rejects MiniMax fallback arguments when the terminal callback validation throws', async () => {
+    const runTool = vi.fn(async () => {
+      throw new Error('PRIVATE_CALLBACK_REJECTION');
+    });
+    nock(API_BASE_URL)
+      .post('/chat/completions')
+      .reply(200, {
+        choices: [{ message: { role: 'assistant', content: 'I will remember that.' } }],
+        usage: { prompt_tokens: 10, completion_tokens: 2, total_tokens: 12, cost: 0.0001 },
+      })
+      .post('/chat/completions')
+      .reply(200, {
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content: '{"content":"Garage code is 7241."}',
+            },
+          },
+        ],
+        usage: { prompt_tokens: 20, completion_tokens: 4, total_tokens: 24, cost: 0.0002 },
+      });
+
+    const result = await createClientWithConfig({ model: 'minimax/minimax-m3' }).run({
+      systemPrompt: 'Use the note tool.',
+      messages: [{ role: 'user', content: 'Remember the garage code.' }],
+      tools: [
+        {
+          name: 'create_note',
+          description: 'Create a note preview.',
+          parameters: { type: 'object', required: ['content'] },
+          stopAfterRun: true,
+          run: runTool,
+        },
+      ],
+      toolChoice: 'required',
+      maxIterations: 1,
+      matrixCorpusContext: {
+        version: 1,
+        runId: 'run_1',
+        scenarioId: 'scenario_006',
+        sessionId: 'session_6',
+        turnIndex: 0,
+        stage: 'agent_generation',
+        callOrdinal: 1,
+      },
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: { code: 'API_ERROR', message: 'Tool calling loop exceeded maxIterations' },
+    });
+    expect(runTool).toHaveBeenCalledOnce();
+    expect(
+      JSON.stringify([
+        vi.mocked(mockLogger.warn).mock.calls,
+        vi.mocked(mockLogger.error).mock.calls,
+      ])
+    ).not.toContain('PRIVATE_CALLBACK_REJECTION');
+  });
+
   it('logs ownerType and zero usage when OpenRouter omits usage metadata', async () => {
     nock(API_BASE_URL)
       .post('/chat/completions')

--- a/packages/infra-openrouter/src/toolCallingClient.ts
+++ b/packages/infra-openrouter/src/toolCallingClient.ts
@@ -240,6 +240,11 @@ export function createOpenRouterToolCallingClient(
       let providerReportedUsd = 0;
       let responsesWithUsage = 0;
       let hasUnknownProviderCost = false;
+      const retryOptions = {
+        maxAttempts,
+        baseDelayMs: 500,
+        ...(deadlineAtMs === undefined ? {} : { deadlineAtMs }),
+      };
 
       function completeUsage(): NormalizedUsage {
         if (hasUnknownProviderCost || responsesWithUsage === 0) {
@@ -263,6 +268,38 @@ export function createOpenRouterToolCallingClient(
         return hasUnknownProviderCost || responsesWithUsage === 0 ? null : providerReportedUsd;
       }
 
+      async function recordProviderResponse(
+        data: OpenRouterToolCallingResponse,
+        callOrdinal: number
+      ): Promise<ReturnType<typeof extractUsage>> {
+        const usage = extractUsage(data.usage);
+        if (params.matrixCorpusContext !== undefined) {
+          const providerCall: MatrixCorpusProviderCallUsageV1 = {
+            context: {
+              ...params.matrixCorpusContext,
+              callOrdinal: params.matrixCorpusContext.callOrdinal + callOrdinal - 1,
+            },
+            modelId: evidenceModelId,
+            inputTokens: usage.normalized.inputTokens,
+            outputTokens: usage.normalized.outputTokens,
+            totalTokens: usage.normalized.totalTokens,
+            ...(usage.providerReportedUsd === null
+              ? {}
+              : { providerReportedUsd: usage.providerReportedUsd }),
+          };
+          providerCalls.push(providerCall);
+          await params.onMatrixCorpusProviderCall?.(providerCall);
+        }
+        aggregatedUsage = addUsage(aggregatedUsage, usage.normalized);
+        responsesWithUsage++;
+        if (usage.providerReportedUsd === null) {
+          hasUnknownProviderCost = true;
+        } else {
+          providerReportedUsd += usage.providerReportedUsd;
+        }
+        return usage;
+      }
+
       try {
         for (let attempt = 0; attempt < 2; attempt++) {
           while (iteration < effectiveMax) {
@@ -277,48 +314,17 @@ export function createOpenRouterToolCallingClient(
               iteration
             );
 
-            const responseResult = await withRetry(
-              async () => {
-                try {
-                  return ok(await postChatCompletion(requestBody));
-                } catch (error) {
-                  return err(mapOpenRouterError(error));
-                }
-              },
-              {
-                maxAttempts,
-                baseDelayMs: 500,
-                ...(deadlineAtMs === undefined ? {} : { deadlineAtMs }),
+            const responseResult = await withRetry(async () => {
+              try {
+                return ok(await postChatCompletion(requestBody));
+              } catch (error) {
+                return err(mapOpenRouterError(error));
               }
-            );
+            }, retryOptions);
             if (!responseResult.ok) throw new OpenRouterLlmError(responseResult.error);
             const data = responseResult.value;
             const message = data.choices[0]?.message;
-            const usage = extractUsage(data.usage);
-            if (params.matrixCorpusContext !== undefined) {
-              const providerCall: MatrixCorpusProviderCallUsageV1 = {
-                context: {
-                  ...params.matrixCorpusContext,
-                  callOrdinal: params.matrixCorpusContext.callOrdinal + iteration - 1,
-                },
-                modelId: evidenceModelId,
-                inputTokens: usage.normalized.inputTokens,
-                outputTokens: usage.normalized.outputTokens,
-                totalTokens: usage.normalized.totalTokens,
-                ...(usage.providerReportedUsd === null
-                  ? {}
-                  : { providerReportedUsd: usage.providerReportedUsd }),
-              };
-              providerCalls.push(providerCall);
-              await params.onMatrixCorpusProviderCall?.(providerCall);
-            }
-            aggregatedUsage = addUsage(aggregatedUsage, usage.normalized);
-            responsesWithUsage++;
-            if (usage.providerReportedUsd === null) {
-              hasUnknownProviderCost = true;
-            } else {
-              providerReportedUsd += usage.providerReportedUsd;
-            }
+            const usage = await recordProviderResponse(data, iteration);
 
             const toolCalls = message?.tool_calls ?? [];
             if (toolCalls.length > 0) {
@@ -467,6 +473,78 @@ export function createOpenRouterToolCallingClient(
           break;
         }
 
+        const fallbackTool = requiredTerminalToolArgsFallback(
+          model,
+          tools,
+          toolChoice,
+          totalToolCalls,
+          onExhausted === undefined
+        );
+        if (fallbackTool !== undefined) {
+          iteration++;
+          const responseResult = await withRetry(async () => {
+            try {
+              return ok(
+                await postChatCompletion(
+                  buildToolArgsFallbackRequestBody(model, systemPrompt, messages, fallbackTool)
+                )
+              );
+            } catch (error) {
+              return err(mapOpenRouterError(error));
+            }
+          }, retryOptions);
+          if (!responseResult.ok) throw new OpenRouterLlmError(responseResult.error);
+          const data = responseResult.value;
+          await recordProviderResponse(data, iteration);
+          const fallbackArgs = parsePromptJsonObject(data.choices[0]?.message.content);
+          if (fallbackArgs !== undefined) {
+            const toolResponse = await runToolCall(
+              toolMap,
+              {
+                id: `fallback_${String(iteration)}`,
+                type: 'function',
+                function: {
+                  name: fallbackTool.name,
+                  arguments: JSON.stringify(fallbackArgs),
+                },
+              },
+              logger,
+              iteration,
+              params.matrixCorpusContext !== undefined
+            );
+            totalToolCalls++;
+            if (toolResponse.accepted) {
+              logger.info(
+                { iteration, totalToolCalls },
+                'OpenRouter tool calling: completed MiniMax required-tool argument fallback'
+              );
+              trackUsage(
+                completeUsage(),
+                true,
+                Date.now() - runStart,
+                undefined,
+                completeProviderReportedUsd(),
+                promptType
+              );
+              return ok({
+                content: '',
+                toolCallsMade: totalToolCalls,
+                iterationCount: iteration,
+                usage: completeUsage(),
+                ...(params.matrixCorpusContext === undefined ? {} : { providerCalls }),
+              });
+            }
+          }
+          logger.warn(
+            {
+              iteration,
+              errorCode: 'MINIMAX_REQUIRED_TOOL_ARGUMENT_FALLBACK_REJECTED',
+              ...(params.matrixCorpusContext === undefined ? {} : { _skipSentry: true }),
+            },
+            'OpenRouter tool calling: MiniMax required-tool argument fallback rejected'
+          );
+        }
+
         trackUsage(
           completeUsage(),
           false,
@@ -554,13 +632,56 @@ function requiredToolRetryMessage(tools: ToolDefinition[]): string {
   return `Call the required ${onlyTool.name} tool now with arguments derived from the original request. Do not return final text before calling the tool.`;
 }
 
+function requiredTerminalToolArgsFallback(
+  model: string,
+  tools: ToolDefinition[],
+  toolChoice: 'auto' | 'required',
+  totalToolCalls: number,
+  allowFallback: boolean
+): ToolDefinition | undefined {
+  if (
+    !allowFallback ||
+    !/^(?:or:)?minimax\/minimax-m3$/iu.test(model) ||
+    toolChoice !== 'required' ||
+    totalToolCalls !== 0 ||
+    tools.length !== 1 ||
+    tools[0]?.stopAfterRun !== true
+  ) {
+    return undefined;
+  }
+  return tools[0];
+}
+
+function buildToolArgsFallbackRequestBody(
+  model: string,
+  systemPrompt: string,
+  messages: ToolCallingMessage[],
+  tool: ToolDefinition
+): Record<string, unknown> {
+  const fallbackInstruction = [
+    `Return only the JSON object of arguments for the required ${tool.name} tool.`,
+    'Derive every argument from the original user request and conversation.',
+    'Do not include markdown, commentary, the tool name, or an outer wrapper.',
+    `Tool purpose: ${tool.description}`,
+    `Arguments JSON Schema: ${JSON.stringify(tool.parameters)}`,
+  ].join('\n');
+  return {
+    model,
+    messages: [
+      ...buildInitialMessages(systemPrompt, messages),
+      { role: 'user', content: fallbackInstruction },
+    ],
+    temperature: 0,
+  };
+}
+
 async function runToolCall(
   toolMap: Map<string, ToolDefinition>,
   toolCall: OpenRouterToolCall,
   logger: Logger,
   iteration: number,
   matrixCorpus: boolean
-): Promise<Readonly<{ content: string; stopAfterRun: boolean }>> {
+): Promise<Readonly<{ accepted: boolean; content: string; stopAfterRun: boolean }>> {
   const toolName = toolCall.function?.name ?? '';
   const toolArgs = parseToolArgs(toolCall.function?.arguments);
   const toolDef = toolMap.get(toolName);
@@ -576,6 +697,7 @@ async function runToolCall(
       'OpenRouter tool calling: hallucinated tool name'
     );
     return {
+      accepted: false,
       content: JSON.stringify({
         error: matrixCorpus ? 'Unknown tool' : `Unknown tool: ${toolName}`,
       }),
@@ -585,6 +707,7 @@ async function runToolCall(
 
   try {
     return {
+      accepted: true,
       content: await toolDef.run(toolArgs),
       stopAfterRun: toolDef.stopAfterRun === true,
     };
@@ -597,6 +720,7 @@ async function runToolCall(
       'OpenRouter tool calling: run callback threw'
     );
     return {
+      accepted: false,
       content: JSON.stringify({ error: matrixCorpus ? 'Tool execution failed' : errorMsg }),
       stopAfterRun: false,
     };
@@ -616,6 +740,21 @@ function parseToolArgs(rawArgs: string | undefined): Record<string, unknown> {
     return {};
   } catch {
     return {};
+  }
+}
+
+function parsePromptJsonObject(
+  rawContent: string | null | undefined
+): Record<string, unknown> | undefined {
+  if (typeof rawContent !== 'string') return undefined;
+  const trimmed = rawContent.trim();
+  const fenced = /^```(?:json)?\s*([\s\S]*?)\s*```$/iu.exec(trimmed);
+  const candidate = fenced?.[1]?.trim() ?? trimmed;
+  try {
+    const parsed = JSON.parse(candidate) as unknown;
+    return isRecord(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
   }
 }
 


### PR DESCRIPTION
## Summary

- add a MiniMax M3-only fallback that synthesizes validated JSON arguments after native function calling exhausts
- restrict fallback to one required terminal tool and preserve explicit caller exhaustion behavior
- record fallback provider usage and Matrix corpus evidence with the next exact call ordinal
- cover success, provider failure, malformed output, rejected callback, privacy, and non-Matrix behavior

## Verification

- `pnpm run ci:tracked` (6901 tests passed)
- targeted infra-openrouter coverage: 100% branches
- independent review: no findings

## Linear

Linear: omitted by `$commit-push`; GitHub automation will create or link the Linear issue after PR creation.
