### PR TITLE
[INT-1970] fix(deploy): harden digest cutover resume

### DIFF
--- a/scripts/__tests__/message-digest-cutover.test.ts
+++ b/scripts/__tests__/message-digest-cutover.test.ts
@@ -1261,6 +1261,56 @@ command cat "$TRACE_FILE"
 });
 
 describe('Message Digest candidate stack and cutover script', () => {
+  it('keeps silent Hetzner cutover SSH sessions alive and fails dead transports promptly', () => {
+    const deploy = readFileSync(deployPath, 'utf8');
+    const sshCommand = deploy.slice(
+      deploy.indexOf('ssh_command_string() {'),
+      deploy.indexOf('\n}\n\nprepare_remote_terraform()')
+    );
+    const remoteCommand = deploy.slice(
+      deploy.indexOf('run_remote_at() {'),
+      deploy.indexOf('\n}\n\nrun_remote()')
+    );
+
+    for (const block of [sshCommand, remoteCommand]) {
+      expect(block).toContain('ServerAliveInterval=15');
+      expect(block).toContain('ServerAliveCountMax=8');
+    }
+  });
+
+  it('restarts hidden candidate services only when resuming a pre-activation checkpoint', () => {
+    const invoke = (completedStepCount: number): ReturnType<typeof spawnSync> =>
+      runShellLibrary(
+        cutoverPath,
+        `
+state_completed_count() { printf '%s' "$TEST_COMPLETED_STEP_COUNT"; }
+start_candidate_compensation_stack() { printf 'restart-candidate\\n'; }
+restart_candidate_stack_for_resumed_pre_activation
+`,
+        { TEST_COMPLETED_STEP_COUNT: String(completedStepCount) }
+      );
+
+    for (const completedStepCount of [0, 1, 2, 14, 15, 16, 17]) {
+      const freshOrSwitched = invoke(completedStepCount);
+      expect(freshOrSwitched.status, freshOrSwitched.stderr).toBe(0);
+      expect(freshOrSwitched.stdout).toBe('');
+    }
+    for (const completedStepCount of [3, 11, 12, 13]) {
+      const resumedCandidate = invoke(completedStepCount);
+      expect(resumedCandidate.status, resumedCandidate.stderr).toBe(0);
+      expect(resumedCandidate.stdout).toBe('restart-candidate\n');
+    }
+
+    const cutover = readFileSync(cutoverPath, 'utf8');
+    const main = cutover.slice(cutover.indexOf('main() {'));
+    expect(main.indexOf('acquire_durable_lease')).toBeLessThan(
+      main.indexOf('restart_candidate_stack_for_resumed_pre_activation')
+    );
+    expect(main.indexOf('restart_candidate_stack_for_resumed_pre_activation')).toBeLessThan(
+      main.indexOf('run_step "verify-tested-release"')
+    );
+  });
+
   it('stages one pinned and hash-verified Terraform runtime outside the immutable release', () => {
     const deploy = readFileSync(deployPath, 'utf8');
     const main = deploy.slice(deploy.indexOf('main() {'));

--- a/scripts/hetzner/cutover-message-digests.sh
+++ b/scripts/hetzner/cutover-message-digests.sh
@@ -383,6 +383,14 @@ start_candidate_compensation_stack() {
   done
 }
 
+restart_candidate_stack_for_resumed_pre_activation() {
+  local completed=""
+  completed="$(state_completed_count)"
+  if ((completed >= 3 && completed < 14)); then
+    start_candidate_compensation_stack
+  fi
+}
+
 stop_candidate_compensation_stack() {
   local service=""
   local failed="0"
@@ -932,6 +940,7 @@ main() {
   if [[ "${CUTOVER_STATUS}" == "compensating" ]]; then
     fail "Previous Message Digest compensation is incomplete"
   fi
+  restart_candidate_stack_for_resumed_pre_activation
 
   run_step "verify-tested-release" verify_tested_release
   run_step "assert-pending-migration-128" assert_pending_migration_128

--- a/scripts/hetzner/github-actions-deploy.sh
+++ b/scripts/hetzner/github-actions-deploy.sh
@@ -189,7 +189,7 @@ setup_ssh() {
 }
 
 ssh_command_string() {
-  printf 'ssh -i %q -p %q -o BatchMode=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile=%q' \
+  printf 'ssh -i %q -p %q -o BatchMode=yes -o ServerAliveInterval=15 -o ServerAliveCountMax=8 -o StrictHostKeyChecking=yes -o UserKnownHostsFile=%q' \
     "${KEY_FILE}" \
     "${SSH_PORT}" \
     "${KNOWN_HOSTS_FILE}"
@@ -275,6 +275,8 @@ run_remote_at() {
   ssh -i "${KEY_FILE}" \
     -p "${SSH_PORT}" \
     -o BatchMode=yes \
+    -o ServerAliveInterval=15 \
+    -o ServerAliveCountMax=8 \
     -o StrictHostKeyChecking=yes \
     -o UserKnownHostsFile="${KNOWN_HOSTS_FILE}" \
     "${REMOTE_USER}@${HETZNER_PROD_HOST}" \


### PR DESCRIPTION
## Summary
- keep silent long-running Hetzner SSH sessions alive and detect dead transports within two minutes
- restart the isolated candidate service stack when a cutover resumes after candidate startup but before the runtime switch
- preserve all checkpoint, compensation, activation, and admission boundaries

## Production evidence
Deployment 30638495065 attempt 1 completed 146/146 hidden runs with outbox 0 and checkpointed migration-apply, then lost its SSH process while GitHub remained in progress. Attempt 2 resumed and the corrected migration-verify passed, but the orphaned candidate Message Digest process returned HTTP 503 during candidate-zero-send-proof. Compensation completed before admission. A controlled fresh restart of only candidate-message-digest-service returned HTTP 200 with both staged visibility flags false and was immediately stopped.

## Verification
- TDD: both keepalive and resume-restart regressions failed before implementation
- focused cutover/candidate/runtime suites: 114/114 passed
- bash syntax checks passed
- independent review: no P1/P2 findings
- pnpm run ci:tracked passed: 7,663 tests plus type, lint, static validation, coverage, build, format, and post-build checks
- Tested-Tree: c1203f119c2442fb9cd7b172a8ff12ae68623703

Production remains on the previous healthy runtime, the cutover is compensated, and no outbound effects occurred.