### PR TITLE
[INT-1968] fix(message-digests): normalize OpenRouter model selector

### DIFF
--- a/scripts/__tests__/fishing-group-message-digest-production-ports.test.ts
+++ b/scripts/__tests__/fishing-group-message-digest-production-ports.test.ts
@@ -313,6 +313,44 @@ describe('fishing migration replay aggregator', () => {
     });
   });
 
+  it('normalizes an internal OpenRouter selector before provider and usage requests', async () => {
+    const requests: { url: string; body: Record<string, unknown> }[] = [];
+    const aggregate = createFishingMigrationAggregator({
+      apiKey: 'private-openrouter-key',
+      model: 'or:google/gemini-3-flash-preview',
+      usageServiceUrl: 'https://usage.internal.example',
+      internalAuthToken: 'private-internal-token',
+      fetchImplementation: vi.fn(async (url: string | URL, init?: RequestInit) => {
+        requests.push({
+          url: String(url),
+          body: JSON.parse(String(init?.body)) as Record<string, unknown>,
+        });
+        if (String(url).includes('openrouter.ai')) {
+          return jsonResponse(
+            openRouterResponse({
+              headline: 'Wędkarskie ustalenia',
+              summaryMarkdown: '- Ustalono termin spotkania.',
+              evidenceMessageRefs: [SOURCE_REF],
+              continuityMemoryMarkdown: 'Termin pozostaje aktualny.',
+            })
+          );
+        }
+        return jsonResponse({ success: true, data: { accepted: 1 } });
+      }),
+      randomUUID: () => '00000000-0000-4000-8000-000000000005',
+      now: () => '2026-07-28T12:00:00.000Z',
+      environment: 'prod',
+    });
+
+    await expect(aggregate(aggregateInput())).resolves.toMatchObject({
+      model: 'or:google/gemini-3-flash-preview',
+    });
+    expect(requests[0]?.body).toMatchObject({ model: 'google/gemini-3-flash-preview' });
+    expect(requests[1]?.body).toMatchObject({
+      events: [{ request: { model: 'google/gemini-3-flash-preview' } }],
+    });
+  });
+
   it('chunks a large safe day, synthesizes it once, and accounts for every provider call', async () => {
     const input = aggregateInput();
     const firstMessage = required(input.messages[0]);

--- a/scripts/message-digests/fishing-group-production-ports.mjs
+++ b/scripts/message-digests/fishing-group-production-ports.mjs
@@ -107,7 +107,11 @@ export function createFishingMigrationSourcePort(config) {
 
 export function createFishingMigrationAggregator(config) {
   const apiKey = requiredOperationalString(config?.apiKey, 'MIGRATION_LLM_CONFIG_INVALID');
-  const model = requiredOperationalString(config?.model, 'MIGRATION_LLM_CONFIG_INVALID');
+  const configuredModel = requiredOperationalString(config?.model, 'MIGRATION_LLM_CONFIG_INVALID');
+  const providerModel = requiredOperationalString(
+    configuredModel.startsWith('or:') ? configuredModel.slice(3) : configuredModel,
+    'MIGRATION_LLM_CONFIG_INVALID'
+  );
   const usageServiceUrl = normalizeBaseUrl(config?.usageServiceUrl);
   const internalAuthToken = requiredOperationalString(
     config?.internalAuthToken,
@@ -133,7 +137,7 @@ export function createFishingMigrationAggregator(config) {
     try {
       result = await requestOpenRouter({
         apiKey,
-        model,
+        model: providerModel,
         prompt,
         fetchImplementation,
       });
@@ -146,7 +150,7 @@ export function createFishingMigrationAggregator(config) {
         now,
         environment,
         userId,
-        model,
+        model: providerModel,
         promptType,
         requestId,
         startedAt,
@@ -164,7 +168,7 @@ export function createFishingMigrationAggregator(config) {
       now,
       environment,
       userId,
-      model,
+      model: providerModel,
       promptType,
       requestId,
       startedAt,
@@ -225,7 +229,7 @@ export function createFishingMigrationAggregator(config) {
     return {
       ...final.aggregate,
       promptVersion: `${final.promptIdentity.promptType}@${final.promptIdentity.version}`,
-      model,
+      model: configuredModel,
       usage,
     };
   };


### PR DESCRIPTION
## Co naprawia

- usuwa wewnętrzny prefiks `or:` wyłącznie z modelu wysyłanego bezpośrednio do OpenRouter
- zachowuje kanoniczny selektor `or:...` w danych Message Digest
- dodaje regresyjny test kontraktu requestu i ewidencji użycia

## Dlaczego

Produkcyjna migracja grupy wędkarskiej dochodziła do agregacji, ale OpenRouter odrzucał identyfikator `or:google/gemini-3-flash-preview`. Katalog dostawcy używa identyfikatora `google/gemini-3-flash-preview`.

## Weryfikacja

- regresyjny test portu produkcyjnego: zielony
- pełne `pnpm run ci:tracked`: 7 663 testy i cały pipeline lokalny zielony
- końcowa weryfikacja produkcyjna zostanie wykonana po scaleniu