### PR TITLE
[INT-1964] fix: freeze fishing digest state at continuity checkpoint

### DIFF
--- a/scripts/__tests__/fishing-group-message-digest-migration.test.ts
+++ b/scripts/__tests__/fishing-group-message-digest-migration.test.ts
@@ -515,6 +515,27 @@ describe('fishing Message Digest migration dry-run', () => {
     expect(fixture.ports.publish).not.toHaveBeenCalled();
   });
 
+  it('keeps later legacy states as audit while freezing continuity at the last meaningful checkpoint', async () => {
+    const fixture = dryRunFixture();
+    fixture.archive.states.push(legacyStateDocument('2026-07-30'));
+
+    const result = await runDryRun(fixture);
+
+    expect(result.report).toMatchObject({
+      counts: {
+        frozenLegacyStateDocuments: 1,
+        postCheckpointLegacyStateDocuments: 1,
+      },
+      hashes: {
+        legacyStates: fixture.binding.expectedLegacyStateHash,
+        postCheckpointLegacyStates: expect.stringMatching(/^[0-9a-f]{64}$/u),
+      },
+    });
+    expect(result.preflight.legacyStates.map((document) => document.data.date)).toEqual([
+      '2026-07-03',
+    ]);
+  });
+
   it.each([
     { label: 'zero source matches', sourceMatches: [] },
     {
@@ -803,6 +824,19 @@ describe('fishing Message Digest migration apply', () => {
     });
     expect(fixture.candidate.state?.continuityMemoryMarkdown.length).toBeLessThanOrEqual(8_000);
     expect(fixture.candidate.activation?.replayHash).toBe(ordered.at(-1)?.runHash);
+  });
+
+  it('builds imported continuity from the exact meaningful checkpoint, not a later audit state', async () => {
+    const fixture = applyFixture();
+    fixture.archive.states.push(legacyStateDocument('2026-07-30'));
+
+    await runApply(fixture);
+
+    const checkpointRun = fixture.candidate.runs.find(
+      (run) => run.provenance === 'legacy_mobile_notification' && run.migrationDate === '2026-07-03'
+    );
+    expect(checkpointRun?.continuityMemoryMarkdown).toContain('2026-07-03T03:06:00.000Z');
+    expect(checkpointRun?.continuityMemoryMarkdown).not.toContain('2026-07-30T03:06:00.000Z');
   });
 
   it('resumes a partial failure invisibly and does not regenerate already staged days', async () => {

--- a/scripts/__tests__/resolve-fishing-migration-binding.test.ts
+++ b/scripts/__tests__/resolve-fishing-migration-binding.test.ts
@@ -2,7 +2,10 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { resolve } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
-import { FISHING_GROUP_KEY } from '../message-digests/fishing-group-migration.mjs';
+import {
+  FISHING_GROUP_KEY,
+  hashArchiveDocuments,
+} from '../message-digests/fishing-group-migration.mjs';
 import { resolveFishingMigrationBinding } from '../message-digests/resolve-fishing-migration-binding.mjs';
 
 interface StoredDocument {
@@ -167,6 +170,50 @@ describe('Fishing migration binding resolver', () => {
   it('rejects empty audited legacy ownership', async () => {
     const fixture = createFixture({
       digests: [legacyDigest('post-audit', { date: '2026-07-27' })],
+    });
+    try {
+      await expect(resolveBinding(fixture)).rejects.toThrow('MIGRATION_BINDING_LEGACY_EMPTY');
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('freezes the state hash at the last meaningful checkpoint and ignores later audit states', async () => {
+    const frozenState = legacyState('state-frozen');
+    const fixture = createFixture({
+      states: [
+        frozenState,
+        legacyState('state-later', {
+          date: '2026-07-30',
+          state: {
+            userId: 'user-owner',
+            groupKey: FISHING_GROUP_KEY,
+            updatedAt: '2026-07-30T03:06:00.000Z',
+          },
+        }),
+      ],
+    });
+    try {
+      await expect(resolveBinding(fixture)).resolves.toMatchObject({
+        INTEXURAOS_MESSAGE_DIGEST_MIGRATION_LEGACY_STATE_HASH: hashArchiveDocuments([frozenState]),
+      });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it('rejects an archive that has later audit states but no frozen checkpoint state', async () => {
+    const fixture = createFixture({
+      states: [
+        legacyState('state-later', {
+          date: '2026-07-30',
+          state: {
+            userId: 'user-owner',
+            groupKey: FISHING_GROUP_KEY,
+            updatedAt: '2026-07-30T03:06:00.000Z',
+          },
+        }),
+      ],
     });
     try {
       await expect(resolveBinding(fixture)).rejects.toThrow('MIGRATION_BINDING_LEGACY_EMPTY');
@@ -356,7 +403,7 @@ function legacyDigest(id: string, overrides: Record<string, unknown> = {}): Stor
   };
 }
 
-function legacyState(id: string): StoredDocument {
+function legacyState(id: string, overrides: Record<string, unknown> = {}): StoredDocument {
   return {
     id,
     data: {
@@ -364,6 +411,7 @@ function legacyState(id: string): StoredDocument {
       groupKey: FISHING_GROUP_KEY,
       date: '2026-07-03',
       state: { userId: 'user-owner', groupKey: FISHING_GROUP_KEY },
+      ...overrides,
     },
   };
 }

--- a/scripts/message-digests/fishing-group-migration.mjs
+++ b/scripts/message-digests/fishing-group-migration.mjs
@@ -327,11 +327,7 @@ export async function runFishingMigrationDryRun(input, ports) {
       documents: normalizedArchive.digests,
       expectedHash: binding.expectedLegacyDigestHash,
     });
-    const stateHash = hashArchiveDocuments(normalizedArchive.states);
-    if (stateHash !== binding.expectedLegacyStateHash) {
-      throw contractError('LEGACY_STATE_BASELINE_CHANGED');
-    }
-    validateLegacyStateCheckpoint(normalizedArchive.states, binding);
+    const stateBaseline = analyzeLegacyStateBaseline(normalizedArchive.states, binding);
 
     const definitionId = deterministicDefinitionId(migrationId);
     const candidate = await ports.migration.inspectCandidate({ migrationId, definitionId });
@@ -397,6 +393,8 @@ export async function runFishingMigrationDryRun(input, ports) {
         auditedLegacyDocuments: baseline.auditedDocumentCount,
         meaningfulLegacyDocuments: baseline.auditedMeaningfulCount,
         postAuditDocuments: baseline.postAuditDocumentCount,
+        frozenLegacyStateDocuments: stateBaseline.frozenDocumentCount,
+        postCheckpointLegacyStateDocuments: stateBaseline.postCheckpointDocumentCount,
         replayDates: plan.replayDates.length,
         visibleReplayRuns,
         sourceMessages,
@@ -404,7 +402,8 @@ export async function runFishingMigrationDryRun(input, ports) {
       },
       hashes: {
         baseline: baseline.digestHash,
-        legacyStates: stateHash,
+        legacyStates: stateBaseline.frozenHash,
+        postCheckpointLegacyStates: stateBaseline.postCheckpointHash,
         postAudit: baseline.postAuditHash,
         sourcePlan: sourcePlanHash,
       },
@@ -418,7 +417,7 @@ export async function runFishingMigrationDryRun(input, ports) {
         binding,
         plan,
         baseline,
-        legacyStates: normalizedArchive.states,
+        legacyStates: stateBaseline.checkpointDocuments,
         source,
         readiness,
         effects,
@@ -1503,12 +1502,16 @@ function renderLegacySummaryMarkdown(summary) {
 }
 
 function renderLegacyContinuityMarkdown(states, summaries) {
-  const latestState = [...states]
-    .sort((left, right) => left.data.date.localeCompare(right.data.date))
-    .at(-1);
+  const checkpointStates = states.filter(
+    (document) => document.data.date === LAST_MEANINGFUL_LEGACY_DATE
+  );
+  if (checkpointStates.length !== 1) {
+    throw contractError('LEGACY_STATE_BASELINE_CHANGED');
+  }
+  const checkpointState = checkpointStates[0];
   const content = [
     '## Legacy continuity checkpoint',
-    latestState === undefined ? '' : stableSerialize(latestState.data.state),
+    stableSerialize(checkpointState.data.state),
     '## Previous summaries',
     ...summaries.map((document) => renderLegacySummaryMarkdown(document.data.summary)),
   ].join('\n');
@@ -1598,7 +1601,7 @@ function isOwnedLegacyRecord(value, binding) {
   );
 }
 
-function validateLegacyStateCheckpoint(states, binding) {
+function analyzeLegacyStateBaseline(states, binding) {
   if (states.length === 0) throw contractError('LEGACY_STATE_BASELINE_CHANGED');
   for (const document of states) {
     if (
@@ -1612,13 +1615,30 @@ function validateLegacyStateCheckpoint(states, binding) {
       throw contractError('LEGACY_STATE_BASELINE_CHANGED');
     }
   }
-  const latest = states
-    .map((document) => document.data.date)
-    .sort((left, right) => left.localeCompare(right))
-    .at(-1);
-  if (latest !== LAST_MEANINGFUL_LEGACY_DATE) {
+  const frozenDocuments = states.filter(
+    (document) => document.data.date <= LAST_MEANINGFUL_LEGACY_DATE
+  );
+  const checkpointDocuments = frozenDocuments.filter(
+    (document) => document.data.date === LAST_MEANINGFUL_LEGACY_DATE
+  );
+  const postCheckpointDocuments = states.filter(
+    (document) => document.data.date > LAST_MEANINGFUL_LEGACY_DATE
+  );
+  const frozenHash = hashArchiveDocuments(frozenDocuments);
+  if (
+    frozenDocuments.length === 0 ||
+    checkpointDocuments.length !== 1 ||
+    frozenHash !== binding.expectedLegacyStateHash
+  ) {
     throw contractError('LEGACY_STATE_BASELINE_CHANGED');
   }
+  return {
+    frozenDocumentCount: frozenDocuments.length,
+    postCheckpointDocumentCount: postCheckpointDocuments.length,
+    frozenHash,
+    postCheckpointHash: hashArchiveDocuments(postCheckpointDocuments),
+    checkpointDocuments,
+  };
 }
 
 function isCompatibleCandidate(candidate, migrationId, definitionId) {

--- a/scripts/message-digests/resolve-fishing-migration-binding.mjs
+++ b/scripts/message-digests/resolve-fishing-migration-binding.mjs
@@ -17,6 +17,7 @@ import { getFirestore } from 'firebase-admin/firestore';
 import {
   AUDIT_CUTOFF_DATE,
   FISHING_GROUP_KEY,
+  LAST_MEANINGFUL_LEGACY_DATE,
   hashArchiveDocuments,
   hashLegacyDocuments,
 } from './fishing-group-migration.mjs';
@@ -52,7 +53,14 @@ export async function resolveFishingMigrationBinding(options) {
   const auditedDigests = digests.filter(
     (document) => typeof document.data.date === 'string' && document.data.date <= AUDIT_CUTOFF_DATE
   );
-  if (auditedDigests.length === 0 || states.length === 0) {
+  const frozenStates = states.filter(
+    (document) =>
+      typeof document.data.date === 'string' && document.data.date <= LAST_MEANINGFUL_LEGACY_DATE
+  );
+  const checkpointStates = frozenStates.filter(
+    (document) => document.data.date === LAST_MEANINGFUL_LEGACY_DATE
+  );
+  if (auditedDigests.length === 0 || frozenStates.length === 0 || checkpointStates.length !== 1) {
     throw safeError('MIGRATION_BINDING_LEGACY_EMPTY');
   }
   const candidate = await resolveWhatsAppMigrationBinding({
@@ -70,7 +78,7 @@ export async function resolveFishingMigrationBinding(options) {
     INTEXURAOS_MESSAGE_DIGEST_MIGRATION_CHAT_ID: candidate.chatId,
     INTEXURAOS_MESSAGE_DIGEST_MIGRATION_GROUP_NAME: candidate.displayName,
     INTEXURAOS_MESSAGE_DIGEST_MIGRATION_LEGACY_DIGEST_HASH: hashLegacyDocuments(auditedDigests),
-    INTEXURAOS_MESSAGE_DIGEST_MIGRATION_LEGACY_STATE_HASH: hashArchiveDocuments(states),
+    INTEXURAOS_MESSAGE_DIGEST_MIGRATION_LEGACY_STATE_HASH: hashArchiveDocuments(frozenStates),
   };
 }
 


### PR DESCRIPTION
## Summary

- freeze the protected legacy state baseline at the exact `2026-07-03` continuity checkpoint
- retain and validate later state snapshots as read-only audit instead of treating them as baseline drift
- build imported continuity from the unique checkpoint state and report only safe counts and hashes

## Production incident

- deploy run `30616275967` stopped before migration or infrastructure writes with `LEGACY_STATE_BASELINE_CHANGED`
- compensation restored the previous healthy release
- the contract rejected valid post-checkpoint audit snapshots because it compared the globally latest state date with the continuity checkpoint

## Verification

- focused migration/cutover suite: 129 tests passed
- independent P1/P2 review: no blockers
- `pnpm run ci:tracked`: 7,663 tests plus typecheck, lint, static validation, coverage, build, format, and post-build checks passed
- tested tree: `3f7f9240828ddd40e080c605bf2c5500dbc9aebc`

## Linear

Linear: omitted by `$commit-push`; GitHub automation will create or link the Linear issue after PR creation.
