### PR TITLE
[INT-1966] Fix Message Digest production cutover bootstrap

### DIFF
--- a/scripts/__tests__/hetzner-runtime.test.ts
+++ b/scripts/__tests__/hetzner-runtime.test.ts
@@ -2210,6 +2210,82 @@ describe('Hetzner secret loader', () => {
     }
   });
 
+  it('grants the Hetzner provisioner the standard roles required for Terraform deployment', () => {
+    const terraform = readRequired(terraformDevMainPath);
+    const resourceStart = terraform.indexOf(
+      'resource "google_storage_bucket_iam_member" "hetzner_provisioner_terraform_state" {'
+    );
+    const resourceEnd = terraform.indexOf('\n}\n', resourceStart) + 3;
+    const resource = terraform.slice(resourceStart, resourceEnd);
+
+    expect(resourceStart).toBeGreaterThanOrEqual(0);
+    expect(resource).toContain('bucket = "${var.project_id}-terraform-state"');
+    expect(resource).toContain('role   = "roles/storage.objectAdmin"');
+    expect(resource).toContain(
+      'member = "serviceAccount:${google_service_account.hetzner_provisioner.email}"'
+    );
+    expect(resource).not.toContain('roles/storage.admin');
+
+    const projectRolesStart = terraform.indexOf(
+      'resource "google_project_iam_member" "hetzner_provisioner_deployment_roles" {'
+    );
+    const projectRolesEnd = terraform.indexOf('\n}\n', projectRolesStart) + 3;
+    const projectRoles = terraform.slice(projectRolesStart, projectRolesEnd);
+
+    expect(projectRolesStart).toBeGreaterThanOrEqual(0);
+    for (const role of [
+      'roles/cloudscheduler.admin',
+      'roles/iam.serviceAccountViewer',
+      'roles/pubsub.admin',
+      'roles/serviceusage.serviceUsageConsumer',
+    ]) {
+      expect(projectRoles).toContain(`"${role}"`);
+    }
+    expect(projectRoles).not.toContain('roles/editor');
+    expect(projectRoles).not.toContain('roles/owner');
+    expect(projectRoles).not.toContain('roles/iam.serviceAccountAdmin');
+    expect(projectRoles).not.toContain('roles/iam.serviceAccountCreator');
+    expect(projectRoles).not.toContain('roles/iam.serviceAccountDeleter');
+    expect(projectRoles).not.toContain('roles/iam.serviceAccountUser');
+    expect(projectRoles).toContain('project = var.project_id');
+    expect(projectRoles).toContain(
+      'member  = "serviceAccount:${google_service_account.hetzner_provisioner.email}"'
+    );
+
+    const messageDigestUserStart = terraform.indexOf(
+      'resource "google_service_account_iam_member" "hetzner_provisioner_message_digest_user" {'
+    );
+    const messageDigestUserEnd = terraform.indexOf('\n}\n', messageDigestUserStart) + 3;
+    const messageDigestUser = terraform.slice(messageDigestUserStart, messageDigestUserEnd);
+
+    expect(messageDigestUserStart).toBeGreaterThanOrEqual(0);
+    expect(messageDigestUser).toContain(
+      'service_account_id = google_service_account.message_digest_service.name'
+    );
+    expect(messageDigestUser).toContain('role               = "roles/iam.serviceAccountUser"');
+    expect(messageDigestUser).toContain(
+      'member             = "serviceAccount:${google_service_account.hetzner_provisioner.email}"'
+    );
+    expect(messageDigestUser).not.toContain('condition {');
+
+    const schedulerUserStart = terraform.indexOf(
+      'resource "google_service_account_iam_member" "hetzner_provisioner_scheduler_user" {'
+    );
+    const schedulerUserEnd = terraform.indexOf('\n}\n', schedulerUserStart) + 3;
+    const schedulerUser = terraform.slice(schedulerUserStart, schedulerUserEnd);
+
+    expect(schedulerUserStart).toBeGreaterThanOrEqual(0);
+    expect(schedulerUser).toContain(
+      'service_account_id = google_service_account.cloud_scheduler.name'
+    );
+    expect(schedulerUser).toContain('role               = "roles/iam.serviceAccountUser"');
+    expect(schedulerUser).toContain(
+      'member             = "serviceAccount:${google_service_account.hetzner_provisioner.email}"'
+    );
+    expect(schedulerUser).not.toContain('condition {');
+    expect(terraform).not.toContain('roles/iam.serviceAccountDeleter');
+  });
+
   it('removes the legacy GCP web app hosting knobs after Hetzner cutover', () => {
     const terraform = readRequired(terraformDevMainPath);
     const tfvarsExample = readRequired(terraformDevTfvarsExamplePath);

--- a/scripts/__tests__/message-digest-cutover.test.ts
+++ b/scripts/__tests__/message-digest-cutover.test.ts
@@ -1,5 +1,13 @@
 import { execFileSync, spawnSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
@@ -239,13 +247,12 @@ migration_activate
     expect(
       validateTerraformPlan('dev', {
         resource_changes: [
-          change('google_service_account.message_digest_service', ['create']),
           change('google_pubsub_topic.message_digest_runs', ['create']),
           change('google_pubsub_topic_iam_member.message_digest_publishes_runs', ['create']),
           change('google_pubsub_topic_iam_member.message_digest_publishes_whatsapp', ['create']),
         ],
       })
-    ).toHaveLength(4);
+    ).toHaveLength(3);
 
     expect(
       validateTerraformPlan('prod', {
@@ -307,7 +314,6 @@ migration_activate
     ).toThrow('CUTOVER_TERRAFORM_PLAN_UNSAFE');
 
     const completeDevInverse = [
-      change('google_service_account.message_digest_service', ['delete']),
       change('google_pubsub_topic.message_digest_runs', ['delete']),
       change('google_pubsub_topic_iam_member.message_digest_publishes_runs', ['delete']),
       change('google_pubsub_topic_iam_member.message_digest_publishes_whatsapp', ['delete']),
@@ -335,7 +341,7 @@ migration_activate
       validateTerraformPlan('dev-inverse-complete', {
         resource_changes: completeDevInverse,
       })
-    ).toHaveLength(4);
+    ).toHaveLength(3);
     expect(
       validateTerraformPlan('prod-inverse-complete', {
         resource_changes: completeProdInverse,
@@ -352,7 +358,6 @@ migration_activate
     const directory = mkdtempSync(resolve(tmpdir(), 'message-digest-terraform-targets-'));
     const tracePath = resolve(directory, 'terraform-plan-trace.txt');
     const devTargets = [
-      '-target=google_service_account.message_digest_service',
       '-target=google_pubsub_topic.message_digest_runs',
       '-target=google_pubsub_topic_iam_member.message_digest_publishes_runs',
       '-target=google_pubsub_topic_iam_member.message_digest_publishes_whatsapp',
@@ -425,6 +430,197 @@ cat "$TRACE_FILE"
     }
   });
 
+  it('does not mark a Terraform mutation before the forward plan passes validation', () => {
+    const directory = mkdtempSync(resolve(tmpdir(), 'message-digest-terraform-pre-plan-'));
+    try {
+      const result = runShellLibrary(
+        cutoverPath,
+        `
+terraform_environment() { return 42; }
+ATTEMPT_DIR="$TEST_ATTEMPT_DIR"
+TERRAFORM_DATA_ROOT="$ATTEMPT_DIR/terraform-data"
+TERRAFORM_PLAN_ROOT="$ATTEMPT_DIR/terraform-plans"
+mkdir -p "$TERRAFORM_DATA_ROOT" "$TERRAFORM_PLAN_ROOT"
+forward_terraform_dev
+`,
+        {
+          RELEASE_DIR: repoRoot,
+          TEST_ATTEMPT_DIR: directory,
+        }
+      );
+
+      expect(result.status).not.toBe(0);
+      expect(existsSync(resolve(directory, 'terraform-dev-forward.started'))).toBe(false);
+      expect(existsSync(resolve(directory, 'terraform-dev-forward.apply-started'))).toBe(false);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('records Terraform apply intent after validation and before invoking apply', () => {
+    const directory = mkdtempSync(resolve(tmpdir(), 'message-digest-terraform-apply-intent-'));
+    const tracePath = resolve(directory, 'trace.txt');
+    try {
+      const result = runShellLibrary(
+        cutoverPath,
+        `
+TRACE_FILE="$TEST_TRACE_FILE"
+terraform_environment() {
+  local argument=""
+  local operation=""
+  for argument in "$@"; do
+    case "$argument" in
+      init|plan|show|apply) operation="$argument" ;;
+    esac
+  done
+  printf '%s\n' "$operation" >> "$TRACE_FILE"
+  if [[ "$operation" == "show" ]]; then
+    printf '{"resource_changes":[]}\n'
+  elif [[ "$operation" == "apply" ]]; then
+    return 42
+  fi
+}
+validate_terraform_plan() { printf 'validated\n' >> "$TRACE_FILE"; }
+ATTEMPT_DIR="$TEST_ATTEMPT_DIR"
+TERRAFORM_DATA_ROOT="$ATTEMPT_DIR/terraform-data"
+TERRAFORM_PLAN_ROOT="$ATTEMPT_DIR/terraform-plans"
+mkdir -p "$TERRAFORM_DATA_ROOT" "$TERRAFORM_PLAN_ROOT"
+forward_terraform_dev
+`,
+        {
+          RELEASE_DIR: repoRoot,
+          TEST_ATTEMPT_DIR: directory,
+          TEST_TRACE_FILE: tracePath,
+        }
+      );
+
+      expect(result.status).not.toBe(0);
+      expect(readFileSync(tracePath, 'utf8').trim().split('\n')).toEqual([
+        'init',
+        'plan',
+        'show',
+        'validated',
+        'apply',
+      ]);
+      expect(existsSync(resolve(directory, 'terraform-dev-forward.started'))).toBe(false);
+      expect(existsSync(resolve(directory, 'terraform-dev-forward.apply-started'))).toBe(true);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('persists Terraform apply intent durably before remote mutation begins', () => {
+    const directory = mkdtempSync(resolve(tmpdir(), 'message-digest-durable-marker-'));
+    const markerPath = resolve(directory, 'terraform-dev-forward.apply-started');
+    try {
+      const result = runShellLibrary(cutoverPath, 'write_durable_marker "$TEST_MARKER_PATH"', {
+        TEST_MARKER_PATH: markerPath,
+      });
+
+      expect(result.status, result.stderr).toBe(0);
+      expect(readFileSync(markerPath, 'utf8')).toBe('apply-started\n');
+      expect(statSync(markerPath).mode & 0o777).toBe(0o600);
+
+      const cutover = readFileSync(cutoverPath, 'utf8');
+      const writer = cutover.slice(
+        cutover.indexOf('write_durable_marker() {'),
+        cutover.indexOf('\n}\n\nplan_and_apply_terraform()')
+      );
+      expect(writer).toContain('fsyncSync(markerDescriptor)');
+      expect(writer).toContain('renameSync(temporaryPath, markerPath)');
+      expect(writer).toContain('fsyncSync(directoryDescriptor)');
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('runs inverse Terraform only when a forward apply could have mutated state', () => {
+    const invokeRollback = (marker: string): string[] => {
+      const directory = mkdtempSync(resolve(tmpdir(), 'message-digest-terraform-rollback-'));
+      const attemptDirectory = resolve(directory, 'attempt');
+      const tracePath = resolve(directory, 'trace.txt');
+      const statePath = resolve(directory, 'state.json');
+      mkdirSync(attemptDirectory);
+      writeFileSync(resolve(attemptDirectory, marker), '', 'utf8');
+      writeFileSync(statePath, '{}\n', 'utf8');
+      try {
+        const result = runShellLibrary(
+          cutoverPath,
+          `
+TRACE_FILE="$TEST_TRACE_FILE"
+ATTEMPT_DIR="$TEST_ATTEMPT_DIR"
+STATE_PATH="$TEST_STATE_PATH"
+CUTOVER_ADMITTED="false"
+ROLLBACK_RUNNING="false"
+MERGE_SHA="${'a'.repeat(40)}"
+DEPLOYMENT_ID="deployment-123"
+node() { :; }
+state_completed_count() { printf '5'; }
+hold_affected_ingress_fail_closed() { printf 'hold\n' >> "$TRACE_FILE"; }
+restore_previous_runtime() { printf 'runtime\n' >> "$TRACE_FILE"; }
+rollback_terraform_prod() { printf 'prod-inverse\n' >> "$TRACE_FILE"; }
+rollback_terraform_dev() { printf 'dev-inverse\n' >> "$TRACE_FILE"; }
+restore_previous_ingress() { printf 'ingress\n' >> "$TRACE_FILE"; }
+rollback_pre_admission
+cat "$TRACE_FILE"
+`,
+          {
+            TEST_ATTEMPT_DIR: attemptDirectory,
+            TEST_STATE_PATH: statePath,
+            TEST_TRACE_FILE: tracePath,
+          }
+        );
+
+        expect(result.status, result.stderr).toBe(0);
+        return result.stdout.trim().split('\n');
+      } finally {
+        rmSync(directory, { recursive: true, force: true });
+      }
+    };
+
+    expect(invokeRollback('terraform-dev-forward.started')).toEqual(['hold', 'runtime', 'ingress']);
+    expect(invokeRollback('terraform-dev-forward.apply-started')).toEqual([
+      'hold',
+      'runtime',
+      'dev-inverse',
+      'ingress',
+    ]);
+  });
+
+  it('does not apply an inverse plan after planning fails inside rollback error handling', () => {
+    const directory = mkdtempSync(resolve(tmpdir(), 'message-digest-terraform-fail-fast-'));
+    const tracePath = resolve(directory, 'trace.txt');
+    try {
+      const result = runShellLibrary(
+        cutoverPath,
+        `
+TRACE_FILE="$TEST_TRACE_FILE"
+plan_terraform() { printf 'plan\n' >> "$TRACE_FILE"; return 42; }
+terraform_environment() { printf 'apply\n' >> "$TRACE_FILE"; }
+PREVIOUS_RELEASE_DIR="$TEST_PREVIOUS_RELEASE_DIR"
+TERRAFORM_DATA_ROOT="$TEST_ATTEMPT_DIR/terraform-data"
+TERRAFORM_PLAN_ROOT="$TEST_ATTEMPT_DIR/terraform-plans"
+if rollback_terraform_dev; then
+  printf 'rollback-success\n' >> "$TRACE_FILE"
+else
+  printf 'rollback-failed\n' >> "$TRACE_FILE"
+fi
+cat "$TRACE_FILE"
+`,
+        {
+          TEST_ATTEMPT_DIR: directory,
+          TEST_PREVIOUS_RELEASE_DIR: repoRoot,
+          TEST_TRACE_FILE: tracePath,
+        }
+      );
+
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stdout.trim().split('\n')).toEqual(['plan', 'rollback-failed']);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
   it('reviews complete inverse plans from the previous release after both forward applies', () => {
     const directory = mkdtempSync(resolve(tmpdir(), 'message-digest-inverse-proof-'));
     const tracePath = resolve(directory, 'terraform-trace.txt');
@@ -432,7 +628,6 @@ cat "$TRACE_FILE"
     const currentRelease = resolve(directory, 'current-release');
     const previousRelease = resolve(directory, 'previous-release');
     const devAddresses = [
-      'google_service_account.message_digest_service',
       'google_pubsub_topic.message_digest_runs',
       'google_pubsub_topic_iam_member.message_digest_publishes_runs',
       'google_pubsub_topic_iam_member.message_digest_publishes_whatsapp',
@@ -587,8 +782,9 @@ command cat "$TRACE_FILE"
       resolve(repoRoot, 'scripts/hetzner/message-digest-cutover-support.mjs'),
       'utf8'
     );
+    expect(cutover).not.toContain('google_service_account.message_digest_service');
+    expect(support).not.toContain('google_service_account.message_digest_service');
     for (const source of [cutover, support]) {
-      expect(source).toContain('google_service_account.message_digest_service');
       expect(source).not.toContain('module.iam.google_service_account.message_digest_service');
       expect(source).toContain('google_pubsub_topic_iam_member.message_digest_publishes_whatsapp');
       expect(source).not.toContain(
@@ -1195,7 +1391,7 @@ run_message_digest_cutover
     const result = runShellLibrary(
       cutoverPath,
       `
-terraform_environment bash -c 'printf "google=%s\\nhcloud=%s\\nfirestore=%s\\nstorage=%s\\npubsub=%s\\n" "$GOOGLE_APPLICATION_CREDENTIALS" "\${HCLOUD_TOKEN-unset}" "\${FIRESTORE_EMULATOR_HOST-unset}" "\${STORAGE_EMULATOR_HOST-unset}" "\${PUBSUB_EMULATOR_HOST-unset}"'
+terraform_environment bash -c 'printf "google=%s\\nhcloud=%s\\nfirestore=%s\\nstorage=%s\\npubsub=%s\\nproject=%s\\nowner=%s\\nconnection=%s\\n" "$GOOGLE_APPLICATION_CREDENTIALS" "\${HCLOUD_TOKEN-unset}" "\${FIRESTORE_EMULATOR_HOST-unset}" "\${STORAGE_EMULATOR_HOST-unset}" "\${PUBSUB_EMULATOR_HOST-unset}" "$TF_VAR_project_id" "$TF_VAR_github_owner" "$TF_VAR_github_connection_name"'
 `,
       {
         HCLOUD_TOKEN: 'must-not-flow',
@@ -1203,13 +1399,16 @@ terraform_environment bash -c 'printf "google=%s\\nhcloud=%s\\nfirestore=%s\\nst
         STORAGE_EMULATOR_HOST: 'must-not-flow',
         PUBSUB_EMULATOR_HOST: 'must-not-flow',
         HETZNER_PROVISIONER_GOOGLE_APPLICATION_CREDENTIALS: '/safe/provisioner.json',
+        PROJECT_ID: 'synthetic-project',
+        TERRAFORM_GITHUB_OWNER: 'synthetic-owner',
+        TERRAFORM_GITHUB_CONNECTION_NAME: 'synthetic-connection',
       }
     );
 
     expect(result.status).toBe(0);
     expect(result.stderr).toBe('');
     expect(result.stdout).toBe(
-      'google=/safe/provisioner.json\nhcloud=unset\nfirestore=unset\nstorage=unset\npubsub=unset\n'
+      'google=/safe/provisioner.json\nhcloud=unset\nfirestore=unset\nstorage=unset\npubsub=unset\nproject=synthetic-project\nowner=synthetic-owner\nconnection=synthetic-connection\n'
     );
   });
 

--- a/scripts/hetzner/cutover-message-digests.sh
+++ b/scripts/hetzner/cutover-message-digests.sh
@@ -19,6 +19,8 @@ LEGACY_WEB_ROOT="${LEGACY_WEB_ROOT:-/var/www/intexuraos/web/dist}"
 WEB_RELEASES_ROOT="${WEB_RELEASES_ROOT:-/var/www/intexuraos/web/releases}"
 WEB_CURRENT_LINK="${WEB_CURRENT_LINK:-/var/www/intexuraos/web/current}"
 PROJECT_ID="${PROJECT_ID:-intexuraos-dev-pbuchman}"
+TERRAFORM_GITHUB_OWNER="${TERRAFORM_GITHUB_OWNER:-pbuchman}"
+TERRAFORM_GITHUB_CONNECTION_NAME="${TERRAFORM_GITHUB_CONNECTION_NAME:-pbuchman-github}"
 STATE_HELPER="${RELEASE_DIR}/scripts/hetzner/message-digest-cutover-state.mjs"
 SUPPORT_HELPER="${RELEASE_DIR}/scripts/hetzner/message-digest-cutover-support.mjs"
 TEMPLATE_VERIFIER="${RELEASE_DIR}/scripts/hetzner/verify-whatsapp-message-digest-template.mjs"
@@ -45,7 +47,6 @@ CUTOVER_DEADLINE=""
 CUTOVER_STATUS=""
 
 DEV_TERRAFORM_TARGETS=(
-  '-target=google_service_account.message_digest_service'
   '-target=google_pubsub_topic.message_digest_runs'
   '-target=google_pubsub_topic_iam_member.message_digest_publishes_runs'
   '-target=google_pubsub_topic_iam_member.message_digest_publishes_whatsapp'
@@ -437,6 +438,9 @@ terraform_environment() {
     -u FIRESTORE_EMULATOR_HOST \
     -u PUBSUB_EMULATOR_HOST \
     GOOGLE_APPLICATION_CREDENTIALS="${HETZNER_PROVISIONER_GOOGLE_APPLICATION_CREDENTIALS:-/home/deploy/provisioner-sa-key.json}" \
+    TF_VAR_project_id="${PROJECT_ID}" \
+    TF_VAR_github_owner="${TERRAFORM_GITHUB_OWNER}" \
+    TF_VAR_github_connection_name="${TERRAFORM_GITHUB_CONNECTION_NAME}" \
     "$@"
 }
 
@@ -459,15 +463,65 @@ plan_terraform() {
   shift 4
   local target_args=("$@")
   local plan_json="${plan_file}.json"
-  mkdir -p "${data_dir}" "$(dirname "${plan_file}")"
+  mkdir -p "${data_dir}" "$(dirname "${plan_file}")" || return $?
   terraform_environment TF_DATA_DIR="${data_dir}" \
-    terraform -chdir="${root}" init -input=false -reconfigure
+    terraform -chdir="${root}" init -input=false -reconfigure || return $?
   terraform_environment TF_DATA_DIR="${data_dir}" \
     terraform -chdir="${root}" plan -input=false -lock-timeout=5m \
-    "${target_args[@]}" -out="${plan_file}"
+    "${target_args[@]}" -out="${plan_file}" || return $?
   terraform_environment TF_DATA_DIR="${data_dir}" \
-    terraform -chdir="${root}" show -json "${plan_file}" > "${plan_json}"
-  validate_terraform_plan "${contract}" "${plan_json}"
+    terraform -chdir="${root}" show -json "${plan_file}" > "${plan_json}" || return $?
+  validate_terraform_plan "${contract}" "${plan_json}" || return $?
+}
+
+write_durable_marker() {
+  local marker_path="$1"
+  node --input-type=module - "${marker_path}" <<'NODE'
+import {
+  closeSync,
+  fsyncSync,
+  openSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { basename, dirname, isAbsolute } from 'node:path';
+
+const markerPath = process.argv[2];
+if (
+  !isAbsolute(markerPath) ||
+  !/^terraform-(?:dev|prod)-forward\.apply-started$/u.test(basename(markerPath))
+) {
+  process.exit(1);
+}
+
+const directory = dirname(markerPath);
+const temporaryPath = `${markerPath}.${process.pid}.${Date.now()}.tmp`;
+let markerDescriptor;
+let renamed = false;
+try {
+  markerDescriptor = openSync(temporaryPath, 'wx', 0o600);
+  writeFileSync(markerDescriptor, 'apply-started\n', 'utf8');
+  fsyncSync(markerDescriptor);
+  closeSync(markerDescriptor);
+  markerDescriptor = undefined;
+  renameSync(temporaryPath, markerPath);
+  renamed = true;
+  const directoryDescriptor = openSync(directory, 'r');
+  try {
+    fsyncSync(directoryDescriptor);
+  } finally {
+    closeSync(directoryDescriptor);
+  }
+} finally {
+  if (markerDescriptor !== undefined) closeSync(markerDescriptor);
+  if (!renamed) {
+    try {
+      unlinkSync(temporaryPath);
+    } catch {}
+  }
+}
+NODE
 }
 
 plan_and_apply_terraform() {
@@ -475,35 +529,39 @@ plan_and_apply_terraform() {
   local root="$2"
   local data_dir="$3"
   local plan_file="$4"
-  shift 4
+  local apply_started_marker="$5"
+  shift 5
   local target_args=("$@")
   plan_terraform \
     "${contract}" \
     "${root}" \
     "${data_dir}" \
     "${plan_file}" \
-    "${target_args[@]}"
+    "${target_args[@]}" || return $?
+  if [[ -n "${apply_started_marker}" ]]; then
+    write_durable_marker "${apply_started_marker}" || return $?
+  fi
   terraform_environment TF_DATA_DIR="${data_dir}" \
-    terraform -chdir="${root}" apply -input=false -auto-approve "${plan_file}"
+    terraform -chdir="${root}" apply -input=false -auto-approve "${plan_file}" || return $?
 }
 
 forward_terraform_dev() {
-  : > "${ATTEMPT_DIR}/terraform-dev-forward.started"
   plan_and_apply_terraform \
     dev \
     "${RELEASE_DIR}/terraform/environments/dev" \
     "${TERRAFORM_DATA_ROOT}/dev-forward" \
     "${TERRAFORM_PLAN_ROOT}/dev-forward.tfplan" \
+    "${ATTEMPT_DIR}/terraform-dev-forward.apply-started" \
     "${DEV_TERRAFORM_TARGETS[@]}"
 }
 
 forward_terraform_prod() {
-  : > "${ATTEMPT_DIR}/terraform-prod-forward.started"
   plan_and_apply_terraform \
     prod \
     "${RELEASE_DIR}/terraform/hetzner-prod" \
     "${TERRAFORM_DATA_ROOT}/prod-forward" \
     "${TERRAFORM_PLAN_ROOT}/prod-forward.tfplan" \
+    "${ATTEMPT_DIR}/terraform-prod-forward.apply-started" \
     "${PROD_TERRAFORM_TARGETS[@]}"
 }
 
@@ -733,6 +791,7 @@ rollback_terraform_prod() {
     "${PREVIOUS_RELEASE_DIR}/terraform/hetzner-prod" \
     "${TERRAFORM_DATA_ROOT}/prod-inverse" \
     "${TERRAFORM_PLAN_ROOT}/prod-inverse.tfplan" \
+    "" \
     "${PROD_TERRAFORM_TARGETS[@]}"
 }
 
@@ -742,6 +801,7 @@ rollback_terraform_dev() {
     "${PREVIOUS_RELEASE_DIR}/terraform/environments/dev" \
     "${TERRAFORM_DATA_ROOT}/dev-inverse" \
     "${TERRAFORM_PLAN_ROOT}/dev-inverse.tfplan" \
+    "" \
     "${DEV_TERRAFORM_TARGETS[@]}"
 }
 
@@ -813,13 +873,13 @@ rollback_pre_admission() {
       rollback_failed=1
     fi
   fi
-  if [[ -f "${ATTEMPT_DIR}/terraform-prod-forward.started" ]]; then
+  if [[ -f "${ATTEMPT_DIR}/terraform-prod-forward.apply-started" ]]; then
     if ! rollback_terraform_prod; then
       printf 'ERROR: Could not restore the production Terraform root\n' >&2
       rollback_failed=1
     fi
   fi
-  if [[ -f "${ATTEMPT_DIR}/terraform-dev-forward.started" ]]; then
+  if [[ -f "${ATTEMPT_DIR}/terraform-dev-forward.apply-started" ]]; then
     if ! rollback_terraform_dev; then
       printf 'ERROR: Could not restore the development Terraform root\n' >&2
       rollback_failed=1

--- a/scripts/hetzner/message-digest-cutover-support.mjs
+++ b/scripts/hetzner/message-digest-cutover-support.mjs
@@ -6,7 +6,6 @@ const THIRTY_MINUTES_MS = 30 * 60 * 1_000;
 
 const TERRAFORM_CONTRACTS = Object.freeze({
   dev: new Map([
-    ['google_service_account.message_digest_service', 'create'],
     ['google_pubsub_topic.message_digest_runs', 'create'],
     ['google_pubsub_topic_iam_member.message_digest_publishes_runs', 'create'],
     ['google_pubsub_topic_iam_member.message_digest_publishes_whatsapp', 'create'],
@@ -24,7 +23,6 @@ const TERRAFORM_CONTRACTS = Object.freeze({
     ['google_cloud_scheduler_job.hetzner_http["mobile_notifications_digest_yesterday"]', 'delete'],
   ]),
   'dev-inverse': new Map([
-    ['google_service_account.message_digest_service', 'delete'],
     ['google_pubsub_topic.message_digest_runs', 'delete'],
     ['google_pubsub_topic_iam_member.message_digest_publishes_runs', 'delete'],
     ['google_pubsub_topic_iam_member.message_digest_publishes_whatsapp', 'delete'],

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -634,6 +634,37 @@ resource "google_secret_manager_secret_iam_member" "hetzner_provisioner_ssl_priv
   member    = "serviceAccount:${google_service_account.hetzner_provisioner.email}"
 }
 
+resource "google_storage_bucket_iam_member" "hetzner_provisioner_terraform_state" {
+  bucket = "${var.project_id}-terraform-state"
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.hetzner_provisioner.email}"
+}
+
+resource "google_project_iam_member" "hetzner_provisioner_deployment_roles" {
+  for_each = toset([
+    "roles/cloudscheduler.admin",
+    "roles/iam.serviceAccountViewer",
+    "roles/pubsub.admin",
+    "roles/serviceusage.serviceUsageConsumer",
+  ])
+
+  project = var.project_id
+  role    = each.value
+  member  = "serviceAccount:${google_service_account.hetzner_provisioner.email}"
+}
+
+resource "google_service_account_iam_member" "hetzner_provisioner_message_digest_user" {
+  service_account_id = google_service_account.message_digest_service.name
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:${google_service_account.hetzner_provisioner.email}"
+}
+
+resource "google_service_account_iam_member" "hetzner_provisioner_scheduler_user" {
+  service_account_id = google_service_account.cloud_scheduler.name
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:${google_service_account.hetzner_provisioner.email}"
+}
+
 resource "google_secret_manager_secret_iam_member" "hetzner_runtime_secrets" {
   for_each = local.hetzner_runtime_secret_names
 


### PR DESCRIPTION
## Summary

- grant the Hetzner provisioner the narrowly scoped state, Pub/Sub, Scheduler, and service-account permissions required by the Message Digest cutover
- pre-bootstrap the persistent Message Digest identity and keep it outside reversible cutover targets
- inject required Terraform variables and make plan/apply plus rollback markers fail-fast and durable
- cover the recovery paths and exact Terraform mutation contracts with regression tests

## Verification

- `pnpm run ci:tracked` (7,663 tests passed)
- focused Message Digest/Hetzner suite (97 tests passed)
- both Terraform roots validate
- live effective-permission probes: `actAs` only for Message Digest and Scheduler; no `actAs` for the administrative account and no service-account delete permission
- actual provisioner dev plan validates as 3 creates, 0 changes, 0 destroys

## Linear

Linear: omitted by `$commit-push`; GitHub automation will create or link the Linear issue after PR creation.
