### PR TITLE
[INT-2042] fix(intex-agent): confirm unique calendar lookups

### DIFF
--- a/apps/intex-agent/src/__tests__/domain/intexAgentRunner.test.ts
+++ b/apps/intex-agent/src/__tests__/domain/intexAgentRunner.test.ts
@@ -6628,6 +6628,12 @@ describe('createIntexAgentRunner', () => {
           truncated: false,
         },
       },
+      {
+        label: 'the same address repeated with different casing',
+        message:
+          'Invite Jakub (jakub@example.com JAKUB@EXAMPLE.COM) to the existing Bagrowa event.',
+        replyContext: undefined,
+      },
     ])('accepts a valid attendee email from $label', async ({ message, replyContext }) => {
       const client = new FakeToolCallingClient([passThroughResult]);
       const runner = createIntexAgentRunner({
@@ -6721,6 +6727,156 @@ describe('createIntexAgentRunner', () => {
         outcome: 'needs_clarification',
         missingFields: ['attendeeEmail'],
       });
+      expect(client.calls).toHaveLength(0);
+    });
+
+    it('rejects conflicting attendee addresses between the request and an inbound quote', async () => {
+      const client = new FakeToolCallingClient([]);
+      const runner = createIntexAgentRunner({
+        client,
+        intentClassifier: toolIntentClassifier(['update_calendar_event']),
+        toolExecutor: fakeToolExecutor(),
+      });
+
+      await expect(
+        runner.run({
+          session: session(),
+          events: [],
+          message: 'Invite Jakub (jakub@example.com) to the existing Bagrowa event.',
+          replyContext: {
+            replyToWamid: 'wamid-conflicting-email',
+            source: 'inbound_user_message',
+            text: 'anna@example.com',
+            truncated: false,
+          },
+          currentDateTime: CURRENT_DATE_TIME,
+        })
+      ).resolves.toMatchObject({
+        outcome: 'needs_clarification',
+        missingFields: ['attendeeEmail'],
+      });
+      expect(client.calls).toHaveLength(0);
+    });
+
+    it('rejects a second active email outside the addressed attendee segment', async () => {
+      let queryCalls = 0;
+      const client = new FakeToolCallingClient([passThroughResult]);
+      const runner = createIntexAgentRunner({
+        client,
+        intentClassifier: toolIntentClassifier(['update_calendar_event']),
+        toolExecutor: fakeToolExecutor({
+          queryCalendarEvents: async () => {
+            queryCalls += 1;
+            return JSON.stringify(calendarUpdateLookupResult());
+          },
+        }),
+      });
+
+      await expect(
+        runner.run({
+          session: session(),
+          events: [],
+          message:
+            'Invite Jakub (jakub@example.com) to the existing Bagrowa event. Email: anna@example.com.',
+          currentDateTime: CURRENT_DATE_TIME,
+        })
+      ).resolves.toMatchObject({
+        outcome: 'needs_clarification',
+        missingFields: ['attendeeEmail'],
+        candidateIntents: ['update_calendar_event'],
+      });
+      expect(client.calls).toHaveLength(0);
+      expect(queryCalls).toBe(0);
+    });
+
+    it('accepts one addressed attendee segment as an active email-clarification answer', async () => {
+      const client = new FakeToolCallingClient([passThroughResult]);
+      const runner = createIntexAgentRunner({
+        client,
+        intentClassifier: {
+          async classify() {
+            return {
+              kind: 'needs_clarification' as const,
+              question: 'Which event?',
+              blockerReason: 'missing_required_details' as const,
+              missingFields: ['event'],
+              candidateIntents: ['update_calendar_event' as const],
+            };
+          },
+        },
+        toolExecutor: fakeToolExecutor(),
+      });
+
+      await runner.run({
+        session: session(),
+        events: [
+          event('user_message', {
+            text: 'Invite Jakub to the existing Bagrowa event.',
+          }),
+          event('clarification_requested', {
+            message: "What is the attendee's email address?",
+            blockerReason: 'missing_required_details',
+            missingFields: ['attendeeEmail'],
+            candidateIntents: ['update_calendar_event'],
+          }),
+          event('assistant_message', { text: "What is the attendee's email address?" }),
+        ],
+        message: 'Invite Jakub (jakub@example.com) to the existing Bagrowa event.',
+        currentDateTime: CURRENT_DATE_TIME,
+      });
+
+      expect(client.calls).toHaveLength(1);
+    });
+
+    it('rejects a quoted address when the active attendee segment contains multiple addresses', async () => {
+      const client = new FakeToolCallingClient([]);
+      const runner = createIntexAgentRunner({
+        client,
+        intentClassifier: {
+          async classify() {
+            return {
+              kind: 'needs_clarification' as const,
+              question: 'Which event?',
+              blockerReason: 'missing_required_details' as const,
+              missingFields: ['event'],
+              candidateIntents: ['update_calendar_event' as const],
+            };
+          },
+        },
+        toolExecutor: fakeToolExecutor(),
+      });
+
+      await expect(
+        runner.run({
+          session: session(),
+          events: [
+            event('user_message', {
+              text: 'Invite Jakub to the existing Bagrowa event.',
+            }),
+            event('clarification_requested', {
+              message: "What is the attendee's email address?",
+              blockerReason: 'missing_required_details',
+              missingFields: ['attendeeEmail'],
+              candidateIntents: ['update_calendar_event'],
+            }),
+            event('assistant_message', { text: "What is the attendee's email address?" }),
+          ],
+          message:
+            'Invite Jakub (jakub.one@example.com jakub.two@example.com) to the existing Bagrowa event.',
+          replyContext: {
+            replyToWamid: 'wamid-authoritative-email',
+            source: 'inbound_user_message',
+            text: 'jakub.confirmed@example.com',
+            truncated: false,
+          },
+          currentDateTime: CURRENT_DATE_TIME,
+        })
+      ).resolves.toMatchObject({
+        outcome: 'needs_clarification',
+        missingFields: ['attendeeEmail'],
+        candidateIntents: ['update_calendar_event'],
+      });
+
       expect(client.calls).toHaveLength(0);
     });
 
@@ -7202,7 +7358,7 @@ describe('createIntexAgentRunner', () => {
       expect(client.calls).toHaveLength(0);
     });
 
-    it('does not carry a stale email across a confirmation boundary', async () => {
+    it('does not carry a stale email across a rejected confirmation boundary', async () => {
       const client = new FakeToolCallingClient([]);
       const runner = createIntexAgentRunner({
         client,
@@ -7227,6 +7383,10 @@ describe('createIntexAgentRunner', () => {
             event('confirmation_requested', {
               toolName: 'update_calendar_event',
               toolArgs: {},
+            }),
+            event('confirmation_resolved', {
+              toolName: 'update_calendar_event',
+              accepted: false,
             }),
             event('assistant_message', { text: 'Confirm this update.' }),
           ],
@@ -7981,6 +8141,68 @@ describe('createIntexAgentRunner', () => {
     });
   });
 
+  it('uses the authoritative attendee email when the model proposes a different address', async () => {
+    const selectionGateCalls: {
+      toolName: IntexAgentToolName;
+      args: Record<string, unknown>;
+    }[] = [];
+    const client = new ToolExecutingFakeToolCallingClient(
+      [
+        { toolName: 'query_calendar_events', args: calendarUpdateQueryArgs() },
+        {
+          toolName: 'update_calendar_event',
+          args: {
+            eventId: 'event-bagrowa',
+            eventSummary: 'Bagrowa',
+            attendeesToAdd: ['someone-else@example.com'],
+          },
+        },
+      ],
+      [
+        ok(
+          toolResult({
+            outcome: 'completed',
+            reply: 'Ready.',
+            toolName: 'update_calendar_event',
+          })
+        ),
+      ]
+    );
+    const runner = createIntexAgentRunner({
+      client,
+      intentClassifier: toolIntentClassifier(['update_calendar_event']),
+      toolExecutor: fakeToolExecutor({
+        queryCalendarEvents: async () => JSON.stringify(calendarUpdateLookupResult()),
+      }),
+      toolSelectionGate: async ({ toolName, args }) => {
+        selectionGateCalls.push({ toolName, args: { ...args } });
+        return {
+          decision: 'allow',
+          metadata: { turnIndex: 0, ordinal: selectionGateCalls.length },
+        };
+      },
+    });
+
+    await expect(
+      runner.run({
+        session: session(),
+        events: [],
+        message: 'Zaproś Patryka (patryk@example.com) na Bagrową.',
+        currentDateTime: CURRENT_DATE_TIME,
+        timeZone: 'Europe/Warsaw',
+      })
+    ).resolves.toMatchObject({
+      outcome: 'needs_confirmation',
+      toolName: 'update_calendar_event',
+      toolArgs: { attendeesToAdd: ['patryk@example.com'] },
+    });
+    const updateGateCalls = selectionGateCalls.filter(
+      (call) => call.toolName === 'update_calendar_event'
+    );
+    expect(updateGateCalls).toHaveLength(1);
+    expect(updateGateCalls[0]?.args['attendeesToAdd']).toEqual(['patryk@example.com']);
+  });
+
   it.each([
     { label: 'an array snapshot', start: [] },
     { label: 'a snapshot without a date', start: {} },
@@ -8300,6 +8522,372 @@ describe('createIntexAgentRunner', () => {
       missingFields: ['event'],
       candidateIntents: ['update_calendar_event'],
       suggestedNextStep: 'Wskaż dokładnie jedno istniejące wydarzenie.',
+    });
+  });
+
+  it.each([
+    {
+      label: 'completed',
+      runnerResult: ok(
+        toolResult({
+          outcome: 'completed',
+          reply: 'Zaktualizowałem wydarzenie.',
+          toolName: 'query_calendar_events',
+          summary: 'Fałszywe podsumowanie lookup-only.',
+        })
+      ),
+    },
+    {
+      label: 'no_action',
+      runnerResult: ok(toolResult({ outcome: 'no_action', reply: 'Nic nie zmieniłem.' })),
+    },
+    {
+      label: 'unsupported',
+      runnerResult: ok(
+        toolResult({
+          outcome: 'unsupported',
+          reply: 'Nie mogę tego zrobić.',
+          blockerReason: 'unsupported_action',
+          suggestedNextStep: 'Spróbuj inaczej.',
+        })
+      ),
+    },
+    {
+      label: 'needs_clarification',
+      runnerResult: ok(
+        toolResult({
+          outcome: 'needs_clarification',
+          reply: 'Które wydarzenie masz na myśli?',
+          blockerReason: 'missing_required_details',
+          missingFields: ['event'],
+          candidateIntents: ['update_calendar_event'],
+          suggestedNextStep: 'Wskaż wydarzenie.',
+        })
+      ),
+    },
+    {
+      label: 'invalid',
+      runnerResult: ok({
+        content: 'malformed runner output',
+        toolCallsMade: 1,
+        iterationCount: 2,
+        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2, costUsd: 0 },
+      }),
+    },
+  ])(
+    'prepares a deterministic attendee-update confirmation after a complete unique lookup and $label runner output',
+    async ({ runnerResult }) => {
+      const queryResult = calendarUpdateLookupResult();
+      const client = new ToolExecutingFakeToolCallingClient(
+        {
+          toolName: 'query_calendar_events',
+          args: calendarUpdateQueryArgs(),
+        },
+        [runnerResult]
+      );
+      const runner = createIntexAgentRunner({
+        client,
+        intentClassifier: toolIntentClassifier(['update_calendar_event']),
+        toolExecutor: fakeToolExecutor({
+          queryCalendarEvents: async () => JSON.stringify(queryResult),
+        }),
+      });
+
+      await expect(
+        runner.run({
+          session: session(),
+          events: [
+            event('user_message', {
+              text: 'Invite Anna (stale-anna@example.com) to an existing event.',
+            }),
+            event('confirmation_requested', { toolName: 'update_calendar_event' }),
+            event('confirmation_resolved', {
+              toolName: 'update_calendar_event',
+              accepted: false,
+            }),
+            event('assistant_message', { text: 'Okay, I will not run this action.' }),
+            event('user_message', {
+              text: 'Zaproś Martę Testową do istniejącego wydarzenia „Bagrowa”.',
+            }),
+            event('clarification_requested', {
+              message: 'Jaki jest adres e-mail uczestnika?',
+              blockerReason: 'missing_required_details',
+              missingFields: ['attendeeEmail'],
+              candidateIntents: ['update_calendar_event'],
+            }),
+            event('assistant_message', { text: 'Jaki jest adres e-mail uczestnika?' }),
+          ],
+          message: 'Jej adres e-mail to marta@example.com.',
+          currentDateTime: CURRENT_DATE_TIME,
+          timeZone: 'Europe/Warsaw',
+        })
+      ).resolves.toEqual({
+        outcome: 'needs_confirmation',
+        reply: [
+          'Czy dodać uczestników do istniejącego wydarzenia w kalendarzu?',
+          '',
+          'Tytuł: Bagrowa',
+          'Początek: 25 czerwca 2026, 18:00',
+          'Koniec: 25 czerwca 2026, 20:30',
+          'Uczestnicy: marta@example.com',
+          'Pozostałe dane wydarzenia pozostaną bez zmian.',
+        ].join('\n'),
+        toolName: 'update_calendar_event',
+        toolArgs: {
+          eventId: 'event-bagrowa',
+          eventSummary: 'Bagrowa',
+          attendeesToAdd: ['marta@example.com'],
+          calendarId: 'primary',
+          expectedEtag: '"event-bagrowa-v1"',
+          eventStart: { dateTime: '2026-06-25T18:00:00+02:00' },
+          eventEnd: { dateTime: '2026-06-25T20:30:00+02:00' },
+        },
+        supportingToolCompletions: [
+          {
+            toolName: 'query_calendar_events',
+            result: queryResult,
+          },
+        ],
+      });
+    }
+  );
+
+  it('uses one exact canonical attendee-email preference for a unique lookup-only update', async () => {
+    const queryResult = calendarUpdateLookupResult();
+    const client = new ToolExecutingFakeToolCallingClient(
+      { toolName: 'query_calendar_events', args: calendarUpdateQueryArgs() },
+      [ok(toolResult({ outcome: 'no_action', reply: 'Nothing changed.' }))]
+    );
+    const runner = createIntexAgentRunner({
+      client,
+      intentClassifier: toolIntentClassifier(['update_calendar_event']),
+      toolExecutor: fakeToolExecutor({
+        queryCalendarEvents: async () => JSON.stringify(queryResult),
+      }),
+      userPreferences:
+        'User Preferences v1:\n1. (id: pref_jakub) "When I ask to invite Jakub, invite jakub.saved@example.com."',
+    });
+
+    await expect(
+      runner.run({
+        session: session(),
+        events: [],
+        message: 'Invite Jakub to the Bagrowa event.',
+        currentDateTime: CURRENT_DATE_TIME,
+        timeZone: 'Europe/Warsaw',
+      })
+    ).resolves.toMatchObject({
+      outcome: 'needs_confirmation',
+      toolName: 'update_calendar_event',
+      toolArgs: { attendeesToAdd: ['jakub.saved@example.com'] },
+    });
+  });
+
+  it('routes a synthesized attendee update through the selection gate', async () => {
+    const selectedTools: IntexAgentToolName[] = [];
+    const client = new ToolExecutingFakeToolCallingClient(
+      { toolName: 'query_calendar_events', args: calendarUpdateQueryArgs() },
+      [ok(toolResult({ outcome: 'no_action', reply: 'Nothing changed.' }))]
+    );
+    const runner = createIntexAgentRunner({
+      client,
+      intentClassifier: toolIntentClassifier(['update_calendar_event']),
+      toolExecutor: fakeToolExecutor({
+        queryCalendarEvents: async () => JSON.stringify(calendarUpdateLookupResult()),
+      }),
+      toolSelectionGate: async ({ toolName }) => {
+        selectedTools.push(toolName);
+        return toolName === 'update_calendar_event'
+          ? {
+              decision: 'reject',
+              category: 'safety_stop',
+              code: 'SYNTHETIC_UPDATE_REJECTED',
+              metadata: { turnIndex: 0, ordinal: 2 },
+            }
+          : { decision: 'allow', metadata: { turnIndex: 0, ordinal: 1 } };
+      },
+    });
+
+    await expect(
+      runner.run({
+        session: session(),
+        events: [],
+        message: 'Invite Patryk (patryk@example.com) to the Bagrowa event.',
+        currentDateTime: CURRENT_DATE_TIME,
+        timeZone: 'Europe/Warsaw',
+      })
+    ).resolves.toMatchObject({
+      outcome: 'tool_selection_rejected',
+      toolName: 'update_calendar_event',
+      code: 'SYNTHETIC_UPDATE_REJECTED',
+    });
+    expect(selectedTools).toEqual(['query_calendar_events', 'update_calendar_event']);
+  });
+
+  it('surfaces a synthesized attendee-update selection-gate failure', async () => {
+    const client = new ToolExecutingFakeToolCallingClient(
+      { toolName: 'query_calendar_events', args: calendarUpdateQueryArgs() },
+      [
+        ok(
+          toolResult({
+            outcome: 'completed',
+            reply: 'The attendee was added successfully.',
+            toolName: 'update_calendar_event',
+          })
+        ),
+      ]
+    );
+    const runner = createIntexAgentRunner({
+      client,
+      intentClassifier: toolIntentClassifier(['update_calendar_event']),
+      toolExecutor: fakeToolExecutor({
+        queryCalendarEvents: async () => JSON.stringify(calendarUpdateLookupResult()),
+      }),
+      toolSelectionGate: async ({ toolName }) => {
+        if (toolName === 'update_calendar_event') {
+          throw new Error('Synthetic selection gate failed');
+        }
+        return { decision: 'allow', metadata: { turnIndex: 0, ordinal: 1 } };
+      },
+    });
+
+    const result = await runner.run({
+      session: session(),
+      events: [],
+      message: 'Invite Patryk (patryk@example.com) to the Bagrowa event.',
+      currentDateTime: CURRENT_DATE_TIME,
+      timeZone: 'Europe/Warsaw',
+    });
+
+    expect(result).toMatchObject({
+      outcome: 'tool_failed',
+      toolName: 'update_calendar_event',
+      error: 'Synthetic selection gate failed',
+    });
+    expect(result.reply).toBe(
+      'I could not execute this action: Synthetic selection gate failed. Please try again later.'
+    );
+    expect(result.reply).not.toContain('successfully');
+  });
+
+  it.each([
+    {
+      label: 'zero matches',
+      queryArgs: calendarUpdateQueryArgs(),
+      queryResult: calendarUpdateLookupResult({ count: 0, events: [] }),
+    },
+    {
+      label: 'multiple matches',
+      queryArgs: calendarUpdateQueryArgs(),
+      queryResult: calendarUpdateLookupResult({
+        count: 2,
+        events: [
+          calendarUpdateLookupEvent({ id: 'event-bagrowa-1' }),
+          calendarUpdateLookupEvent({ id: 'event-bagrowa-2' }),
+        ],
+      }),
+    },
+    {
+      label: 'a truncated result',
+      queryArgs: calendarUpdateQueryArgs(),
+      queryResult: calendarUpdateLookupResult({ truncated: true }),
+    },
+    {
+      label: 'an incomplete snapshot',
+      queryArgs: calendarUpdateQueryArgs(),
+      queryResult: calendarUpdateLookupResult({
+        events: [calendarUpdateLookupEvent({ etag: '' })],
+      }),
+    },
+    {
+      label: 'a syntactically malformed date-time snapshot',
+      queryArgs: calendarUpdateQueryArgs(),
+      queryResult: calendarUpdateLookupResult({
+        events: [calendarUpdateLookupEvent({ start: { dateTime: 'not-a-date' } })],
+      }),
+    },
+    {
+      label: 'an invalid snapshot time zone',
+      queryArgs: calendarUpdateQueryArgs(),
+      queryResult: calendarUpdateLookupResult({
+        events: [
+          calendarUpdateLookupEvent({
+            start: { dateTime: '2026-06-25T18:00:00+02:00', timeZone: 'Mars/Olympus' },
+          }),
+        ],
+      }),
+    },
+    {
+      label: 'a query absent from the active request',
+      queryArgs: { ...calendarUpdateQueryArgs(), query: 'Dentist' },
+      queryResult: calendarUpdateLookupResult({
+        events: [calendarUpdateLookupEvent({ summary: 'Dentist' })],
+      }),
+    },
+    {
+      label: 'a query different from the matched summary',
+      queryArgs: calendarUpdateQueryArgs(),
+      queryResult: calendarUpdateLookupResult({
+        events: [calendarUpdateLookupEvent({ summary: 'Dentist' })],
+      }),
+    },
+    {
+      label: 'a lookup without a query',
+      queryArgs: {
+        mode: 'list',
+        timeMin: '2026-06-25T00:00:00+02:00',
+        timeMax: '2026-06-26T00:00:00+02:00',
+      },
+      queryResult: calendarUpdateLookupResult(),
+    },
+    {
+      label: 'an event from a calendar different from the requested calendar',
+      queryArgs: { ...calendarUpdateQueryArgs(), calendarId: 'team@example.com' },
+      queryResult: calendarUpdateLookupResult(),
+    },
+    {
+      label: 'a non-primary calendar',
+      queryArgs: { ...calendarUpdateQueryArgs(), calendarId: 'team@example.com' },
+      queryResult: calendarUpdateLookupResult({
+        events: [calendarUpdateLookupEvent({ calendarId: 'team@example.com' })],
+      }),
+    },
+  ])('keeps a lookup-only calendar update closed for $label', async ({ queryArgs, queryResult }) => {
+    const client = new ToolExecutingFakeToolCallingClient(
+      {
+        toolName: 'query_calendar_events',
+        args: queryArgs,
+      },
+      [
+        ok(
+          toolResult({
+            outcome: 'completed',
+            reply: 'Zaktualizowałem wydarzenie.',
+            toolName: 'query_calendar_events',
+          })
+        ),
+      ]
+    );
+    const runner = createIntexAgentRunner({
+      client,
+      intentClassifier: toolIntentClassifier(['update_calendar_event']),
+      toolExecutor: fakeToolExecutor({
+        queryCalendarEvents: async () => JSON.stringify(queryResult),
+      }),
+    });
+
+    await expect(
+      runner.run({
+        session: session(),
+        events: [],
+        message: 'Zaproś Patryka (patryk@example.com) na Bagrową.',
+        currentDateTime: CURRENT_DATE_TIME,
+        timeZone: 'Europe/Warsaw',
+      })
+    ).resolves.toMatchObject({
+      outcome: 'needs_clarification',
+      missingFields: ['event'],
+      candidateIntents: ['update_calendar_event'],
     });
   });
 
@@ -10962,6 +11550,46 @@ describe('createIntexAgentRunner', () => {
     expect(repairClient.calls).toHaveLength(0);
   });
 });
+
+function calendarUpdateQueryArgs(): Record<string, unknown> {
+  return {
+    mode: 'list',
+    timeMin: '2026-06-25T00:00:00+02:00',
+    timeMax: '2026-06-26T00:00:00+02:00',
+    query: 'Bagrowa',
+  };
+}
+
+function calendarUpdateLookupEvent(
+  overrides: Record<string, unknown> = {}
+): Record<string, unknown> {
+  return {
+    id: 'event-bagrowa',
+    etag: '"event-bagrowa-v1"',
+    summary: 'Bagrowa',
+    calendarId: 'primary',
+    start: { dateTime: '2026-06-25T18:00:00+02:00' },
+    end: { dateTime: '2026-06-25T20:30:00+02:00' },
+    ...overrides,
+  };
+}
+
+function calendarUpdateLookupResult(
+  overrides: Partial<{
+    count: number;
+    truncated: boolean;
+    events: Record<string, unknown>[];
+  }> = {}
+): Record<string, unknown> {
+  return {
+    status: 'completed',
+    mode: 'list',
+    count: 1,
+    truncated: false,
+    events: [calendarUpdateLookupEvent()],
+    ...overrides,
+  };
+}
 
 function toolResult(content: Record<string, unknown>): ToolCallingResult {
   return {

--- a/apps/intex-agent/src/domain/agent/intexAgentRunner.ts
+++ b/apps/intex-agent/src/domain/agent/intexAgentRunner.ts
@@ -5,6 +5,7 @@ import {
 } from '@intexuraos/http-contracts';
 import type {
   MatrixCorpusProviderCallUsageV1,
+  ToolDefinition,
   ToolCallingClient,
   ToolCallingMessage,
 } from '@intexuraos/llm-contract';
@@ -619,15 +620,29 @@ export function createIntexAgentRunner(config: IntexAgentRunnerConfig): IntexAge
         };
       }
 
+      const calendarUpdateContext = {
+        message: input.message,
+        events: input.events,
+        replyContext: input.replyContext,
+        userPreferences: config.userPreferences ?? null,
+      };
+      const calendarUpdateRelevantTexts = isCalendarUpdateIntent(intent)
+        ? activeCalendarAttendeeRelevantTexts(calendarUpdateContext)
+        : undefined;
+      const calendarUpdateAttendeeEmails = isCalendarUpdateIntent(intent)
+        ? resolveActiveCalendarAttendeeEmails(calendarUpdateContext)
+        : undefined;
       const toolExecutions: IntexAgentToolExecution[] = [];
       const allowedToolNames = resolveRunnerToolNames(intent);
+      const trackingToolExecutor = createTrackingToolExecutor(
+        createConfirmationPreviewExecutor(config.toolExecutor),
+        toolExecutions,
+        config.toolSelectionGate,
+        resolveCurrentPreferenceVersion(config.userPreferences),
+        calendarUpdateAttendeeEmails
+      );
       const tools = createIntexAgentToolDefinitions(
-        createTrackingToolExecutor(
-          createConfirmationPreviewExecutor(config.toolExecutor),
-          toolExecutions,
-          config.toolSelectionGate,
-          resolveCurrentPreferenceVersion(config.userPreferences)
-        )
+        trackingToolExecutor
       )
         .filter(
           (tool) =>
@@ -695,6 +710,14 @@ export function createIntexAgentRunner(config: IntexAgentRunnerConfig): IntexAge
         }
       }
 
+      const synthesizedCalendarUpdatePreview = await appendDeterministicCalendarUpdatePreview({
+        intent,
+        toolExecutions,
+        tools,
+        attendeesToAdd: calendarUpdateAttendeeEmails as string[],
+        activeUserTexts: calendarUpdateRelevantTexts,
+      });
+
       const runnerResult = await parseRunnerContent(
         {
           content: result.value.content,
@@ -704,6 +727,12 @@ export function createIntexAgentRunner(config: IntexAgentRunnerConfig): IntexAge
           intent,
           exposedToolNames,
           currentMessage: input.message,
+          ...(calendarUpdateAttendeeEmails !== undefined
+            ? { calendarUpdateAttendeeEmails }
+            : {}),
+          ...(synthesizedCalendarUpdatePreview
+            ? { synthesizedCalendarUpdatePreview: true }
+            : {}),
           ...(config.matrixCorpusLlm === undefined
             ? {}
             : { matrixCorpusLlm: config.matrixCorpusLlm }),
@@ -1149,6 +1178,16 @@ function hasCalendarAttendeeEmailContext(
     userPreferences: string | null;
   }>
 ): boolean {
+  return resolveActiveCalendarAttendeeEmails(context) !== undefined;
+}
+
+function activeCalendarAttendeeRelevantTexts(
+  context: Readonly<{
+    message: string;
+    events: readonly IntexAgentSessionEvent[];
+    replyContext: IntexIncomingMessageReplyContext | undefined;
+  }>
+): string[] | undefined {
   const userTurns = activeCalendarAttendeeUserTurns(context);
   const attendeeTurnIndex = userTurns.findIndex((turn) =>
     turn.some((text) => extractCalendarAttendeeSegments(text).length > 0)
@@ -1156,17 +1195,63 @@ function hasCalendarAttendeeEmailContext(
   const relevantTurns =
     attendeeTurnIndex === -1 ? userTurns.slice(0, 1) : userTurns.slice(0, attendeeTurnIndex + 1);
   const relevantTexts = relevantTurns.flat();
-  if (
-    relevantTexts
-      .flatMap(extractCalendarAttendeeSegments)
-      .some(isAmbiguousCalendarAttendeeSegment)
-  ) {
-    return false;
-  }
-  return (
-    relevantTexts.some(containsAssociatedAttendeeEmailSignal) ||
-    hasUnambiguousMatchingAttendeeEmailPreference(context.userPreferences, relevantTexts)
+  return relevantTexts
+    .flatMap(extractCalendarAttendeeSegments)
+    .some(isAmbiguousCalendarAttendeeSegment)
+    ? undefined
+    : relevantTexts;
+}
+
+function resolveActiveCalendarAttendeeEmails(
+  context: Readonly<{
+    message: string;
+    events: readonly IntexAgentSessionEvent[];
+    replyContext: IntexIncomingMessageReplyContext | undefined;
+    userPreferences: string | null;
+  }>
+): string[] | undefined {
+  const relevantTexts = activeCalendarAttendeeRelevantTexts(context);
+  if (relevantTexts === undefined) return undefined;
+
+  const allEmails = new Set(
+    relevantTexts.flatMap(uniqueValidAttendeeEmails).map(normalizeAttendeeEmail)
   );
+  if (allEmails.size > 1) return undefined;
+
+  const associatedEmails = new Set(
+    relevantTexts.flatMap(extractAssociatedAttendeeEmails).map(normalizeAttendeeEmail)
+  );
+  if (associatedEmails.size === 1) return [...associatedEmails];
+
+  const preferenceEmail = resolveUnambiguousMatchingAttendeeEmailPreference(
+    context.userPreferences,
+    relevantTexts
+  );
+  return preferenceEmail === undefined ? undefined : [preferenceEmail];
+}
+
+function extractAssociatedAttendeeEmails(message: string): string[] {
+  const attendeeSegmentEmails = extractCalendarAttendeeSegments(message)
+    .map(uniqueValidAttendeeEmails)
+    .filter((emails) => emails.length > 0);
+  if (attendeeSegmentEmails.length > 0) {
+    return attendeeSegmentEmails.flat();
+  }
+  return containsStandaloneAttendeeEmailSignal(message)
+    ? uniqueValidAttendeeEmails(message)
+    : [];
+}
+
+function uniqueValidAttendeeEmails(message: string): string[] {
+  const byNormalizedEmail = new Map<string, string>();
+  for (const email of extractAttendeeEmailCandidates(message).filter(isValidCalendarAttendeeEmail)) {
+    byNormalizedEmail.set(normalizeAttendeeEmail(email), email);
+  }
+  return [...byNormalizedEmail.values()];
+}
+
+function normalizeAttendeeEmail(email: string): string {
+  return email.toLocaleLowerCase('en-US');
 }
 
 function isAnsweringActiveCalendarAttendeeEmailClarification(
@@ -1183,7 +1268,7 @@ function isAnsweringActiveCalendarAttendeeEmailClarification(
   return [
     context.message,
     ...(context.replyContext?.source === 'inbound_user_message' ? [context.replyContext.text] : []),
-  ].some(containsAssociatedAttendeeEmailSignal);
+  ].some((text) => extractAssociatedAttendeeEmails(text).length > 0);
 }
 
 function activeCalendarAttendeeUserTurns(
@@ -1286,12 +1371,12 @@ function isCalendarAttendeeClarificationBridgeEvent(event: IntexAgentSessionEven
   );
 }
 
-function hasUnambiguousMatchingAttendeeEmailPreference(
+function resolveUnambiguousMatchingAttendeeEmailPreference(
   userPreferences: string | null,
   userTexts: readonly string[]
-): boolean {
+): string | undefined {
   const attendeeObjects = userTexts.flatMap(extractCalendarAttendeeObjects);
-  if (attendeeObjects.length === 0) return false;
+  if (attendeeObjects.length === 0) return undefined;
 
   const matchingEmails = new Set<string>();
   for (const preferenceText of parseCanonicalPreferenceTexts(userPreferences)) {
@@ -1301,18 +1386,18 @@ function hasUnambiguousMatchingAttendeeEmailPreference(
         extractAttendeeEmailCandidates(preferenceText).length > 0 &&
         attendeeObjects.some((attendee) => sharesPersonToken(attendee, preferenceText))
       ) {
-        return false;
+        return undefined;
       }
       continue;
     }
     if (!attendeeObjects.some((attendee) => isExactPersonLabelMatch(attendee, parsedMapping.person))) {
       continue;
     }
-    if (parsedMapping.email === null) return false;
+    if (parsedMapping.email === null) return undefined;
     matchingEmails.add(parsedMapping.email);
   }
 
-  return matchingEmails.size === 1;
+  return matchingEmails.size === 1 ? [...matchingEmails][0] : undefined;
 }
 
 function parseCanonicalPreferenceTexts(userPreferences: string | null): string[] {
@@ -1443,27 +1528,12 @@ function personTokens(value: string): string[] {
     .match(/[\p{L}\p{N}]+/gu) ?? [];
 }
 
-function containsAssociatedAttendeeEmailSignal(message: string): boolean {
-  const emails = extractAttendeeEmailCandidates(message).filter(isValidCalendarAttendeeEmail);
-  if (emails.length === 0) return false;
-  const attendeeSegmentsWithEmail = extractCalendarAttendeeSegments(message).filter((segment) =>
-    extractAttendeeEmailCandidates(segment).some(isValidCalendarAttendeeEmail)
-  );
-  if (
-    attendeeSegmentsWithEmail.some(
-      (segment) =>
-        extractAttendeeEmailCandidates(segment).filter(isValidCalendarAttendeeEmail).length !== 1
-    )
-  ) {
-    return false;
-  }
-  if (attendeeSegmentsWithEmail.length > 0) {
-    return true;
-  }
+function containsStandaloneAttendeeEmailSignal(message: string): boolean {
+  const emails = uniqueValidAttendeeEmails(message);
   if (emails.length !== 1) return false;
 
   let withoutEmails = message;
-  for (const email of emails) {
+  for (const email of extractAttendeeEmailCandidates(message)) {
     withoutEmails = withoutEmails.replace(email, ' ');
   }
   if (withoutEmails.replace(/[\s.,;:!?()[\]{}"'“”„-]+/gu, '') === '') return true;
@@ -2220,6 +2290,8 @@ interface RunnerOutputValidationInput {
   intent: IntexAgentIntentClassification | IntexAgentIntentDecision;
   exposedToolNames: IntexAgentToolName[];
   currentMessage: string;
+  calendarUpdateAttendeeEmails?: string[];
+  synthesizedCalendarUpdatePreview?: true;
   matrixCorpusLlm?: MatrixCorpusLlmRecorder;
 }
 
@@ -2271,11 +2343,12 @@ async function parseRunnerContent(
   );
   if (toolExecution?.error !== undefined) {
     const failureMetadata = toolFailureMetadata(toolExecution.toolName, toolExecution.error);
+    const deterministicFailureReply = `${GENERIC_EXECUTION_FAILURE_PREFIX[replyLanguage]}${toolExecution.error}${GENERIC_EXECUTION_FAILURE_SUFFIX[replyLanguage]}`;
     return {
       outcome: 'tool_failed',
-      reply:
-        parsed?.reply ??
-        `${GENERIC_EXECUTION_FAILURE_PREFIX[replyLanguage]}${toolExecution.error}${GENERIC_EXECUTION_FAILURE_SUFFIX[replyLanguage]}`,
+      reply: isMutatingToolName(toolExecution.toolName)
+        ? deterministicFailureReply
+        : (parsed?.reply ?? deterministicFailureReply),
       toolName: toolExecution.toolName,
       error: toolExecution.error,
       errorCategory: toolExecution.errorCategory ?? failureMetadata.errorCategory,
@@ -2288,7 +2361,11 @@ async function parseRunnerContent(
   }
   const calendarUpdateArgs =
     toolExecution?.toolName === 'update_calendar_event'
-      ? buildCalendarUpdateConfirmationArgs(toolExecutions, toolExecution)
+      ? buildCalendarUpdateConfirmationArgs(
+          toolExecutions,
+          toolExecution,
+          input.calendarUpdateAttendeeEmails
+        )
       : undefined;
   if (toolExecution?.toolName === 'update_calendar_event' && calendarUpdateArgs === undefined) {
     return calendarUpdateLookupResult(replyLanguage);
@@ -2318,7 +2395,9 @@ async function parseRunnerContent(
         ? { toolSelection: toolExecution.selectionMetadata }
         : {}),
       ...(supportingToolCompletions.length > 0 ? { supportingToolCompletions } : {}),
-      ...(parsed?.summary !== undefined ? { summary: parsed.summary } : {}),
+      ...(parsed?.summary !== undefined && input.synthesizedCalendarUpdatePreview !== true
+        ? { summary: parsed.summary }
+        : {}),
     };
   }
 
@@ -2473,6 +2552,53 @@ function isCalendarUpdateIntent(
   return intent.kind === 'tool' && intent.allowedToolNames.includes('update_calendar_event');
 }
 
+function isSingleCalendarUpdateIntent(
+  intent: IntexAgentIntentClassification | IntexAgentIntentDecision
+): boolean {
+  if (intent.kind !== 'tool') return false;
+  const toolNames = new Set(intent.allowedToolNames);
+  return (
+    toolNames.size === intent.allowedToolNames.length &&
+    toolNames.has('update_calendar_event') &&
+    [...toolNames].every(
+      (toolName) =>
+        toolName === 'query_calendar_events' || toolName === 'update_calendar_event'
+    )
+  );
+}
+
+async function appendDeterministicCalendarUpdatePreview(input: Readonly<{
+  intent: IntexAgentIntentClassification | IntexAgentIntentDecision;
+  toolExecutions: IntexAgentToolExecution[];
+  tools: readonly ToolDefinition[];
+  attendeesToAdd: string[];
+  activeUserTexts: string[] | undefined;
+}>): Promise<boolean> {
+  if (!isSingleCalendarUpdateIntent(input.intent) || input.toolExecutions.length !== 1) {
+    return false;
+  }
+  const queryExecution = input.toolExecutions[0];
+  if (queryExecution?.toolName !== 'query_calendar_events') return false;
+
+  const updateArgs = buildCalendarUpdateArgsFromUniqueLookup(
+    queryExecution,
+    input.attendeesToAdd,
+    input.activeUserTexts
+  );
+  if (updateArgs === undefined) return false;
+
+  try {
+    const updateTool = input.tools.find(
+      (tool) => tool.name === 'update_calendar_event'
+    ) as ToolDefinition;
+    await updateTool.run({ ...updateArgs });
+    return true;
+  } catch {
+    // Match the regular tool-calling path: the tracked failure is normalized downstream.
+    return false;
+  }
+}
+
 function calendarUpdateMalformedResult(
   replyLanguage: IntexAgentReplyLanguage
 ): IntexAgentRunnerResult {
@@ -2502,7 +2628,8 @@ function calendarUpdateLookupResult(
 
 function buildCalendarUpdateConfirmationArgs(
   toolExecutions: IntexAgentToolExecution[],
-  updateExecution: IntexAgentToolExecution
+  updateExecution: IntexAgentToolExecution,
+  authoritativeAttendeeEmails: string[] | undefined
 ): Record<string, unknown> | undefined {
   const updateIndex = toolExecutions.indexOf(updateExecution);
   const precedingExecutions = toolExecutions.slice(0, updateIndex);
@@ -2511,11 +2638,68 @@ function buildCalendarUpdateConfirmationArgs(
     .find((execution) => execution.toolName === 'query_calendar_events');
   if (queryExecution === undefined) return undefined;
 
+  const snapshot = readCalendarUpdateLookupSnapshot(queryExecution);
+  if (snapshot === undefined) return undefined;
+
+  const requestedCalendarId = readNonEmptyString(updateExecution.args, 'calendarId');
+  if (
+    authoritativeAttendeeEmails === undefined ||
+    snapshot.eventId !== readNonEmptyString(updateExecution.args, 'eventId') ||
+    snapshot.eventSummary !== readNonEmptyString(updateExecution.args, 'eventSummary') ||
+    (requestedCalendarId !== undefined && requestedCalendarId !== snapshot.calendarId)
+  ) {
+    return undefined;
+  }
+
+  return {
+    ...updateExecution.args,
+    attendeesToAdd: authoritativeAttendeeEmails,
+    ...snapshot,
+  };
+}
+
+function buildCalendarUpdateArgsFromUniqueLookup(
+  queryExecution: IntexAgentToolExecution,
+  attendeesToAdd: string[],
+  activeUserTexts: string[] | undefined
+): UpdateCalendarEventToolArgs | undefined {
+  const query = readNonEmptyString(queryExecution.args, 'query');
+  if (query === undefined || activeUserTexts === undefined) return undefined;
+  const snapshot = readCalendarUpdateLookupSnapshot(queryExecution);
+  if (snapshot?.calendarId !== 'primary') return undefined;
+
+  const normalizedQuery = normalizeCalendarLookupIdentity(query);
+  if (
+    normalizedQuery === '' ||
+    normalizeCalendarLookupIdentity(snapshot.eventSummary) !== normalizedQuery ||
+    !activeUserTexts.some((text) =>
+      normalizeCalendarLookupIdentity(text).includes(normalizedQuery)
+    )
+  ) {
+    return undefined;
+  }
+  return { ...snapshot, attendeesToAdd };
+}
+
+function normalizeCalendarLookupIdentity(value: string): string {
+  return value.normalize('NFKC').toLocaleLowerCase('en-US').replace(/\s+/gu, ' ').trim();
+}
+
+function readCalendarUpdateLookupSnapshot(
+  queryExecution: IntexAgentToolExecution
+): Required<
+  Pick<
+    UpdateCalendarEventToolArgs,
+    'eventId' | 'eventSummary' | 'calendarId' | 'expectedEtag' | 'eventStart' | 'eventEnd'
+  >
+> | undefined {
+
   if (
     queryExecution.error !== undefined ||
     queryExecution.args['mode'] !== 'list' ||
     queryExecution.result?.['status'] !== 'completed' ||
     queryExecution.result['mode'] !== 'list' ||
+    queryExecution.result['count'] !== 1 ||
     queryExecution.result['truncated'] !== false
   ) {
     return undefined;
@@ -2550,18 +2734,9 @@ function buildCalendarUpdateConfirmationArgs(
   }
 
   const queriedCalendarId = readNonEmptyString(queryExecution.args, 'calendarId') ?? 'primary';
-  const requestedCalendarId = readNonEmptyString(updateExecution.args, 'calendarId');
-  if (
-    eventId !== readNonEmptyString(updateExecution.args, 'eventId') ||
-    eventSummary !== readNonEmptyString(updateExecution.args, 'eventSummary') ||
-    calendarId !== queriedCalendarId ||
-    (requestedCalendarId !== undefined && requestedCalendarId !== calendarId)
-  ) {
-    return undefined;
-  }
+  if (calendarId !== queriedCalendarId) return undefined;
 
   return {
-    ...updateExecution.args,
     eventId,
     eventSummary,
     calendarId,
@@ -2591,6 +2766,7 @@ function readCalendarEventDateTimeSnapshot(
   const timeZone = readNonEmptyString(snapshot, 'timeZone');
   if ((dateTime === undefined) === (date === undefined)) return undefined;
   if (snapshot['timeZone'] !== undefined && timeZone === undefined) return undefined;
+  if (timeZone !== undefined && !isValidExplicitTimeZone(timeZone)) return undefined;
   if (dateTime !== undefined && !isValidReplyDateTime(dateTime)) return undefined;
   if (date !== undefined && !isValidCalendarDate(date)) return undefined;
   return {
@@ -2804,7 +2980,8 @@ function createTrackingToolExecutor(
   executor: IntexAgentToolExecutor,
   toolExecutions: IntexAgentToolExecution[],
   toolSelectionGate?: IntexAgentRunnerConfig['toolSelectionGate'],
-  currentPreferenceVersion?: number
+  currentPreferenceVersion?: number,
+  authoritativeCalendarAttendeeEmails?: string[]
 ): IntexAgentToolExecutor {
   async function track(
     toolName: IntexAgentToolName,
@@ -2866,10 +3043,14 @@ function createTrackingToolExecutor(
       );
     },
     async updateCalendarEvent(args: UpdateCalendarEventToolArgs): Promise<string> {
+      const normalizedArgs =
+        authoritativeCalendarAttendeeEmails === undefined
+          ? args
+          : { ...args, attendeesToAdd: authoritativeCalendarAttendeeEmails };
       return await track(
         'update_calendar_event',
-        toRecord(args),
-        async () => await executor.updateCalendarEvent(args)
+        toRecord(normalizedArgs),
+        async () => await executor.updateCalendarEvent(normalizedArgs)
       );
     },
     async queryCalendarEvents(args: QueryCalendarEventsToolArgs): Promise<string> {
@@ -3040,18 +3221,22 @@ function getCompletedToolExecution(
     return toolExecutions[0];
   }
 
+  const terminalExecution = toolExecutions.at(-1);
+  if (terminalExecution === undefined || !isMutatingToolName(terminalExecution.toolName)) {
+    return undefined;
+  }
+  const precedingExecutions = toolExecutions.slice(0, -1);
   if (
-    toolExecutions.some(
-      (execution) => execution.error !== undefined || execution.selectionRejection !== undefined
+    precedingExecutions.some(
+      (execution) =>
+        isMutatingToolName(execution.toolName) ||
+        execution.error !== undefined ||
+        execution.selectionRejection !== undefined
     )
   ) {
     return undefined;
   }
-
-  const mutatingExecutions = toolExecutions.filter((execution) =>
-    isMutatingToolName(execution.toolName)
-  );
-  return mutatingExecutions.length === 1 ? mutatingExecutions[0] : undefined;
+  return terminalExecution;
 }
 
 function parseToolResult(rawResult: string): Record<string, unknown> | undefined {
@@ -3354,7 +3539,8 @@ function formatReplyDateRecords(
 }
 
 function isValidReplyDateTime(value: string): boolean {
-  const match = STRICT_REPLY_DATE_TIME_PATTERN.exec(value) as RegExpExecArray;
+  const match = STRICT_REPLY_DATE_TIME_PATTERN.exec(value);
+  if (match === null) return false;
   const year = Number(match[1]);
   const month = Number(match[2]);
   const day = Number(match[3]);


### PR DESCRIPTION
## Summary
- synthesize a confirmation preview after one complete, unique calendar lookup instead of returning a false event ambiguity
- resolve the attendee email from the active request chain and make that value authoritative before the safety gate
- fail closed for stale history, multiple emails, malformed snapshots, pagination, non-primary calendars, and selection failures

## Verification
- pnpm run ci (7861 tests; coverage, build, format, bundle checks passed)
- Intex Agent coverage: 2013/2013 tests
- Matrix composition: 20/20 scenarios, 59/59 turns
- independent review: no P1/P2/P3 findings