### PR TITLE
[INT-1967] fix: allow Firebase service status reads

### DIFF
--- a/scripts/__tests__/hetzner-runtime.test.ts
+++ b/scripts/__tests__/hetzner-runtime.test.ts
@@ -2238,6 +2238,7 @@ describe('Hetzner secret loader', () => {
       'roles/iam.serviceAccountViewer',
       'roles/pubsub.admin',
       'roles/serviceusage.serviceUsageConsumer',
+      'roles/serviceusage.serviceUsageViewer',
     ]) {
       expect(projectRoles).toContain(`"${role}"`);
     }

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -646,6 +646,7 @@ resource "google_project_iam_member" "hetzner_provisioner_deployment_roles" {
     "roles/iam.serviceAccountViewer",
     "roles/pubsub.admin",
     "roles/serviceusage.serviceUsageConsumer",
+    "roles/serviceusage.serviceUsageViewer",
   ])
 
   project = var.project_id


### PR DESCRIPTION
## Summary
- grant the Hetzner provisioner read-only Service Usage visibility required by Firebase CLI
- lock the permission into the existing Terraform regression test

## Production evidence
- run 30628001723 reached Firestore migration 128 and failed only because `serviceusage.services.get` was denied
- targeted bootstrap plan/apply: 1 add, 0 change, 0 destroy
- live IAM policy now contains the exact provisioner binding

## Verification
- focused Hetzner runtime suite: 63/63 passed
- Terraform fmt/validate passed
- `pnpm run ci:tracked`: 7,663 tests plus type, lint, static validation, coverage, build, format, and post-build checks passed
- Tested-Tree: d3c0ab27c37510c182fa7f3511253c524cc477fd