### PR TITLE
[INT-1984] fix: show WhatsApp typing while Intex responds

### DIFF
--- a/apps/whatsapp-service/src/__tests__/pubsubRoutes.test.ts
+++ b/apps/whatsapp-service/src/__tests__/pubsubRoutes.test.ts
@@ -4463,6 +4463,7 @@ describe('Pub/Sub Routes', () => {
       });
       expect(eventPublisher.getIntexMessageIngestEvents()).toHaveLength(1);
       expect(whatsappCloudApi.getSentMessages()).toHaveLength(0);
+      expect(whatsappCloudApi.getMarkedAsReadWithTypingMessages()).toHaveLength(0);
     });
 
     it('returns 400 when the transcription event type is unexpected', async () => {
@@ -4690,6 +4691,36 @@ describe('Pub/Sub Routes', () => {
       expect(response.statusCode).toBe(200);
       expect(eventPublisher.getIntexMessageIngestEvents()).toHaveLength(1);
       expect(whatsappCloudApi.getSentMessages()).toHaveLength(0);
+      expect(whatsappCloudApi.getMarkedAsReadWithTypingMessages()).toEqual([
+        { phoneNumberId: '123456789012345', messageId: 'wamid.voice.1' },
+      ]);
+    });
+
+    it('continues after the typing indicator fails for an accepted transcript', async () => {
+      setStoredAudioMessage();
+      whatsappCloudApi.setFailMarkAsRead(true);
+
+      const body = createPubSubBody({
+        type: 'srt.transcription.completed',
+        userId: 'user-audio',
+        messageId: 'stored-audio-1',
+        jobId: 'job-123',
+        status: 'completed',
+        transcript: 'Buy milk.',
+        timestamp: '2026-06-28T10:00:00.000Z',
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/internal/whatsapp/pubsub/transcription-completed',
+        headers: { 'x-internal-auth': INTERNAL_AUTH_TOKEN },
+        payload: body,
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(eventPublisher.getIntexMessageIngestEvents()).toHaveLength(1);
+      expect(whatsappCloudApi.getSentMessages()).toHaveLength(1);
+      expect(whatsappCloudApi.getMarkedAsReadWithTypingMessages()).toHaveLength(0);
     });
 
     it('acks the transcription when saving reply correlation fails after sending the reply', async () => {
@@ -4758,6 +4789,9 @@ describe('Pub/Sub Routes', () => {
           messageId: expect.any(String),
         },
       ]);
+      expect(whatsappCloudApi.getMarkedAsReadWithTypingMessages()).toEqual([
+        { phoneNumberId: '123456789012345', messageId: 'wamid.voice.1' },
+      ]);
       expect(eventPublisher.getIntexMessageIngestEvents()).toEqual([
         {
           type: 'intex.message.ingest',
@@ -4821,6 +4855,9 @@ describe('Pub/Sub Routes', () => {
           whatsappSender: '15551234567',
           timestamp: '2026-06-28T10:05:00.000Z',
         },
+      ]);
+      expect(whatsappCloudApi.getMarkedAsReadWithTypingMessages()).toEqual([
+        { phoneNumberId: '123456789012345', messageId: 'wamid.video.1' },
       ]);
     });
 

--- a/apps/whatsapp-service/src/__tests__/usecases/processWebhookEventTextOnly.test.ts
+++ b/apps/whatsapp-service/src/__tests__/usecases/processWebhookEventTextOnly.test.ts
@@ -365,7 +365,8 @@ describe('ProcessWebhookEventUseCase text-only branches', () => {
     expect(messageRepository.getAll()[0]?.text).toBe('new session: normal message');
     expect(eventPublisher.getIntexMessageIngestEvents()[0]).toMatchObject({ text: 'new session: normal message', sourceType: 'whatsapp_text' });
     expect(eventPublisher.getExtractLinkPreviewsEvents()).toHaveLength(1);
-    expect(whatsappCloudApi.getMarkedAsReadMessages()).toHaveLength(1);
+    expect(whatsappCloudApi.getMarkedAsReadMessages()).toHaveLength(0);
+    expect(whatsappCloudApi.getMarkedAsReadWithTypingMessages()).toHaveLength(1);
     const eventResult = await webhookEventRepository.getEvent(savedEvent.id);
     expect(eventResult.ok && eventResult.value?.status).toBe('completed');
     expect(
@@ -494,7 +495,7 @@ describe('ProcessWebhookEventUseCase text-only branches', () => {
     expect(whatsappCloudApi.getSentMessages()).toHaveLength(0);
   });
 
-  it('ignores button messages even when marking the source message as read fails', async () => {
+  it('keeps unsupported button read failures non-fatal without showing typing', async () => {
     const { savedEvent, useCase, userMappingRepository, webhookEventRepository, whatsappCloudApi } =
       await createHarness();
     const log = logger();
@@ -514,15 +515,22 @@ describe('ProcessWebhookEventUseCase text-only branches', () => {
     const eventResult = await webhookEventRepository.getEvent(savedEvent.id);
     expect(eventResult.ok && eventResult.value?.status).toBe('ignored');
     expect(eventResult.ok && eventResult.value?.ignoredReason?.code).toBe('BUTTON_NOT_SUPPORTED');
+    expect(whatsappCloudApi.getMarkedAsReadWithTypingMessages()).toHaveLength(0);
     expect(log.error).toHaveBeenCalledWith(
       expect.objectContaining({ messageId: expect.stringMatching(/^wamid\.button/) }),
-      'Failed to mark button message as read with typing'
+      'Failed to mark message as read'
     );
   });
 
   it('publishes Intex confirmation button messages to the ingest topic', async () => {
-    const { savedEvent, useCase, userMappingRepository, webhookEventRepository, eventPublisher } =
-      await createHarness();
+    const {
+      savedEvent,
+      useCase,
+      userMappingRepository,
+      webhookEventRepository,
+      eventPublisher,
+      whatsappCloudApi,
+    } = await createHarness();
     await userMappingRepository.saveMapping('user-1', ['15551234567']);
 
     await useCase.execute(
@@ -553,11 +561,18 @@ describe('ProcessWebhookEventUseCase text-only branches', () => {
         timestamp: '1234567890',
       },
     ]);
+    expect(whatsappCloudApi.getMarkedAsReadWithTypingMessages()).toHaveLength(1);
   });
 
   it('marks Intex confirmation button publishing failures as retryable', async () => {
-    const { savedEvent, useCase, userMappingRepository, webhookEventRepository, eventPublisher } =
-      await createHarness();
+    const {
+      savedEvent,
+      useCase,
+      userMappingRepository,
+      webhookEventRepository,
+      eventPublisher,
+      whatsappCloudApi,
+    } = await createHarness();
     await userMappingRepository.saveMapping('user-1', ['15551234567']);
     eventPublisher.setIntexMessageIngestFailure('pubsub unavailable');
 
@@ -582,6 +597,7 @@ describe('ProcessWebhookEventUseCase text-only branches', () => {
       'Failed to publish intex message ingest: pubsub unavailable'
     );
     expect(eventPublisher.getIntexMessageIngestEvents()).toEqual([]);
+    expect(whatsappCloudApi.getMarkedAsReadWithTypingMessages()).toHaveLength(0);
   });
 
   it('ignores button messages without attempting read receipts when phoneNumberId is missing', async () => {

--- a/apps/whatsapp-service/src/__tests__/webhookAsyncProcessing.test.ts
+++ b/apps/whatsapp-service/src/__tests__/webhookAsyncProcessing.test.ts
@@ -261,8 +261,8 @@ describe('Webhook async processing', () => {
     });
   });
 
-  describe('markMessageAsRead', () => {
-    it('marks message as read when text webhook is successfully processed', async () => {
+  describe('markMessageAsReadWithTyping', () => {
+    it('marks text messages as read with typing when handed to Intex', async () => {
       // Setup user mapping
       const senderPhone = '15551234567';
       const userId = 'test-user-id';
@@ -285,7 +285,7 @@ describe('Webhook async processing', () => {
 
       expect(response.statusCode).toBe(200);
 
-      // Wait for async processing including mark as read
+      // Wait for async processing including mark as read with typing
       await triggerWebhookProcessing();
 
       // Verify event was processed
@@ -293,9 +293,13 @@ describe('Webhook async processing', () => {
       expect(events.length).toBe(1);
       expect(events[0]?.status).toBe('completed');
 
-      // Verify message was marked as read via whatsappCloudApi
-      const markedAsRead = ctx.whatsappCloudApi.getMarkedAsReadMessages();
-      expect(markedAsRead.length).toBeGreaterThan(0);
+      expect(ctx.whatsappCloudApi.getMarkedAsReadMessages()).toHaveLength(0);
+      expect(ctx.whatsappCloudApi.getMarkedAsReadWithTypingMessages()).toEqual([
+        {
+          phoneNumberId: '123456789012345',
+          messageId: 'wamid.HBgNMTU1NTEyMzQ1Njc4FQIAEhgUM0VCMDRBNzYwREQ0RjMwMjYzMDcA',
+        },
+      ]);
     });
 
     it('handles sendWhatsAppMessage failure gracefully', async () => {
@@ -649,7 +653,7 @@ describe('Webhook async processing', () => {
       expect(events[0]?.status).toBe('failed');
     });
 
-    it('marks message as read after successful image processing', async () => {
+    it('marks image messages as read with typing when handed to Intex', async () => {
       const senderPhone = '15551234567';
       const userId = 'test-user-id';
 
@@ -682,9 +686,8 @@ describe('Webhook async processing', () => {
 
       await triggerWebhookProcessing();
 
-      // Verify message was marked as read via whatsappCloudApi
-      const markedAsRead = ctx.whatsappCloudApi.getMarkedAsReadMessages();
-      expect(markedAsRead.length).toBeGreaterThan(0);
+      expect(ctx.whatsappCloudApi.getMarkedAsReadMessages()).toHaveLength(0);
+      expect(ctx.whatsappCloudApi.getMarkedAsReadWithTypingMessages()).toHaveLength(1);
     });
   });
 
@@ -1945,6 +1948,7 @@ describe('Webhook async processing', () => {
           },
         }),
       ]);
+      expect(ctx.whatsappCloudApi.getMarkedAsReadWithTypingMessages()).toHaveLength(1);
     });
 
     it('ignores interactive buttons without publishing Intex messages', async () => {
@@ -1976,6 +1980,8 @@ describe('Webhook async processing', () => {
       expect(events[0]?.status).toBe('ignored');
       expect(events[0]?.ignoredReason?.code).toBe('BUTTON_NOT_SUPPORTED');
       expect(ctx.eventPublisher.getIntexMessageIngestEvents()).toHaveLength(0);
+      expect(ctx.whatsappCloudApi.getMarkedAsReadMessages()).toHaveLength(1);
+      expect(ctx.whatsappCloudApi.getMarkedAsReadWithTypingMessages()).toHaveLength(0);
     });
   });
 

--- a/apps/whatsapp-service/src/domain/whatsapp/usecases/processWebhookEventUseCase.ts
+++ b/apps/whatsapp-service/src/domain/whatsapp/usecases/processWebhookEventUseCase.ts
@@ -567,7 +567,7 @@ export class ProcessWebhookEventUseCase {
       throw new RetryableWebhookProcessingError(failureDetails);
     }
 
-    await this.markMessageAsRead(payload, savedEvent, logger);
+    await this.markMessageAsReadWithTyping(payload, savedEvent, logger);
   }
 
   /**
@@ -622,7 +622,7 @@ export class ProcessWebhookEventUseCase {
     }
 
     if (phoneNumberId !== null) {
-      await this.markAudioAsReadWithTyping(payload, savedEvent, whatsappCloudApi, logger);
+      await this.markMessageAsReadWithTyping(payload, savedEvent, logger);
     } else {
       logger.info(
         { eventId: savedEvent.id },
@@ -683,7 +683,7 @@ export class ProcessWebhookEventUseCase {
     }
 
     if (phoneNumberId !== null) {
-      await this.markAudioAsReadWithTyping(payload, savedEvent, whatsappCloudApi, logger);
+      await this.markMessageAsReadWithTyping(payload, savedEvent, logger);
     } else {
       logger.info(
         { eventId: savedEvent.id },
@@ -705,26 +705,7 @@ export class ProcessWebhookEventUseCase {
     buttonResponse: { buttonId: string; buttonTitle: string; replyToWamid: string },
     logger: Logger
   ): Promise<void> {
-    const { webhookEventRepository, whatsappCloudApi, eventPublisher } = this.deps;
-
-    // Fire-and-forget: mark as read + show typing indicator
-    const originalMessageId = extractMessageId(payload);
-    const phoneNumberId = extractPhoneNumberId(payload);
-    if (phoneNumberId !== null && originalMessageId !== null) {
-      whatsappCloudApi.markAsReadWithTyping(phoneNumberId, originalMessageId).then(
-        (result) => {
-          if (!result.ok) {
-            logger.error(
-              { eventId: savedEvent.id, error: result.error, messageId: originalMessageId },
-              'Failed to mark button message as read with typing'
-            );
-          }
-        },
-        (error: unknown) => {
-          logger.error({ error }, 'markAsReadWithTyping threw unexpectedly');
-        }
-      );
-    }
+    const { webhookEventRepository, eventPublisher } = this.deps;
 
     if (buttonResponse.buttonId.startsWith('intex_confirm:')) {
       logger.info(
@@ -762,6 +743,7 @@ export class ProcessWebhookEventUseCase {
         throw new RetryableWebhookProcessingError(failureDetails);
       }
 
+      await this.markMessageAsReadWithTyping(payload, savedEvent, logger);
       await webhookEventRepository.updateEventStatus(savedEvent.id, 'completed', {});
       return;
     }
@@ -776,6 +758,7 @@ export class ProcessWebhookEventUseCase {
       },
       'Ignoring button message because Intex is text-only'
     );
+    await this.markMessageAsReadOnly(payload, savedEvent, logger);
     await webhookEventRepository.updateEventStatus(savedEvent.id, 'ignored', {
       ignoredReason: {
         code: 'BUTTON_NOT_SUPPORTED',
@@ -964,6 +947,8 @@ export class ProcessWebhookEventUseCase {
       throw new RetryableWebhookProcessingError(failureDetails);
     }
 
+    await this.markMessageAsReadWithTyping(payload, savedEvent, logger);
+
     // Publish link preview extraction event to Pub/Sub
     const linkPreviewPublishResult = await eventPublisher.publishExtractLinkPreviews({
       type: 'whatsapp.linkpreview.extract',
@@ -985,7 +970,6 @@ export class ProcessWebhookEventUseCase {
     );
 
     await webhookEventRepository.updateEventStatus(savedEvent.id, 'completed', {});
-    await this.markMessageAsRead(payload, savedEvent, logger);
   }
 
   private async resolveReplyContext(
@@ -1043,11 +1027,8 @@ export class ProcessWebhookEventUseCase {
     return undefined;
   }
 
-  /**
-   * Mark the incoming message as read (displays two blue check marks).
-   * Used for text and image messages instead of sending a confirmation message.
-   */
-  private async markMessageAsRead(
+  /** Mark an ignored message as read without suggesting that Intex will answer it. */
+  private async markMessageAsReadOnly(
     payload: WebhookPayload,
     savedEvent: { id: string },
     logger: Logger
@@ -1056,9 +1037,10 @@ export class ProcessWebhookEventUseCase {
     const phoneNumberId = extractPhoneNumberId(payload);
 
     if (phoneNumberId !== null && originalMessageId !== null) {
-      const { whatsappCloudApi } = this.deps;
-
-      const markResult = await whatsappCloudApi.markAsRead(phoneNumberId, originalMessageId);
+      const markResult = await this.deps.whatsappCloudApi.markAsRead(
+        phoneNumberId,
+        originalMessageId
+      );
 
       if (markResult.ok) {
         logger.info(
@@ -1075,33 +1057,33 @@ export class ProcessWebhookEventUseCase {
   }
 
   /**
-   * Mark audio message as read with typing indicator.
-   * This shows the user something is happening (typing indicator shows for up to 25s
-   * or until the next message is sent).
+   * Mark an accepted message as read and show the typing indicator while Intex prepares a reply.
    */
-  private async markAudioAsReadWithTyping(
+  private async markMessageAsReadWithTyping(
     payload: WebhookPayload,
     savedEvent: { id: string },
-    whatsappCloudApi: WhatsAppCloudApiPort,
     logger: Logger
   ): Promise<void> {
     const originalMessageId = extractMessageId(payload);
     const phoneNumberId = extractPhoneNumberId(payload);
 
-    /* v8 ignore start -- ts-type: audio webhook payloads always include phoneNumberId and messageId @preserve */
     if (phoneNumberId !== null && originalMessageId !== null) {
-      /* v8 ignore stop @preserve */
-      const result = await whatsappCloudApi.markAsReadWithTyping(phoneNumberId, originalMessageId);
+      const { whatsappCloudApi } = this.deps;
 
-      if (result.ok) {
+      const markResult = await whatsappCloudApi.markAsReadWithTyping(
+        phoneNumberId,
+        originalMessageId
+      );
+
+      if (markResult.ok) {
         logger.info(
           { eventId: savedEvent.id, messageId: originalMessageId },
-          'Marked audio message as read with typing indicator'
+          'Marked message as read with typing indicator'
         );
       } else {
         logger.error(
-          { eventId: savedEvent.id, error: result.error, messageId: originalMessageId },
-          'Failed to mark audio message as read with typing indicator'
+          { eventId: savedEvent.id, error: markResult.error, messageId: originalMessageId },
+          'Failed to mark message as read with typing indicator'
         );
       }
     }

--- a/apps/whatsapp-service/src/routes/pubsubRoutes.ts
+++ b/apps/whatsapp-service/src/routes/pubsubRoutes.ts
@@ -385,6 +385,30 @@ async function sendTranscriptionReplyIfPossible(
   }
 }
 
+async function showAgentTypingAfterTranscription(
+  message: WhatsAppMessage,
+  request: FastifyRequest
+): Promise<void> {
+  const phoneNumberId = message.metadata?.phoneNumberId;
+  if (phoneNumberId === undefined || phoneNumberId.trim() === '') return;
+
+  const result = await getServices().whatsappCloudApi.markAsReadWithTyping(
+    phoneNumberId,
+    message.waMessageId
+  );
+  if (!result.ok) {
+    request.log.error(
+      {
+        userId: message.userId,
+        messageId: message.id,
+        waMessageId: message.waMessageId,
+        error: result.error.message,
+      },
+      'Failed to show typing indicator after transcription'
+    );
+  }
+}
+
 /**
  * Creates Pub/Sub routes plugin with config.
  */
@@ -1640,6 +1664,7 @@ export function createPubsubRoutes(): FastifyPluginCallback {
             `transcription:${eventData.messageId}:${eventData.jobId}`,
             request
           );
+          await showAgentTypingAfterTranscription(message, request);
         } else {
           await sendTranscriptionReplyIfPossible(
             message,


### PR DESCRIPTION
## Summary

- show WhatsApp typing for text and image messages accepted by Intex
- restart typing after public audio/video transcription messages
- keep ignored buttons read without showing a false typing state

## Verification

- `pnpm run verify:workspace:tracked whatsapp-service` — 2660/2660 tests passed
- `pnpm run ci:tracked` — 7717 tests passed, including type, lint, coverage, build, format, and bundle checks
- post-sync resource-timeout rerun — all 167 affected tests passed separately

## Endpoint Changes

- Modified: none
- Created: none
- Removed: none
- Unchanged: existing WhatsApp webhook and transcription completion contracts

## Linear

Linear: omitted by `$commit-push`; GitHub automation will create or link the Linear issue after PR creation.
