### PR TITLE
[INT-2040] fix(intex-agent): ask for attendee email before lookup

### DIFF
--- a/apps/intex-agent/src/__tests__/domain/handleIncomingMessage.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/handleIncomingMessage.test.ts
@@ -671,7 +671,7 @@ describe('handleIncomingMessage', () => {
     await handleIncomingMessage(
       message({
         messageId: 'wamid-calendar-update-request',
-        text: 'Zaproś Patryka na Bagrową jutro.',
+        text: 'Zaproś Patryka (patryk@example.com) na Bagrową jutro.',
       }),
       deps(repo, runner, replies, { now: () => NOW }, async () =>
         ok({

--- a/apps/intex-agent/src/__tests__/domain/intexAgentRunner.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/intexAgentRunner.test.ts
@@ -5072,7 +5072,8 @@ describe('createIntexAgentRunner', () => {
       runner.run({
         session: session(),
         events: [],
-        message: 'Zaproś Patryka na istniejące wydarzenie Bagrowa jutro.',
+        message:
+          'Zaproś Patryka (patryk@example.com) na istniejące wydarzenie Bagrowa jutro.',
         currentDateTime: CURRENT_DATE_TIME,
         timeZone: 'Europe/Warsaw',
       })
@@ -6468,6 +6469,858 @@ describe('createIntexAgentRunner', () => {
     }
   );
 
+  describe('calendar attendee email precondition', () => {
+    const emailClarification = {
+      outcome: 'needs_clarification',
+      reply: 'Jaki jest adres e-mail uczestnika?',
+      blockerReason: 'missing_required_details',
+      missingFields: ['attendeeEmail'],
+      candidateIntents: ['update_calendar_event'],
+      suggestedNextStep: 'Podaj adres e-mail uczestnika.',
+    } as const;
+    const passThroughResult = ok(
+      toolResult({
+        outcome: 'needs_clarification',
+        reply: 'Which existing event should I update?',
+        blockerReason: 'missing_required_details',
+        missingFields: ['event'],
+        candidateIntents: ['update_calendar_event'],
+        suggestedNextStep: 'Identify one event.',
+      })
+    );
+
+    it('asks for the attendee email before invoking the runner or calendar lookup', async () => {
+      let queryCalls = 0;
+      const client = new FakeToolCallingClient([]);
+      const runner = createIntexAgentRunner({
+        client,
+        intentClassifier: toolIntentClassifier(['update_calendar_event']),
+        toolExecutor: fakeToolExecutor({
+          queryCalendarEvents: async () => {
+            queryCalls += 1;
+            return 'unused';
+          },
+        }),
+      });
+
+      await expect(
+        runner.run({
+          session: session(),
+          events: [],
+          message:
+            'Zaproś Martę Testową A6F3 do istniejącego wydarzenia „INTEX-WA-E2E-ATTENDEE-20260810-A6F3” 11 sierpnia 2026 o 15:00.',
+          currentDateTime: CURRENT_DATE_TIME,
+          timeZone: 'Europe/Warsaw',
+        })
+      ).resolves.toEqual(emailClarification);
+      expect(client.calls).toHaveLength(0);
+      expect(queryCalls).toBe(0);
+    });
+
+    it('overrides a false event clarification and ignores an unrelated saved email mapping', async () => {
+      const client = new FakeToolCallingClient([]);
+      const runner = createIntexAgentRunner({
+        client,
+        intentClassifier: {
+          async classify() {
+            return {
+              kind: 'needs_clarification' as const,
+              question: 'Które wydarzenie masz na myśli?',
+              blockerReason: 'missing_required_details' as const,
+              missingFields: ['event'],
+              candidateIntents: ['update_calendar_event' as const],
+            };
+          },
+        },
+        toolExecutor: fakeToolExecutor(),
+        userPreferences:
+          'User Preferences v1:\n1. (id: pref_jakub) "When I ask to invite Jakub, invite jakub@example.com."\nUse expectedVersion 1 for preference mutation tools.',
+      });
+
+      await expect(
+        runner.run({
+          session: session(),
+          events: [],
+          message:
+            'Zaproś Martę Testową A6F3 do istniejącego wydarzenia „INTEX-WA-E2E-ATTENDEE-20260810-A6F3” 11 sierpnia 2026 o 15:00.',
+          currentDateTime: CURRENT_DATE_TIME,
+          timeZone: 'Europe/Warsaw',
+        })
+      ).resolves.toEqual(emailClarification);
+      expect(client.calls).toHaveLength(0);
+    });
+
+    it('preserves classifier decision metadata while replacing a missing-email tool intent', async () => {
+      const client = new FakeToolCallingClient([]);
+      const runner = createIntexAgentRunner({
+        client,
+        intentClassifier: {
+          async classify() {
+            return {
+              kind: 'tool' as const,
+              allowedToolNames: ['update_calendar_event' as const],
+              stylePreferenceAction: 'none' as const,
+              languageOverride: 'pl' as const,
+              decisionEvidence: 'The attendee email is absent.',
+            };
+          },
+        },
+        toolExecutor: fakeToolExecutor(),
+      });
+
+      await expect(
+        runner.run({
+          session: session(),
+          events: [],
+          message: 'Zaproś Martę na istniejące wydarzenie Bagrowa jutro.',
+          currentDateTime: CURRENT_DATE_TIME,
+        })
+      ).resolves.toEqual(emailClarification);
+      expect(client.calls).toHaveLength(0);
+    });
+
+    it('preserves a genuine event clarification when an email is already present', async () => {
+      const client = new FakeToolCallingClient([]);
+      const runner = createIntexAgentRunner({
+        client,
+        intentClassifier: {
+          async classify() {
+            return {
+              kind: 'needs_clarification' as const,
+              question: 'Which event?',
+              blockerReason: 'missing_required_details' as const,
+              missingFields: ['event'],
+              candidateIntents: ['update_calendar_event' as const],
+            };
+          },
+        },
+        toolExecutor: fakeToolExecutor(),
+      });
+
+      await expect(
+        runner.run({
+          session: session(),
+          events: [],
+          message: 'Invite Marta (marta@example.com) to an existing event.',
+          currentDateTime: CURRENT_DATE_TIME,
+        })
+      ).resolves.toMatchObject({
+        outcome: 'needs_clarification',
+        reply: 'Which event?',
+        missingFields: ['event'],
+      });
+      expect(client.calls).toHaveLength(0);
+    });
+
+    it.each([
+      {
+        label: 'the current request',
+        message: 'Invite Jakub (jakub@example.com) to the existing Bagrowa event.',
+        replyContext: undefined,
+      },
+      {
+        label: 'an inbound user quote',
+        message: 'Invite Jakub to the existing Bagrowa event.',
+        replyContext: {
+          replyToWamid: 'wamid-inbound-email',
+          source: 'inbound_user_message' as const,
+          text: 'Jakub uses jakub@example.com.',
+          truncated: false,
+        },
+      },
+    ])('accepts a valid attendee email from $label', async ({ message, replyContext }) => {
+      const client = new FakeToolCallingClient([passThroughResult]);
+      const runner = createIntexAgentRunner({
+        client,
+        intentClassifier: toolIntentClassifier(['update_calendar_event']),
+        toolExecutor: fakeToolExecutor(),
+      });
+
+      await runner.run({
+        session: session(),
+        events: [],
+        message,
+        ...(replyContext !== undefined ? { replyContext } : {}),
+        currentDateTime: CURRENT_DATE_TIME,
+      });
+
+      expect(client.calls).toHaveLength(1);
+    });
+
+    it.each([
+      {
+        label: 'an invalid address',
+        replyContext: undefined,
+        message: 'Invite Jakub (jakub@example) to the existing Bagrowa event.',
+      },
+      {
+        label: 'an address rejected by the calendar contract',
+        replyContext: undefined,
+        message: 'Invite Jakub (john..doe@example.com) to the existing Bagrowa event.',
+      },
+      {
+        label: 'an unrelated calendar address',
+        replyContext: undefined,
+        message: 'Invite Jakub to the event in team@example.com calendar.',
+      },
+      {
+        label: 'one address for multiple named attendees',
+        replyContext: undefined,
+        message:
+          'Invite Jakub and Anna (anna@example.com) to the existing Bagrowa event.',
+      },
+      {
+        label: 'alternative addresses for one attendee',
+        replyContext: undefined,
+        message:
+          'Invite Jakub (jakub.one@example.com or jakub.two@example.com) to the existing Bagrowa event.',
+      },
+      {
+        label: 'multiple unseparated addresses for one attendee',
+        replyContext: undefined,
+        message:
+          'Invite Jakub (jakub.one@example.com jakub.two@example.com) to the existing Bagrowa event.',
+      },
+      {
+        label: 'alternative addresses in an email reply',
+        replyContext: undefined,
+        message: 'Email: jakub.one@example.com or jakub.two@example.com.',
+      },
+      {
+        label: 'multiple bare addresses in an email reply',
+        replyContext: undefined,
+        message: 'jakub.one@example.com jakub.two@example.com',
+      },
+      {
+        label: 'an outbound assistant quote',
+        message: 'Invite Jakub to the existing Bagrowa event.',
+        replyContext: {
+          replyToWamid: 'wamid-outbound-email',
+          source: 'outbound_assistant_message' as const,
+          text: 'Jakub uses jakub@example.com.',
+          truncated: false,
+        },
+      },
+    ])('does not accept $label as attendee email context', async ({ message, replyContext }) => {
+      const client = new FakeToolCallingClient([]);
+      const runner = createIntexAgentRunner({
+        client,
+        intentClassifier: toolIntentClassifier(['update_calendar_event']),
+        toolExecutor: fakeToolExecutor(),
+      });
+
+      await expect(
+        runner.run({
+          session: session(),
+          events: [],
+          message,
+          ...(replyContext !== undefined ? { replyContext } : {}),
+          currentDateTime: CURRENT_DATE_TIME,
+        })
+      ).resolves.toMatchObject({
+        outcome: 'needs_clarification',
+        missingFields: ['attendeeEmail'],
+      });
+      expect(client.calls).toHaveLength(0);
+    });
+
+    it('continues when an email-only reply answers the active attendee clarification', async () => {
+      const client = new FakeToolCallingClient([passThroughResult]);
+      const runner = createIntexAgentRunner({
+        client,
+        intentClassifier: {
+          async classify() {
+            return {
+              kind: 'needs_clarification' as const,
+              question: 'Which event?',
+              blockerReason: 'missing_required_details' as const,
+              missingFields: ['event'],
+              candidateIntents: ['update_calendar_event' as const],
+            };
+          },
+        },
+        toolExecutor: fakeToolExecutor(),
+      });
+
+      await runner.run({
+        session: session(),
+        events: [
+          event('user_message', {
+            text: 'Invite Marta to the existing Bagrowa event tomorrow.',
+          }),
+          event('clarification_requested', {
+            message: "What is the attendee's email address?",
+            blockerReason: 'missing_required_details',
+            missingFields: ['attendeeEmail'],
+            candidateIntents: ['update_calendar_event'],
+          }),
+          event('assistant_message', { text: "What is the attendee's email address?" }),
+        ],
+        message: 'marta@example.com',
+        currentDateTime: CURRENT_DATE_TIME,
+      });
+
+      expect(client.calls).toHaveLength(1);
+    });
+
+    it('continues when an inbound user quote answers the active attendee clarification', async () => {
+      const client = new FakeToolCallingClient([passThroughResult]);
+      const runner = createIntexAgentRunner({
+        client,
+        intentClassifier: {
+          async classify() {
+            return {
+              kind: 'needs_clarification' as const,
+              question: 'Which event?',
+              blockerReason: 'missing_required_details' as const,
+              missingFields: ['event'],
+              candidateIntents: ['update_calendar_event' as const],
+            };
+          },
+        },
+        toolExecutor: fakeToolExecutor(),
+      });
+
+      await runner.run({
+        session: session(),
+        events: [
+          event('user_message', {
+            text: 'Invite Marta to the existing Bagrowa event tomorrow.',
+          }),
+          event('clarification_requested', {
+            message: "What is the attendee's email address?",
+            blockerReason: 'missing_required_details',
+            missingFields: ['attendeeEmail'],
+            candidateIntents: ['update_calendar_event'],
+          }),
+          event('assistant_message', { text: "What is the attendee's email address?" }),
+        ],
+        message: 'Use the quoted address.',
+        replyContext: {
+          replyToWamid: 'wamid-email-answer',
+          source: 'inbound_user_message',
+          text: 'marta@example.com',
+          truncated: false,
+        },
+        currentDateTime: CURRENT_DATE_TIME,
+      });
+
+      expect(client.calls).toHaveLength(1);
+    });
+
+    it('keeps asking when one email answers a multi-attendee request', async () => {
+      const client = new FakeToolCallingClient([]);
+      const runner = createIntexAgentRunner({
+        client,
+        intentClassifier: toolIntentClassifier(['update_calendar_event']),
+        toolExecutor: fakeToolExecutor(),
+      });
+
+      await expect(
+        runner.run({
+          session: session(),
+          events: [
+            event('user_message', {
+              text: 'Invite Anna and Bob to the existing Bagrowa event tomorrow.',
+            }),
+            event('clarification_requested', {
+              message: "What is the attendees' email address?",
+              blockerReason: 'missing_required_details',
+              missingFields: ['attendeeEmail'],
+              candidateIntents: ['update_calendar_event'],
+            }),
+            event('assistant_message', { text: "What is the attendees' email address?" }),
+          ],
+          message: 'anna@example.com',
+          currentDateTime: CURRENT_DATE_TIME,
+        })
+      ).resolves.toMatchObject({
+        outcome: 'needs_clarification',
+        missingFields: ['attendeeEmail'],
+      });
+      expect(client.calls).toHaveLength(0);
+    });
+
+    it.each([
+      'Actually invite Anna to the existing Dentist event tomorrow.',
+      'Actually invite Anna and Bob to the existing Dentist event tomorrow.',
+    ])('drops an inherited email after the attendee changes: %s', async (message) => {
+      const client = new FakeToolCallingClient([]);
+      const runner = createIntexAgentRunner({
+        client,
+        intentClassifier: toolIntentClassifier(['update_calendar_event']),
+        toolExecutor: fakeToolExecutor(),
+        userPreferences:
+          'User Preferences v1:\n1. (id: pref_marta) "Invite Marta via marta.saved@example.com."',
+      });
+
+      await expect(
+        runner.run({
+          session: session(),
+          events: [
+            event('user_message', {
+              text: 'Invite Marta (marta@example.com) to an existing event.',
+            }),
+            event('clarification_requested', {
+              message: 'Which event?',
+              blockerReason: 'missing_required_details',
+              missingFields: ['event'],
+              candidateIntents: ['update_calendar_event'],
+            }),
+            event('assistant_message', { text: 'Which event?' }),
+          ],
+          message,
+          currentDateTime: CURRENT_DATE_TIME,
+        })
+      ).resolves.toMatchObject({
+        outcome: 'needs_clarification',
+        missingFields: ['attendeeEmail'],
+      });
+      expect(client.calls).toHaveLength(0);
+    });
+
+    it('carries an explicit email through an unresolved attendee-update clarification chain', async () => {
+      const client = new FakeToolCallingClient([passThroughResult]);
+      const runner = createIntexAgentRunner({
+        client,
+        intentClassifier: toolIntentClassifier(['update_calendar_event']),
+        toolExecutor: fakeToolExecutor(),
+      });
+
+      await runner.run({
+        session: session(),
+        events: [
+          event('user_message', {
+            text: 'Invite Marta (marta@example.com) to an existing calendar event.',
+          }),
+          event('clarification_requested', {
+            message: 'Which event?',
+            blockerReason: 'missing_required_details',
+            missingFields: ['event'],
+            candidateIntents: ['update_calendar_event'],
+          }),
+          event('assistant_message', { text: 'Which event?' }),
+          event('turn_processing_completed', {}),
+        ],
+        message: 'The Bagrowa event tomorrow at 18:00.',
+        currentDateTime: CURRENT_DATE_TIME,
+      });
+
+      expect(client.calls).toHaveLength(1);
+    });
+
+    it('walks a multi-step attendee-update chain across query and diagnostic events', async () => {
+      const client = new FakeToolCallingClient([passThroughResult]);
+      const runner = createIntexAgentRunner({
+        client,
+        intentClassifier: toolIntentClassifier(['update_calendar_event']),
+        toolExecutor: fakeToolExecutor(),
+      });
+
+      await runner.run({
+        session: session(),
+        events: [
+          event('user_message', {
+            text: 'Invite Marta (marta@example.com) to an existing calendar event.',
+          }),
+          event('clarification_requested', {
+            message: 'Which day?',
+            blockerReason: 'missing_required_details',
+            missingFields: ['event'],
+            candidateIntents: ['update_calendar_event'],
+          }),
+          event('assistant_message', { text: 'Which day?' }),
+          event('turn_processing_completed', {}),
+          event('user_message', { text: 'Tomorrow.' }),
+          event('tool_call_started', { toolName: 'query_calendar_events' }),
+          event('tool_call_completed', { toolName: 'query_calendar_events' }),
+          event('clarification_requested', {
+            message: 'Which event?',
+            blockerReason: 'missing_required_details',
+            missingFields: ['event'],
+            candidateIntents: ['update_calendar_event'],
+          }),
+          event('assistant_message', { text: 'Which event?' }),
+          event('turn_processing_completed', {}),
+        ],
+        message: 'The Bagrowa event.',
+        currentDateTime: CURRENT_DATE_TIME,
+      });
+
+      expect(client.calls).toHaveLength(1);
+    });
+
+    it.each([
+      {
+        label: 'a prior user event with only inbound reply context',
+        events: [
+          event('user_message', {
+            text: false,
+            replyContext: {
+              replyToWamid: 'wamid-prior-email',
+              source: 'inbound_user_message',
+              text: 'marta@example.com',
+              truncated: false,
+            },
+          }),
+          event('clarification_requested', {
+            message: 'Which event?',
+            blockerReason: 'missing_required_details',
+            missingFields: ['event'],
+            candidateIntents: ['update_calendar_event'],
+          }),
+          event('assistant_message', { text: 'Which event?' }),
+        ],
+      },
+      {
+        label: 'a prior user event without usable text',
+        events: [
+          event('user_message', { text: false }),
+          event('clarification_requested', {
+            message: 'Which event?',
+            blockerReason: 'missing_required_details',
+            missingFields: ['event'],
+            candidateIntents: ['update_calendar_event'],
+          }),
+          event('assistant_message', { text: 'Which event?' }),
+        ],
+      },
+      {
+        label: 'an earlier clarification for a different intent',
+        events: [
+          event('user_message', {
+            text: 'Invite Marta (marta@example.com) to an existing event.',
+          }),
+          event('clarification_requested', {
+            message: 'What note?',
+            blockerReason: 'missing_required_details',
+            missingFields: ['content'],
+            candidateIntents: ['create_note'],
+          }),
+          event('assistant_message', { text: 'What note?' }),
+          event('user_message', { text: 'Tomorrow.' }),
+          event('clarification_requested', {
+            message: 'Which event?',
+            blockerReason: 'missing_required_details',
+            missingFields: ['event'],
+            candidateIntents: ['update_calendar_event'],
+          }),
+          event('assistant_message', { text: 'Which event?' }),
+        ],
+      },
+      {
+        label: 'a non-query tool boundary before the active clarification',
+        events: [
+          event('user_message', {
+            text: 'Invite Marta (marta@example.com) to an existing event.',
+          }),
+          event('tool_call_completed', { toolName: 'create_note' }),
+          event('clarification_requested', {
+            message: 'Which event?',
+            blockerReason: 'missing_required_details',
+            missingFields: ['event'],
+            candidateIntents: ['update_calendar_event'],
+          }),
+          event('assistant_message', { text: 'Which event?' }),
+        ],
+      },
+      {
+        label: 'a confirmation boundary between clarification turns',
+        events: [
+          event('user_message', {
+            text: 'Invite Marta (marta@example.com) to an existing event.',
+          }),
+          event('confirmation_requested', { toolName: 'update_calendar_event' }),
+          event('user_message', { text: 'Tomorrow.' }),
+          event('clarification_requested', {
+            message: 'Which event?',
+            blockerReason: 'missing_required_details',
+            missingFields: ['event'],
+            candidateIntents: ['update_calendar_event'],
+          }),
+          event('assistant_message', { text: 'Which event?' }),
+        ],
+      },
+    ])('does not inherit an email across $label', async ({ events }) => {
+      const client = new FakeToolCallingClient([]);
+      const runner = createIntexAgentRunner({
+        client,
+        intentClassifier: toolIntentClassifier(['update_calendar_event']),
+        toolExecutor: fakeToolExecutor(),
+      });
+
+      await expect(
+        runner.run({
+          session: session(),
+          events,
+          message: 'The Bagrowa event tomorrow.',
+          currentDateTime: CURRENT_DATE_TIME,
+        })
+      ).resolves.toMatchObject({
+        outcome: 'needs_clarification',
+        missingFields: ['attendeeEmail'],
+      });
+      expect(client.calls).toHaveLength(0);
+    });
+
+    it.each([
+      {
+        label: 'a non-update clarification',
+        events: [
+          event('clarification_requested', {
+            message: 'What note?',
+            blockerReason: 'missing_required_details',
+            missingFields: ['content'],
+            candidateIntents: ['create_note'],
+          }),
+          event('assistant_message', { text: 'What note?' }),
+        ],
+      },
+      {
+        label: 'a trailing user-message boundary',
+        events: [event('user_message', { text: 'Old unrelated request.' })],
+      },
+    ])('does not open an attendee chain through $label', async ({ events }) => {
+      const client = new FakeToolCallingClient([]);
+      const runner = createIntexAgentRunner({
+        client,
+        intentClassifier: toolIntentClassifier(['update_calendar_event']),
+        toolExecutor: fakeToolExecutor(),
+      });
+
+      await expect(
+        runner.run({
+          session: session(),
+          events,
+          message: 'Invite Marta to the existing Bagrowa event tomorrow.',
+          currentDateTime: CURRENT_DATE_TIME,
+        })
+      ).resolves.toMatchObject({
+        outcome: 'needs_clarification',
+        missingFields: ['attendeeEmail'],
+      });
+      expect(client.calls).toHaveLength(0);
+    });
+
+    it('does not carry a stale email across a confirmation boundary', async () => {
+      const client = new FakeToolCallingClient([]);
+      const runner = createIntexAgentRunner({
+        client,
+        intentClassifier: toolIntentClassifier(['update_calendar_event']),
+        toolExecutor: fakeToolExecutor(),
+      });
+
+      await expect(
+        runner.run({
+          session: session(),
+          events: [
+            event('user_message', {
+              text: 'Invite Marta (old-marta@example.com) to an existing event.',
+            }),
+            event('clarification_requested', {
+              message: 'Which event?',
+              blockerReason: 'missing_required_details',
+              missingFields: ['event'],
+              candidateIntents: ['update_calendar_event'],
+            }),
+            event('assistant_message', { text: 'Which event?' }),
+            event('confirmation_requested', {
+              toolName: 'update_calendar_event',
+              toolArgs: {},
+            }),
+            event('assistant_message', { text: 'Confirm this update.' }),
+          ],
+          message: 'Invite Anna to the existing Dentist event tomorrow.',
+          currentDateTime: CURRENT_DATE_TIME,
+        })
+      ).resolves.toMatchObject({
+        outcome: 'needs_clarification',
+        missingFields: ['attendeeEmail'],
+      });
+      expect(client.calls).toHaveLength(0);
+    });
+
+    it.each([
+      {
+        label: 'a rendered preference block',
+        userPreferences:
+          'User Preferences v1:\n1. (id: pref_jakub) "When I ask to invite Jakub, invite jakub@example.com."\nUse expectedVersion 1 for preference mutation tools.',
+      },
+      {
+        label: 'a Matrix prompt-context envelope',
+        userPreferences: JSON.stringify({
+          version: 1,
+          userPreferences:
+            'User Preferences v1:\n1. (id: pref_jakub) "Invite Jakub via jakub@example.com."',
+        }),
+      },
+      {
+        label: 'the documented event-specific mapping form',
+        userPreferences:
+          'User Preferences v1:\n1. (id: pref_jakub) "When I ask to invite Jakub to an event, invite jakub@example.com."',
+      },
+      {
+        label: 'the documented compact mapping form',
+        userPreferences:
+          'User Preferences v1:\n1. (id: pref_jakub) "When I invite Jakub, use jakub@example.com."',
+      },
+    ])('uses one unambiguous matching person-to-email mapping from $label', async ({ userPreferences }) => {
+      const client = new FakeToolCallingClient([passThroughResult]);
+      const runner = createIntexAgentRunner({
+        client,
+        intentClassifier: toolIntentClassifier(['update_calendar_event']),
+        toolExecutor: fakeToolExecutor(),
+        userPreferences,
+      });
+
+      await runner.run({
+        session: session(),
+        events: [],
+        message: 'Invite Jakub to the existing Bagrowa event tomorrow.',
+        currentDateTime: CURRENT_DATE_TIME,
+      });
+
+      expect(client.calls).toHaveLength(1);
+    });
+
+    it.each([
+      {
+        label: 'conflicting mappings',
+        rows: [
+          '1. (id: pref_jakub_1) "When I invite Jakub, use jakub.one@example.com."',
+          '2. (id: pref_jakub_2) "Invite Jakub via jakub.two@example.com."',
+        ],
+      },
+      {
+        label: 'multiple emails in one mapping',
+        rows: [
+          '1. (id: pref_jakub) "Invite Jakub via jakub.one@example.com and jakub.two@example.com."',
+        ],
+      },
+      {
+        label: 'a generic attendee label',
+        rows: ['1. (id: pref_generic) "Invite the attendee via generic@example.com."'],
+      },
+      {
+        label: 'a generic guest label',
+        rows: ['1. (id: pref_generic) "Invite my guest via generic@example.com."'],
+      },
+      {
+        label: 'one mapping for multiple named attendees',
+        rows: ['1. (id: pref_jakub) "Invite Jakub via jakub@example.com."'],
+        message: 'Invite Jakub and Anna to the existing Bagrowa event tomorrow.',
+      },
+      {
+        label: 'a mapping rejected by the calendar email contract',
+        rows: ['1. (id: pref_jakub) "Invite Jakub via john..doe@example.com."'],
+      },
+      {
+        label: 'a non-string canonical row payload',
+        rows: ['1. (id: pref_jakub) 123'],
+      },
+      {
+        label: 'an overlong person label',
+        rows: [
+          '1. (id: pref_long) "Invite One Two Three Four Five Six Seven via long@example.com."',
+        ],
+      },
+      {
+        label: 'a person label longer than the requested identity',
+        rows: ['1. (id: pref_jakub) "Invite Jakub Nowak via jakub@example.com."'],
+      },
+      {
+        label: 'an invalid address as the only attendee object',
+        rows: ['1. (id: pref_jakub) "Invite Jakub via jakub@example.com."'],
+        message: 'Invite john..doe@example.com to the existing Bagrowa event tomorrow.',
+      },
+    ])('asks for an email when saved preferences contain $label', async ({ rows, ...testCase }) => {
+      const client = new FakeToolCallingClient([]);
+      const runner = createIntexAgentRunner({
+        client,
+        intentClassifier: toolIntentClassifier(['update_calendar_event']),
+        toolExecutor: fakeToolExecutor(),
+        userPreferences: ['User Preferences v2:', ...rows].join('\n'),
+      });
+
+      await expect(
+        runner.run({
+          session: session(),
+          events: [],
+          message:
+            'message' in testCase
+              ? testCase.message
+              : 'Invite Jakub to the existing Bagrowa event tomorrow.',
+          currentDateTime: CURRENT_DATE_TIME,
+        })
+      ).resolves.toMatchObject({
+        outcome: 'needs_clarification',
+        missingFields: ['attendeeEmail'],
+      });
+      expect(client.calls).toHaveLength(0);
+    });
+
+    it('ignores a non-canonical Matrix preference envelope', async () => {
+      const client = new FakeToolCallingClient([]);
+      const runner = createIntexAgentRunner({
+        client,
+        intentClassifier: toolIntentClassifier(['update_calendar_event']),
+        toolExecutor: fakeToolExecutor(),
+        userPreferences: JSON.stringify({
+          version: 1,
+          userPreferences:
+            'User Preferences v1:\n1. (id: pref_jakub) "Invite Jakub via jakub@example.com."',
+          extra: true,
+        }),
+      });
+
+      await expect(
+        runner.run({
+          session: session(),
+          events: [],
+          message: 'Invite Jakub to the existing Bagrowa event tomorrow.',
+          currentDateTime: CURRENT_DATE_TIME,
+        })
+      ).resolves.toMatchObject({
+        outcome: 'needs_clarification',
+        missingFields: ['attendeeEmail'],
+      });
+      expect(client.calls).toHaveLength(0);
+    });
+
+    it('preserves a genuinely ambiguous classifier result', async () => {
+      const client = new FakeToolCallingClient([]);
+      const runner = createIntexAgentRunner({
+        client,
+        intentClassifier: {
+          async classify() {
+            return {
+              kind: 'needs_clarification' as const,
+              question: 'Should I update the event or save a note?',
+              blockerReason: 'multiple_possible_intents' as const,
+              candidateIntents: ['update_calendar_event' as const, 'create_note' as const],
+            };
+          },
+        },
+        toolExecutor: fakeToolExecutor(),
+      });
+
+      await expect(
+        runner.run({
+          session: session(),
+          events: [],
+          message: 'Add Marta to Bagrowa and remember it.',
+          currentDateTime: CURRENT_DATE_TIME,
+        })
+      ).resolves.toEqual({
+        outcome: 'needs_clarification',
+        reply: 'Should I update the event or save a note?',
+        blockerReason: 'multiple_possible_intents',
+        candidateIntents: ['update_calendar_event', 'create_note'],
+      });
+      expect(client.calls).toHaveLength(0);
+    });
+  });
+
   it.each(['id', 'eventId'] as const)(
     'queries an existing event before preparing an attendee-update confirmation with %s identity',
     async (eventIdentityField) => {
@@ -6539,7 +7392,7 @@ describe('createIntexAgentRunner', () => {
     const preview = await runner.run({
       session: session(),
       events: [],
-      message: 'Zaproś Patryka na Bagrową jutro.',
+      message: 'Zaproś Patryka (patryk@example.com) na Bagrową jutro.',
       currentDateTime: CURRENT_DATE_TIME,
       timeZone: 'Europe/Warsaw',
     });
@@ -6643,7 +7496,7 @@ describe('createIntexAgentRunner', () => {
     const result = await runner.run({
       session: session(),
       events: [],
-      message: 'Zaproś Patryka na Bagrową.',
+      message: 'Zaproś Patryka (patryk@example.com) na Bagrową.',
       currentDateTime: CURRENT_DATE_TIME,
       timeZone: 'Europe/Warsaw',
     });
@@ -7013,7 +7866,7 @@ describe('createIntexAgentRunner', () => {
       runner.run({
         session: session(),
         events: [],
-        message: 'Zaproś Patryka na Bagrową.',
+        message: 'Zaproś Patryka (patryk@example.com) na Bagrową.',
         currentDateTime: CURRENT_DATE_TIME,
         timeZone: 'Europe/Warsaw',
       })
@@ -7098,7 +7951,7 @@ describe('createIntexAgentRunner', () => {
       runner.run({
         session: session(),
         events: [],
-        message: 'Zaproś Patryka na Bagrową.',
+        message: 'Zaproś Patryka (patryk@example.com) na Bagrową.',
         currentDateTime: CURRENT_DATE_TIME,
         timeZone: 'Europe/Warsaw',
       })
@@ -7110,12 +7963,12 @@ describe('createIntexAgentRunner', () => {
 
   it.each([
     {
-      message: 'Zaproś Patryka na Bagrową.',
+      message: 'Zaproś Patryka (patryk@example.com) na Bagrową.',
       expectedStart: 'Początek: 25 czerwca 2026',
       expectedEnd: 'Koniec: 26 czerwca 2026',
     },
     {
-      message: 'Invite Patryk to the Bagrowa event.',
+      message: 'Invite Patryk (patryk@example.com) to the Bagrowa event.',
       expectedStart: 'Start: 25 June 2026',
       expectedEnd: 'End: 26 June 2026',
     },
@@ -7335,7 +8188,7 @@ describe('createIntexAgentRunner', () => {
       runner.run({
         session: session(),
         events: [],
-        message: 'Zaproś Patryka na Bagrową.',
+        message: 'Zaproś Patryka (patryk@example.com) na Bagrową.',
         currentDateTime: CURRENT_DATE_TIME,
         timeZone: 'Europe/Warsaw',
       })
@@ -7395,7 +8248,7 @@ describe('createIntexAgentRunner', () => {
       runner.run({
         session: session(),
         events: [],
-        message: 'Zaproś Patryka na Bagrową.',
+        message: 'Zaproś Patryka (patryk@example.com) na Bagrową.',
         currentDateTime: CURRENT_DATE_TIME,
         timeZone: 'Europe/Warsaw',
       })
@@ -7455,7 +8308,7 @@ describe('createIntexAgentRunner', () => {
       runner.run({
         session: session(),
         events: [],
-        message: 'Zaproś Patryka na Bagrową.',
+        message: 'Zaproś Patryka (patryk@example.com) na Bagrową.',
         currentDateTime: CURRENT_DATE_TIME,
         timeZone: 'Europe/Warsaw',
       })

--- a/apps/intex-agent/src/domain/agent/intexAgentRunner.ts
+++ b/apps/intex-agent/src/domain/agent/intexAgentRunner.ts
@@ -1,5 +1,8 @@
 import { getErrorMessage } from '@intexuraos/common-core';
-import { WHATSAPP_INTERACTIVE_BODY_MAX_LENGTH } from '@intexuraos/http-contracts';
+import {
+  calendarUpdateEventAttendeesRequestSchema,
+  WHATSAPP_INTERACTIVE_BODY_MAX_LENGTH,
+} from '@intexuraos/http-contracts';
 import type {
   MatrixCorpusProviderCallUsageV1,
   ToolCallingClient,
@@ -322,6 +325,16 @@ const CALENDAR_UPDATE_LOOKUP_NEXT_STEPS: LocalizedText = {
   pl: 'Wskaż dokładnie jedno istniejące wydarzenie.',
 };
 
+const CALENDAR_UPDATE_EMAIL_CLARIFICATION_REPLIES: LocalizedText = {
+  en: "What is the attendee's email address?",
+  pl: 'Jaki jest adres e-mail uczestnika?',
+};
+
+const CALENDAR_UPDATE_EMAIL_CLARIFICATION_NEXT_STEPS: LocalizedText = {
+  en: 'Provide the attendee email address.',
+  pl: 'Podaj adres e-mail uczestnika.',
+};
+
 const CONFIRMATION_LABELS = {
   title: { en: 'Title', pl: 'Tytuł' },
   content: { en: 'Content', pl: 'Treść' },
@@ -535,11 +548,18 @@ export function createIntexAgentRunner(config: IntexAgentRunnerConfig): IntexAge
         events: input.events,
         replyContext: input.replyContext,
       });
-      const intent = applyMissingCalendarDateClarification(queryNormalizedIntent, {
+      const dateNormalizedIntent = applyMissingCalendarDateClarification(queryNormalizedIntent, {
         message: input.message,
         events: input.events,
         replyContext: input.replyContext,
         replyLanguage: replyLanguageForIntent(queryNormalizedIntent, detectedReplyLanguage),
+      });
+      const intent = applyMissingCalendarAttendeeEmailClarification(dateNormalizedIntent, {
+        message: input.message,
+        events: input.events,
+        replyContext: input.replyContext,
+        replyLanguage: replyLanguageForIntent(dateNormalizedIntent, detectedReplyLanguage),
+        userPreferences: config.userPreferences ?? null,
       });
       const replyLanguage = replyLanguageForIntent(intent, detectedReplyLanguage);
       if (intent.kind === 'unsupported') {
@@ -1075,6 +1095,406 @@ function applyDerivedCalendarQueryContext(
     ...(intent.languageOverride !== undefined ? { languageOverride: intent.languageOverride } : {}),
     ...(intent.decisionEvidence !== undefined ? { decisionEvidence: intent.decisionEvidence } : {}),
   };
+}
+
+function applyMissingCalendarAttendeeEmailClarification(
+  intent: IntexAgentIntentClassification,
+  context: Readonly<{
+    message: string;
+    events: readonly IntexAgentSessionEvent[];
+    replyContext: IntexIncomingMessageReplyContext | undefined;
+    replyLanguage: IntexAgentReplyLanguage;
+    userPreferences: string | null;
+  }>
+): IntexAgentIntentClassification {
+  const isUpdateToolIntent =
+    intent.kind === 'tool' && intent.allowedToolNames.includes('update_calendar_event');
+  const isSingleUpdateClarification =
+    intent.kind === 'needs_clarification' &&
+    intent.blockerReason === 'missing_required_details' &&
+    intent.candidateIntents?.length === 1 &&
+    intent.candidateIntents[0] === 'update_calendar_event';
+
+  if (!isUpdateToolIntent && !isSingleUpdateClarification) {
+    return intent;
+  }
+
+  if (hasCalendarAttendeeEmailContext(context)) {
+    return isSingleUpdateClarification &&
+      isAnsweringActiveCalendarAttendeeEmailClarification(context)
+      ? clarificationToToolIntent(intent, 'update_calendar_event')
+      : intent;
+  }
+
+  return {
+    kind: 'needs_clarification',
+    question: CALENDAR_UPDATE_EMAIL_CLARIFICATION_REPLIES[context.replyLanguage],
+    blockerReason: 'missing_required_details',
+    missingFields: ['attendeeEmail'],
+    candidateIntents: ['update_calendar_event'],
+    suggestedNextStep: CALENDAR_UPDATE_EMAIL_CLARIFICATION_NEXT_STEPS[context.replyLanguage],
+    ...(intent.stylePreferenceAction !== undefined
+      ? { stylePreferenceAction: intent.stylePreferenceAction }
+      : {}),
+    ...(intent.languageOverride !== undefined ? { languageOverride: intent.languageOverride } : {}),
+    ...(intent.decisionEvidence !== undefined ? { decisionEvidence: intent.decisionEvidence } : {}),
+  };
+}
+
+function hasCalendarAttendeeEmailContext(
+  context: Readonly<{
+    message: string;
+    events: readonly IntexAgentSessionEvent[];
+    replyContext: IntexIncomingMessageReplyContext | undefined;
+    userPreferences: string | null;
+  }>
+): boolean {
+  const userTurns = activeCalendarAttendeeUserTurns(context);
+  const attendeeTurnIndex = userTurns.findIndex((turn) =>
+    turn.some((text) => extractCalendarAttendeeSegments(text).length > 0)
+  );
+  const relevantTurns =
+    attendeeTurnIndex === -1 ? userTurns.slice(0, 1) : userTurns.slice(0, attendeeTurnIndex + 1);
+  const relevantTexts = relevantTurns.flat();
+  if (
+    relevantTexts
+      .flatMap(extractCalendarAttendeeSegments)
+      .some(isAmbiguousCalendarAttendeeSegment)
+  ) {
+    return false;
+  }
+  return (
+    relevantTexts.some(containsAssociatedAttendeeEmailSignal) ||
+    hasUnambiguousMatchingAttendeeEmailPreference(context.userPreferences, relevantTexts)
+  );
+}
+
+function isAnsweringActiveCalendarAttendeeEmailClarification(
+  context: Readonly<{
+    message: string;
+    events: readonly IntexAgentSessionEvent[];
+    replyContext: IntexIncomingMessageReplyContext | undefined;
+  }>
+): boolean {
+  const activeClarification = findActiveCalendarAttendeeClarification(context.events);
+  const missingFields = activeClarification?.event.payload['missingFields'];
+  if (!Array.isArray(missingFields) || !missingFields.includes('attendeeEmail')) return false;
+
+  return [
+    context.message,
+    ...(context.replyContext?.source === 'inbound_user_message' ? [context.replyContext.text] : []),
+  ].some(containsAssociatedAttendeeEmailSignal);
+}
+
+function activeCalendarAttendeeUserTurns(
+  context: Readonly<{
+    message: string;
+    events: readonly IntexAgentSessionEvent[];
+    replyContext: IntexIncomingMessageReplyContext | undefined;
+  }>
+): string[][] {
+  const currentTurn = [context.message];
+  if (context.replyContext?.source === 'inbound_user_message') {
+    currentTurn.push(context.replyContext.text);
+  }
+  const turns = [currentTurn];
+
+  const activeClarification = findActiveCalendarAttendeeClarification(context.events);
+  if (activeClarification === undefined) return turns;
+
+  let expectsUserMessage = true;
+
+  for (let index = activeClarification.index - 1; index >= 0; index -= 1) {
+    const event = context.events[index];
+    /* v8 ignore start -- ts-type: noUncheckedIndexedAccess requires a fallback despite the bounded array index @preserve */
+    if (event === undefined) continue;
+    /* v8 ignore stop @preserve */
+
+    if (expectsUserMessage) {
+      if (event.type === 'user_message') {
+        const turn: string[] = [];
+        const priorMessage = event.payload['text'];
+        if (typeof priorMessage === 'string') turn.push(priorMessage);
+        const priorReplyContext = parseIncomingReplyContext(event.payload['replyContext']);
+        if (priorReplyContext?.source === 'inbound_user_message') {
+          turn.push(priorReplyContext.text);
+        }
+        if (turn.length > 0) turns.push(turn);
+        expectsUserMessage = false;
+        continue;
+      }
+      if (isCalendarAttendeeClarificationBridgeEvent(event)) continue;
+      break;
+    }
+
+    if (event.type === 'clarification_requested') {
+      if (!isCalendarAttendeeUpdateClarification(event)) break;
+      expectsUserMessage = true;
+      continue;
+    }
+    if (isCalendarAttendeeClarificationBridgeEvent(event)) continue;
+    break;
+  }
+
+  return turns;
+}
+
+function findActiveCalendarAttendeeClarification(
+  events: readonly IntexAgentSessionEvent[]
+): Readonly<{ event: IntexAgentSessionEvent; index: number }> | undefined {
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const event = events[index];
+    /* v8 ignore start -- ts-type: noUncheckedIndexedAccess requires a fallback despite the bounded array index @preserve */
+    if (event === undefined) continue;
+    /* v8 ignore stop @preserve */
+    if (event.type === 'clarification_requested') {
+      return isCalendarAttendeeUpdateClarification(event) ? { event, index } : undefined;
+    }
+    if (event.type === 'user_message') return undefined;
+    if (!isCalendarAttendeeClarificationTrailEvent(event)) return undefined;
+  }
+
+  return undefined;
+}
+
+function isCalendarAttendeeUpdateClarification(event: IntexAgentSessionEvent): boolean {
+  const candidateIntents = event.payload['candidateIntents'];
+  return (
+    event.payload['blockerReason'] === 'missing_required_details' &&
+    Array.isArray(candidateIntents) &&
+    candidateIntents.length === 1 &&
+    candidateIntents[0] === 'update_calendar_event'
+  );
+}
+
+function isCalendarAttendeeClarificationTrailEvent(event: IntexAgentSessionEvent): boolean {
+  return (
+    event.type === 'assistant_message' ||
+    event.type === 'agent_fallback' ||
+    event.type === 'llm_call_usage' ||
+    event.type === 'llm_usage_summary' ||
+    event.type === 'turn_processing_completed' ||
+    event.type === 'matrix_corpus_execution_boundary'
+  );
+}
+
+function isCalendarAttendeeClarificationBridgeEvent(event: IntexAgentSessionEvent): boolean {
+  return (
+    isCalendarAttendeeClarificationTrailEvent(event) ||
+    ((event.type === 'tool_call_started' || event.type === 'tool_call_completed') &&
+      event.payload['toolName'] === 'query_calendar_events')
+  );
+}
+
+function hasUnambiguousMatchingAttendeeEmailPreference(
+  userPreferences: string | null,
+  userTexts: readonly string[]
+): boolean {
+  const attendeeObjects = userTexts.flatMap(extractCalendarAttendeeObjects);
+  if (attendeeObjects.length === 0) return false;
+
+  const matchingEmails = new Set<string>();
+  for (const preferenceText of parseCanonicalPreferenceTexts(userPreferences)) {
+    const parsedMapping = parseAttendeeEmailPreference(preferenceText);
+    if (parsedMapping === undefined) {
+      if (
+        extractAttendeeEmailCandidates(preferenceText).length > 0 &&
+        attendeeObjects.some((attendee) => sharesPersonToken(attendee, preferenceText))
+      ) {
+        return false;
+      }
+      continue;
+    }
+    if (!attendeeObjects.some((attendee) => isExactPersonLabelMatch(attendee, parsedMapping.person))) {
+      continue;
+    }
+    if (parsedMapping.email === null) return false;
+    matchingEmails.add(parsedMapping.email);
+  }
+
+  return matchingEmails.size === 1;
+}
+
+function parseCanonicalPreferenceTexts(userPreferences: string | null): string[] {
+  const rendered = unwrapRenderedUserPreferences(userPreferences);
+  if (rendered === null) return [];
+
+  return rendered.split('\n').flatMap((line) => {
+    const match = /^\d+\.\s+\(id:\s+[^)]+\)\s+(.+)$/u.exec(line);
+    if (match?.[1] === undefined) return [];
+    try {
+      const decoded: unknown = JSON.parse(match[1]);
+      return typeof decoded === 'string' ? [decoded] : [];
+    } catch {
+      return [];
+    }
+  });
+}
+
+function unwrapRenderedUserPreferences(userPreferences: string | null): string | null {
+  if (userPreferences === null) return null;
+  const normalized = userPreferences.trim();
+  if (!normalized.startsWith('{')) return normalized;
+
+  try {
+    const envelope: unknown = JSON.parse(normalized);
+    return isMatrixPromptContextEnvelope(envelope) ? envelope.userPreferences : null;
+  } catch {
+    return null;
+  }
+}
+
+function parseAttendeeEmailPreference(
+  preferenceText: string
+): Readonly<{ person: string; email: string | null }> | undefined {
+  const emailCandidates = extractAttendeeEmailCandidates(preferenceText);
+  const validEmails = emailCandidates.filter(isValidCalendarAttendeeEmail);
+  const normalized = normalizePreferenceMappingText(preferenceText, emailCandidates);
+  const person =
+    /^(?:when i ask to invite|when i invite)\s+(.+?)(?:\s+to an event)?\s*,\s*(?:invite|use)\s+__email__\.?$/u.exec(
+      normalized
+    )?.[1] ?? /^invite\s+(.+?)\s+via\s+__email__\.?$/u.exec(normalized)?.[1];
+  if (person === undefined || !isSpecificPersonLabel(person)) return undefined;
+  const soleValidEmail = validEmails.length === 1 ? validEmails[0] : undefined;
+  return {
+    person,
+    email:
+      emailCandidates.length === 1 && soleValidEmail !== undefined
+        ? soleValidEmail.toLocaleLowerCase('en-US')
+        : null,
+  };
+}
+
+function normalizePreferenceMappingText(preferenceText: string, emails: readonly string[]): string {
+  let normalized = preferenceText.normalize('NFKC').toLocaleLowerCase('en-US');
+  for (const email of emails) {
+    normalized = normalized.replace(email.toLocaleLowerCase('en-US'), '__email__');
+  }
+  return normalized.trim().replace(/\s+/gu, ' ');
+}
+
+function extractCalendarAttendeeObjects(message: string): string[] {
+  return extractCalendarAttendeeSegments(message).flatMap((segment) => {
+    let withoutEmails = segment;
+    for (const email of extractAttendeeEmailCandidates(segment)) {
+      withoutEmails = withoutEmails.replace(email, ' ');
+    }
+    return isSpecificPersonLabel(withoutEmails) ? [withoutEmails] : [];
+  });
+}
+
+function extractCalendarAttendeeSegments(message: string): string[] {
+  const patterns = [
+    /\b(?:invite|add)\s+(.+?)\s+(?:to|into)\b/giu,
+    /\b(?:zaproś|zapros|dodaj)\s+(.+?)\s+(?:do|na)\b/giu,
+  ];
+  return patterns.flatMap((pattern) =>
+    [...message.matchAll(pattern)].map((match) => match[1] as string)
+  );
+}
+
+function isSpecificPersonLabel(value: string): boolean {
+  const tokens = personTokens(value);
+  if (tokens.length === 0 || tokens.length > 6) return false;
+  const genericTokens = new Set([
+    'attendee',
+    'a',
+    'an',
+    'guest',
+    'her',
+    'him',
+    'my',
+    'participant',
+    'person',
+    'someone',
+    'the',
+    'this',
+    'them',
+    'uczestnik',
+    'uczestnika',
+    'uczestniczke',
+  ]);
+  return tokens.every((token) => token.length >= 2 && !genericTokens.has(token));
+}
+
+function isExactPersonLabelMatch(attendeeObject: string, person: string): boolean {
+  const attendeeTokens = personTokens(attendeeObject);
+  const personLabelTokens = personTokens(person);
+  if (personLabelTokens.length === 0 || personLabelTokens.length > attendeeTokens.length) return false;
+
+  return attendeeTokens.some((_token, startIndex) =>
+    personLabelTokens.every(
+      (personToken, offset) => attendeeTokens[startIndex + offset] === personToken
+    )
+  );
+}
+
+function sharesPersonToken(attendeeObject: string, preferenceText: string): boolean {
+  const attendeeTokens = personTokens(attendeeObject).filter((token) => token.length >= 3);
+  const preferenceTokens = new Set(personTokens(preferenceText));
+  return attendeeTokens.some((token) => preferenceTokens.has(token));
+}
+
+function personTokens(value: string): string[] {
+  return value
+    .normalize('NFKD')
+    .replace(/\p{M}/gu, '')
+    .toLocaleLowerCase('en-US')
+    .match(/[\p{L}\p{N}]+/gu) ?? [];
+}
+
+function containsAssociatedAttendeeEmailSignal(message: string): boolean {
+  const emails = extractAttendeeEmailCandidates(message).filter(isValidCalendarAttendeeEmail);
+  if (emails.length === 0) return false;
+  const attendeeSegmentsWithEmail = extractCalendarAttendeeSegments(message).filter((segment) =>
+    extractAttendeeEmailCandidates(segment).some(isValidCalendarAttendeeEmail)
+  );
+  if (
+    attendeeSegmentsWithEmail.some(
+      (segment) =>
+        extractAttendeeEmailCandidates(segment).filter(isValidCalendarAttendeeEmail).length !== 1
+    )
+  ) {
+    return false;
+  }
+  if (attendeeSegmentsWithEmail.length > 0) {
+    return true;
+  }
+  if (emails.length !== 1) return false;
+
+  let withoutEmails = message;
+  for (const email of emails) {
+    withoutEmails = withoutEmails.replace(email, ' ');
+  }
+  if (withoutEmails.replace(/[\s.,;:!?()[\]{}"'“”„-]+/gu, '') === '') return true;
+  return /\b(?:adres(?:\s+e-?mail)?|e-?mail|uses?|używa|uzywa)\b/iu.test(message);
+}
+
+function isAmbiguousCalendarAttendeeSegment(segment: string): boolean {
+  let withoutEmails = segment;
+  for (const email of extractAttendeeEmailCandidates(segment)) {
+    withoutEmails = withoutEmails.replace(email, ' ');
+  }
+  return /\b(?:and|or|i|lub|oraz)\b|[,&;/]/iu.test(withoutEmails);
+}
+
+function extractAttendeeEmailCandidates(message: string): string[] {
+  return (
+    message
+      .normalize('NFKC')
+      .match(
+        /(?<![\p{L}\p{N}._%+-])[\p{L}\p{N}._%+-]+@[\p{L}\p{N}.-]+\.[\p{L}]{2,63}(?![\p{L}\p{N}_%+-]|\.[\p{L}\p{N}])/giu
+      ) ?? []
+  );
+}
+
+function isValidCalendarAttendeeEmail(email: string): boolean {
+  return calendarUpdateEventAttendeesRequestSchema.safeParse({
+    userId: 'intex-agent-email-precondition',
+    calendarId: 'primary',
+    expectedEtag: 'email-precondition',
+    attendeesToAdd: [{ email }],
+  }).success;
 }
 
 function applyMissingCalendarDateClarification(


### PR DESCRIPTION
## Summary
- ask for the attendee email deterministically before any calendar lookup or runner call
- accept only a valid email from the active attendee request chain or one unambiguous canonical person-to-email preference
- resume the update flow after an email-only clarification reply, while rejecting stale, unrelated, invalid, or ambiguous addresses

## Verification
- pnpm run ci
- 7,825 tests passed
- full coverage validation, build, format, and bundle budget passed
- independent P1/P2 review completed with no remaining findings