### PR TITLE
[INT-1969] fix(message-digests): ignore hidden aliases during verify

### DIFF
--- a/scripts/__tests__/fishing-group-message-digest-production-ports.test.ts
+++ b/scripts/__tests__/fishing-group-message-digest-production-ports.test.ts
@@ -780,6 +780,25 @@ describe('fishing migration Firestore ports', () => {
     ).toBe(true);
   });
 
+  it('ignores an older compensated alias while verifying a replacement candidate', async () => {
+    const previous = structuredClone(migrationShell().definition);
+    previous.definitionId = 'md_previous_hidden';
+    fake.seedCollection('message_digest_definitions', [
+      { id: 'md_previous_hidden', data: previous },
+    ]);
+    const ports = createFishingMigrationFirestorePorts({
+      firestore: fake as unknown as Firestore,
+    });
+    await seedStagedCandidate(ports);
+
+    await expect(
+      ports.visibility.readFishing({
+        userId: 'owner-001',
+        legacyGroupKey: 'fishing-group',
+      })
+    ).resolves.toEqual({ definitions: [], runs: [] });
+  });
+
   it('atomically restages a compensated hidden chain for the same migration identity', async () => {
     const ports = createFishingMigrationFirestorePorts({
       firestore: fake as unknown as Firestore,

--- a/scripts/message-digests/fishing-group-production-ports.mjs
+++ b/scripts/message-digests/fishing-group-production-ports.mjs
@@ -1609,6 +1609,7 @@ function createVisibilityStore(firestore) {
         .collection(DEFINITIONS_COLLECTION)
         .where('userId', '==', input.userId)
         .where('legacyAlias.groupKey', '==', input.legacyGroupKey)
+        .where('status', 'in', ['active', 'paused'])
         .get();
       const definitions = snapshot.docs
         .map(ownedData)
@@ -1616,6 +1617,8 @@ function createVisibilityStore(firestore) {
           (definition) =>
             definition.userId === input.userId &&
             definition.legacyAlias?.groupKey === input.legacyGroupKey &&
+            ['active', 'paused'].includes(definition.status) &&
+            definition.activeMigrationId !== null &&
             definition.source?.chatType === 'group'
         );
       if (definitions.length > 1) throw safeError('MIGRATION_VISIBILITY_CONFLICT');


### PR DESCRIPTION
## Summary
- make migration visibility verification match the runtime store
- ignore hidden migrating/compensated definitions when resolving the fishing-group alias
- retain fail-closed behavior for multiple genuinely visible aliases

## Production evidence
Production deployment 30635229167 completed all 146 hidden candidate runs with zero outbox entries, then verification saw an older compensated candidate sharing the legacy alias. Compensation completed durably and the old production runtime remains healthy.

## Verification
- regression test reproduced the prior MIGRATION_VISIBILITY_CONFLICT before the fix
- focused migration/cutover/runtime suites: 122/122 passed
- independent review: no P1/P2 findings
- pnpm run ci:tracked: passed (7,663 tests plus type, lint, static validation, coverage, build, format, and post-build checks)
- Tested-Tree: caa7a3d6a793f7a125e7cb0f75f4d81e33d6e1e8

No data deletion and no outbound WhatsApp effects are introduced by this patch.