### PR TITLE
[INT-1935] Fix Matrix agent usage evidence bounds

### DIFF
--- a/packages/http-contracts/src/__tests__/intexAgentTestRuns.test.ts
+++ b/packages/http-contracts/src/__tests__/intexAgentTestRuns.test.ts
@@ -518,8 +518,9 @@ describe('Intex Agent Test Runs public contracts', () => {
       costNanoUsd: 1,
     };
     expect(safeAgentUsageV1Schema.safeParse(usage).success).toBe(true);
-    expect(safeAgentUsageV1Schema.safeParse({ ...usage, callOrdinal: 5 }).success).toBe(true);
-    expect(safeAgentUsageV1Schema.safeParse({ ...usage, callOrdinal: 6 }).success).toBe(false);
+    expect(safeAgentUsageV1Schema.safeParse({ ...usage, callOrdinal: 6 }).success).toBe(true);
+    expect(safeAgentUsageV1Schema.safeParse({ ...usage, callOrdinal: 60 }).success).toBe(true);
+    expect(safeAgentUsageV1Schema.safeParse({ ...usage, callOrdinal: 61 }).success).toBe(false);
     expect(safeAgentUsageV1Schema.safeParse({ ...usage, turnIndex: 20 }).success).toBe(false);
   });
 

--- a/packages/http-contracts/src/intexAgentTestRuns.ts
+++ b/packages/http-contracts/src/intexAgentTestRuns.ts
@@ -13,7 +13,7 @@ export const INTEX_AGENT_TEST_RUN_MAX_TOOL_FACTS = 16 as const;
 export const INTEX_AGENT_TEST_RUN_MAX_DETERMINISTIC_CHECKS = 240 as const;
 export const INTEX_AGENT_TEST_RUN_MAX_REPLY_EVALUATIONS = 100 as const;
 export const INTEX_AGENT_TEST_RUN_MAX_AGENT_USAGE = 60 as const;
-export const INTEX_AGENT_TEST_RUN_MAX_AGENT_CALL_ORDINAL = 5 as const;
+export const INTEX_AGENT_TEST_RUN_MAX_AGENT_CALL_ORDINAL = 60 as const;
 export const INTEX_AGENT_TEST_RUN_MAX_REPLIES_PER_TURN = 5 as const;
 
 const safeIntegerSchema = z.number().int().min(0).max(Number.MAX_SAFE_INTEGER);


### PR DESCRIPTION
## Summary
- align the shared agent usage call ordinal limit with the production evidence endpoint
- accept valid sixth-through-sixtieth MiniMax generation calls
- retain the aggregate 60-record cap and reject ordinal 61

## Verification
- pnpm run ci:tracked (6903 tests passed)
- targeted Matrix contract, live execution, and route tests (144 passed)
- reviewer: no findings

Linear: omitted by `$commit-push`; GitHub automation will create or link the Linear issue after PR creation.