### PR TITLE
[INT-1972] fix(whatsapp): redact private webhook identifiers

### DIFF
--- a/apps/whatsapp-service/src/__tests__/infra/cloudApiAdapter.test.ts
+++ b/apps/whatsapp-service/src/__tests__/infra/cloudApiAdapter.test.ts
@@ -3,7 +3,21 @@
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { err, ok } from '@intexuraos/common-core';
+import type { Logger } from 'pino';
 import { WhatsAppCloudApiAdapter } from '../../infra/whatsapp/index.js';
+
+const { infoSpy, errorSpy } = vi.hoisted(() => ({
+  infoSpy: vi.fn(),
+  errorSpy: vi.fn(),
+}));
+
+vi.mock('@intexuraos/infra-sentry', () => ({
+  createAppLogger: (): Logger =>
+    ({
+      info: infoSpy,
+      error: errorSpy,
+    }) as unknown as Logger,
+}));
 
 const mockClient = {
   getMediaUrl: vi.fn(),
@@ -24,6 +38,47 @@ describe('WhatsAppCloudApiAdapter', () => {
   beforeEach(() => {
     adapter = new WhatsAppCloudApiAdapter(accessToken);
     vi.clearAllMocks();
+  });
+
+  it('never writes provider identifiers, recipient phones, or media URLs to logs', async () => {
+    const privateValues = {
+      mediaId: 'private-media-id-123',
+      mediaUrl: 'https://lookaside.fbsbx.com/private-media-token',
+      phoneNumberId: 'private-phone-number-id-456',
+      recipientPhone: '+48123123123',
+      replyToMessageId: 'private-reply-id-789',
+      messageId: 'private-message-id-321',
+    };
+
+    mockClient.getMediaUrl.mockResolvedValue(
+      ok({
+        url: privateValues.mediaUrl,
+        mimeType: 'image/jpeg',
+        sha256: 'private-media-sha',
+        fileSize: 123,
+      })
+    );
+    mockClient.downloadMedia.mockResolvedValue(ok(Buffer.from('private media bytes')));
+    mockClient.sendTextMessage.mockResolvedValue(ok({ messageId: privateValues.messageId }));
+    mockClient.markAsRead.mockResolvedValue(ok(undefined));
+    mockClient.markAsReadWithTyping.mockResolvedValue(ok(undefined));
+
+    await adapter.getMediaUrl(privateValues.mediaId);
+    await adapter.downloadMedia(privateValues.mediaUrl);
+    await adapter.sendMessage(
+      privateValues.phoneNumberId,
+      privateValues.recipientPhone,
+      'private message body',
+      privateValues.replyToMessageId
+    );
+    await adapter.markAsRead(privateValues.phoneNumberId, privateValues.messageId);
+    await adapter.markAsReadWithTyping(privateValues.phoneNumberId, privateValues.messageId);
+
+    const serializedLogs = JSON.stringify([...infoSpy.mock.calls, ...errorSpy.mock.calls]);
+    for (const privateValue of Object.values(privateValues)) {
+      expect(serializedLogs).not.toContain(privateValue);
+    }
+    expect(serializedLogs).not.toContain('private message body');
   });
 
   describe('getMediaUrl', () => {

--- a/apps/whatsapp-service/src/__tests__/infra/sender.test.ts
+++ b/apps/whatsapp-service/src/__tests__/infra/sender.test.ts
@@ -897,11 +897,12 @@ describe('WhatsAppCloudApiSender', () => {
 
     it('never writes the full or normalized recipient to success and failure logs', async () => {
       const recipient = '+48123456789';
+      const privateWamid = 'wamid.digest-private';
       const scenarios = [
         vi.fn().mockResolvedValue({
           ok: true,
           json: (): Promise<{ messages: { id: string }[] }> =>
-            Promise.resolve({ messages: [{ id: 'wamid.digest-private' }] }),
+            Promise.resolve({ messages: [{ id: privateWamid }] }),
         }),
         vi.fn().mockResolvedValue({
           ok: false,
@@ -920,6 +921,9 @@ describe('WhatsAppCloudApiSender', () => {
         );
         expect(JSON.stringify([infoSpy.mock.calls, warnSpy.mock.calls, errorSpy.mock.calls])).not.toContain(
           recipient.slice(1)
+        );
+        expect(JSON.stringify([infoSpy.mock.calls, warnSpy.mock.calls, errorSpy.mock.calls])).not.toContain(
+          privateWamid
         );
         infoSpy.mockClear();
         warnSpy.mockClear();

--- a/apps/whatsapp-service/src/__tests__/usecases/ingestPrivateWhatsAppEvents.test.ts
+++ b/apps/whatsapp-service/src/__tests__/usecases/ingestPrivateWhatsAppEvents.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { err, ok, type Result } from '@intexuraos/common-core';
 import {
   type AudioStoredEvent,
@@ -349,6 +349,34 @@ describe('IngestPrivateWhatsAppEventsUseCase', () => {
     expect(repository.stored[0]?.deliveryMode).toBe('live');
     expect(repository.stored[0]?.message.text).toBe('hello from private whatsapp');
     expect(repository.stored[0]?.message.direction).toBe('incoming');
+  });
+
+  it('does not write private source-account identifiers to success or failure logs', async () => {
+    const privateSourceAccountId = 'private-source-account-must-not-be-logged';
+    const privacyLogger: Logger = {
+      info: vi.fn(),
+      error: vi.fn(),
+    };
+
+    const success = await useCase.execute(
+      createInput({ sourceAccountId: privateSourceAccountId }),
+      privacyLogger
+    );
+    expect(success.ok).toBe(true);
+
+    repository.failNextStore = true;
+    const failure = await useCase.execute(
+      createInput({ sourceAccountId: privateSourceAccountId }),
+      privacyLogger
+    );
+    expect(failure.ok).toBe(false);
+
+    expect(
+      JSON.stringify([
+        vi.mocked(privacyLogger.info).mock.calls,
+        vi.mocked(privacyLogger.error).mock.calls,
+      ])
+    ).not.toContain(privateSourceAccountId);
   });
 
   it('stores outgoing Matrix events from the private account owner', async () => {

--- a/apps/whatsapp-service/src/__tests__/usecases/processWebhookEventTextOnly.test.ts
+++ b/apps/whatsapp-service/src/__tests__/usecases/processWebhookEventTextOnly.test.ts
@@ -354,8 +354,13 @@ describe('ProcessWebhookEventUseCase text-only branches', () => {
   it('keeps an ordinary new-session text message byte-compatible', async () => {
     const { savedEvent, useCase, userMappingRepository, webhookEventRepository, messageRepository, eventPublisher, whatsappCloudApi } = await createHarness();
     await userMappingRepository.saveMapping('user-1', ['15551234567']);
+    const privacyLogger = logger();
 
-    await useCase.execute(createTextPayload('new session: normal message'), savedEvent, logger());
+    await useCase.execute(
+      createTextPayload('new session: normal message'),
+      savedEvent,
+      privacyLogger
+    );
 
     expect(messageRepository.getAll()[0]?.text).toBe('new session: normal message');
     expect(eventPublisher.getIntexMessageIngestEvents()[0]).toMatchObject({ text: 'new session: normal message', sourceType: 'whatsapp_text' });
@@ -363,6 +368,14 @@ describe('ProcessWebhookEventUseCase text-only branches', () => {
     expect(whatsappCloudApi.getMarkedAsReadMessages()).toHaveLength(1);
     const eventResult = await webhookEventRepository.getEvent(savedEvent.id);
     expect(eventResult.ok && eventResult.value?.status).toBe('completed');
+    expect(
+      JSON.stringify([
+        vi.mocked(privacyLogger.info).mock.calls,
+        vi.mocked(privacyLogger.warn).mock.calls,
+        vi.mocked(privacyLogger.error).mock.calls,
+        vi.mocked(privacyLogger.debug).mock.calls,
+      ])
+    ).not.toContain('15551234567');
   });
 
   it('completes audio messages without sending a response when phoneNumberId is missing', async () => {

--- a/apps/whatsapp-service/src/__tests__/webhookAsyncProcessing.test.ts
+++ b/apps/whatsapp-service/src/__tests__/webhookAsyncProcessing.test.ts
@@ -1540,7 +1540,7 @@ describe('Webhook async processing', () => {
       expect(messages[0]?.toNumber).toBe(''); // Empty string fallback
     });
 
-    it('handles null wabaId in error message (uses "null" fallback)', async () => {
+    it('rejects a missing wabaId without reflecting the identifier', async () => {
       // Create payload with null WABA ID (missing entry)
       const payload = {
         object: 'whatsapp_business_account',
@@ -1563,11 +1563,11 @@ describe('Webhook async processing', () => {
       // Should reject with 403
       expect(response.statusCode).toBe(403);
       const body = JSON.parse(response.body) as { error: { message: string } };
-      expect(body.error.message).toContain('waba_id');
-      expect(body.error.message).toContain('null');
+      expect(body.error.message).toBe('Webhook rejected: waba_id not allowed');
+      expect(body.error.message).not.toContain('null');
     });
 
-    it('handles null phoneNumberId in error message (uses "null" fallback)', async () => {
+    it('rejects a missing phoneNumberId without reflecting the identifier', async () => {
       // Create payload with valid WABA but missing phone_number_id
       const payload = {
         object: 'whatsapp_business_account',
@@ -1606,8 +1606,8 @@ describe('Webhook async processing', () => {
       // Should reject with 403
       expect(response.statusCode).toBe(403);
       const body = JSON.parse(response.body) as { error: { message: string } };
-      expect(body.error.message).toContain('phone_number_id');
-      expect(body.error.message).toContain('null');
+      expect(body.error.message).toBe('Webhook rejected: phone_number_id not allowed');
+      expect(body.error.message).not.toContain('null');
     });
 
     it('handles null messageType in error message (uses "unknown" fallback)', async () => {

--- a/apps/whatsapp-service/src/__tests__/webhookPrivacyLogging.test.ts
+++ b/apps/whatsapp-service/src/__tests__/webhookPrivacyLogging.test.ts
@@ -1,0 +1,86 @@
+import { vi } from 'vitest';
+import { Writable } from 'node:stream';
+
+const commonHttpState = vi.hoisted(() => ({
+  logIncomingRequest: vi.fn(),
+}));
+
+vi.mock('@intexuraos/common-http', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@intexuraos/common-http')>();
+  return { ...actual, logIncomingRequest: commonHttpState.logIncomingRequest };
+});
+
+import {
+  beforeEach,
+  createSignature,
+  createWebhookPayload,
+  describe,
+  expect,
+  it,
+  setupTestContext,
+  testConfig,
+} from './testUtils.js';
+import { buildServer } from '../server.js';
+
+describe('POST /webhooks privacy logging', () => {
+  const ctx = setupTestContext();
+
+  beforeEach(() => {
+    commonHttpState.logIncomingRequest.mockClear();
+  });
+
+  it('never includes the WhatsApp payload in the incoming-request preview', async () => {
+    const payloadString = JSON.stringify(createWebhookPayload());
+
+    const response = await ctx.app.inject({
+      method: 'POST',
+      url: '/webhooks',
+      headers: {
+        'content-type': 'application/json',
+        'x-hub-signature-256': createSignature(payloadString, testConfig.appSecret),
+      },
+      payload: payloadString,
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(commonHttpState.logIncomingRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ bodyPreviewLength: 0 })
+    );
+  });
+
+  it('redacts private WhatsApp identifiers at the service logger boundary', async () => {
+    const chunks: string[] = [];
+    const stream = new Writable({
+      write(chunk, _encoding, callback): void {
+        chunks.push(String(chunk));
+        callback();
+      },
+    });
+    const app = await buildServer(testConfig, stream);
+    const privateValues = {
+      userId: 'auth0|private-user-id',
+      sourceAccountId: 'private-source-account',
+      chatId: 'private-chat-id',
+      matrixEventId: 'private-matrix-event',
+      matrixRoomId: 'private-matrix-room',
+      phoneNumber: '+48111111111',
+      fromNumber: '+48222222222',
+      recipientPhone: '+48333333333',
+      phoneNumberId: 'private-provider-phone-id',
+      waMessageId: 'private-inbound-wamid',
+      wamid: 'private-outbound-wamid',
+      bodyPreview: 'private message content',
+    };
+
+    app.log.info(privateValues, 'privacy boundary probe');
+    await new Promise((resolve) => setImmediate(resolve));
+    await app.close();
+
+    const logOutput = chunks.join('');
+    for (const privateValue of Object.values(privateValues)) {
+      expect(logOutput).not.toContain(privateValue);
+    }
+    expect(logOutput).toContain('[Redacted]');
+  });
+});

--- a/apps/whatsapp-service/src/domain/whatsapp/usecases/ingestPrivateWhatsAppEvents.ts
+++ b/apps/whatsapp-service/src/domain/whatsapp/usecases/ingestPrivateWhatsAppEvents.ts
@@ -136,8 +136,6 @@ export class IngestPrivateWhatsAppEventsUseCase {
       if (!storeResult.ok) {
         logger.error(
           {
-            matrixEventId: event.matrixEventId,
-            sourceAccountId: input.sourceAccountId,
             error: storeResult.error,
           },
           'Failed to store private WhatsApp event'
@@ -169,7 +167,6 @@ export class IngestPrivateWhatsAppEventsUseCase {
     const summary = summarize(messages);
     logger.info(
       {
-        sourceAccountId: input.sourceAccountId,
         deliveryMode: input.deliveryMode,
         accepted: summary.accepted,
         duplicates: summary.duplicates,

--- a/apps/whatsapp-service/src/domain/whatsapp/usecases/processWebhookEventUseCase.ts
+++ b/apps/whatsapp-service/src/domain/whatsapp/usecases/processWebhookEventUseCase.ts
@@ -133,7 +133,7 @@ export class ProcessWebhookEventUseCase {
       logger.info(
         {
           eventId: savedEvent.id,
-          ...(isMatrixCorpusReserved ? { matrixCorpusReserved: true } : { fromNumber }),
+          ...(isMatrixCorpusReserved ? { matrixCorpusReserved: true } : { hasSender: true }),
           messageType,
           hasText: messageText !== null,
           hasImage: imageMedia !== null,
@@ -240,7 +240,7 @@ export class ProcessWebhookEventUseCase {
       logger.info(
         {
           eventId: savedEvent.id,
-          ...(isMatrixCorpusReserved ? { matrixCorpusReserved: true } : { fromNumber }),
+          ...(isMatrixCorpusReserved ? { matrixCorpusReserved: true } : { hasSender: true }),
         },
         'Looking up user by phone number'
       );
@@ -254,7 +254,7 @@ export class ProcessWebhookEventUseCase {
                 matrixCorpusReserved: true,
                 reason: 'mapping_lookup_failed',
               }
-            : { eventId: savedEvent.id, fromNumber, error: userIdResult.error },
+            : { eventId: savedEvent.id, error: userIdResult.error },
           'Failed to look up user by phone number'
         );
         await webhookEventRepository.updateEventStatus(savedEvent.id, 'failed', {
@@ -269,7 +269,7 @@ export class ProcessWebhookEventUseCase {
         logger.info(
           {
             eventId: savedEvent.id,
-            ...(isMatrixCorpusReserved ? { matrixCorpusReserved: true } : { fromNumber }),
+            ...(isMatrixCorpusReserved ? { matrixCorpusReserved: true } : { hasSender: true }),
           },
           'No user mapping found for phone number'
         );
@@ -295,7 +295,7 @@ export class ProcessWebhookEventUseCase {
           eventId: savedEvent.id,
           ...(isMatrixCorpusReserved
             ? { matrixCorpusReserved: true }
-            : { fromNumber, userId }),
+            : { hasSender: true, userId }),
         },
         'User mapping found for phone number'
       );

--- a/apps/whatsapp-service/src/infra/whatsapp/cloudApiAdapter.ts
+++ b/apps/whatsapp-service/src/infra/whatsapp/cloudApiAdapter.ts
@@ -29,11 +29,11 @@ export class WhatsAppCloudApiAdapter implements WhatsAppCloudApiPort {
   }
 
   async getMediaUrl(mediaId: string): Promise<Result<MediaUrlInfo, WhatsAppError>> {
-    logger.info({ mediaId }, 'Fetching media URL from WhatsApp');
+    logger.info({}, 'Fetching media URL from WhatsApp');
     const result = await this.mediaClient.getMediaUrl(mediaId);
 
     if (!result.ok) {
-      logger.error({ mediaId, code: result.error.code }, 'Failed to fetch media URL');
+      logger.error({ code: result.error.code }, 'Failed to fetch media URL');
       return err({
         code: 'INTERNAL_ERROR',
         message: result.error.message,
@@ -44,18 +44,18 @@ export class WhatsAppCloudApiAdapter implements WhatsAppCloudApiPort {
   }
 
   async downloadMedia(url: string): Promise<Result<Buffer, WhatsAppError>> {
-    logger.info({ url }, 'Downloading media from WhatsApp');
+    logger.info({}, 'Downloading media from WhatsApp');
     const result = await this.mediaClient.downloadMedia(url);
 
     if (!result.ok) {
-      logger.error({ url, code: result.error.code }, 'Failed to download media');
+      logger.error({ code: result.error.code }, 'Failed to download media');
       return err({
         code: 'INTERNAL_ERROR',
         message: result.error.message,
       });
     }
 
-    logger.info({ url, contentLength: result.value.length }, 'Media downloaded successfully');
+    logger.info({ contentLength: result.value.length }, 'Media downloaded successfully');
     return ok(result.value);
   }
 
@@ -66,7 +66,7 @@ export class WhatsAppCloudApiAdapter implements WhatsAppCloudApiPort {
     replyToMessageId?: string
   ): Promise<Result<SendMessageResult, WhatsAppError>> {
     logger.info(
-      { phoneNumberId, recipientPhone, messageLength: message.length, replyToMessageId },
+      { messageLength: message.length, hasReplyToMessageId: replyToMessageId !== undefined },
       'Sending WhatsApp message'
     );
     const client = createWhatsAppClient({
@@ -84,19 +84,19 @@ export class WhatsAppCloudApiAdapter implements WhatsAppCloudApiPort {
     const result = await client.sendTextMessage(params);
 
     if (!result.ok) {
-      logger.error({ phoneNumberId, recipientPhone, code: result.error.code }, 'Failed to send message');
+      logger.error({ code: result.error.code }, 'Failed to send message');
       return err({
         code: 'INTERNAL_ERROR',
         message: result.error.message,
       });
     }
 
-    logger.info({ phoneNumberId, recipientPhone, messageId: result.value.messageId }, 'Message sent successfully');
+    logger.info({}, 'Message sent successfully');
     return ok({ messageId: result.value.messageId });
   }
 
   async markAsRead(phoneNumberId: string, messageId: string): Promise<Result<void, WhatsAppError>> {
-    logger.info({ phoneNumberId, messageId }, 'Marking message as read');
+    logger.info({}, 'Marking message as read');
     const client = createWhatsAppClient({
       accessToken: this.accessToken,
       phoneNumberId,
@@ -105,14 +105,14 @@ export class WhatsAppCloudApiAdapter implements WhatsAppCloudApiPort {
     const result = await client.markAsRead(messageId);
 
     if (!result.ok) {
-      logger.error({ phoneNumberId, messageId, code: result.error.code }, 'Failed to mark message as read');
+      logger.error({ code: result.error.code }, 'Failed to mark message as read');
       return err({
         code: 'INTERNAL_ERROR',
         message: result.error.message,
       });
     }
 
-    logger.info({ phoneNumberId, messageId }, 'Message marked as read successfully');
+    logger.info({}, 'Message marked as read successfully');
     return ok(undefined);
   }
 
@@ -120,7 +120,7 @@ export class WhatsAppCloudApiAdapter implements WhatsAppCloudApiPort {
     phoneNumberId: string,
     messageId: string
   ): Promise<Result<void, WhatsAppError>> {
-    logger.info({ phoneNumberId, messageId }, 'Marking message as read with typing indicator');
+    logger.info({}, 'Marking message as read with typing indicator');
     const client = createWhatsAppClient({
       accessToken: this.accessToken,
       phoneNumberId,
@@ -130,7 +130,7 @@ export class WhatsAppCloudApiAdapter implements WhatsAppCloudApiPort {
 
     if (!result.ok) {
       logger.error(
-        { phoneNumberId, messageId, code: result.error.code },
+        { code: result.error.code },
         'Failed to mark message as read with typing'
       );
       return err({
@@ -139,7 +139,7 @@ export class WhatsAppCloudApiAdapter implements WhatsAppCloudApiPort {
       });
     }
 
-    logger.info({ phoneNumberId, messageId }, 'Message marked as read with typing indicator successfully');
+    logger.info({}, 'Message marked as read with typing indicator successfully');
     return ok(undefined);
   }
 }

--- a/apps/whatsapp-service/src/infra/whatsapp/sender.ts
+++ b/apps/whatsapp-service/src/infra/whatsapp/sender.ts
@@ -247,7 +247,7 @@ export class WhatsAppCloudApiSender implements WhatsAppMessageSender {
       };
       const wamid = responseBody.messages?.[0]?.id ?? `unknown-${String(Date.now())}`;
 
-      logger.info({ recipientHint, wamid }, `${messageTypeLabel} message sent successfully`);
+      logger.info({ recipientHint }, `${messageTypeLabel} message sent successfully`);
       return ok({ wamid });
     } catch (error) {
       if (error instanceof Error && error.name === 'AbortError') {

--- a/apps/whatsapp-service/src/routes/webhookRoutes.ts
+++ b/apps/whatsapp-service/src/routes/webhookRoutes.ts
@@ -150,10 +150,10 @@ export function createWebhookRoutes(config: Config): FastifyPluginCallback {
         },
       },
       async (request: FastifyRequest<{ Body: WebhookPayload }>, reply: FastifyReply) => {
-        // Log incoming request (before validation for debugging)
+        // Log request metadata only. Webhook payloads contain phone numbers and message text.
         logIncomingRequest(request, {
           message: 'Received WhatsApp webhook POST',
-          bodyPreviewLength: 500,
+          bodyPreviewLength: 0,
         });
 
         // Get raw body for signature validation
@@ -177,7 +177,7 @@ export function createWebhookRoutes(config: Config): FastifyPluginCallback {
 
         if (!signatureValid) {
           request.log.warn(
-            { reason: 'invalid_signature', signatureReceived: signature },
+            { reason: 'invalid_signature' },
             'Webhook rejected: invalid signature'
           );
           return await reply.fail('FORBIDDEN', 'Invalid webhook signature');
@@ -193,17 +193,13 @@ export function createWebhookRoutes(config: Config): FastifyPluginCallback {
           request.log.warn(
             {
               reason: 'waba_id_mismatch',
-              receivedWabaId: wabaId,
-              receivedPhoneNumberId: phoneNumberId,
-              receivedDisplayPhoneNumber: displayPhoneNumber,
-              allowedWabaIds: config.allowedWabaIds,
+              hasWabaId: wabaId !== null,
+              hasPhoneNumberId: phoneNumberId !== null,
+              hasDisplayPhoneNumber: displayPhoneNumber !== null,
             },
             'Webhook rejected: waba_id not in allowed list'
           );
-          return await reply.fail(
-            'FORBIDDEN',
-            `Webhook rejected: waba_id "${wabaId ?? 'null'}" not allowed`
-          );
+          return await reply.fail('FORBIDDEN', 'Webhook rejected: waba_id not allowed');
         }
 
         // Validate phone number ID
@@ -211,17 +207,13 @@ export function createWebhookRoutes(config: Config): FastifyPluginCallback {
           request.log.warn(
             {
               reason: 'phone_number_id_mismatch',
-              receivedWabaId: wabaId,
-              receivedPhoneNumberId: phoneNumberId,
-              receivedDisplayPhoneNumber: displayPhoneNumber,
-              allowedPhoneNumberIds: config.allowedPhoneNumberIds,
+              wabaValidated: true,
+              hasPhoneNumberId: phoneNumberId !== null,
+              hasDisplayPhoneNumber: displayPhoneNumber !== null,
             },
             'Webhook rejected: phone_number_id not in allowed list'
           );
-          return await reply.fail(
-            'FORBIDDEN',
-            `Webhook rejected: phone_number_id "${phoneNumberId ?? 'null'}" not allowed`
-          );
+          return await reply.fail('FORBIDDEN', 'Webhook rejected: phone_number_id not allowed');
         }
 
         // Persist webhook event with initial PENDING status

--- a/apps/whatsapp-service/src/server.ts
+++ b/apps/whatsapp-service/src/server.ts
@@ -18,6 +18,47 @@ import { getServices, initServices } from './services.js';
 
 const SERVICE_NAME = 'whatsapp-service';
 const SERVICE_VERSION = '0.0.4';
+const WHATSAPP_LOG_REDACTION = {
+  paths: [
+    'bodyPreview',
+    'rawBody',
+    'signatureReceived',
+    'userId',
+    'ownerUserId',
+    'auth0UserId',
+    'sourceAccountId',
+    'chatId',
+    'matrixEventId',
+    'matrixRoomId',
+    'phoneNumber',
+    'normalizedPhone',
+    'fromNumber',
+    'recipientPhone',
+    'phoneNumberId',
+    'displayPhoneNumber',
+    'senderPhoneNumber',
+    'whatsappSender',
+    'wabaId',
+    'receivedWabaId',
+    'receivedPhoneNumberId',
+    'receivedDisplayPhoneNumber',
+    'allowedWabaIds',
+    'allowedPhoneNumberIds',
+    'messageId',
+    'waMessageId',
+    'wamid',
+    'replyToWamid',
+    'replyToMessageId',
+    'mediaId',
+    'body.phoneNumber',
+    'body.userId',
+    'error.details.phoneNumber',
+    'error.details.userId',
+    'err.details.phoneNumber',
+    'err.details.userId',
+  ],
+  censor: '[Redacted]',
+};
 
 /**
  * Probe required secrets using this service's bespoke validation logic
@@ -152,11 +193,12 @@ export async function buildServer(
     // produce the documented validation response.
     routerOptions: { maxParamLength: 512 },
     logger: testLoggerStream
-      ? { level: 'info', stream: testLoggerStream }
+      ? { level: 'info', redact: WHATSAPP_LOG_REDACTION, stream: testLoggerStream }
       : process.env['NODE_ENV'] === 'test'
         ? false
         : {
             level: process.env['LOG_LEVEL'] ?? 'info',
+            redact: WHATSAPP_LOG_REDACTION,
             stream: createLogStream(),
           },
     disableRequestLogging: true, // We'll handle logging ourselves to skip health checks


### PR DESCRIPTION
## Summary

- remove phone numbers, provider identifiers, message identifiers, media URLs, and private source-account identifiers from WhatsApp logs
- redact private WhatsApp and Auth0 fields at the Fastify logger boundary
- stop reflecting provider identifiers in webhook rejection responses and add regression coverage

## Verification

- `pnpm run ci:tracked` — 7,677 tests passed; typecheck, lint, static validation, coverage, build, and format passed
- focused privacy tests — 102 tests passed across webhook, sender, Cloud API adapter, and private-ingest paths
- independent review — no remaining P1/P2 findings

## Linear

Linear: omitted by `$commit-push`; GitHub automation will create or link the Linear issue after PR creation.
