### PR TITLE
[INT-1978] Complete Message Digest Pub/Sub message metadata

### DIFF
--- a/apps/message-digest-service/src/__tests__/internalMessageDigestRoutes.test.ts
+++ b/apps/message-digest-service/src/__tests__/internalMessageDigestRoutes.test.ts
@@ -509,12 +509,21 @@ describe('Message Digest internal routes', () => {
     );
   });
 
-  it('accepts the documented Pub/Sub delivery attempt while keeping the envelope closed', async () => {
+  it('accepts documented Pub/Sub delivery metadata while keeping the envelope closed', async () => {
     const envelope = pubsubEnvelope(runRequest());
+    const message = envelope['message'] as Record<string, unknown>;
     const response = await app.inject({
       method: 'POST',
       url: '/internal/message-digests/pubsub/run',
-      payload: { ...envelope, deliveryAttempt: 1 },
+      payload: {
+        ...envelope,
+        deliveryAttempt: 1,
+        message: {
+          ...message,
+          attributes: { intexuraos_operator_replay: 'synthetic-hotfix' },
+          orderingKey: 'synthetic-ordering-key',
+        },
+      },
     });
 
     expect(response.statusCode).toBe(200);
@@ -533,6 +542,32 @@ describe('Message Digest internal routes', () => {
         method: 'POST',
         url: '/internal/message-digests/pubsub/run',
         payload: { ...envelope, deliveryAttempt: invalidDeliveryAttempt },
+      });
+      expect(invalid.statusCode).toBe(400);
+    }
+
+    const unexpectedMessageField = await app.inject({
+      method: 'POST',
+      url: '/internal/message-digests/pubsub/run',
+      payload: { ...envelope, message: { ...message, unexpectedField: 1 } },
+    });
+    expect(unexpectedMessageField.statusCode).toBe(400);
+
+    const tooManyAttributes = Object.fromEntries(
+      Array.from({ length: 101 }, (_, index) => [`key-${String(index)}`, 'value'])
+    );
+    for (const invalidMessage of [
+      { ...message, attributes: { invalid: { nested: true } } },
+      { ...message, orderingKey: { nested: true } },
+      { ...message, attributes: tooManyAttributes },
+      { ...message, attributes: { ['k'.repeat(257)]: 'value' } },
+      { ...message, attributes: { key: 'v'.repeat(1_025) } },
+      { ...message, orderingKey: 'o'.repeat(1_025) },
+    ]) {
+      const invalid = await app.inject({
+        method: 'POST',
+        url: '/internal/message-digests/pubsub/run',
+        payload: { ...envelope, message: invalidMessage },
       });
       expect(invalid.statusCode).toBe(400);
     }

--- a/apps/message-digest-service/src/routes/internalMessageDigestRoutes.ts
+++ b/apps/message-digest-service/src/routes/internalMessageDigestRoutes.ts
@@ -28,6 +28,8 @@ interface PubSubPushBody {
     data: string;
     messageId: string;
     publishTime: string;
+    attributes?: Record<string, string> | undefined;
+    orderingKey?: string | undefined;
   };
   subscription: string;
   deliveryAttempt?: number | undefined;
@@ -86,6 +88,13 @@ const pubsubPushBodySchema = {
         data: { type: 'string', minLength: 4, maxLength: 400_000 },
         messageId: { type: 'string', minLength: 1, maxLength: 256 },
         publishTime: { type: 'string', format: 'date-time' },
+        attributes: {
+          type: 'object',
+          maxProperties: 100,
+          propertyNames: { type: 'string', minLength: 1, maxLength: 256 },
+          additionalProperties: { type: 'string', maxLength: 1_024 },
+        },
+        orderingKey: { type: 'string', maxLength: 1_024 },
       },
     },
     subscription: { type: 'string', minLength: 1, maxLength: 1_024 },

--- a/docs/superpowers/plans/2026-07-31-message-digest-pubsub-delivery-attempt-hotfix.md
+++ b/docs/superpowers/plans/2026-07-31-message-digest-pubsub-delivery-attempt-hotfix.md
@@ -26,6 +26,31 @@ top-level field, deploy the exact tested commit, and resume the existing queued 
 This change is deliberately narrow: keep the Message Digest push envelope closed and add only
 the documented optional field. Do not log, persist, or use `deliveryAttempt` in business logic.
 
+## Post-deployment continuation: nested Pub/Sub message metadata
+
+The first deployed fix exposed the next validation error from the same real envelope:
+`body/message must NOT have additional properties`. A selected DLQ replay and a second publish of
+the exact frozen payload without explicit operator attributes both reproduced it before the run
+processor. The run therefore remains `queued`, generation attempts remain zero, delivery remains
+`not_sent`, and the original selected DLQ message remains unacknowledged.
+
+Google's wrapped `PubsubMessage` contract permits optional string `attributes` and an optional
+`orderingKey`. Complete the same closed-envelope fix as follows before another replay:
+
+1. RED — extend the route regression test with top-level `deliveryAttempt`, a bounded string
+   attributes map, and an ordering key. Require HTTP 200 and one processor call. In the same test,
+   prove an unrelated nested message field is still HTTP 400 and does not invoke the processor
+   again.
+2. Confirm the deployed-equivalent schema fails the new valid envelope with HTTP 400.
+3. GREEN — add optional `attributes` and `orderingKey` to the TypeScript envelope and JSON schema.
+   Bound attributes to Pub/Sub's key/value/count limits, keep both message-level and top-level
+   `additionalProperties: false`, and neither log nor pass the metadata into business logic.
+4. Repeat focused tests, read-only review, the one required final `ci:tracked` gate, PR, exact-tree
+   deployment, and only then resume the selected one-message recovery.
+5. After the exact run has one terminal WhatsApp receipt, ACK the original selected DLQ record and
+   classify/ACK only the operator-created poison replay copies with the same payload hash; never
+   replay those copies again.
+
 ## Files
 
 - Modify `apps/message-digest-service/src/__tests__/internalMessageDigestRoutes.test.ts`.
@@ -127,8 +152,9 @@ Use Computer Use only with the already-running system Google Chrome and its exis
 ### Modified
 
 - `POST /internal/message-digests/pubsub/run`: the wrapped Google Pub/Sub request body now permits
-  the documented optional top-level non-negative integer `deliveryAttempt`. The decoded business
-  payload, authentication, status mapping, and response contract are unchanged.
+  the documented optional top-level non-negative integer `deliveryAttempt` plus bounded optional
+  `message.attributes` and `message.orderingKey` metadata. The decoded business payload,
+  authentication, status mapping, and response contract are unchanged.
 
 ### Created
 


### PR DESCRIPTION
## Summary

- accept bounded standard `message.attributes` and `message.orderingKey` fields on the closed Message Digest Pub/Sub push envelope
- preserve strict rejection of unrelated metadata, invalid shapes, and values beyond Pub/Sub limits
- document the production evidence and exact one-message recovery continuation

## Verification

- focused RED reproduced HTTP 400 for the real nested Pub/Sub message metadata
- focused GREEN: `internalMessageDigestRoutes.test.ts` (14/14)
- Message Digest service: 625/625 tests
- read-only review findings resolved for all metadata bounds
- `pnpm run ci:tracked` (7,677 tests; all gates passed)
- Tested tree: `9e2b4a4cc6286fd566c1559056f9292803d9e430`

## Linear

Linear: omitted by `$commit-push`; GitHub automation will create or link the Linear issue after PR creation.
