### PR TITLE
[INT-1949] Fix Sentry regression Linear issue isolation

### DIFF
--- a/apps/code-agent/src/__tests__/infra/firestore/sentryIssueEventRepository.test.ts
+++ b/apps/code-agent/src/__tests__/infra/firestore/sentryIssueEventRepository.test.ts
@@ -494,6 +494,7 @@ describe('createFirestoreSentryIssueEventRepository', () => {
       issueKey: first.issueKey,
       leaseToken: first.leaseToken,
       codeTaskId: first.codeTaskId,
+      linearIssueId: 'INT-200',
     });
     const laterEvent = buildEvent({ action: 'regressed' });
 
@@ -508,6 +509,7 @@ describe('createFirestoreSentryIssueEventRepository', () => {
 
     expect(staleApproval.ok && staleApproval.value.kind).toBe('inspect_linked_task');
     expect(approved.codeTaskId).toBe('task_later');
+    expect(approved.linearIssueId).toBeUndefined();
   });
 
   it('lazily migrates a linked legacy transition and preserves exact-event duplicate behavior', async () => {

--- a/apps/code-agent/src/infra/firestore/sentryIssueEventRepository.ts
+++ b/apps/code-agent/src/infra/firestore/sentryIssueEventRepository.ts
@@ -475,7 +475,7 @@ export function createFirestoreSentryIssueEventRepository(deps: {
           failureReason: undefined,
           eventId: input.event.eventId,
         };
-        const linearIssueId = exactTransition?.linearIssueId ?? issueReservation?.linearIssueId;
+        const linearIssueId = exactTransition?.linearIssueId;
         const reservedFields = {
           transitionKey,
           event: input.event,


### PR DESCRIPTION
## Summary

- keep a checkpointed Linear issue scoped to the exact Sentry transition that created it
- make a later Sentry regression create its own Linear issue while preserving same-transition retry recovery
- cover the replacement path with the prior generation's Linear linkage present

## Verification

- `pnpm run ci:tracked` — 7,233 tests, typecheck, lint, static validation, coverage, build, and format passed
- focused repository suite — 38/38 passed
- independent review — ready, no findings

## Linear

Linear: omitted by `$commit-push`; GitHub automation will create or link the Linear issue after PR creation.
