### PR TITLE
[INT-1960] fix: harden SentryBox-only cutover

### DIFF
--- a/.claude/skills/linear/workflows/sentry-integration.md
+++ b/.claude/skills/linear/workflows/sentry-integration.md
@@ -11,9 +11,11 @@ Legacy Sentry SaaS or a second error provider.
    and whose path matches `/organizations/intexuraos/issues/<id>/`.
 2. Verify the `error_hub` and Linear MCP servers are available. Do not fall back
    to a server named `sentry` or to a REST token.
-3. Call `mcp__error_hub__get_issue_details` with the exact issue URL. Extract
-   the title, project, environment, release, occurrence count, timestamps, and
-   stack evidence returned by SentryBox.
+3. Call the `error_hub` server's `execute_sentry_tool` tool with
+   `name`: `get_issue_details` and
+   `arguments`: `{ issueUrl: <exact issue URL> }`.
+   Extract the title, project, environment, release, occurrence count,
+   timestamps, and stack evidence returned by SentryBox.
 4. Search Linear for an existing issue with the same SentryBox issue URL or
    title. If a match exists, report it instead of creating a duplicate.
 5. Create one unassigned Linear issue in team `IntexuraOS`, state `Backlog`,

--- a/apps/code-agent/src/__tests__/routes/webhooks/sentry.test.ts
+++ b/apps/code-agent/src/__tests__/routes/webhooks/sentry.test.ts
@@ -22,14 +22,16 @@ const ERROR_HUB_EVENT_ALERT_RAW = readFileSync(
   'utf8',
 );
 
-function buildIssueBody(): Record<string, unknown> {
+function buildIssueBody(
+  issueUrl = 'https://home-dev.example.ts.net:8443/organizations/intexuraos/issues/4509001/'
+): Record<string, unknown> {
   return {
     action: 'created',
     data: {
       issue: {
         id: '4509001',
         title: 'TypeError: Cannot read properties of undefined',
-        permalink: 'https://intexuraos-dev-pbuchman.sentry.io/issues/4509001/',
+        permalink: issueUrl,
         project: {
           slug: 'intexuraos-development',
         },
@@ -132,7 +134,7 @@ describe('POST /webhooks/sentry', () => {
     }));
   });
 
-  it('accepts a signed issue webhook and creates a Sentry code task', async () => {
+  it('accepts a signed SentryBox issue webhook and creates a Sentry code task', async () => {
     const rawBody = JSON.stringify(buildIssueBody());
 
     const response = await app.inject({
@@ -163,6 +165,34 @@ describe('POST /webhooks/sentry', () => {
         issueTitle: 'TypeError: Cannot read properties of undefined',
       }),
     }));
+  });
+
+  it('rejects a signed Legacy Sentry issue URL before reserving or creating a task', async () => {
+    const rawBody = JSON.stringify(
+      buildIssueBody('https://intexuraos-dev-pbuchman.sentry.io/issues/4509001/')
+    );
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/webhooks/sentry',
+      headers: {
+        'content-type': 'application/json',
+        'sentry-hook-resource': 'issue',
+        'sentry-hook-signature': sign(rawBody),
+      },
+      payload: rawBody,
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(JSON.parse(response.body)).toEqual(expect.objectContaining({
+      success: false,
+      error: {
+        code: 'INVALID_REQUEST',
+        message: 'Sentry webhook issue URL is not a private SentryBox URL',
+      },
+    }));
+    expect(sentryReservationAcquire).not.toHaveBeenCalled();
+    expect(codeTaskCreate).not.toHaveBeenCalled();
   });
 
   it('accepts the exact signed Error Hub event_alert contract without route changes', async () => {

--- a/apps/code-agent/src/__tests__/usecases/processSentryWebhook.test.ts
+++ b/apps/code-agent/src/__tests__/usecases/processSentryWebhook.test.ts
@@ -17,8 +17,8 @@ import { createFakeTask } from '../helpers/mockFirestore.js';
 const WEBHOOK_SECRET = 'sentry-webhook-secret';
 const ORCHESTRATOR_SECRET = 'orchestrator-secret';
 const AUTOMATION_USER_ID = 'sentry-automation-user';
-const TRANSITION_KEY = 'sentry:intexuraos-dev-pbuchman:100:4509001:issue:created';
-const ISSUE_KEY = 'sentry-task:intexuraos-dev-pbuchman:100:4509001';
+const TRANSITION_KEY = 'sentry:intexuraos:100:4509001:issue:created';
+const ISSUE_KEY = 'sentry-task:intexuraos:100:4509001';
 const LEASE_TOKEN = 'lease-token';
 
 function buildIssueBody(): Record<string, unknown> {
@@ -29,7 +29,8 @@ function buildIssueBody(): Record<string, unknown> {
         id: '4509001',
         shortId: 'INTEXURAOS-DEVELOPMENT-7',
         title: 'TypeError: Cannot read properties of undefined',
-        permalink: 'https://intexuraos-dev-pbuchman.sentry.io/issues/4509001/',
+        permalink:
+          'https://home-dev.example.ts.net:8443/organizations/intexuraos/issues/4509001/',
         status: 'unresolved',
         project: { id: '100', slug: 'intexuraos-development' },
       },
@@ -44,8 +45,10 @@ function buildEventAlertBody(): Record<string, unknown> {
       event: {
         event_id: 'event-4509002',
         title: 'Error: fetch failed',
-        web_url: 'https://intexuraos-dev-pbuchman.sentry.io/issues/4509002/events/event-4509002/',
-        issue: 'https://intexuraos-dev-pbuchman.sentry.io/issues/4509002/',
+        web_url:
+          'https://home-dev.example.ts.net:8443/organizations/intexuraos/issues/4509002/events/event-4509002/',
+        issue:
+          'https://home-dev.example.ts.net:8443/organizations/intexuraos/issues/4509002/',
         project: 'intexuraos-web-development',
       },
     },
@@ -63,7 +66,8 @@ function buildResolvedEventAlertBody(): Record<string, unknown> {
           id: '4509003',
           title: 'Resolved issue',
           status: 'resolved',
-          url: 'https://intexuraos-dev-pbuchman.sentry.io/issues/4509003/',
+          url:
+            'https://home-dev.example.ts.net:8443/organizations/intexuraos/issues/4509003/',
           project: { slug: 'intexuraos-web-development' },
         },
       },
@@ -79,8 +83,10 @@ function buildSampleEventAlertBody(): Record<string, unknown> {
         event_id: 'sample-event',
         project: 4510702691024976,
         title: 'This is an example node-fastify exception',
-        web_url: 'https://sentry.io/organizations/intexuraos/issues/1117540176/events/sample-event/',
-        issue_url: 'https://sentry.io/api/0/issues/1117540176/',
+        web_url:
+          'https://home-dev.example.ts.net:8443/organizations/intexuraos/issues/1117540176/events/sample-event/',
+        issue_url:
+          'https://home-dev.example.ts.net:8443/organizations/intexuraos/issues/1117540176/',
         issue_id: '1117540176',
       },
     },
@@ -260,7 +266,7 @@ describe('processSentryWebhook', () => {
       leaseOwner: acquisition.proposedCodeTaskId,
       leaseDurationMs: 300_000,
       event: expect.objectContaining({
-        organizationSlug: 'intexuraos-dev-pbuchman',
+        organizationSlug: 'intexuraos',
         projectId: '100',
         issueId: '4509001',
       }),
@@ -794,7 +800,8 @@ describe('processSentryWebhook', () => {
         issueId: '4509001',
         issueShortId: 'INTEXURAOS-DEVELOPMENT-7',
         issueTitle: 'TypeError',
-        issueUrl: 'https://intexuraos-dev-pbuchman.sentry.io/issues/4509001/',
+        issueUrl:
+          'https://home-dev.example.ts.net:8443/organizations/intexuraos/issues/4509001/',
         status: 'unresolved',
         eventId: undefined,
       }),

--- a/apps/code-agent/src/domain/usecases/processSentryWebhook.ts
+++ b/apps/code-agent/src/domain/usecases/processSentryWebhook.ts
@@ -32,6 +32,8 @@ const SENTRY_AUTOMATION_SELF_ALERT_TITLES = new Set([
   'code worker auth not ready',
   'code worker auth not ready at startup',
 ]);
+const TAILNET_DNS_HOSTNAME_PATTERN =
+  /^(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.){2,}ts\.net$/u;
 
 export type VerifySentrySignature = (payload: Buffer, signature: string, secret: string) => boolean;
 export type ParseSentryIssueEvent = (
@@ -114,6 +116,21 @@ function normalizeToken(value: string | undefined): string | undefined {
 
 function normalizeTitle(value: string): string {
   return value.trim().toLowerCase().replace(/\s+/g, ' ');
+}
+
+function isPrivateSentryBoxIssueUrl(issueUrl: string): boolean {
+  try {
+    const url = new URL(issueUrl);
+    return url.protocol === 'https:'
+      && url.port === '8443'
+      && url.username === ''
+      && url.password === ''
+      && url.search === ''
+      && url.hash === ''
+      && TAILNET_DNS_HOSTNAME_PATTERN.test(url.hostname.toLowerCase());
+  } catch {
+    return false;
+  }
 }
 
 function isTerminalIssueStatus(event: NormalizedSentryIssueEvent): boolean {
@@ -215,6 +232,18 @@ export async function processSentryWebhook(
       return { ok: true, outcome: 'ignored', message: parsed.error.message };
     }
     return { ok: false, reason: 'invalid_payload', message: parsed.error.message };
+  }
+
+  if (!isPrivateSentryBoxIssueUrl(parsed.value.issueUrl)) {
+    logger.warn(
+      { _skipSentry: true },
+      'Rejected Sentry webhook outside the private SentryBox host'
+    );
+    return {
+      ok: false,
+      reason: 'invalid_payload',
+      message: 'Sentry webhook issue URL is not a private SentryBox URL',
+    };
   }
 
   const classification = classifySentryIssueEvent(parsed.value);

--- a/workers/orchestrator/scripts/verify-error-hub-mcp.mjs
+++ b/workers/orchestrator/scripts/verify-error-hub-mcp.mjs
@@ -449,9 +449,11 @@ function validatePrivateHost(value) {
   } catch {
     throw new TypeError('INTEXURAOS_ERROR_HUB_HOST is invalid');
   }
+  const tailnetDnsHostnamePattern =
+    /^(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.){2,}ts\.net$/u;
   if (
     origin.hostname === '' ||
-    !origin.hostname.endsWith('.ts.net') ||
+    !tailnetDnsHostnamePattern.test(origin.hostname.toLowerCase()) ||
     origin.port !== '8443' ||
     origin.host.toLowerCase() !== value.toLowerCase() ||
     origin.username !== '' ||

--- a/workers/orchestrator/src/__tests__/bootstrap/env-config.test.ts
+++ b/workers/orchestrator/src/__tests__/bootstrap/env-config.test.ts
@@ -233,6 +233,11 @@ describe('loadEnvConfig', () => {
     'home-dev.example.ts.net/issues/1',
     'user@home-dev.example.ts.net',
     'home dev.example.ts.net',
+    '.ts.net:8443',
+    'foo..ts.net:8443',
+    '_x.example.ts.net:8443',
+    '-host.example.ts.net:8443',
+    'host-.example.ts.net:8443',
     'home-dev.example.ts.net:0',
     'home-dev.example.ts.net:65536',
   ])('rejects invalid INTEXURAOS_ERROR_HUB_HOST value %s', (value) => {

--- a/workers/orchestrator/src/bootstrap/env-config.ts
+++ b/workers/orchestrator/src/bootstrap/env-config.ts
@@ -122,6 +122,9 @@ function readOptionalString(env: EnvReader, name: string): string | undefined {
   return raw !== undefined && raw !== '' ? raw : undefined;
 }
 
+const TAILNET_DNS_HOSTNAME_PATTERN =
+  /^(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.){2,}ts\.net$/u;
+
 function readErrorHubHost(env: EnvReader): string {
   const value = getRequiredEnv('INTEXURAOS_ERROR_HUB_HOST', env);
   let origin: URL | undefined;
@@ -136,7 +139,7 @@ function readErrorHubHost(env: EnvReader): string {
   if (
     origin === undefined ||
     origin.hostname === '' ||
-    !origin.hostname.endsWith('.ts.net') ||
+    !TAILNET_DNS_HOSTNAME_PATTERN.test(origin.hostname.toLowerCase()) ||
     origin.port !== '8443' ||
     origin.host.toLowerCase() !== value.toLowerCase() ||
     origin.username !== '' ||

--- a/workers/orchestrator/src/services/isolation/__tests__/verify-error-hub-mcp.test.ts
+++ b/workers/orchestrator/src/services/isolation/__tests__/verify-error-hub-mcp.test.ts
@@ -83,6 +83,20 @@ describe('parseVerificationConfiguration', () => {
         INTEXURAOS_ERROR_HUB_HOST: 'errors.intexuraos.cloud:8443',
       },
     },
+    ...[
+      '.ts.net:8443',
+      'foo..ts.net:8443',
+      '_x.example.ts.net:8443',
+      '-host.example.ts.net:8443',
+      'host-.example.ts.net:8443',
+    ].map((host) => ({
+      name: `invalid tailnet DNS host ${host}`,
+      argv: [`https://${host}/organizations/intexuraos/issues/42/`, EVENT_ID],
+      env: {
+        ...validEnvironment(),
+        INTEXURAOS_ERROR_HUB_HOST: host,
+      },
+    })),
   ])('rejects $name before Docker starts', ({ argv, env }) => {
     expect(() => parseVerificationConfiguration(argv, env)).toThrow();
   });

--- a/workers/orchestrator/src/services/isolation/__tests__/worker-image.test.ts
+++ b/workers/orchestrator/src/services/isolation/__tests__/worker-image.test.ts
@@ -113,7 +113,9 @@ describe('code-worker image Codex skill bootstrap', () => {
     const linearCrossLinking = readFileSync(linearCrossLinkingPath, 'utf8');
 
     expect(existsSync(legacySentrySkillPath)).toBe(false);
-    expect(linearWorkflow).toContain('mcp__error_hub__get_issue_details');
+    expect(linearWorkflow).toContain('`execute_sentry_tool`');
+    expect(linearWorkflow).toContain('`get_issue_details`');
+    expect(linearWorkflow).not.toContain('mcp__error_hub__get_issue_details');
     expect(linearWorkflow).not.toContain('mcp__sentry__');
     expect(linearWorkflow).not.toContain('sentry.io');
     expect(linearWorkflow).not.toContain('Seer');


### PR DESCRIPTION
## Summary

- reject signed Code Agent webhook payloads that point to Legacy Sentry or any non-private SentryBox URL before reserving a task
- strictly validate the configured SentryBox tailnet DNS host in both orchestrator startup and the real-image MCP verifier
- align the Worker workflow with SentryBox's actual `execute_sentry_tool` / `get_issue_details` MCP contract

## Verification

- `pnpm run ci:tracked`
- 178 focused Code Agent and orchestrator tests covering webhook routing, tailnet host validation, MCP verification, and Worker instructions

Linear: omitted by `$commit-push`; GitHub automation will create or link the Linear issue after PR creation.
