### PR TITLE
[INT-1937] fix: recover rejected MiniMax tool calls

### DIFF
--- a/packages/infra-openrouter/src/__tests__/toolCallingClient.test.ts
+++ b/packages/infra-openrouter/src/__tests__/toolCallingClient.test.ts
@@ -740,6 +740,316 @@ describe('createOpenRouterToolCallingClient', () => {
     expect(scope.isDone()).toBe(true);
   });
 
+  it('keeps requiring a MiniMax tool until its callback accepts one call', async () => {
+    const capturedBodies: Record<string, unknown>[] = [];
+    const runTool = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('invalid calendar bounds'))
+      .mockResolvedValueOnce('{"events":[]}');
+    nock(API_BASE_URL)
+      .post('/chat/completions', (body) => {
+        capturedBodies.push(body as Record<string, unknown>);
+        return true;
+      })
+      .reply(200, {
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content: null,
+              tool_calls: [
+                {
+                  id: 'call_invalid',
+                  type: 'function',
+                  function: {
+                    name: 'query_calendar_events',
+                    arguments: '{"mode":"list"}',
+                  },
+                },
+              ],
+            },
+          },
+        ],
+        usage: { prompt_tokens: 20, completion_tokens: 5, total_tokens: 25, cost: 0.0002 },
+      })
+      .post('/chat/completions', (body) => {
+        capturedBodies.push(body as Record<string, unknown>);
+        return true;
+      })
+      .reply(200, {
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content: 'Calendar query failed. Please retry.',
+            },
+          },
+        ],
+        usage: { prompt_tokens: 25, completion_tokens: 5, total_tokens: 30, cost: 0.0002 },
+      })
+      .post('/chat/completions', (body) => {
+        capturedBodies.push(body as Record<string, unknown>);
+        return true;
+      })
+      .reply(200, {
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content: null,
+              tool_calls: [
+                {
+                  id: 'call_valid',
+                  type: 'function',
+                  function: {
+                    name: 'query_calendar_events',
+                    arguments:
+                      '{"mode":"list","timeMin":"2026-07-17T00:00:00.000+02:00","timeMax":"2026-07-18T00:00:00.000+02:00"}',
+                  },
+                },
+              ],
+            },
+          },
+        ],
+        usage: { prompt_tokens: 30, completion_tokens: 8, total_tokens: 38, cost: 0.0003 },
+      })
+      .post('/chat/completions', (body) => {
+        capturedBodies.push(body as Record<string, unknown>);
+        return true;
+      })
+      .reply(200, {
+        choices: [{ message: { role: 'assistant', content: 'No events tomorrow.' } }],
+        usage: { prompt_tokens: 35, completion_tokens: 5, total_tokens: 40, cost: 0.0003 },
+      });
+
+    const result = await createClientWithConfig({ model: 'minimax/minimax-m3' }).run({
+      systemPrompt: 'Use the calendar query tool, then answer from its result.',
+      messages: [{ role: 'user', content: 'List my calendar events tomorrow.' }],
+      tools: [
+        {
+          name: 'query_calendar_events',
+          description: 'Query calendar events.',
+          parameters: { type: 'object', required: ['mode', 'timeMin', 'timeMax'] },
+          run: runTool,
+        },
+      ],
+      toolChoice: 'required',
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      value: expect.objectContaining({
+        content: 'No events tomorrow.',
+        toolCallsMade: 2,
+        iterationCount: 4,
+      }),
+    });
+    expect(runTool).toHaveBeenCalledTimes(2);
+    expect(capturedBodies[1]?.['tool_choice']).toBe('required');
+    expect(capturedBodies[2]?.['tool_choice']).toBe('required');
+    expect(capturedBodies[3]).not.toHaveProperty('tools');
+  });
+
+  it.each([
+    { label: 'Matrix', matrix: true },
+    { label: 'ordinary', matrix: false },
+  ])(
+    'falls back to validated MiniMax arguments and renders a non-terminal tool result in $label mode',
+    async ({ matrix }) => {
+      const capturedBodies: Record<string, unknown>[] = [];
+      const runTool = vi
+        .fn()
+        .mockRejectedValueOnce(new Error('invalid calendar bounds'))
+        .mockResolvedValueOnce('{"events":[]}');
+      nock(API_BASE_URL)
+        .post('/chat/completions', (body) => {
+          capturedBodies.push(body as Record<string, unknown>);
+          return true;
+        })
+        .reply(200, {
+          choices: [
+            {
+              message: {
+                role: 'assistant',
+                content: null,
+                tool_calls: [
+                  {
+                    id: 'call_invalid',
+                    type: 'function',
+                    function: {
+                      name: 'query_calendar_events',
+                      arguments: '{"mode":"list"}',
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+          usage: { prompt_tokens: 20, completion_tokens: 5, total_tokens: 25, cost: 0.0002 },
+        })
+        .post('/chat/completions', (body) => {
+          capturedBodies.push(body as Record<string, unknown>);
+          return true;
+        })
+        .reply(200, {
+          choices: [
+            {
+              message: {
+                role: 'assistant',
+                content:
+                  '{"mode":"list","timeMin":"2026-07-17T00:00:00.000+02:00","timeMax":"2026-07-18T00:00:00.000+02:00"}',
+              },
+            },
+          ],
+          usage: { prompt_tokens: 30, completion_tokens: 8, total_tokens: 38, cost: 0.0003 },
+        })
+        .post('/chat/completions', (body) => {
+          capturedBodies.push(body as Record<string, unknown>);
+          return true;
+        })
+        .reply(200, {
+          choices: [{ message: { role: 'assistant', content: 'No events tomorrow.' } }],
+          usage: { prompt_tokens: 35, completion_tokens: 5, total_tokens: 40, cost: 0.0003 },
+        });
+
+      const result = await createClientWithConfig({ model: 'minimax/minimax-m3' }).run({
+        systemPrompt: 'Use the calendar query tool, then answer from its result.',
+        messages: [{ role: 'user', content: 'List my calendar events tomorrow.' }],
+        tools: [
+          {
+            name: 'query_calendar_events',
+            description: 'Query calendar events.',
+            parameters: { type: 'object', required: ['mode', 'timeMin', 'timeMax'] },
+            run: runTool,
+          },
+        ],
+        toolChoice: 'required',
+        maxIterations: 1,
+        ...(matrix
+          ? {
+              matrixCorpusContext: {
+                version: 1 as const,
+                runId: 'run_011',
+                scenarioId: 'intex-eval-011',
+                sessionId: 'session_011',
+                turnIndex: 0,
+                stage: 'agent_generation' as const,
+                callOrdinal: 1,
+              },
+            }
+          : {}),
+      });
+
+      expect(result).toEqual({
+        ok: true,
+        value: expect.objectContaining({
+          content: 'No events tomorrow.',
+          toolCallsMade: 2,
+          iterationCount: 3,
+          ...(matrix
+            ? {
+                providerCalls: [
+                  expect.objectContaining({
+                    context: expect.objectContaining({ callOrdinal: 1 }),
+                  }),
+                  expect.objectContaining({
+                    context: expect.objectContaining({ callOrdinal: 2 }),
+                  }),
+                  expect.objectContaining({
+                    context: expect.objectContaining({ callOrdinal: 3 }),
+                  }),
+                ],
+              }
+            : {}),
+        }),
+      });
+      expect(runTool).toHaveBeenCalledTimes(2);
+      expect(capturedBodies[1]).not.toHaveProperty('tools');
+      expect(capturedBodies[2]).not.toHaveProperty('tools');
+      expect(capturedBodies[2]?.['messages']).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            role: 'tool',
+            name: 'query_calendar_events',
+            content: '{"events":[]}',
+          }),
+        ])
+      );
+    }
+  );
+
+  it.each([
+    {
+      label: 'provider failure',
+      completionStatus: 503,
+      completionBody: 'render unavailable',
+      expected: { code: 'OVERLOADED', message: 'Matrix provider call failed' },
+    },
+    {
+      label: 'empty provider response',
+      completionStatus: 200,
+      completionBody: {
+        choices: [{ message: { role: 'assistant', content: null } }],
+        usage: { prompt_tokens: 35, completion_tokens: 0, total_tokens: 35, cost: 0.0003 },
+      },
+      expected: { code: 'API_ERROR', message: 'Tool calling loop exceeded maxIterations' },
+    },
+  ])(
+    'fails closed when MiniMax non-terminal fallback rendering ends in $label',
+    async ({ completionStatus, completionBody, expected }) => {
+      const runTool = vi.fn().mockResolvedValue('{"events":[]}');
+      nock(API_BASE_URL)
+        .post('/chat/completions')
+        .reply(200, {
+          choices: [{ message: { role: 'assistant', content: 'I should query the calendar.' } }],
+          usage: { prompt_tokens: 20, completion_tokens: 5, total_tokens: 25, cost: 0.0002 },
+        })
+        .post('/chat/completions')
+        .reply(200, {
+          choices: [
+            {
+              message: {
+                role: 'assistant',
+                content:
+                  '{"mode":"list","timeMin":"2026-07-17T00:00:00.000+02:00","timeMax":"2026-07-18T00:00:00.000+02:00"}',
+              },
+            },
+          ],
+          usage: { prompt_tokens: 30, completion_tokens: 8, total_tokens: 38, cost: 0.0003 },
+        })
+        .post('/chat/completions')
+        .reply(completionStatus, completionBody);
+
+      const result = await createClientWithConfig({ model: 'minimax/minimax-m3' }).run({
+        systemPrompt: 'Use the calendar query tool, then answer from its result.',
+        messages: [{ role: 'user', content: 'List my calendar events tomorrow.' }],
+        tools: [
+          {
+            name: 'query_calendar_events',
+            description: 'Query calendar events.',
+            parameters: { type: 'object', required: ['mode', 'timeMin', 'timeMax'] },
+            run: runTool,
+          },
+        ],
+        toolChoice: 'required',
+        maxIterations: 1,
+        matrixCorpusContext: {
+          version: 1,
+          runId: 'run_011',
+          scenarioId: 'intex-eval-011',
+          sessionId: 'session_011',
+          turnIndex: 0,
+          stage: 'agent_generation',
+          callOrdinal: 1,
+        },
+      });
+
+      expect(result).toEqual({ ok: false, error: expected });
+      expect(runTool).toHaveBeenCalledOnce();
+      expect(nock.isDone()).toBe(true);
+    }
+  );
+
   it('returns a non-Matrix MiniMax fallback result from bare JSON', async () => {
     const runTool = vi.fn().mockResolvedValue('{"status":"needs_confirmation"}');
     nock(API_BASE_URL)
@@ -1376,7 +1686,7 @@ describe('createOpenRouterToolCallingClient', () => {
     });
     expect(runTool).toHaveBeenCalledTimes(2);
     expect(capturedBodies[1]).toHaveProperty('tools');
-    expect(capturedBodies[1]?.['tool_choice']).toBe('auto');
+    expect(capturedBodies[1]?.['tool_choice']).toBe('required');
     expect(capturedBodies[2]).not.toHaveProperty('tools');
     expect(capturedBodies[2]).not.toHaveProperty('tool_choice');
   });

--- a/packages/infra-openrouter/src/toolCallingClient.ts
+++ b/packages/infra-openrouter/src/toolCallingClient.ts
@@ -242,6 +242,7 @@ export function createOpenRouterToolCallingClient(
       let responsesWithUsage = 0;
       let hasUnknownProviderCost = false;
       const suppressSingleToolAfterAcceptedCall = isMiniMaxM3Model(model) && tools.length === 1;
+      const requireAcceptedToolCall = isMiniMaxM3Model(model);
       const retryOptions = {
         maxAttempts,
         baseDelayMs: 500,
@@ -311,7 +312,7 @@ export function createOpenRouterToolCallingClient(
               model,
               conversation,
               acceptedToolCallMade && suppressSingleToolAfterAcceptedCall ? [] : tools,
-              totalToolCalls,
+              acceptedToolCallMade || (!requireAcceptedToolCall && totalToolCalls > 0),
               toolChoice,
               iteration
             );
@@ -427,7 +428,12 @@ export function createOpenRouterToolCallingClient(
               );
               return err({ code: 'API_ERROR', message: 'Empty response from model' });
             }
-            if (tools.length > 0 && toolChoice === 'required' && totalToolCalls === 0) {
+            if (
+              tools.length > 0 &&
+              toolChoice === 'required' &&
+              !acceptedToolCallMade &&
+              (requireAcceptedToolCall || totalToolCalls === 0)
+            ) {
               conversation.push({ role: 'assistant', content: finalText });
               conversation.push({
                 role: 'user',
@@ -489,11 +495,11 @@ export function createOpenRouterToolCallingClient(
           break;
         }
 
-        const fallbackTool = requiredTerminalToolArgsFallback(
+        const fallbackTool = requiredToolArgsFallback(
           model,
           tools,
           toolChoice,
-          totalToolCalls,
+          acceptedToolCallMade,
           onExhausted === undefined
         );
         if (fallbackTool !== undefined) {
@@ -530,25 +536,89 @@ export function createOpenRouterToolCallingClient(
             );
             totalToolCalls++;
             if (toolResponse.accepted) {
-              logger.info(
-                { iteration, totalToolCalls },
-                'OpenRouter tool calling: completed MiniMax required-tool argument fallback'
-              );
-              trackUsage(
-                completeUsage(),
-                true,
-                Date.now() - runStart,
-                undefined,
-                completeProviderReportedUsd(),
-                promptType
-              );
-              return ok({
-                content: '',
-                toolCallsMade: totalToolCalls,
-                iterationCount: iteration,
-                usage: completeUsage(),
-                ...(params.matrixCorpusContext === undefined ? {} : { providerCalls }),
-              });
+              if (fallbackTool.stopAfterRun !== true) {
+                const fallbackToolCallId = `fallback_${String(iteration)}`;
+                const completionConversation = buildInitialMessages(systemPrompt, messages);
+                completionConversation.push({
+                  role: 'assistant',
+                  content: null,
+                  tool_calls: [
+                    {
+                      id: fallbackToolCallId,
+                      type: 'function',
+                      function: {
+                        name: fallbackTool.name,
+                        arguments: JSON.stringify(fallbackArgs),
+                      },
+                    },
+                  ],
+                });
+                completionConversation.push({
+                  role: 'tool',
+                  tool_call_id: fallbackToolCallId,
+                  name: fallbackTool.name,
+                  content: toolResponse.content,
+                });
+                iteration++;
+                const completionResponseResult = await withRetry(async () => {
+                  try {
+                    return ok(
+                      await postChatCompletion(
+                        buildRequestBody(model, completionConversation, [], true, 'auto', iteration)
+                      )
+                    );
+                  } catch (error) {
+                    return err(mapOpenRouterError(error));
+                  }
+                }, retryOptions);
+                if (!completionResponseResult.ok) {
+                  throw new OpenRouterLlmError(completionResponseResult.error);
+                }
+                const completionData = completionResponseResult.value;
+                await recordProviderResponse(completionData, iteration);
+                const completionContent = completionData.choices[0]?.message.content;
+                if (typeof completionContent === 'string' && completionContent !== '') {
+                  logger.info(
+                    { iteration, totalToolCalls },
+                    'OpenRouter tool calling: rendered MiniMax fallback tool result'
+                  );
+                  trackUsage(
+                    completeUsage(),
+                    true,
+                    Date.now() - runStart,
+                    undefined,
+                    completeProviderReportedUsd(),
+                    promptType
+                  );
+                  return ok({
+                    content: completionContent,
+                    toolCallsMade: totalToolCalls,
+                    iterationCount: iteration,
+                    usage: completeUsage(),
+                    ...(params.matrixCorpusContext === undefined ? {} : { providerCalls }),
+                  });
+                }
+              } else {
+                logger.info(
+                  { iteration, totalToolCalls },
+                  'OpenRouter tool calling: completed MiniMax required-tool argument fallback'
+                );
+                trackUsage(
+                  completeUsage(),
+                  true,
+                  Date.now() - runStart,
+                  undefined,
+                  completeProviderReportedUsd(),
+                  promptType
+                );
+                return ok({
+                  content: '',
+                  toolCallsMade: totalToolCalls,
+                  iterationCount: iteration,
+                  usage: completeUsage(),
+                  ...(params.matrixCorpusContext === undefined ? {} : { providerCalls }),
+                });
+              }
             }
           }
           logger.warn(
@@ -615,7 +685,7 @@ function buildRequestBody(
   model: string,
   messages: OpenRouterMessage[],
   tools: ToolDefinition[],
-  totalToolCalls: number,
+  acceptedToolCallMade: boolean,
   toolChoice: 'auto' | 'required',
   iteration: number
 ): Record<string, unknown> {
@@ -637,7 +707,7 @@ function buildRequestBody(
           parameters: tool.parameters,
         },
       })),
-      tool_choice: totalToolCalls === 0 ? initialToolChoice : 'auto',
+      tool_choice: acceptedToolCallMade ? 'auto' : initialToolChoice,
     }),
   };
 }
@@ -648,20 +718,19 @@ function requiredToolRetryMessage(tools: ToolDefinition[]): string {
   return `Call the required ${onlyTool.name} tool now with arguments derived from the original request. Do not return final text before calling the tool.`;
 }
 
-function requiredTerminalToolArgsFallback(
+function requiredToolArgsFallback(
   model: string,
   tools: ToolDefinition[],
   toolChoice: 'auto' | 'required',
-  totalToolCalls: number,
+  acceptedToolCallMade: boolean,
   allowFallback: boolean
 ): ToolDefinition | undefined {
   if (
     !allowFallback ||
     !isMiniMaxM3Model(model) ||
     toolChoice !== 'required' ||
-    totalToolCalls !== 0 ||
-    tools.length !== 1 ||
-    tools[0]?.stopAfterRun !== true
+    acceptedToolCallMade ||
+    tools.length !== 1
   ) {
     return undefined;
   }


### PR DESCRIPTION
## Summary
- require an accepted MiniMax callback before a required tool turn can finish
- add JSON-argument fallback and result rendering for non-terminal read tools
- cover native recovery, fallback, Matrix evidence, and fail-closed branches

## Verification
- pnpm run ci:tracked (6909 tests passed)
- targeted infra-openrouter and Intex Agent tests

Linear: omitted by `$commit-push`; GitHub automation will create or link the Linear issue after PR creation.