### PR TITLE
[INT-1946] Fix Linear idempotent issue UUID format

### DIFF
--- a/apps/linear-agent/src/__tests__/routes/internalIssuesRoutes.test.ts
+++ b/apps/linear-agent/src/__tests__/routes/internalIssuesRoutes.test.ts
@@ -189,6 +189,7 @@ describe('internalIssuesRoutes', () => {
     });
 
     it('returns the same Linear issue for the same creation idempotency key', async () => {
+      const createIssue = vi.spyOn(fakeLinearClient, 'createIssue');
       const request = {
         method: 'POST' as const,
         url: '/internal/issues',
@@ -213,6 +214,9 @@ describe('internalIssuesRoutes', () => {
       expect(second.statusCode).toBe(200);
       expect(secondBody.data).toEqual(firstBody.data);
       expect(issues.ok && issues.value).toHaveLength(1);
+      expect(createIssue.mock.calls[0]?.[1].id).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u
+      );
     });
 
     it('returns the Linear lookup error before idempotent creation', async () => {

--- a/apps/linear-agent/src/routes/internalIssuesRoutes.ts
+++ b/apps/linear-agent/src/routes/internalIssuesRoutes.ts
@@ -55,7 +55,7 @@ interface IssueResponse {
 
 function idempotentLinearIssueId(userId: string, idempotencyKey: string): string {
   const hash = createHash('sha256').update(`${userId}\0${idempotencyKey}`).digest('hex');
-  return `${hash.slice(0, 8)}-${hash.slice(8, 12)}-5${hash.slice(13, 16)}-a${hash.slice(17, 20)}-${hash.slice(20, 32)}`;
+  return `${hash.slice(0, 8)}-${hash.slice(8, 12)}-4${hash.slice(13, 16)}-a${hash.slice(17, 20)}-${hash.slice(20, 32)}`;
 }
 
 function toIssueResponse(issue: { id: string; identifier: string; title: string; url: string }): IssueResponse {


### PR DESCRIPTION
## Root cause

The deterministic Linear issue ID used UUID version 5 formatting, while Linear IssueCreateInput accepts only UUID v4. The lookup succeeded as not-found, but createIssue was rejected with Argument Validation Error, so SentryBox webhook deliveries returned HTTP 500.

## Fix

- retain deterministic IDs and change only the UUID version nibble to v4
- assert the exact ID passed to the Linear client matches UUID v4

No data migration is required because Linear rejected every prior v5-formatted create before persisting an issue.

## Verification

- focused regression test failed before the fix and passes after it
- internalIssuesRoutes: 94/94
- linear-agent typecheck
- ESLint and Prettier
- independent review: READY