### PR TITLE
[INT-1944] fix(code-worker): support private SentryBox IPv6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -353,15 +353,12 @@ jobs:
             -f docker/code-worker/Dockerfile.test \
             docker/code-worker/
 
-      - name: Create worker network
+      - name: Create and revalidate worker network
         run: |
-          docker network create \
-            --driver bridge \
-            --subnet 172.28.0.0/16 \
-            code-worker-net
+          ./scripts/setup-worker-network.sh
+          ./scripts/setup-worker-network.sh
 
       - name: Run E2E isolation tests
         run: pnpm --filter orchestrator test:e2e
         env:
           WORKER_IMAGE: code-worker:test
-          WORKER_NETWORK: code-worker-net

--- a/docs/services/code-worker/technical.md
+++ b/docs/services/code-worker/technical.md
@@ -12,7 +12,7 @@ graph TB
         Orchestrator[Orchestrator Process]
 
         subgraph "Docker Engine"
-            Network[code-worker-net<br/>172.28.0.0/16]
+            Network[code-worker-net<br/>172.28.0.0/16<br/>fd00:172:28::/64]
 
             subgraph "Container: code-worker-{taskId}"
                 Entrypoint[entrypoint.sh]
@@ -139,12 +139,12 @@ Added timeout enforcement for the Linear MCP server integration to prevent hung 
 
 | Target                                    | Access  | Enforcement                 |
 | ----------------------------------------- | ------- | --------------------------- |
-| Public internet                           | Allowed | Default Docker bridge       |
+| Public internet                           | Allowed | User-defined worker bridge  |
 | Cloud metadata                            | Blocked | iptables on production host |
 | Localhost (127.0.0.0/8)                   | Blocked | iptables on production host |
 | Private IPs (10/8, 172.16/12, 192.168/16) | Blocked | iptables on production host |
 
-Network: `code-worker-net` (bridge driver, subnet `172.28.0.0/16`, IP masquerade enabled).
+Network: `code-worker-net` (dual-stack bridge driver, fixed Linux bridge `code-worker-br`, IPv4 subnet `172.28.0.0/16`, IPv6 subnet `fd00:172:28::/64`, IP masquerade enabled).
 
 ## Mount Points
 

--- a/docs/services/code-worker/tutorial.md
+++ b/docs/services/code-worker/tutorial.md
@@ -63,18 +63,25 @@ Create the isolated Docker network that worker containers use:
 ./scripts/setup-worker-network.sh
 ```
 
-This creates a bridge network named `code-worker-net` on subnet `172.28.0.0/16`.
+This creates a non-internal dual-stack Docker bridge named `code-worker-net` on the fixed
+Linux interface `code-worker-br`, IPv4 subnet `172.28.0.0/16`, and IPv6 subnet
+`fd00:172:28::/64`. IP masquerading is enabled and both gateway modes must be absent
+(Docker's `nat` default) or explicitly `nat`. The setup fails closed when a network with
+the same name exists but does not satisfy this exact contract.
 
 To verify:
 
 ```bash
-docker network inspect code-worker-net --format '{{.Name}}: {{range .IPAM.Config}}{{.Subnet}}{{end}}'
+./scripts/setup-worker-network.sh
 ```
 
 **Expected output:**
 
 ```
-code-worker-net: 172.28.0.0/16
+Network 'code-worker-net' already exists
+Network details:
+code-worker-net: 172.28.0.0/16 fd00:172:28::/64
+Network setup complete: code-worker-net
 ```
 
 ---
@@ -320,13 +327,13 @@ The E2E test suite verifies container lifecycle, mount permissions, input/output
 
 ```bash
 docker build -t code-worker:test -f docker/code-worker/Dockerfile.test docker/code-worker/
-docker network create --driver bridge --subnet 172.28.0.0/16 code-worker-net 2>/dev/null || true
+./scripts/setup-worker-network.sh
 ```
 
 ### Step 7.2: Run the E2E tests
 
 ```bash
-WORKER_IMAGE=code-worker:test WORKER_NETWORK=code-worker-net pnpm --filter orchestrator test:e2e
+WORKER_IMAGE=code-worker:test pnpm --filter orchestrator test:e2e
 ```
 
 **Expected test suites:**

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -142,7 +142,9 @@ Deploys Cloud Function workers to GCS. Builds the worker, generates a production
 
 ### setup-worker-network.sh
 
-Creates an isolated Docker network for code-worker containers with IP-level restrictions blocking metadata server, localhost, and private IP ranges.
+Creates and validates the dual-stack Docker network for code-worker containers. Existing
+networks that do not match the required IPv4, IPv6, fixed Linux bridge name, and masquerade
+contract are rejected without modification.
 
 ```bash
 ./scripts/setup-worker-network.sh

--- a/scripts/__tests__/setup-worker-network.test.ts
+++ b/scripts/__tests__/setup-worker-network.test.ts
@@ -1,0 +1,265 @@
+import { spawnSync } from 'node:child_process';
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const repoRoot = resolve(__dirname, '..', '..');
+const setupScript = resolve(repoRoot, 'scripts/setup-worker-network.sh');
+const temporaryDirectories: string[] = [];
+
+const _networkStates = [
+  'missing',
+  'valid',
+  'nat-gateway-modes',
+  'wrong-driver',
+  'nondefault-ipam',
+  'internal',
+  'ipv6-disabled',
+  'bridge-name-mismatch',
+  'bridge-name-missing',
+  'masquerade-disabled',
+  'masquerade-missing',
+  'ipv4-subnet-mismatch',
+  'ipv6-subnet-mismatch',
+  'extra-subnet',
+  'ipv4-gateway-routed',
+  'ipv6-gateway-routed',
+] as const;
+
+type NetworkState = (typeof _networkStates)[number];
+
+interface RunResult {
+  readonly createArgs: readonly string[];
+  readonly status: number | null;
+  readonly stderr: string;
+  readonly stdout: string;
+}
+
+function runSetup(
+  networkState: NetworkState,
+  overrides: Readonly<Record<string, string>> = {}
+): RunResult {
+  const directory = mkdtempSync(join(tmpdir(), 'setup-worker-network-'));
+  temporaryDirectories.push(directory);
+  const dockerPath = join(directory, 'docker');
+  const createArgsPath = join(directory, 'create-args');
+  const createdPath = join(directory, 'created');
+
+  writeFileSync(
+    dockerPath,
+    `#!/bin/bash
+set -euo pipefail
+
+if [[ "$1" == "network" && "$2" == "create" ]]; then
+  printf '%s\\n' "$@" > "$FAKE_DOCKER_CREATE_ARGS"
+  touch "$FAKE_DOCKER_CREATED"
+  exit 0
+fi
+
+if [[ "$1" != "network" || "$2" != "inspect" ]]; then
+  exit 64
+fi
+
+if [[ "$FAKE_NETWORK_STATE" == "missing" && ! -f "$FAKE_DOCKER_CREATED" ]]; then
+  exit 1
+fi
+
+state="$FAKE_NETWORK_STATE"
+if [[ -f "$FAKE_DOCKER_CREATED" ]]; then
+  state="valid"
+fi
+
+format=""
+previous=""
+for argument in "$@"; do
+  if [[ "$previous" == "--format" ]]; then
+    format="$argument"
+    break
+  fi
+  previous="$argument"
+done
+
+case "$format" in
+  '') ;;
+  '{{.Driver}}')
+    [[ "$state" == "wrong-driver" ]] && printf 'overlay\\n' || printf 'bridge\\n'
+    ;;
+  '{{.IPAM.Driver}}')
+    [[ "$state" == "nondefault-ipam" ]] && printf 'custom-ipam\\n' || printf 'default\\n'
+    ;;
+  '{{.Internal}}')
+    [[ "$state" == "internal" ]] && printf 'true\\n' || printf 'false\\n'
+    ;;
+  '{{.EnableIPv6}}')
+    [[ "$state" == "ipv6-disabled" ]] && printf 'false\\n' || printf 'true\\n'
+    ;;
+  '{{index .Options "com.docker.network.bridge.enable_ip_masquerade"}}')
+    if [[ "$state" == "masquerade-disabled" ]]; then
+      printf 'false\\n'
+    elif [[ "$state" == "masquerade-missing" ]]; then
+      printf '\\n'
+    else
+      printf 'true\\n'
+    fi
+    ;;
+  '{{index .Options "com.docker.network.bridge.name"}}')
+    if [[ "$state" == "bridge-name-mismatch" ]]; then
+      printf 'br-deadbeef\\n'
+    elif [[ "$state" == "bridge-name-missing" ]]; then
+      printf '\\n'
+    else
+      printf 'code-worker-br\\n'
+    fi
+    ;;
+  '{{index .Options "com.docker.network.bridge.gateway_mode_ipv4"}}')
+    if [[ "$state" == "ipv4-gateway-routed" ]]; then
+      printf 'routed\\n'
+    elif [[ "$state" == "nat-gateway-modes" ]]; then
+      printf 'nat\\n'
+    else
+      printf '\\n'
+    fi
+    ;;
+  '{{index .Options "com.docker.network.bridge.gateway_mode_ipv6"}}')
+    if [[ "$state" == "ipv6-gateway-routed" ]]; then
+      printf 'routed\\n'
+    elif [[ "$state" == "nat-gateway-modes" ]]; then
+      printf 'nat\\n'
+    else
+      printf '\\n'
+    fi
+    ;;
+  '{{range .IPAM.Config}}{{println .Subnet}}{{end}}')
+    if [[ "$state" == "ipv4-subnet-mismatch" ]]; then
+      printf '192.0.2.0/24\\n'
+    else
+      printf '172.28.0.0/16\\n'
+    fi
+    if [[ "$state" == "ipv6-subnet-mismatch" ]]; then
+      printf 'fd00:172:29::/64\\n'
+    else
+      printf 'fd00:172:28::/64\\n'
+    fi
+    if [[ "$state" == "extra-subnet" ]]; then
+      printf '198.51.100.0/24\\n'
+    fi
+    ;;
+  '{{.Name}}: {{range .IPAM.Config}}{{.Subnet}} {{end}}')
+    printf 'code-worker-net: 172.28.0.0/16 fd00:172:28::/64 \\n'
+    ;;
+  *) exit 65 ;;
+esac
+`,
+    'utf8'
+  );
+  chmodSync(dockerPath, 0o755);
+
+  const result = spawnSync('bash', [setupScript], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      BRIDGE_NAME: 'code-worker-br',
+      FAKE_DOCKER_CREATE_ARGS: createArgsPath,
+      FAKE_DOCKER_CREATED: createdPath,
+      FAKE_NETWORK_STATE: networkState,
+      IPV6_SUBNET: 'fd00:172:28::/64',
+      NETWORK_NAME: 'code-worker-net',
+      PATH: `${directory}:${process.env['PATH'] ?? ''}`,
+      SUBNET: '172.28.0.0/16',
+      ...overrides,
+    },
+  });
+
+  return {
+    createArgs: existsSync(createArgsPath)
+      ? readFileSync(createArgsPath, 'utf8').trim().split('\n')
+      : [],
+    status: result.status,
+    stderr: result.stderr,
+    stdout: result.stdout,
+  };
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+describe('setup-worker-network.sh', () => {
+  it('creates the exact worker network contract with argument boundaries preserved', () => {
+    const result = runSetup('missing');
+
+    expect(result.status).toBe(0);
+    expect(result.createArgs).toEqual([
+      'network',
+      'create',
+      '--driver',
+      'bridge',
+      '--ipv6',
+      '--opt',
+      'com.docker.network.bridge.name=code-worker-br',
+      '--opt',
+      'com.docker.network.bridge.enable_ip_masquerade=true',
+      '--subnet',
+      '172.28.0.0/16',
+      '--subnet',
+      'fd00:172:28::/64',
+      'code-worker-net',
+    ]);
+  });
+
+  it('ignores ambient overrides and still creates the exact worker network contract', () => {
+    const result = runSetup('missing', {
+      BRIDGE_NAME: 'é'.repeat(15),
+      IPV6_SUBNET: 'fd00:ffff::/64',
+      NETWORK_NAME: 'custom-worker-net',
+      SUBNET: '192.0.2.0/24',
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.createArgs.at(-1)).toBe('code-worker-net');
+    expect(result.createArgs).toContain('com.docker.network.bridge.name=code-worker-br');
+    expect(result.createArgs).toContain('172.28.0.0/16');
+    expect(result.createArgs).toContain('fd00:172:28::/64');
+  });
+
+  it.each(['valid', 'nat-gateway-modes'] as const)(
+    'accepts an existing network that satisfies the exact contract: %s',
+    (networkState) => {
+      const result = runSetup(networkState);
+
+      expect(result.status).toBe(0);
+      expect(result.createArgs).toEqual([]);
+      expect(result.stdout).toContain("Network 'code-worker-net' already exists");
+    }
+  );
+
+  it.each([
+    ['wrong-driver', 'driver must be bridge'],
+    ['nondefault-ipam', 'IPAM driver must be default'],
+    ['internal', 'network must not be internal'],
+    ['ipv6-disabled', 'IPv6 must be enabled'],
+    ['bridge-name-mismatch', 'Linux bridge name must be code-worker-br'],
+    ['bridge-name-missing', 'Linux bridge name must be code-worker-br'],
+    ['masquerade-disabled', 'IP masquerade must be enabled'],
+    ['masquerade-missing', 'IP masquerade must be enabled'],
+    ['ipv4-subnet-mismatch', 'IPAM subnets must be exactly'],
+    ['ipv6-subnet-mismatch', 'IPAM subnets must be exactly'],
+    ['extra-subnet', 'IPAM subnets must be exactly'],
+    ['ipv4-gateway-routed', 'IPv4 gateway mode must be nat'],
+    ['ipv6-gateway-routed', 'IPv6 gateway mode must be nat'],
+  ] as const)(
+    'fails closed without recreating an incompatible existing network: %s',
+    (networkState, expectedError) => {
+      const result = runSetup(networkState);
+
+      expect(result.status).not.toBe(0);
+      expect(result.createArgs).toEqual([]);
+      expect(result.stderr).toContain(expectedError);
+      expect(result.stderr).toContain('Refusing to modify or replace');
+    }
+  );
+});

--- a/scripts/setup-worker-network.sh
+++ b/scripts/setup-worker-network.sh
@@ -11,15 +11,65 @@ set -euo pipefail
 #   - Private IP ranges
 # ==============================================================================
 
-NETWORK_NAME="${NETWORK_NAME:-code-worker-net}"
-SUBNET="${SUBNET:-172.28.0.0/16}"
+readonly NETWORK_NAME="code-worker-net"
+readonly BRIDGE_NAME="code-worker-br"
+readonly SUBNET="172.28.0.0/16"
+readonly IPV6_SUBNET="fd00:172:28::/64"
 
 echo "========================================"
 echo "Setting up Code worker network"
 echo "========================================"
 echo "Network: $NETWORK_NAME"
+echo "Linux bridge: $BRIDGE_NAME"
 echo "Subnet: $SUBNET"
+echo "IPv6 subnet: $IPV6_SUBNET"
 echo ""
+
+validate_network_contract() {
+    local driver ipam_driver internal bridge_name enable_ipv6 enable_ip_masquerade
+    local gateway_mode_ipv4 gateway_mode_ipv6 subnets subnet subnet_count
+    local has_ipv4_subnet has_ipv6_subnet
+    local errors=()
+
+    driver="$(docker network inspect "$NETWORK_NAME" --format '{{.Driver}}')"
+    ipam_driver="$(docker network inspect "$NETWORK_NAME" --format '{{.IPAM.Driver}}')"
+    internal="$(docker network inspect "$NETWORK_NAME" --format '{{.Internal}}')"
+    bridge_name="$(docker network inspect "$NETWORK_NAME" --format '{{index .Options "com.docker.network.bridge.name"}}')"
+    enable_ipv6="$(docker network inspect "$NETWORK_NAME" --format '{{.EnableIPv6}}')"
+    enable_ip_masquerade="$(docker network inspect "$NETWORK_NAME" --format '{{index .Options "com.docker.network.bridge.enable_ip_masquerade"}}')"
+    gateway_mode_ipv4="$(docker network inspect "$NETWORK_NAME" --format '{{index .Options "com.docker.network.bridge.gateway_mode_ipv4"}}')"
+    gateway_mode_ipv6="$(docker network inspect "$NETWORK_NAME" --format '{{index .Options "com.docker.network.bridge.gateway_mode_ipv6"}}')"
+    subnets="$(docker network inspect "$NETWORK_NAME" --format '{{range .IPAM.Config}}{{println .Subnet}}{{end}}')"
+
+    [[ "$driver" == "bridge" ]] || errors+=("driver must be bridge (found: $driver)")
+    [[ "$ipam_driver" == "default" ]] || errors+=("IPAM driver must be default (found: $ipam_driver)")
+    [[ "$internal" == "false" ]] || errors+=("network must not be internal")
+    [[ "$bridge_name" == "$BRIDGE_NAME" ]] || errors+=("Linux bridge name must be $BRIDGE_NAME (found: $bridge_name)")
+    [[ "$enable_ipv6" == "true" ]] || errors+=("IPv6 must be enabled")
+    [[ "$enable_ip_masquerade" == "true" ]] || errors+=("IP masquerade must be enabled")
+    [[ -z "$gateway_mode_ipv4" || "$gateway_mode_ipv4" == "nat" ]] || errors+=("IPv4 gateway mode must be nat when configured (found: $gateway_mode_ipv4)")
+    [[ -z "$gateway_mode_ipv6" || "$gateway_mode_ipv6" == "nat" ]] || errors+=("IPv6 gateway mode must be nat when configured (found: $gateway_mode_ipv6)")
+
+    subnet_count=0
+    has_ipv4_subnet=false
+    has_ipv6_subnet=false
+    while IFS= read -r subnet; do
+        [[ -z "$subnet" ]] && continue
+        subnet_count=$((subnet_count + 1))
+        [[ "$subnet" == "$SUBNET" ]] && has_ipv4_subnet=true
+        [[ "$subnet" == "$IPV6_SUBNET" ]] && has_ipv6_subnet=true
+    done <<< "$subnets"
+    if [[ "$subnet_count" -ne 2 || "$has_ipv4_subnet" != "true" || "$has_ipv6_subnet" != "true" ]]; then
+        errors+=("IPAM subnets must be exactly $SUBNET and $IPV6_SUBNET")
+    fi
+
+    if (( ${#errors[@]} > 0 )); then
+        echo "Network '$NETWORK_NAME' does not satisfy the required Code worker dual-stack contract:" >&2
+        printf '  - %s\n' "${errors[@]}" >&2
+        echo "Refusing to modify or replace an existing Docker network." >&2
+        return 1
+    fi
+}
 
 # Create network if not exists
 if docker network inspect "$NETWORK_NAME" >/dev/null 2>&1; then
@@ -28,15 +78,20 @@ else
     echo "Creating Docker network: $NETWORK_NAME"
     docker network create \
         --driver bridge \
+        --ipv6 \
+        --opt "com.docker.network.bridge.name=$BRIDGE_NAME" \
         --opt com.docker.network.bridge.enable_ip_masquerade=true \
         --subnet "$SUBNET" \
+        --subnet "$IPV6_SUBNET" \
         "$NETWORK_NAME"
     echo "Network created successfully"
 fi
 
+validate_network_contract
+
 echo ""
 echo "Network details:"
-docker network inspect "$NETWORK_NAME" --format '{{.Name}}: {{range .IPAM.Config}}{{.Subnet}}{{end}}'
+docker network inspect "$NETWORK_NAME" --format '{{.Name}}: {{range .IPAM.Config}}{{.Subnet}} {{end}}'
 
 # Note: iptables rules for blocking metadata server etc. should be applied
 # at the host level on Linux. On macOS with Docker Desktop, network isolation

--- a/workers/orchestrator/README.md
+++ b/workers/orchestrator/README.md
@@ -661,11 +661,11 @@ pnpm typecheck    # Type checking
 
 ### E2E Prerequisites
 
-| Requirement    | Check Command                            | Install                             |
-| -------------- | ---------------------------------------- | ----------------------------------- |
-| Docker daemon  | `docker info`                            | Docker Desktop                      |
-| Docker network | `docker network inspect code-worker-net` | `./scripts/setup-worker-network.sh` |
-| Test image     | `docker image inspect code-worker:test`  | See below                           |
+| Requirement    | Check Command                           | Install                           |
+| -------------- | --------------------------------------- | --------------------------------- |
+| Docker daemon  | `docker info`                           | Docker Desktop                    |
+| Docker network | `./scripts/setup-worker-network.sh`     | Same command creates or validates |
+| Test image     | `docker image inspect code-worker:test` | See below                         |
 
 ```bash
 # Setup

--- a/workers/orchestrator/scripts/verify-error-hub-mcp.mjs
+++ b/workers/orchestrator/scripts/verify-error-hub-mcp.mjs
@@ -21,7 +21,7 @@ const EVENT_ID_PATTERN = /^[a-f0-9]{32}$/u;
 
 export function parseVerificationConfiguration(argv, environment) {
   if (!Array.isArray(argv) || argv.length !== 2) {
-    throw new TypeError('usage: verify:error-hub-mcp -- <private issue URL> <event ID>');
+    throw new TypeError('usage: verify:error-hub-mcp <private issue URL> <event ID>');
   }
 
   const issueUrlText = requiredString(argv[0], 'private issue URL');

--- a/workers/orchestrator/src/services/isolation/__tests__/aaaa-only-docker-proxy.test.ts
+++ b/workers/orchestrator/src/services/isolation/__tests__/aaaa-only-docker-proxy.test.ts
@@ -1,0 +1,80 @@
+import { spawnSync } from 'node:child_process';
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createAaaaOnlyDockerProxy } from './aaaa-only-docker-proxy.js';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+describe('createAaaaOnlyDockerProxy', () => {
+  it('injects one IPv6-only hosts entry before the verifier image argument', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'aaaa-only-docker-proxy-'));
+    temporaryDirectories.push(directory);
+    const argumentsPath = join(directory, 'arguments');
+    const realDockerPath = join(directory, 'real-docker');
+    writeFileSync(
+      realDockerPath,
+      '#!/bin/bash\nprintf \'%s\\n\' "$@" > "$CAPTURED_DOCKER_ARGUMENTS"\n',
+      'utf8'
+    );
+    chmodSync(realDockerPath, 0o755);
+    const proxy = createAaaaOnlyDockerProxy({
+      directory,
+      host: 'fixture.test.ts.net',
+      ipv6Address: 'fd00:172:28::42',
+      realDockerPath,
+    });
+
+    const result = spawnSync(proxy.executable, ['run', '--rm', 'sha256:image'], {
+      encoding: 'utf8',
+      env: { ...process.env, ...proxy.environment, CAPTURED_DOCKER_ARGUMENTS: argumentsPath },
+    });
+
+    expect(result.status).toBe(0);
+    expect(readFileSync(argumentsPath, 'utf8').trim().split('\n')).toEqual([
+      'run',
+      '--rm',
+      '--add-host',
+      'fixture.test.ts.net=fd00:172:28::42',
+      'sha256:image',
+    ]);
+  });
+
+  it('passes non-run Docker commands through unchanged', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'aaaa-only-docker-proxy-'));
+    temporaryDirectories.push(directory);
+    const argumentsPath = join(directory, 'arguments');
+    const realDockerPath = join(directory, 'real-docker');
+    writeFileSync(
+      realDockerPath,
+      '#!/bin/bash\nprintf \'%s\\n\' "$@" > "$CAPTURED_DOCKER_ARGUMENTS"\n',
+      'utf8'
+    );
+    chmodSync(realDockerPath, 0o755);
+    const proxy = createAaaaOnlyDockerProxy({
+      directory,
+      host: 'fixture.test.ts.net',
+      ipv6Address: 'fd00:172:28::42',
+      realDockerPath,
+    });
+
+    const result = spawnSync(proxy.executable, ['network', 'inspect', 'code-worker-net'], {
+      encoding: 'utf8',
+      env: { ...process.env, ...proxy.environment, CAPTURED_DOCKER_ARGUMENTS: argumentsPath },
+    });
+
+    expect(result.status).toBe(0);
+    expect(readFileSync(argumentsPath, 'utf8').trim().split('\n')).toEqual([
+      'network',
+      'inspect',
+      'code-worker-net',
+    ]);
+  });
+});

--- a/workers/orchestrator/src/services/isolation/__tests__/aaaa-only-docker-proxy.ts
+++ b/workers/orchestrator/src/services/isolation/__tests__/aaaa-only-docker-proxy.ts
@@ -1,0 +1,46 @@
+import { chmodSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+interface AaaaOnlyDockerProxyConfig {
+  readonly directory: string;
+  readonly host: string;
+  readonly ipv6Address: string;
+  readonly realDockerPath: string;
+}
+
+interface AaaaOnlyDockerProxy {
+  readonly environment: Readonly<Record<string, string>>;
+  readonly executable: string;
+}
+
+export function createAaaaOnlyDockerProxy(config: AaaaOnlyDockerProxyConfig): AaaaOnlyDockerProxy {
+  const executable = join(config.directory, 'docker');
+  writeFileSync(
+    executable,
+    `#!/bin/bash
+set -euo pipefail
+
+if [[ "\${1:-}" == "run" ]]; then
+  arguments=("$@")
+  image_index=$((\${#arguments[@]} - 1))
+  exec "$AAAA_ONLY_REAL_DOCKER" \
+    "\${arguments[@]:0:image_index}" \
+    --add-host "$AAAA_ONLY_HOST=$AAAA_ONLY_IPV6" \
+    "\${arguments[@]:image_index}"
+fi
+
+exec "$AAAA_ONLY_REAL_DOCKER" "$@"
+`,
+    'utf8'
+  );
+  chmodSync(executable, 0o755);
+
+  return {
+    environment: {
+      AAAA_ONLY_HOST: config.host,
+      AAAA_ONLY_IPV6: config.ipv6Address,
+      AAAA_ONLY_REAL_DOCKER: config.realDockerPath,
+    },
+    executable,
+  };
+}

--- a/workers/orchestrator/src/services/isolation/__tests__/e2e-container.test.ts
+++ b/workers/orchestrator/src/services/isolation/__tests__/e2e-container.test.ts
@@ -7,7 +7,7 @@
  * Prerequisites:
  * - Docker daemon running
  * - Test worker image built: docker build -t code-worker:test -f Dockerfile.test .
- * - Worker network created: docker network create code-worker-net
+ * - Dual-stack worker network created: ./scripts/setup-worker-network.sh
  *
  * To run locally:
  *   pnpm --filter orchestrator test:e2e
@@ -21,9 +21,10 @@ import * as os from 'node:os';
 import { execSync } from 'node:child_process';
 import { DockerProvider } from '../docker-provider.js';
 import type { WorkerConfig } from '../types.js';
+import { assertWorkerNetworkContract, WORKER_NETWORK_NAME } from './worker-network-contract.js';
 
 const TEST_IMAGE = process.env['WORKER_IMAGE'] ?? 'code-worker:test';
-const TEST_NETWORK = process.env['WORKER_NETWORK'] ?? 'code-worker-net';
+const TEST_NETWORK = WORKER_NETWORK_NAME;
 const TEST_TIMEOUT = 60_000;
 
 function isDockerAvailable(): boolean {
@@ -84,6 +85,10 @@ describe.skipIf(skipIfNoDocker)('E2E Container Tests', () => {
   let testWorktreePath: string;
   let testSecretsPath: string;
   const createdTaskIds: string[] = [];
+
+  it('requires the exact dual-stack worker network contract', () => {
+    expect(() => assertWorkerNetworkContract()).not.toThrow();
+  });
 
   beforeAll(async () => {
     if (skipIfNoImage) {

--- a/workers/orchestrator/src/services/isolation/__tests__/fixtures/error-hub-mcp-server.mjs
+++ b/workers/orchestrator/src/services/isolation/__tests__/fixtures/error-hub-mcp-server.mjs
@@ -1,4 +1,4 @@
-import { readFileSync } from 'node:fs';
+import { readFileSync, writeFileSync } from 'node:fs';
 import { createServer } from 'node:https';
 
 const eventId = process.env['FIXTURE_EVENT_ID'];
@@ -75,6 +75,13 @@ const server = createServer(
     key: readFileSync('/fixture/tls/key.pem'),
   },
   (request, response) => {
+    writeFileSync(
+      '/tmp/last-peer.json',
+      JSON.stringify({
+        address: request.socket.remoteAddress,
+        family: request.socket.remoteFamily,
+      })
+    );
     if (request.method === 'GET' && request.url === '/health') {
       sendJson(response, 200, { ok: true });
       return;
@@ -137,7 +144,7 @@ const server = createServer(
   }
 );
 
-server.listen(8443, '0.0.0.0');
+server.listen({ host: '::', ipv6Only: true, port: 8443 });
 
 for (const signal of ['SIGINT', 'SIGTERM']) {
   process.on(signal, () => server.close(() => process.exit(0)));

--- a/workers/orchestrator/src/services/isolation/__tests__/verify-error-hub-mcp.e2e.test.ts
+++ b/workers/orchestrator/src/services/isolation/__tests__/verify-error-hub-mcp.e2e.test.ts
@@ -4,10 +4,12 @@ import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { promisify } from 'node:util';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { assertWorkerNetworkContract, WORKER_NETWORK_NAME } from './worker-network-contract.js';
+import { createAaaaOnlyDockerProxy } from './aaaa-only-docker-proxy.js';
 
 const execFileAsync = promisify(execFile);
 const workerImage = process.env['ERROR_HUB_MCP_E2E_IMAGE'] ?? process.env['WORKER_IMAGE'];
-const network = 'code-worker-net';
+const network = WORKER_NETWORK_NAME;
 const eventId = 'cccccccccccccccccccccccccccccccc';
 const fixtureHost = `error-hub-mcp-${String(process.pid)}.test.ts.net`;
 const fixtureContainer = `error-hub-mcp-fixture-${String(process.pid)}`;
@@ -36,10 +38,12 @@ const prerequisitesAvailable =
 
 describe.skipIf(!prerequisitesAvailable)('Error Hub MCP worker image verification', () => {
   let directory = '';
+  let dockerProxyEnvironment: Readonly<Record<string, string>> = {};
   let trustedImageId = '';
   let workerPlatform = '';
 
   beforeAll(async () => {
+    assertWorkerNetworkContract();
     directory = mkdtempSync(join(tmpdir(), 'error-hub-mcp-e2e-'));
     const tlsDirectory = join(directory, 'tls');
     const trustDirectory = join(directory, 'trust');
@@ -149,6 +153,30 @@ USER claude
       { stdio: 'ignore' }
     );
 
+    const fixtureIpv6Address = execFileSync(
+      'docker',
+      [
+        'container',
+        'inspect',
+        '--format',
+        '{{range .NetworkSettings.Networks}}{{.GlobalIPv6Address}}{{end}}',
+        fixtureContainer,
+      ],
+      { encoding: 'utf8' }
+    ).trim();
+    if (!fixtureIpv6Address.startsWith('fd00:172:28:')) {
+      throw new Error(`HTTPS SentryBox fixture has invalid IPv6 address: ${fixtureIpv6Address}`);
+    }
+    const realDockerPath = execFileSync('sh', ['-c', 'command -v docker'], {
+      encoding: 'utf8',
+    }).trim();
+    dockerProxyEnvironment = createAaaaOnlyDockerProxy({
+      directory,
+      host: fixtureHost,
+      ipv6Address: fixtureIpv6Address,
+      realDockerPath,
+    }).environment;
+
     let ready = false;
     for (let attempt = 0; attempt < 40; attempt += 1) {
       ready = commandSucceeds('docker', [
@@ -157,7 +185,7 @@ USER claude
         'node',
         '--input-type=module',
         '--eval',
-        "process.env.NODE_TLS_REJECT_UNAUTHORIZED='0';const r=await fetch('https://127.0.0.1:8443/health');if(!r.ok)process.exit(1)",
+        "process.env.NODE_TLS_REJECT_UNAUTHORIZED='0';const r=await fetch('https://[::1]:8443/health');if(!r.ok)process.exit(1)",
       ]);
       if (ready) break;
       await new Promise((resolveWait) => setTimeout(resolveWait, 250));
@@ -182,8 +210,10 @@ USER claude
     const { stdout } = await execFileAsync(process.execPath, [scriptPath, issueUrl, eventId], {
       env: {
         ...process.env,
+        ...dockerProxyEnvironment,
         INTEXURAOS_CODE_WORKER_IMAGE: trustedImageId,
         INTEXURAOS_ERROR_HUB_HOST: `${fixtureHost}:8443`,
+        PATH: `${directory}:${process.env['PATH'] ?? ''}`,
       },
       maxBuffer: 1024 * 1024,
       timeout: 90_000,
@@ -202,5 +232,13 @@ USER claude
       title: 'Controlled SentryBox validation fault',
       tools: ['get_issue_details', 'search_issue_events'],
     });
+
+    const peerEvidence = JSON.parse(
+      execFileSync('docker', ['exec', fixtureContainer, 'cat', '/tmp/last-peer.json'], {
+        encoding: 'utf8',
+      })
+    ) as unknown;
+    expect(peerEvidence).toMatchObject({ family: 'IPv6' });
+    expect(peerEvidence).toHaveProperty('address', expect.stringMatching(/^fd00:172:28:/u));
   }, 120_000);
 });

--- a/workers/orchestrator/src/services/isolation/__tests__/worker-network-contract.test.ts
+++ b/workers/orchestrator/src/services/isolation/__tests__/worker-network-contract.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest';
+import { assertWorkerNetworkInspection } from './worker-network-contract.js';
+
+function validInspection(): Record<string, unknown> {
+  return {
+    Name: 'code-worker-net',
+    Driver: 'bridge',
+    EnableIPv6: true,
+    Internal: false,
+    IPAM: {
+      Driver: 'default',
+      Config: [{ Subnet: '172.28.0.0/16' }, { Subnet: 'fd00:172:28::/64' }],
+    },
+    Options: {
+      'com.docker.network.bridge.enable_ip_masquerade': 'true',
+      'com.docker.network.bridge.name': 'code-worker-br',
+    },
+  };
+}
+
+describe('assertWorkerNetworkInspection', () => {
+  it.each([
+    {},
+    {
+      'com.docker.network.bridge.gateway_mode_ipv4': 'nat',
+      'com.docker.network.bridge.gateway_mode_ipv6': 'nat',
+    },
+  ])('accepts the exact contract with absent-or-nat gateway modes', (gatewayModes) => {
+    const inspection = validInspection();
+    inspection['Options'] = { ...(inspection['Options'] as object), ...gatewayModes };
+
+    expect(() => assertWorkerNetworkInspection(inspection)).not.toThrow();
+  });
+
+  it.each([
+    ['network name', { Name: 'custom-worker-net' }, 'name must be code-worker-net'],
+    ['network driver', { Driver: 'overlay' }, 'driver must be bridge'],
+    ['IPv6 disabled', { EnableIPv6: false }, 'IPv6 must be enabled'],
+    ['internal network', { Internal: true }, 'network must not be internal'],
+    [
+      'non-default IPAM',
+      { IPAM: { Driver: 'custom-ipam', Config: validInspectionIpamConfig() } },
+      'IPAM driver must be default',
+    ],
+    [
+      'wrong IPv4 subnet',
+      {
+        IPAM: {
+          Driver: 'default',
+          Config: [{ Subnet: '192.0.2.0/24' }, { Subnet: 'fd00:172:28::/64' }],
+        },
+      },
+      'IPAM subnets must be exactly',
+    ],
+    [
+      'wrong IPv6 subnet',
+      {
+        IPAM: {
+          Driver: 'default',
+          Config: [{ Subnet: '172.28.0.0/16' }, { Subnet: 'fd00:172:29::/64' }],
+        },
+      },
+      'IPAM subnets must be exactly',
+    ],
+    [
+      'additional subnet',
+      {
+        IPAM: {
+          Driver: 'default',
+          Config: [
+            { Subnet: '172.28.0.0/16' },
+            { Subnet: 'fd00:172:28::/64' },
+            { Subnet: '198.51.100.0/24' },
+          ],
+        },
+      },
+      'IPAM subnets must be exactly',
+    ],
+    [
+      'wrong bridge name',
+      {
+        Options: {
+          'com.docker.network.bridge.enable_ip_masquerade': 'true',
+          'com.docker.network.bridge.name': 'br-deadbeef',
+        },
+      },
+      'Linux bridge name must be code-worker-br',
+    ],
+    [
+      'masquerade disabled',
+      {
+        Options: {
+          'com.docker.network.bridge.enable_ip_masquerade': 'false',
+          'com.docker.network.bridge.name': 'code-worker-br',
+        },
+      },
+      'IP masquerade must be enabled',
+    ],
+    [
+      'IPv4 routed gateway',
+      {
+        Options: {
+          'com.docker.network.bridge.enable_ip_masquerade': 'true',
+          'com.docker.network.bridge.gateway_mode_ipv4': 'routed',
+          'com.docker.network.bridge.name': 'code-worker-br',
+        },
+      },
+      'IPv4 gateway mode must be nat',
+    ],
+    [
+      'IPv6 routed gateway',
+      {
+        Options: {
+          'com.docker.network.bridge.enable_ip_masquerade': 'true',
+          'com.docker.network.bridge.gateway_mode_ipv6': 'routed',
+          'com.docker.network.bridge.name': 'code-worker-br',
+        },
+      },
+      'IPv6 gateway mode must be nat',
+    ],
+  ] as const)('rejects incompatible %s', (_name, override, expectedError) => {
+    const inspection = { ...validInspection(), ...override };
+
+    expect(() => assertWorkerNetworkInspection(inspection)).toThrow(expectedError);
+  });
+
+  it('rejects malformed Docker inspection output with an actionable error', () => {
+    expect(() => assertWorkerNetworkInspection({ Driver: 'bridge' })).toThrow(
+      'Docker network inspection is missing IPAM.Config'
+    );
+  });
+});
+
+function validInspectionIpamConfig(): readonly Record<string, string>[] {
+  return [{ Subnet: '172.28.0.0/16' }, { Subnet: 'fd00:172:28::/64' }];
+}

--- a/workers/orchestrator/src/services/isolation/__tests__/worker-network-contract.ts
+++ b/workers/orchestrator/src/services/isolation/__tests__/worker-network-contract.ts
@@ -1,0 +1,110 @@
+import { execFileSync } from 'node:child_process';
+
+export const WORKER_NETWORK_NAME = 'code-worker-net';
+
+const WORKER_BRIDGE_NAME = 'code-worker-br';
+const WORKER_IPV4_SUBNET = '172.28.0.0/16';
+const WORKER_IPV6_SUBNET = 'fd00:172:28::/64';
+
+const BRIDGE_NAME_OPTION = 'com.docker.network.bridge.name';
+const MASQUERADE_OPTION = 'com.docker.network.bridge.enable_ip_masquerade';
+const IPV4_GATEWAY_MODE_OPTION = 'com.docker.network.bridge.gateway_mode_ipv4';
+const IPV6_GATEWAY_MODE_OPTION = 'com.docker.network.bridge.gateway_mode_ipv6';
+
+type UnknownRecord = Record<string, unknown>;
+
+export function assertWorkerNetworkInspection(value: unknown): void {
+  const inspection = requiredRecord(value, 'Docker network inspection');
+  const ipam = optionalRecord(inspection['IPAM']);
+  const config = inspectionArray(ipam['Config']);
+  const options = optionalRecord(inspection['Options']);
+  const errors: string[] = [];
+
+  if (inspection['Name'] !== WORKER_NETWORK_NAME) {
+    errors.push(`name must be ${WORKER_NETWORK_NAME}`);
+  }
+  if (inspection['Driver'] !== 'bridge') {
+    errors.push('driver must be bridge');
+  }
+  if (ipam['Driver'] !== 'default') {
+    errors.push('IPAM driver must be default');
+  }
+  if (inspection['Internal'] !== false) {
+    errors.push('network must not be internal');
+  }
+  if (inspection['EnableIPv6'] !== true) {
+    errors.push('IPv6 must be enabled');
+  }
+  if (options[BRIDGE_NAME_OPTION] !== WORKER_BRIDGE_NAME) {
+    errors.push(`Linux bridge name must be ${WORKER_BRIDGE_NAME}`);
+  }
+  if (options[MASQUERADE_OPTION] !== 'true') {
+    errors.push('IP masquerade must be enabled');
+  }
+  if (!isNatOrAbsent(options[IPV4_GATEWAY_MODE_OPTION])) {
+    errors.push('IPv4 gateway mode must be nat when configured');
+  }
+  if (!isNatOrAbsent(options[IPV6_GATEWAY_MODE_OPTION])) {
+    errors.push('IPv6 gateway mode must be nat when configured');
+  }
+
+  const subnets = config
+    .map((entry) => optionalRecord(entry)['Subnet'])
+    .filter((subnet): subnet is string => typeof subnet === 'string');
+  if (
+    subnets.length !== 2 ||
+    !subnets.includes(WORKER_IPV4_SUBNET) ||
+    !subnets.includes(WORKER_IPV6_SUBNET)
+  ) {
+    errors.push(`IPAM subnets must be exactly ${WORKER_IPV4_SUBNET} and ${WORKER_IPV6_SUBNET}`);
+  }
+
+  if (errors.length > 0) {
+    throw new Error(
+      `Worker network '${WORKER_NETWORK_NAME}' does not satisfy the required dual-stack contract:\n${errors.map((error) => `  - ${error}`).join('\n')}\nRun ./scripts/setup-worker-network.sh.`
+    );
+  }
+}
+
+export function assertWorkerNetworkContract(): void {
+  let inspection: unknown;
+  try {
+    const output = execFileSync(
+      'docker',
+      ['network', 'inspect', WORKER_NETWORK_NAME, '--format', '{{json .}}'],
+      { encoding: 'utf8' }
+    );
+    inspection = JSON.parse(output);
+  } catch {
+    throw new Error(
+      `Unable to inspect worker network '${WORKER_NETWORK_NAME}'; run ./scripts/setup-worker-network.sh`
+    );
+  }
+
+  assertWorkerNetworkInspection(inspection);
+}
+
+function inspectionArray(value: unknown): readonly unknown[] {
+  if (!Array.isArray(value)) {
+    throw new Error('Docker network inspection is missing IPAM.Config');
+  }
+  return value;
+}
+
+function requiredRecord(value: unknown, name: string): UnknownRecord {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error(`${name} must be an object`);
+  }
+  return value as UnknownRecord;
+}
+
+function optionalRecord(value: unknown): UnknownRecord {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return {};
+  }
+  return value as UnknownRecord;
+}
+
+function isNatOrAbsent(value: unknown): boolean {
+  return value === undefined || value === 'nat';
+}


### PR DESCRIPTION
## Summary
- create and validate the Code Worker bridge as exact dual-stack IPv4/IPv6
- keep the existing IPv4 metadata boundary while allowing private Tailscale IPv6 access through the reviewed host firewall
- cover idempotent setup, AAAA-only reachability, and exact network contract validation

## Verification
- `pnpm run ci:tracked` passed twice on the final commit (7,233 tests each run)
- independent review: no Critical, Important, or Minor findings
- local immutable worker E2E remains intentionally deferred until Home Dev has the reviewed dual-stack network; GitHub runs the isolated E2E contract

## Tracking
Linear: omitted by $commit-push; GitHub automation will create or link the Linear issue after PR creation.