### PR TITLE
[INT-1973] fix(whatsapp): remove private PubSub log metadata

### DIFF
--- a/apps/whatsapp-service/src/__tests__/infra/pubsubPublisher.test.ts
+++ b/apps/whatsapp-service/src/__tests__/infra/pubsubPublisher.test.ts
@@ -8,8 +8,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { GcpPubSubPublisher } from '../../infra/pubsub/index.js';
 
 const mockPublishToTopic = vi.fn();
+const mockPublishToTopicSafely = vi.fn();
 const mockPublishToTopicWithSafeReceipt = vi.fn();
 const mockPublishToOptionalTopic = vi.fn();
+const mockPublishToOptionalTopicSafely = vi.fn();
 
 vi.mock('@intexuraos/infra-pubsub', () => ({
   BasePubSubPublisher: class {
@@ -41,6 +43,28 @@ vi.mock('@intexuraos/infra-pubsub', () => ({
       return mockPublishToOptionalTopic(topicName, data, attributes);
     }
 
+    async publishToTopicSafely(
+      topicName: string,
+      data: unknown,
+      attributes: Record<string, string>,
+      _description: string
+    ): Promise<
+      { ok: true; value: undefined } | { ok: false; error: { code: string; message: string } }
+    > {
+      return mockPublishToTopicSafely(topicName, data, attributes);
+    }
+
+    async publishToOptionalTopicSafely(
+      topicName: string | null,
+      data: unknown,
+      attributes: Record<string, string>,
+      _description: string
+    ): Promise<
+      { ok: true; value: undefined } | { ok: false; error: { code: string; message: string } }
+    > {
+      return mockPublishToOptionalTopicSafely(topicName, data, attributes);
+    }
+
     async publishToTopicWithSafeReceipt(
       topicName: string,
       data: unknown,
@@ -59,14 +83,18 @@ describe('GcpPubSubPublisher', () => {
 
   beforeEach(() => {
     mockPublishToTopic.mockReset();
+    mockPublishToTopicSafely.mockReset();
     mockPublishToTopicWithSafeReceipt.mockReset();
     mockPublishToOptionalTopic.mockReset();
+    mockPublishToOptionalTopicSafely.mockReset();
     mockPublishToTopic.mockResolvedValue({ ok: true, value: undefined });
+    mockPublishToTopicSafely.mockResolvedValue({ ok: true, value: undefined });
     mockPublishToTopicWithSafeReceipt.mockResolvedValue({
       ok: true,
       value: 'provider-receipt-private',
     });
     mockPublishToOptionalTopic.mockResolvedValue({ ok: true, value: undefined });
+    mockPublishToOptionalTopicSafely.mockResolvedValue({ ok: true, value: undefined });
     publisher = new GcpPubSubPublisher({
       projectId: 'test-project',
       mediaCleanupTopic: 'media-cleanup-topic',
@@ -121,15 +149,15 @@ describe('GcpPubSubPublisher', () => {
       const result = await publisher.publishMediaCleanup(event);
 
       expect(result.ok).toBe(true);
-      expect(mockPublishToTopic).toHaveBeenCalledWith('media-cleanup-topic', event, {
-        messageId: 'msg-123',
+      expect(mockPublishToTopicSafely).toHaveBeenCalledWith('media-cleanup-topic', event, {
+        eventKind: 'media_cleanup',
       });
     });
 
     it('returns error when publish fails', async () => {
-      mockPublishToTopic.mockResolvedValue({
+      mockPublishToTopicSafely.mockResolvedValue({
         ok: false,
-        error: { code: 'PUBLISH_FAILED', message: 'Pub/Sub unavailable' },
+        error: { code: 'PUBLISH_FAILED', message: 'Pub/Sub publication failed' },
       });
 
       const result = await publisher.publishMediaCleanup({
@@ -143,7 +171,7 @@ describe('GcpPubSubPublisher', () => {
       expect(result.ok).toBe(false);
       if (!result.ok) {
         expect(result.error.code).toBe('INTERNAL_ERROR');
-        expect(result.error.message).toContain('Pub/Sub unavailable');
+        expect(result.error.message).toBe('Pub/Sub publication failed');
       }
     });
   });
@@ -163,8 +191,30 @@ describe('GcpPubSubPublisher', () => {
       const result = await publisher.publishAudioStored(event);
 
       expect(result.ok).toBe(true);
-      expect(mockPublishToTopic).toHaveBeenCalledWith('audio-stored-topic', event, {
-        messageId: 'stored-audio-1',
+      expect(mockPublishToTopicSafely).toHaveBeenCalledWith('audio-stored-topic', event, {
+        eventKind: 'audio_stored',
+      });
+    });
+  });
+
+  describe('publishMediaTranscriptionRequested', () => {
+    it('publishes to the audio topic with content-free logging context', async () => {
+      const event = {
+        type: 'whatsapp.media.transcription.requested' as const,
+        messageId: 'private-message-id',
+        userId: 'private-user-id',
+        mediaId: 'private-media-id',
+        gcsPath: 'whatsapp/private-user-id/private-message-id/audio.ogg',
+        mimeType: 'audio/ogg',
+        mediaKind: 'audio' as const,
+        timestamp: new Date().toISOString(),
+      };
+
+      const result = await publisher.publishMediaTranscriptionRequested(event);
+
+      expect(result.ok).toBe(true);
+      expect(mockPublishToTopicSafely).toHaveBeenCalledWith('audio-stored-topic', event, {
+        eventKind: 'media_transcription_requested',
       });
     });
   });
@@ -184,10 +234,10 @@ describe('GcpPubSubPublisher', () => {
       const result = await publisher.publishIntexMessageIngest(event);
 
       expect(result.ok).toBe(true);
-      expect(mockPublishToTopic).toHaveBeenCalledWith('intex-message-ingest-topic', event, {
-        messageId: 'wamid.abc',
+      expect(mockPublishToTopicSafely).toHaveBeenCalledWith('intex-message-ingest-topic', event, {
+        eventKind: 'intex_message_ingest',
       });
-      expect(mockPublishToOptionalTopic).not.toHaveBeenCalled();
+      expect(mockPublishToOptionalTopicSafely).not.toHaveBeenCalled();
     });
   });
 
@@ -249,8 +299,8 @@ describe('GcpPubSubPublisher', () => {
       const result = await publisher.publishWebhookProcess(event);
 
       expect(result.ok).toBe(true);
-      expect(mockPublishToOptionalTopic).toHaveBeenCalledWith(null, event, {
-        eventId: 'event-123',
+      expect(mockPublishToOptionalTopicSafely).toHaveBeenCalledWith(null, event, {
+        eventKind: 'webhook_process',
       });
     });
 
@@ -275,9 +325,11 @@ describe('GcpPubSubPublisher', () => {
       const result = await publisherWithTopic.publishWebhookProcess(event);
 
       expect(result.ok).toBe(true);
-      expect(mockPublishToOptionalTopic).toHaveBeenCalledWith('webhook-process-topic', event, {
-        eventId: 'event-123',
-      });
+      expect(mockPublishToOptionalTopicSafely).toHaveBeenCalledWith(
+        'webhook-process-topic',
+        event,
+        { eventKind: 'webhook_process' }
+      );
     });
 
     it('returns error when publish fails', async () => {
@@ -289,9 +341,9 @@ describe('GcpPubSubPublisher', () => {
         webhookProcessTopic: 'webhook-process-topic',
         logger: pino({ name: 'test', level: 'silent' }),
       });
-      mockPublishToOptionalTopic.mockResolvedValue({
+      mockPublishToOptionalTopicSafely.mockResolvedValue({
         ok: false,
-        error: { code: 'PUBLISH_FAILED', message: 'Connection failed' },
+        error: { code: 'PUBLISH_FAILED', message: 'Pub/Sub publication failed' },
       });
 
       const result = await publisherWithTopic.publishWebhookProcess({
@@ -305,7 +357,7 @@ describe('GcpPubSubPublisher', () => {
       expect(result.ok).toBe(false);
       if (!result.ok) {
         expect(result.error.code).toBe('INTERNAL_ERROR');
-        expect(result.error.message).toContain('Connection failed');
+        expect(result.error.message).toBe('Pub/Sub publication failed');
       }
     });
   });
@@ -330,9 +382,8 @@ describe('GcpPubSubPublisher', () => {
       const result = await publisherWithTopic.publishConversationAssistantPreparation(event);
 
       expect(result.ok).toBe(true);
-      expect(mockPublishToTopic).toHaveBeenCalledWith('webhook-process-topic', event, {
-        sessionId: 'whatsapp-conv-session-123',
-        userId: 'user-456',
+      expect(mockPublishToTopicSafely).toHaveBeenCalledWith('webhook-process-topic', event, {
+        eventKind: 'conversation_assistant_preparation',
         attempt: '2',
       });
     });
@@ -352,7 +403,7 @@ describe('GcpPubSubPublisher', () => {
           message: 'Conversation Assistant preparation topic is not configured',
         },
       });
-      expect(mockPublishToTopic).not.toHaveBeenCalled();
+      expect(mockPublishToTopicSafely).not.toHaveBeenCalled();
     });
   });
 
@@ -379,10 +430,13 @@ describe('GcpPubSubPublisher', () => {
         await publisherWithTopic.publishConversationAssistantContextAttachmentPreparation(event);
 
       expect(result.ok).toBe(true);
-      expect(mockPublishToTopic).toHaveBeenCalledWith(
+      expect(mockPublishToTopicSafely).toHaveBeenCalledWith(
         'webhook-process-topic',
         event,
-        { attempt: '2' }
+        {
+          eventKind: 'conversation_assistant_context_attachment_preparation',
+          attempt: '2',
+        }
       );
     });
 
@@ -403,7 +457,7 @@ describe('GcpPubSubPublisher', () => {
           message: 'Conversation Assistant context attachment preparation topic is not configured',
         },
       });
-      expect(mockPublishToTopic).not.toHaveBeenCalled();
+      expect(mockPublishToTopicSafely).not.toHaveBeenCalled();
     });
   });
 
@@ -429,12 +483,12 @@ describe('GcpPubSubPublisher', () => {
       const result = await publisherWithTopic.publishPrivateWhatsAppErasure(event);
 
       expect(result.ok).toBe(true);
-      expect(mockPublishToTopic).toHaveBeenCalledWith(
+      expect(mockPublishToTopicSafely).toHaveBeenCalledWith(
         'webhook-process-topic',
         event,
-        { attempt: '3' }
+        { eventKind: 'private_whatsapp_erasure', attempt: '3' }
       );
-      expect(JSON.stringify(mockPublishToTopic.mock.calls[0]?.[2])).not.toContain('secret');
+      expect(JSON.stringify(mockPublishToTopicSafely.mock.calls[0]?.[2])).not.toContain('secret');
     });
 
     it('returns an explicit retryable error when the process topic is not configured', async () => {
@@ -447,7 +501,7 @@ describe('GcpPubSubPublisher', () => {
           message: 'Private WhatsApp erasure topic is not configured',
         },
       });
-      expect(mockPublishToTopic).not.toHaveBeenCalled();
+      expect(mockPublishToTopicSafely).not.toHaveBeenCalled();
     });
   });
 
@@ -463,8 +517,8 @@ describe('GcpPubSubPublisher', () => {
       const result = await publisher.publishExtractLinkPreviews(event);
 
       expect(result.ok).toBe(true);
-      expect(mockPublishToOptionalTopic).toHaveBeenCalledWith(null, event, {
-        messageId: 'msg-123',
+      expect(mockPublishToOptionalTopicSafely).toHaveBeenCalledWith(null, event, {
+        eventKind: 'extract_link_previews',
       });
     });
 
@@ -488,9 +542,11 @@ describe('GcpPubSubPublisher', () => {
       const result = await publisherWithTopic.publishExtractLinkPreviews(event);
 
       expect(result.ok).toBe(true);
-      expect(mockPublishToOptionalTopic).toHaveBeenCalledWith('webhook-process-topic', event, {
-        messageId: 'msg-123',
-      });
+      expect(mockPublishToOptionalTopicSafely).toHaveBeenCalledWith(
+        'webhook-process-topic',
+        event,
+        { eventKind: 'extract_link_previews' }
+      );
     });
 
     it('returns error when publish fails', async () => {
@@ -502,9 +558,9 @@ describe('GcpPubSubPublisher', () => {
         webhookProcessTopic: 'webhook-process-topic',
         logger: pino({ name: 'test', level: 'silent' }),
       });
-      mockPublishToOptionalTopic.mockResolvedValue({
+      mockPublishToOptionalTopicSafely.mockResolvedValue({
         ok: false,
-        error: { code: 'PUBLISH_FAILED', message: 'Network error' },
+        error: { code: 'PUBLISH_FAILED', message: 'Pub/Sub publication failed' },
       });
 
       const result = await publisherWithTopic.publishExtractLinkPreviews({
@@ -517,7 +573,7 @@ describe('GcpPubSubPublisher', () => {
       expect(result.ok).toBe(false);
       if (!result.ok) {
         expect(result.error.code).toBe('INTERNAL_ERROR');
-        expect(result.error.message).toContain('Network error');
+        expect(result.error.message).toBe('Pub/Sub publication failed');
       }
     });
   });

--- a/apps/whatsapp-service/src/infra/pubsub/publisher.ts
+++ b/apps/whatsapp-service/src/infra/pubsub/publisher.ts
@@ -69,20 +69,20 @@ export class GcpPubSubPublisher
   }
 
   async publishMediaCleanup(event: MediaCleanupEvent): Promise<Result<void, WhatsAppError>> {
-    const result = await this.publishToTopic(
+    const result = await this.publishToTopicSafely(
       this.mediaCleanupTopic,
       event,
-      { messageId: event.messageId },
+      { eventKind: 'media_cleanup' },
       'media cleanup'
     );
     return this.mapToWhatsAppError(result);
   }
 
   async publishAudioStored(event: AudioStoredEvent): Promise<Result<void, WhatsAppError>> {
-    const result = await this.publishToTopic(
+    const result = await this.publishToTopicSafely(
       this.audioStoredTopic,
       event,
-      { messageId: event.messageId },
+      { eventKind: 'audio_stored' },
       'audio stored'
     );
     return this.mapToWhatsAppError(result);
@@ -91,10 +91,10 @@ export class GcpPubSubPublisher
   async publishMediaTranscriptionRequested(
     event: MediaTranscriptionRequestedEvent
   ): Promise<Result<void, WhatsAppError>> {
-    const result = await this.publishToTopic(
+    const result = await this.publishToTopicSafely(
       this.audioStoredTopic,
       event,
-      { messageId: event.messageId },
+      { eventKind: 'media_transcription_requested' },
       'media transcription requested'
     );
     return this.mapToWhatsAppError(result);
@@ -103,10 +103,10 @@ export class GcpPubSubPublisher
   async publishIntexMessageIngest(
     event: IntexMessageIngestEvent
   ): Promise<Result<void, WhatsAppError>> {
-    const result = await this.publishToTopic(
+    const result = await this.publishToTopicSafely(
       this.intexMessageIngestTopic,
       event,
-      { messageId: event.messageId },
+      { eventKind: 'intex_message_ingest' },
       'intex message ingest'
     );
     return this.mapToWhatsAppError(result);
@@ -132,10 +132,10 @@ export class GcpPubSubPublisher
   }
 
   async publishWebhookProcess(event: WebhookProcessEvent): Promise<Result<void, WhatsAppError>> {
-    const result = await this.publishToOptionalTopic(
+    const result = await this.publishToOptionalTopicSafely(
       this.webhookProcessTopic,
       event,
-      { eventId: event.eventId },
+      { eventKind: 'webhook_process' },
       'webhook process'
     );
     return this.mapToWhatsAppError(result);
@@ -144,10 +144,10 @@ export class GcpPubSubPublisher
   async publishExtractLinkPreviews(
     event: ExtractLinkPreviewsEvent
   ): Promise<Result<void, WhatsAppError>> {
-    const result = await this.publishToOptionalTopic(
+    const result = await this.publishToOptionalTopicSafely(
       this.webhookProcessTopic,
       event,
-      { messageId: event.messageId },
+      { eventKind: 'extract_link_previews' },
       'extract link previews'
     );
     return this.mapToWhatsAppError(result);
@@ -162,10 +162,10 @@ export class GcpPubSubPublisher
         message: 'Conversation Assistant preparation topic is not configured',
       });
     }
-    const result = await this.publishToTopic(
+    const result = await this.publishToTopicSafely(
       this.webhookProcessTopic,
       event,
-      { sessionId: event.sessionId, userId: event.userId, attempt: String(event.attempt) },
+      { eventKind: 'conversation_assistant_preparation', attempt: String(event.attempt) },
       'conversation assistant preparation'
     );
     return this.mapToWhatsAppError(result);
@@ -181,10 +181,13 @@ export class GcpPubSubPublisher
           'Conversation Assistant context attachment preparation topic is not configured',
       });
     }
-    const result = await this.publishToTopic(
+    const result = await this.publishToTopicSafely(
       this.webhookProcessTopic,
       event,
-      { attempt: String(event.attempt) },
+      {
+        eventKind: 'conversation_assistant_context_attachment_preparation',
+        attempt: String(event.attempt),
+      },
       'conversation assistant context attachment preparation'
     );
     return this.mapToWhatsAppError(result);
@@ -199,10 +202,10 @@ export class GcpPubSubPublisher
         message: 'Private WhatsApp erasure topic is not configured',
       });
     }
-    const result = await this.publishToTopic(
+    const result = await this.publishToTopicSafely(
       this.webhookProcessTopic,
       event,
-      { attempt: String(event.attempt) },
+      { eventKind: 'private_whatsapp_erasure', attempt: String(event.attempt) },
       'private WhatsApp erasure'
     );
     return this.mapToWhatsAppError(result);

--- a/packages/infra-pubsub/src/__tests__/basePublisher.test.ts
+++ b/packages/infra-pubsub/src/__tests__/basePublisher.test.ts
@@ -60,6 +60,27 @@ class TestPublisher extends BasePubSubPublisher {
       'test safe receipt event'
     );
   }
+
+  async publishSafely(
+    topicName: string,
+    event: unknown,
+    context: PublishContext
+  ): Promise<Result<void, PublishError>> {
+    return await this.publishToTopicSafely(topicName, event, context, 'test safe event');
+  }
+
+  async publishOptionalSafely(
+    topicName: string | null,
+    event: unknown,
+    context: PublishContext
+  ): Promise<Result<void, PublishError>> {
+    return await this.publishToOptionalTopicSafely(
+      topicName,
+      event,
+      context,
+      'test safe optional event'
+    );
+  }
 }
 
 describe('BasePubSubPublisher', () => {
@@ -86,11 +107,12 @@ describe('BasePubSubPublisher', () => {
 
     it('redacts provider failures from the safe receipt result and application logs', async () => {
       const privateProviderError = 'private-provider-error-fixture';
+      const info = vi.fn();
       const error = vi.fn();
       const safePublisher = new TestPublisher({
         projectId: 'test-project',
         logger: {
-          info: vi.fn(),
+          info,
           error,
         } as unknown as pino.Logger,
       });
@@ -99,7 +121,7 @@ describe('BasePubSubPublisher', () => {
       const result = await safePublisher.publishWithSafeReceipt(
         'test-topic',
         { data: 'private-payload-fixture' },
-        { eventKind: 'matrix_corpus_ingest' }
+        { messageId: 'private-context-fixture' }
       );
 
       expect(result).toEqual({
@@ -108,6 +130,43 @@ describe('BasePubSubPublisher', () => {
       });
       expect(JSON.stringify(error.mock.calls)).not.toContain(privateProviderError);
       expect(JSON.stringify(error.mock.calls)).not.toContain('private-payload-fixture');
+      expect(JSON.stringify(error.mock.calls)).not.toContain('private-context-fixture');
+      expect(JSON.stringify(info.mock.calls)).not.toContain('private-context-fixture');
+    });
+
+    it('returns a content-free failure from the safe void publishing seam', async () => {
+      const privateProviderError = 'private-provider-error-fixture';
+      const error = vi.fn();
+      const safePublisher = new TestPublisher({
+        projectId: 'test-project',
+        logger: { info: vi.fn(), error } as unknown as pino.Logger,
+      });
+      mockPublishMessage.mockRejectedValueOnce(new Error(privateProviderError));
+
+      const result = await safePublisher.publishSafely(
+        'test-topic',
+        { text: 'private-payload-fixture' },
+        { messageId: 'private-context-fixture' }
+      );
+
+      expect(result).toEqual({
+        ok: false,
+        error: { code: 'PUBLISH_FAILED', message: 'Pub/Sub publication failed' },
+      });
+      expect(JSON.stringify(error.mock.calls)).not.toContain(privateProviderError);
+      expect(JSON.stringify(error.mock.calls)).not.toContain('private-payload-fixture');
+      expect(JSON.stringify(error.mock.calls)).not.toContain('private-context-fixture');
+    });
+
+    it('returns success without exposing the provider receipt from the safe void seam', async () => {
+      const result = await publisher.publishSafely(
+        'test-topic',
+        { text: 'private-payload-fixture' },
+        { messageId: 'private-context-fixture' }
+      );
+
+      expect(result).toEqual({ ok: true, value: undefined });
+      expect(mockPublishMessage).toHaveBeenCalledTimes(1);
     });
 
     it('publishes event successfully', async () => {
@@ -171,6 +230,28 @@ describe('BasePubSubPublisher', () => {
       expect(mockPublishMessage).not.toHaveBeenCalled();
     });
 
+    it('does not write the skipped event payload to application logs', async () => {
+      const debug = vi.fn();
+      const privatePublisher = new TestPublisher({
+        projectId: 'test-project',
+        logger: { debug } as unknown as pino.Logger,
+      });
+
+      await privatePublisher.publishOptionalSafely(
+        null,
+        { messageId: 'private-message-id', text: 'private-message-body' },
+        { messageId: 'private-context-id' }
+      );
+
+      expect(debug).toHaveBeenCalledWith(
+        {},
+        'Topic not configured, skipping test safe optional event'
+      );
+      expect(JSON.stringify(debug.mock.calls)).not.toContain('private-message-id');
+      expect(JSON.stringify(debug.mock.calls)).not.toContain('private-message-body');
+      expect(JSON.stringify(debug.mock.calls)).not.toContain('private-context-id');
+    });
+
     it('publishes when topic is provided', async () => {
       const result = await publisher.publishOptional(
         'optional-topic',
@@ -179,6 +260,17 @@ describe('BasePubSubPublisher', () => {
       );
 
       expect(result.ok).toBe(true);
+      expect(mockPublishMessage).toHaveBeenCalledTimes(1);
+    });
+
+    it('publishes safely when the optional topic is provided', async () => {
+      const result = await publisher.publishOptionalSafely(
+        'optional-topic',
+        { text: 'private-payload-fixture' },
+        { messageId: 'private-context-fixture' }
+      );
+
+      expect(result).toEqual({ ok: true, value: undefined });
       expect(mockPublishMessage).toHaveBeenCalledTimes(1);
     });
 

--- a/packages/infra-pubsub/src/basePublisher.ts
+++ b/packages/infra-pubsub/src/basePublisher.ts
@@ -18,6 +18,9 @@ export interface BasePubSubPublisherConfig {
 
 /**
  * Context for logging during publish operations.
+ *
+ * Values are accepted for source compatibility but deliberately excluded from
+ * application logs. Event payloads and identifiers may be private.
  */
 export type PublishContext = Record<string, unknown>;
 
@@ -45,7 +48,7 @@ export abstract class BasePubSubPublisher {
    *
    * @param topicName - The topic to publish to (required, non-null)
    * @param event - The event payload (will be JSON serialized)
-   * @param context - Additional context for logging (e.g., { messageId, userId })
+   * @param context - Opaque caller context; deliberately excluded from logs
    * @param eventDescription - Human-readable description for logs (e.g., "media cleanup")
    * @returns Result indicating success or failure
    */
@@ -71,33 +74,27 @@ export abstract class BasePubSubPublisher {
   protected async publishToTopicWithReceipt(
     topicName: string,
     event: unknown,
-    context: PublishContext,
+    _context: PublishContext,
     eventDescription: string
   ): Promise<Result<string, PublishError>> {
     try {
       const topic = this.getTopic(topicName);
       const data = Buffer.from(JSON.stringify(event));
 
-      this.logger.info(
-        { topic: topicName, ...context },
-        `Publishing ${eventDescription} event to Pub/Sub`
-      );
+      this.logger.info({ topic: topicName }, `Publishing ${eventDescription} event to Pub/Sub`);
 
       const attributes = buildPublishAttributes();
 
       const publicationReceipt = await topic.publishMessage({ data, attributes });
 
-      this.logger.info(
-        { topic: topicName, ...context },
-        `Successfully published ${eventDescription} event`
-      );
+      this.logger.info({ topic: topicName }, `Successfully published ${eventDescription} event`);
 
       return ok(publicationReceipt);
     } catch (error) {
       const errorMessage = getErrorMessage(error);
 
       this.logger.error(
-        { topic: topicName, ...context, error: errorMessage },
+        { topic: topicName, error: errorMessage },
         `Failed to publish ${eventDescription} event`
       );
 
@@ -113,36 +110,46 @@ export abstract class BasePubSubPublisher {
   protected async publishToTopicWithSafeReceipt(
     topicName: string,
     event: unknown,
-    context: PublishContext,
+    _context: PublishContext,
     eventDescription: string
   ): Promise<Result<string, PublishError>> {
     try {
       const topic = this.getTopic(topicName);
       const data = Buffer.from(JSON.stringify(event));
 
-      this.logger.info(
-        { topic: topicName, ...context },
-        `Publishing ${eventDescription} event to Pub/Sub`
-      );
+      this.logger.info({ topic: topicName }, `Publishing ${eventDescription} event to Pub/Sub`);
 
       const publicationReceipt = await topic.publishMessage({
         data,
         attributes: buildPublishAttributes(),
       });
 
-      this.logger.info(
-        { topic: topicName, ...context },
-        `Successfully published ${eventDescription} event`
-      );
+      this.logger.info({ topic: topicName }, `Successfully published ${eventDescription} event`);
 
       return ok(publicationReceipt);
     } catch {
-      this.logger.error(
-        { topic: topicName, ...context },
-        `Failed to publish ${eventDescription} event`
-      );
+      this.logger.error({ topic: topicName }, `Failed to publish ${eventDescription} event`);
       return err({ code: 'PUBLISH_FAILED', message: 'Pub/Sub publication failed' });
     }
+  }
+
+  /**
+   * Publish a privacy-sensitive event without exposing provider errors, payloads,
+   * publication receipts, or caller context through logs and return values.
+   */
+  protected async publishToTopicSafely(
+    topicName: string,
+    event: unknown,
+    context: PublishContext,
+    eventDescription: string
+  ): Promise<Result<void, PublishError>> {
+    const result = await this.publishToTopicWithSafeReceipt(
+      topicName,
+      event,
+      context,
+      eventDescription
+    );
+    return result.ok ? ok(undefined) : result;
   }
 
   /**
@@ -156,7 +163,7 @@ export abstract class BasePubSubPublisher {
    *
    * @param topicName - The topic to publish to, or `null` to skip
    * @param event - The event payload (will be JSON serialized)
-   * @param context - Additional context for logging
+   * @param context - Opaque caller context; deliberately excluded from logs
    * @param eventDescription - Human-readable description for logs
    * @returns Result indicating success or failure (skip is success)
    */
@@ -167,14 +174,28 @@ export abstract class BasePubSubPublisher {
     eventDescription: string
   ): Promise<Result<void, PublishError>> {
     if (topicName === null) {
-      this.logger.debug(
-        { ...context, event },
-        `Topic not configured, skipping ${eventDescription}`
-      );
+      this.logger.debug({}, `Topic not configured, skipping ${eventDescription}`);
       return ok(undefined);
     }
 
     return await this.publishToTopic(topicName, event, context, eventDescription);
+  }
+
+  /**
+   * Privacy-safe counterpart of {@link publishToOptionalTopic}.
+   */
+  protected async publishToOptionalTopicSafely(
+    topicName: string | null,
+    event: unknown,
+    context: PublishContext,
+    eventDescription: string
+  ): Promise<Result<void, PublishError>> {
+    if (topicName === null) {
+      this.logger.debug({}, `Topic not configured, skipping ${eventDescription}`);
+      return ok(undefined);
+    }
+
+    return await this.publishToTopicSafely(topicName, event, context, eventDescription);
   }
 
   /**


### PR DESCRIPTION
## Summary
- exclude caller context and skipped event payloads from Pub/Sub application logs
- publish private WhatsApp events through privacy-safe seams with static provider failures
- preserve outbound Pub/Sub payloads unchanged

## Verification
- pnpm run ci:tracked (7,677 tests, coverage, build, lint, typechecks, format)
- targeted BasePubSubPublisher coverage: 100% statements, branches, functions, and lines
- independent privacy review: resolved with no remaining actionable findings

Linear: omitted by $commit-push; GitHub automation will create or link the Linear issue after PR creation.