### PR TITLE
[INT-1971] fix(migration): preserve digest definition timestamps

### DIFF
--- a/scripts/__tests__/fishing-group-message-digest-production-ports.test.ts
+++ b/scripts/__tests__/fishing-group-message-digest-production-ports.test.ts
@@ -623,6 +623,14 @@ describe('fishing migration Firestore ports', () => {
         state: firstState,
       })
     ).resolves.toMatchObject({ disposition: 'created', run: first });
+    await expect(
+      ports.migration.inspectCandidate({
+        migrationId: 'mdm_release_001',
+        definitionId: 'md_definition',
+      })
+    ).resolves.toMatchObject({
+      definition: { updatedAt: shell.definition.updatedAt },
+    });
 
     const second = canonicalRun('mdr_second', '2026-07-02', first.runHash, 'b'.repeat(64));
     const secondState = migrationState({
@@ -665,7 +673,11 @@ describe('fishing migration Firestore ports', () => {
       definitionId: 'md_definition',
     });
     expect(candidate).toMatchObject({
-      definition: { status: 'migrating', hasRuns: true },
+      definition: {
+        status: 'migrating',
+        hasRuns: true,
+        updatedAt: shell.definition.updatedAt,
+      },
       state: secondState,
       activation: {
         status: 'staging',

--- a/scripts/message-digests/fishing-group-production-ports.mjs
+++ b/scripts/message-digests/fishing-group-production-ports.mjs
@@ -1101,7 +1101,7 @@ function createMigrationStore(firestore) {
           checkpointAt: input.state.checkpointAt,
           lastRunAt: input.run.completedAt,
           latestRun: latestRunProjection(input.run),
-          updatedAt: input.run.updatedAt,
+          updatedAt: laterInstant(definition.updatedAt, input.run.updatedAt),
         });
         return { disposition: 'created', run: input.run };
       });
@@ -1156,7 +1156,7 @@ function createMigrationStore(firestore) {
           checkpointAt: state.checkpointAt,
           lastRunAt: lastRun.completedAt,
           latestRun: latestRunProjection(lastRun),
-          updatedAt: input.finalState.updatedAt,
+          updatedAt: laterInstant(definition.updatedAt, input.finalState.updatedAt),
         });
         return { disposition: 'staged' };
       });
@@ -1399,6 +1399,15 @@ function latestRunProjection(run) {
     processingStage: run.processingStage,
     deliveryStatus: run.delivery?.status,
   };
+}
+
+function laterInstant(left, right) {
+  const leftTimestamp = Date.parse(left);
+  const rightTimestamp = Date.parse(right);
+  if (!Number.isFinite(leftTimestamp) || !Number.isFinite(rightTimestamp)) {
+    throw safeError('MIGRATION_DOCUMENT_INVALID');
+  }
+  return leftTimestamp >= rightTimestamp ? left : right;
 }
 
 function isAlreadyActive(definition, state, activation, runs, outbox, input) {


### PR DESCRIPTION
## Summary

- keep Message Digest definition timestamps monotonic while historical runs are staged
- prevent the runtime schema from rejecting a staged definition whose replay data predates the cutover
- cover both per-run projection updates and the final staging write with regression assertions

## Production evidence

Deploy 30642664597 staged and verified 146/146 runs with zero outbound effects, then failed the pre-admission visibility gate. The production document reproduced the exact schema error: staged updatedAt 2026-07-30T22:00:00.000Z preceded createdAt 2026-07-31T15:27:29.957Z. Automatic compensation completed with admitted=false and the old runtime healthy.

## Verification

- red test reproduced the timestamp regression before implementation
- focused migration/candidate/cutover suites: 130/130
- independent review: no P1/P2 findings
- pnpm run ci:tracked: 7,663 tests plus type, lint, static validation, coverage, build, format, and post-build checks
- Tested-Tree: 678b2da02bc47ab0033416531df48bd13c9e31fb
