### PR TITLE
[INT-2036] fix(deploy): verify backend health over HTTPS

### DIFF
--- a/scripts/__tests__/hetzner-runtime.test.ts
+++ b/scripts/__tests__/hetzner-runtime.test.ts
@@ -850,7 +850,13 @@ describe('Hetzner web asset deployment', () => {
     expect(readinessFlow).toContain('/api/intex-agent/health');
     expect(backendReadinessFlow).toContain('verify-matrix-corpus-runtime.sh');
     expect(backendReadinessFlow).toContain('/api/intex-agent/health');
-    expect(backendReadinessFlow).toContain('verify-semantic-health.mjs');
+    expect(backendReadinessFlow.match(/verify_semantic_health/g)).toHaveLength(2);
+    expect(backendReadinessFlow).not.toContain('http://127.0.0.1/api/');
+    expect(
+      backendReadinessFlow.match(/--resolve "\$\{PUBLIC_DOMAIN\}:443:\$\{HETZNER_PROD_HOST\}"/g)
+    ).toHaveLength(2);
+    expect(backendReadinessFlow).toContain('"direct-origin WhatsApp"');
+    expect(backendReadinessFlow).toContain('"direct-origin Intex Agent"');
     expect(readinessFlow).toContain('--resolve "${PUBLIC_DOMAIN}:443:${HETZNER_PROD_HOST}"');
     expect(attestationFlow.match(/\/deployment\.json/g)).toHaveLength(2);
     expect(attestationFlow).toContain('--resolve "${PUBLIC_DOMAIN}:443:${HETZNER_PROD_HOST}"');

--- a/scripts/hetzner/github-actions-deploy.sh
+++ b/scripts/hetzner/github-actions-deploy.sh
@@ -557,13 +557,17 @@ verify_semantic_health() {
 }
 
 verify_backend_readiness() {
-  run_remote 'curl --fail --silent --show-error --max-time 10 http://127.0.0.1/api/whatsapp/health | node scripts/hetzner/verify-semantic-health.mjs whatsapp-service firestore'
-  run_remote 'curl --fail --silent --show-error --max-time 10 http://127.0.0.1/api/intex-agent/health | node scripts/hetzner/verify-semantic-health.mjs intex-agent firestore'
   run_remote 'INTEXURAOS_ENVIRONMENT=prod bash scripts/hetzner/verify-matrix-corpus-runtime.sh'
   verify_semantic_health \
     "direct-origin WhatsApp" \
     "https://${PUBLIC_DOMAIN}/api/whatsapp/health" \
     "whatsapp-service" \
+    "firestore" \
+    --resolve "${PUBLIC_DOMAIN}:443:${HETZNER_PROD_HOST}"
+  verify_semantic_health \
+    "direct-origin Intex Agent" \
+    "https://${PUBLIC_DOMAIN}/api/intex-agent/health" \
+    "intex-agent" \
     "firestore" \
     --resolve "${PUBLIC_DOMAIN}:443:${HETZNER_PROD_HOST}"
   verify_code_agent_readiness


### PR DESCRIPTION
## Summary
- replace two localhost HTTP semantic checks that receive nginx 301 pages
- verify WhatsApp and Intex through HTTPS with direct-origin address pinning
- preserve TLS SNI, certificate validation, Host routing and Firestore semantics

## Root cause
Deploy run 31410269865 started the correct release, but verify_backend_readiness called http://127.0.0.1/api/... . nginx returned its expected 301 HTML response; curl --fail accepted that status and the semantic JSON verifier rejected the HTML as HEALTH_JSON_INVALID.

## Validation
- reproduced the 301 on the production host
- both replacement direct-origin checks pass against production
- targeted Hetzner tests: 65/65
- full pnpm ci:tracked: 7,779 tests passed
- independent review confirmed the TLS/Host approach

The historical WhatsApp webhook replay remains intentionally paused until this release is attested healthy.