### PR TITLE
[INT-1945] fix(linear-agent): allow first idempotent issue creation

### DIFF
--- a/apps/linear-agent/src/__tests__/infra/linearApiClient.test.ts
+++ b/apps/linear-agent/src/__tests__/infra/linearApiClient.test.ts
@@ -9,6 +9,7 @@ import { clearClientCache, createLinearApiClient } from '../../infra/linear/line
 
 const mocks = vi.hoisted(() => ({
   issues: vi.fn(),
+  issue: vi.fn(),
   info: vi.fn(),
   warn: vi.fn(),
   error: vi.fn(),
@@ -19,6 +20,7 @@ vi.mock('@linear/sdk', () => ({
   LinearClient: vi.fn(function LinearClient() {
     return {
       issues: mocks.issues,
+      issue: mocks.issue,
     };
   }),
 }));
@@ -288,6 +290,34 @@ describe('LinearApiClient', () => {
       const result = await fakeClient.getIssue('api-key', 'issue-123');
 
       expect(result.ok).toBe(false);
+    });
+
+    it('returns null when the Linear SDK reports that the issue does not exist', async () => {
+      mocks.issue.mockRejectedValueOnce(new Error('Entity not found: Issue'));
+      const client = createLinearApiClient();
+
+      const result = await client.getIssue('api-key', 'stable-idempotent-issue-id');
+
+      expect(result).toEqual({ ok: true, value: null });
+      expect(mocks.error).not.toHaveBeenCalled();
+      expect(mocks.info).toHaveBeenCalledWith(
+        { issueId: 'stable-idempotent-issue-id' },
+        'Issue not found by ID'
+      );
+    });
+
+    it('does not hide a mapping failure for an issue that was found', async () => {
+      mocks.issue.mockResolvedValueOnce({
+        state: Promise.resolve(null),
+        children: vi.fn().mockResolvedValue({ nodes: [] }),
+        parent: Promise.reject(new Error('Entity not found: Issue')),
+      });
+      const client = createLinearApiClient();
+
+      const result = await client.getIssue('api-key', 'existing-issue-id');
+
+      expect(result.ok).toBe(false);
+      expect(mocks.error).toHaveBeenCalled();
     });
   });
 

--- a/apps/linear-agent/src/infra/linear/linearApiClient.ts
+++ b/apps/linear-agent/src/infra/linear/linearApiClient.ts
@@ -235,7 +235,16 @@ export function createLinearApiClient(): LinearApiClient {
 
           const client = getOrCreateClient(apiKey);
 
-          const issue = await client.issue(issueId);
+          let issue: Issue;
+          try {
+            issue = await client.issue(issueId);
+          } catch (error) {
+            if (/entity not found:\s*issue\b/iu.test(getErrorMessage(error, ''))) {
+              logger.info({ issueId }, 'Issue not found by ID');
+              return null;
+            }
+            throw error;
+          }
           return await mapSingleIssue(issue);
         });
 


### PR DESCRIPTION
## Problem

The real Linear SDK throws `Entity not found: Issue` when the deterministic idempotency ID has not been created yet. The adapter returned that as an error, so the create route stopped with 502 before calling Linear. SentryBox consequently retried the Code Agent webhook and received HTTP 500.

## Fix

- Treat only a direct `client.issue(issueId)` not-found result as `ok(null)`.
- Keep mapping and related-entity failures as errors.
- Add regression coverage for both paths.

## Verification

- 116 focused Linear Agent tests pass.
- Linear Agent typecheck and lint pass.
- Prettier and `git diff --check` pass.
- Independent review: READY.