### PR TITLE
[INT-2041] fix(intex-agent): preserve language after email clarification

### DIFF
--- a/apps/intex-agent/src/__tests__/domain/capabilities.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/capabilities.test.ts
@@ -146,6 +146,49 @@ describe('Intex Agent capabilities replies', () => {
     ).toBe('en');
   });
 
+  it.each([
+    'marta@example.com',
+    'marta@example.com.',
+    'Email: marta@example.com',
+    'Marta: marta@example.com',
+  ])('treats the single-email contact detail %s as language-neutral', (text) => {
+    expect(
+      selectIntexAgentReplyLanguage({
+        currentMessage: { text },
+        priorMessages: [{ text: 'Podaj proszę jej adres e-mail.' }],
+      })
+    ).toBe('pl');
+    expect(
+      selectIntexAgentReplyLanguage({
+        currentMessage: { text },
+        priorMessages: [{ text: 'Please provide her email address.' }],
+      })
+    ).toBe('en');
+  });
+
+  it.each([
+    ['Jej adres e-mail to marta@example.com.', 'Podaj jej dane.', 'pl'],
+    ['Adres e-mail Marty to marta@example.com.', 'Podaj jej dane.', 'pl'],
+    ['To jest adres e-mail Marty: marta@example.com.', 'Podaj jej dane.', 'pl'],
+    ['Adres mailowy Marty: marta@example.com.', 'Podaj jej dane.', 'pl'],
+    ['Her email address is marta@example.com.', 'Please provide her details.', 'en'],
+    [
+      'Please reply in English. Her email address is marta@example.com.',
+      'Podaj proszę jej dane.',
+      'en',
+    ],
+  ] as const)(
+    'classifies an explicit email sentence in its own language: %s',
+    (text, priorText, expectedLanguage) => {
+      expect(
+        selectIntexAgentReplyLanguage({
+          currentMessage: { text },
+          priorMessages: [{ text: priorText }],
+        })
+      ).toBe(expectedLanguage);
+    }
+  );
+
   it('uses deterministic button language hints without classifying plain short text', () => {
     expect(
       selectIntexAgentReplyLanguage({

--- a/apps/intex-agent/src/__tests__/domain/intexAgentRunner.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/intexAgentRunner.test.ts
@@ -6763,6 +6763,106 @@ describe('createIntexAgentRunner', () => {
       expect(client.calls).toHaveLength(1);
     });
 
+    it('keeps a Polish attendee-update confirmation after a short email follow-up', async () => {
+      const eventSummary = 'INTEX-WA-E2E-ATTENDEE-20260810-B7G4';
+      const client = new ToolExecutingFakeToolCallingClient(
+        [
+          {
+            toolName: 'query_calendar_events',
+            args: {
+              mode: 'list',
+              timeMin: '2026-08-11T00:00:00+02:00',
+              timeMax: '2026-08-12T00:00:00+02:00',
+              query: eventSummary,
+            },
+          },
+          {
+            toolName: 'update_calendar_event',
+            args: {
+              eventId: 'event-b7g4',
+              eventSummary,
+              attendeesToAdd: ['marta.intex-eval-008@example.com'],
+            },
+          },
+        ],
+        [
+          ok(
+            toolResult({
+              outcome: 'completed',
+              reply: 'Ready.',
+              toolName: 'update_calendar_event',
+            })
+          ),
+        ]
+      );
+      const runner = createIntexAgentRunner({
+        client,
+        intentClassifier: {
+          async classify() {
+            return {
+              kind: 'needs_clarification' as const,
+              question: 'Które wydarzenie masz na myśli?',
+              blockerReason: 'missing_required_details' as const,
+              missingFields: ['event'],
+              candidateIntents: ['update_calendar_event' as const],
+            };
+          },
+        },
+        toolExecutor: fakeToolExecutor({
+          queryCalendarEvents: async () =>
+            JSON.stringify({
+              status: 'completed',
+              mode: 'list',
+              count: 1,
+              truncated: false,
+              events: [
+                {
+                  id: 'event-b7g4',
+                  etag: '"event-b7g4-v1"',
+                  summary: eventSummary,
+                  calendarId: 'primary',
+                  start: { dateTime: '2026-08-11T16:30:00+02:00' },
+                  end: { dateTime: '2026-08-11T17:30:00+02:00' },
+                },
+              ],
+            }),
+        }),
+      });
+
+      const result = await runner.run({
+        session: session(),
+        events: [
+          event('user_message', {
+            text: `Zaproś Martę Testową B7G4 do istniejącego wydarzenia „${eventSummary}” 11 sierpnia 2026 o 16:30.`,
+          }),
+          event('clarification_requested', {
+            message: 'Jaki jest adres e-mail uczestnika?',
+            blockerReason: 'missing_required_details',
+            missingFields: ['attendeeEmail'],
+            candidateIntents: ['update_calendar_event'],
+          }),
+          event('assistant_message', { text: 'Jaki jest adres e-mail uczestnika?' }),
+        ],
+        message: 'Jej adres e-mail to marta.intex-eval-008@example.com.',
+        currentDateTime: CURRENT_DATE_TIME,
+        timeZone: 'Europe/Warsaw',
+      });
+
+      expect(result).toMatchObject({
+        outcome: 'needs_confirmation',
+        reply: [
+          'Czy dodać uczestników do istniejącego wydarzenia w kalendarzu?',
+          '',
+          `Tytuł: ${eventSummary}`,
+          'Początek: 11 sierpnia 2026, 16:30',
+          'Koniec: 11 sierpnia 2026, 17:30',
+          'Uczestnicy: marta.intex-eval-008@example.com',
+          'Pozostałe dane wydarzenia pozostaną bez zmian.',
+        ].join('\n'),
+        toolName: 'update_calendar_event',
+      });
+    });
+
     it('continues when an inbound user quote answers the active attendee clarification', async () => {
       const client = new FakeToolCallingClient([passThroughResult]);
       const runner = createIntexAgentRunner({

--- a/apps/intex-agent/src/domain/agent/capabilities.ts
+++ b/apps/intex-agent/src/domain/agent/capabilities.ts
@@ -52,6 +52,9 @@ const GREETING_REPLIES: Record<IntexAgentReplyLanguage, string> = {
   pl: 'Cześć! U mnie wszystko w porządku. W czym mogę pomóc?',
 };
 
+const EMAIL_ADDRESS_PATTERN =
+  /(?<![\p{Letter}\p{Number}._%+-])[\p{Letter}\p{Number}.!#$%&'*+/=?^_`{|}~-]+@[\p{Letter}\p{Number}](?:[\p{Letter}\p{Number}-]*[\p{Letter}\p{Number}])?(?:\.[\p{Letter}\p{Number}](?:[\p{Letter}\p{Number}-]*[\p{Letter}\p{Number}])?)+(?![\p{Letter}\p{Number}_%+-]|\.+[\p{Letter}\p{Number}])/giu;
+
 export function detectIntexAgentReplyLanguage(text: string): IntexAgentReplyLanguage {
   return isLikelyPolish(text) ? 'pl' : 'en';
 }
@@ -112,7 +115,7 @@ function isLikelyPolish(text: string): boolean {
     return true;
   }
 
-  return /\b(czy|jakie|jaki|jaka|mam|masz|mamy|mozesz|utworz|stworz|dodaj|zapisz|zapamietaj|wysl\w*|paragon\w*|firm\w*|rachun\w*|notatk\w*|kalendarz\w*|wydarzen\w*|spotkan\w*|termin\w*|woln\w*|dzisiaj|jutro|teraz|prosze|pomoc|preferencj\w*|brak|linku|dostal\w*|kup|bilet|koncert)\b/iu.test(
+  return /\b(czy|jakie|jaki|jaka|mam|masz|mamy|mozesz|utworz|stworz|dodaj|zapisz|zapamietaj|wysl\w*|adres\w*|paragon\w*|firm\w*|rachun\w*|notatk\w*|kalendarz\w*|wydarzen\w*|spotkan\w*|termin\w*|woln\w*|dzisiaj|jutro|teraz|prosze|pomoc|preferencj\w*|brak|linku|dostal\w*|kup|bilet|koncert)\b/iu.test(
     normalized
   );
 }
@@ -131,13 +134,17 @@ function classifyReasonableIntexAgentReplyLanguage(
   if (isBareLink(normalizedText) || isAttachmentOnlyMessage(message, normalizedText)) {
     return null;
   }
-  if (isTrivialGreeting(normalizedText) || isAmbiguousShortMessage(normalizedText)) {
+  const languageText = normalizedText.replace(EMAIL_ADDRESS_PATTERN, ' ').trim();
+  if (languageText === '') {
     return null;
   }
-  if (isLikelyPolish(normalizedText)) {
+  if (isTrivialGreeting(languageText) || isAmbiguousShortMessage(languageText)) {
+    return null;
+  }
+  if (isLikelyPolish(languageText)) {
     return 'pl';
   }
-  if (isLikelyEnglish(normalizedText)) {
+  if (isLikelyEnglish(languageText)) {
     return 'en';
   }
   return null;


### PR DESCRIPTION
## Summary
- treat a standalone or short contact-email reply as language-neutral so it inherits the active conversation language
- recognize common Polish address phrases before the generic English word-count fallback
- cover the exact WhatsApp attendee-update follow-up and confirmation copy end to end

## Verification
- full local CI: 7,836/7,836 tests passed
- typecheck, lint, static validation, coverage, build, and format passed
- independent final review: no P1/P2 findings