### PR TITLE
[INT-1963] fix: prepare web release layout before deployment

### DIFF
--- a/scripts/__tests__/hetzner-runtime.test.ts
+++ b/scripts/__tests__/hetzner-runtime.test.ts
@@ -1192,6 +1192,7 @@ describe('Hetzner web asset deployment', () => {
   it('builds the SPA into an inactive release and atomically switches the nginx web root', () => {
     const script = readRequired(deployWebPath);
     const provision = readRequired(provisionPath);
+    const bootstrap = readRequired(terraformHetznerBootstrapPath);
     const runbook = readRequired(runbookPath);
     const webHosting = readRequired(webHostingPath);
 
@@ -1232,6 +1233,15 @@ describe('Hetzner web asset deployment', () => {
     expect(script).toContain('mv -Tf "${next_link}" "${WEB_CURRENT_LINK}"');
     expect(script).toContain('ACTIVATE_WEB="false"');
     expect(script).toContain('apps/web/dist/index.html');
+    expect(provision).toContain(
+      'WEB_RELEASES_ROOT="${WEB_RELEASES_ROOT:-$(dirname "${WEB_ROOT}")/releases}"'
+    );
+    expect(provision).toContain('"$(dirname "${WEB_ROOT}")"');
+    expect(provision).toContain('"${WEB_ROOT}"');
+    expect(provision).toContain('"${WEB_RELEASES_ROOT}"');
+    expect(bootstrap).toContain(
+      '/var/www/intexuraos/web /var/www/intexuraos/web/dist /var/www/intexuraos/web/releases'
+    );
     expect(readRequired(nginxConfigPath)).not.toContain('root /var/www/intexuraos/web/dist;');
     expect(provision).toContain('rsync');
     expect(runbook).toContain('scripts/hetzner/deploy-web.sh');

--- a/scripts/__tests__/message-digest-cutover.test.ts
+++ b/scripts/__tests__/message-digest-cutover.test.ts
@@ -1117,6 +1117,37 @@ prepare_remote_terraform
     }
   });
 
+  it('repairs the deploy-owned Web release layout before either activation path', () => {
+    const deploy = readFileSync(deployPath, 'utf8');
+    const main = deploy.slice(deploy.indexOf('main() {'));
+    const result = runShellLibrary(
+      deployPath,
+      `
+run_remote_at() { printf 'directory=%s\\ncommand=%s\\n' "$1" "$2"; }
+prepare_remote_web_layout
+`,
+      {}
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(result.stdout).toContain('directory=/opt/intexuraos');
+    expect(result.stdout).toContain('web_owner="$(id -un)"');
+    expect(result.stdout).toContain('web_group="$(id -gn)"');
+    expect(result.stdout).toContain(
+      'sudo -n install -d -o "${web_owner}" -g "${web_group}" -m 755 -- /var/www/intexuraos/web /var/www/intexuraos/web/releases'
+    );
+    expect(result.stdout).toContain('test -w /var/www/intexuraos/web');
+    expect(result.stdout).toContain('test -w /var/www/intexuraos/web/releases');
+    expect(main.indexOf('prepare_remote_web_layout')).toBeGreaterThan(-1);
+    expect(main.indexOf('prepare_remote_web_layout')).toBeLessThan(
+      main.indexOf('run_message_digest_cutover')
+    );
+    expect(main.indexOf('prepare_remote_web_layout')).toBeLessThan(
+      main.indexOf('deploy_web_and_edge')
+    );
+  });
+
   it('runs first activation without forwarding a Hetzner provider credential', () => {
     const result = runShellLibrary(
       deployPath,

--- a/scripts/hetzner/github-actions-deploy.sh
+++ b/scripts/hetzner/github-actions-deploy.sh
@@ -286,6 +286,13 @@ run_remote() {
   run_remote_at "${REMOTE_RELEASE_DIR}" "$1"
 }
 
+prepare_remote_web_layout() {
+  # Identity expansion must happen on the remote host.
+  # shellcheck disable=SC2016
+  run_remote_at "${REMOTE_REPO_DIR}" \
+    'web_owner="$(id -un)"; web_group="$(id -gn)"; sudo -n install -d -o "${web_owner}" -g "${web_group}" -m 755 -- /var/www/intexuraos/web /var/www/intexuraos/web/releases; test -w /var/www/intexuraos/web; test -w /var/www/intexuraos/web/releases'
+}
+
 read_remote_cutover_status() {
   local state_path_quoted=""
   printf -v state_path_quoted '%q' "${REMOTE_CUTOVER_STATE_PATH}"
@@ -663,6 +670,7 @@ main() {
     sync_repo
     verify_remote_release_manifest
     cleanup_retired_remote_paths
+    prepare_remote_web_layout
     prepare_runtime_dependencies
     if [[ "${ACTIVATION_MODE}" == "cutover" ]]; then
       run_message_digest_cutover

--- a/scripts/hetzner/provision.sh
+++ b/scripts/hetzner/provision.sh
@@ -10,6 +10,7 @@ DOMAIN="${DOMAIN:-intexuraos.cloud}"
 DEPLOY_USER="${DEPLOY_USER:-deploy}"
 DEPLOY_DIR="${DEPLOY_DIR:-/opt/intexuraos}"
 WEB_ROOT="${WEB_ROOT:-/var/www/intexuraos/web/dist}"
+WEB_RELEASES_ROOT="${WEB_RELEASES_ROOT:-$(dirname "${WEB_ROOT}")/releases}"
 CERTBOT_EMAIL="${CERTBOT_EMAIL:-}"
 SWAP_FILE="${SWAP_FILE:-/swapfile}"
 SWAP_SIZE="${SWAP_SIZE:-4G}"
@@ -197,8 +198,11 @@ prepare_user_and_directories() {
   printf '%s ALL=(ALL) NOPASSWD:ALL\n' "${DEPLOY_USER}" > "/etc/sudoers.d/90-intexuraos-${DEPLOY_USER}"
   chmod 0440 "/etc/sudoers.d/90-intexuraos-${DEPLOY_USER}"
 
-  install -d -o "${DEPLOY_USER}" -g "${DEPLOY_USER}" -m 755 "${DEPLOY_DIR}"
-  install -d -o "${DEPLOY_USER}" -g "${DEPLOY_USER}" -m 755 "${WEB_ROOT}"
+  install -d -o "${DEPLOY_USER}" -g "${DEPLOY_USER}" -m 755 \
+    "${DEPLOY_DIR}" \
+    "$(dirname "${WEB_ROOT}")" \
+    "${WEB_ROOT}" \
+    "${WEB_RELEASES_ROOT}"
   install -d -o root -g root -m 755 /etc/intexuraos
 }
 

--- a/terraform/hetzner-prod/bootstrap.tf
+++ b/terraform/hetzner-prod/bootstrap.tf
@@ -43,7 +43,7 @@ resource "terraform_data" "bootstrap_prod" {
   provisioner "remote-exec" {
     inline = [
       "cloud-init status --wait || true",
-      "install -d -o deploy -g deploy -m 755 /opt/intexuraos /var/www/intexuraos/web/dist",
+      "install -d -o deploy -g deploy -m 755 /opt/intexuraos /var/www/intexuraos/web /var/www/intexuraos/web/dist /var/www/intexuraos/web/releases",
       "install -d -o deploy -g deploy -m 700 /home/deploy/.ssh",
       "printf '%s\\n' '${var.deploy_ssh_public_key}' > /home/deploy/.ssh/authorized_keys",
       "chown deploy:deploy /home/deploy/.ssh /home/deploy/.ssh/authorized_keys",


### PR DESCRIPTION
## Summary

- prepare the immutable web release parent and releases directory with deploy-user ownership before both cutover and ordinary web activation
- keep bootstrap, provisioning, and runtime deployment directory contracts aligned
- cover ordering, ownership, writability, and retry behavior with focused deployment tests

## Why

The automatic Message Digests deployment reached candidate startup but could not create `/var/www/intexuraos/web/current.next.*` because the parent directory was root-owned. Compensation completed and production remained on the previous healthy release. This change fixes that exact pre-activation failure while preserving the existing fail-closed cutover behavior.

## Verification

- `pnpm run ci:tracked` — passed: 7,663 tests, coverage, build, format, types, lint, static validation
- focused deployment suites — 91/91 passed
- `bash -n scripts/hetzner/github-actions-deploy.sh scripts/hetzner/provision.sh`
- `shellcheck scripts/hetzner/github-actions-deploy.sh scripts/hetzner/provision.sh`
- `terraform fmt -check terraform/hetzner-prod/bootstrap.tf`
- independent read-only review: no P1/P2 blockers

Linear: omitted by $commit-push; GitHub automation will create or link the Linear issue after PR creation.