### PR TITLE
[INT-1936] fix: recover missed matrix eval replies

### DIFF
--- a/apps/intex-agent/src/__tests__/domain/intexAgentRunner.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/intexAgentRunner.test.ts
@@ -829,6 +829,120 @@ describe('createIntexAgentRunner', () => {
     expect(client.calls).toEqual([]);
   });
 
+  it('narrows a spurious note candidate when a timed calendar request only lacks its date', async () => {
+    const client = new FakeToolCallingClient([]);
+    const runner = createIntexAgentRunner({
+      client,
+      intentClassifier: {
+        async classify() {
+          return {
+            kind: 'needs_clarification',
+            question: 'What would you like me to do with this?',
+            blockerReason: 'missing_required_details',
+            missingFields: ['end', 'summary'],
+            candidateIntents: ['create_calendar_event', 'create_note'],
+            suggestedNextStep:
+              'Ask for the missing end time and confirm whether this is a calendar event or a note.',
+            reason: 'The timed request may be a calendar event or a note.',
+            stylePreferenceAction: 'none',
+            languageOverride: 'en',
+            decisionEvidence: 'The request has a substantive title and clock time but no date.',
+          } as const;
+        },
+      },
+      toolExecutor: fakeToolExecutor(),
+    });
+
+    await expect(
+      runner.run({
+        session: session(),
+        events: [],
+        message: 'Add lunch with Marta at noon.',
+        currentDateTime: CURRENT_DATE_TIME,
+      })
+    ).resolves.toEqual({
+      outcome: 'needs_clarification',
+      reply: 'Which day or date should I use for this calendar event?',
+      blockerReason: 'missing_required_details',
+      missingFields: ['date'],
+      candidateIntents: ['create_calendar_event'],
+      suggestedNextStep: 'Provide the day or date for the calendar event.',
+    });
+    expect(client.calls).toEqual([]);
+  });
+
+  it('keeps a genuine note-and-calendar request on the clarification path', async () => {
+    const classified: IntexAgentIntentClassification = {
+      kind: 'needs_clarification',
+      question: 'Should I save the PIN or schedule lunch first?',
+      blockerReason: 'missing_required_details',
+      missingFields: ['date'],
+      candidateIntents: ['create_note', 'create_calendar_event'],
+      suggestedNextStep: 'Choose which action to handle first.',
+      reason: 'The request contains two actions.',
+      stylePreferenceAction: 'none',
+      languageOverride: 'en',
+      decisionEvidence: 'The user explicitly asked to remember data and add a timed event.',
+    };
+    const runner = createIntexAgentRunner({
+      client: new FakeToolCallingClient([]),
+      intentClassifier: { classify: async () => classified },
+      toolExecutor: fakeToolExecutor(),
+    });
+
+    await expect(
+      runner.run({
+        session: session(),
+        events: [],
+        message: 'Remember the PIN and add lunch with Marta at noon.',
+        currentDateTime: CURRENT_DATE_TIME,
+      })
+    ).resolves.toEqual({
+      outcome: 'needs_clarification',
+      reply: classified.question,
+      blockerReason: classified.blockerReason,
+      missingFields: classified.missingFields,
+      candidateIntents: classified.candidateIntents,
+      suggestedNextStep: classified.suggestedNextStep,
+    });
+  });
+
+  it('keeps an explicit Polish note request on the clarification path', async () => {
+    const classified: IntexAgentIntentClassification = {
+      kind: 'needs_clarification',
+      question: 'Czy zapisać notatkę, czy utworzyć wydarzenie?',
+      blockerReason: 'missing_required_details',
+      missingFields: ['date'],
+      candidateIntents: ['create_note', 'create_calendar_event'],
+      suggestedNextStep: 'Wybierz akcję.',
+      reason: 'Wiadomość zawiera rzeczownik notatka i godzinę.',
+      stylePreferenceAction: 'none',
+      languageOverride: 'pl',
+      decisionEvidence: 'Użytkownik jawnie poprosił o notatkę.',
+    };
+    const runner = createIntexAgentRunner({
+      client: new FakeToolCallingClient([]),
+      intentClassifier: { classify: async () => classified },
+      toolExecutor: fakeToolExecutor(),
+    });
+
+    await expect(
+      runner.run({
+        session: session(),
+        events: [],
+        message: 'Dodaj notatkę o lunchu z Martą o 12.',
+        currentDateTime: CURRENT_DATE_TIME,
+      })
+    ).resolves.toEqual({
+      outcome: 'needs_clarification',
+      reply: classified.question,
+      blockerReason: classified.blockerReason,
+      missingFields: classified.missingFields,
+      candidateIntents: classified.candidateIntents,
+      suggestedNextStep: classified.suggestedNextStep,
+    });
+  });
+
   it('uses the accepted calendar title from the active clarification chain', async () => {
     const client = new ToolExecutingFakeToolCallingClient(
       {

--- a/apps/intex-agent/src/domain/agent/intexAgentRunner.ts
+++ b/apps/intex-agent/src/domain/agent/intexAgentRunner.ts
@@ -1017,10 +1017,22 @@ function applyMissingCalendarDateClarification(
     replyLanguage: IntexAgentReplyLanguage;
   }>
 ): IntexAgentIntentClassification {
+  const candidateIntents = intent.kind === 'needs_clarification' ? intent.candidateIntents : undefined;
+  const singleCalendarCandidate =
+    candidateIntents?.length === 1 && candidateIntents[0] === 'create_calendar_event';
+  const safelyNarrowedCalendarCandidate =
+    intent.kind === 'needs_clarification' &&
+    intent.blockerReason === 'missing_required_details' &&
+    candidateIntents?.length === 2 &&
+    candidateIntents.includes('create_calendar_event') &&
+    candidateIntents.includes('create_note') &&
+    containsExplicitCalendarSummarySignal(context.message) &&
+    containsCalendarClockTimeSignal(context.message) &&
+    !containsCalendarTimeWithdrawalSignal(context.message) &&
+    !containsExplicitNoteActionSignal(context.message);
   if (
     intent.kind !== 'needs_clarification' ||
-    intent.candidateIntents?.length !== 1 ||
-    intent.candidateIntents[0] !== 'create_calendar_event' ||
+    (!singleCalendarCandidate && !safelyNarrowedCalendarCandidate) ||
     hasCalendarDateSignal(context.message, context.events, context.replyContext)
   ) {
     return intent;
@@ -1041,6 +1053,12 @@ function applyMissingCalendarDateClarification(
     ...(intent.reason !== undefined ? { reason: intent.reason } : {}),
     ...(intent.decisionEvidence !== undefined ? { decisionEvidence: intent.decisionEvidence } : {}),
   };
+}
+
+function containsExplicitNoteActionSignal(message: string): boolean {
+  return /(?<![\p{L}\p{N}])(?:remember|save|store|write\s+down|take\s+(?:a\s+)?note|notes?|memo|zapamiętaj|zapamietaj|zapisz|zanotuj|notatk[\p{L}]*)(?![\p{L}\p{N}])/iu.test(
+    message.normalize('NFKC')
+  );
 }
 
 function isOptionalNoteField(field: string): boolean {

--- a/tools/intex-agent-evals/src/__tests__/matrixCorpusCorrelation.test.ts
+++ b/tools/intex-agent-evals/src/__tests__/matrixCorpusCorrelation.test.ts
@@ -206,6 +206,114 @@ describe('Matrix corpus reply correlation', () => {
     });
   });
 
+  it('recovers a digest-bound reply from recent Matrix history after incremental sync misses it', async () => {
+    const assistantReply = 'Add this preference?';
+    const outbound = reply('$sent-1', 'Scenario turn', '@operator:home-dev');
+    const matrix = matrixWith([
+      { ok: true, nextBatch: 'cursor-2', limited: false, events: [] },
+      { ok: true, nextBatch: 'cursor-3', limited: false, events: [] },
+      {
+        ok: true,
+        nextBatch: 'snapshot-cursor',
+        limited: true,
+        events: [
+          reply('$old-identical', assistantReply),
+          outbound,
+          reply('$reply-current', `${assistantReply}${MATRIX_WHATSAPP_CONFIRMATION_MIRROR_SUFFIX}`),
+        ],
+      },
+    ]);
+
+    const result = await collectCorrelatedReplies({
+      ...baseInput(
+        matrix,
+        evidenceWith([
+          ...Array.from({ length: 2 }, () => ({
+            status: 'completed' as const,
+            replyCount: 1,
+            replyDigests: [digestMatrixReply(assistantReply)],
+          })),
+        ])
+      ),
+      outboundMatrixEventId: outbound.eventId as string,
+      expectedReplyRendering: 'whatsapp_confirmation_buttons',
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      cursor: 'snapshot-cursor',
+      replies: [{ eventId: '$reply-current', body: assistantReply }],
+    });
+    expect(matrix.syncTargetRoom).toHaveBeenNthCalledWith(
+      3,
+      expect.not.objectContaining({ since: expect.anything() })
+    );
+  });
+
+  it('does not bind a matching reply that follows a later self-authored outbound', async () => {
+    const expectedReply = 'Matching reply';
+    const matrix = matrixWith([
+      { ok: true, nextBatch: 'cursor-2', limited: false, events: [] },
+      { ok: true, nextBatch: 'cursor-3', limited: false, events: [] },
+      {
+        ok: true,
+        nextBatch: 'snapshot-cursor',
+        limited: true,
+        events: [
+          reply('$sent-1', 'Scenario turn', '@operator:home-dev'),
+          reply('$sent-later', 'Unrelated later message', '@operator:home-dev'),
+          reply('$reply-later', expectedReply),
+        ],
+      },
+    ]);
+
+    await expect(
+      collectCorrelatedReplies(
+        baseInput(
+          matrix,
+          evidenceWith(
+            Array.from({ length: 2 }, () => ({
+              status: 'completed' as const,
+              replyCount: 1,
+              replyDigests: [digestMatrixReply(expectedReply)],
+            }))
+          )
+        )
+      )
+    ).resolves.toEqual({ ok: false, code: 'unbound_reply' });
+  });
+
+  it('fails closed when recent Matrix history contains a changed reply after the outbound anchor', async () => {
+    const matrix = matrixWith([
+      { ok: true, nextBatch: 'cursor-2', limited: false, events: [] },
+      { ok: true, nextBatch: 'cursor-3', limited: false, events: [] },
+      {
+        ok: true,
+        nextBatch: 'snapshot-cursor',
+        limited: true,
+        events: [
+          reply('$sent-1', 'Scenario turn', '@operator:home-dev'),
+          reply('$changed-reply', 'Changed reply'),
+        ],
+      },
+    ]);
+
+    await expect(
+      collectCorrelatedReplies(
+        baseInput(
+          matrix,
+          evidenceWith(
+            Array.from({ length: 2 }, () => ({
+              status: 'completed' as const,
+              replyCount: 1,
+              replyDigests: [digestMatrixReply('Expected reply')],
+            }))
+          )
+        )
+      )
+    ).resolves.toEqual({ ok: false, code: 'unbound_reply' });
+  });
+
   it('correlates the exact WhatsApp confirmation mirror with the durable assistant reply', async () => {
     const assistantReply = 'Save this note?\n\nContent: [redacted]';
     const matrix = matrixWith([
@@ -498,6 +606,8 @@ function baseInput(
     cursor: 'cursor-1',
     matrixUserId: '@operator:home-dev',
     expectedPuppetSender: PUPPET,
+    outboundMatrixEventId: '$sent-1',
+    outboundMessageText: 'Scenario turn',
     runId: 'run_1',
     scenarioId: 'intex-eval-001',
     turnIndex: 0,

--- a/tools/intex-agent-evals/src/matrixCorpus/correlation.ts
+++ b/tools/intex-agent-evals/src/matrixCorpus/correlation.ts
@@ -148,6 +148,8 @@ export async function collectCorrelatedReplies(input: {
   initialEvents?: readonly MatrixTimelineEvent[];
   matrixUserId: string;
   expectedPuppetSender: string;
+  outboundMatrixEventId: string;
+  outboundMessageText: string;
   runId: string;
   scenarioId: string;
   turnIndex: number;
@@ -156,11 +158,10 @@ export async function collectCorrelatedReplies(input: {
   signal: AbortSignal;
 }): Promise<MatrixCorpusCorrelatedRepliesResult> {
   let cursor = input.cursor;
-  const replies: CorrelatedMatrixReply[] = [];
-  const byEventId = new Map<string, CorrelatedMatrixReply>();
-  const rawBodiesByEventId = new Map<string, string>();
-  const redactedEventIds = new Set<string>();
+  const replyState = createReplyCollectionState();
+  const replies = replyState.replies;
   let initialEvents = input.initialEvents;
+  let completedReplyDeficitPolls = 0;
 
   for (;;) {
     if (input.signal.aborted) return { ok: false, code: 'reply_timeout' };
@@ -181,48 +182,13 @@ export async function collectCorrelatedReplies(input: {
       initialEvents = undefined;
     }
 
-    for (const event of events) {
-      if (event.type === 'm.room.redaction') {
-        if (event.eventId === undefined || event.redacts === undefined) {
-          return { ok: false, code: 'matrix_sync_invalid' };
-        }
-        redactedEventIds.add(event.redacts);
-        if (byEventId.has(event.redacts)) return { ok: false, code: 'unbound_reply' };
-        continue;
-      }
-      const candidate = classifyReplyEvent(event, input.matrixUserId, input.expectedPuppetSender);
-      if (candidate.kind === 'ignore') continue;
-      if (candidate.kind === 'failure') return { ok: false, code: candidate.code };
-      if (redactedEventIds.has(candidate.reply.eventId)) {
-        return { ok: false, code: 'unbound_reply' };
-      }
-      const previousRawBody = rawBodiesByEventId.get(candidate.reply.eventId);
-      if (previousRawBody !== undefined && previousRawBody !== candidate.reply.body) {
-        return { ok: false, code: 'unbound_reply' };
-      }
-      const canonicalBody = canonicalMatrixReplyBody(candidate.reply.body);
-      if (canonicalBody === undefined) return { ok: false, code: 'unbound_reply' };
-      const previous = byEventId.get(candidate.reply.eventId);
-      if (previous !== undefined) {
-        if (
-          previous.body !== canonicalBody ||
-          previous.originServerTs !== candidate.reply.originServerTs
-        ) {
-          return { ok: false, code: 'unbound_reply' };
-        }
-        continue;
-      }
-      const reply = {
-        ...candidate.reply,
-        body: canonicalBody,
-        digest: digestMatrixReply(canonicalBody, replies.length),
-      };
-      rawBodiesByEventId.set(reply.eventId, candidate.reply.body);
-      byEventId.set(reply.eventId, reply);
-      replies.push(reply);
-      if (replies.length > MATRIX_CORPUS_MAX_REPLIES_PER_TURN)
-        return { ok: false, code: 'reply_overflow' };
-    }
+    const collected = collectReplyEvents(
+      events,
+      replyState,
+      input.matrixUserId,
+      input.expectedPuppetSender
+    );
+    if (!collected.ok) return collected;
 
     const terminal = await input.evidence.getTurnTerminal({
       runId: input.runId,
@@ -245,12 +211,180 @@ export async function collectCorrelatedReplies(input: {
     if (replies.some((reply) => !terminal.replyDigests.includes(reply.digest))) {
       return { ok: false, code: 'unbound_reply' };
     }
-    if (replies.length < terminal.replyCount) continue;
+    if (replies.length < terminal.replyCount) {
+      if (completedReplyDeficitPolls === 0) {
+        completedReplyDeficitPolls += 1;
+        continue;
+      }
+      const recovered = await recoverRepliesFromRecentTimeline({
+        matrix: input.matrix,
+        context: input.context,
+        matrixUserId: input.matrixUserId,
+        expectedPuppetSender: input.expectedPuppetSender,
+        outboundMatrixEventId: input.outboundMatrixEventId,
+        outboundMessageText: input.outboundMessageText,
+        terminal,
+        signal: input.signal,
+      });
+      if (recovered !== undefined) {
+        return recovered.ok
+          ? { ok: true, cursor: recovered.cursor, replies: recovered.replies }
+          : recovered;
+      }
+      continue;
+    }
     if (replies.some((reply, index) => reply.digest !== terminal.replyDigests[index])) {
       return { ok: false, code: 'unbound_reply' };
     }
     return { ok: true, cursor, replies };
   }
+}
+
+async function recoverRepliesFromRecentTimeline(input: {
+  matrix: MatrixClient;
+  context: MatrixCorpusMatrixContext;
+  matrixUserId: string;
+  expectedPuppetSender: string;
+  outboundMatrixEventId: string;
+  outboundMessageText: string;
+  terminal: Extract<MatrixCorpusTurnTerminal, { status: 'completed' }>;
+  signal: AbortSignal;
+}): Promise<
+  | {
+      readonly ok: true;
+      readonly cursor: string;
+      readonly replies: readonly CorrelatedMatrixReply[];
+    }
+  | { readonly ok: false; readonly code: MatrixCorpusCorrelationFailureCode }
+  | undefined
+> {
+  const recent = await input.matrix.syncTargetRoom({
+    ...input.context,
+    timeoutMs: 0,
+    signal: input.signal,
+  });
+  if (!recent.ok) return undefined;
+
+  const anchorIndex = recent.events.findIndex(
+    (event) => event.eventId === input.outboundMatrixEventId
+  );
+  if (anchorIndex < 0) return undefined;
+  const anchor = recent.events[anchorIndex];
+  if (
+    anchor?.type !== 'm.room.message' ||
+    anchor.sender !== input.matrixUserId ||
+    anchor.content?.msgtype !== 'm.text' ||
+    anchor.content.body !== input.outboundMessageText ||
+    anchor.content['m.relates_to']?.rel_type === 'm.replace' ||
+    anchor.unsigned?.redacted_because !== undefined
+  ) {
+    return { ok: false, code: 'outbound_event_mismatch' };
+  }
+
+  const eventsAfterAnchor = recent.events.slice(anchorIndex + 1);
+  const nextOutboundIndex = eventsAfterAnchor.findIndex(
+    (event) =>
+      event.type === 'm.room.message' &&
+      event.sender === input.matrixUserId &&
+      event.content?.msgtype === 'm.text' &&
+      event.content['m.relates_to']?.rel_type !== 'm.replace' &&
+      event.unsigned?.redacted_because === undefined
+  );
+  const boundedEvents =
+    nextOutboundIndex < 0 ? eventsAfterAnchor : eventsAfterAnchor.slice(0, nextOutboundIndex);
+  const replyState = createReplyCollectionState();
+  const collected = collectReplyEvents(
+    boundedEvents,
+    replyState,
+    input.matrixUserId,
+    input.expectedPuppetSender
+  );
+  if (!collected.ok) return collected;
+  const { replies } = replyState;
+
+  if (replies.length > input.terminal.replyCount) {
+    return { ok: false, code: 'unbound_reply' };
+  }
+  if (replies.some((reply) => !input.terminal.replyDigests.includes(reply.digest))) {
+    return { ok: false, code: 'unbound_reply' };
+  }
+  if (replies.length < input.terminal.replyCount) {
+    return nextOutboundIndex < 0 ? undefined : { ok: false, code: 'unbound_reply' };
+  }
+  if (replies.some((reply, index) => reply.digest !== input.terminal.replyDigests[index])) {
+    return { ok: false, code: 'unbound_reply' };
+  }
+  return { ok: true, cursor: recent.nextBatch, replies };
+}
+
+interface ReplyCollectionState {
+  readonly replies: CorrelatedMatrixReply[];
+  readonly byEventId: Map<string, CorrelatedMatrixReply>;
+  readonly rawBodiesByEventId: Map<string, string>;
+  readonly redactedEventIds: Set<string>;
+}
+
+function createReplyCollectionState(): ReplyCollectionState {
+  return {
+    replies: [],
+    byEventId: new Map(),
+    rawBodiesByEventId: new Map(),
+    redactedEventIds: new Set(),
+  };
+}
+
+function collectReplyEvents(
+  events: readonly MatrixTimelineEvent[],
+  state: ReplyCollectionState,
+  matrixUserId: string,
+  expectedPuppetSender: string
+):
+  | { readonly ok: true }
+  | { readonly ok: false; readonly code: MatrixCorpusCorrelationFailureCode } {
+  for (const event of events) {
+    if (event.type === 'm.room.redaction') {
+      if (event.eventId === undefined || event.redacts === undefined) {
+        return { ok: false, code: 'matrix_sync_invalid' };
+      }
+      state.redactedEventIds.add(event.redacts);
+      if (state.byEventId.has(event.redacts)) return { ok: false, code: 'unbound_reply' };
+      continue;
+    }
+    const candidate = classifyReplyEvent(event, matrixUserId, expectedPuppetSender);
+    if (candidate.kind === 'ignore') continue;
+    if (candidate.kind === 'failure') return { ok: false, code: candidate.code };
+    if (state.redactedEventIds.has(candidate.reply.eventId)) {
+      return { ok: false, code: 'unbound_reply' };
+    }
+    const previousRawBody = state.rawBodiesByEventId.get(candidate.reply.eventId);
+    if (previousRawBody !== undefined && previousRawBody !== candidate.reply.body) {
+      return { ok: false, code: 'unbound_reply' };
+    }
+    const canonicalBody = canonicalMatrixReplyBody(candidate.reply.body);
+    if (canonicalBody === undefined) return { ok: false, code: 'unbound_reply' };
+    const previous = state.byEventId.get(candidate.reply.eventId);
+    if (previous !== undefined) {
+      if (
+        previous.body !== canonicalBody ||
+        previous.originServerTs !== candidate.reply.originServerTs
+      ) {
+        return { ok: false, code: 'unbound_reply' };
+      }
+      continue;
+    }
+    const reply = {
+      ...candidate.reply,
+      body: canonicalBody,
+      digest: digestMatrixReply(canonicalBody, state.replies.length),
+    };
+    state.rawBodiesByEventId.set(reply.eventId, candidate.reply.body);
+    state.byEventId.set(reply.eventId, reply);
+    state.replies.push(reply);
+    if (state.replies.length > MATRIX_CORPUS_MAX_REPLIES_PER_TURN) {
+      return { ok: false, code: 'reply_overflow' };
+    }
+  }
+  return { ok: true };
 }
 
 function canonicalMatrixReplyBody(body: string): string | undefined {

--- a/tools/intex-agent-evals/src/matrixCorpus/liveExecution.ts
+++ b/tools/intex-agent-evals/src/matrixCorpus/liveExecution.ts
@@ -1128,6 +1128,8 @@ async function executeLiveTurn(input: {
         initialEvents: observedProof.eventsAfterOutbound,
         matrixUserId: input.state.prepared.account.matrixUserId,
         expectedPuppetSender: input.state.prepared.expectedPuppetSender,
+        outboundMatrixEventId: sent.matrixEventId,
+        outboundMessageText: messageText,
         runId: input.runId,
         scenarioId: input.scenario.id,
         turnIndex: input.turnIndex,


### PR DESCRIPTION
## Summary
- narrow MiniMax calendar clarification when a timed request only lacks its date
- recover digest-bound WhatsApp replies from Matrix history after an incremental sync miss
- fail closed across later outbound messages and advance the recovered Matrix cursor

## Testing
- pnpm run ci:tracked (6909 tests passed)
- targeted Matrix corpus and Intex Agent suites (404 tests passed)

Linear: omitted by `$commit-push`; GitHub automation will create or link the Linear issue after PR creation.