### PR TITLE
[INT-1932] fix: stop repeated MiniMax single-tool calls

### DIFF
--- a/packages/infra-openrouter/src/__tests__/toolCallingClient.test.ts
+++ b/packages/infra-openrouter/src/__tests__/toolCallingClient.test.ts
@@ -1136,6 +1136,251 @@ describe('createOpenRouterToolCallingClient', () => {
     );
   });
 
+  it('does not expose the same single tool again after MiniMax runs it successfully', async () => {
+    const capturedBodies: Record<string, unknown>[] = [];
+    const runTool = vi.fn().mockResolvedValue('{"events":[]}');
+    nock(API_BASE_URL)
+      .post('/chat/completions', (body) => {
+        capturedBodies.push(body as Record<string, unknown>);
+        return true;
+      })
+      .reply(200, {
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content: null,
+              tool_calls: [
+                {
+                  id: 'call_query',
+                  type: 'function',
+                  function: {
+                    name: 'query_calendar_events',
+                    arguments: '{"mode":"list","query":"today meetings"}',
+                  },
+                },
+              ],
+            },
+          },
+        ],
+        usage: { prompt_tokens: 20, completion_tokens: 5, total_tokens: 25, cost: 0.0002 },
+      })
+      .post('/chat/completions', (body) => {
+        capturedBodies.push(body as Record<string, unknown>);
+        return true;
+      })
+      .reply(200, {
+        choices: [{ message: { role: 'assistant', content: 'You have no meetings today.' } }],
+        usage: { prompt_tokens: 25, completion_tokens: 6, total_tokens: 31, cost: 0.0003 },
+      });
+
+    const result = await createClientWithConfig({ model: 'minimax/minimax-m3' }).run({
+      systemPrompt: 'Use the calendar query tool, then answer from its result.',
+      messages: [{ role: 'user', content: 'What meetings do I have today?' }],
+      tools: [
+        {
+          name: 'query_calendar_events',
+          description: 'Query calendar events.',
+          parameters: {
+            type: 'object',
+            required: ['mode'],
+            properties: {
+              mode: { type: 'string' },
+              query: { type: 'string' },
+            },
+          },
+          run: runTool,
+        },
+      ],
+      toolChoice: 'required',
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      value: expect.objectContaining({
+        content: 'You have no meetings today.',
+        toolCallsMade: 1,
+        iterationCount: 2,
+      }),
+    });
+    expect(runTool).toHaveBeenCalledOnce();
+    expect(capturedBodies[0]).toHaveProperty('tools');
+    expect(capturedBodies[1]).not.toHaveProperty('tools');
+    expect(capturedBodies[1]).not.toHaveProperty('tool_choice');
+  });
+
+  it('runs only the first accepted single MiniMax tool call from one response', async () => {
+    const capturedBodies: Record<string, unknown>[] = [];
+    const runTool = vi.fn().mockResolvedValue('{"events":[]}');
+    nock(API_BASE_URL)
+      .post('/chat/completions', (body) => {
+        capturedBodies.push(body as Record<string, unknown>);
+        return true;
+      })
+      .reply(200, {
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content: null,
+              tool_calls: [
+                {
+                  id: 'call_query_1',
+                  type: 'function',
+                  function: {
+                    name: 'query_calendar_events',
+                    arguments: '{"mode":"list","query":"today meetings"}',
+                  },
+                },
+                {},
+              ],
+            },
+          },
+        ],
+        usage: { prompt_tokens: 20, completion_tokens: 8, total_tokens: 28, cost: 0.0002 },
+      })
+      .post('/chat/completions', (body) => {
+        capturedBodies.push(body as Record<string, unknown>);
+        return true;
+      })
+      .reply(200, {
+        choices: [{ message: { role: 'assistant', content: 'You have no meetings today.' } }],
+        usage: { prompt_tokens: 25, completion_tokens: 6, total_tokens: 31, cost: 0.0003 },
+      });
+
+    const result = await createClientWithConfig({ model: 'minimax/minimax-m3' }).run({
+      systemPrompt: 'Use the calendar query tool, then answer from its result.',
+      messages: [{ role: 'user', content: 'What meetings do I have today?' }],
+      tools: [
+        {
+          name: 'query_calendar_events',
+          description: 'Query calendar events.',
+          parameters: { type: 'object', required: ['mode'] },
+          run: runTool,
+        },
+      ],
+      toolChoice: 'required',
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      value: expect.objectContaining({
+        content: 'You have no meetings today.',
+        toolCallsMade: 1,
+        iterationCount: 2,
+      }),
+    });
+    expect(runTool).toHaveBeenCalledOnce();
+    expect(capturedBodies[1]).not.toHaveProperty('tools');
+    expect(capturedBodies[1]?.['messages']).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          role: 'tool',
+          tool_call_id: 'call_query_1',
+          content: '{"events":[]}',
+        }),
+        expect.objectContaining({
+          role: 'tool',
+          tool_call_id: 'call_1_1',
+          name: '',
+          content: '{"error":"Tool already completed"}',
+        }),
+      ])
+    );
+  });
+
+  it('keeps the single MiniMax tool available until one callback succeeds', async () => {
+    const capturedBodies: Record<string, unknown>[] = [];
+    const runTool = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('invalid query'))
+      .mockResolvedValueOnce('{"events":[]}');
+    nock(API_BASE_URL)
+      .post('/chat/completions', (body) => {
+        capturedBodies.push(body as Record<string, unknown>);
+        return true;
+      })
+      .reply(200, {
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content: null,
+              tool_calls: [
+                {
+                  id: 'call_invalid',
+                  type: 'function',
+                  function: { name: 'query_calendar_events', arguments: '{"mode":"list"}' },
+                },
+              ],
+            },
+          },
+        ],
+        usage: { prompt_tokens: 20, completion_tokens: 5, total_tokens: 25, cost: 0.0002 },
+      })
+      .post('/chat/completions', (body) => {
+        capturedBodies.push(body as Record<string, unknown>);
+        return true;
+      })
+      .reply(200, {
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content: null,
+              tool_calls: [
+                {
+                  id: 'call_repaired',
+                  type: 'function',
+                  function: {
+                    name: 'query_calendar_events',
+                    arguments: '{"mode":"list","query":"today meetings"}',
+                  },
+                },
+              ],
+            },
+          },
+        ],
+        usage: { prompt_tokens: 25, completion_tokens: 5, total_tokens: 30, cost: 0.0002 },
+      })
+      .post('/chat/completions', (body) => {
+        capturedBodies.push(body as Record<string, unknown>);
+        return true;
+      })
+      .reply(200, {
+        choices: [{ message: { role: 'assistant', content: 'You have no meetings today.' } }],
+        usage: { prompt_tokens: 30, completion_tokens: 6, total_tokens: 36, cost: 0.0003 },
+      });
+
+    const result = await createClientWithConfig({ model: 'minimax/minimax-m3' }).run({
+      systemPrompt: 'Use the calendar query tool, then answer from its result.',
+      messages: [{ role: 'user', content: 'What meetings do I have today?' }],
+      tools: [
+        {
+          name: 'query_calendar_events',
+          description: 'Query calendar events.',
+          parameters: { type: 'object', required: ['mode'] },
+          run: runTool,
+        },
+      ],
+      toolChoice: 'required',
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      value: expect.objectContaining({
+        content: 'You have no meetings today.',
+        toolCallsMade: 2,
+        iterationCount: 3,
+      }),
+    });
+    expect(runTool).toHaveBeenCalledTimes(2);
+    expect(capturedBodies[1]).toHaveProperty('tools');
+    expect(capturedBodies[1]?.['tool_choice']).toBe('auto');
+    expect(capturedBodies[2]).not.toHaveProperty('tools');
+    expect(capturedBodies[2]).not.toHaveProperty('tool_choice');
+  });
+
   it('keeps generic required tool choice when multiple tools are available', async () => {
     const capturedBodies: Record<string, unknown>[] = [];
     nock(API_BASE_URL)
@@ -1177,7 +1422,7 @@ describe('createOpenRouterToolCallingClient', () => {
         usage: { prompt_tokens: 10, completion_tokens: 4, total_tokens: 14, cost: 0.0001 },
       });
 
-    const result = await createClient().run({
+    const result = await createClientWithConfig({ model: 'minimax/minimax-m3' }).run({
       systemPrompt: 'Use one appropriate tool.',
       messages: [{ role: 'user', content: 'Store this.' }],
       tools: [

--- a/packages/infra-openrouter/src/toolCallingClient.ts
+++ b/packages/infra-openrouter/src/toolCallingClient.ts
@@ -226,6 +226,7 @@ export function createOpenRouterToolCallingClient(
 
       const runStart = Date.now();
       let totalToolCalls = 0;
+      let acceptedToolCallMade = false;
       let iteration = 0;
       let effectiveMax = maxIterations;
       let onExhaustedFn = onExhausted;
@@ -240,6 +241,7 @@ export function createOpenRouterToolCallingClient(
       let providerReportedUsd = 0;
       let responsesWithUsage = 0;
       let hasUnknownProviderCost = false;
+      const suppressSingleToolAfterAcceptedCall = isMiniMaxM3Model(model) && tools.length === 1;
       const retryOptions = {
         maxAttempts,
         baseDelayMs: 500,
@@ -308,7 +310,7 @@ export function createOpenRouterToolCallingClient(
             const requestBody = buildRequestBody(
               model,
               conversation,
-              tools,
+              acceptedToolCallMade && suppressSingleToolAfterAcceptedCall ? [] : tools,
               totalToolCalls,
               toolChoice,
               iteration
@@ -335,6 +337,19 @@ export function createOpenRouterToolCallingClient(
               });
 
               for (const [index, toolCall] of toolCalls.entries()) {
+                if (acceptedToolCallMade && suppressSingleToolAfterAcceptedCall) {
+                  conversation.push({
+                    role: 'tool',
+                    tool_call_id: toolCall.id ?? `call_${String(iteration)}_${String(index)}`,
+                    name: toolCall.function?.name ?? '',
+                    content: JSON.stringify({ error: 'Tool already completed' }),
+                  });
+                  logger.info(
+                    { iteration },
+                    'OpenRouter tool calling: skipped duplicate MiniMax single-tool call'
+                  );
+                  continue;
+                }
                 const toolResponse = await runToolCall(
                   toolMap,
                   toolCall,
@@ -343,6 +358,7 @@ export function createOpenRouterToolCallingClient(
                   params.matrixCorpusContext !== undefined
                 );
                 totalToolCalls++;
+                if (toolResponse.accepted) acceptedToolCallMade = true;
                 conversation.push({
                   role: 'tool',
                   tool_call_id: toolCall.id ?? `call_${String(iteration)}_${String(index)}`,
@@ -641,7 +657,7 @@ function requiredTerminalToolArgsFallback(
 ): ToolDefinition | undefined {
   if (
     !allowFallback ||
-    !/^(?:or:)?minimax\/minimax-m3$/iu.test(model) ||
+    !isMiniMaxM3Model(model) ||
     toolChoice !== 'required' ||
     totalToolCalls !== 0 ||
     tools.length !== 1 ||
@@ -650,6 +666,10 @@ function requiredTerminalToolArgsFallback(
     return undefined;
   }
   return tools[0];
+}
+
+function isMiniMaxM3Model(model: string): boolean {
+  return /^(?:or:)?minimax\/minimax-m3$/iu.test(model);
 }
 
 function buildToolArgsFallbackRequestBody(


### PR DESCRIPTION
## Summary

- stop re-exposing one successfully executed tool to MiniMax M3 on the next provider iteration
- skip duplicate tool calls in the same MiniMax response after the first callback succeeds
- preserve repair access after rejected callbacks and preserve multiple-tool behavior
- cover sequential duplicates, same-response duplicates, callback repair, and model/tool-count boundaries

## Verification

- `pnpm run ci:tracked` (6901 tests passed)
- targeted infra-openrouter coverage: 100% branches
- production run `eval-3d79819e-a8fc-4f08-b2d0-aa0a87945c77` reproduced the duplicate-call failure in scenario 11
- independent review: no findings

## Linear

Linear: omitted by `$commit-push`; GitHub automation will create or link the Linear issue after PR creation.
