### PR TITLE
[INT-1985] Fix Intex preference mutation replies

### DIFF
--- a/apps/intex-agent/src/__tests__/domain/intexAgentRunner.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/intexAgentRunner.test.ts
@@ -8275,7 +8275,54 @@ describe('createIntexAgentRunner', () => {
     });
   });
 
-  it('returns the updated preference block after a confirmed preference add succeeds', async () => {
+  it.each([
+    [
+      'add_user_preference',
+      { text: 'Prefer focus blocks before noon.', expectedVersion: 0 },
+    ],
+    [
+      'update_user_preference',
+      {
+        itemId: 'pref_focus',
+        text: 'Prefer focus blocks before 10:00.',
+        expectedVersion: 0,
+      },
+    ],
+    ['delete_user_preference', { itemId: 'pref_focus', expectedVersion: 0 }],
+  ] as const)('keeps the updated preference block internal after confirmed %s succeeds', async (
+    toolName,
+    toolArgs
+  ) => {
+    const promptBlock =
+      'User Preferences v1:\n1. (id: pref_focus) "Prefer focus blocks before noon."';
+    const runner = createIntexAgentRunner({
+      client: new FakeToolCallingClient([]),
+      toolExecutor: fakeToolExecutor({
+        addUserPreference: async () =>
+          JSON.stringify({ status: 'completed', currentVersion: 1, promptBlock }),
+        updateUserPreference: async () =>
+          JSON.stringify({ status: 'completed', currentVersion: 1, promptBlock }),
+        deleteUserPreference: async () =>
+          JSON.stringify({ status: 'completed', currentVersion: 1, promptBlock }),
+      }),
+    });
+
+    await expect(
+      runner.executeConfirmed({
+        session: session(),
+        toolName,
+        toolArgs,
+        currentDateTime: CURRENT_DATE_TIME,
+      })
+    ).resolves.toMatchObject({
+      outcome: 'completed',
+      reply: 'Updated the instruction memory.',
+      toolName,
+      toolResult: { status: 'completed', currentVersion: 1, promptBlock },
+    });
+  });
+
+  it('localizes the confirmed preference reply without exposing the internal block', async () => {
     const promptBlock =
       'User Preferences v1:\n1. (id: pref_focus) "Prefer focus blocks before noon."';
     const runner = createIntexAgentRunner({
@@ -8289,16 +8336,14 @@ describe('createIntexAgentRunner', () => {
     await expect(
       runner.executeConfirmed({
         session: session(),
+        events: [event('user_message', { text: 'Dodaj tę preferencję.' })],
         toolName: 'add_user_preference',
-        toolArgs: {
-          text: 'Prefer focus blocks before noon.',
-          expectedVersion: 0,
-        },
+        toolArgs: { text: 'Preferuj poranne spotkania.', expectedVersion: 0 },
         currentDateTime: CURRENT_DATE_TIME,
       })
     ).resolves.toMatchObject({
       outcome: 'completed',
-      reply: promptBlock,
+      reply: 'Zaktualizowałem pamięć instrukcji.',
       toolName: 'add_user_preference',
       toolResult: { status: 'completed', currentVersion: 1, promptBlock },
     });
@@ -8308,17 +8353,17 @@ describe('createIntexAgentRunner', () => {
     [
       'add_user_preference',
       { text: 'Prefer concise replies.', expectedVersion: 0 },
-      'User Preferences:\n- Updated preference entry.',
+      'Updated the instruction memory.',
     ],
     [
       'update_user_preference',
       { itemId: 'pref_synthetic', text: 'Prefer concise replies.', expectedVersion: 0 },
-      'User Preferences:\n- Updated preference entry.',
+      'Updated the instruction memory.',
     ],
     [
       'delete_user_preference',
       { itemId: 'pref_synthetic', expectedVersion: 0 },
-      'No Intex Agent preferences are defined yet.',
+      'Updated the instruction memory.',
     ],
   ] as const)(
     'reports a successful %s strict-mock mutation even when the result has no prompt block',

--- a/apps/intex-agent/src/__tests__/domain/testToolMocks.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/testToolMocks.test.ts
@@ -156,7 +156,7 @@ describe('test tool mocks', () => {
     expect(deleted['promptBlock']).toBe('');
   });
 
-  it('returns the actual sanitized resulting-state replies for preference mutations', async () => {
+  it('returns friendly sanitized replies for preference mutations', async () => {
     const calls: CapturedToolCall[] = [];
     const runner = createIntexAgentRunner({
       client: {} as Parameters<typeof createIntexAgentRunner>[0]['client'],
@@ -201,9 +201,9 @@ describe('test tool mocks', () => {
     );
 
     expect(sanitizedReplies.map((reply) => reply.message)).toEqual([
-      'User Preferences: [redacted] [redacted-preference-item]',
-      'User Preferences: [redacted] [redacted-preference-item]',
-      'No Intex Agent preferences are defined yet.',
+      'Updated the instruction memory.',
+      'Updated the instruction memory.',
+      'Updated the instruction memory.',
     ]);
     expect(calls.map((call) => call.toolName)).toEqual([
       'add_user_preference',

--- a/apps/intex-agent/src/domain/agent/intexAgentRunner.ts
+++ b/apps/intex-agent/src/domain/agent/intexAgentRunner.ts
@@ -288,10 +288,6 @@ const COMPLETED_REPLIES = {
     en: 'No Intex Agent preferences are defined yet.',
     pl: 'Nie zdefiniowano jeszcze preferencji agenta Intex.',
   },
-  preferenceUpdatedState: {
-    en: 'User Preferences:\n- Updated preference entry.',
-    pl: 'Preferencje:\n- Zaktualizowany wpis.',
-  },
   linkUrl: { en: 'Saved the link.', pl: 'Zapisałem link.' },
 } satisfies Record<string, LocalizedText>;
 
@@ -2633,18 +2629,18 @@ function buildCompletedReply(
   }
 
   if (isPreferenceToolName(toolName)) {
+    if (toolName !== 'get_user_preferences') {
+      return { reply: COMPLETED_REPLIES.preference[replyLanguage] };
+    }
     const promptBlock = readRawString(result, 'promptBlock');
     const renderedPromptBlock =
       promptBlock !== undefined && promptBlock.trim() !== '' ? promptBlock : undefined;
-    const overlayBlock =
-      toolName === 'get_user_preferences' ? renderPreferenceOverlayItems(result) : undefined;
+    const overlayBlock = renderPreferenceOverlayItems(result);
     return {
       reply:
         renderedPromptBlock ??
         overlayBlock ??
-        (toolName === 'get_user_preferences' || toolName === 'delete_user_preference'
-          ? COMPLETED_REPLIES.preferencesEmpty[replyLanguage]
-          : COMPLETED_REPLIES.preferenceUpdatedState[replyLanguage]),
+        COMPLETED_REPLIES.preferencesEmpty[replyLanguage],
     };
   }
 

--- a/scripts/__tests__/fishing-group-message-digest-migration.test.ts
+++ b/scripts/__tests__/fishing-group-message-digest-migration.test.ts
@@ -1287,7 +1287,7 @@ describe('fishing Message Digest migration activation and compensation', () => {
     expect(fixture.ports.aggregateDay).toHaveBeenCalledTimes(aggregatesBeforeRetry);
     expect(fixture.candidate.runs.every((run) => run.visibilityMigrationId === null)).toBe(true);
     expect(fixture.ports.publish).not.toHaveBeenCalled();
-  });
+  }, 30_000);
 });
 
 function auditedLegacyDocuments(): LegacyDocument[] {


### PR DESCRIPTION
## Summary

- keep internal preference prompt blocks out of mutation confirmations
- return localized user-facing acknowledgements for add, update, and delete preference operations
- cover real and strict-mock preference mutation paths
- stabilize the long Fishing migration cycle test under coverage load

## Verification

- `pnpm run ci:tracked`

## Linear

Linear: omitted by `$commit-push`; GitHub automation will create or link the Linear issue after PR creation.
