### PR TITLE
[INT-1979] Tolerate provider-owned Pub/Sub metadata

### DIFF
--- a/apps/message-digest-service/src/__tests__/internalMessageDigestRoutes.test.ts
+++ b/apps/message-digest-service/src/__tests__/internalMessageDigestRoutes.test.ts
@@ -509,7 +509,7 @@ describe('Message Digest internal routes', () => {
     );
   });
 
-  it('accepts documented Pub/Sub delivery metadata while keeping the envelope closed', async () => {
+  it('accepts and ignores provider-owned Pub/Sub metadata while keeping known fields bounded', async () => {
     const envelope = pubsubEnvelope(runRequest());
     const message = envelope['message'] as Record<string, unknown>;
     const response = await app.inject({
@@ -521,7 +521,9 @@ describe('Message Digest internal routes', () => {
         message: {
           ...message,
           attributes: { intexuraos_operator_replay: 'synthetic-hotfix' },
+          message_id: 'synthetic-provider-alias-must-be-ignored',
           orderingKey: 'synthetic-ordering-key',
+          publish_time: '2026-07-27T12:59:00.000Z',
         },
       },
     });
@@ -549,9 +551,22 @@ describe('Message Digest internal routes', () => {
     const unexpectedMessageField = await app.inject({
       method: 'POST',
       url: '/internal/message-digests/pubsub/run',
-      payload: { ...envelope, message: { ...message, unexpectedField: 1 } },
+      payload: {
+        ...envelope,
+        message: { ...message, providerOwnedMetadata: { opaque: true } },
+      },
     });
-    expect(unexpectedMessageField.statusCode).toBe(400);
+    expect(unexpectedMessageField.statusCode).toBe(200);
+    expect(processMessageDigestRun).toHaveBeenNthCalledWith(
+      2,
+      {
+        userId: 'synthetic-user-001',
+        definitionId: 'md_definition_001',
+        runId: 'mdr_run_001',
+        workerId: 'pubsub:synthetic-message-001',
+      },
+      expect.any(Object)
+    );
 
     const tooManyAttributes = Object.fromEntries(
       Array.from({ length: 101 }, (_, index) => [`key-${String(index)}`, 'value'])
@@ -578,7 +593,7 @@ describe('Message Digest internal routes', () => {
       payload: { ...envelope, unexpectedField: 1 },
     });
     expect(unexpected.statusCode).toBe(400);
-    expect(processMessageDigestRun).toHaveBeenCalledTimes(1);
+    expect(processMessageDigestRun).toHaveBeenCalledTimes(2);
   });
 
   it('acks terminal duplicates and asks Pub/Sub to retry a busy lease', async () => {

--- a/apps/message-digest-service/src/routes/internalMessageDigestRoutes.ts
+++ b/apps/message-digest-service/src/routes/internalMessageDigestRoutes.ts
@@ -27,7 +27,9 @@ interface PubSubPushBody {
   message: {
     data: string;
     messageId: string;
+    message_id?: string | undefined;
     publishTime: string;
+    publish_time?: string | undefined;
     attributes?: Record<string, string> | undefined;
     orderingKey?: string | undefined;
   };
@@ -82,7 +84,7 @@ const pubsubPushBodySchema = {
   properties: {
     message: {
       type: 'object',
-      additionalProperties: false,
+      additionalProperties: true,
       required: ['data', 'messageId', 'publishTime'],
       properties: {
         data: { type: 'string', minLength: 4, maxLength: 400_000 },

--- a/docs/superpowers/plans/2026-07-31-message-digest-pubsub-delivery-attempt-hotfix.md
+++ b/docs/superpowers/plans/2026-07-31-message-digest-pubsub-delivery-attempt-hotfix.md
@@ -51,6 +51,33 @@ Google's wrapped `PubsubMessage` contract permits optional string `attributes` a
    classify/ACK only the operator-created poison replay copies with the same payload hash; never
    replay those copies again.
 
+## Final provider-envelope correction: metadata is not an application contract
+
+The second deployed fix accepted `attributes` and `orderingKey`, but the same production push was
+still rejected before the processor. The current official Google wrapped-push example includes
+both camel-case and snake-case aliases (`messageId` plus `message_id`, and `publishTime` plus
+`publish_time`). The prior fixture covered only the camel-case representation, so the strict
+message-level schema was modeling an incomplete provider envelope. The production run remains
+queued with zero generation attempts and no delivery.
+
+Fix the boundary once rather than enumerating provider-owned metadata indefinitely:
+
+1. RED — use the complete official wrapped envelope in the route test, including
+   `deliveryAttempt`, `attributes`, `orderingKey`, `message_id`, and `publish_time`. Require HTTP
+   200 and exactly one processor call. Confirm the current deployed schema returns HTTP 400.
+2. GREEN — keep the top-level push object closed and keep strict bounds on every application-used
+   field, especially the required base64 `message.data`. Change only the nested provider-owned
+   `message` object to tolerate additional metadata. The handler must continue to decode and pass
+   only `message.data`; metadata must not be logged, persisted, or forwarded.
+3. Replace the obsolete assertion that an unknown nested metadata key returns HTTP 400 with proof
+   that provider metadata is ignored and cannot alter the single decoded processor input. Retain
+   all malformed known-field, unknown top-level, authentication, and duplicate-call assertions.
+4. Run the focused RED/GREEN route test, the complete Message Digest service suite and coverage,
+   typecheck/lint/format, one read-only review, and one final repository `ci:tracked` gate.
+5. Deploy the exact tested tree through a single PR, verify exact production SHA and health, then
+   replay one selected frozen run message. ACK only after one terminal generation result and one
+   sent receipt; clean matching poison copies without replay.
+
 ## Files
 
 - Modify `apps/message-digest-service/src/__tests__/internalMessageDigestRoutes.test.ts`.


### PR DESCRIPTION
## Summary
- accept Google wrapped-push snake_case aliases and future provider-owned message metadata
- keep the top-level envelope and every application-used field strictly validated
- prove conflicting provider aliases cannot change the canonical worker identity or business input

## Verification
- focused RED reproduced production HTTP 400 for the official complete envelope
- Message Digest service: 625/625 tests, 100% coverage
- `pnpm run ci:tracked`: 7,677 tests and all type/lint/static/coverage/build/format checks passed
- read-only review completed; P2 test-strengthening finding applied
- tested tree: `b57ff3383beb4e15300286f0a4d4ce62bcded64d`

## Tracking
Linear: N/A — bounded production incident hotfix continuing the active Message Digest delivery goal.