### PR TITLE
[INT-1965] fix: bound WhatsApp digest reactions to source window

### DIFF
--- a/apps/whatsapp-service/src/__tests__/domain/whatsapp/privateWhatsAppDigestSource.test.ts
+++ b/apps/whatsapp-service/src/__tests__/domain/whatsapp/privateWhatsAppDigestSource.test.ts
@@ -866,6 +866,93 @@ describe('private WhatsApp digest source', () => {
     expect(serialized).not.toContain('@private-sender');
   });
 
+  it('keeps projected reactions inside the exact half-open source window', async () => {
+    const repository = {
+      queryMessages: vi.fn().mockResolvedValue(
+        ok({
+          messages: [
+            message({
+              id: 'reaction-target',
+              reactions: [
+                {
+                  id: 'before-window',
+                  emoji: '1️⃣',
+                  direction: 'incoming',
+                  eventTimestamp: '2026-07-26T23:59:59.999Z',
+                },
+                {
+                  id: 'at-window-start',
+                  emoji: '2️⃣',
+                  direction: 'incoming',
+                  eventTimestamp: '2026-07-27T00:00:00.000Z',
+                },
+                {
+                  id: 'inside-window',
+                  emoji: '3️⃣',
+                  direction: 'outgoing',
+                  eventTimestamp: '2026-07-27T23:59:59.999Z',
+                },
+                {
+                  id: 'at-window-end',
+                  emoji: '4️⃣',
+                  direction: 'incoming',
+                  eventTimestamp: '2026-07-28T00:00:00.000Z',
+                },
+                {
+                  id: 'after-window',
+                  emoji: '5️⃣',
+                  direction: 'incoming',
+                  eventTimestamp: '2026-07-28T00:00:00.001Z',
+                },
+              ],
+            }),
+          ],
+          sourceRevision: 'opaque-revision',
+          highWatermark: 'opaque-watermark',
+          nextCursor: null,
+        })
+      ),
+    };
+    const createMessageRef = vi
+      .fn()
+      .mockImplementation(
+        (input: { projectionKey: string }) => `opaque-reference:${input.projectionKey}`
+      );
+
+    const result = await readPrivateWhatsAppDigestSource(
+      {
+        userId: 'user-1',
+        sourceAccountId: 'source-1',
+        generationId: 'generation-1',
+        chatId: 'chat-1',
+        chatType: 'group',
+        windowStart: '2026-07-27T00:00:00.000Z',
+        windowEnd: '2026-07-28T00:00:00.000Z',
+        limit: 50,
+      },
+      { repository, tokens: { createMessageRef } }
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      value: {
+        messages: [
+          { contentKind: 'text', eventTimestamp: '2026-07-27T07:00:00.000Z' },
+          {
+            messageRef: 'opaque-reference:reaction:at-window-start',
+            contentKind: 'reaction',
+            eventTimestamp: '2026-07-27T00:00:00.000Z',
+          },
+          {
+            messageRef: 'opaque-reference:reaction:inside-window',
+            contentKind: 'reaction',
+            eventTimestamp: '2026-07-27T23:59:59.999Z',
+          },
+        ],
+      },
+    });
+  });
+
   it('maps repository and timestamp failures to content-free read errors', async () => {
     const baseInput = {
       userId: 'user-1',

--- a/apps/whatsapp-service/src/domain/whatsapp/usecases/readPrivateWhatsAppDigestSource.ts
+++ b/apps/whatsapp-service/src/domain/whatsapp/usecases/readPrivateWhatsAppDigestSource.ts
@@ -26,9 +26,11 @@ export async function readPrivateWhatsAppDigestSource(
   if (windowStart === undefined || windowEnd === undefined) {
     return err({ code: 'VALIDATION_ERROR', message: 'Invalid private digest source query' });
   }
-
-  return ok({
-    messages: projectPrivateDigestMessages(rawPage.value.messages, ({ messageId, projectionKey }) =>
+  const windowStartTime = Date.parse(windowStart);
+  const windowEndTime = Date.parse(windowEnd);
+  const projectedMessages = projectPrivateDigestMessages(
+    rawPage.value.messages,
+    ({ messageId, projectionKey }) =>
       deps.tokens.createMessageRef({
         userId: input.userId,
         sourceAccountId: input.sourceAccountId,
@@ -40,7 +42,13 @@ export async function readPrivateWhatsAppDigestSource(
         messageId,
         projectionKey,
       })
-    ),
+  );
+
+  return ok({
+    messages: projectedMessages.filter((message) => {
+      const eventTime = Date.parse(message.eventTimestamp);
+      return Number.isFinite(eventTime) && eventTime >= windowStartTime && eventTime < windowEndTime;
+    }),
     sourceRevision: rawPage.value.sourceRevision,
     highWatermark: rawPage.value.highWatermark,
     nextCursor: rawPage.value.nextCursor,


### PR DESCRIPTION
## Summary

- enforce the exact half-open source window on final WhatsApp digest projections
- omit effective reactions whose event timestamp belongs outside the requested replay day
- preserve raw paging, source revision, watermark, and cursor semantics

## Production evidence

Deploy run 30620140796 passed the corrected legacy-state baseline and failed closed at SOURCE_WINDOW_INVALID. A read-only metadata audit found 11 out-of-window reaction projections across 7 replay dates and no ownership, duplicate-reference, content, or other projection anomalies. Automatic compensation kept production on the previous healthy SHA.

## Verification

- red-first boundary regression test
- 175 focused source, route, repository, client, and migration tests
- WhatsApp Service typecheck and targeted lint
- independent review: no P1/P2 blockers
- CI=true pnpm run ci:tracked: 7,663 tests plus type, lint, static, coverage, build, format, and post-build checks

Tested-Tree: 7cb3a91fccd7fc71bd056f0dca5ae922b19c566f